### PR TITLE
examples: add context-restore plugin (post-compaction boot)

### DIFF
--- a/examples/plugins/context-restore/README.md
+++ b/examples/plugins/context-restore/README.md
@@ -1,0 +1,110 @@
+# Context Restore Plugin
+
+An example OpenClaw plugin that prevents **identity and context drift** in
+long-running agents after LCM (Lossless Context Management) compaction.
+
+## The Problem
+
+OpenClaw agents maintain context by keeping recent conversation history in the
+active window. When that window fills up, LCM compacts older messages into a
+summary. This is efficient — but it has a side effect: the agent may lose
+awareness of its own configuration files (guidelines, persona, security rules,
+memory) that were only read at session start.
+
+After compaction, an agent that has not re-read its core files may:
+
+- Forget role-specific guidelines or tone
+- Drift away from security or safety rules
+- Miss recent memory written earlier in the session
+- Answer questions as if it had no prior context
+
+## The Solution: Two Layers
+
+This plugin uses two complementary hooks:
+
+### Layer 1 — Static System Anchor (every turn)
+
+On every turn, the plugin appends a short configurable text block to the system
+prompt via `appendSystemContext`. Because this text is **stable across turns**,
+Anthropic-hosted models can cache it — the marginal token cost after the first
+turn is effectively zero.
+
+Use this layer for brief, always-relevant reminders: the agent's name, a pointer
+to its config files, or its most important rule.
+
+### Layer 2 — Post-Compaction File Restore
+
+After compaction fires (the `after_compaction` hook), the plugin enqueues a
+system event instructing the agent to re-read a configurable list of files.
+The agent processes this silently (replying `NO_REPLY`) before the next user
+turn, fully restoring its context.
+
+Use this layer for the full set of files that define the agent's identity and
+working state.
+
+## Configuration
+
+Add to your agent config (e.g. `openclaw.json` under `plugins`):
+
+```json
+{
+  "id": "context-restore",
+  "config": {
+    "anchorText": "CONTEXT ANCHOR: You are MyAgent. Re-read AGENTS.md and SOUL.md if your context was recently compacted.",
+    "restoreFiles": ["SOUL.md", "AGENTS.md", "SECURITY.md", "memory/2025-01-15.md"],
+    "sessionPrefix": "agent:main:"
+  }
+}
+```
+
+### Options
+
+| Key             | Type       | Default                                                      | Description                                                                                |
+| --------------- | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `anchorText`    | `string`   | A generic reminder to re-read config files after compaction. | Text appended to the system prompt every turn. Keep it short for best cache hit rate.      |
+| `restoreFiles`  | `string[]` | `["AGENTS.md"]`                                              | Files to re-read after compaction, relative to the agent workspace.                        |
+| `sessionPrefix` | `string`   | `""` (all sessions)                                          | If set, only applies to sessions whose key starts with this prefix (e.g. `"agent:main:"`). |
+
+### Dynamic file paths
+
+`restoreFiles` can include dynamic tokens that the agent will resolve at
+restore time. For example, to include today's memory note:
+
+```json
+"restoreFiles": ["AGENTS.md", "SOUL.md", "memory/YYYY-MM-DD.md"]
+```
+
+The agent is instructed to read the file named with today's date substituted
+for `YYYY-MM-DD`.
+
+## How It Works
+
+```
+Every turn
+  └─ before_prompt_build → appendSystemContext(anchorText)
+                           (Anthropic caches this; ~0 marginal tokens)
+
+After compaction
+  └─ after_compaction → enqueueSystemEvent(
+       "Re-read: SOUL.md, AGENTS.md, SECURITY.md, memory/YYYY-MM-DD.md"
+     )
+       └─ agent turn: reads files, replies NO_REPLY (silent)
+```
+
+## Hooks Used
+
+| Hook                  | Purpose                                    |
+| --------------------- | ------------------------------------------ |
+| `before_prompt_build` | Inject static anchor into system prompt.   |
+| `after_compaction`    | Trigger file-restore after LCM compaction. |
+
+Both hooks are stable public APIs available since OpenClaw 2026.3.7.
+
+## Extending This Example
+
+- **Group agents**: set `sessionPrefix` per-agent to target only the sessions
+  that need it (e.g. `"agent:mygroup:"`).
+- **Multiple agents, different files**: deploy one plugin instance per agent
+  with different `restoreFiles` lists.
+- **Minimal mode**: omit `restoreFiles` and rely only on `anchorText` for a
+  lightweight, zero-side-effect anchor.

--- a/examples/plugins/context-restore/README.md
+++ b/examples/plugins/context-restore/README.md
@@ -67,15 +67,14 @@ Add to your agent config (e.g. `openclaw.json` under `plugins`):
 
 ### Dynamic file paths
 
-`restoreFiles` can include dynamic tokens that the agent will resolve at
-restore time. For example, to include today's memory note:
+The plugin substitutes `YYYY-MM-DD` with today's date before building the
+restore prompt. For example:
 
 ```json
 "restoreFiles": ["AGENTS.md", "SOUL.md", "memory/YYYY-MM-DD.md"]
 ```
 
-The agent is instructed to read the file named with today's date substituted
-for `YYYY-MM-DD`.
+This resolves to today's date automatically (e.g. `memory/2025-01-15.md`).
 
 ## How It Works
 
@@ -106,5 +105,5 @@ Both hooks are stable public APIs available since OpenClaw 2026.3.7.
   that need it (e.g. `"agent:mygroup:"`).
 - **Multiple agents, different files**: deploy one plugin instance per agent
   with different `restoreFiles` lists.
-- **Minimal mode**: omit `restoreFiles` and rely only on `anchorText` for a
-  lightweight, zero-side-effect anchor.
+- **Minimal mode**: set `restoreFiles: []` to disable layer 2 and rely only
+  on `anchorText` for a lightweight, zero-side-effect anchor.

--- a/examples/plugins/context-restore/config.ts
+++ b/examples/plugins/context-restore/config.ts
@@ -18,6 +18,11 @@ export const contextRestoreConfigSchema = {
       description:
         "Only apply to sessions whose key starts with this value. Leave empty (default) to apply to all sessions.",
     },
+    timezone: {
+      type: "string",
+      description:
+        'IANA timezone for date math (e.g. "Asia/Jerusalem"). Defaults to server local timezone when omitted.',
+    },
   },
 };
 
@@ -25,4 +30,5 @@ export type ContextRestoreConfig = {
   anchorText?: string;
   restoreFiles?: string[];
   sessionPrefix?: string;
+  timezone?: string;
 };

--- a/examples/plugins/context-restore/config.ts
+++ b/examples/plugins/context-restore/config.ts
@@ -1,0 +1,28 @@
+export const contextRestoreConfigSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    anchorText: {
+      type: "string",
+      description:
+        "Text appended to the system prompt on every turn. Keep it short and stable so Anthropic can cache it.",
+    },
+    restoreFiles: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        'List of file paths (relative to the agent workspace) to re-read after compaction. Example: ["AGENTS.md", "SOUL.md", "SECURITY.md"]',
+    },
+    sessionPrefix: {
+      type: "string",
+      description:
+        "Only apply to sessions whose key starts with this value. Leave empty (default) to apply to all sessions.",
+    },
+  },
+};
+
+export type ContextRestoreConfig = {
+  anchorText?: string;
+  restoreFiles?: string[];
+  sessionPrefix?: string;
+};

--- a/examples/plugins/context-restore/index.ts
+++ b/examples/plugins/context-restore/index.ts
@@ -87,7 +87,8 @@ export default definePluginEntry({
           return;
         }
 
-        const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+        const now = new Date();
+        const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`; // YYYY-MM-DD local timezone
         const resolvedFiles = restoreFiles.map((f) => f.replace(/YYYY-MM-DD/g, today));
         const fileList = resolvedFiles.map((f, i) => `${i + 1}. Read ${f}`).join("\n");
 

--- a/examples/plugins/context-restore/index.ts
+++ b/examples/plugins/context-restore/index.ts
@@ -27,6 +27,8 @@
  *                   after compaction. Default: ["AGENTS.md"].
  *   sessionPrefix — only apply to sessions whose key starts with this string.
  *                   Default: "" (all sessions).
+ *   timezone      — IANA timezone for date math (e.g. "Asia/Jerusalem").
+ *                   Default: server local timezone.
  */
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { contextRestoreConfigSchema, type ContextRestoreConfig } from "./config.js";
@@ -47,6 +49,8 @@ export default definePluginEntry({
     const restoreFiles: string[] = cfg.restoreFiles ?? ["AGENTS.md"];
 
     const sessionPrefix: string = cfg.sessionPrefix ?? "";
+
+    const timezone: string | undefined = cfg.timezone;
 
     // ── 1. Static system context anchor (every turn) ─────────────────────────
     api.on(
@@ -88,7 +92,16 @@ export default definePluginEntry({
         }
 
         const now = new Date();
-        const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`; // YYYY-MM-DD local timezone
+        const parts = new Intl.DateTimeFormat("en-CA", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          ...(timezone ? { timeZone: timezone } : {}),
+        }).formatToParts(now);
+        const today = parts
+          .filter((p) => p.type !== "literal")
+          .map((p) => p.value)
+          .join("-"); // YYYY-MM-DD, respects configured timezone
         const resolvedFiles = restoreFiles.map((f) => f.replace(/YYYY-MM-DD/g, today));
         const fileList = resolvedFiles.map((f, i) => `${i + 1}. Read ${f}`).join("\n");
 

--- a/examples/plugins/context-restore/index.ts
+++ b/examples/plugins/context-restore/index.ts
@@ -38,7 +38,7 @@ export default definePluginEntry({
     "Two-layer context protection: static system-prompt anchor every turn, plus automatic file restore after LCM compaction.",
   configSchema: contextRestoreConfigSchema,
   register(api: OpenClawPluginApi) {
-    const cfg = api.pluginConfig as ContextRestoreConfig;
+    const cfg = (api.pluginConfig ?? {}) as ContextRestoreConfig;
 
     const anchorText =
       cfg.anchorText ??
@@ -83,15 +83,24 @@ export default definePluginEntry({
         const compactedCount =
           typeof rawCount === "number" || typeof rawCount === "string" ? String(rawCount) : "?";
 
-        const fileList = restoreFiles.map((f, i) => `${i + 1}. Read ${f}`).join("\n");
+        if (restoreFiles.length === 0) {
+          return;
+        }
+
+        const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+        const resolvedFiles = restoreFiles.map((f) => f.replace(/YYYY-MM-DD/g, today));
+        const fileList = resolvedFiles.map((f, i) => `${i + 1}. Read ${f}`).join("\n");
 
         const prompt = [
           `[CONTEXT RESTORE] Context compacted (${compactedCount} messages compacted). Re-read the following files now to restore full awareness:`,
           fileList,
-          "Reply NO_REPLY when done. This is a silent restoration.",
+          "Re-read these files silently and continue normally.",
         ].join("\n");
 
-        api.runtime?.system?.enqueueSystemEvent?.(prompt, { sessionKey });
+        api.runtime?.system?.enqueueSystemEvent?.(prompt, {
+          sessionKey,
+          contextKey: `context-restore-${Date.now()}`,
+        });
       },
       { priority: 10 },
     );

--- a/examples/plugins/context-restore/index.ts
+++ b/examples/plugins/context-restore/index.ts
@@ -1,0 +1,99 @@
+/**
+ * Context Restore Plugin
+ *
+ * Solves a real problem: long-running OpenClaw agents suffer identity and
+ * context drift after LCM compaction. When the conversation history is
+ * compacted, the agent loses awareness of its own configuration, guidelines,
+ * and recent memory — and may behave inconsistently until it re-reads them.
+ *
+ * Two-layer approach:
+ *
+ * 1. STATIC SYSTEM CONTEXT (every turn, via appendSystemContext):
+ *    Appends a configurable anchor text to the system prompt on every turn.
+ *    When using Anthropic models, this block is cache-eligible — zero marginal
+ *    token cost after the first turn. Use it for short, stable reminders that
+ *    should survive any compaction.
+ *
+ * 2. POST-COMPACTION RESTORE (via after_compaction hook):
+ *    After compaction fires, enqueues a system event telling the agent to
+ *    re-read a configurable list of files (e.g. SOUL.md, AGENTS.md, SECURITY.md,
+ *    today's memory). The agent silently restores its context before the next
+ *    user turn.
+ *
+ * Configuration:
+ *   anchorText    — text appended to the system prompt every turn.
+ *                   Default: a short reminder to check config files after compaction.
+ *   restoreFiles  — list of file paths (relative to agent workspace) to re-read
+ *                   after compaction. Default: ["AGENTS.md"].
+ *   sessionPrefix — only apply to sessions whose key starts with this string.
+ *                   Default: "" (all sessions).
+ */
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { contextRestoreConfigSchema, type ContextRestoreConfig } from "./config.js";
+
+export default definePluginEntry({
+  id: "context-restore",
+  name: "Context Restore",
+  description:
+    "Two-layer context protection: static system-prompt anchor every turn, plus automatic file restore after LCM compaction.",
+  configSchema: contextRestoreConfigSchema,
+  register(api: OpenClawPluginApi) {
+    const cfg = api.pluginConfig as ContextRestoreConfig;
+
+    const anchorText =
+      cfg.anchorText ??
+      "CONTEXT ANCHOR: If your context was recently compacted, re-read your core config files before responding.";
+
+    const restoreFiles: string[] = cfg.restoreFiles ?? ["AGENTS.md"];
+
+    const sessionPrefix: string = cfg.sessionPrefix ?? "";
+
+    // ── 1. Static system context anchor (every turn) ─────────────────────────
+    api.on(
+      "before_prompt_build",
+      async (_event: unknown, ctx: Record<string, unknown>) => {
+        const sessionKey = typeof ctx?.sessionKey === "string" ? ctx.sessionKey : "";
+        if (sessionPrefix && !sessionKey.startsWith(sessionPrefix)) {
+          return {};
+        }
+        return { appendSystemContext: anchorText };
+      },
+      { priority: 5 },
+    );
+
+    // ── 2. Post-compaction file restore ──────────────────────────────────────
+    //
+    // Hook name: "after_compaction" (typed plugin hook)
+    // Event shape (PluginHookAfterCompactionEvent):
+    //   { messageCount, tokenCount?, compactedCount, sessionFile? }
+    // Context shape (PluginHookAgentContext):
+    //   { agentId?, sessionKey?, sessionId?, workspaceDir? }
+    api.on(
+      "after_compaction",
+      async (event: Record<string, unknown>, ctx: Record<string, unknown>) => {
+        const sessionKey = typeof ctx?.sessionKey === "string" ? ctx.sessionKey : "";
+        if (!sessionKey) {
+          return;
+        }
+        if (sessionPrefix && !sessionKey.startsWith(sessionPrefix)) {
+          return;
+        }
+
+        const rawCount = event?.compactedCount;
+        const compactedCount =
+          typeof rawCount === "number" || typeof rawCount === "string" ? String(rawCount) : "?";
+
+        const fileList = restoreFiles.map((f, i) => `${i + 1}. Read ${f}`).join("\n");
+
+        const prompt = [
+          `[CONTEXT RESTORE] Context compacted (${compactedCount} messages compacted). Re-read the following files now to restore full awareness:`,
+          fileList,
+          "Reply NO_REPLY when done. This is a silent restoration.",
+        ].join("\n");
+
+        api.runtime?.system?.enqueueSystemEvent?.(prompt, { sessionKey });
+      },
+      { priority: 10 },
+    );
+  },
+});

--- a/examples/plugins/context-restore/openclaw.plugin.json
+++ b/examples/plugins/context-restore/openclaw.plugin.json
@@ -19,6 +19,10 @@
       "sessionPrefix": {
         "type": "string",
         "description": "Only apply to sessions whose key starts with this value. Empty = all sessions."
+      },
+      "timezone": {
+        "type": "string",
+        "description": "IANA timezone for date math (e.g. \"Asia/Jerusalem\"). Defaults to server local timezone when omitted."
       }
     }
   }

--- a/examples/plugins/context-restore/openclaw.plugin.json
+++ b/examples/plugins/context-restore/openclaw.plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "context-restore",
+  "name": "Context Restore",
+  "version": "1.0.0",
+  "description": "Two-layer context protection: (1) appends a configurable static anchor to the system prompt every turn (Anthropic cache-eligible, zero marginal cost); (2) after LCM compaction, enqueues a system event to re-read a configurable list of files. Prevents identity and context drift in long-running agents.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "anchorText": {
+        "type": "string",
+        "description": "Text appended to the system prompt on every turn."
+      },
+      "restoreFiles": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Files to re-read after compaction (relative to agent workspace)."
+      },
+      "sessionPrefix": {
+        "type": "string",
+        "description": "Only apply to sessions whose key starts with this value. Empty = all sessions."
+      }
+    }
+  }
+}

--- a/examples/plugins/context-restore/package.json
+++ b/examples/plugins/context-restore/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/example-context-restore",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Example OpenClaw plugin: two-layer context protection against LCM compaction drift",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/examples/plugins/context-restore/package.json
+++ b/examples/plugins/context-restore/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "description": "Example OpenClaw plugin: two-layer context protection against LCM compaction drift",
   "type": "module",
+  "devDependencies": {
+    "openclaw": "*"
+  },
+  "peerDependencies": {
+    "openclaw": "*"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
## Problem: context drift after LCM compaction

Long-running OpenClaw agents can lose awareness of their own configuration — identity guidelines, security rules, workspace instructions, recent memory — when LCM compacts the conversation history. After compaction, the agent may behave inconsistently until it re-reads its core files.

## Solution: two-layer context protection

This PR adds `examples/plugins/context-restore/`, a fully configurable example plugin that prevents this drift.

### Layer 1 — Static system anchor (every turn)

On every turn, the plugin appends a short configurable text block to the system prompt via `appendSystemContext`. Because the text is stable across turns, Anthropic-hosted models can cache it — **zero marginal token cost after the first turn**. Use it for brief reminders that should survive any compaction.

### Layer 2 — Post-compaction file restore

After compaction fires (the `after_compaction` hook), the plugin enqueues a system event instructing the agent to re-read a configurable list of files. The agent processes this silently (`NO_REPLY`) before the next user turn, fully restoring its context.

## Configuration

```json
{
  "id": "context-restore",
  "config": {
    "anchorText": "CONTEXT ANCHOR: You are MyAgent. Re-read AGENTS.md if your context was recently compacted.",
    "restoreFiles": ["SOUL.md", "AGENTS.md", "SECURITY.md", "memory/YYYY-MM-DD.md"],
    "sessionPrefix": "agent:main:"
  }
}
```

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `anchorText` | `string` | Generic reminder | Text appended to system prompt every turn. Short = better cache hit rate. |
| `restoreFiles` | `string[]` | `["AGENTS.md"]` | Files to re-read after compaction, relative to agent workspace. |
| `sessionPrefix` | `string` | `""` (all) | Limit to sessions whose key starts with this prefix. |

## Hooks used

- `before_prompt_build` — inject static anchor into system prompt
- `after_compaction` — trigger file restore after LCM compaction

Both are stable public APIs (available since OpenClaw 2026.3.7).

## Files

- `index.ts` — plugin entry point, registers both hooks
- `config.ts` — config type and schema
- `openclaw.plugin.json` — plugin manifest with configSchema
- `package.json` — minimal ESM package
- `README.md` — problem statement, architecture, configuration reference\n\n---\n\n## AI Disclosure 🤖\n\nThis PR was AI-assisted (Claude). The author understands and has reviewed all code changes.\n\n**Testing degree:** Lightly tested — verified locally against a running OpenClaw instance.
