### PR TITLE
fix(acpx): add skipJsonFormatArgs to avoid passing --format to native Claude Code

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -53,17 +53,24 @@
             },
             "args": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "description": "Arguments to pass to the command"
             },
             "env": {
               "type": "object",
-              "additionalProperties": { "type": "string" },
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "Environment variables for the MCP server"
             }
           },
           "required": ["command"]
         }
+      },
+      "skipJsonFormatArgs": {
+        "type": "boolean"
       }
     }
   },

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -269,6 +269,26 @@ describe("acpx plugin config parsing", () => {
     ).toThrow("strictWindowsCmdWrapper must be a boolean");
   });
 
+  it("accepts skipJsonFormatArgs override", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        skipJsonFormatArgs: true,
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.skipJsonFormatArgs).toBe(true);
+  });
+
+  it("skipJsonFormatArgs defaults to false", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.skipJsonFormatArgs).toBe(false);
+  });
+
   it("keeps the runtime json schema in sync with the manifest config schema", () => {
     const manifest = JSON.parse(
       fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -93,6 +93,7 @@ export type AcpxPluginConfig = {
   nonInteractivePermissions?: AcpxNonInteractivePermissionPolicy;
   pluginToolsMcpBridge?: boolean;
   strictWindowsCmdWrapper?: boolean;
+  skipJsonFormatArgs?: boolean;
   timeoutSeconds?: number;
   queueOwnerTtlSeconds?: number;
   mcpServers?: Record<string, McpServerConfig>;
@@ -109,6 +110,7 @@ export type ResolvedAcpxPluginConfig = {
   nonInteractivePermissions: AcpxNonInteractivePermissionPolicy;
   pluginToolsMcpBridge: boolean;
   strictWindowsCmdWrapper: boolean;
+  skipJsonFormatArgs: boolean;
   timeoutSeconds?: number;
   queueOwnerTtlSeconds: number;
   mcpServers: Record<string, McpServerConfig>;
@@ -162,6 +164,7 @@ const AcpxPluginConfigSchema = z.strictObject({
   strictWindowsCmdWrapper: z
     .boolean({ error: "strictWindowsCmdWrapper must be a boolean" })
     .optional(),
+  skipJsonFormatArgs: z.boolean({ error: "skipJsonFormatArgs must be a boolean" }).optional(),
   timeoutSeconds: z
     .number({ error: "timeoutSeconds must be a number >= 0.001" })
     .min(0.001, { error: "timeoutSeconds must be a number >= 0.001" })
@@ -323,6 +326,7 @@ export function resolveAcpxPluginConfig(params: {
     pluginToolsMcpBridge,
     strictWindowsCmdWrapper:
       normalized.strictWindowsCmdWrapper ?? DEFAULT_STRICT_WINDOWS_CMD_WRAPPER,
+    skipJsonFormatArgs: normalized.skipJsonFormatArgs ?? false,
     timeoutSeconds: normalized.timeoutSeconds,
     queueOwnerTtlSeconds: normalized.queueOwnerTtlSeconds ?? DEFAULT_QUEUE_OWNER_TTL_SECONDS,
     mcpServers,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1023,12 +1023,12 @@ export class AcpxRuntime implements AcpRuntime {
     sessionName: string;
     cwd: string;
   }): Promise<string[]> {
+    const baseArgs = ["--cwd", params.cwd];
+    if (!this.config.skipJsonFormatArgs) {
+      baseArgs.push("--format", "json", "--json-strict");
+    }
     const prefix = [
-      "--format",
-      "json",
-      "--json-strict",
-      "--cwd",
-      params.cwd,
+      ...baseArgs,
       ...buildPermissionArgs(this.config.permissionMode),
       "--non-interactive-permissions",
       this.config.nonInteractivePermissions,
@@ -1051,7 +1051,11 @@ export class AcpxRuntime implements AcpRuntime {
     command: string[];
     prefix?: string[];
   }): Promise<string[]> {
-    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cwd", params.cwd];
+    const baseArgs = ["--cwd", params.cwd];
+    if (!this.config.skipJsonFormatArgs) {
+      baseArgs.push("--format", "json", "--json-strict");
+    }
+    const prefix = params.prefix ?? baseArgs;
     const agentCommand = await this.resolveRawAgentCommand({
       agent: params.agent,
       cwd: params.cwd,


### PR DESCRIPTION
## Summary

When using a custom command path (e.g., native Claude Code installed at ~/.local/bin/claude), acpx was passing `--format json --json-strict` to the sub-command in `buildVerbArgs`, which caused `unknown option '--format'` errors since native Claude Code does not support these flags.

## Fix

Add `skipJsonFormatArgs` config option (default `false`) that, when set to `true`, omits `--format json --json-strict` from the prefix args passed to the sub-command. This allows acpx to work with native Claude Code and other agents that don't support these CLI flags.

## Usage

Users can enable this by adding to their openclaw config:

```json
{
  "plugins": {
    "entries": {
      "acpx": {
        "config": {
          "skipJsonFormatArgs": true
        }
      }
    }
  }
}
```

## Changes

- **config.ts**: Added `skipJsonFormatArgs?: boolean` to `AcpxPluginConfig` and `ResolvedAcpxPluginConfig`, with schema validation and default `false`
- **runtime.ts**: Modified `buildPromptArgs` and `buildVerbArgs` to skip `--format json --json-strict` when `skipJsonFormatArgs` is `true`
- **config.test.ts**: Added 2 tests for `skipJsonFormatArgs` override and default value
- **openclaw.plugin.json**: Updated manifest schema to include the new field

## Testing

All 108 acpx tests pass.

Fixes #60365