### PR TITLE
fix: harden parent fork overflow guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 - Discord/voice: make READY auto-join fire-and-forget while keeping the shorter initial voice-connect timeout separate from the longer playback-start wait. (#60345) Thanks @geekhuashan.
 - Agents/skills: add inherited `agents.defaults.skills` allowlists, make per-agent `agents.list[].skills` replace defaults instead of merging, and scope embedded, session, sandbox, and cron skill snapshots through the effective runtime agent. (#59992) Thanks @gumadeiras.
 - Matrix/Telegram exec approvals: recover stored same-channel account bindings even when session reply state drifted to another channel, so foreign-channel approvals route to the bound account instead of fanning out or being rejected as ambiguous. (#60417) thanks @gumadeiras.
+- Sessions/forking: fall back to transcript-estimated parent token counts when cached totals are stale or missing, so oversized thread forks start fresh instead of cloning the full parent transcript. (#60463) Thanks @jalehman.
 
 ## 2026.4.2
 

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -1,5 +1,8 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { estimateMessagesTokens } from "../../agents/compaction.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions/types.js";
+import { readSessionMessages } from "../../gateway/session-utils.fs.js";
 
 /**
  * Default max parent token count beyond which thread/session parent forking is skipped.
@@ -14,6 +17,44 @@ export function resolveParentForkMaxTokens(cfg: OpenClawConfig): number {
     return Math.floor(configured);
   }
   return DEFAULT_PARENT_FORK_MAX_TOKENS;
+}
+
+function resolvePositiveTokenCount(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+/**
+ * Resolve the best available token estimate for deciding whether parent-session
+ * forking is safe. Prefer fresh persisted totals, then estimate from the
+ * transcript when cached totals are stale or missing.
+ */
+export function resolveParentForkTokenCount(params: {
+  parentEntry: SessionEntry;
+  storePath: string;
+}): number | undefined {
+  const freshPersistedTokens = resolveFreshSessionTotalTokens(params.parentEntry);
+  if (typeof freshPersistedTokens === "number") {
+    return freshPersistedTokens;
+  }
+
+  const transcriptMessages = readSessionMessages(
+    params.parentEntry.sessionId,
+    params.storePath,
+    params.parentEntry.sessionFile,
+  ) as AgentMessage[];
+  if (transcriptMessages.length > 0) {
+    const estimatedTokens = estimateMessagesTokens(transcriptMessages);
+    const transcriptTokens = resolvePositiveTokenCount(
+      Number.isFinite(estimatedTokens) ? Math.ceil(estimatedTokens) : undefined,
+    );
+    if (typeof transcriptTokens === "number") {
+      return transcriptTokens;
+    }
+  }
+
+  return resolvePositiveTokenCount(params.parentEntry.totalTokens);
 }
 
 export async function forkSessionFromParent(params: {

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -39,19 +39,23 @@ export function resolveParentForkTokenCount(params: {
     return freshPersistedTokens;
   }
 
-  const transcriptMessages = readSessionMessages(
-    params.parentEntry.sessionId,
-    params.storePath,
-    params.parentEntry.sessionFile,
-  ) as AgentMessage[];
-  if (transcriptMessages.length > 0) {
-    const estimatedTokens = estimateMessagesTokens(transcriptMessages);
-    const transcriptTokens = resolvePositiveTokenCount(
-      Number.isFinite(estimatedTokens) ? Math.ceil(estimatedTokens) : undefined,
-    );
-    if (typeof transcriptTokens === "number") {
-      return transcriptTokens;
+  try {
+    const transcriptMessages = readSessionMessages(
+      params.parentEntry.sessionId,
+      params.storePath,
+      params.parentEntry.sessionFile,
+    ) as AgentMessage[];
+    if (transcriptMessages.length > 0) {
+      const estimatedTokens = estimateMessagesTokens(transcriptMessages);
+      const transcriptTokens = resolvePositiveTokenCount(
+        Number.isFinite(estimatedTokens) ? Math.ceil(estimatedTokens) : undefined,
+      );
+      if (typeof transcriptTokens === "number") {
+        return transcriptTokens;
+      }
     }
+  } catch {
+    // Fall back to cached totals/unknown tokens when the transcript cannot be read.
   }
 
   return resolvePositiveTokenCount(params.parentEntry.totalTokens);

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -442,6 +442,79 @@ describe("initSessionState thread forking", () => {
     expect(result.sessionEntry.sessionFile).not.toBe(parentSessionFile);
   });
 
+  it("skips fork when parent transcript estimate exceeds threshold and cached total is stale", async () => {
+    const root = await makeCaseDir("openclaw-thread-session-overflow-transcript-fallback-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+
+    const parentSessionId = "parent-overflow-transcript";
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    const lines = [
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: parentSessionId,
+        timestamp: new Date().toISOString(),
+        cwd: process.cwd(),
+      }),
+    ];
+    for (let index = 0; index < 40; index += 1) {
+      const userId = `u${index}`;
+      const assistantId = `a${index}`;
+      const body = `turn-${index} ${"x".repeat(12_000)}`;
+      lines.push(
+        JSON.stringify({
+          type: "message",
+          id: userId,
+          parentId: index === 0 ? null : `a${index - 1}`,
+          timestamp: new Date().toISOString(),
+          message: { role: "user", content: body },
+        }),
+      );
+      lines.push(
+        JSON.stringify({
+          type: "message",
+          id: assistantId,
+          parentId: userId,
+          timestamp: new Date().toISOString(),
+          message: { role: "assistant", content: body },
+        }),
+      );
+    }
+    await fs.writeFile(parentSessionFile, `${lines.join("\n")}\n`, "utf-8");
+
+    const storePath = path.join(root, "sessions.json");
+    const parentSessionKey = "agent:main:slack:channel:c1";
+    await writeSessionStoreFast(storePath, {
+      [parentSessionKey]: {
+        sessionId: parentSessionId,
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 1,
+        totalTokensFresh: false,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const threadSessionKey = "agent:main:slack:channel:c1:thread:457";
+    const result = await initSessionState({
+      ctx: {
+        Body: "Thread reply",
+        SessionKey: threadSessionKey,
+        ParentSessionKey: parentSessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.forkedFromParent).toBe(true);
+    expect(result.sessionEntry.sessionId).not.toBe(parentSessionId);
+    expect(result.sessionEntry.sessionFile).not.toBe(parentSessionFile);
+  });
+
   it("respects session.parentForkMaxTokens override", async () => {
     const root = await makeCaseDir("openclaw-thread-session-overflow-override-");
     const sessionsDir = path.join(root, "sessions");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -47,7 +47,11 @@ import {
   resolveLastChannelRaw,
   resolveLastToRaw,
 } from "./session-delivery.js";
-import { forkSessionFromParent, resolveParentForkMaxTokens } from "./session-fork.js";
+import {
+  forkSessionFromParent,
+  resolveParentForkMaxTokens,
+  resolveParentForkTokenCount,
+} from "./session-fork.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
 
 const log = createSubsystemLogger("session-init");
@@ -597,23 +601,31 @@ export async function initSessionState(params: {
     sessionStore[parentSessionKey] &&
     !alreadyForked
   ) {
-    const parentTokens = sessionStore[parentSessionKey].totalTokens ?? 0;
-    if (parentForkMaxTokens > 0 && parentTokens > parentForkMaxTokens) {
+    const parentEntry = sessionStore[parentSessionKey];
+    const parentTokens = resolveParentForkTokenCount({
+      parentEntry,
+      storePath,
+    });
+    if (
+      parentForkMaxTokens > 0 &&
+      typeof parentTokens === "number" &&
+      parentTokens > parentForkMaxTokens
+    ) {
       // Parent context is too large — forking would create a thread session
       // that immediately overflows the model's context window. Start fresh
       // instead and mark as forked to prevent re-attempts. See #26905.
       log.warn(
         `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${parentTokens} maxTokens=${parentForkMaxTokens}`,
+          `parentTokens=${parentTokens ?? "unknown"} maxTokens=${parentForkMaxTokens}`,
       );
       sessionEntry.forkedFromParent = true;
     } else {
       log.warn(
         `forking from parent session: parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${parentTokens}`,
+          `parentTokens=${parentTokens ?? "unknown"}`,
       );
       const forked = await forkSessionFromParent({
-        parentEntry: sessionStore[parentSessionKey],
+        parentEntry,
         agentId,
         sessionsDir: path.dirname(storePath),
       });

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -602,10 +602,13 @@ export async function initSessionState(params: {
     !alreadyForked
   ) {
     const parentEntry = sessionStore[parentSessionKey];
-    const parentTokens = resolveParentForkTokenCount({
-      parentEntry,
-      storePath,
-    });
+    const parentTokens =
+      parentForkMaxTokens > 0
+        ? resolveParentForkTokenCount({
+            parentEntry,
+            storePath,
+          })
+        : undefined;
     if (
       parentForkMaxTokens > 0 &&
       typeof parentTokens === "number" &&
@@ -616,7 +619,7 @@ export async function initSessionState(params: {
       // instead and mark as forked to prevent re-attempts. See #26905.
       log.warn(
         `skipping parent fork (parent too large): parentKey=${parentSessionKey} → sessionKey=${sessionKey} ` +
-          `parentTokens=${parentTokens ?? "unknown"} maxTokens=${parentForkMaxTokens}`,
+          `parentTokens=${parentTokens} maxTokens=${parentForkMaxTokens}`,
       );
       sessionEntry.forkedFromParent = true;
     } else {


### PR DESCRIPTION
## What
This PR makes the parent-session fork guard reliable when cached token metadata is stale or missing. Instead of trusting only `sessionStore[parent].totalTokens`, OpenClaw now falls back to estimating token usage from the parent transcript before deciding whether a child thread session should fork or start fresh.

## Why
OpenClaw already had a size-based guard for the broader fork-overflow problem, but that guard could still under-estimate very large parent sessions when `totalTokens` was absent or marked stale. In that case a child session could still clone an oversized raw parent transcript and recreate the original overflow behavior.

## Changes
- Add transcript-based parent fork token fallback
- Use fallback during session init fork gating
- Add regression for stale parent token metadata

## Testing
- `pnpm exec oxfmt --check src/auto-reply/reply/session-fork.ts src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts`
- `pnpm exec oxlint src/auto-reply/reply/session-fork.ts src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts`
- `pnpm exec vitest run --config /tmp/openclaw-vitest-auto-reply.config.ts src/auto-reply/reply/session.test.ts -t "parent"`
- Full repo pre-commit `pnpm check` is currently blocked by unrelated existing typecheck failures in `extensions/bluebubbles` and `extensions/telegram`
