### PR TITLE
test: add coverage for Ollama thinking + tool_calls streaming

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -871,6 +871,115 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("preserves tool_calls when preceded by thinking chunks", async () => {
+    // Regression test for #60101: thinking-capable models (qwen3.5) send
+    // thinking chunks before tool_calls. The stream accumulator must not
+    // lose the tool_calls just because thinking chunks arrived first.
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"Let me think about this..."},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":" I should run a command."},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls -la"}}}]},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":15,"eval_count":8}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        // No text content was emitted, so only a done event with toolUse
+        const types = events.map((e) => e.type);
+        expect(types).toEqual(["done"]);
+
+        const doneEvent = events[0];
+        if (doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+        expect(doneEvent.reason).toBe("toolUse");
+
+        // The tool_calls must be present in the final message
+        const toolCalls = doneEvent.message.content.filter((c) => c.type === "toolCall") as Array<{
+          type: "toolCall";
+          name: string;
+          arguments: Record<string, unknown>;
+        }>;
+        expect(toolCalls).toHaveLength(1);
+        expect(toolCalls[0].name).toBe("bash");
+        expect(toolCalls[0].arguments).toEqual({ command: "ls -la" });
+      },
+    );
+  });
+
+  it("preserves tool_calls when tool_calls arrive in done:true chunk with thinking", async () => {
+    // Edge case: some Ollama models deliver tool_calls in the done:true chunk
+    // rather than in an intermediate chunk, especially when thinking is enabled.
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"reasoning here"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"read","arguments":{"path":"/tmp/file"}}}]},"done":true,"prompt_eval_count":10,"eval_count":5}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const types = events.map((e) => e.type);
+        expect(types).toEqual(["done"]);
+
+        const doneEvent = events[0];
+        if (doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+        expect(doneEvent.reason).toBe("toolUse");
+
+        const toolCalls = doneEvent.message.content.filter((c) => c.type === "toolCall") as Array<{
+          type: "toolCall";
+          name: string;
+        }>;
+        expect(toolCalls).toHaveLength(1);
+        expect(toolCalls[0].name).toBe("read");
+      },
+    );
+  });
+
+  it("handles thinking + text + tool_calls in correct order", async () => {
+    // Mixed scenario: thinking, then text, then tool_calls
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"planning..."},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"I will check."},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"pwd"}}}]},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":10,"eval_count":5}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const types = events.map((e) => e.type);
+        // Text content was emitted, so we get streaming events before done
+        expect(types).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+
+        const doneEvent = events.at(-1);
+        if (doneEvent?.type !== "done") {
+          throw new Error("Expected done event");
+        }
+        expect(doneEvent.reason).toBe("toolUse");
+
+        // Both text and tool_calls should be in the final message
+        const textParts = doneEvent.message.content.filter((c) => c.type === "text") as Array<{
+          type: "text";
+          text: string;
+        }>;
+        const toolParts = doneEvent.message.content.filter((c) => c.type === "toolCall") as Array<{
+          type: "toolCall";
+          name: string;
+        }>;
+        expect(textParts).toHaveLength(1);
+        expect(textParts[0].text).toBe("I will check.");
+        expect(toolParts).toHaveLength(1);
+        expect(toolParts[0].name).toBe("bash");
+      },
+    );
+  });
+
   it("prefers streamed content over earlier reasoning chunks", async () => {
     await expectDoneEventContent(
       [


### PR DESCRIPTION
## Summary

Add three test cases that exercise the Ollama streaming adapter when thinking-capable models (e.g. `qwen3.5`) send thinking/reasoning chunks before or alongside `tool_calls`.

### Test scenarios

1. **thinking → tool_calls (no text):** verifies `tool_calls` are preserved and `stopReason` is `toolUse`
2. **thinking → tool_calls in done:true chunk:** edge case where `tool_calls` arrive in the final response chunk
3. **thinking → text → tool_calls:** mixed scenario verifying correct ordering of text streaming events and tool call accumulation

### Motivation

These tests cover the scenario reported in #60101 where `tool_calls` could be dropped when the response includes a `thinking` field. They serve as regression coverage to prevent future breakage of the thinking + tool_calls code path.

Closes #60101