### PR TITLE
fix: normalize routed reply directives and thread transport

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -175,6 +175,49 @@ describe("routeReply", () => {
     await expectSlackNoDelivery({ text: SILENT_REPLY_TOKEN });
   });
 
+  it("normalizes routed reply_to_current directives before send", async () => {
+    await routeReply({
+      payload: { text: "[[reply_to_current]] hi", replyToId: "1710000000.0001" },
+      channel: "slack",
+      to: "channel:C123",
+      cfg: {} as never,
+    });
+    expectLastDelivery({
+      payloads: [
+        expect.objectContaining({
+          text: "hi",
+          replyToId: "1710000000.0001",
+        }),
+      ],
+      replyToId: "1710000000.0001",
+    });
+  });
+
+  it("does not send raw routed reply directives", async () => {
+    await routeReply({
+      payload: { text: "before [[reply_to_current]] after", replyToId: "1710000000.0001" },
+      channel: "slack",
+      to: "channel:C123",
+      cfg: {} as never,
+    });
+    expectLastDelivery({
+      payloads: [
+        expect.objectContaining({
+          text: "before after",
+        }),
+      ],
+    });
+    const [{ payloads }] = mocks.deliverOutboundPayloads.mock.calls.at(-1) ?? [];
+    expect(payloads?.[0]?.text).not.toContain("[[reply_to_current]]");
+  });
+
+  it("skips routed sends when reply normalization strips all content", async () => {
+    await expectSlackNoDelivery({
+      text: "[[reply_to_current]]",
+      replyToId: "1710000000.0001",
+    });
+  });
+
   it("does not drop payloads that merely start with the silent token", async () => {
     const res = await routeReply({
       payload: { text: `${SILENT_REPLY_TOKEN} -- (why am I here?)` },

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -22,6 +22,8 @@ import {
   formatBtwTextForExternalDelivery,
   shouldSuppressReasoningPayload,
 } from "./reply-payloads.js";
+import { extractReplyToTag } from "./reply-tags.js";
+import { compileSlackInteractiveReplies } from "./slack-directives.js";
 
 let deliverRuntimePromise: Promise<
   typeof import("../../infra/outbound/deliver-runtime.js")
@@ -105,10 +107,23 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
   if (!normalized) {
     return { ok: true };
   }
-  const externalPayload: ReplyPayload = {
+  const normalizedReplyTo = extractReplyToTag(normalized.text, normalized.replyToId);
+  const normalizedForExternal: ReplyPayload = {
     ...normalized,
-    text: formatBtwTextForExternalDelivery(normalized),
+    text: normalizedReplyTo.cleaned,
+    replyToId: normalizedReplyTo.replyToId ?? normalized.replyToId,
   };
+  const formattedPayload: ReplyPayload = {
+    ...normalizedForExternal,
+    text: formatBtwTextForExternalDelivery(normalizedForExternal),
+  };
+  // Compile interactive directives (e.g. [[slack_select:...]]) into structured
+  // payloads when the channel plugin opts in. Without this, directive-only
+  // routed replies would be sent as raw text or dropped as empty.
+  const interactiveEnabled = plugin?.messaging?.enableInteractiveReplies?.({ cfg }) === true;
+  const externalPayload: ReplyPayload = interactiveEnabled
+    ? compileSlackInteractiveReplies(formattedPayload)
+    : formattedPayload;
 
   let text = externalPayload.text ?? "";
   let mediaUrls = (externalPayload.mediaUrls?.filter(Boolean) ?? []).length
@@ -158,7 +173,13 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       threadId,
       replyToId,
     }) ?? null;
-  const resolvedReplyToId = replyTransport?.replyToId ?? replyToId ?? undefined;
+  // When no channel-specific transport resolver exists and replyToId is absent,
+  // fall back to threadId so threaded replies are anchored correctly (Mattermost
+  // and similar providers that treat threadId as the root post to reply under).
+  const resolvedReplyToId =
+    replyTransport?.replyToId ??
+    replyToId ??
+    (threadId != null && threadId !== "" ? String(threadId) : undefined);
   const resolvedThreadId =
     replyTransport && Object.hasOwn(replyTransport, "threadId")
       ? (replyTransport.threadId ?? null)


### PR DESCRIPTION
Fix routed reply normalization and thread transport.

## What was wrong
Routed replies were bypassing parts of the normal reply processing path. Because of that:
- raw ` ` could leak into outbound messages
- raw `[[slack_select:...]]` could leak instead of becoming interactive payloads
- channels without a custom `resolveReplyTransport` (for example Mattermost) could lose the `threadId -> replyToId` fallback

## What changed
- normalize inline reply tags in `routeReply()`
- compile Slack interactive directives in routed replies when interactive replies are enabled
- fall back from `threadId` to `replyToId` when no channel-specific transport resolver provides one

## Why it matters
This prevents raw control directives from appearing in outbound messages and restores proper threaded reply anchoring for routed replies.

## Verification
- Added/updated routed reply tests in `src/auto-reply/reply/route-reply.test.ts`
- Verified with targeted test run: 26 passed, 0 failed

## Issue
Closes #60484