### PR TITLE
docs: add Railway Telegram setup guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4,6 +4,22 @@
     "target": "OpenClaw"
   },
   {
+    "source": "Devices CLI",
+    "target": "设备 CLI"
+  },
+  {
+    "source": "Gateway",
+    "target": "Gateway 网关"
+  },
+  {
+    "source": "Gateway troubleshooting",
+    "target": "Gateway 故障排除"
+  },
+  {
+    "source": "Pairing",
+    "target": "配对"
+  },
+  {
     "source": "Railway",
     "target": "Railway"
   },
@@ -18,22 +34,6 @@
   {
     "source": "Telegram",
     "target": "Telegram"
-  },
-  {
-    "source": "Pairing",
-    "target": "配对"
-  },
-  {
-    "source": "Devices CLI",
-    "target": "设备 CLI"
-  },
-  {
-    "source": "Gateway troubleshooting",
-    "target": "Gateway 故障排除"
-  },
-  {
-    "source": "Gateway",
-    "target": "Gateway 网关"
   },
   {
     "source": "Pi",

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4,6 +4,34 @@
     "target": "OpenClaw"
   },
   {
+    "source": "Railway",
+    "target": "Railway"
+  },
+  {
+    "source": "Railway plus Telegram Quick Reference",
+    "target": "Railway 与 Telegram 快速参考"
+  },
+  {
+    "source": "Railway with Telegram",
+    "target": "Railway 与 Telegram"
+  },
+  {
+    "source": "Telegram",
+    "target": "Telegram"
+  },
+  {
+    "source": "Pairing",
+    "target": "配对"
+  },
+  {
+    "source": "Devices CLI",
+    "target": "设备 CLI"
+  },
+  {
+    "source": "Gateway troubleshooting",
+    "target": "Gateway 故障排除"
+  },
+  {
     "source": "Gateway",
     "target": "Gateway 网关"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -946,6 +946,7 @@
                   "install/northflank",
                   "install/oracle",
                   "install/railway",
+                  "install/railway-telegram-setup",
                   "install/raspberry-pi",
                   "install/render"
                 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -947,6 +947,7 @@
                   "install/oracle",
                   "install/railway",
                   "install/railway-telegram-setup",
+                  "install/railway-telegram-quick-ref",
                   "install/raspberry-pi",
                   "install/render"
                 ]

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -146,6 +146,7 @@ Deploy OpenClaw on a cloud server or VPS:
   <Card title="GCP" href="/install/gcp">Google Cloud</Card>
   <Card title="Azure" href="/install/azure">Azure</Card>
   <Card title="Railway" href="/install/railway">Railway</Card>
+  <Card title="Railway + Telegram" href="/install/railway-telegram-setup">Railway with Telegram Bot</Card>
   <Card title="Render" href="/install/render">Render</Card>
   <Card title="Northflank" href="/install/northflank">Northflank</Card>
 </CardGroup>

--- a/docs/install/railway-telegram-quick-ref.md
+++ b/docs/install/railway-telegram-quick-ref.md
@@ -1,41 +1,59 @@
-# Railway + Telegram Setup - Quick Reference
-
-Quick reference for the detailed [Railway + Telegram Setup Guide](railway-telegram-setup.md).
-
-## 🚀 Quick Start (5 minutes)
-
-1. **Deploy on Railway**: Use OpenClaw template
-2. **Create Telegram Bot**: Chat with @BotFather
-3. **Set Environment Variables**:
-   ```bash
-   OPENCLAW_GATEWAY_TOKEN=your-64-char-hex-token
-   TELEGRAM_BOT_TOKEN=your-bot-token-from-botfather
-   ```
-4. **Connect Mobile Device**: Use setup code from guide
-5. **Run Auto-Approval**: Use provided script for device pairing
-
-## 📋 Essential Information
-
-**Your Railway URL Format:**  
-`https://your-project-name-production-xxxxx.up.railway.app`
-
-**Mobile Setup Code Generation:**
-
-```bash
-echo -n 'https://your-app-url|your-gateway-token' | base64 -w 0
-```
-
-**Auto-Approval Script:** Available in main guide  
-**Troubleshooting:** Comprehensive section in main guide
-
-## 🔗 Links
-
-- **Full Guide**: [railway-telegram-setup.md](railway-telegram-setup.md)
-- **Railway Docs**: [docs.railway.app](https://docs.railway.app)
-- **Telegram Bot API**: [core.telegram.org/bots](https://core.telegram.org/bots)
-
+---
+summary: "Quick checklist for a Railway plus Telegram OpenClaw deployment"
+read_when:
+  - You already know the flow and only need the short version
+title: "Railway plus Telegram Quick Reference"
 ---
 
-**Created:** April 2026  
-**Based on:** Live configuration experience  
-**Status:** Production-ready
+Quick checklist for the full [Railway with Telegram](/install/railway-telegram-setup) guide.
+
+## Quick start
+
+1. Deploy OpenClaw on Railway.
+2. Attach a volume at `/data`.
+3. Set:
+
+```bash
+OPENCLAW_GATEWAY_PORT=8080
+OPENCLAW_GATEWAY_TOKEN=<64-char-hex-token>
+OPENCLAW_STATE_DIR=/data/.openclaw
+OPENCLAW_WORKSPACE_DIR=/data/workspace
+TELEGRAM_BOT_TOKEN=<telegram-bot-token>
+```
+
+4. If using Groq, add `GROQ_API_KEY`.
+5. Open `https://<your-domain>/openclaw`.
+6. If the dashboard says `pairing required`, run:
+
+```bash
+openclaw devices list
+openclaw devices approve <requestId>
+```
+
+7. For a personal Telegram bot, prefer:
+
+```json5
+{
+  channels: {
+    telegram: {
+      enabled: true,
+      dmPolicy: "allowlist",
+      allowFrom: ["<your-telegram-user-id>"],
+    },
+  },
+}
+```
+
+## Common fixes
+
+- `502` on Railway domain: check that public networking and service domains target `8080`
+- `origin not allowed`: set `gateway.controlUi.allowedOrigins`
+- `OpenClaw: access not configured` in Telegram: fix `dmPolicy` and `allowFrom`, or approve the Telegram pairing code
+- `HTTP 401: Invalid API Key`: replace the model provider key, for example `GROQ_API_KEY`
+
+## Related docs
+
+- [Railway with Telegram](/install/railway-telegram-setup)
+- [Railway](/install/railway)
+- [Telegram](/channels/telegram)
+- [Devices CLI](/cli/devices)

--- a/docs/install/railway-telegram-quick-ref.md
+++ b/docs/install/railway-telegram-quick-ref.md
@@ -1,0 +1,41 @@
+# Railway + Telegram Setup - Quick Reference
+
+Quick reference for the detailed [Railway + Telegram Setup Guide](railway-telegram-setup.md).
+
+## 🚀 Quick Start (5 minutes)
+
+1. **Deploy on Railway**: Use OpenClaw template
+2. **Create Telegram Bot**: Chat with @BotFather
+3. **Set Environment Variables**:
+   ```bash
+   OPENCLAW_GATEWAY_TOKEN=your-64-char-hex-token
+   TELEGRAM_BOT_TOKEN=your-bot-token-from-botfather
+   ```
+4. **Connect Mobile Device**: Use setup code from guide
+5. **Run Auto-Approval**: Use provided script for device pairing
+
+## 📋 Essential Information
+
+**Your Railway URL Format:**  
+`https://your-project-name-production-xxxxx.up.railway.app`
+
+**Mobile Setup Code Generation:**
+
+```bash
+echo -n 'https://your-app-url|your-gateway-token' | base64 -w 0
+```
+
+**Auto-Approval Script:** Available in main guide  
+**Troubleshooting:** Comprehensive section in main guide
+
+## 🔗 Links
+
+- **Full Guide**: [railway-telegram-setup.md](railway-telegram-setup.md)
+- **Railway Docs**: [docs.railway.app](https://docs.railway.app)
+- **Telegram Bot API**: [core.telegram.org/bots](https://core.telegram.org/bots)
+
+---
+
+**Created:** April 2026  
+**Based on:** Live configuration experience  
+**Status:** Production-ready

--- a/docs/install/railway-telegram-setup.md
+++ b/docs/install/railway-telegram-setup.md
@@ -8,7 +8,7 @@ title: "Railway with Telegram"
 
 Deploy OpenClaw on Railway, connect it to Telegram, and use either the web Control UI or Telegram DMs as your main chat surface.
 
-This guide is the detailed companion to [Railway](/install/railway). It focuses on the setup that was validated end to end in a live Railway deployment, including the Control UI, Telegram DM access, and the most common Railway-specific fixes.
+This guide is the detailed companion to [Railway](/install/railway). It focuses on the setup that was validated end-to-end in a live Railway deployment, including the Control UI, Telegram DM access, and the most common Railway-specific fixes.
 
 If you already know the flow and only need the short version, use [Railway plus Telegram Quick Reference](/install/railway-telegram-quick-ref).
 
@@ -171,6 +171,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 ```
 
 Read `from.id` from the update payload.
+
+If `getUpdates` returns nothing because your bot is using webhooks, follow the [Telegram channel guide](/channels/telegram) and use logs to read the same `from.id` value instead.
 
 This ID is what you put in `channels.telegram.allowFrom`.
 

--- a/docs/install/railway-telegram-setup.md
+++ b/docs/install/railway-telegram-setup.md
@@ -1,0 +1,475 @@
+# OpenClaw Installation Guide: Railway + Telegram Setup
+
+This comprehensive guide walks you through deploying OpenClaw on Railway with Telegram integration, including mobile device pairing and troubleshooting.
+
+## 📋 Prerequisites
+
+- **Railway account** (free tier available)
+- **Telegram account**
+- **Mobile device** (Android/iOS) with OpenClaw app
+- **Basic terminal/command line knowledge**
+
+## 🚀 Step 1: Railway Deployment
+
+### 1.1 Deploy OpenClaw Template
+
+1. **Go to Railway**: Visit [railway.app](https://railway.app)
+2. **Login/Signup**: Create account or login
+3. **Deploy Template**:
+   - Click "Deploy Now" on OpenClaw template
+   - Or use: `https://railway.app/template/openclaw`
+4. **Configure Project**:
+   - Choose project name (e.g., `my-openclaw-bot`)
+   - Select region closest to you
+   - Click "Deploy"
+
+### 1.2 Get Railway CLI (Optional but Recommended)
+
+```bash
+# Install Railway CLI
+npm install -g @railway/cli
+
+# Login to Railway
+railway login
+
+# Link to your project
+railway link
+```
+
+## 🤖 Step 2: Telegram Bot Setup
+
+### 2.1 Create Telegram Bot
+
+1. **Open Telegram** and search for `@BotFather`
+2. **Start conversation** with BotFather
+3. **Create bot**: Send `/newbot`
+4. **Choose bot name**: e.g., "My OpenClaw Assistant"
+5. **Choose username**: e.g., "myopenclaw_bot" (must end with 'bot')
+6. **Save the token**: You'll get something like `1234567890:ABCdefGHIjklMNOpqrSTUvwxyz`
+
+### 2.2 Configure Bot Permissions
+
+Send these commands to @BotFather:
+
+```
+/setprivacy
+# Select your bot
+# Choose "Disable" to allow bot to read all messages
+
+/setcommands
+# Select your bot
+# Add these commands:
+help - Show available commands
+status - Check bot status
+start - Initialize conversation
+```
+
+## ⚙️ Step 3: Environment Configuration
+
+### 3.1 Required Environment Variables
+
+In your Railway dashboard, go to your project → Variables tab and add:
+
+```bash
+# Core OpenClaw Configuration
+OPENCLAW_GATEWAY_TOKEN=your-secure-token-here
+OPENCLAW_GATEWAY_MODE=local
+
+# Telegram Bot Configuration
+TELEGRAM_BOT_TOKEN=1234567890:your-bot-token-from-botfather
+
+# Optional: Custom Configuration
+OPENCLAW_LOG_LEVEL=info
+OPENCLAW_DEVICE_AUTO_APPROVE=false
+```
+
+### 3.2 Generate Gateway Token
+
+**Option 1 - Use Railway CLI:**
+
+```bash
+railway run node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+**Option 2 - Generate locally:**
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+**Option 3 - Online generator:**
+
+- Visit any secure random string generator
+- Generate 64-character hex string
+
+### 3.3 Set Environment Variables
+
+**Via Railway Dashboard:**
+
+1. Go to your project → Variables
+2. Click "New Variable"
+3. Add each variable name and value
+
+**Via Railway CLI:**
+
+```bash
+railway variables set OPENCLAW_GATEWAY_TOKEN=your-token-here
+railway variables set TELEGRAM_BOT_TOKEN=your-bot-token-here
+```
+
+## 📱 Step 4: Mobile Device Connection
+
+### 4.1 Get Connection Information
+
+Your Railway app URL format:
+
+```
+https://your-project-name-production-xxxxx.up.railway.app
+```
+
+**Find your URL:**
+
+- Railway Dashboard → Your Project → Deployments → Domain
+- Or via CLI: `railway status`
+
+### 4.2 Mobile App Setup
+
+**For Android OpenClaw App:**
+
+**Method 1 - Setup Code:**
+
+```bash
+# Generate setup code (run in terminal with your details)
+echo -n 'https://your-app-url|your-gateway-token' | base64 -w 0
+```
+
+**Method 2 - Manual Configuration:**
+
+- Gateway URL: `your-app-url` (without https://)
+- Token: `your-gateway-token`
+
+**Method 3 - QR Code URL:**
+
+```
+https://your-app-url?mobile-code=<base64-encoded-token>
+```
+
+### 4.3 Device Pairing Process
+
+1. **Open OpenClaw mobile app**
+2. **Navigate to connection settings** (Connect/Setup tab)
+3. **Enter configuration**:
+   - Paste setup code, OR
+   - Enter URL and token manually
+4. **Connect**: App will show "Pairing Required"
+5. **Approve device** (see Step 5)
+
+## 🔐 Step 5: Device Approval
+
+### 5.1 Automatic Approval Script
+
+Create this script to auto-approve devices:
+
+```javascript
+// auto-approve.js
+const WebSocket = require("ws");
+
+const TOKEN = "your-gateway-token";
+const GATEWAY = "wss://your-app-url";
+
+console.log("🚀 OpenClaw Auto-Approval Service Starting...");
+
+function createConnection() {
+  const ws = new WebSocket(GATEWAY);
+  let authenticated = false;
+  let checkInterval;
+
+  ws.on("open", () => {
+    console.log("✅ Connected to OpenClaw Gateway");
+  });
+
+  ws.on("message", (data) => {
+    const msg = JSON.parse(data.toString());
+
+    // Handle authentication
+    if (msg.type === "event" && msg.event === "connect.challenge") {
+      ws.send(
+        JSON.stringify({
+          id: "auth-" + Date.now(),
+          method: "auth.token",
+          params: { token: TOKEN, nonce: msg.payload.nonce },
+        }),
+      );
+    }
+
+    // Start monitoring after auth
+    else if (msg.result !== undefined && !authenticated) {
+      authenticated = true;
+      console.log("🎯 Authenticated! Monitoring for devices...");
+
+      checkInterval = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(
+            JSON.stringify({
+              id: "list-" + Date.now(),
+              method: "device.list",
+              params: {},
+            }),
+          );
+        }
+      }, 3000);
+    }
+
+    // Auto-approve pending devices
+    else if (msg.result && msg.result.pending && msg.result.pending.length > 0) {
+      console.log("📱 Device found! Auto-approving...");
+      msg.result.pending.forEach((device) => {
+        ws.send(
+          JSON.stringify({
+            id: "approve-" + Date.now(),
+            method: "device.approve",
+            params: { requestId: device.requestId },
+          }),
+        );
+      });
+    }
+
+    // Confirm approval
+    else if (msg.result !== undefined && msg.id && msg.id.startsWith("approve-")) {
+      console.log("🎉 Device approved successfully!");
+    }
+  });
+
+  ws.on("close", () => {
+    console.log("Connection closed, reconnecting...");
+    if (checkInterval) clearInterval(checkInterval);
+    setTimeout(createConnection, 5000);
+  });
+}
+
+createConnection();
+```
+
+### 5.2 Run Approval Script
+
+```bash
+# Install WebSocket dependency
+npm install ws
+
+# Run the script
+node auto-approve.js
+```
+
+### 5.3 Manual Approval (Alternative)
+
+**Via Railway CLI:**
+
+```bash
+railway connect
+# Then use OpenClaw admin commands to approve devices
+```
+
+**Via Web Interface:**
+
+- Access your Railway app URL directly
+- Login with gateway token
+- Go to device management
+- Approve pending devices
+
+## 🧪 Step 6: Testing Your Setup
+
+### 6.1 Test Telegram Bot
+
+```bash
+# Send test message to your bot
+curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H 'Content-Type: application/json' \
+  -d '{"chat_id": "your-chat-id", "text": "Test message from OpenClaw!"}'
+```
+
+### 6.2 Test Mobile Connection
+
+1. **Open OpenClaw mobile app**
+2. **Send test message** to your Telegram bot
+3. **Verify message appears** in mobile app
+4. **Reply from mobile** and check Telegram
+
+### 6.3 Test Commands
+
+Try these in Telegram:
+
+```
+/start
+/help
+/status
+@your_bot_username Hello from Telegram!
+```
+
+## 🐛 Troubleshooting
+
+### Common Issues & Solutions
+
+#### ❌ "Pairing Required" Error
+
+**Problem:** Mobile app shows pairing required
+**Solutions:**
+
+1. Run auto-approval script
+2. Check gateway token matches
+3. Verify Railway app is running
+4. Check device approval in logs
+
+#### ❌ Telegram Bot Not Responding
+
+**Problem:** Bot doesn't reply to messages
+**Solutions:**
+
+1. Verify `TELEGRAM_BOT_TOKEN` is correct
+2. Check Railway app logs: `railway logs`
+3. Ensure bot privacy is disabled
+4. Test bot token with Telegram API
+
+#### ❌ Mobile App Connection Failed
+
+**Problem:** Cannot connect mobile app
+**Solutions:**
+
+1. Verify Railway app URL is accessible
+2. Check gateway token format (64 hex chars)
+3. Try different connection methods (manual vs. setup code)
+4. Check Railway app is deployed and running
+
+#### ❌ Railway Deployment Failed
+
+**Problem:** Deployment fails or crashes
+**Solutions:**
+
+1. Check Railway logs for errors
+2. Verify environment variables are set
+3. Ensure proper resource limits
+4. Redeploy with correct configuration
+
+### Debug Commands
+
+```bash
+# Check Railway status
+railway status
+
+# View live logs
+railway logs
+
+# Check environment variables
+railway variables
+
+# Connect to Railway service
+railway connect
+
+# Test connectivity
+curl -I https://your-app-url
+```
+
+## 📊 Monitoring & Maintenance
+
+### 6.1 Check Health Status
+
+**Via Railway Dashboard:**
+
+- Monitor CPU/Memory usage
+- Check deployment status
+- Review error logs
+
+**Via CLI:**
+
+```bash
+# Service status
+railway status
+
+# Resource usage
+railway logs --tail
+
+# Environment check
+railway variables
+```
+
+### 6.2 Update Configuration
+
+**Add new environment variables:**
+
+```bash
+railway variables set NEW_VARIABLE=value
+```
+
+**Update existing variables:**
+
+```bash
+railway variables set TELEGRAM_BOT_TOKEN=new-token
+```
+
+### 6.3 Scaling & Limits
+
+**Free Tier Limits:**
+
+- 500 hours/month runtime
+- 1GB RAM
+- 1GB storage
+- No custom domain
+
+**Upgrade for:**
+
+- More resources
+- Custom domains
+- Priority support
+- Advanced monitoring
+
+## 🔒 Security Best Practices
+
+### 7.1 Token Security
+
+- **Never commit tokens** to version control
+- **Use Railway environment variables** only
+- **Rotate tokens** regularly
+- **Monitor access logs**
+
+### 7.2 Bot Security
+
+- **Enable bot privacy** when appropriate
+- **Use webhooks** instead of polling for production
+- **Implement rate limiting**
+- **Validate all inputs**
+
+### 7.3 Network Security
+
+- **Use HTTPS** for all connections
+- **Validate SSL certificates**
+- **Monitor for suspicious activity**
+- **Keep dependencies updated**
+
+## 📚 Additional Resources
+
+- **OpenClaw Documentation**: [docs.openclaw.ai](https://docs.openclaw.ai)
+- **Railway Docs**: [docs.railway.app](https://docs.railway.app)
+- **Telegram Bot API**: [core.telegram.org/bots](https://core.telegram.org/bots)
+- **GitHub Repository**: [github.com/openclaw/openclaw](https://github.com/openclaw/openclaw)
+
+## 🆘 Getting Help
+
+**If you encounter issues:**
+
+1. **Check logs first**: `railway logs`
+2. **Review this guide** step by step
+3. **Search existing issues**: GitHub Issues
+4. **Ask in community**: Discord/Telegram groups
+5. **Create new issue**: Provide logs and configuration details
+
+---
+
+**⚡ Quick Start Summary:**
+
+1. Deploy Railway template
+2. Create Telegram bot with @BotFather
+3. Set environment variables in Railway
+4. Connect mobile app with generated setup code
+5. Run auto-approval script for device pairing
+6. Test end-to-end functionality
+
+**🎉 You're now ready to use OpenClaw with Railway and Telegram!**

--- a/docs/install/railway-telegram-setup.md
+++ b/docs/install/railway-telegram-setup.md
@@ -1,475 +1,309 @@
-# OpenClaw Installation Guide: Railway + Telegram Setup
+---
+summary: "Deploy OpenClaw on Railway and use it from Telegram and the Control UI"
+read_when:
+  - You want a hosted Railway plus Telegram setup
+  - You want the exact Railway and Telegram flow validated in a live deployment
+title: "Railway with Telegram"
+---
 
-This comprehensive guide walks you through deploying OpenClaw on Railway with Telegram integration, including mobile device pairing and troubleshooting.
+Deploy OpenClaw on Railway, connect it to Telegram, and use either the web Control UI or Telegram DMs as your main chat surface.
 
-## 📋 Prerequisites
+This guide is the detailed companion to [Railway](/install/railway). It focuses on the setup that was validated end to end in a live Railway deployment, including the Control UI, Telegram DM access, and the most common Railway-specific fixes.
 
-- **Railway account** (free tier available)
-- **Telegram account**
-- **Mobile device** (Android/iOS) with OpenClaw app
-- **Basic terminal/command line knowledge**
+If you already know the flow and only need the short version, use [Railway plus Telegram Quick Reference](/install/railway-telegram-quick-ref).
 
-## 🚀 Step 1: Railway Deployment
+## Before you start
 
-### 1.1 Deploy OpenClaw Template
+You need:
 
-1. **Go to Railway**: Visit [railway.app](https://railway.app)
-2. **Login/Signup**: Create account or login
-3. **Deploy Template**:
-   - Click "Deploy Now" on OpenClaw template
-   - Or use: `https://railway.app/template/openclaw`
-4. **Configure Project**:
-   - Choose project name (e.g., `my-openclaw-bot`)
-   - Select region closest to you
-   - Click "Deploy"
+- a Railway account
+- a Telegram account
+- a Telegram bot token from `@BotFather`
+- one model provider key, such as Groq
 
-### 1.2 Get Railway CLI (Optional but Recommended)
+For the fastest personal setup, use:
 
-```bash
-# Install Railway CLI
-npm install -g @railway/cli
+- Railway for hosting
+- Telegram for chat
+- `dmPolicy: "allowlist"` for one-owner bots
 
-# Login to Railway
-railway login
+## 1. Deploy OpenClaw on Railway
 
-# Link to your project
-railway link
-```
+Start with [Railway](/install/railway), then make sure these Railway settings are correct.
 
-## 🤖 Step 2: Telegram Bot Setup
+### Required Railway settings
 
-### 2.1 Create Telegram Bot
-
-1. **Open Telegram** and search for `@BotFather`
-2. **Start conversation** with BotFather
-3. **Create bot**: Send `/newbot`
-4. **Choose bot name**: e.g., "My OpenClaw Assistant"
-5. **Choose username**: e.g., "myopenclaw_bot" (must end with 'bot')
-6. **Save the token**: You'll get something like `1234567890:ABCdefGHIjklMNOpqrSTUvwxyz`
-
-### 2.2 Configure Bot Permissions
-
-Send these commands to @BotFather:
-
-```
-/setprivacy
-# Select your bot
-# Choose "Disable" to allow bot to read all messages
-
-/setcommands
-# Select your bot
-# Add these commands:
-help - Show available commands
-status - Check bot status
-start - Initialize conversation
-```
-
-## ⚙️ Step 3: Environment Configuration
-
-### 3.1 Required Environment Variables
-
-In your Railway dashboard, go to your project → Variables tab and add:
+- Attach a Volume mounted at `/data`
+- Enable public networking on port `8080`
+- Set these variables:
 
 ```bash
-# Core OpenClaw Configuration
-OPENCLAW_GATEWAY_TOKEN=your-secure-token-here
-OPENCLAW_GATEWAY_MODE=local
-
-# Telegram Bot Configuration
-TELEGRAM_BOT_TOKEN=1234567890:your-bot-token-from-botfather
-
-# Optional: Custom Configuration
-OPENCLAW_LOG_LEVEL=info
-OPENCLAW_DEVICE_AUTO_APPROVE=false
+OPENCLAW_GATEWAY_PORT=8080
+OPENCLAW_GATEWAY_TOKEN=<64-char-hex-token>
+OPENCLAW_STATE_DIR=/data/.openclaw
+OPENCLAW_WORKSPACE_DIR=/data/workspace
+TELEGRAM_BOT_TOKEN=<telegram-bot-token>
 ```
 
-### 3.2 Generate Gateway Token
-
-**Option 1 - Use Railway CLI:**
+If you are using Groq, also set:
 
 ```bash
-railway run node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+GROQ_API_KEY=<your-groq-key>
 ```
 
-**Option 2 - Generate locally:**
+If your provider key is invalid, OpenClaw still boots, but model requests fail later with provider auth errors.
+
+### Generate a gateway token
 
 ```bash
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-**Option 3 - Online generator:**
+## 2. Open the Control UI
 
-- Visit any secure random string generator
-- Generate 64-character hex string
+After deploy, open:
 
-### 3.3 Set Environment Variables
+- `https://<your-railway-domain>/openclaw`
 
-**Via Railway Dashboard:**
+Log in with `OPENCLAW_GATEWAY_TOKEN`.
 
-1. Go to your project → Variables
-2. Click "New Variable"
-3. Add each variable name and value
+### If the dashboard says `pairing required`
 
-**Via Railway CLI:**
+That means the browser device identity reached the gateway, but the device was not approved yet.
 
-```bash
-railway variables set OPENCLAW_GATEWAY_TOKEN=your-token-here
-railway variables set TELEGRAM_BOT_TOKEN=your-bot-token-here
-```
-
-## 📱 Step 4: Mobile Device Connection
-
-### 4.1 Get Connection Information
-
-Your Railway app URL format:
-
-```
-https://your-project-name-production-xxxxx.up.railway.app
-```
-
-**Find your URL:**
-
-- Railway Dashboard → Your Project → Deployments → Domain
-- Or via CLI: `railway status`
-
-### 4.2 Mobile App Setup
-
-**For Android OpenClaw App:**
-
-**Method 1 - Setup Code:**
+Approve it from the gateway host:
 
 ```bash
-# Generate setup code (run in terminal with your details)
-echo -n 'https://your-app-url|your-gateway-token' | base64 -w 0
+openclaw devices list
+openclaw devices approve <requestId>
 ```
 
-**Method 2 - Manual Configuration:**
+Then reload the dashboard.
 
-- Gateway URL: `your-app-url` (without https://)
-- Token: `your-gateway-token`
+If you are opening the dashboard from mobile, generate the URL on a trusted desktop first and keep the full URL, including `#token=...`, when transferring it.
 
-**Method 3 - QR Code URL:**
+### If the dashboard says `origin not allowed`
 
-```
-https://your-app-url?mobile-code=<base64-encoded-token>
-```
+Add your public Railway domains to:
 
-### 4.3 Device Pairing Process
+- `gateway.controlUi.allowedOrigins`
 
-1. **Open OpenClaw mobile app**
-2. **Navigate to connection settings** (Connect/Setup tab)
-3. **Enter configuration**:
-   - Paste setup code, OR
-   - Enter URL and token manually
-4. **Connect**: App will show "Pairing Required"
-5. **Approve device** (see Step 5)
+Example:
 
-## 🔐 Step 5: Device Approval
-
-### 5.1 Automatic Approval Script
-
-Create this script to auto-approve devices:
-
-```javascript
-// auto-approve.js
-const WebSocket = require("ws");
-
-const TOKEN = "your-gateway-token";
-const GATEWAY = "wss://your-app-url";
-
-console.log("🚀 OpenClaw Auto-Approval Service Starting...");
-
-function createConnection() {
-  const ws = new WebSocket(GATEWAY);
-  let authenticated = false;
-  let checkInterval;
-
-  ws.on("open", () => {
-    console.log("✅ Connected to OpenClaw Gateway");
-  });
-
-  ws.on("message", (data) => {
-    const msg = JSON.parse(data.toString());
-
-    // Handle authentication
-    if (msg.type === "event" && msg.event === "connect.challenge") {
-      ws.send(
-        JSON.stringify({
-          id: "auth-" + Date.now(),
-          method: "auth.token",
-          params: { token: TOKEN, nonce: msg.payload.nonce },
-        }),
-      );
-    }
-
-    // Start monitoring after auth
-    else if (msg.result !== undefined && !authenticated) {
-      authenticated = true;
-      console.log("🎯 Authenticated! Monitoring for devices...");
-
-      checkInterval = setInterval(() => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(
-            JSON.stringify({
-              id: "list-" + Date.now(),
-              method: "device.list",
-              params: {},
-            }),
-          );
-        }
-      }, 3000);
-    }
-
-    // Auto-approve pending devices
-    else if (msg.result && msg.result.pending && msg.result.pending.length > 0) {
-      console.log("📱 Device found! Auto-approving...");
-      msg.result.pending.forEach((device) => {
-        ws.send(
-          JSON.stringify({
-            id: "approve-" + Date.now(),
-            method: "device.approve",
-            params: { requestId: device.requestId },
-          }),
-        );
-      });
-    }
-
-    // Confirm approval
-    else if (msg.result !== undefined && msg.id && msg.id.startsWith("approve-")) {
-      console.log("🎉 Device approved successfully!");
-    }
-  });
-
-  ws.on("close", () => {
-    console.log("Connection closed, reconnecting...");
-    if (checkInterval) clearInterval(checkInterval);
-    setTimeout(createConnection, 5000);
-  });
+```json5
+{
+  gateway: {
+    controlUi: {
+      allowedOrigins: [
+        "https://your-service-production-a123.up.railway.app",
+        "https://your-service-production-b456.up.railway.app",
+      ],
+    },
+  },
 }
-
-createConnection();
 ```
 
-### 5.2 Run Approval Script
+This is required for public Control UI use behind Railway's proxy.
+
+## 3. Create the Telegram bot
+
+In Telegram, talk to `@BotFather` and run:
+
+```text
+/newbot
+```
+
+Save the bot token and put it in `TELEGRAM_BOT_TOKEN`.
+
+If you want the bot to read all group messages, adjust privacy mode with `@BotFather`. For DM-only use, the default bot settings are fine.
+
+## 4. Choose your Telegram DM access model
+
+Telegram DMs can use one of these policies:
+
+- `pairing`
+- `allowlist`
+- `open`
+- `disabled`
+
+For a one-owner Railway bot, prefer `allowlist` with your numeric Telegram user ID. It is more durable than re-approving pairing codes after environment resets.
+
+Example:
+
+```json5
+{
+  channels: {
+    telegram: {
+      enabled: true,
+      dmPolicy: "allowlist",
+      allowFrom: ["<your-telegram-user-id>"],
+    },
+  },
+}
+```
+
+If you prefer the default pairing flow instead, keep:
+
+```json5
+{
+  channels: {
+    telegram: {
+      enabled: true,
+      dmPolicy: "pairing",
+    },
+  },
+}
+```
+
+Then approve the first DM with:
 
 ```bash
-# Install WebSocket dependency
-npm install ws
-
-# Run the script
-node auto-approve.js
+openclaw pairing list telegram
+openclaw pairing approve telegram <CODE>
 ```
 
-### 5.3 Manual Approval (Alternative)
+## 5. Find your Telegram user ID
 
-**Via Railway CLI:**
+You can get your numeric Telegram user ID by messaging your bot and calling the Bot API:
 
 ```bash
-railway connect
-# Then use OpenClaw admin commands to approve devices
+curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 ```
 
-**Via Web Interface:**
+Read `from.id` from the update payload.
 
-- Access your Railway app URL directly
-- Login with gateway token
-- Go to device management
-- Approve pending devices
+This ID is what you put in `channels.telegram.allowFrom`.
 
-## 🧪 Step 6: Testing Your Setup
+## 6. Start chatting from Telegram
 
-### 6.1 Test Telegram Bot
+Once Telegram access is configured:
+
+1. open the bot chat
+2. send `/start` or a plain message such as `hello`
+3. wait for the bot reply
+4. continue the conversation normally
+
+Examples:
+
+- `summarize this text`
+- `write a short reply in English`
+- `explain this error`
+
+## 7. Validate the deployment
+
+Use these checks after deploy or after config changes.
+
+### Railway and Control UI checks
+
+Open:
+
+- `https://<your-domain>/healthz`
+- `https://<your-domain>/openclaw`
+
+Expected results:
+
+- `/healthz` returns `200`
+- `/openclaw` loads the dashboard login screen or dashboard itself
+
+### Telegram checks
+
+Expected runtime state:
+
+- Telegram configured
+- Telegram running
+- mode `polling` or webhook if you configured webhook mode
+- no `lastError`
+
+## Railway-specific troubleshooting
+
+### Public domain returns `502 Application failed to respond`
+
+On Railway, OpenClaw's public wrapper listens on port `8080`.
+
+Check:
+
+- Railway public networking targets port `8080`
+- every generated Railway service domain also targets port `8080`
+
+If an older generated Railway domain still points at `3000`, it can stay broken while a newer one works. Update the stale domain or remove it.
+
+### `HTTP 401: Invalid API Key`
+
+This is usually your model provider key, not the gateway token.
+
+Common example:
+
+- invalid `GROQ_API_KEY`
+
+Fix the provider key in Railway Variables, redeploy or restart, and test again.
+
+### Telegram says `OpenClaw: access not configured`
+
+That means Telegram DM access is still blocked by policy.
+
+Use one of these:
+
+- keep `dmPolicy: "pairing"` and approve the code with `openclaw pairing approve telegram <CODE>`
+- or switch to `dmPolicy: "allowlist"` and add your numeric Telegram user ID to `allowFrom`
+
+For personal bots on Railway, `allowlist` is the simpler long-term choice.
+
+### Telegram bot is healthy but does not reply
+
+Check these in order:
+
+1. `TELEGRAM_BOT_TOKEN` is valid
+2. your Telegram user ID is approved by pairing or allowlist
+3. your model provider key is valid
+4. the gateway shows Telegram `running: true`
+
+### Dashboard pairing comes back after a redeploy
+
+If the browser creates a new device identity or the old identity is not reused, the dashboard can request pairing again.
+
+Approve the new request with:
 
 ```bash
-# Send test message to your bot
-curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-  -H 'Content-Type: application/json' \
-  -d '{"chat_id": "your-chat-id", "text": "Test message from OpenClaw!"}'
+openclaw devices list
+openclaw devices approve <requestId>
 ```
 
-### 6.2 Test Mobile Connection
+## Recommended production baseline
 
-1. **Open OpenClaw mobile app**
-2. **Send test message** to your Telegram bot
-3. **Verify message appears** in mobile app
-4. **Reply from mobile** and check Telegram
+For a single-owner Railway plus Telegram deployment, this is a practical baseline:
 
-### 6.3 Test Commands
-
-Try these in Telegram:
-
-```
-/start
-/help
-/status
-@your_bot_username Hello from Telegram!
-```
-
-## 🐛 Troubleshooting
-
-### Common Issues & Solutions
-
-#### ❌ "Pairing Required" Error
-
-**Problem:** Mobile app shows pairing required
-**Solutions:**
-
-1. Run auto-approval script
-2. Check gateway token matches
-3. Verify Railway app is running
-4. Check device approval in logs
-
-#### ❌ Telegram Bot Not Responding
-
-**Problem:** Bot doesn't reply to messages
-**Solutions:**
-
-1. Verify `TELEGRAM_BOT_TOKEN` is correct
-2. Check Railway app logs: `railway logs`
-3. Ensure bot privacy is disabled
-4. Test bot token with Telegram API
-
-#### ❌ Mobile App Connection Failed
-
-**Problem:** Cannot connect mobile app
-**Solutions:**
-
-1. Verify Railway app URL is accessible
-2. Check gateway token format (64 hex chars)
-3. Try different connection methods (manual vs. setup code)
-4. Check Railway app is deployed and running
-
-#### ❌ Railway Deployment Failed
-
-**Problem:** Deployment fails or crashes
-**Solutions:**
-
-1. Check Railway logs for errors
-2. Verify environment variables are set
-3. Ensure proper resource limits
-4. Redeploy with correct configuration
-
-### Debug Commands
-
-```bash
-# Check Railway status
-railway status
-
-# View live logs
-railway logs
-
-# Check environment variables
-railway variables
-
-# Connect to Railway service
-railway connect
-
-# Test connectivity
-curl -I https://your-app-url
+```json5
+{
+  agents: {
+    defaults: {
+      workspace: "/data/workspace",
+      model: {
+        primary: "groq/llama-3.3-70b-versatile",
+      },
+    },
+  },
+  channels: {
+    telegram: {
+      enabled: true,
+      dmPolicy: "allowlist",
+      allowFrom: ["<your-telegram-user-id>"],
+    },
+  },
+  gateway: {
+    controlUi: {
+      allowedOrigins: ["https://<your-railway-domain>"],
+    },
+  },
+}
 ```
 
-## 📊 Monitoring & Maintenance
+Replace the Telegram user ID and domain with your own values.
 
-### 6.1 Check Health Status
+## Related docs
 
-**Via Railway Dashboard:**
-
-- Monitor CPU/Memory usage
-- Check deployment status
-- Review error logs
-
-**Via CLI:**
-
-```bash
-# Service status
-railway status
-
-# Resource usage
-railway logs --tail
-
-# Environment check
-railway variables
-```
-
-### 6.2 Update Configuration
-
-**Add new environment variables:**
-
-```bash
-railway variables set NEW_VARIABLE=value
-```
-
-**Update existing variables:**
-
-```bash
-railway variables set TELEGRAM_BOT_TOKEN=new-token
-```
-
-### 6.3 Scaling & Limits
-
-**Free Tier Limits:**
-
-- 500 hours/month runtime
-- 1GB RAM
-- 1GB storage
-- No custom domain
-
-**Upgrade for:**
-
-- More resources
-- Custom domains
-- Priority support
-- Advanced monitoring
-
-## 🔒 Security Best Practices
-
-### 7.1 Token Security
-
-- **Never commit tokens** to version control
-- **Use Railway environment variables** only
-- **Rotate tokens** regularly
-- **Monitor access logs**
-
-### 7.2 Bot Security
-
-- **Enable bot privacy** when appropriate
-- **Use webhooks** instead of polling for production
-- **Implement rate limiting**
-- **Validate all inputs**
-
-### 7.3 Network Security
-
-- **Use HTTPS** for all connections
-- **Validate SSL certificates**
-- **Monitor for suspicious activity**
-- **Keep dependencies updated**
-
-## 📚 Additional Resources
-
-- **OpenClaw Documentation**: [docs.openclaw.ai](https://docs.openclaw.ai)
-- **Railway Docs**: [docs.railway.app](https://docs.railway.app)
-- **Telegram Bot API**: [core.telegram.org/bots](https://core.telegram.org/bots)
-- **GitHub Repository**: [github.com/openclaw/openclaw](https://github.com/openclaw/openclaw)
-
-## 🆘 Getting Help
-
-**If you encounter issues:**
-
-1. **Check logs first**: `railway logs`
-2. **Review this guide** step by step
-3. **Search existing issues**: GitHub Issues
-4. **Ask in community**: Discord/Telegram groups
-5. **Create new issue**: Provide logs and configuration details
-
----
-
-**⚡ Quick Start Summary:**
-
-1. Deploy Railway template
-2. Create Telegram bot with @BotFather
-3. Set environment variables in Railway
-4. Connect mobile app with generated setup code
-5. Run auto-approval script for device pairing
-6. Test end-to-end functionality
-
-**🎉 You're now ready to use OpenClaw with Railway and Telegram!**
+- [Railway plus Telegram Quick Reference](/install/railway-telegram-quick-ref)
+- [Railway](/install/railway)
+- [Telegram](/channels/telegram)
+- [Pairing](/channels/pairing)
+- [Devices CLI](/cli/devices)
+- [Gateway troubleshooting](/gateway/troubleshooting)

--- a/docs/install/railway.mdx
+++ b/docs/install/railway.mdx
@@ -34,6 +34,8 @@ Then open:
 
 - `https://<your-railway-domain>/openclaw` — Control UI
 
+If you specifically want Railway plus Telegram, follow the detailed [Railway with Telegram](/install/railway-telegram-setup) guide.
+
 ## What you get
 
 - Hosted OpenClaw Gateway + Control UI
@@ -69,6 +71,12 @@ Use the Control UI at `/openclaw` or run `openclaw onboard` via Railway's shell 
 - [Telegram](/channels/telegram) (fastest — just a bot token)
 - [Discord](/channels/discord)
 - [All channels](/channels)
+
+## Common Railway fixes
+
+- If your Railway domain returns `502 Application failed to respond`, make sure public networking targets `8080` and any generated service domains also target `8080`.
+- If `/openclaw` loads but the browser shows `origin not allowed`, add your public Railway domain to `gateway.controlUi.allowedOrigins`.
+- If the dashboard shows `pairing required`, approve the pending browser device with `openclaw devices list` and `openclaw devices approve <requestId>`.
 
 ## Backups & migration
 


### PR DESCRIPTION
## Summary

- Problem: Railway setup guidance for Telegram was missing a complete end-to-end guide.
- Why it matters: users need a clear deployment path and quick reference when setting up OpenClaw with Railway and Telegram.
- What changed: added a comprehensive setup guide, a quick reference page, and linked both into the install docs navigation.
- What did NOT change (scope boundary): no runtime, gateway, channel, or auth behavior changed.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- Added a Railway + Telegram setup guide.
- Added a quick reference page for Railway + Telegram.
- Added install-doc navigation entries for the new pages.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: dev container
- Model/provider: N/A
- Integration/channel (if any): Telegram docs only
- Relevant config (redacted): N/A

### Steps

1. Review the docs diff against `origin/main`.
2. Confirm new pages are linked from install navigation.
3. Run repository verification.

### Expected

- New docs pages are present and linked correctly.

### Actual

- Docs pages and nav changes are present.
- `git diff --check origin/main...HEAD` passed.
- `pnpm check` was interrupted during `tsgo` with `SIGTERM` in this container.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: reviewed the changed docs pages and nav file inclusion.
- Edge cases checked: confirmed the branch is clean and there was no existing PR for it before creation.
- What you did **not** verify: full repo verification did not complete because `tsgo` was terminated with `SIGTERM`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

- Risk: doc instructions may still need maintainer review for completeness.
  - Mitigation: PR is scoped to documentation only and isolated from runtime code.
