### PR TITLE
fix: strip hostnameAllowlist from SSRF policy when validating explicit proxy

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -461,6 +461,85 @@ describe("fetchWithSsrFGuard hardening", () => {
     await result.release();
   });
 
+  it("allows explicit private proxy when policy has hostnameAllowlist and allowPrivateProxy", async () => {
+    // Regression: hostnameAllowlist restricts *target* URLs (e.g. api.telegram.org),
+    // but was incorrectly applied to the *proxy* hostname (e.g. 172.18.0.1),
+    // blocking legitimate private proxies even when allowPrivateProxy was set.
+    const lookupFn = vi.fn(async (hostname: string) => [
+      {
+        address: hostname === "172.18.0.1" ? "172.18.0.1" : "93.184.216.34",
+        family: 4,
+      },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.telegram.org/file/bot123/documents/file.md",
+      fetchImpl,
+      lookupFn,
+      policy: { hostnameAllowlist: ["api.telegram.org"] },
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://172.18.0.1:18080",
+        allowPrivateProxy: true,
+      },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
+
+  it("allows explicit public proxy when policy has hostnameAllowlist", async () => {
+    // A public proxy hostname should not be blocked by a target-URL allowlist.
+    const lookupFn = vi.fn(async (hostname: string) => [
+      {
+        address: hostname === "proxy.cdn.example.com" ? "93.184.215.14" : "93.184.216.34",
+        family: 4,
+      },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.telegram.org/file/bot123/documents/file.md",
+      fetchImpl,
+      lookupFn,
+      policy: { hostnameAllowlist: ["api.telegram.org"] },
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://proxy.cdn.example.com:8080",
+      },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
+
+  it("still blocks explicit private proxy with hostnameAllowlist when allowPrivateProxy is not set", async () => {
+    // Security invariant: a private proxy must be explicitly opted in via allowPrivateProxy.
+    // The hostnameAllowlist fix must not weaken this check.
+    const lookupFn = vi.fn(async (hostname: string) => [
+      {
+        address: hostname === "172.18.0.1" ? "172.18.0.1" : "93.184.216.34",
+        family: 4,
+      },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://api.telegram.org/file/bot123/documents/file.md",
+        fetchImpl,
+        lookupFn,
+        policy: { hostnameAllowlist: ["api.telegram.org"] },
+        dispatcherPolicy: {
+          mode: "explicit-proxy",
+          proxyUrl: "http://172.18.0.1:18080",
+        },
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("blocks redirect chains that hop to private hosts", async () => {
     const lookupFn = createPublicLookup();
     const fetchImpl = await expectRedirectFailure({

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -143,15 +143,21 @@ async function assertExplicitProxyAllowed(
   if (!["http:", "https:"].includes(parsedProxyUrl.protocol)) {
     throw new Error("Explicit proxy URL must use http or https");
   }
+  // Build a proxy-specific policy that drops the target-URL hostname allowlist.
+  // The `hostnameAllowlist` restricts which *target* hosts the fetch may reach
+  // (e.g. `["api.telegram.org"]`).  Applying it to the *proxy* hostname would
+  // incorrectly block any proxy whose hostname is not in that list — for example
+  // a private-IP proxy at `172.18.0.1` used to route Telegram traffic.
+  const { hostnameAllowlist: _stripTargetAllowlist, ...proxyPolicy } = policy ?? {};
   await resolvePinnedHostnameWithPolicy(parsedProxyUrl.hostname, {
     lookupFn,
     policy:
       dispatcherPolicy.allowPrivateProxy === true
         ? {
-            ...policy,
+            ...proxyPolicy,
             allowPrivateNetwork: true,
           }
-        : policy,
+        : proxyPolicy,
   });
 }
 


### PR DESCRIPTION
## Summary

- Fixes `MediaFetchError: Blocked hostname (not in allowlist)` when Telegram media downloads go through an explicit HTTP proxy (e.g. WARP/gost chain for blocked Telegram API subnets)
- The `hostnameAllowlist` in the SSRF policy is a **target-URL** restriction (e.g. "only download from `api.telegram.org`"), but `assertExplicitProxyAllowed` was passing it through to the proxy hostname resolver, causing the proxy IP to be rejected
- Adds 3 test cases covering the regression scenario, public proxy variant, and security invariant preservation

## Problem

When `fetchWithSsrFGuard` is called with:
- An explicit proxy (`dispatcherPolicy.mode: "explicit-proxy"`)
- A policy containing `hostnameAllowlist` (e.g. `["api.telegram.org"]`)

The proxy hostname (e.g. `172.18.0.1`) is checked against `hostnameAllowlist` inside `resolvePinnedHostnameWithPolicy`, and rejected because it doesn't match `api.telegram.org`. This happens even when `allowPrivateProxy: true` is set, because the allowlist check at ssrf.ts:324 executes before the private-network bypass at ssrf.ts:328.

### Reproduction

Any Telegram bot setup using `channels.telegram.proxy` with an HTTP proxy on a private IP triggers this on inbound media (file uploads, photos, documents):

```
MediaFetchError: Failed to fetch media from https://api.telegram.org/file/bot.../documents/file.md:
  Blocked hostname (not in allowlist): 172.18.0.1
```

## Fix

In `assertExplicitProxyAllowed`, destructure the policy to strip `hostnameAllowlist` before passing it to `resolvePinnedHostnameWithPolicy`:

```ts
const { hostnameAllowlist: _stripTargetAllowlist, ...proxyPolicy } = policy ?? {};
```

This preserves all other SSRF checks (`allowPrivateNetwork`, IP blocking, etc.) while removing the target-URL-specific restriction from proxy validation.

## Tests

3 new test cases in `fetch-guard.ssrf.test.ts`:

1. **Private proxy + hostnameAllowlist + allowPrivateProxy** — the exact regression scenario. Previously threw `Blocked hostname`, now passes.
2. **Public proxy + hostnameAllowlist** — public proxy hostname not in the target allowlist. Verifies the fix works for non-private proxies too.
3. **Private proxy + hostnameAllowlist WITHOUT allowPrivateProxy** — security invariant: private proxies still require explicit opt-in. The fix must not weaken this.

All 24 tests in the file pass. All 41 tests in related `ssrf.test.ts` and `ssrf.pinning.test.ts` pass.

## Affected code path

```
processInboundMessage (bot.ts)
  → resolveMedia (delivery.resolve-media.ts)
    → downloadAndSaveTelegramFile
      → fetchRemoteMedia (fetch.ts)
        → fetchWithSsrFGuard (fetch-guard.ts)
          → assertExplicitProxyAllowed  ← FIX HERE
            → resolvePinnedHostnameWithPolicy (ssrf.ts)
              → matchesHostnameAllowlist  ← BLOCKS proxy hostname
```

`buildTelegramMediaSsrfPolicy` (delivery.resolve-media.ts) correctly sets `hostnameAllowlist: ["api.telegram.org"]` for the target URL. The bug is that this allowlist leaks into the proxy validation path.