### PR TITLE
Fix: suppress false-positive WARN for internal health probe closes (issue #60510)

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -228,6 +228,17 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         userAgent?.toLowerCase().includes("swiftpm-testing-helper") && isLoopbackAddress(remote),
       );
 
+    // Check if this is an internal health probe connection (loopback + self-origin + code 1000)
+    // These are false-positives that flood logs with WARN "closed before connect"
+    const isInternalProbeClose = (
+      remote: string | undefined,
+      origin: string | undefined,
+      code: number | undefined,
+    ) =>
+      isLoopbackAddress(remote) &&
+      origin === requestHost &&
+      code === 1000;
+
     socket.once("close", (code, reason) => {
       const durationMs = Date.now() - openedAt;
       const logForwardedFor = sanitizeLogValue(forwardedFor);
@@ -249,9 +260,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         ...closeMeta,
       };
       if (!client) {
-        const logFn = isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr)
-          ? logWsControl.debug
-          : logWsControl.warn;
+        const isNoisy = isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr);
+        const isProbe = isInternalProbeClose(remoteAddr, logOrigin, code);
+        const logFn = isNoisy || isProbe ? logWsControl.debug : logWsControl.warn;
         logFn(
           `closed before connect conn=${connId} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}`,
           closeContext,


### PR DESCRIPTION
Good day

## Summary

Internal health probes connecting to the gateway's own loopback address trigger a WARN log "closed before connect" when they close before completing the handshake. This floods logs with ~700 entries/day.

## The Fix

Adds  check that identifies probe closes:
- remote is loopback AND
- origin matches gateway's own host AND  
- close code is 1000 (normal closure)

These are now logged at DEBUG level instead of WARN.

## Testing

The fix follows the existing pattern of  which already filters similar false-positives. The logic checks for the same conditions described in the issue.

感谢你们的奉献希望能提供帮助。如果我解决得有问题或有待商妥的地方，请在下面留言，我会来处理。

Warmly,