### PR TITLE
fix: preserve retry intent, clean session rollover, machine-clean JSON, and one-shot sandbox teardown

### DIFF
--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveFallbackRetryPrompt, sessionFileHasContent } from "./attempt-execution.js";
+import {
+  clearSessionScopedFieldsOnSessionIdRollover,
+  resolveFallbackRetryPrompt,
+  sessionFileHasContent,
+} from "./attempt-execution.js";
 
 describe("resolveFallbackRetryPrompt", () => {
   const originalBody = "Summarize the quarterly earnings report and highlight key trends.";
@@ -16,14 +20,14 @@ describe("resolveFallbackRetryPrompt", () => {
     ).toBe(originalBody);
   });
 
-  it("returns recovery prompt for fallback retry with existing session history", () => {
+  it("preserves original body for fallback retry with existing session history", () => {
     expect(
       resolveFallbackRetryPrompt({
         body: originalBody,
         isFallbackRetry: true,
         sessionHasHistory: true,
       }),
-    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+    ).toBe(originalBody);
   });
 
   it("preserves original body for fallback retry when session has no history (subagent spawn)", () => {
@@ -71,6 +75,76 @@ describe("resolveFallbackRetryPrompt", () => {
         sessionHasHistory: false,
       }),
     ).toBe(originalBody);
+  });
+
+  it("uses the recovery prompt only when the fallback body is empty", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: "",
+        isFallbackRetry: true,
+        sessionHasHistory: true,
+      }),
+    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+
+    expect(
+      resolveFallbackRetryPrompt({
+        body: "   ",
+        isFallbackRetry: true,
+        sessionHasHistory: false,
+      }),
+    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+  });
+});
+
+describe("clearSessionScopedFieldsOnSessionIdRollover", () => {
+  it("clears session-scoped continuity fields when the session id changes", () => {
+    expect(
+      clearSessionScopedFieldsOnSessionIdRollover(
+        {
+          sessionId: "old-session",
+          updatedAt: 100,
+          sessionFile: "/tmp/old-session.jsonl",
+          cliSessionIds: { "github-copilot": "cli-old" },
+          systemPromptReport: { warnings: ["stale"] },
+          abortedLastRun: true,
+          thinkingLevel: "high",
+        },
+        {
+          sessionId: "new-session",
+          updatedAt: 200,
+        },
+      ),
+    ).toEqual({
+      sessionId: "old-session",
+      updatedAt: 100,
+      thinkingLevel: "high",
+    });
+  });
+
+  it("preserves session-scoped continuity fields when the session id is unchanged", () => {
+    expect(
+      clearSessionScopedFieldsOnSessionIdRollover(
+        {
+          sessionId: "same-session",
+          updatedAt: 100,
+          sessionFile: "/tmp/same-session.jsonl",
+          cliSessionIds: { "github-copilot": "cli-same" },
+          systemPromptReport: { warnings: ["keep"] },
+          abortedLastRun: true,
+        },
+        {
+          sessionId: "same-session",
+          updatedAt: 200,
+        },
+      ),
+    ).toEqual({
+      sessionId: "same-session",
+      updatedAt: 100,
+      sessionFile: "/tmp/same-session.jsonl",
+      cliSessionIds: { "github-copilot": "cli-same" },
+      systemPromptReport: { warnings: ["keep"] },
+      abortedLastRun: true,
+    });
   });
 });
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -100,9 +100,33 @@ export type PersistSessionEntryParams = {
   clearedFields?: string[];
 };
 
+const SESSION_FIELDS_CLEARED_ON_SESSION_ID_ROLLOVER = [
+  "sessionFile",
+  "cliSessionIds",
+  "systemPromptReport",
+  "abortedLastRun",
+] as const;
+
+export function clearSessionScopedFieldsOnSessionIdRollover(
+  existing: SessionEntry | undefined,
+  patch: SessionEntry,
+): SessionEntry | undefined {
+  if (!existing?.sessionId || !patch.sessionId || existing.sessionId === patch.sessionId) {
+    return existing;
+  }
+  const next = { ...existing };
+  for (const field of SESSION_FIELDS_CLEARED_ON_SESSION_ID_ROLLOVER) {
+    Reflect.deleteProperty(next, field);
+  }
+  return next;
+}
+
 export async function persistSessionEntry(params: PersistSessionEntryParams): Promise<void> {
   const persisted = await updateSessionStore(params.storePath, (store) => {
-    const merged = mergeSessionEntry(store[params.sessionKey], params.entry);
+    const merged = mergeSessionEntry(
+      clearSessionScopedFieldsOnSessionIdRollover(store[params.sessionKey], params.entry),
+      params.entry,
+    );
     for (const field of params.clearedFields ?? []) {
       if (!Object.hasOwn(params.entry, field)) {
         Reflect.deleteProperty(merged, field);
@@ -119,15 +143,7 @@ export function resolveFallbackRetryPrompt(params: {
   isFallbackRetry: boolean;
   sessionHasHistory?: boolean;
 }): string {
-  if (!params.isFallbackRetry) {
-    return params.body;
-  }
-  // When the session has no persisted history (e.g. a freshly-spawned subagent
-  // whose first attempt failed before the SessionManager flushed the user
-  // message to disk), the fallback model would receive only the generic
-  // recovery prompt and lose the original task entirely.  Preserve the
-  // original body in that case so the fallback model can execute the task.
-  if (!params.sessionHasHistory) {
+  if (!params.isFallbackRetry || params.body.trim()) {
     return params.body;
   }
   return "Continue where you left off. The previous model attempt failed or timed out.";

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -20,7 +20,7 @@ import {
   normalizeOutboundPayloadsForJson,
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { writeRuntimeJson, type RuntimeEnv } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -251,15 +251,13 @@ export async function deliverAgentCommandResult(params: {
   });
   const normalizedPayloads = normalizeOutboundPayloadsForJson(normalizedReplyPayloads);
   if (opts.json) {
-    runtime.log(
-      JSON.stringify(
-        buildOutboundResultEnvelope({
-          payloads: normalizedPayloads,
-          meta: result.meta,
-        }),
-        null,
-        2,
-      ),
+    writeRuntimeJson(
+      runtime,
+      buildOutboundResultEnvelope({
+        payloads: normalizedPayloads,
+        meta: result.meta,
+      }),
+      2,
     );
     if (!deliver) {
       return { payloads: normalizedPayloads, meta: result.meta };

--- a/src/agents/command/session.test.ts
+++ b/src/agents/command/session.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+
+const hoisted = vi.hoisted(() => ({
+  clearBootstrapSnapshotOnSessionRolloverMock: vi.fn(),
+  evaluateSessionFreshnessMock: vi.fn(),
+  loadSessionStoreMock: vi.fn<(storePath: string) => Record<string, SessionEntry>>(),
+}));
+
+vi.mock("../../config/sessions.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
+    "../../config/sessions.js",
+  );
+  return {
+    ...actual,
+    evaluateSessionFreshness: (params: unknown) => hoisted.evaluateSessionFreshnessMock(params),
+    loadSessionStore: (storePath: string) => hoisted.loadSessionStoreMock(storePath),
+    resolveAgentIdFromSessionKey: () => "business-main",
+    resolveChannelResetConfig: () => null,
+    resolveExplicitAgentSessionKey: () => undefined,
+    resolveSessionKey: () => "agent:business-main:main",
+    resolveSessionResetPolicy: () => ({ kind: "stub" }),
+    resolveSessionResetType: () => ({ kind: "stub" }),
+    resolveStorePath: () => "/stores/business-main.json",
+  };
+});
+
+vi.mock("../agent-scope.js", () => ({
+  listAgentIds: () => ["business-main"],
+}));
+
+vi.mock("../bootstrap-cache.js", () => ({
+  clearBootstrapSnapshotOnSessionRollover: (params: unknown) =>
+    hoisted.clearBootstrapSnapshotOnSessionRolloverMock(params),
+}));
+
+const { resolveSession } = await import("./session.js");
+
+describe("resolveSession", () => {
+  beforeEach(() => {
+    hoisted.clearBootstrapSnapshotOnSessionRolloverMock.mockReset();
+    hoisted.evaluateSessionFreshnessMock.mockReset();
+    hoisted.loadSessionStoreMock.mockReset();
+  });
+
+  it("rolls the main session forward when an explicit new session id is requested", () => {
+    const store = {
+      "agent:business-main:main": {
+        sessionId: "old-session",
+        updatedAt: 123,
+        thinkingLevel: "medium",
+        verboseLevel: "on",
+        cliSessionIds: { "github-copilot": "old-cli-session" },
+      },
+    } satisfies Record<string, SessionEntry>;
+    hoisted.loadSessionStoreMock.mockReturnValue(store);
+    hoisted.evaluateSessionFreshnessMock.mockReturnValue({ fresh: true });
+
+    const result = resolveSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:business-main:main",
+      sessionId: "new-session",
+    });
+
+    expect(result.sessionId).toBe("new-session");
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry).toBeUndefined();
+    expect(result.persistedThinking).toBeUndefined();
+    expect(result.persistedVerbose).toBeUndefined();
+    expect(store["agent:business-main:main"]).toBeUndefined();
+    expect(hoisted.clearBootstrapSnapshotOnSessionRolloverMock).toHaveBeenCalledWith({
+      sessionKey: "agent:business-main:main",
+      previousSessionId: "old-session",
+    });
+  });
+
+  it("preserves continuation when the explicit session id matches the stored session", () => {
+    const sessionEntry = {
+      sessionId: "same-session",
+      updatedAt: 123,
+      thinkingLevel: "medium",
+      verboseLevel: "on",
+    } satisfies SessionEntry;
+    const store = {
+      "agent:business-main:main": sessionEntry,
+    } satisfies Record<string, SessionEntry>;
+    hoisted.loadSessionStoreMock.mockReturnValue(store);
+    hoisted.evaluateSessionFreshnessMock.mockReturnValue({ fresh: false });
+
+    const result = resolveSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:business-main:main",
+      sessionId: "same-session",
+    });
+
+    expect(result.sessionId).toBe("same-session");
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionEntry).toEqual(sessionEntry);
+    expect(result.persistedThinking).toBe("medium");
+    expect(result.persistedVerbose).toBe("on");
+    expect(store["agent:business-main:main"]).toEqual(sessionEntry);
+    expect(hoisted.clearBootstrapSnapshotOnSessionRolloverMock).toHaveBeenCalledWith({
+      sessionKey: "agent:business-main:main",
+      previousSessionId: undefined,
+    });
+  });
+
+  it("reuses a fresh stored main session when no explicit session id is passed", () => {
+    const sessionEntry = {
+      sessionId: "existing-session",
+      updatedAt: 123,
+      thinkingLevel: "low",
+      verboseLevel: "off",
+    } satisfies SessionEntry;
+    const store = {
+      "agent:business-main:main": sessionEntry,
+    } satisfies Record<string, SessionEntry>;
+    hoisted.loadSessionStoreMock.mockReturnValue(store);
+    hoisted.evaluateSessionFreshnessMock.mockReturnValue({ fresh: true });
+
+    const result = resolveSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:business-main:main",
+    });
+
+    expect(result.sessionId).toBe("existing-session");
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionEntry).toEqual(sessionEntry);
+    expect(result.persistedThinking).toBe("low");
+    expect(result.persistedVerbose).toBe("off");
+  });
+});

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -182,28 +182,37 @@ export function resolveSession(opts: {
     ? evaluateSessionFreshness({ updatedAt: sessionEntry.updatedAt, now, policy: resetPolicy })
         .fresh
     : false;
+  const explicitSessionId = opts.sessionId?.trim() || undefined;
+  const reuseExistingSession = explicitSessionId
+    ? sessionEntry?.sessionId === explicitSessionId
+    : fresh;
   const sessionId =
-    opts.sessionId?.trim() || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
-  const isNewSession = !fresh && !opts.sessionId;
+    explicitSessionId ||
+    (reuseExistingSession ? sessionEntry?.sessionId : undefined) ||
+    crypto.randomUUID();
+  const isNewSession = !reuseExistingSession;
+  const persistedSessionEntry = reuseExistingSession ? sessionEntry : undefined;
+
+  if (isNewSession && sessionKey && sessionStore[sessionKey]) {
+    delete sessionStore[sessionKey];
+  }
 
   clearBootstrapSnapshotOnSessionRollover({
     sessionKey,
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,
   });
 
-  const persistedThinking =
-    fresh && sessionEntry?.thinkingLevel
-      ? normalizeThinkLevel(sessionEntry.thinkingLevel)
-      : undefined;
-  const persistedVerbose =
-    fresh && sessionEntry?.verboseLevel
-      ? normalizeVerboseLevel(sessionEntry.verboseLevel)
-      : undefined;
+  const persistedThinking = persistedSessionEntry?.thinkingLevel
+    ? normalizeThinkLevel(persistedSessionEntry.thinkingLevel)
+    : undefined;
+  const persistedVerbose = persistedSessionEntry?.verboseLevel
+    ? normalizeVerboseLevel(persistedSessionEntry.verboseLevel)
+    : undefined;
 
   return {
     sessionId,
     sessionKey,
-    sessionEntry,
+    sessionEntry: persistedSessionEntry,
     sessionStore,
     storePath,
     isNewSession,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -278,4 +278,37 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(releaseMock).toHaveBeenCalledTimes(1);
     expect(hoisted.releaseWsSessionMock).toHaveBeenCalledWith("embedded-session");
   });
+
+  it("disposes the sandbox context after the attempt finishes", async () => {
+    const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
+    const sandbox = {
+      enabled: false,
+      sessionKey,
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/openclaw-test-workspace",
+      agentWorkspaceDir: "/tmp/openclaw-test-workspace",
+      workspaceAccess: "rw",
+      backendId: "docker",
+      runtimeId: "test-runtime",
+      runtimeLabel: "Test Runtime",
+      containerName: "test-runtime",
+      containerWorkdir: "/workspace",
+      docker: {} as never,
+      tools: {} as never,
+      browserAllowHostControl: false,
+    };
+    hoisted.resolveSandboxContextMock.mockResolvedValue(sandbox);
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: {
+        bootstrap,
+        assemble,
+      },
+      sessionKey,
+      tempPaths,
+    });
+
+    expect(result.promptError).toBeNull();
+    expect(hoisted.disposeSandboxContextMock).toHaveBeenCalledWith(sandbox);
+  });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -32,6 +32,7 @@ const hoisted = vi.hoisted(() => {
   const createAgentSessionMock = vi.fn();
   const sessionManagerOpenMock = vi.fn();
   const resolveSandboxContextMock = vi.fn();
+  const disposeSandboxContextMock = vi.fn(async () => {});
   const installToolResultContextGuardMock = vi.fn(() => () => {});
   const flushPendingToolResultsAfterIdleMock = vi.fn(async () => {});
   const releaseWsSessionMock = vi.fn(() => {});
@@ -77,6 +78,7 @@ const hoisted = vi.hoisted(() => {
     createAgentSessionMock,
     sessionManagerOpenMock,
     resolveSandboxContextMock,
+    disposeSandboxContextMock,
     subscribeEmbeddedPiSessionMock,
     acquireSessionWriteLockMock,
     installToolResultContextGuardMock,
@@ -119,6 +121,7 @@ vi.mock("../../subagent-spawn.js", () => ({
 
 vi.mock("../../sandbox.js", () => ({
   resolveSandboxContext: (...args: unknown[]) => hoisted.resolveSandboxContextMock(...args),
+  disposeSandboxContext: (...args: unknown[]) => hoisted.disposeSandboxContextMock(...args),
 }));
 
 vi.mock("../../session-tool-result-guard-wrapper.js", () => ({
@@ -338,6 +341,7 @@ vi.mock("../../provider-stream.js", () => ({
 }));
 
 vi.mock("../../owner-display.js", () => ({
+  ensureOwnerDisplaySecret: (config: unknown) => ({ config }),
   resolveOwnerDisplaySetting: () => ({
     ownerDisplay: undefined,
     ownerDisplaySecret: undefined,
@@ -534,6 +538,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.createAgentSessionMock.mockReset();
   hoisted.sessionManagerOpenMock.mockReset().mockReturnValue(hoisted.sessionManager);
   hoisted.resolveSandboxContextMock.mockReset();
+  hoisted.disposeSandboxContextMock.mockReset().mockResolvedValue(undefined);
   hoisted.subscribeEmbeddedPiSessionMock
     .mockReset()
     .mockImplementation(() => createSubscriptionMock());

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -75,7 +75,7 @@ import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
-import { resolveSandboxContext } from "../../sandbox.js";
+import { disposeSandboxContext, resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
@@ -336,7 +336,7 @@ export async function runEmbeddedAttempt(
   await fs.mkdir(resolvedWorkspace, { recursive: true });
 
   const sandboxSessionKey = params.sessionKey?.trim() || params.sessionId;
-  const sandbox = await resolveSandboxContext({
+  let sandbox = await resolveSandboxContext({
     config: params.config,
     sessionKey: sandboxSessionKey,
     workspaceDir: resolvedWorkspace,
@@ -1973,6 +1973,7 @@ export async function runEmbeddedAttempt(
       }
     }
   } finally {
+    await disposeSandboxContext(sandbox).catch(() => undefined);
     restoreSkillEnv?.();
   }
 }

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -10,7 +10,11 @@ export {
   DEFAULT_SANDBOX_COMMON_IMAGE,
   DEFAULT_SANDBOX_IMAGE,
 } from "./sandbox/constants.js";
-export { ensureSandboxWorkspaceForSession, resolveSandboxContext } from "./sandbox/context.js";
+export {
+  disposeSandboxContext,
+  ensureSandboxWorkspaceForSession,
+  resolveSandboxContext,
+} from "./sandbox/context.js";
 export {
   getSandboxBackendFactory,
   getSandboxBackendManager,

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -5,6 +5,7 @@ import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 
 let BROWSER_BRIDGES: Map<string, unknown>;
 let ensureSandboxBrowser: typeof import("./browser.js").ensureSandboxBrowser;
+let disposeSandboxContext: typeof import("./sandbox/context.js").disposeSandboxContext;
 let resetNoVncObserverTokensForTests: typeof import("./novnc-auth.js").resetNoVncObserverTokensForTests;
 
 const dockerMocks = vi.hoisted(() => ({
@@ -51,6 +52,7 @@ async function loadFreshBrowserModulesForTest() {
   vi.resetModules();
   ({ BROWSER_BRIDGES } = await import("./browser-bridges.js"));
   ({ ensureSandboxBrowser } = await import("./browser.js"));
+  ({ disposeSandboxContext } = await import("./context.js"));
   ({ resetNoVncObserverTokensForTests } = await import("./novnc-auth.js"));
 }
 
@@ -235,5 +237,29 @@ describe("ensureSandboxBrowser create args", () => {
     const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
     const labels = collectDockerFlagValues(createArgs ?? [], "--label");
     expect(labels).toContain(`openclaw.mountFormatVersion=${SANDBOX_MOUNT_FORMAT_VERSION}`);
+  });
+
+  it("disposes the browser bridge for a matching sandbox scope", async () => {
+    BROWSER_BRIDGES.set("session:test", {
+      bridge: { server: {} },
+      containerName: "openclaw-sbx-browser-test",
+    });
+
+    await disposeSandboxContext({ scopeKey: "session:test" } as never);
+
+    expect(bridgeMocks.stopBrowserBridgeServer).toHaveBeenCalledWith({});
+    expect(BROWSER_BRIDGES.has("session:test")).toBe(false);
+  });
+
+  it("is a no-op when disposing a sandbox scope without a browser bridge", async () => {
+    BROWSER_BRIDGES.set("session:test", {
+      bridge: { server: {} },
+      containerName: "openclaw-sbx-browser-test",
+    });
+
+    await disposeSandboxContext({ scopeKey: "session:other" } as never);
+
+    expect(bridgeMocks.stopBrowserBridgeServer).not.toHaveBeenCalled();
+    expect(BROWSER_BRIDGES.has("session:test")).toBe(true);
   });
 });

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
+import { stopBrowserBridgeServer } from "../../plugin-sdk/browser-bridge.js";
 import { DEFAULT_BROWSER_EVALUATE_ENABLED } from "../../plugin-sdk/browser-config.js";
 import {
   ensureBrowserControlAuth,
@@ -11,6 +12,7 @@ import { resolveUserPath } from "../../utils.js";
 import { syncSkillsToWorkspace } from "../skills.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "../workspace.js";
 import { requireSandboxBackendFactory } from "./backend.js";
+import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import { ensureSandboxBrowser } from "./browser.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
@@ -194,6 +196,7 @@ export async function resolveSandboxContext(params: {
     enabled: true,
     backendId: backend.id,
     sessionKey: rawSessionKey,
+    scopeKey,
     workspaceDir,
     agentWorkspaceDir,
     workspaceAccess: resolvedCfg.workspaceAccess,
@@ -213,6 +216,21 @@ export async function resolveSandboxContext(params: {
     createSandboxFsBridge({ sandbox: sandboxContext });
 
   return sandboxContext;
+}
+
+export async function disposeSandboxContext(
+  context: Pick<SandboxContext, "scopeKey"> | null | undefined,
+): Promise<void> {
+  const scopeKey = typeof context?.scopeKey === "string" ? context.scopeKey.trim() : "";
+  if (!scopeKey) {
+    return;
+  }
+  const bridge = BROWSER_BRIDGES.get(scopeKey);
+  if (!bridge) {
+    return;
+  }
+  await stopBrowserBridgeServer(bridge.bridge.server).catch(() => undefined);
+  BROWSER_BRIDGES.delete(scopeKey);
 }
 
 export async function ensureSandboxWorkspaceForSession(params: {

--- a/src/agents/sandbox/test-fixtures.ts
+++ b/src/agents/sandbox/test-fixtures.ts
@@ -30,6 +30,7 @@ export function createSandboxTestContext(params?: {
     enabled: true,
     backendId: "docker",
     sessionKey: "sandbox:test",
+    scopeKey: "sandbox:test",
     workspaceDir: "/tmp/workspace",
     agentWorkspaceDir: "/tmp/workspace",
     workspaceAccess: "rw",

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -90,6 +90,7 @@ export type SandboxContext = {
   enabled: boolean;
   backendId: SandboxBackendId;
   sessionKey: string;
+  scopeKey: string;
   workspaceDir: string;
   agentWorkspaceDir: string;
   workspaceAccess: SandboxWorkspaceAccess;

--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -3,7 +3,7 @@ import type { ReplyPayload } from "../auto-reply/types.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
-import type { RuntimeEnv } from "../runtime.js";
+import type { OutputRuntimeEnv, RuntimeEnv } from "../runtime.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 
 const mocks = vi.hoisted(() => ({
@@ -37,6 +37,16 @@ describe("deliverAgentCommandResult", () => {
       log: vi.fn(),
       error: vi.fn(),
     } as unknown as RuntimeEnv;
+  }
+
+  function createJsonRuntime(): OutputRuntimeEnv {
+    return {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn() as never,
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+    };
   }
 
   function createResult(text = "hi") {
@@ -317,5 +327,35 @@ describe("deliverAgentCommandResult", () => {
       ],
       meta: { durationMs: 1 },
     });
+  });
+
+  it("writes JSON payloads through the runtime JSON writer when available", async () => {
+    const runtime = createJsonRuntime();
+    await runDelivery({
+      runtime,
+      payloads: [{ text: "voice caption", mediaUrl: "file:///tmp/clip.mp3", audioAsVoice: true }],
+      opts: {
+        message: "hello",
+        deliver: false,
+        json: true,
+      },
+    });
+
+    expect(runtime.writeJson).toHaveBeenCalledTimes(1);
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        payloads: [
+          {
+            text: "voice caption",
+            mediaUrl: "file:///tmp/clip.mp3",
+            mediaUrls: ["file:///tmp/clip.mp3"],
+            audioAsVoice: true,
+          },
+        ],
+        meta: { durationMs: 1 },
+      },
+      2,
+    );
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining('"payloads"'));
   });
 });


### PR DESCRIPTION
## Summary

This PR lands four runtime correctness fixes that were first validated in a clean RC branch and published on the fork as tag `v2026.4.3-rc.1`.

Fix set:
1. Preserve the original self-contained request body across model fallback retry
2. Clear stale session-scoped continuity state on explicit session-id rollover
3. Make `openclaw agent --json` write machine-clean JSON to stdout
4. Dispose one-shot sandbox browser-bridge resources so agent runs exit cleanly

## Root problems addressed

### 1. Fallback retry intent loss

Fallback retry previously replaced the original request body with:

> Continue where you left off. The previous model attempt failed or timed out.

That corrupted fresh self-contained requests and caused downstream behavior to ask for prior context instead of executing the original task.

### 2. Stale-session continuity bleed

Explicit fresh session IDs could still inherit old session-scoped fields from persisted main-session state, including old transcript bindings and continuity metadata.

### 3. JSON stdout contamination

`openclaw agent --json` emitted the final envelope through the normal log sink instead of the JSON writer, so stdout was not reliably machine-parseable.

### 4. One-shot agent non-exit

Successful one-shot runs could linger because the sandbox browser bridge HTTP server remained open after output delivery.

## What changed

### Runtime behavior

- fallback preserves the original request body whenever a non-empty body exists
- continuity wording is used only as a last resort when there is no body to resend
- explicit session-id rollover clears stale session-scoped fields before merge
- JSON mode writes the final envelope through the runtime JSON writer
- one-shot embedded attempts dispose sandbox/browser-bridge resources in teardown

### Source areas touched

- attempt execution and retry handling
- session rollover and persistence merge
- agent delivery JSON path
- sandbox context and teardown
- embedded attempt lifecycle

## Tests

Focused tests were added or updated for:
- fallback preserves the original self-contained body
- continuity wording appears only when the retry body is empty
- explicit new session id rolls state forward and clears stale session fields
- same-session continuation still preserves the correct fields
- `agent --json` writes machine-clean JSON
- one-shot sandbox/browser-bridge cleanup occurs and exit behavior remains clean

RC verification result:
- 49 focused tests passed in the clean RC branch

## Validation notes

This fix set was validated against:
- fresh explicit-session fallback behavior
- stale-session-sensitive repros
- machine-clean JSON stdout/stderr separation
- one-shot agent clean exit after output

## RC provenance

Fork RC branch:
- `admin-astrummsp/openclaw-1:codex/runtime-rc-2026-04-03`

Fork RC tag:
- `admin-astrummsp/openclaw-1` tag `v2026.4.3-rc.1`

RC commit:
- `ff9889edd991f456799b2e3a33a6246abd8fbb7e`

## Maintainer next step

After review:
- merge this branch into `main`
- cut the canonical RC tag from the reviewed commit, ideally using:
  - `v2026.4.3-rc.1`
