### PR TITLE
fix(infra): catch res.json() parse errors in provider-usage fetchers

### DIFF
--- a/src/infra/provider-usage.fetch.claude.test.ts
+++ b/src/infra/provider-usage.fetch.claude.test.ts
@@ -247,4 +247,13 @@ describe("fetchClaudeUsage", () => {
       expectMissingScopeError(result);
     },
   );
+
+  it("returns error snapshot for malformed JSON body on oauth usage", async () => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, "<html>Bad Gateway</html>"));
+    const result = await fetchClaudeUsage("token", 5000, mockFetch);
+
+    expect(result.error).toBe("Invalid JSON");
+    expect(result.windows).toHaveLength(0);
+    expect(result.provider).toBe("anthropic");
+  });
 });

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -1,4 +1,4 @@
-import { buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
+import { buildUsageErrorSnapshot, buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
 
@@ -83,7 +83,10 @@ async function fetchClaudeWebUsage(
     return null;
   }
 
-  const orgs = (await orgRes.json()) as ClaudeWebOrganizationsResponse;
+  const orgs = (await orgRes.json().catch(() => null)) as ClaudeWebOrganizationsResponse | null;
+  if (!orgs) {
+    return null;
+  }
   const orgId = orgs?.[0]?.uuid?.trim();
   if (!orgId) {
     return null;
@@ -99,7 +102,10 @@ async function fetchClaudeWebUsage(
     return null;
   }
 
-  const data = (await usageRes.json()) as ClaudeWebUsageResponse;
+  const data = (await usageRes.json().catch(() => null)) as ClaudeWebUsageResponse | null;
+  if (!data) {
+    return null;
+  }
   const windows = buildClaudeUsageWindows(data);
 
   if (windows.length === 0) {
@@ -166,7 +172,10 @@ export async function fetchClaudeUsage(
     });
   }
 
-  const data = (await res.json()) as ClaudeUsageResponse;
+  const data = (await res.json().catch(() => null)) as ClaudeUsageResponse | null;
+  if (!data) {
+    return buildUsageErrorSnapshot("anthropic", "Invalid JSON");
+  }
   const windows = buildClaudeUsageWindows(data);
 
   return {

--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -147,4 +147,13 @@ describe("fetchCodexUsage", () => {
     const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
     expect(result.plan).toBe("Plus ($0.00)");
   });
+
+  it("returns error snapshot for malformed JSON body", async () => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, "<html>error</html>"));
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+
+    expect(result.error).toBe("Invalid JSON");
+    expect(result.windows).toHaveLength(0);
+    expect(result.provider).toBe("openai-codex");
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -1,4 +1,4 @@
-import { buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
+import { buildUsageErrorSnapshot, buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
 
@@ -77,7 +77,10 @@ export async function fetchCodexUsage(
     });
   }
 
-  const data = (await res.json()) as CodexUsageResponse;
+  const data = (await res.json().catch(() => null)) as CodexUsageResponse | null;
+  if (!data) {
+    return buildUsageErrorSnapshot("openai-codex", "Invalid JSON");
+  }
   const windows: UsageWindow[] = [];
 
   if (data.rate_limit?.primary_window) {

--- a/src/infra/provider-usage.fetch.gemini.test.ts
+++ b/src/infra/provider-usage.fetch.gemini.test.ts
@@ -71,4 +71,13 @@ describe("fetchGeminiUsage", () => {
       { label: "Flash", usedPercent: 0 },
     ]);
   });
+
+  it("returns error snapshot for malformed JSON body", async () => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, "<html>error</html>"));
+    const result = await fetchGeminiUsage("token", 5000, mockFetch, "google-gemini-cli");
+
+    expect(result.error).toBe("Invalid JSON");
+    expect(result.windows).toHaveLength(0);
+    expect(result.provider).toBe("google-gemini-cli");
+  });
 });

--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -1,4 +1,4 @@
-import { buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
+import { buildUsageErrorSnapshot, buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type {
   ProviderUsageSnapshot,
@@ -37,7 +37,10 @@ export async function fetchGeminiUsage(
     });
   }
 
-  const data = (await res.json()) as GeminiUsageResponse;
+  const data = (await res.json().catch(() => null)) as GeminiUsageResponse | null;
+  if (!data) {
+    return buildUsageErrorSnapshot(provider, "Invalid JSON");
+  }
   const quotas: Record<string, number> = {};
 
   for (const bucket of data.buckets || []) {

--- a/src/infra/provider-usage.fetch.zai.test.ts
+++ b/src/infra/provider-usage.fetch.zai.test.ts
@@ -140,4 +140,13 @@ describe("fetchZaiUsage", () => {
       },
     ]);
   });
+
+  it("returns error snapshot for malformed JSON body", async () => {
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, "<html>Bad Gateway</html>"));
+    const result = await fetchZaiUsage("key", 5000, mockFetch);
+
+    expect(result.error).toBe("Invalid JSON");
+    expect(result.windows).toHaveLength(0);
+    expect(result.provider).toBe("zai");
+  });
 });

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -1,4 +1,4 @@
-import { buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
+import { buildUsageErrorSnapshot, buildUsageHttpErrorSnapshot, fetchJson } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
 
@@ -44,7 +44,10 @@ export async function fetchZaiUsage(
     });
   }
 
-  const data = (await res.json()) as ZaiUsageResponse;
+  const data = (await res.json().catch(() => null)) as ZaiUsageResponse | null;
+  if (!data) {
+    return buildUsageErrorSnapshot("zai", "Invalid JSON");
+  }
   if (!data.success || data.code !== 200) {
     const errorMessage = typeof data.msg === "string" ? data.msg.trim() : "";
     return {


### PR DESCRIPTION
Ran into this while debugging why `openclaw status` occasionally shows no usage data at all — not even for providers that are working fine. Traced it to a missing error guard on `res.json()` in the usage fetchers.

### The problem

`loadProviderUsageSummary` runs all provider usage fetches in parallel via `Promise.all`. Each fetcher checks `res.ok` before calling `res.json()`, but none of them (except minimax) catch JSON parse failures. If a provider API returns HTTP 200 with a non-JSON body — e.g. an HTML error page from a CDN or corporate proxy, a truncated response, or a Cloudflare challenge page — `res.json()` throws a `SyntaxError`.

Since `withTimeout` in `provider-usage.shared.ts` wraps the work promise with `Promise.race` but doesn't catch rejections from the work side, the `SyntaxError` propagates straight into `Promise.all`, which rejects as soon as any single promise rejects. The result: **one bad response from one provider wipes usage data for every provider**, including ones that responded correctly.

Reproduction:
```
node -e "
const withTimeout = async (work, ms, fb) => {
  let t; try { return await Promise.race([work, new Promise(r => { t = setTimeout(() => r(fb), ms) })]) } finally { clearTimeout(t) }
};
async function badProvider() { const r = new Response('not json', {status:200}); return await r.json(); }
async function goodProvider() { return {provider:'ok', windows:[{label:'Pro',usedPercent:50}]}; }
Promise.all([
  withTimeout(badProvider(), 5000, {error:'Timeout'}),
  withTimeout(goodProvider(), 5000, {error:'Timeout'}),
]).then(r => console.log('OK:', r)).catch(e => console.log('BUG:', e.message));
"
# => BUG: Unexpected token 'o', "not json" is not valid JSON
```

### The fix

The minimax fetcher already handles this at line 325 of `provider-usage.fetch.minimax.ts`:

```typescript
const data = (await res.json().catch(() => null)) as MinimaxUsageResponse;
if (!isRecord(data)) {
  return { provider: "minimax", ..., error: "Invalid JSON" };
}
```

This change applies the same `.catch(() => null)` pattern to the zai, codex, gemini, and claude fetchers so a single malformed response degrades gracefully for that provider instead of taking down the entire usage summary.

### What changed

- **provider-usage.fetch.zai.ts**: guard `res.json()` with `.catch(() => null)`, return error snapshot on null
- **provider-usage.fetch.codex.ts**: same
- **provider-usage.fetch.gemini.ts**: same
- **provider-usage.fetch.claude.ts**: guard all three `res.json()` call sites (web orgs, web usage, API usage)
- **Tests added** for zai, codex, and gemini: verify that a 200 response with non-JSON body returns an error snapshot instead of throwing