### PR TITLE
fix(tasks): reconcile orphaned running cron tasks

### DIFF
--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -39,6 +39,8 @@ export type TaskRegistryMaintenanceSummary = {
   pruned: number;
 };
 
+type TaskBackingEvidence = "present" | "missing" | "unknown";
+
 function findSessionEntryByKey(store: Record<string, unknown>, sessionKey: string): unknown {
   const direct = store[sessionKey];
   if (direct) {
@@ -77,43 +79,44 @@ function hasActiveCliRun(task: TaskRecord): boolean {
   return false;
 }
 
-function hasBackingSession(task: TaskRecord): boolean {
+function resolveMissingChildSessionEvidence(task: TaskRecord): TaskBackingEvidence {
   if (task.runtime === "cron") {
     const jobId = task.sourceId?.trim();
-    return jobId ? isCronJobActive(jobId) : false;
+    return jobId && isCronJobActive(jobId) ? "present" : "missing";
   }
-
-  if (task.runtime === "cli" && hasActiveCliRun(task)) {
-    return true;
+  if (task.runtime === "cli") {
+    return hasActiveCliRun(task) ? "present" : "missing";
   }
+  return "unknown";
+}
 
+function resolveBackingEvidence(task: TaskRecord): TaskBackingEvidence {
   const childSessionKey = task.childSessionKey?.trim();
   if (!childSessionKey) {
-    return true;
+    return resolveMissingChildSessionEvidence(task);
   }
   if (task.runtime === "acp") {
     const acpEntry = readAcpSessionEntry({
       sessionKey: childSessionKey,
     });
     if (!acpEntry || acpEntry.storeReadFailed) {
-      return true;
+      return "unknown";
     }
-    return Boolean(acpEntry.entry);
+    return acpEntry.entry ? "present" : "missing";
   }
-  if (task.runtime === "subagent" || task.runtime === "cli") {
+  if (task.runtime === "subagent" || task.runtime === "cli" || task.runtime === "cron") {
     if (task.runtime === "cli") {
       const chatType = deriveSessionChatType(childSessionKey);
       if (chatType === "channel" || chatType === "group" || chatType === "direct") {
-        return false;
+        return "present";
       }
     }
     const agentId = parseAgentSessionKey(childSessionKey)?.agentId;
     const storePath = resolveStorePath(undefined, { agentId });
     const store = loadSessionStore(storePath);
-    return Boolean(findSessionEntryByKey(store, childSessionKey));
+    return findSessionEntryByKey(store, childSessionKey) ? "present" : "missing";
   }
-
-  return true;
+  return "unknown";
 }
 
 function shouldMarkLost(task: TaskRecord, now: number): boolean {
@@ -123,7 +126,7 @@ function shouldMarkLost(task: TaskRecord, now: number): boolean {
   if (!hasLostGraceExpired(task, now)) {
     return false;
   }
-  return !hasBackingSession(task);
+  return resolveBackingEvidence(task) === "missing";
 }
 
 function shouldPruneTerminalTask(task: TaskRecord, now: number): boolean {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -91,13 +91,14 @@ async function loadFreshTaskRegistryModulesForControlTest() {
 async function loadFreshTaskRegistryMaintenanceModuleForTest(params: {
   currentTasks: Map<string, ReturnType<typeof createTaskRecord>>;
   snapshotTasks: ReturnType<typeof createTaskRecord>[];
+  sessionStore?: Record<string, unknown>;
 }) {
   vi.resetModules();
   vi.doMock("../acp/runtime/session-meta.js", () => ({
     readAcpSessionEntry: () => ({ entry: undefined, storeReadFailed: false }),
   }));
   vi.doMock("../config/sessions.js", () => ({
-    loadSessionStore: () => ({}),
+    loadSessionStore: () => params.sessionStore ?? {},
     resolveStorePath: () => "",
   }));
   vi.doMock("../routing/session-key.js", () => ({
@@ -1286,6 +1287,111 @@ describe("task-registry", () => {
         error: "backing session missing",
       });
       expect(getTaskById(task.taskId)?.cleanupAfter).toBeGreaterThan(now);
+    });
+  });
+
+  it("marks stale cron tasks without child-session linkage as lost after grace expires", async () => {
+    const now = Date.now();
+    const snapshotTask = createTaskRecord({
+      runtime: "cron",
+      ownerKey: "",
+      scopeKind: "system",
+      runId: "run-cron-missing-child",
+      task: "Missing cron child session",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+    });
+    const staleTask = {
+      ...snapshotTask,
+      lastEventAt: now - 10 * 60_000,
+    };
+    const currentTasks = new Map([[snapshotTask.taskId, staleTask]]);
+    const { runTaskRegistryMaintenance } = await loadFreshTaskRegistryMaintenanceModuleForTest({
+      currentTasks,
+      snapshotTasks: [staleTask],
+    });
+
+    expect(await runTaskRegistryMaintenance()).toEqual({
+      reconciled: 1,
+      cleanupStamped: 0,
+      pruned: 0,
+    });
+    expect(currentTasks.get(snapshotTask.taskId)).toMatchObject({
+      status: "lost",
+      error: "backing session missing",
+    });
+    expect(currentTasks.get(snapshotTask.taskId)?.endedAt).toBeGreaterThanOrEqual(now);
+  });
+
+  it("keeps cron tasks active when their linked child session still exists", async () => {
+    const now = Date.now();
+    const snapshotTask = createTaskRecord({
+      runtime: "cron",
+      ownerKey: "",
+      scopeKind: "system",
+      childSessionKey: "agent:main:cron:nightly",
+      runId: "run-cron-active-child",
+      task: "Cron child session still exists",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+    });
+    const staleTask = {
+      ...snapshotTask,
+      lastEventAt: now - 10 * 60_000,
+    };
+    const currentTasks = new Map([[snapshotTask.taskId, staleTask]]);
+    const { runTaskRegistryMaintenance } = await loadFreshTaskRegistryMaintenanceModuleForTest({
+      currentTasks,
+      snapshotTasks: [staleTask],
+      sessionStore: {
+        "agent:main:cron:nightly": { id: "session-present" },
+      },
+    });
+
+    expect(await runTaskRegistryMaintenance()).toEqual({
+      reconciled: 0,
+      cleanupStamped: 0,
+      pruned: 0,
+    });
+    expect(currentTasks.get(snapshotTask.taskId)).toMatchObject({
+      status: "running",
+      childSessionKey: "agent:main:cron:nightly",
+      lastEventAt: staleTask.lastEventAt,
+    });
+  });
+
+  it("keeps fresh cron tasks without child-session linkage inside the grace period", async () => {
+    const now = Date.now();
+    const snapshotTask = createTaskRecord({
+      runtime: "cron",
+      ownerKey: "",
+      scopeKind: "system",
+      runId: "run-cron-fresh-missing-child",
+      task: "Fresh cron task without child session",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+    });
+    const freshTask = {
+      ...snapshotTask,
+      lastEventAt: now - 60_000,
+    };
+    const currentTasks = new Map([[snapshotTask.taskId, freshTask]]);
+    const { runTaskRegistryMaintenance } = await loadFreshTaskRegistryMaintenanceModuleForTest({
+      currentTasks,
+      snapshotTasks: [freshTask],
+    });
+
+    expect(await runTaskRegistryMaintenance()).toEqual({
+      reconciled: 0,
+      cleanupStamped: 0,
+      pruned: 0,
+    });
+    expect(currentTasks.get(snapshotTask.taskId)).toMatchObject({
+      status: "running",
+      lastEventAt: freshTask.lastEventAt,
     });
   });
 


### PR DESCRIPTION
## Summary
- reconcile orphaned active cron/cli tasks without `childSessionKey` as missing backing execution after the existing grace period
- keep ACP/subagent handling conservative when backing evidence is unknown
- add focused task-registry coverage for stale missing-child, healthy linked, and fresh missing-child cron cases

## Problem
We hit a real runtime bug where a cron task stayed `running` forever after gateway restart with:
- no `childSessionKey`
- no `endedAt`
- no backing execution left alive

Current reconciliation treated missing `childSessionKey` as effectively healthy, so these rows never transitioned to `lost`.

## Fix
Introduce a narrower backing-evidence check in task maintenance:
- `cron`/`cli` without `childSessionKey` => `missing`
- `cron`/`cli`/`subagent` with `childSessionKey` => inspect session store
- `acp` with `childSessionKey` => inspect ACP session metadata
- `acp`/`subagent` without `childSessionKey` => `unknown` (stay conservative)

Active tasks are marked `lost` only when backing evidence is explicitly `missing` and the grace period has expired.

## Validation
- `pnpm test -- src/tasks/task-registry.test.ts`
- targeted task-registry tests pass (41 passing locally)
