### PR TITLE
Avoid redundant cloning on fresh session store loads

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -761,4 +761,31 @@ describe("sessions", () => {
     expect(store[mainSessionKey]?.providerOverride).toBe("anthropic");
     expect(store[mainSessionKey]?.thinkingLevel).toBe("high");
   });
+
+  it("loadSessionStore skipCache returns a fresh mutable store without tainting cached reads", async () => {
+    const mainSessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "loadSessionStore-skip-cache-fresh",
+      entries: {
+        [mainSessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 123,
+          thinkingLevel: "low",
+        },
+      },
+    });
+
+    const fresh = loadSessionStore(storePath, { skipCache: true });
+    expect(fresh[mainSessionKey]?.thinkingLevel).toBe("low");
+
+    fresh[mainSessionKey] = {
+      ...fresh[mainSessionKey],
+      thinkingLevel: "high",
+    };
+
+    expect(loadSessionStore(storePath)[mainSessionKey]?.thinkingLevel).toBe("low");
+    expect(loadSessionStore(storePath, { skipCache: true })[mainSessionKey]?.thinkingLevel).toBe(
+      "low",
+    );
+  });
 });

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -129,5 +129,12 @@ export function loadSessionStore(
     });
   }
 
+  // `skipCache` callers already forced a fresh disk load, so there is no shared
+  // cached object to protect here. Returning the parsed store directly avoids an
+  // extra full-store clone on hot read-modify-write paths.
+  if (opts.skipCache) {
+    return store;
+  }
+
   return structuredClone(store);
 }


### PR DESCRIPTION
## Summary

`loadSessionStore(..., { skipCache: true })` already forces a fresh disk read, but it still returns `structuredClone(store)` afterward.

On this path, the parsed store is not shared with the cache, so the extra clone is unnecessary. This change returns the parsed store directly when `skipCache` is true, while preserving the defensive clone behavior for normal cached reads.

## Why

Session store update paths currently re-read the full store from disk with `skipCache: true`, mutate one entry, and then write the full JSON back out. The full rewrite is still the dominant cost, but the extra clone adds avoidable O(n) overhead on the read side of that hot path.

## Tests

- `corepack pnpm install --frozen-lockfile` on Linux
- `corepack pnpm protocol:check` on Linux
- targeted `src/config/sessions.test.ts` regression run attempted locally; final pass/fail should come from GitHub CI

## Note

- This PR intentionally contains only the original session-store `skipCache` minimal change in `src/config/sessions/store-load.ts` and `src/config/sessions.test.ts`.
