### PR TITLE
fix(tools): move Gemini API key from URL query param to x-goog-api-key header

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -150,11 +150,11 @@ export async function geminiAnalyzePdf(params: {
     /\/v1beta$/i,
     "",
   );
-  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent`;
 
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
     body: JSON.stringify({
       contents: [{ role: "user", parts }],
     }),


### PR DESCRIPTION
## Summary

- Problem: `pdf-native-providers.ts:153` passes the Gemini API key as `?key=` in the URL query string
- Why it matters: the key leaks to HTTP proxy logs, CDN access logs, and any intermediary that logs request URLs. The codebase's own `redact-sensitive-url.ts` marks `key` as a sensitive query parameter (line 7)
- What changed: moved API key from `?key=` query param to `x-goog-api-key` header, matching every other Google API call in the codebase
- What did NOT change (scope boundary): no change to the API request body, model selection, or response handling

The rest of the codebase consistently uses the `x-goog-api-key` header:
- `extensions/google/api.ts:159`
- `extensions/google/src/gemini-web-search-provider.ts:96`
- `src/infra/gemini-auth.ts:36`
- `packages/memory-host-sdk/src/host/embeddings.ts`

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the PDF provider was written using the Google `?key=` URL authentication style while the rest of the codebase standardized on the `x-goog-api-key` header
- Missing detection / guardrail: no lint rule or test asserts that API keys are not placed in URL query parameters
- Prior context: `redact-sensitive-url.ts` was added to detect and redact sensitive URL parameters, confirming the team considers this pattern risky

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/pdf-native-providers.ts` (no test file exists currently)
- Scenario the test should lock in: Gemini API calls should not contain API keys in URL query parameters
- If no new test is added, why not: no existing test file for this module. The fix removes the code path entirely (key is moved to headers). A test could be added to assert the fetch URL contains no `?key=` parameter.

## User-visible / Behavior Changes

None. The Gemini `generateContent` endpoint accepts authentication via both `?key=` and `x-goog-api-key` header. The request behavior is identical.

## Diagram (if applicable)

```text
Before:
[OpenClaw] -> GET ...generateContent?key=AIza... -> [proxy logs key] -> [Google API]

After:
[OpenClaw] -> GET ...generateContent (x-goog-api-key: AIza...) -> [proxy sees no key in URL] -> [Google API]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: API key moved from URL query string (visible in logs) to HTTP header (not logged by default). Same authentication mechanism, reduced exposure surface.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25.2.1

### Steps

1. Use the PDF analysis tool with a Gemini model
2. Observe the outbound HTTP request URL

### Expected

URL should not contain the API key

### Actual

Before fix: `https://generativelanguage.googleapis.com/v1beta/models/...:generateContent?key=AIza...`
After fix: `https://generativelanguage.googleapis.com/v1beta/models/...:generateContent` (key in header)

## Evidence

- [x] Trace/log snippets

The codebase's own `src/shared/net/redact-sensitive-url.ts` line 7 lists `"key"` as a sensitive query parameter name:
```typescript
const SENSITIVE_URL_QUERY_PARAM_NAMES = new Set([
  "token", "key", "api_key", "apikey", "secret", ...
]);
```

All other Google API calls use header auth:
```
extensions/google/api.ts:159               → "x-goog-api-key": apiKey
extensions/google/gemini-web-search.ts:96  → "x-goog-api-key": params.apiKey
src/infra/gemini-auth.ts:36                → "x-goog-api-key": apiKey
```

## Human Verification (required)

- Verified scenarios: diff is 2 lines, moving key from URL to header. The `generateContent` endpoint accepts `x-goog-api-key` header (confirmed by `gemini-web-search-provider.ts` using the same endpoint with header auth)
- Edge cases checked: custom `baseUrl` via transport config still works (URL construction is unchanged, only auth method differs)
- What I did NOT verify: live API call (no Gemini API key in test environment). No existing test file for this module.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: some non-standard Gemini endpoint or proxy might only accept `?key=` auth
  - Mitigation: all other Google API calls in the codebase use header auth successfully. The standard `generativelanguage.googleapis.com` endpoint accepts both. If a specific deployment requires `?key=`, this would surface as an auth failure and can be reported.

---

AI-assisted: yes (analysis and PR preparation with Claude). Fix is a 2-line change, fully understood and manually verified against the codebase's established pattern.