### PR TITLE
fix: Control UI context % shows 100% when actual is ~56%

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1285,6 +1285,8 @@ export function buildGatewaySessionRow(params: {
     outputTokens: entry?.outputTokens,
     totalTokens,
     totalTokensFresh,
+    // currentWindowTokens: actual context in use (post-compaction = transcript tokens when fresh=false)
+    currentWindowTokens: totalTokensFresh ? totalTokens : (transcriptUsage?.totalTokens ?? totalTokens),
     estimatedCostUsd,
     status: subagentRun ? subagentStatus : entry?.status,
     startedAt: subagentRun ? subagentStartedAt : entry?.startedAt,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -48,6 +48,8 @@ export type GatewaySessionRow = {
   outputTokens?: number;
   totalTokens?: number;
   totalTokensFresh?: boolean;
+  /** Current context window tokens (post-compaction). Use this for UI context %, not totalTokens which is lifetime. */
+  currentWindowTokens?: number;
   estimatedCostUsd?: number;
   status?: SessionRunStatus;
   startedAt?: number;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -294,10 +294,9 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  if (session?.totalTokensFresh === false) {
-    return nothing;
-  }
-  const used = session?.totalTokens ?? 0;
+  // Use currentWindowTokens if available (post-compaction), fall back to totalTokens (lifetime)
+  // Note: We no longer hide when totalTokensFresh=false because currentWindowTokens is valid
+  const used = session?.currentWindowTokens ?? session?.totalTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
Root cause: UI used lifetime accumulated tokens (totalTokens) for context percentage, which stays high after compaction. Should use current window tokens (post-compaction) instead.

Fix:
1. Add currentWindowTokens field to GatewaySessionRow type
2. Gateway computes it: when totalTokensFresh=false (post-compaction), use transcriptUsage.totalTokens (current window), else use totalTokens  
3. UI uses currentWindowTokens for context % calculation, with fallback to totalTokens for backwards compatibility
4. Remove early return when totalTokensFresh=false - now shows correct post-compaction percentage via currentWindowTokens

Fixes #48252