### PR TITLE
fix: Keep incomplete-thinking messages instead of dropping

### DIFF
--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -204,7 +204,7 @@ export function sanitizeThinkingForRecovery(messages: AgentMessage[]): {
   if (assessment === "valid") {
     return { messages, prefill: false };
   }
-  if (assessment === "incomplete-text") {
+  if (assessment === "incomplete-text" || assessment === "incomplete-thinking") {
     return { messages, prefill: true };
   }
 

--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -95,21 +95,58 @@ function didEditLikelyApply(params: {
     return false;
   }
 
-  let withoutInsertedNewText = normalizedCurrent;
+  // Use before/after occurrence counts for more robust detection.
+  // This handles the case where newText pre-existed in the file.
+  const countOccurrences = (hay: string, needle: string): number => {
+    if (needle.length === 0) {
+      return 0;
+    }
+    let count = 0;
+    let idx = 0;
+    while ((idx = hay.indexOf(needle, idx)) !== -1) {
+      count++;
+      idx += needle.length;
+    }
+    return count;
+  };
+
   for (const edit of params.edits) {
     const normalizedNew = normalizeToLF(edit.newText);
+    const normalizedOld = normalizeToLF(edit.oldText);
+
+    // Check if newText exists in current content
     if (normalizedNew.length > 0 && !normalizedCurrent.includes(normalizedNew)) {
       return false;
     }
-    withoutInsertedNewText =
-      normalizedNew.length > 0
-        ? removeExactOccurrences(withoutInsertedNewText, normalizedNew)
-        : withoutInsertedNewText;
-  }
 
-  for (const edit of params.edits) {
-    const normalizedOld = normalizeToLF(edit.oldText);
-    if (withoutInsertedNewText.includes(normalizedOld)) {
+    // Count occurrences before and after
+    const newTextCountAfter = countOccurrences(normalizedCurrent, normalizedNew);
+    const newTextCountBefore =
+      normalizedOriginal !== undefined ? countOccurrences(normalizedOriginal, normalizedNew) : 0;
+
+    // Evidence the edit added at least one new occurrence of newText
+    const editAddedNewText = newTextCountAfter > newTextCountBefore;
+
+    // For oldText checking, strip newText occurrences to handle the case where
+    // oldText is a substring of newText (e.g. appending/wrapping, #49363)
+    const stripNewText = (s: string): string =>
+      normalizedOld.length > 0 && normalizedNew.includes(normalizedOld)
+        ? s.split(normalizedNew).join("")
+        : s;
+
+    const contentAfterStrip = stripNewText(normalizedCurrent);
+    const stillHasOld = normalizedOld.length > 0 && contentAfterStrip.includes(normalizedOld);
+
+    // When original is available, check that oldText count decreased
+    const oldTextDecreasedOrAbsent =
+      !stillHasOld &&
+      (normalizedOriginal === undefined ||
+        countOccurrences(stripNewText(normalizedCurrent), normalizedOld) <=
+          countOccurrences(stripNewText(normalizedOriginal), normalizedOld));
+
+    // Recover only when: newText added AND oldText decreased/absent
+    const recovered = editAddedNewText && oldTextDecreasedOrAbsent;
+    if (!recovered) {
       return false;
     }
   }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1285,6 +1285,8 @@ export function buildGatewaySessionRow(params: {
     outputTokens: entry?.outputTokens,
     totalTokens,
     totalTokensFresh,
+    // currentWindowTokens: actual context in use (post-compaction = transcript tokens when fresh=false)
+    currentWindowTokens: totalTokensFresh ? totalTokens : (transcriptUsage?.totalTokens ?? totalTokens),
     estimatedCostUsd,
     status: subagentRun ? subagentStatus : entry?.status,
     startedAt: subagentRun ? subagentStartedAt : entry?.startedAt,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -48,6 +48,8 @@ export type GatewaySessionRow = {
   outputTokens?: number;
   totalTokens?: number;
   totalTokensFresh?: boolean;
+  /** Current context window tokens (post-compaction). Use this for UI context %, not totalTokens which is lifetime. */
+  currentWindowTokens?: number;
   estimatedCostUsd?: number;
   status?: SessionRunStatus;
   startedAt?: number;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -294,10 +294,9 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  if (session?.totalTokensFresh === false) {
-    return nothing;
-  }
-  const used = session?.totalTokens ?? 0;
+  // Use currentWindowTokens if available (post-compaction), fall back to totalTokens (lifetime)
+  // Note: We no longer hide when totalTokensFresh=false because currentWindowTokens is valid
+  const used = session?.currentWindowTokens ?? session?.totalTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
Problem: When thinking block was incomplete (e.g. timeout), the message was dropped entirely. This caused sent messages to disappear without any user notification.

Fix: Treat incomplete-thinking like incomplete-text - keep the message and set prefill=true so the model can resume from where it left off.

This is safer because:
1. User gets a response instead of silence
2. Model can potentially continue with prefill
3. No information is lost

Related: Messages about PRs were disappearing due to MiniMax timeouts causing incomplete thinking blocks.