### PR TITLE
fix(control-ui): keep browser session-key helpers off server-only imports

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,4 +1,3 @@
-import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { setLastActiveSessionKey } from "./app-settings.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
@@ -10,6 +9,7 @@ import { loadModels } from "./controllers/models.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
+import { parseAgentSessionKey } from "./session-key.ts";
 import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
 import type { SessionsListResult } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,5 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
-import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
@@ -16,6 +15,7 @@ import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
+import { parseAgentSessionKey } from "./session-key.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
 import type { SessionsListResult } from "./types.ts";

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,9 +1,4 @@
 import { html, nothing } from "lit";
-import {
-  buildAgentMainSessionKey,
-  parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
-} from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
@@ -91,10 +86,15 @@ import {
   updateSkillEdit,
   updateSkillEnabled,
 } from "./controllers/skills.ts";
-import "./components/dashboard-header.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
+import "./components/dashboard-header.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import {
+  buildAgentMainSessionKey,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "./session-key.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
   resolveAgentConfig,

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1,6 +1,5 @@
 import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { resolveAgentIdFromSessionKey } from "../../../src/routing/session-key.js";
 import { i18n, I18nController, isSupportedLocale } from "../i18n/index.ts";
 import {
   handleChannelConfigReload as handleChannelConfigReloadInternal,
@@ -70,6 +69,7 @@ import type {
 } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
+import { resolveAgentIdFromSessionKey } from "./session-key.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
 import type {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -9,14 +9,14 @@ import {
   normalizeVerboseLevel,
   resolveThinkingDefaultForModel,
 } from "../../../../src/auto-reply/thinking.shared.js";
+import { createChatModelOverride, resolvePreferredServerChatModel } from "../chat-model-ref.ts";
+import type { GatewayBrowserClient } from "../gateway.ts";
 import {
   DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   isSubagentSessionKey,
   parseAgentSessionKey,
-} from "../../../../src/routing/session-key.js";
-import { createChatModelOverride, resolvePreferredServerChatModel } from "../chat-model-ref.ts";
-import type { GatewayBrowserClient } from "../gateway.ts";
+} from "../session-key.ts";
 import type {
   AgentsListResult,
   ChatModelOverride,

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -1,9 +1,9 @@
-import { resolveAgentIdFromSessionKey } from "../../../../src/routing/session-key.js";
 import {
   resolveChatModelOverride,
   resolvePreferredServerChatModelValue,
 } from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
+import { resolveAgentIdFromSessionKey } from "../session-key.ts";
 import type {
   AgentsListResult,
   ChatModelOverride,

--- a/ui/src/ui/session-key.test.ts
+++ b/ui/src/ui/session-key.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_AGENT_ID,
+  DEFAULT_MAIN_KEY,
+  isSubagentSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "./session-key.ts";
+
+const CONTROL_UI_SESSION_KEY_CONSUMERS = [
+  "app.ts",
+  "app-chat.ts",
+  "app-render.ts",
+  "app-render.helpers.ts",
+  "chat/slash-command-executor.ts",
+  "controllers/agents.ts",
+] as const;
+
+const FORBIDDEN_SESSION_KEY_IMPORT_RE =
+  /src\/(?:routing\/session-key|sessions\/session-key-utils)\.js/;
+const FORBIDDEN_BROWSER_RUNTIME_RE =
+  /\b(?:contract-surfaces|createJiti|discoverOpenClawPlugins|loadPluginManifestRegistry)\b/;
+
+function readUiSource(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+describe("ui session-key helpers", () => {
+  it("parses canonical agent-scoped session keys", () => {
+    expect(parseAgentSessionKey("AGENT:Ops:Discord:Direct:User-42")).toEqual({
+      agentId: "ops",
+      rest: "discord:direct:user-42",
+    });
+  });
+
+  it("normalizes agent ids into the browser-safe canonical form", () => {
+    expect(normalizeAgentId("  Ops Team/Primary  ")).toBe("ops-team-primary");
+    expect(normalizeAgentId("")).toBe(DEFAULT_AGENT_ID);
+  });
+
+  it("builds agent main session keys with the default main key", () => {
+    expect(buildAgentMainSessionKey({ agentId: "Ops Team" })).toBe("agent:ops-team:main");
+    expect(buildAgentMainSessionKey({ agentId: "main", mainKey: DEFAULT_MAIN_KEY })).toBe(
+      "agent:main:main",
+    );
+  });
+
+  it("resolves the default agent id for malformed or missing keys", () => {
+    expect(resolveAgentIdFromSessionKey("main")).toBe(DEFAULT_AGENT_ID);
+    expect(resolveAgentIdFromSessionKey(undefined)).toBe(DEFAULT_AGENT_ID);
+  });
+
+  it("detects nested subagent session keys", () => {
+    expect(isSubagentSessionKey("subagent:run-1")).toBe(true);
+    expect(isSubagentSessionKey("agent:ops:subagent:run-1")).toBe(true);
+    expect(isSubagentSessionKey("agent:ops:main")).toBe(false);
+  });
+});
+
+describe("ui session-key import guardrails", () => {
+  it("keeps the browser helper free of server-side session key dependencies", () => {
+    const source = readUiSource("./session-key.ts");
+
+    expect(source).not.toMatch(FORBIDDEN_SESSION_KEY_IMPORT_RE);
+    expect(source).not.toMatch(FORBIDDEN_BROWSER_RUNTIME_RE);
+  });
+
+  it("keeps control ui entry points off the server-side session key chain", () => {
+    for (const relativePath of CONTROL_UI_SESSION_KEY_CONSUMERS) {
+      const source = readUiSource(`./${relativePath}`);
+      expect(source, relativePath).not.toMatch(FORBIDDEN_SESSION_KEY_IMPORT_RE);
+    }
+  });
+});

--- a/ui/src/ui/session-key.ts
+++ b/ui/src/ui/session-key.ts
@@ -1,0 +1,75 @@
+export const DEFAULT_AGENT_ID = "main";
+export const DEFAULT_MAIN_KEY = "main";
+
+export type ParsedAgentSessionKey = {
+  agentId: string;
+  rest: string;
+};
+
+const VALID_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+const INVALID_CHARS_RE = /[^a-z0-9_-]+/g;
+const LEADING_DASH_RE = /^-+/;
+const TRAILING_DASH_RE = /-+$/;
+
+export function parseAgentSessionKey(
+  sessionKey: string | undefined | null,
+): ParsedAgentSessionKey | null {
+  const raw = (sessionKey ?? "").trim().toLowerCase();
+  if (!raw) {
+    return null;
+  }
+  const parts = raw.split(":").filter(Boolean);
+  if (parts.length < 3 || parts[0] !== "agent") {
+    return null;
+  }
+  const agentId = parts[1]?.trim();
+  const rest = parts.slice(2).join(":");
+  if (!agentId || !rest) {
+    return null;
+  }
+  return { agentId, rest };
+}
+
+export function normalizeAgentId(value: string | undefined | null): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) {
+    return DEFAULT_AGENT_ID;
+  }
+  if (VALID_ID_RE.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  return (
+    trimmed
+      .toLowerCase()
+      .replace(INVALID_CHARS_RE, "-")
+      .replace(LEADING_DASH_RE, "")
+      .replace(TRAILING_DASH_RE, "")
+      .slice(0, 64) || DEFAULT_AGENT_ID
+  );
+}
+
+export function buildAgentMainSessionKey(params: {
+  agentId: string;
+  mainKey?: string | undefined;
+}): string {
+  const agentId = normalizeAgentId(params.agentId);
+  const mainKey = (params.mainKey ?? "").trim().toLowerCase() || DEFAULT_MAIN_KEY;
+  return `agent:${agentId}:${mainKey}`;
+}
+
+export function resolveAgentIdFromSessionKey(sessionKey: string | undefined | null): string {
+  const parsed = parseAgentSessionKey(sessionKey);
+  return normalizeAgentId(parsed?.agentId ?? DEFAULT_AGENT_ID);
+}
+
+export function isSubagentSessionKey(sessionKey: string | undefined | null): boolean {
+  const raw = (sessionKey ?? "").trim();
+  if (!raw) {
+    return false;
+  }
+  if (raw.toLowerCase().startsWith("subagent:")) {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(raw);
+  return Boolean((parsed?.rest ?? "").toLowerCase().startsWith("subagent:"));
+}


### PR DESCRIPTION
## Summary

Fix a Control UI startup regression where browser entry points imported session-key helpers through server-only modules.

This moves the small session-key helpers that Control UI actually needs into a browser-safe local module and rewires the UI entry points to use it.

## Root cause

Several Control UI files were importing `src/routing/session-key.ts` or `src/sessions/session-key-utils.ts`.

That server-side chain now reaches `src/channels/plugins/contract-surfaces.ts`, which pulls in Node-only and plugin-loader dependencies such as `jiti`. Once that chain entered the browser bundle, Control UI could fail at startup with errors like:

`jiti.cjs:1 Uncaught TypeError: (0 , e.platform) is not a function`

## Changes

- add `ui/src/ui/session-key.ts` with the browser-safe helpers Control UI needs
- switch Control UI consumers to import from the local helper instead of the server-side chain
- add `ui/src/ui/session-key.test.ts` regression coverage for helper behavior and import guardrails

## Testing

- `node scripts/ui.js build`
- `pnpm build`
- targeted session-key regression tests passed

## Notes

The repo-wide pre-commit `pnpm check` currently hits an unrelated existing TypeScript failure in `extensions/nextcloud-talk/src/channel-api.ts` for `clearAccountEntryFields`. This change does not touch that surface.