### PR TITLE
fix(auth): proactively refresh OAuth token before expiry to prevent concurrent-agent race condition

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -282,7 +282,9 @@ async function tryResolveOAuthProfile(
     return null;
   }
 
-  if (Date.now() < cred.expires) {
+  // Apply EXTERNAL_CLI_NEAR_EXPIRY_MS buffer here too for consistency with the other
+  // expiry checks — ensures fallback profile path also proactively refreshes.
+  if (Date.now() < cred.expires - EXTERNAL_CLI_NEAR_EXPIRY_MS) {
     return await buildOAuthProfileResult({
       provider: cred.provider,
       credentials: cred,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -13,7 +13,7 @@ import {
 } from "../../plugins/provider-runtime.runtime.js";
 import { resolveSecretRefString, type SecretRefResolveCache } from "../../secrets/resolve.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
-import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
+import { AUTH_STORE_LOCK_OPTIONS, EXTERNAL_CLI_NEAR_EXPIRY_MS, log } from "./constants.js";
 import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import {
@@ -177,7 +177,10 @@ async function refreshOAuthTokenWithLock(params: {
       return null;
     }
 
-    if (Date.now() < cred.expires) {
+    // Refresh proactively within EXTERNAL_CLI_NEAR_EXPIRY_MS of expiry, not just after.
+    // This prevents concurrent agents from all hitting expiry at the same moment and
+    // racing to refresh the same single-use refresh token simultaneously.
+    if (Date.now() < cred.expires - EXTERNAL_CLI_NEAR_EXPIRY_MS) {
       return {
         apiKey: await buildOAuthApiKey(cred.provider, cred),
         newCredentials: cred,
@@ -430,7 +433,10 @@ export async function resolveApiKeyForProfile(
       cred,
     }) ?? cred;
 
-  if (Date.now() < oauthCred.expires) {
+  // Use EXTERNAL_CLI_NEAR_EXPIRY_MS buffer: refresh proactively before expiry to avoid
+  // race condition where multiple concurrent agents all attempt to refresh the same
+  // single-use refresh token at the exact moment it expires.
+  if (Date.now() < oauthCred.expires - EXTERNAL_CLI_NEAR_EXPIRY_MS) {
     return await buildOAuthProfileResult({
       provider: oauthCred.provider,
       credentials: oauthCred,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -452,6 +452,15 @@ export async function resolveApiKeyForProfile(
       agentDir: params.agentDir,
     });
     if (!result) {
+      // If refresh returned null (e.g. provider has no refreshOAuth implementation)
+      // but the token hasn't actually expired yet, fall back to the existing token.
+      if (Date.now() < oauthCred.expires) {
+        return await buildOAuthProfileResult({
+          provider: oauthCred.provider,
+          credentials: oauthCred,
+          email: oauthCred.email,
+        });
+      }
       return null;
     }
     return buildApiKeyProfileResult({

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -297,6 +297,16 @@ async function tryResolveOAuthProfile(
     agentDir: params.agentDir,
   });
   if (!refreshed) {
+    // If refresh returned null (e.g. provider has no refreshOAuth implementation)
+    // but the token hasn't actually expired yet, fall back to the existing token
+    // rather than dropping the fallback profile entirely.
+    if (Date.now() < cred.expires) {
+      return await buildOAuthProfileResult({
+        provider: cred.provider,
+        credentials: cred,
+        email: cred.email,
+      });
+    }
     return null;
   }
   return buildApiKeyProfileResult({


### PR DESCRIPTION
## Summary

Fixes the OAuth token refresh race condition that occurs when multiple agents run in parallel.

## Root Cause

`EXTERNAL_CLI_NEAR_EXPIRY_MS` (10 min) was defined in `constants.ts` but **never used** in the actual refresh logic in `oauth.ts`. Both expiry check sites used:

```ts
if (Date.now() < cred.expires) {
  return cachedToken; // valid
}
// else: refresh
```

This means tokens are only considered stale at the exact moment they expire. When multiple agents (e.g. 3–5 parallel `claude --print` jobs building different services in a monorepo) all run past the 3-hour mark simultaneously, they all reach `cred.expires` at the same instant.

Even though `withFileLock` serialises the refresh attempts, the **first agent** successfully uses the single-use `refreshToken`, making it invalid. Every subsequent agent then fails with `invalid_grant`, wipes `credentials.json`, and crashes — killing all running sessions and hours of work.

## Fix

Wire up the already-defined `EXTERNAL_CLI_NEAR_EXPIRY_MS` constant into both expiry checks in `oauth.ts`:

```ts
// Before
if (Date.now() < cred.expires) { ... }

// After — treat token as stale 10 min before it actually expires
if (Date.now() < cred.expires - EXTERNAL_CLI_NEAR_EXPIRY_MS) { ... }
```

Now tokens are refreshed **proactively** while still valid. The file lock ensures exactly one agent performs the refresh, saves the new token, and releases. All waiting agents then re-read the freshly refreshed credentials instead of racing on the same dying refresh token.

## Affected files

- `src/agents/auth-profiles/oauth.ts` — 2 expiry checks + import

## Real-world reproduction

Running 3+ parallel Claude Code agents across a monorepo (UTP platform with 5 services) consistently triggered this bug after ~3 hours. Every agent died simultaneously with token errors requiring manual re-login.