### PR TITLE
feat(mac): add Talk Mode toggle to chat widget toolbar

### DIFF
--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -219,8 +219,10 @@ final class WebChatSwiftUIWindowController {
     private let sessionKey: String
     private let hosting: NSHostingController<OpenClawChatView>
     private let contentController: NSViewController
+    private let viewModel: OpenClawChatViewModel
     private var window: NSWindow?
     private var dismissMonitor: Any?
+    private var talkSyncTask: Task<Void, Never>?
     var onClosed: (() -> Void)?
     var onVisibilityChanged: ((Bool) -> Void)?
 
@@ -231,23 +233,35 @@ final class WebChatSwiftUIWindowController {
     init(sessionKey: String, presentation: WebChatPresentation, transport: any OpenClawChatTransport) {
         self.sessionKey = sessionKey
         self.presentation = presentation
+        let appState = AppStateStore.shared
         let vm = OpenClawChatViewModel(
             sessionKey: sessionKey,
             transport: transport,
             initialThinkingLevel: Self.persistedThinkingLevel(),
             onThinkingLevelChanged: { level in
                 UserDefaults.standard.set(level, forKey: webChatThinkingLevelDefaultsKey)
+            },
+            talkAvailable: voiceWakeSupported,
+            talkEnabled: appState.talkEnabled,
+            onTalkToggle: { enabled in
+                Task { await appState.setTalkEnabled(enabled) }
             })
-        let accent = Self.color(fromHex: AppStateStore.shared.seamColorHex)
+        self.viewModel = vm
+        let accent = Self.color(fromHex: appState.seamColorHex)
         self.hosting = NSHostingController(rootView: OpenClawChatView(
             viewModel: vm,
             showsSessionSwitcher: true,
             userAccent: accent))
         self.contentController = Self.makeContentController(for: presentation, hosting: self.hosting)
         self.window = Self.makeWindow(for: presentation, contentViewController: self.contentController)
+        self.talkSyncTask = Task { [weak self] in
+            await self?.observeTalkState()
+        }
     }
 
-    deinit {}
+    deinit {
+        self.talkSyncTask?.cancel()
+    }
 
     var isVisible: Bool {
         self.window?.isVisible ?? false
@@ -334,6 +348,22 @@ final class WebChatSwiftUIWindowController {
 
     private func removeDismissMonitor() {
         OverlayPanelFactory.clearGlobalEventMonitor(&self.dismissMonitor)
+    }
+
+    private func observeTalkState() async {
+        let appState = AppStateStore.shared
+        while !Task.isCancelled {
+            let enabled = await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = appState.talkEnabled
+                } onChange: {
+                    Task { @MainActor in
+                        continuation.resume(returning: appState.talkEnabled)
+                    }
+                }
+            }
+            self.viewModel.updateTalkState(enabled: enabled, available: voiceWakeSupported)
+        }
     }
 
     private static func persistedThinkingLevel() -> String? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -34,6 +34,7 @@ struct OpenClawChatComposer: View {
                     }
                     self.thinkingPicker
                     Spacer()
+                    self.talkToggle
                     self.refreshButton
                     self.attachmentPicker
                 }
@@ -334,6 +335,21 @@ struct OpenClawChatComposer: View {
                 .background(Circle().fill(Color.accentColor))
                 .disabled(!self.viewModel.canSend)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var talkToggle: some View {
+        if self.viewModel.showsTalkToggle {
+            Button {
+                self.viewModel.toggleTalk()
+            } label: {
+                Image(systemName: self.viewModel.talkEnabled ? "waveform.circle.fill" : "waveform.circle")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(self.viewModel.talkEnabled ? .accentColor : nil)
+            .help(self.viewModel.talkEnabled ? "Stop Talk Mode" : "Talk Mode")
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -29,6 +29,8 @@ public final class OpenClawChatViewModel {
     public var attachments: [OpenClawPendingAttachment] = []
     public private(set) var healthOK: Bool = false
     public private(set) var pendingRunCount: Int = 0
+    public private(set) var talkEnabled: Bool = false
+    public private(set) var talkAvailable: Bool = false
 
     public private(set) var sessionKey: String
     public private(set) var sessionId: String?
@@ -39,6 +41,7 @@ public final class OpenClawChatViewModel {
     private var sessionDefaults: OpenClawChatSessionsDefaults?
     private let prefersExplicitThinkingLevel: Bool
     private let onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)?
+    private let onTalkToggle: (@MainActor @Sendable (Bool) -> Void)?
 
     @ObservationIgnored
     private nonisolated(unsafe) var eventTask: Task<Void, Never>?
@@ -77,7 +80,10 @@ public final class OpenClawChatViewModel {
         sessionKey: String,
         transport: any OpenClawChatTransport,
         initialThinkingLevel: String? = nil,
-        onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)? = nil)
+        onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)? = nil,
+        talkAvailable: Bool = false,
+        talkEnabled: Bool = false,
+        onTalkToggle: (@MainActor @Sendable (Bool) -> Void)? = nil)
     {
         self.sessionKey = sessionKey
         self.transport = transport
@@ -85,6 +91,9 @@ public final class OpenClawChatViewModel {
         self.thinkingLevel = normalizedThinkingLevel ?? "off"
         self.prefersExplicitThinkingLevel = normalizedThinkingLevel != nil
         self.onThinkingLevelChanged = onThinkingLevelChanged
+        self.talkAvailable = talkAvailable
+        self.talkEnabled = talkEnabled
+        self.onTalkToggle = onTalkToggle
 
         self.eventTask = Task { [weak self] in
             guard let self else { return }
@@ -207,6 +216,20 @@ public final class OpenClawChatViewModel {
 
     public func removeAttachment(_ id: OpenClawPendingAttachment.ID) {
         self.attachments.removeAll { $0.id == id }
+    }
+
+    public var showsTalkToggle: Bool {
+        self.talkAvailable && self.onTalkToggle != nil
+    }
+
+    public func toggleTalk() {
+        let next = !self.talkEnabled
+        self.onTalkToggle?(next)
+    }
+
+    public func updateTalkState(enabled: Bool, available: Bool) {
+        self.talkEnabled = enabled
+        self.talkAvailable = available
     }
 
     public var canSend: Bool {


### PR DESCRIPTION
## Summary

- Adds a Talk Mode toggle button (waveform icon) to the native macOS chat widget composer toolbar, so users can start/stop Talk Mode directly from the chat panel without navigating to the menubar dropdown.
- The toggle mirrors the existing iOS `HomeToolbar` pattern and stays in two-way sync with `AppState` — toggling from the menubar also updates the chat widget button in real time and vice versa.
- All new ViewModel init parameters default to off/nil, so existing callers (iOS, onboarding) are unaffected.

## Test plan

- [ ] Open the macOS app chat widget (panel or window) and verify the waveform toggle button appears in the composer toolbar
- [ ] Click the toggle and verify Talk Mode activates (overlay appears, waveform icon fills)
- [ ] Toggle Talk Mode from the menubar and verify the chat widget button reflects the change
- [ ] Toggle from the chat widget and verify the menubar item reflects the change
- [ ] Verify iOS builds are unaffected (no new talk button appears since `talkAvailable` defaults to false)

Made with [Cursor](https://cursor.com)