### PR TITLE
fix(imessage): filter tapback reactions in imsg rpc inbound processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage: drop legacy imsg RPC tapback reactions before pairing or agent dispatch while preserving debounced normal text when tapbacks arrive in the same burst. Fixes #60274; refs #39031 and #60677. Thanks @hyperclaw.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -354,3 +354,136 @@ describe("resolveIMessageInboundDecision command auth", () => {
     expect(decision.commandAuthorized).toBe(true);
   });
 });
+
+describe("resolveIMessageInboundDecision tapback filtering", () => {
+  const cfg = {} as OpenClawConfig;
+  type InboundDecisionParams = Parameters<typeof resolveIMessageInboundDecision>[0];
+
+  function resolveDecision(
+    overrides: Omit<Partial<InboundDecisionParams>, "message"> & {
+      message?: Partial<InboundDecisionParams["message"]>;
+    } = {},
+  ) {
+    const { message: messageOverrides, ...restOverrides } = overrides;
+    const message = {
+      id: 42,
+      sender: "+15555550123",
+      text: "ok",
+      is_from_me: false,
+      is_group: false,
+      ...messageOverrides,
+    };
+    const messageText = restOverrides.messageText ?? message.text ?? "";
+    const bodyText = restOverrides.bodyText ?? messageText;
+    return resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      opts: undefined,
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      selfChatCache: undefined,
+      logVerbose: undefined,
+      ...restOverrides,
+      message,
+      messageText,
+      bodyText,
+    });
+  }
+
+  it('drops messages with text starting with "Loved"', () => {
+    const decision = resolveDecision({
+      message: { text: 'Loved \u201cHey there\u201d' },
+      messageText: 'Loved \u201cHey there\u201d',
+      bodyText: 'Loved \u201cHey there\u201d',
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it('drops messages with text starting with "Liked"', () => {
+    const decision = resolveDecision({
+      message: { text: 'Liked \u201cSounds good\u201d' },
+      messageText: 'Liked \u201cSounds good\u201d',
+      bodyText: 'Liked \u201cSounds good\u201d',
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it('drops messages with text starting with "Laughed at"', () => {
+    const decision = resolveDecision({
+      message: { text: 'Laughed at \u201clol\u201d' },
+      messageText: 'Laughed at \u201clol\u201d',
+      bodyText: 'Laughed at \u201clol\u201d',
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it('drops messages with text starting with "Emphasized"', () => {
+    const decision = resolveDecision({
+      message: { text: 'Emphasized \u201cImportant\u201d' },
+      messageText: 'Emphasized \u201cImportant\u201d',
+      bodyText: 'Emphasized \u201cImportant\u201d',
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it('drops messages with text starting with "Questioned"', () => {
+    const decision = resolveDecision({
+      message: { text: 'Questioned \u201cReally?\u201d' },
+      messageText: 'Questioned \u201cReally?\u201d',
+      bodyText: 'Questioned \u201cReally?\u201d',
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it("drops removal tapback patterns", () => {
+    const decision = resolveDecision({
+      message: { text: 'Removed a heart from \u201cHello\u201d' },
+      messageText: 'Removed a heart from \u201cHello\u201d',
+      bodyText: 'Removed a heart from \u201cHello\u201d',
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it("drops messages with is_tapback flag", () => {
+    const decision = resolveDecision({
+      message: { text: "some reaction", is_tapback: true },
+      messageText: "some reaction",
+      bodyText: "some reaction",
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it("drops messages with associated_message_type in tapback range", () => {
+    const decision = resolveDecision({
+      message: { text: "reaction", associated_message_type: 2000 },
+      messageText: "reaction",
+      bodyText: "reaction",
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it("does not drop regular messages that happen to start with tapback-like words", () => {
+    const decision = resolveDecision({
+      message: { text: "Loved the movie we watched last night" },
+      messageText: "Loved the movie we watched last night",
+      bodyText: "Loved the movie we watched last night",
+    });
+    // Should NOT be dropped — no quoted portion after the prefix
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("does not drop messages with associated_message_type outside tapback range", () => {
+    const decision = resolveDecision({
+      message: { text: "normal message", associated_message_type: 0 },
+      messageText: "normal message",
+      bodyText: "normal message",
+    });
+    expect(decision.kind).toBe("dispatch");
+  });
+});

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -3,9 +3,11 @@ import { sanitizeTerminalText } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import {
   describeIMessageEchoDropLog,
+  isIMessageTapback,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
+import type { IMessagePayload } from "./types.js";
 
 describe("resolveIMessageInboundDecision echo detection", () => {
   const cfg = {} as OpenClawConfig;
@@ -355,6 +357,28 @@ describe("resolveIMessageInboundDecision command auth", () => {
   });
 });
 
+describe("isIMessageTapback", () => {
+  it("returns true for explicit tapback flag", () => {
+    expect(isIMessageTapback({ is_tapback: true } as IMessagePayload, "hello")).toBe(true);
+  });
+
+  it("returns true for associated_message_type in tapback range", () => {
+    expect(
+      isIMessageTapback({ associated_message_type: 2001 } as IMessagePayload, "hello"),
+    ).toBe(true);
+  });
+
+  it("returns true for text heuristic with quoted tapback body", () => {
+    expect(isIMessageTapback({} as IMessagePayload, 'Loved “Hello”')).toBe(true);
+  });
+
+  it("returns false for normal text that starts with a tapback-like word", () => {
+    expect(isIMessageTapback({} as IMessagePayload, "Loved the movie we watched last night")).toBe(
+      false,
+    );
+  });
+});
+
 describe("resolveIMessageInboundDecision tapback filtering", () => {
   const cfg = {} as OpenClawConfig;
   type InboundDecisionParams = Parameters<typeof resolveIMessageInboundDecision>[0];
@@ -464,6 +488,15 @@ describe("resolveIMessageInboundDecision tapback filtering", () => {
       message: { text: "some reaction", is_tapback: true },
       messageText: "some reaction",
       bodyText: "some reaction",
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
+  it("drops tapback messages even if text is empty", () => {
+    const decision = resolveDecision({
+      message: { text: "", is_tapback: true },
+      messageText: "",
+      bodyText: "",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   describeIMessageEchoDropLog,
   isIMessageTapback,
+  resolveIMessageDebouncedInboundMessage,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
@@ -363,19 +364,74 @@ describe("isIMessageTapback", () => {
   });
 
   it("returns true for associated_message_type in tapback range", () => {
-    expect(
-      isIMessageTapback({ associated_message_type: 2001 } as IMessagePayload, "hello"),
-    ).toBe(true);
+    expect(isIMessageTapback({ associated_message_type: 2001 } as IMessagePayload, "hello")).toBe(
+      true,
+    );
   });
 
   it("returns true for text heuristic with quoted tapback body", () => {
-    expect(isIMessageTapback({} as IMessagePayload, 'Loved “Hello”')).toBe(true);
+    expect(isIMessageTapback({} as IMessagePayload, "Loved “Hello”")).toBe(true);
+  });
+
+  it("returns true for disliked quoted tapback body", () => {
+    expect(isIMessageTapback({} as IMessagePayload, "Disliked “No way”")).toBe(true);
   });
 
   it("returns false for normal text that starts with a tapback-like word", () => {
     expect(isIMessageTapback({} as IMessagePayload, "Loved the movie we watched last night")).toBe(
       false,
     );
+  });
+});
+
+describe("resolveIMessageDebouncedInboundMessage", () => {
+  it("keeps normal text when a tapback is debounced in the same burst", () => {
+    const message = resolveIMessageDebouncedInboundMessage([
+      {
+        id: 100,
+        sender: "+15555550123",
+        text: "Can you check this?",
+      },
+      {
+        id: 101,
+        sender: "+15555550123",
+        text: "Disliked “No way”",
+      },
+    ]);
+
+    expect(message).toMatchObject({
+      id: 100,
+      text: "Can you check this?",
+    });
+  });
+
+  it("combines multiple normal text messages without tapback payloads", () => {
+    const message = resolveIMessageDebouncedInboundMessage([
+      {
+        id: 100,
+        sender: "+15555550123",
+        text: "first",
+      },
+      {
+        id: 101,
+        sender: "+15555550123",
+        text: "Loved “first”",
+      },
+      {
+        id: 102,
+        sender: "+15555550123",
+        text: "second",
+        attachments: [{ original_path: "ignored.png", mime_type: "image/png" }],
+      },
+    ]);
+
+    expect(message).toMatchObject({
+      id: 102,
+      text: "first\nsecond",
+      attachments: null,
+      is_tapback: false,
+      associated_message_type: undefined,
+    });
   });
 });
 
@@ -422,63 +478,63 @@ describe("resolveIMessageInboundDecision tapback filtering", () => {
 
   it('drops messages with text starting with "Loved"', () => {
     const decision = resolveDecision({
-      message: { text: 'Loved \u201cHey there\u201d' },
-      messageText: 'Loved \u201cHey there\u201d',
-      bodyText: 'Loved \u201cHey there\u201d',
+      message: { text: "Loved \u201cHey there\u201d" },
+      messageText: "Loved \u201cHey there\u201d",
+      bodyText: "Loved \u201cHey there\u201d",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 
   it('drops messages with text starting with "Liked"', () => {
     const decision = resolveDecision({
-      message: { text: 'Liked \u201cSounds good\u201d' },
-      messageText: 'Liked \u201cSounds good\u201d',
-      bodyText: 'Liked \u201cSounds good\u201d',
+      message: { text: "Liked \u201cSounds good\u201d" },
+      messageText: "Liked \u201cSounds good\u201d",
+      bodyText: "Liked \u201cSounds good\u201d",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 
   it('drops messages with text starting with "Disliked"', () => {
     const decision = resolveDecision({
-      message: { text: 'Disliked \u201cNo way\u201d' },
-      messageText: 'Disliked \u201cNo way\u201d',
-      bodyText: 'Disliked \u201cNo way\u201d',
+      message: { text: "Disliked \u201cNo way\u201d" },
+      messageText: "Disliked \u201cNo way\u201d",
+      bodyText: "Disliked \u201cNo way\u201d",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 
   it('drops messages with text starting with "Laughed at"', () => {
     const decision = resolveDecision({
-      message: { text: 'Laughed at \u201clol\u201d' },
-      messageText: 'Laughed at \u201clol\u201d',
-      bodyText: 'Laughed at \u201clol\u201d',
+      message: { text: "Laughed at \u201clol\u201d" },
+      messageText: "Laughed at \u201clol\u201d",
+      bodyText: "Laughed at \u201clol\u201d",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 
   it('drops messages with text starting with "Emphasized"', () => {
     const decision = resolveDecision({
-      message: { text: 'Emphasized \u201cImportant\u201d' },
-      messageText: 'Emphasized \u201cImportant\u201d',
-      bodyText: 'Emphasized \u201cImportant\u201d',
+      message: { text: "Emphasized \u201cImportant\u201d" },
+      messageText: "Emphasized \u201cImportant\u201d",
+      bodyText: "Emphasized \u201cImportant\u201d",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 
   it('drops messages with text starting with "Questioned"', () => {
     const decision = resolveDecision({
-      message: { text: 'Questioned \u201cReally?\u201d' },
-      messageText: 'Questioned \u201cReally?\u201d',
-      bodyText: 'Questioned \u201cReally?\u201d',
+      message: { text: "Questioned \u201cReally?\u201d" },
+      messageText: "Questioned \u201cReally?\u201d",
+      bodyText: "Questioned \u201cReally?\u201d",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 
   it("drops removal tapback patterns", () => {
     const decision = resolveDecision({
-      message: { text: 'Removed a heart from \u201cHello\u201d' },
-      messageText: 'Removed a heart from \u201cHello\u201d',
-      bodyText: 'Removed a heart from \u201cHello\u201d',
+      message: { text: "Removed a heart from \u201cHello\u201d" },
+      messageText: "Removed a heart from \u201cHello\u201d",
+      bodyText: "Removed a heart from \u201cHello\u201d",
     });
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
@@ -534,9 +590,9 @@ describe("resolveIMessageInboundDecision tapback filtering", () => {
     // trigger a pairing challenge. But tapbacks should be dropped before
     // that check ever runs.
     const decision = resolveDecision({
-      message: { text: 'Loved \u201cHello\u201d' },
-      messageText: 'Loved \u201cHello\u201d',
-      bodyText: 'Loved \u201cHello\u201d',
+      message: { text: "Loved \u201cHello\u201d" },
+      messageText: "Loved \u201cHello\u201d",
+      bodyText: "Loved \u201cHello\u201d",
       dmPolicy: "pairing",
       allowFrom: [],
     });

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -414,6 +414,15 @@ describe("resolveIMessageInboundDecision tapback filtering", () => {
     expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 
+  it('drops messages with text starting with "Disliked"', () => {
+    const decision = resolveDecision({
+      message: { text: 'Disliked \u201cNo way\u201d' },
+      messageText: 'Disliked \u201cNo way\u201d',
+      bodyText: 'Disliked \u201cNo way\u201d',
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
+  });
+
   it('drops messages with text starting with "Laughed at"', () => {
     const decision = resolveDecision({
       message: { text: 'Laughed at \u201clol\u201d' },
@@ -485,5 +494,19 @@ describe("resolveIMessageInboundDecision tapback filtering", () => {
       bodyText: "normal message",
     });
     expect(decision.kind).toBe("dispatch");
+  });
+
+  it("drops tapback before access control so pairing is not triggered", () => {
+    // With dmPolicy=pairing, a normal message from an unknown sender would
+    // trigger a pairing challenge. But tapbacks should be dropped before
+    // that check ever runs.
+    const decision = resolveDecision({
+      message: { text: 'Loved \u201cHello\u201d' },
+      messageText: 'Loved \u201cHello\u201d',
+      bodyText: 'Loved \u201cHello\u201d',
+      dmPolicy: "pairing",
+      allowFrom: [],
+    });
+    expect(decision).toEqual({ kind: "drop", reason: "tapback reaction" });
   });
 });

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -40,6 +40,68 @@ import { detectReflectedContent } from "./reflection-guard.js";
 import type { SelfChatCache } from "./self-chat-cache.js";
 import type { MonitorIMessageOpts, IMessagePayload } from "./types.js";
 
+// ---------------------------------------------------------------------------
+// Tapback / reaction detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Known iMessage tapback text patterns.
+ * When a user taps a reaction in Messages.app the system inserts a synthetic
+ * message whose text starts with one of these prefixes followed by the quoted
+ * original text (e.g. 'Loved "Hey there"').
+ */
+const TAPBACK_TEXT_PREFIXES: string[] = [
+  // add reactions
+  "loved",
+  "liked",
+  "disliked",
+  "laughed at",
+  "emphasized",
+  "questioned",
+  // remove reactions
+  "removed a heart from",
+  "removed a like from",
+  "removed a dislike from",
+  "removed a laugh from",
+  "removed an emphasis from",
+  "removed a question from",
+];
+
+/**
+ * Detect whether an inbound iMessage is a tapback reaction.
+ *
+ * Uses three signals (any one is sufficient):
+ * 1. `is_tapback` field from imsg (explicit flag)
+ * 2. `associated_message_type` in the 2000-3999 range (Apple's internal codes)
+ * 3. Text starts with a known tapback prefix like "Loved", "Liked", etc.
+ */
+function isIMessageTapback(message: IMessagePayload, bodyText: string): boolean {
+  // Signal 1: explicit tapback flag from imsg v0.5.0+
+  if (message.is_tapback === true) {
+    return true;
+  }
+
+  // Signal 2: associated_message_type in tapback range (2000-3999)
+  const amt = message.associated_message_type;
+  if (typeof amt === "number" && Number.isFinite(amt) && amt >= 2000 && amt < 4000) {
+    return true;
+  }
+
+  // Signal 3: text-based heuristic — matches patterns like 'Loved "..."'
+  const lower = bodyText.toLowerCase();
+  for (const prefix of TAPBACK_TEXT_PREFIXES) {
+    if (lower.startsWith(prefix)) {
+      // Require a quoted portion after the prefix to reduce false positives
+      const afterPrefix = bodyText.slice(prefix.length).trim();
+      if (/^["\u201c]/.test(afterPrefix)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 type IMessageReplyContext = {
   id?: string;
   body: string;
@@ -329,6 +391,16 @@ export function resolveIMessageInboundDecision(params: {
   const mentionRegexes = buildMentionRegexes(params.cfg, route.agentId);
   if (!bodyText) {
     return { kind: "drop", reason: "empty body" };
+  }
+
+  // Tapback / reaction detection: drop tapback messages so they are not
+  // forwarded to the agent as regular text.  This mirrors the filtering
+  // that the BlueBubbles provider already performs via resolveTapbackContext.
+  if (isIMessageTapback(params.message, bodyText)) {
+    params.logVerbose?.(
+      `imessage: dropping tapback reaction: "${sanitizeTerminalText(truncateUtf16Safe(bodyText, 60))}"`,
+    );
+    return { kind: "drop", reason: "tapback reaction" };
   }
 
   const selfChatHit = skipSelfChatHasCheck

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -102,6 +102,49 @@ export function isIMessageTapback(message: IMessagePayload, bodyText: string): b
   return false;
 }
 
+export function resolveIMessageDebouncedInboundMessage(
+  messages: IMessagePayload[],
+): IMessagePayload | null {
+  const last = messages.at(-1);
+  if (!last) {
+    return null;
+  }
+  if (messages.length === 1) {
+    return last;
+  }
+
+  const textMessages = messages.filter((message) => {
+    const text = (message.text ?? "").trim();
+    return text && !isIMessageTapback(message, text);
+  });
+
+  if (textMessages.length === 0) {
+    return last;
+  }
+
+  if (textMessages.length === 1) {
+    return textMessages[0];
+  }
+
+  const lastTextMessage = textMessages.at(-1);
+  if (!lastTextMessage) {
+    return null;
+  }
+
+  const combinedText = textMessages
+    .map((message) => message.text?.trim() ?? "")
+    .filter(Boolean)
+    .join("\n");
+
+  return {
+    ...lastTextMessage,
+    text: combinedText,
+    attachments: null,
+    is_tapback: false,
+    associated_message_type: undefined,
+  };
+}
+
 type IMessageReplyContext = {
   id?: string;
   body: string;

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -75,7 +75,7 @@ const TAPBACK_TEXT_PREFIXES: string[] = [
  * 2. `associated_message_type` in the 2000-3999 range (Apple's internal codes)
  * 3. Text starts with a known tapback prefix like "Loved", "Liked", etc.
  */
-function isIMessageTapback(message: IMessagePayload, bodyText: string): boolean {
+export function isIMessageTapback(message: IMessagePayload, bodyText: string): boolean {
   // Signal 1: explicit tapback flag from imsg v0.5.0+
   if (message.is_tapback === true) {
     return true;
@@ -327,7 +327,7 @@ export function resolveIMessageInboundDecision(params: {
   // control) so they never trigger pairing flows or agent responses.  This
   // mirrors the filtering that the BlueBubbles provider already performs via
   // resolveTapbackContext.
-  if (bodyText && isIMessageTapback(params.message, bodyText)) {
+  if (isIMessageTapback(params.message, bodyText)) {
     params.logVerbose?.(
       `imessage: dropping tapback reaction: "${sanitizeTerminalText(truncateUtf16Safe(bodyText, 60))}"`,
     );

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -323,6 +323,17 @@ export function resolveIMessageInboundDecision(params: {
     return { kind: "drop", reason: "group without chat_id" };
   }
 
+  // Tapback / reaction detection: drop tapback messages early (before access
+  // control) so they never trigger pairing flows or agent responses.  This
+  // mirrors the filtering that the BlueBubbles provider already performs via
+  // resolveTapbackContext.
+  if (bodyText && isIMessageTapback(params.message, bodyText)) {
+    params.logVerbose?.(
+      `imessage: dropping tapback reaction: "${sanitizeTerminalText(truncateUtf16Safe(bodyText, 60))}"`,
+    );
+    return { kind: "drop", reason: "tapback reaction" };
+  }
+
   const groupId = isGroup ? groupIdCandidate : undefined;
   const accessDecision = resolveDmGroupAccessWithLists({
     isGroup,
@@ -391,16 +402,6 @@ export function resolveIMessageInboundDecision(params: {
   const mentionRegexes = buildMentionRegexes(params.cfg, route.agentId);
   if (!bodyText) {
     return { kind: "drop", reason: "empty body" };
-  }
-
-  // Tapback / reaction detection: drop tapback messages so they are not
-  // forwarded to the agent as regular text.  This mirrors the filtering
-  // that the BlueBubbles provider already performs via resolveTapbackContext.
-  if (isIMessageTapback(params.message, bodyText)) {
-    params.logVerbose?.(
-      `imessage: dropping tapback reaction: "${sanitizeTerminalText(truncateUtf16Safe(bodyText, 60))}"`,
-    );
-    return { kind: "drop", reason: "tapback reaction" };
   }
 
   const selfChatHit = skipSelfChatHasCheck

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -47,6 +47,7 @@ import { deliverReplies } from "./deliver.js";
 import { createSentMessageCache } from "./echo-cache.js";
 import {
   buildIMessageInboundContext,
+  isIMessageTapback,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
 import { createLoopRateLimiter } from "./loop-rate-limiter.js";
@@ -218,14 +219,37 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         await handleMessageNow(last.message);
         return;
       }
-      const combinedText = entries
-        .map((entry) => entry.message.text ?? "")
+
+      const textEntries = entries.filter((entry) => {
+        const text = (entry.message.text ?? "").trim();
+        return text && !isIMessageTapback(entry.message, text);
+      });
+
+      if (textEntries.length === 0) {
+        await handleMessageNow(last.message);
+        return;
+      }
+
+      if (textEntries.length === 1) {
+        await handleMessageNow(textEntries[0].message);
+        return;
+      }
+
+      const lastTextEntry = textEntries.at(-1);
+      if (!lastTextEntry) {
+        return;
+      }
+
+      const combinedText = textEntries
+        .map((entry) => entry.message.text?.trim() ?? "")
         .filter(Boolean)
         .join("\n");
       const syntheticMessage: IMessagePayload = {
-        ...last.message,
+        ...lastTextEntry.message,
         text: combinedText,
         attachments: null,
+        is_tapback: false,
+        associated_message_type: undefined,
       };
       await handleMessageNow(syntheticMessage);
     },

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -47,7 +47,7 @@ import { deliverReplies } from "./deliver.js";
 import { createSentMessageCache } from "./echo-cache.js";
 import {
   buildIMessageInboundContext,
-  isIMessageTapback,
+  resolveIMessageDebouncedInboundMessage,
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
 import { createLoopRateLimiter } from "./loop-rate-limiter.js";
@@ -211,47 +211,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       });
     },
     onFlush: async (entries) => {
-      const last = entries.at(-1);
-      if (!last) {
+      const message = resolveIMessageDebouncedInboundMessage(entries.map((entry) => entry.message));
+      if (!message) {
         return;
       }
-      if (entries.length === 1) {
-        await handleMessageNow(last.message);
-        return;
-      }
-
-      const textEntries = entries.filter((entry) => {
-        const text = (entry.message.text ?? "").trim();
-        return text && !isIMessageTapback(entry.message, text);
-      });
-
-      if (textEntries.length === 0) {
-        await handleMessageNow(last.message);
-        return;
-      }
-
-      if (textEntries.length === 1) {
-        await handleMessageNow(textEntries[0].message);
-        return;
-      }
-
-      const lastTextEntry = textEntries.at(-1);
-      if (!lastTextEntry) {
-        return;
-      }
-
-      const combinedText = textEntries
-        .map((entry) => entry.message.text?.trim() ?? "")
-        .filter(Boolean)
-        .join("\n");
-      const syntheticMessage: IMessagePayload = {
-        ...lastTextEntry.message,
-        text: combinedText,
-        attachments: null,
-        is_tapback: false,
-        associated_message_type: undefined,
-      };
-      await handleMessageNow(syntheticMessage);
+      await handleMessageNow(message);
     },
     onError: (err) => {
       runtime.error?.(`imessage debounce flush failed: ${String(err)}`);

--- a/extensions/imessage/src/monitor/parse-notification.ts
+++ b/extensions/imessage/src/monitor/parse-notification.ts
@@ -74,7 +74,9 @@ export function parseIMessageNotification(raw: unknown): IMessagePayload | null 
     !isOptionalString(message.chat_guid) ||
     !isOptionalString(message.chat_name) ||
     !isOptionalStringArray(message.participants) ||
-    !isOptionalBoolean(message.is_group)
+    !isOptionalBoolean(message.is_group) ||
+    !isOptionalBoolean(message.is_tapback) ||
+    !isOptionalNumber(message.associated_message_type)
   ) {
     return null;
   }

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -25,6 +25,9 @@ export type IMessagePayload = {
   chat_name?: string | null;
   participants?: string[] | null;
   is_group?: boolean | null;
+  // Tapback/reaction fields (imsg v0.5.0+)
+  is_tapback?: boolean | null;
+  associated_message_type?: number | null;
 };
 
 export type MonitorIMessageOpts = {


### PR DESCRIPTION
## Summary

Fixes #60274 — iMessage plugin using `imsg rpc` does not filter tapback reactions, causing them to be delivered to the agent as regular text messages.

## Problem

When a user reacts to a message with a tapback (❤️ Loved, 👍 Liked, 😂 Laughed at, ‼️ Emphasized, ❓ Questioned), the iMessage plugin forwards the synthetic tapback message (e.g. `Loved "Hey there"`) to the agent as a regular text message. The agent then responds to it unnecessarily.

The BlueBubbles provider already handles this correctly via `resolveTapbackContext()` + `parseTapbackText()`, but the imsg rpc code path has no tapback detection at all.

## Solution

Added `isIMessageTapback()` detection in `resolveIMessageInboundDecision()` using three signals (any one is sufficient):

1. **`is_tapback` flag** — explicit boolean from imsg v0.5.0+
2. **`associated_message_type`** in the 2000-3999 range — Apple's internal tapback type codes
3. **Text pattern matching** — known prefixes (`Loved`, `Liked`, `Laughed at`, `Emphasized`, `Questioned`, and their removal counterparts) followed by quoted text

The text-based heuristic requires a quoted portion after the prefix (e.g. `Loved "..."`) to avoid false positives on regular messages like `"Loved the movie we watched last night"`.

Detected tapback messages are dropped with reason `"tapback reaction"` and logged at verbose level.

## Changes

- **`types.ts`** — Added `is_tapback` and `associated_message_type` fields to `IMessagePayload`
- **`parse-notification.ts`** — Added validation for the new optional fields
- **`inbound-processing.ts`** — Added `isIMessageTapback()` function and filtering logic
- **`inbound-processing.test.ts`** — Added 9 test cases covering all tapback patterns, the `is_tapback` flag, `associated_message_type` ranges, and false-positive prevention

## Related Issues

- #60446 — Feature: surface tapback events to agent (this PR lays groundwork)
- #39031 — Feature: forward tapback reactions to agent
- #26924 — (closed/stale) Full imsg v0.5.0 integration proposal