### PR TITLE
fix(acpx): add windowsHide to MCP proxy spawn on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,7 @@ Docs: https://docs.openclaw.ai
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - Process tool: show input-wait hints from `log` and `poll` for idle interactive background sessions so operators can inspect stuck CLIs and resume them with existing input actions. Fixes #33957. Thanks @bitloi and @vincentkoc.
 - Shell env/Windows: hide the login-shell environment probe child window so gateway startup and shell-env refreshes do not flash a console on Windows. Fixes #78159. (#78266) Thanks @BradGroux.
+- ACPX/Windows: hide the MCP proxy target child process window on Windows so ACP-backed agents do not flash or fail because of terminal window handling. Fixes #60672. (#60678) Thanks @KChow-ctrl.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
 - Media/host-read: allow buffer-verified ZIP archives in the host-local media validator so agents can send ZIP attachments via the message tool. Fixes #78057. (#78292) Thanks @Linux2010.
 - Gateway/sessions: fast-path already-qualified model refs while building session-list rows so `openclaw sessions` and Control UI session lists avoid heavyweight model resolution on large stores. (#77902) Thanks @ragesaq.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ Docs: https://docs.openclaw.ai
 - Codex: cross-fill missing `thread.id` and `thread.sessionId` before schema validation so live Codex app-server responses that omit `sessionId` no longer fail `thread/start` or `thread/resume`. Fixes #80124. (#80137) Thanks @kagura-agent.
 - Agents/Pi: wait for embedded abort cleanup to settle before releasing the session write lock, preventing follow-up turns from racing previous prompt teardown. (#80239) Thanks @samzong.
 - WhatsApp: downgrade OpenClaw watchdog-triggered Web reconnects from runtime errors to recovery warnings and clear the recovered reconnect status after the next healthy connection. (#77026) Thanks @rubencu.
+- ACPX/Windows: hide the MCP proxy target child process window on Windows so ACP-backed agents do not flash or fail because of terminal window handling. Fixes #60672. (#60678) Thanks @KChow-ctrl.
 
 ## 2026.5.9
 
@@ -281,7 +282,6 @@ Docs: https://docs.openclaw.ai
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - Process tool: show input-wait hints from `log` and `poll` for idle interactive background sessions so operators can inspect stuck CLIs and resume them with existing input actions. Fixes #33957. Thanks @bitloi and @vincentkoc.
 - Shell env/Windows: hide the login-shell environment probe child window so gateway startup and shell-env refreshes do not flash a console on Windows. Fixes #78159. (#78266) Thanks @BradGroux.
-- ACPX/Windows: hide the MCP proxy target child process window on Windows so ACP-backed agents do not flash or fail because of terminal window handling. Fixes #60672. (#60678) Thanks @KChow-ctrl.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
 - Media/host-read: allow buffer-verified ZIP archives in the host-local media validator so agents can send ZIP attachments via the message tool. Fixes #78057. (#78292) Thanks @Linux2010.
 - Gateway/sessions: fast-path already-qualified model refs while building session-list rows so `openclaw sessions` and Control UI session lists avoid heavyweight model resolution on large stores. (#77902) Thanks @ragesaq.

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
@@ -64,6 +64,17 @@ function rewriteLine(line, mcpServers) {
   }
 }
 
+export function createTargetSpawnOptions(platform = process.platform) {
+  const options = {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: process.env,
+  };
+  if (platform === "win32") {
+    options.windowsHide = true;
+  }
+  return options;
+}
+
 function isMainModule() {
   const mainPath = process.argv[1];
   if (!mainPath) {
@@ -75,10 +86,7 @@ function isMainModule() {
 function main() {
   const { targetCommand, mcpServers } = decodePayload(process.argv.slice(2));
   const target = splitCommandLine(targetCommand);
-  const child = spawn(target.command, target.args, {
-    stdio: ["pipe", "pipe", "inherit"],
-    env: process.env,
-  });
+  const child = spawn(target.command, target.args, createTargetSpawnOptions());
 
   if (!child.stdin || !child.stdout) {
     throw new Error("Failed to create MCP proxy stdio pipes");

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { bundledPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -28,6 +29,17 @@ afterEach(async () => {
 });
 
 describe("mcp-proxy", () => {
+  it("hides the target MCP process window on Windows only", async () => {
+    const moduleUrl = pathToFileURL(proxyPath).href;
+    const { createTargetSpawnOptions } = (await import(moduleUrl)) as {
+      createTargetSpawnOptions: (platform?: NodeJS.Platform) => Record<string, unknown>;
+    };
+
+    expect(createTargetSpawnOptions("win32")).toMatchObject({ windowsHide: true });
+    expect(createTargetSpawnOptions("darwin")).not.toHaveProperty("windowsHide");
+    expect(createTargetSpawnOptions("linux")).not.toHaveProperty("windowsHide");
+  });
+
   it("injects configured MCP servers into ACP session bootstrap requests", async () => {
     const echoServerPath = await makeTempScript(
       "echo-server.cjs",

--- a/src/auto-reply/reply/context-treemap.ts
+++ b/src/auto-reply/reply/context-treemap.ts
@@ -1,9 +1,9 @@
 import crypto from "node:crypto";
 import { writeFile } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import zlib from "node:zlib";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { estimateTokensFromChars } from "../../utils/cjk-chars.js";
 
 type Rect = {
@@ -483,7 +483,10 @@ export async function renderContextTreemapPng(params: {
     rgba(51, 65, 85),
     1,
   );
-  const outPath = path.join(os.tmpdir(), `openclaw-context-map-${crypto.randomUUID()}.png`);
+  const outPath = path.join(
+    resolvePreferredOpenClawTmpDir(),
+    `openclaw-context-map-${crypto.randomUUID()}.png`,
+  );
   await writeFile(outPath, encodePng(canvas.data));
   const caption = [
     "Context treemap",


### PR DESCRIPTION
Fixes #60672.

## Summary

- Set `windowsHide: true` for the acpx MCP proxy target process on Windows.
- Keep non-Windows spawn options unchanged.
- Drop the unrelated Feishu and Ollama changes from the original branch.
- Add focused spawn-option coverage and a changelog entry.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm test extensions/acpx/src/runtime-internals/mcp-proxy.test.ts extensions/acpx/src/runtime-internals/mcp-command-line.test.ts` — 6 tests passed
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/acpx/src/runtime-internals/mcp-proxy.mjs extensions/acpx/src/runtime-internals/mcp-proxy.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Notes

`pnpm test:extensions acpx` passed the acpx shard itself (71 tests) but then continued iterating unrelated extension configs with no matching `acpx` test files; I stopped that broad wrapper after the acpx shard completed and used the focused acpx tests plus `check:changed` as the gate.

Live Windows ACP proof was not run from this macOS maintainer workspace; the issue is source-backed and covered by focused regression tests. A `proof: override` label/comment records that maintainer decision.
