### PR TITLE
fix: fail closed for subagent completion routing

### DIFF
--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -211,7 +211,7 @@ export async function resolveSubagentCompletionOrigin(params: {
     eventKind: "task_completion",
     targetSessionKey: params.childSessionKey,
     requester: requesterConversation,
-    failClosed: false,
+    failClosed: true,
   });
   if (route.mode === "bound" && route.binding) {
     const boundTarget = resolveConversationDeliveryTarget({
@@ -430,17 +430,23 @@ async function sendSubagentAnnounceDirectly(params: {
     const completionDirectOrigin = normalizeDeliveryContext(params.completionDirectOrigin);
     const directOrigin = normalizeDeliveryContext(params.directOrigin);
     const requesterSessionOrigin = normalizeDeliveryContext(params.requesterSessionOrigin);
-    // Merge completionDirectOrigin with directOrigin so that missing fields
-    // (channel, to, accountId) fall back to the originating session's
-    // lastChannel / lastTo. Without this, a completion origin that carries a
-    // channel but not a `to` would prevent external delivery.
-    const effectiveDirectOrigin =
-      params.expectsCompletionMessage && completionDirectOrigin
+    const hasCompletionConversationTarget = Boolean(
+      completionDirectOrigin?.to || completionDirectOrigin?.threadId,
+    );
+    // Completion delivery must fail closed when no completion source
+    // conversation exists. Once the completion origin identifies a real
+    // conversation, it may borrow missing paired fields from the originating
+    // session context.
+    const effectiveDirectOrigin = params.expectsCompletionMessage
+      ? completionDirectOrigin && hasCompletionConversationTarget
         ? mergeDeliveryContext(completionDirectOrigin, directOrigin)
-        : directOrigin;
-    const sessionOnlyOrigin = effectiveDirectOrigin?.channel
+        : undefined
+      : directOrigin;
+    const sessionOnlyOrigin = params.expectsCompletionMessage
       ? effectiveDirectOrigin
-      : requesterSessionOrigin;
+      : effectiveDirectOrigin?.channel
+        ? effectiveDirectOrigin
+        : requesterSessionOrigin;
     const deliveryTarget = !params.requesterIsSubagent
       ? resolveExternalBestEffortDeliveryTarget({
           channel: effectiveDirectOrigin?.channel,

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -18,6 +18,7 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import * as piEmbedded from "./pi-embedded-runner/runs.js";
 import { __testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.js";
+import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 import * as agentStep from "./tools/agent-step.js";
 
 type AgentCallRequest = { method?: string; params?: Record<string, unknown> };
@@ -215,6 +216,7 @@ describe("subagent announce formatting", () => {
   beforeEach(() => {
     // OPENCLAW_TEST_FAST is set in beforeAll before module import
     // to ensure the module-level constant picks it up.
+    resetAnnounceQueuesForTests();
     agentSpy
       .mockClear()
       .mockImplementation(async (_req: AgentCallRequest) => ({ runId: "run-main", status: "ok" }));
@@ -787,6 +789,67 @@ describe("subagent announce formatting", () => {
     expect(didAnnounce).toBe(false);
     expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to a bound child thread when completion source conversation is missing", async () => {
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-bound",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-bound",
+        lastChannel: "discord",
+        lastTo: "channel:stale-parent-thread",
+      },
+    };
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "acct-1",
+      listBySession: (targetSessionKey: string) =>
+        targetSessionKey === "agent:main:subagent:test"
+          ? [
+              {
+                bindingId: "discord:acct-1:thread-bound-1",
+                targetSessionKey,
+                targetKind: "subagent",
+                conversation: {
+                  channel: "discord",
+                  accountId: "acct-1",
+                  conversationId: "thread-bound-1",
+                  parentConversationId: "parent-main",
+                },
+                status: "active",
+                boundAt: Date.now(),
+              },
+            ]
+          : [],
+      resolveByConversation: () => null,
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-session-bound-missing-source",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      spawnMode: "session",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy.mock.calls[0]?.[0]).toMatchObject({
+      method: "agent",
+      params: {
+        sessionKey: "agent:main:main",
+        deliver: false,
+      },
+    });
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBeUndefined();
+    expect(call?.params?.to).toBeUndefined();
   });
 
   it("retries direct agent announce on transient channel-unavailable errors", async () => {
@@ -1708,8 +1771,6 @@ describe("subagent announce formatting", () => {
     sessionStore = {
       "agent:main:main": {
         sessionId: "session-collect",
-        lastChannel: "whatsapp",
-        lastTo: "+1555",
         queueMode: "collect",
         queueDebounceMs: 0,
       },
@@ -1723,6 +1784,7 @@ describe("subagent announce formatting", () => {
       childRunId: "run-completion-direct-fallback",
       requesterSessionKey: "main",
       requesterDisplayKey: "main",
+      requesterOrigin: { channel: "whatsapp", to: "+1555" },
       expectsCompletionMessage: true,
       ...defaultOutcomeAnnounce,
     });
@@ -2029,7 +2091,7 @@ describe("subagent announce formatting", () => {
         childRunId: "run-a",
         requesterSessionKey: "main",
         requesterDisplayKey: "main",
-        requesterOrigin: { accountId: "acct-a" },
+        requesterOrigin: { channel: "whatsapp", accountId: "acct-a" },
         ...defaultOutcomeAnnounce,
       }),
       runSubagentAnnounceFlow({
@@ -2037,7 +2099,7 @@ describe("subagent announce formatting", () => {
         childRunId: "run-b",
         requesterSessionKey: "main",
         requesterDisplayKey: "main",
-        requesterOrigin: { accountId: "acct-b" },
+        requesterOrigin: { channel: "whatsapp", accountId: "acct-b" },
         ...defaultOutcomeAnnounce,
       }),
     ]);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -478,7 +478,7 @@ export async function runSubagentAnnounceFlow(params: {
         ? await resolveSubagentCompletionOrigin({
             childSessionKey: params.childSessionKey,
             requesterSessionKey: targetRequesterSessionKey,
-            requesterOrigin: directOrigin,
+            requesterOrigin: targetRequesterOrigin,
             childRunId: params.childRunId,
             spawnMode: params.spawnMode,
             expectsCompletionMessage,

--- a/src/infra/outbound/bound-delivery-router.test.ts
+++ b/src/infra/outbound/bound-delivery-router.test.ts
@@ -105,7 +105,17 @@ describe("bound delivery router", () => {
       expected: {
         binding: null,
         mode: "fallback",
-        reason: "ambiguous-without-requester",
+        reason: "missing-requester",
+      },
+    },
+    {
+      name: "fails closed when requester signal is missing even with a single binding",
+      bindings: [createDiscordBinding(TARGET_SESSION_KEY, "thread-1", 1)],
+      failClosed: true,
+      expected: {
+        binding: null,
+        mode: "fallback",
+        reason: "missing-requester",
       },
     },
     {

--- a/src/infra/outbound/bound-delivery-router.ts
+++ b/src/infra/outbound/bound-delivery-router.ts
@@ -79,6 +79,13 @@ export function createBoundDeliveryRouter(
       }
 
       if (!input.requester) {
+        if (input.failClosed) {
+          return {
+            binding: null,
+            mode: "fallback",
+            reason: "missing-requester",
+          };
+        }
         if (activeBindings.length === 1) {
           return {
             binding: activeBindings[0] ?? null,


### PR DESCRIPTION
## Summary
- fail closed for completion routing when the originating requester conversation cannot be matched
- use the original requester signal, not a merged fallback route, when resolving completion delivery
- add regression coverage for missing-requester bound routing and missing-source completion delivery

## Testing
- pnpm exec vitest run src/infra/outbound/bound-delivery-router.test.ts src/agents/subagent-announce.format.e2e.test.ts
- pnpm exec vitest run src/agents/subagent-announce.timeout.test.ts