### PR TITLE
channels/telegram: fix hasConfiguredState to detect config-file botToken, tokenFile, and accounts

### DIFF
--- a/extensions/telegram/configured-state.ts
+++ b/extensions/telegram/configured-state.ts
@@ -1,6 +1,28 @@
-export function hasTelegramConfiguredState(params: { env?: NodeJS.ProcessEnv }): boolean {
-  return (
+export function hasTelegramConfiguredState(params: {
+  cfg?: {
+    channels?: {
+      telegram?: { botToken?: string; tokenFile?: string; accounts?: Record<string, unknown> };
+    };
+  };
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  if (
     typeof params.env?.TELEGRAM_BOT_TOKEN === "string" &&
     params.env.TELEGRAM_BOT_TOKEN.trim().length > 0
-  );
+  ) {
+    return true;
+  }
+  const tg = params.cfg?.channels?.telegram;
+  if (tg) {
+    if (typeof tg.botToken === "string" && tg.botToken.trim().length > 0) {
+      return true;
+    }
+    if (typeof tg.tokenFile === "string" && tg.tokenFile.trim().length > 0) {
+      return true;
+    }
+    if (tg.accounts && Object.keys(tg.accounts).length > 0) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/config/channel-configured.test.ts
+++ b/src/config/channel-configured.test.ts
@@ -4,13 +4,20 @@ import { isChannelConfigured } from "./channel-configured.js";
 vi.mock("../channels/plugins/configured-state.js", () => ({
   hasBundledChannelConfiguredState: ({
     channelId,
+    cfg,
     env,
   }: {
     channelId: string;
+    cfg?: { channels?: { telegram?: { botToken?: string; tokenFile?: string; accounts?: Record<string, unknown> } } };
     env?: NodeJS.ProcessEnv;
   }) => {
     if (channelId === "telegram") {
-      return Boolean(env?.TELEGRAM_BOT_TOKEN);
+      if (env?.TELEGRAM_BOT_TOKEN) return true;
+      const tg = cfg?.channels?.telegram;
+      if (tg?.botToken) return true;
+      if (tg?.tokenFile) return true;
+      if (tg?.accounts && Object.keys(tg.accounts).length > 0) return true;
+      return false;
     }
     if (channelId === "discord") {
       return Boolean(env?.DISCORD_BOT_TOKEN);
@@ -42,6 +49,32 @@ vi.mock("../channels/plugins/bootstrap-registry.js", () => ({
 describe("isChannelConfigured", () => {
   it("detects Telegram env configuration through the package metadata seam", () => {
     expect(isChannelConfigured({}, "telegram", { TELEGRAM_BOT_TOKEN: "token" })).toBe(true);
+  });
+
+  it("detects Telegram config-file botToken through the channel plugin seam", () => {
+    expect(
+      isChannelConfigured({ channels: { telegram: { botToken: "123:ABC" } } }, "telegram", {}),
+    ).toBe(true);
+  });
+
+  it("detects Telegram config-file tokenFile through the channel plugin seam", () => {
+    expect(
+      isChannelConfigured(
+        { channels: { telegram: { tokenFile: "/etc/telegram.token" } } },
+        "telegram",
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it("detects Telegram config-file accounts through the channel plugin seam", () => {
+    expect(
+      isChannelConfigured(
+        { channels: { telegram: { accounts: { bot1: { botToken: "123:ABC" } } } } },
+        "telegram",
+        {},
+      ),
+    ).toBe(true);
   });
 
   it("detects Discord env configuration through the package metadata seam", () => {


### PR DESCRIPTION
Fixes #60646

## Summary

- `hasConfiguredState` in `extensions/telegram/contract-surfaces.ts` only checked the `TELEGRAM_BOT_TOKEN` env var, ignoring `botToken`, `tokenFile`, and `accounts` set via config file
- This caused `isChannelConfigured()` to return `false` for config-file-only Telegram setups, which made `shouldLoadChannelPluginInSetupRuntime()` treat the channel as unconfigured — resulting in an empty status table
- Fix: extend `hasConfiguredState` to also check `cfg.channels.telegram.botToken`, `tokenFile`, and `accounts`
- Added three new tests to `src/config/channel-configured.test.ts` covering each config-file detection path

## Test plan

- [ ] `pnpm test src/config/channel-configured.test.ts` — all new cases pass
- [ ] Manual: set `channels.telegram.botToken` in config (no env var) → channels table populates correctly in `openclaw channels status`