### PR TITLE
docs: add managed relay services to iMessage channel docs

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -411,6 +411,42 @@ imsg send <handle> "test"
   </Accordion>
 </AccordionGroup>
 
+## Managed relay services
+
+If you don't want to maintain a Mac or BlueBubbles server, managed relay services handle the Apple infrastructure and expose iMessage over a standard API.
+
+| Service | Protocol | Mac required | Starting price | OpenClaw plugin |
+|---------|----------|-------------|---------------|-----------------|
+| [Claw Messenger](https://clawmessenger.com) | WebSocket | No | $5/mo | `@emotion-machine/claw-messenger` |
+| [Blooio](https://blooio.com) | REST API | No | $39/mo | Community |
+
+### Claw Messenger
+
+WebSocket-based relay designed for OpenClaw agents. Provides a dedicated phone number for iMessage, RCS, and SMS.
+
+```bash
+openclaw plugins install @emotion-machine/claw-messenger
+```
+
+```jsonc
+// ~/.openclaw/openclaw.json
+{
+  "channels": {
+    "claw-messenger": {
+      "enabled": true,
+      "apiKey": "cm_live_xxxxxxxxxxxxxxxx",
+      "serverUrl": "wss://claw-messenger.onrender.com"
+    }
+  }
+}
+```
+
+### Blooio
+
+REST API service using iPhone hardware bridges. Supports iMessage, RCS, and SMS with OAuth authentication. No official OpenClaw plugin yet, but can be integrated via the REST API and a custom channel handler.
+
+See [blooio.com/integrations/api](https://blooio.com/integrations/api) for their API docs.
+
 ## Configuration reference pointers
 
 - [Configuration reference - iMessage](/gateway/configuration-reference#imessage)

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -417,8 +417,14 @@ If you don't want to maintain a Mac or BlueBubbles server, managed relay service
 
 | Service | Protocol | Mac required | Starting price | OpenClaw plugin |
 |---------|----------|-------------|---------------|-----------------|
-| [Claw Messenger](https://clawmessenger.com) | WebSocket | No | $5/mo | `@emotion-machine/claw-messenger` |
 | [Blooio](https://blooio.com) | REST API | No | $39/mo | Community |
+| [Claw Messenger](https://clawmessenger.com) | WebSocket | No | $5/mo | `@emotion-machine/claw-messenger` |
+
+### Blooio
+
+REST API service for iMessage, RCS, and SMS. Supports OAuth (Bearer token) authentication. No official OpenClaw plugin yet, but can be integrated via the REST API and a custom channel handler.
+
+See [blooio.com/integrations/api](https://blooio.com/integrations/api) for API docs.
 
 ### Claw Messenger
 
@@ -442,12 +448,6 @@ openclaw plugins install @emotion-machine/claw-messenger
 ```
 
 See [clawmessenger.com](https://clawmessenger.com) for pricing and docs.
-
-### Blooio
-
-REST API service using iPhone hardware bridges. Supports iMessage, RCS, and SMS with OAuth authentication. No official OpenClaw plugin, but can be integrated via the REST API and a custom channel handler.
-
-See [blooio.com/integrations/api](https://blooio.com/integrations/api) for API docs.
 
 ## Configuration reference pointers
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -413,7 +413,7 @@ imsg send <handle> "test"
 
 ## Managed relay services
 
-If you don't want to maintain a Mac or BlueBubbles server, managed relay services handle the Apple infrastructure and expose iMessage over a standard API.
+If you don't want to maintain a Mac or BlueBubbles server, managed relay services handle the Apple infrastructure and expose iMessage over a standard API. These work on Linux, Windows, VPS, and Docker without any Apple hardware on your end.
 
 | Service | Protocol | Mac required | Starting price | OpenClaw plugin |
 |---------|----------|-------------|---------------|-----------------|
@@ -441,11 +441,13 @@ openclaw plugins install @emotion-machine/claw-messenger
 }
 ```
 
+See [clawmessenger.com](https://clawmessenger.com) for pricing and docs.
+
 ### Blooio
 
-REST API service using iPhone hardware bridges. Supports iMessage, RCS, and SMS with OAuth authentication. No official OpenClaw plugin yet, but can be integrated via the REST API and a custom channel handler.
+REST API service using iPhone hardware bridges. Supports iMessage, RCS, and SMS with OAuth authentication. No official OpenClaw plugin, but can be integrated via the REST API and a custom channel handler.
 
-See [blooio.com/integrations/api](https://blooio.com/integrations/api) for their API docs.
+See [blooio.com/integrations/api](https://blooio.com/integrations/api) for API docs.
 
 ## Configuration reference pointers
 


### PR DESCRIPTION
## Summary

Adds a **Managed relay services** section to `docs/channels/imessage.md`, documenting two Mac-free alternatives for iMessage integration:

- **Blooio** — REST API service for iMessage, RCS, and SMS
- **Claw Messenger** — WebSocket-based relay with an official OpenClaw plugin

This gives Linux, VPS, and Docker users a path to iMessage without maintaining Apple hardware.

## Disclosure

I am the maintainer of Claw Messenger (Emotion Machine). This PR documents both Claw Messenger and Blooio as alternatives, ordered alphabetically per project style guide. The descriptions aim to be neutral and factual.

## Changes

- New "Managed relay services" section after the existing iMessage setup docs
- Comparison table (alphabetical: Blooio, then Claw Messenger)
- Setup instructions for the `@emotion-machine/claw-messenger` plugin
- Links to Blooio API docs

Docs-only change, no code impact.