### PR TITLE
fix: resolve startedAt timestamp inversion in task registry

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -711,7 +711,7 @@ export class AcpSessionManager {
               })
             : null;
         if (taskContext) {
-          this.createBackgroundTaskRecord(taskContext, turnStartedAt);
+          this.createBackgroundTaskRecord(taskContext);
         }
         let taskProgressSummary = "";
         for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -1896,7 +1896,7 @@ export class AcpSessionManager {
     };
   }
 
-  private createBackgroundTaskRecord(context: BackgroundTaskContext, startedAt: number): void {
+  private createBackgroundTaskRecord(context: BackgroundTaskContext): void {
     try {
       createRunningTaskRun({
         runtime: "acp",
@@ -1908,7 +1908,6 @@ export class AcpSessionManager {
         runId: context.runId,
         label: context.label,
         task: context.task,
-        startedAt,
       });
     } catch (error) {
       logVerbose(

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1075,7 +1075,6 @@ export async function spawnAcpDirect(
         task: params.task,
         preferMetadata: true,
         deliveryStatus: requesterInternalKey.trim() ? "pending" : "parent_missing",
-        startedAt: Date.now(),
       });
     } catch (error) {
       log.warn("Failed to create background task for ACP spawn", {
@@ -1107,7 +1106,6 @@ export async function spawnAcpDirect(
       task: params.task,
       preferMetadata: true,
       deliveryStatus: requesterInternalKey.trim() ? "pending" : "parent_missing",
-      startedAt: Date.now(),
     });
   } catch (error) {
     log.warn("Failed to create background task for ACP spawn", {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -338,7 +338,6 @@ export function createSubagentRunManager(params: {
         task: registerParams.task,
         deliveryStatus:
           registerParams.expectsCompletionMessage === false ? "not_applicable" : "pending",
-        startedAt: now,
         lastEventAt: now,
       });
     } catch (error) {

--- a/src/cron/service/cron-timestamp.test.ts
+++ b/src/cron/service/cron-timestamp.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { createRunningTaskRun } from "../../tasks/task-executor.js";
+import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
+
+describe("Cron Task Timestamp Invariants", () => {
+  afterEach(() => {
+    resetTaskRegistryForTests();
+  });
+
+  it("cron tasks explicitly passing startedAt automatically clamp startedAt >= createdAt", async () => {
+    const originalDateNow = globalThis.Date.now;
+
+    const startOfTime = Date.parse("2026-03-23T12:00:00.000Z");
+
+    globalThis.Date.now = () => startOfTime + 5;
+
+    const runId = "cron:test:run-123";
+    createRunningTaskRun({
+      runtime: "cron",
+      sourceId: "test",
+      ownerKey: "system",
+      scopeKind: "session",
+      requesterOrigin: undefined,
+      runId,
+      label: "Test cron task",
+      task: "Doing work",
+      startedAt: startOfTime,
+    });
+
+    const task = findTaskByRunId(runId);
+    expect(task).toBeDefined();
+
+    expect(task!.createdAt).toBe(startOfTime + 5);
+
+    expect(task!.startedAt).toBeGreaterThanOrEqual(task!.createdAt);
+    expect(task!.startedAt).toBe(startOfTime + 5);
+
+    globalThis.Date.now = originalDateNow;
+  });
+
+  it("default execution handlers implicitly receive startedAt identical to createdAt", async () => {
+    const originalDateNow = globalThis.Date.now;
+
+    const startOfTime = Date.parse("2026-03-23T12:00:00.000Z");
+    globalThis.Date.now = () => startOfTime;
+
+    const runId = "subagent:test:run-123";
+    createRunningTaskRun({
+      runtime: "subagent",
+      sourceId: "test",
+      ownerKey: "system",
+      scopeKind: "session",
+      requesterOrigin: undefined,
+      runId,
+      label: "Test subagent task",
+      task: "Doing work",
+    });
+
+    const task = findTaskByRunId(runId);
+    expect(task).toBeDefined();
+
+    expect(task!.createdAt).toBe(startOfTime);
+    expect(task!.startedAt).toBeGreaterThanOrEqual(task!.createdAt);
+    expect(task!.startedAt).toBe(startOfTime);
+
+    globalThis.Date.now = originalDateNow;
+  });
+});

--- a/src/tasks/cron-timestamp.test.ts
+++ b/src/tasks/cron-timestamp.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, afterEach } from "vitest";
-import { createRunningTaskRun } from "../../tasks/task-executor.js";
-import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
+import { createRunningTaskRun } from "./task-executor.js";
+import { findTaskByRunId, resetTaskRegistryForTests } from "./task-registry.js";
 
 describe("Cron Task Timestamp Invariants", () => {
+  const originalDateNow = globalThis.Date.now;
+
   afterEach(() => {
+    globalThis.Date.now = originalDateNow;
     resetTaskRegistryForTests();
   });
 
-  it("cron tasks explicitly passing startedAt automatically clamp startedAt >= createdAt", async () => {
-    const originalDateNow = globalThis.Date.now;
+  it("cron tasks explicitly passing startedAt automatically clamp startedAt >= createdAt", () => {
 
     const startOfTime = Date.parse("2026-03-23T12:00:00.000Z");
 
@@ -35,11 +37,9 @@ describe("Cron Task Timestamp Invariants", () => {
     expect(task!.startedAt).toBeGreaterThanOrEqual(task!.createdAt);
     expect(task!.startedAt).toBe(startOfTime + 5);
 
-    globalThis.Date.now = originalDateNow;
   });
 
-  it("default execution handlers implicitly receive startedAt identical to createdAt", async () => {
-    const originalDateNow = globalThis.Date.now;
+  it("default execution handlers implicitly receive startedAt identical to createdAt", () => {
 
     const startOfTime = Date.parse("2026-03-23T12:00:00.000Z");
     globalThis.Date.now = () => startOfTime;
@@ -63,6 +63,5 @@ describe("Cron Task Timestamp Invariants", () => {
     expect(task!.startedAt).toBeGreaterThanOrEqual(task!.createdAt);
     expect(task!.startedAt).toBe(startOfTime);
 
-    globalThis.Date.now = originalDateNow;
   });
 });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1412,9 +1412,15 @@ export function createTaskRecord(params: {
   if (existing) {
     return mergeExistingTaskForCreate(existing, params);
   }
-  const now = Date.now();
+  const createdAt = Date.now();
   const taskId = crypto.randomUUID();
   const status = normalizeTaskStatus(params.status);
+  const startedAt =
+    params.startedAt !== undefined
+      ? Math.max(createdAt, params.startedAt)
+      : status === "running"
+        ? createdAt
+        : undefined;
   const deliveryStatus =
     params.deliveryStatus ??
     ensureDeliveryStatus({
@@ -1427,7 +1433,7 @@ export function createTaskRecord(params: {
     ownerKey,
     scopeKind,
   });
-  const lastEventAt = params.lastEventAt ?? params.startedAt ?? now;
+  const lastEventAt = params.lastEventAt ?? startedAt ?? createdAt;
   const record: TaskRecord = {
     taskId,
     runtime: params.runtime,
@@ -1445,8 +1451,8 @@ export function createTaskRecord(params: {
     status,
     deliveryStatus,
     notifyPolicy,
-    createdAt: now,
-    startedAt: params.startedAt,
+    createdAt,
+    startedAt,
     lastEventAt,
     cleanupAfter: params.cleanupAfter,
     progressSummary: normalizeTaskSummary(params.progressSummary),
@@ -1515,9 +1521,17 @@ function updateTaskStateByRunId(params: {
     const eventAt = params.lastEventAt ?? params.endedAt ?? Date.now();
     if (params.status) {
       patch.status = normalizeTaskStatus(params.status);
+      if (
+        patch.status === "running" &&
+        current.status !== "running" &&
+        current.startedAt == null &&
+        params.startedAt == null
+      ) {
+        patch.startedAt = eventAt;
+      }
     }
     if (params.startedAt != null) {
-      patch.startedAt = params.startedAt;
+      patch.startedAt = Math.max(current.createdAt, params.startedAt);
     }
     if (params.endedAt != null) {
       patch.endedAt = params.endedAt;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1204,9 +1204,13 @@ export function setTaskTimingById(params: {
   lastEventAt?: number;
 }): TaskRecord | null {
   ensureTaskRegistryReady();
+  const existing = getTaskById(params.taskId);
+  if (!existing) {
+    return null;
+  }
   const patch: Partial<TaskRecord> = {};
   if (params.startedAt != null) {
-    patch.startedAt = params.startedAt;
+    patch.startedAt = Math.max(existing.createdAt, params.startedAt);
   }
   if (params.endedAt != null) {
     patch.endedAt = params.endedAt;


### PR DESCRIPTION
## Summary

- Problem: Task metadata records show `startedAt < createdAt` because callers assign `startedAt = Date.now()` prematurely before the registry inserts the record.
- Why it matters: This logic invalidates chronological order, breaking observability/audit tools that expect strict `startedAt >= createdAt` invariants.
- What changed: Moved `startedAt` default generation directly into [task-registry.ts](cci:7://file:///home/akram/openclaw/src/tasks/task-registry.ts:0:0-0:0) at the exact point of execution insertion. Clamped explicitly passed `startedAt` values (like from `cron`) safely via `Math.max(createdAt, startedAt)`.
- What did NOT change: `createdAt` assignment logic remained completely immutable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60632
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Race conditions springing from execution handlers manually injecting `Date.now()` into `startedAt` fractions of a millisecond prior to the database/registry generating `createdAt`.
- Missing detection / guardrail: No system-level validation checked if `startedAt >= createdAt` before assignment.
- Contributing context (if known): Cron jobs must calculate their theoretical timing prior to their insertion tick.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: [src/cron/service/cron-timestamp.test.ts](cci:7://file:///home/akram/openclaw/src/cron/service/cron-timestamp.test.ts:0:0-0:0)
- Scenario the test should lock in: Mocking `Date.now()` moving forward between payload generation and registry insertion, ensuring bounds are clamped correctly.
- Why this is the smallest reliable guardrail: Simulates exactly the timeline delay identified in local auditing.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[Runner eval: T] -> [Registry Insert: T+2] -> [Result: startedAt=T, createdAt=T+2 (Invalid)]

After:
[Runner eval: T] -> [Registry Insert: T+2] -> [Result: startedAt=T+2, createdAt=T+2 (Valid)]
