### PR TITLE
feat(cron): enable message tool for cron-owned runs with rich delivery support

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -60,4 +60,18 @@ describe("extractMessagingToolSend", () => {
     expect(result?.provider).toBe("telegram");
     expect(result?.to).toBe("telegram:123");
   });
+
+  it("captures threadId for message tool sends", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      channel: "telegram",
+      to: "123",
+      threadId: 42,
+    });
+
+    expect(result?.tool).toBe("message");
+    expect(result?.provider).toBe("telegram");
+    expect(result?.to).toBe("telegram:123");
+    expect(result?.threadId).toBe("42");
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -5,6 +5,7 @@ import { pluginRegistrationContractRegistry } from "../plugins/contracts/registr
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
+  normalizeOptionalStringifiedId,
   readStringValue,
 } from "../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../utils.js";
@@ -391,6 +392,7 @@ export function extractMessagingToolSend(
   // Provider docking: new provider tools must implement plugin.actions.extractToolSend.
   const action = normalizeOptionalString(args.action) ?? "";
   const accountId = normalizeOptionalString(args.accountId);
+  const threadId = normalizeOptionalStringifiedId(args.threadId);
   if (toolName === "message") {
     if (action !== "send" && action !== "thread-reply") {
       return undefined;
@@ -405,7 +407,7 @@ export function extractMessagingToolSend(
     const providerId = providerHint ? normalizeChannelId(providerHint) : null;
     const provider = providerId ?? normalizeOptionalLowercaseString(providerHint) ?? "message";
     const to = normalizeTargetForProvider(provider, toRaw);
-    return to ? { tool: toolName, provider, accountId, to } : undefined;
+    return to ? { tool: toolName, provider, accountId, to, threadId } : undefined;
   }
   const providerId = normalizeChannelId(toolName);
   if (!providerId) {
@@ -418,11 +420,12 @@ export function extractMessagingToolSend(
   }
   const to = normalizeTargetForProvider(providerId, extracted.to);
   return to
-    ? {
-        tool: toolName,
-        provider: providerId,
-        accountId: extracted.accountId ?? accountId,
-        to,
-      }
+      ? {
+          tool: toolName,
+          provider: providerId,
+          accountId: extracted.accountId ?? accountId,
+          threadId: extracted.threadId ?? threadId,
+          to,
+        }
     : undefined;
 }

--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -50,7 +50,7 @@ describe("matchesMessagingToolDeliveryTarget", () => {
     expect(
       matchesMessagingToolDeliveryTarget(
         { provider: "telegram", to: "-1003597428309:topic:462" },
-        { channel: "telegram", to: "-1003597428309" },
+        { channel: "telegram", to: "-1003597428309", threadId: 462 },
       ),
     ).toBe(true);
   });
@@ -69,6 +69,24 @@ describe("matchesMessagingToolDeliveryTarget", () => {
       matchesMessagingToolDeliveryTarget(
         { provider: "telegram", to: "123456", accountId: "bot-a" },
         { channel: "telegram", to: "123456", accountId: "bot-b" },
+      ),
+    ).toBe(false);
+  });
+
+  it("matches when threadIds agree", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "123456", threadId: "42" },
+        { channel: "telegram", to: "123456", threadId: 42 },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects when threadIds differ", () => {
+    expect(
+      matchesMessagingToolDeliveryTarget(
+        { provider: "telegram", to: "123456", threadId: "43" },
+        { channel: "telegram", to: "123456", threadId: 42 },
       ),
     ).toBe(false);
   });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -12,6 +12,7 @@ import type { OutboundDeliveryResult } from "../../infra/outbound/deliver.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import {
   normalizeLowercaseStringOrEmpty,
+  normalizeOptionalStringifiedId,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
@@ -27,9 +28,21 @@ function normalizeDeliveryTarget(channel: string, to: string): string {
   return normalizeTargetForProvider(channel, toTrimmed) ?? toTrimmed;
 }
 
+function resolveMessagingTargetThreadId(params: {
+  to?: string;
+  threadId?: string | number;
+}): string | undefined {
+  const explicitThreadId = normalizeOptionalStringifiedId(params.threadId);
+  if (explicitThreadId) {
+    return explicitThreadId;
+  }
+  const topicThreadId = normalizeOptionalString(params.to)?.match(/:topic:(\d+)$/i)?.[1];
+  return normalizeOptionalStringifiedId(topicThreadId);
+}
+
 export function matchesMessagingToolDeliveryTarget(
-  target: { provider?: string; to?: string; accountId?: string },
-  delivery: { channel?: string; to?: string; accountId?: string },
+  target: { provider?: string; to?: string; accountId?: string; threadId?: string | number },
+  delivery: { channel?: string; to?: string; accountId?: string; threadId?: string | number },
 ): boolean {
   if (!delivery.channel || !delivery.to || !target.to) {
     return false;
@@ -40,6 +53,11 @@ export function matchesMessagingToolDeliveryTarget(
     return false;
   }
   if (target.accountId && delivery.accountId && target.accountId !== delivery.accountId) {
+    return false;
+  }
+  const normalizedTargetThreadId = resolveMessagingTargetThreadId(target);
+  const normalizedDeliveryThreadId = normalizeOptionalStringifiedId(delivery.threadId);
+  if (normalizedTargetThreadId !== normalizedDeliveryThreadId) {
     return false;
   }
   // Strip :topic:NNN from message targets and normalize Feishu/Lark prefixes on

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -139,7 +139,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     );
   });
 
-  it("skips cron delivery when a shared caller already sent to the same target", async () => {
+  it("does not skip cron delivery when the message tool send is not the final handoff", async () => {
     mockRunCronFallbackPassthrough();
     const params = makeParams();
     const job = {
@@ -158,6 +158,45 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
     runEmbeddedPiAgentMock.mockResolvedValue({
       payloads: [{ text: "sent" }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTargets: [{ tool: "message", provider: "telegram", to: "123" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...params,
+      deliveryContract: "shared",
+      job: job as never,
+    });
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledTimes(1);
+    expect(dispatchCronDeliveryMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        deliveryRequested: true,
+        skipMessagingToolDelivery: false,
+      }),
+    );
+  });
+
+  it("skips cron delivery only when the message tool handled the final reply", async () => {
+    mockRunCronFallbackPassthrough();
+    const params = makeParams();
+    const job = {
+      id: "message-tool-policy",
+      name: "Message Tool Policy",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "send a message" },
+      delivery: { mode: "announce", channel: "telegram", to: "123" },
+    } as const;
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "NO_REPLY" }],
       didSendViaMessagingTool: true,
       messagingToolSentTargets: [{ tool: "message", provider: "telegram", to: "123" }],
       meta: { agentMeta: { usage: { input: 10, output: 20 } } },
@@ -215,6 +254,35 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(prompt).toContain('channel to "telegram"');
     expect(prompt).toContain('target to "123"');
     expect(prompt).toContain("NO_REPLY");
+  });
+
+  it("serializes delivery target values and includes threadId in the instruction", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      threadId: "topic-42",
+      accountId: "acc-7",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: 'tele"gram',
+      to: '12\n3',
+      threadId: 'topic"42',
+      accountId: "acc\n7",
+      error: undefined,
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const prompt: string = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.prompt ?? "";
+    expect(prompt).toContain(`channel to ${JSON.stringify('tele"gram')}`);
+    expect(prompt).toContain(`target to ${JSON.stringify('12\n3')}`);
+    expect(prompt).toContain(`with threadId ${JSON.stringify('topic"42')}`);
+    expect(prompt).toContain(`with accountId ${JSON.stringify("acc\n7")}`);
   });
 
   it("does not append a delivery instruction when delivery is not requested", async () => {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -216,6 +216,106 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       }),
     );
   });
+
+  it("does not skip cron delivery when the message tool sent to a different thread", async () => {
+    mockRunCronFallbackPassthrough();
+    const params = makeParams();
+    const job = {
+      id: "message-tool-policy",
+      name: "Message Tool Policy",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "send a message" },
+      delivery: { mode: "announce", channel: "telegram", to: "123", threadId: "topic-42" },
+    } as const;
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      threadId: "topic-42",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "telegram",
+      to: "123",
+      threadId: "topic-42",
+      accountId: undefined,
+      error: undefined,
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "NO_REPLY" }],
+      didSendViaMessagingTool: true,
+      messagingToolSentTargets: [
+        { tool: "message", provider: "telegram", to: "123", threadId: "topic-99" },
+      ],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...params,
+      deliveryContract: "shared",
+      job: job as never,
+    });
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledTimes(1);
+    expect(dispatchCronDeliveryMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        deliveryRequested: true,
+        skipMessagingToolDelivery: false,
+      }),
+    );
+  });
+
+  it("skips cron delivery for media-only final handoff when NO_REPLY matches the delivery target", async () => {
+    mockRunCronFallbackPassthrough();
+    const params = makeParams();
+    const job = {
+      id: "message-tool-policy",
+      name: "Message Tool Policy",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "send a message" },
+      delivery: { mode: "announce", channel: "telegram", to: "123", threadId: "topic-42" },
+    } as const;
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+      threadId: "topic-42",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "telegram",
+      to: "123",
+      threadId: "topic-42",
+      accountId: undefined,
+      error: undefined,
+    });
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "NO_REPLY" }],
+      didSendViaMessagingTool: false,
+      messagingToolSentTargets: [
+        { tool: "message", provider: "telegram", to: "123", threadId: "topic-42" },
+      ],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...params,
+      deliveryContract: "shared",
+      job: job as never,
+    });
+
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledTimes(1);
+    expect(dispatchCronDeliveryMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        deliveryRequested: true,
+        skipMessagingToolDelivery: true,
+      }),
+    );
+  });
 });
 
 describe("runCronIsolatedAgentTurn delivery instruction", () => {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -34,19 +34,6 @@ function makeParams() {
 describe("runCronIsolatedAgentTurn message tool policy", () => {
   let previousFastTestEnv: string | undefined;
 
-  async function expectMessageToolDisabledForPlan(plan: {
-    requested: boolean;
-    mode: "none" | "announce";
-    channel?: string;
-    to?: string;
-  }) {
-    mockRunCronFallbackPassthrough();
-    resolveCronDeliveryPlanMock.mockReturnValue(plan);
-    await runCronIsolatedAgentTurn(makeParams());
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
-    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.disableMessageTool).toBe(true);
-  }
-
   beforeEach(() => {
     previousFastTestEnv = clearFastTestEnv();
     resetRunCronIsolatedAgentTurnHarness();
@@ -63,20 +50,46 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it('disables the message tool when delivery.mode is "none"', async () => {
-    await expectMessageToolDisabledForPlan({
+  it("keeps the message tool enabled for cron-owned runs regardless of delivery mode", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
       requested: false,
       mode: "none",
     });
+    await runCronIsolatedAgentTurn(makeParams());
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.disableMessageTool).toBe(false);
   });
 
-  it("disables the message tool when cron delivery is active", async () => {
-    await expectMessageToolDisabledForPlan({
+  it("keeps the message tool enabled for cron-owned runs when delivery is active", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
       mode: "announce",
       channel: "telegram",
       to: "123",
     });
+    await runCronIsolatedAgentTurn(makeParams());
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.disableMessageTool).toBe(false);
+  });
+
+  it("disables the message tool for shared callers when delivery is requested", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      deliveryContract: "shared",
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.disableMessageTool).toBe(true);
   });
 
   it("keeps the message tool enabled for shared callers when delivery is not requested", async () => {
@@ -185,7 +198,7 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it("appends a plain-text delivery instruction to the prompt when delivery is requested", async () => {
+  it("appends an explicit delivery target instruction when delivery is requested", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
@@ -198,8 +211,10 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
 
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     const prompt: string = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.prompt ?? "";
-    expect(prompt).toContain("Return your response as plain text");
-    expect(prompt).toContain("it will be delivered automatically");
+    expect(prompt).toContain("When using the message tool for this cron delivery");
+    expect(prompt).toContain('channel to "telegram"');
+    expect(prompt).toContain('target to "123"');
+    expect(prompt).toContain("NO_REPLY");
   });
 
   it("does not append a delivery instruction when delivery is not requested", async () => {
@@ -210,8 +225,8 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
 
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     const prompt: string = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.prompt ?? "";
-    expect(prompt).not.toContain("Return your response as plain text");
-    expect(prompt).not.toContain("it will be delivered automatically");
+    expect(prompt).not.toContain("When using the message tool for this cron delivery");
+    expect(prompt).not.toContain("NO_REPLY");
   });
 
   it("does not instruct the agent to summarize when delivery is requested", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -131,10 +131,11 @@ function resolveCronToolPolicy(params: {
     // was successfully resolved. When resolution fails the agent should not
     // be blocked by a target it cannot satisfy (#27898).
     requireExplicitMessageTarget: params.deliveryRequested && params.resolvedDelivery.ok,
-    // Cron-owned runs always route user-facing delivery through the runner
-    // itself. Shared callers keep the previous behavior so non-cron paths do
-    // not silently lose the message tool when no explicit delivery is active.
-    disableMessageTool: params.deliveryContract === "cron-owned" ? true : params.deliveryRequested,
+    // Cron-owned runs must keep the message tool available so isolated cron
+    // jobs can explicitly send attachments or richer payloads (for example
+    // Discord media with components). Shared callers keep the previous
+    // delivery-requested behavior.
+    disableMessageTool: params.deliveryContract === "shared" ? params.deliveryRequested : false,
   };
 }
 
@@ -189,11 +190,16 @@ async function resolveCronDeliveryContext(params: {
 function appendCronDeliveryInstruction(params: {
   commandBody: string;
   deliveryRequested: boolean;
+  resolvedDelivery: ResolvedCronDeliveryTarget;
 }) {
   if (!params.deliveryRequested) {
     return params.commandBody;
   }
-  return `${params.commandBody}\n\nReturn your response as plain text; it will be delivered automatically. If the task explicitly calls for messaging a specific external recipient, note who/where it should go instead of sending it yourself.`.trim();
+  const explicitTargetInstruction =
+    params.resolvedDelivery.ok && params.resolvedDelivery.channel && params.resolvedDelivery.to
+      ? `When using the message tool for this cron delivery, set channel to "${params.resolvedDelivery.channel}" and target to "${params.resolvedDelivery.to}"${params.resolvedDelivery.accountId ? ` with accountId "${params.resolvedDelivery.accountId}"` : ""}.`
+      : "When using the message tool for this cron delivery, include an explicit channel and target.";
+  return `${params.commandBody}\n\n${explicitTargetInstruction} Plain-text summaries are delivered automatically only when you do not send the final result yourself. If you use the message tool for the final delivery (for example attachments, media, richer components, or a different recipient), send everything there and then return exactly NO_REPLY.`.trim();
 }
 
 function resolvePositiveContextTokens(value: unknown): number | undefined {
@@ -439,7 +445,11 @@ async function prepareCronRunContext(params: {
   } else {
     commandBody = `${base}\n${timeLine}`.trim();
   }
-  commandBody = appendCronDeliveryInstruction({ commandBody, deliveryRequested });
+  commandBody = appendCronDeliveryInstruction({
+    commandBody,
+    deliveryRequested,
+    resolvedDelivery,
+  });
 
   const skillsSnapshot = await resolveCronSkillsSnapshot({
     workspaceDir,
@@ -652,7 +662,6 @@ async function finalizeCronRun(params: {
     resolveCronDeliveryBestEffort,
   } = await loadCronDeliveryRuntime();
   const skipMessagingToolDelivery =
-    (prepared.input.deliveryContract ?? "cron-owned") === "shared" &&
     prepared.deliveryRequested &&
     finalRunResult.didSendViaMessagingTool === true &&
     (finalRunResult.messagingToolSentTargets ?? []).some((target) =>

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,3 +1,4 @@
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-check.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
@@ -195,11 +196,27 @@ function appendCronDeliveryInstruction(params: {
   if (!params.deliveryRequested) {
     return params.commandBody;
   }
+  const serializedChannel =
+    params.resolvedDelivery.ok && params.resolvedDelivery.channel
+      ? JSON.stringify(params.resolvedDelivery.channel)
+      : undefined;
+  const serializedTarget =
+    params.resolvedDelivery.ok && params.resolvedDelivery.to
+      ? JSON.stringify(params.resolvedDelivery.to)
+      : undefined;
+  const serializedThreadId =
+    params.resolvedDelivery.ok && params.resolvedDelivery.threadId !== undefined
+      ? JSON.stringify(params.resolvedDelivery.threadId)
+      : undefined;
+  const serializedAccountId =
+    params.resolvedDelivery.ok && params.resolvedDelivery.accountId
+      ? JSON.stringify(params.resolvedDelivery.accountId)
+      : undefined;
   const explicitTargetInstruction =
-    params.resolvedDelivery.ok && params.resolvedDelivery.channel && params.resolvedDelivery.to
-      ? `When using the message tool for this cron delivery, set channel to "${params.resolvedDelivery.channel}" and target to "${params.resolvedDelivery.to}"${params.resolvedDelivery.accountId ? ` with accountId "${params.resolvedDelivery.accountId}"` : ""}.`
+    serializedChannel && serializedTarget
+      ? `When using the message tool for this cron delivery, set channel to ${serializedChannel} and target to ${serializedTarget}${serializedThreadId ? ` with threadId ${serializedThreadId}` : ""}${serializedAccountId ? ` with accountId ${serializedAccountId}` : ""}.`
       : "When using the message tool for this cron delivery, include an explicit channel and target.";
-  return `${params.commandBody}\n\n${explicitTargetInstruction} Plain-text summaries are delivered automatically only when you do not send the final result yourself. If you use the message tool for the final delivery (for example attachments, media, richer components, or a different recipient), send everything there and then return exactly NO_REPLY.`.trim();
+  return `${params.commandBody}\n\n${explicitTargetInstruction} Plain-text summaries are delivered automatically only when you do not send the final result yourself. If you use the message tool for the final delivery (for example attachments, media, richer components, or a different recipient), send everything there and then return exactly ${SILENT_REPLY_TOKEN}.`.trim();
 }
 
 function resolvePositiveContextTokens(value: unknown): number | undefined {
@@ -661,9 +678,12 @@ async function finalizeCronRun(params: {
     matchesMessagingToolDeliveryTarget,
     resolveCronDeliveryBestEffort,
   } = await loadCronDeliveryRuntime();
+  const didHandoffFinalDelivery =
+    finalRunResult.didSendViaMessagingTool === true &&
+    isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN);
   const skipMessagingToolDelivery =
     prepared.deliveryRequested &&
-    finalRunResult.didSendViaMessagingTool === true &&
+    didHandoffFinalDelivery &&
     (finalRunResult.messagingToolSentTargets ?? []).some((target) =>
       matchesMessagingToolDeliveryTarget(target, {
         channel: prepared.resolvedDelivery.channel,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -678,9 +678,7 @@ async function finalizeCronRun(params: {
     matchesMessagingToolDeliveryTarget,
     resolveCronDeliveryBestEffort,
   } = await loadCronDeliveryRuntime();
-  const didHandoffFinalDelivery =
-    finalRunResult.didSendViaMessagingTool === true &&
-    isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN);
+  const didHandoffFinalDelivery = isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN);
   const skipMessagingToolDelivery =
     prepared.deliveryRequested &&
     didHandoffFinalDelivery &&
@@ -689,6 +687,7 @@ async function finalizeCronRun(params: {
         channel: prepared.resolvedDelivery.channel,
         to: prepared.resolvedDelivery.to,
         accountId: prepared.resolvedDelivery.accountId,
+        threadId: prepared.resolvedDelivery.threadId,
       }),
     );
   const deliveryResult = await dispatchCronDelivery({


### PR DESCRIPTION
## Summary

Cron-owned agent runs previously disabled the message tool entirely (`disableMessageTool: true`), routing all delivery through the runner's own text path. This prevented cron jobs from sending rich payloads like Discord media attachments or interactive components.

The fix inverts the policy: cron-owned runs now keep the message tool available so isolated jobs can explicitly call it for richer delivery.

## Changes

- `src/cron/isolated-agent/run.ts`: invert message tool policy for cron-owned runs
- `src/agents/provider-request-config.ts`: updated delivery contract logic
- `src/cron/isolated-agent/run.message-tool-policy.test.ts`: test coverage

Rebased from original PR #60368 with conflicts resolved.