### PR TITLE
fix(discord): read RadioGroup modal field values from raw interaction payload

### DIFF
--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -8,7 +8,8 @@ import {
   type StringSelectMenuInteraction,
   type UserSelectMenuInteraction,
 } from "@buape/carbon";
-import { ChannelType } from "discord-api-types/v10";
+import type { ModalSubmitLabelComponent } from "discord-api-types/v10";
+import { ChannelType, ComponentType } from "discord-api-types/v10";
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
 import { resolveCommandAuthorizedFromAuthorizers } from "openclaw/plugin-sdk/command-auth-native";
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
@@ -727,6 +728,27 @@ export function mapSelectValues(entry: DiscordComponentEntry, values: string[]):
   return values;
 }
 
+/**
+ * Read a RadioGroup's selected value directly from the raw interaction payload.
+ * Carbon's FieldsHandler reads `.values` (array) for non-TextInput components,
+ * but Discord's RadioGroup submission uses `.value` (singular string | null).
+ * This bypasses Carbon to read the correct field.
+ */
+function resolveRadioGroupValueFromRaw(
+  interaction: ModalInteraction,
+  fieldId: string,
+): string | null {
+  for (const component of interaction.rawData.data.components ?? []) {
+    if (component.type === ComponentType.Label) {
+      const sub = (component as ModalSubmitLabelComponent).component;
+      if (sub?.custom_id === fieldId && sub.type === ComponentType.RadioGroup) {
+        return sub.value ?? null;
+      }
+    }
+  }
+  return null;
+}
+
 export function resolveModalFieldValues(
   field: DiscordModalEntry["fields"][number],
   interaction: ModalInteraction,
@@ -743,9 +765,15 @@ export function resolveModalFieldValues(
         const value = required ? fields.getText(field.id, true) : fields.getText(field.id);
         return value ? [value] : [];
       }
-      case "select":
-      case "checkbox":
       case "radio": {
+        const value = resolveRadioGroupValueFromRaw(interaction, field.id);
+        if (required && !value) {
+          throw new Error(`Missing required field: ${field.id}`);
+        }
+        return value ? mapOptionLabels(optionLabels, [value]) : [];
+      }
+      case "select":
+      case "checkbox": {
         const values = required
           ? fields.getStringSelect(field.id, true)
           : (fields.getStringSelect(field.id) ?? []);

--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -738,7 +738,15 @@ function resolveRadioGroupValueFromRaw(
   interaction: ModalInteraction,
   fieldId: string,
 ): string | null {
-  for (const component of interaction.rawData.data.components ?? []) {
+  const rawData = interaction.rawData;
+  const components =
+    rawData && typeof rawData === "object"
+      ? (rawData as { data?: { components?: unknown } }).data?.components
+      : undefined;
+  if (!Array.isArray(components)) {
+    return null;
+  }
+  for (const component of components) {
     if (component.type === ComponentType.Label) {
       const sub = (component as ModalSubmitLabelComponent).component;
       if (sub?.custom_id === fieldId && sub.type === ComponentType.RadioGroup) {
@@ -768,6 +776,8 @@ export function resolveModalFieldValues(
       case "radio": {
         const value = resolveRadioGroupValueFromRaw(interaction, field.id);
         if (required && !value) {
+          // Discord enforces required selections in the modal UI; this throw is
+          // only a defensive fallback when the payload is unexpectedly incomplete.
           throw new Error(`Missing required field: ${field.id}`);
         }
         return value ? mapOptionLabels(optionLabels, [value]) : [];
@@ -802,6 +812,7 @@ export function resolveModalFieldValues(
         return [];
     }
   } catch (err) {
+    // Keep modal submissions non-fatal when Carbon/raw payload parsing drifts.
     logError(`agent modal: failed to read field ${field.id}: ${String(err)}`);
     return [];
   }

--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -748,7 +748,7 @@ function resolveRadioGroupValueFromRaw(
   }
   for (const component of components) {
     // oxlint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- ComponentType is a discriminated-union discriminant here; narrowing is intentional
-    if (component.type === ComponentType.Label) {
+    if ((component as { type?: unknown }).type === ComponentType.Label) {
       const sub = (component as ModalSubmitLabelComponent).component;
       if (sub?.custom_id === fieldId && sub.type === ComponentType.RadioGroup) {
         return sub.value ?? null;
@@ -768,21 +768,25 @@ export function resolveModalFieldValues(
     label: option.label,
   }));
   const required = field.required === true;
+
+  // Radio fields are resolved directly from the raw payload (bypassing Carbon's
+  // FieldsHandler). The required check is performed here, outside the try/catch,
+  // so a missing required radio value throws rather than being swallowed.
+  if (field.type === "radio") {
+    const value = resolveRadioGroupValueFromRaw(interaction, field.id);
+    if (required && !value) {
+      throw new Error(`Missing required field: ${field.id}`);
+    }
+    return value ? mapOptionLabels(optionLabels, [value]) : [];
+  }
+
   try {
     switch (field.type) {
       case "text": {
         const value = required ? fields.getText(field.id, true) : fields.getText(field.id);
         return value ? [value] : [];
       }
-      case "radio": {
-        const value = resolveRadioGroupValueFromRaw(interaction, field.id);
-        if (required && !value) {
-          // Discord enforces required selections in the modal UI; this throw is
-          // only a defensive fallback when the payload is unexpectedly incomplete.
-          throw new Error(`Missing required field: ${field.id}`);
-        }
-        return value ? mapOptionLabels(optionLabels, [value]) : [];
-      }
+
       case "select":
       case "checkbox": {
         const values = required

--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -747,6 +747,7 @@ function resolveRadioGroupValueFromRaw(
     return null;
   }
   for (const component of components) {
+    // oxlint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- ComponentType is a discriminated-union discriminant here; narrowing is intentional
     if (component.type === ComponentType.Label) {
       const sub = (component as ModalSubmitLabelComponent).component;
       if (sub?.custom_id === fieldId && sub.type === ComponentType.RadioGroup) {

--- a/extensions/discord/src/monitor/monitor.agent-components.modal-radio.test.ts
+++ b/extensions/discord/src/monitor/monitor.agent-components.modal-radio.test.ts
@@ -1,0 +1,203 @@
+import type { ModalInteraction } from "@buape/carbon";
+import { ComponentType } from "discord-api-types/v10";
+import { describe, expect, it } from "vitest";
+import { resolveModalFieldValues } from "./agent-components-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal ModalInteraction mock whose rawData.data.components list
+ * contains whatever the caller provides.  The fields handler is stubbed to
+ * throw for any getText/getStringSelect call so tests that reach it
+ * accidentally will fail loudly.
+ */
+const makeModalInteraction = (
+  overrides: {
+    rawDataComponents?: unknown[];
+    rawData?: unknown;
+  } = {},
+): ModalInteraction => {
+  const rawData =
+    overrides.rawData !== undefined
+      ? overrides.rawData
+      : {
+          data: {
+            components: overrides.rawDataComponents ?? [],
+          },
+        };
+
+  return {
+    rawData,
+    fields: {
+      getText: () => {
+        throw new Error("not a text field");
+      },
+      getStringSelect: () => {
+        throw new Error("not a select field");
+      },
+      getRoleSelect: () => {
+        throw new Error("not a role select field");
+      },
+      getUserSelect: () => {
+        throw new Error("not a user select field");
+      },
+    },
+  } as unknown as ModalInteraction;
+};
+
+/**
+ * Build a raw Label+RadioGroup component pair as Discord sends it in a modal
+ * submit payload.
+ *
+ * ComponentType.Label  = 18
+ * ComponentType.RadioGroup = 21
+ */
+const makeRadioComponent = (fieldId: string, value: string | null) => ({
+  type: ComponentType.Label, // 18
+  component: {
+    type: ComponentType.RadioGroup, // 21
+    custom_id: fieldId,
+    value,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveModalFieldValues – radio branch", () => {
+  it("returns the mapped option label when the radio has a matching value", () => {
+    const interaction = makeModalInteraction({
+      rawDataComponents: [makeRadioComponent("size", "lg")],
+    });
+
+    const result = resolveModalFieldValues(
+      {
+        id: "size",
+        type: "radio",
+        label: "Size",
+        required: false,
+        options: [
+          { value: "sm", label: "Small" },
+          { value: "lg", label: "Large" },
+        ],
+      },
+      interaction,
+    );
+
+    expect(result).toEqual(["Large"]);
+  });
+
+  it("returns the raw value when the selected value is not in the options list", () => {
+    const interaction = makeModalInteraction({
+      rawDataComponents: [makeRadioComponent("size", "xl")],
+    });
+
+    const result = resolveModalFieldValues(
+      {
+        id: "size",
+        type: "radio",
+        label: "Size",
+        required: false,
+        options: [
+          { value: "sm", label: "Small" },
+          { value: "lg", label: "Large" },
+        ],
+      },
+      interaction,
+    );
+
+    // mapOptionLabels falls back to the raw value when not found
+    expect(result).toEqual(["xl"]);
+  });
+
+  it("returns [] when radio has no value and field is not required", () => {
+    const interaction = makeModalInteraction({
+      rawDataComponents: [makeRadioComponent("size", null)],
+    });
+
+    const result = resolveModalFieldValues(
+      {
+        id: "size",
+        type: "radio",
+        label: "Size",
+        required: false,
+        options: [{ value: "sm", label: "Small" }],
+      },
+      interaction,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("throws 'Missing required field' when radio has no value and field is required", () => {
+    const interaction = makeModalInteraction({
+      rawDataComponents: [makeRadioComponent("size", null)],
+    });
+
+    expect(() =>
+      resolveModalFieldValues(
+        {
+          id: "size",
+          type: "radio",
+          label: "Size",
+          required: true,
+          options: [{ value: "sm", label: "Small" }],
+        },
+        interaction,
+      ),
+    ).toThrow("Missing required field: size");
+  });
+
+  it("returns [] (non-required) when rawData.data is undefined (malformed payload)", () => {
+    // Simulate a payload where rawData exists but data is absent
+    const interaction = makeModalInteraction({
+      rawData: {
+        /* no data key */
+      },
+    });
+
+    const result = resolveModalFieldValues(
+      {
+        id: "size",
+        type: "radio",
+        label: "Size",
+        required: false,
+        options: [{ value: "sm", label: "Small" }],
+      },
+      interaction,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("resolves value from the correct Label+RadioGroup structure (type=Label wrapping RadioGroup)", () => {
+    // Ensure the component traversal correctly handles the Label wrapper
+    const interaction = makeModalInteraction({
+      rawDataComponents: [
+        // A different field first, to verify we match by custom_id
+        makeRadioComponent("color", "blue"),
+        makeRadioComponent("size", "md"),
+      ],
+    });
+
+    const result = resolveModalFieldValues(
+      {
+        id: "size",
+        type: "radio",
+        label: "Size",
+        required: true,
+        options: [
+          { value: "sm", label: "Small" },
+          { value: "md", label: "Medium" },
+          { value: "lg", label: "Large" },
+        ],
+      },
+      interaction,
+    );
+
+    expect(result).toEqual(["Medium"]);
+  });
+});

--- a/extensions/discord/src/monitor/monitor.agent-components.test.ts
+++ b/extensions/discord/src/monitor/monitor.agent-components.test.ts
@@ -1,5 +1,10 @@
-import type { ButtonInteraction, ComponentData, StringSelectMenuInteraction } from "@buape/carbon";
-import { ChannelType } from "discord-api-types/v10";
+import type {
+  ButtonInteraction,
+  ComponentData,
+  ModalInteraction,
+  StringSelectMenuInteraction,
+} from "@buape/carbon";
+import { ChannelType, ComponentType } from "discord-api-types/v10";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
@@ -12,7 +17,10 @@ import {
   resetDiscordComponentRuntimeMocks,
   upsertPairingRequestMock,
 } from "../test-support/component-runtime.js";
-import { resolveComponentInteractionContext } from "./agent-components-helpers.js";
+import {
+  resolveComponentInteractionContext,
+  resolveModalFieldValues,
+} from "./agent-components-helpers.js";
 import {
   createAgentComponentButton,
   createAgentSelectMenu,
@@ -68,6 +76,20 @@ describe("agent components", () => {
       defer,
       reply,
     };
+  };
+
+  const createModalInteraction = (overrides: Record<string, unknown> = {}) => {
+    const interaction = {
+      fields: {
+        getText: vi.fn(),
+        getStringSelect: vi.fn(),
+        getRoleSelect: vi.fn(),
+        getUserSelect: vi.fn(),
+      },
+      rawData: { data: { components: [] } },
+      ...overrides,
+    };
+    return interaction as unknown as ModalInteraction;
   };
 
   const createBaseGroupDmInteraction = (overrides: Record<string, unknown> = {}) => {
@@ -261,6 +283,55 @@ describe("agent components", () => {
       dmPolicy: "open",
       expectPairingStoreRead: false,
     });
+  });
+
+  it("reads radio modal values from the raw Discord interaction payload", () => {
+    const interaction = createModalInteraction({
+      rawData: {
+        data: {
+          components: [
+            {
+              type: ComponentType.Label,
+              component: {
+                type: ComponentType.RadioGroup,
+                custom_id: "priority",
+                value: "high",
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(
+      resolveModalFieldValues(
+        {
+          id: "priority",
+          label: "Priority",
+          type: "radio",
+          options: [{ label: "High", value: "high" }],
+        } as never,
+        interaction,
+      ),
+    ).toEqual(["High"]);
+  });
+
+  it("returns an empty radio selection when raw modal components are missing", () => {
+    const interaction = createModalInteraction({
+      rawData: {},
+    });
+
+    expect(
+      resolveModalFieldValues(
+        {
+          id: "priority",
+          label: "Priority",
+          type: "radio",
+          options: [{ label: "High", value: "high" }],
+        } as never,
+        interaction,
+      ),
+    ).toEqual([]);
   });
 
   it("uses user conversation ids for direct-message component originating targets", () => {


### PR DESCRIPTION
## Summary

Fix RadioGroup fields in Discord modals always failing with `Missing required field` errors on submission.

**Root cause**: Carbon's `FieldsHandler` reads `.values` (array) for non-TextInput modal components, but Discord's `APIModalSubmitRadioGroupComponent` uses `.value` (singular `string | null`). This mismatch caused RadioGroup fields to always fail.

**Fix**: Add `resolveRadioGroupValueFromRaw()` that reads the raw interaction payload directly, bypassing Carbon's `FieldsHandler` for radio fields.

## Changes

- `extensions/discord/src/monitor/agent-components-helpers.ts`:
  - Add `ComponentType` and `ModalSubmitLabelComponent` imports
  - Add `resolveRadioGroupValueFromRaw()` helper
  - Handle `radio` case separately from `select`/`checkbox` in `resolveModalFieldValues`

Rebased/re-implemented from original PR #47415 (closed - structural mismatch with main).