### PR TITLE
fix(schema): hoist plugin/channel $defs to root level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1028,6 +1028,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/SecretRef: resolve restart token drift checks with merged service/runtime env sources and hard-fail unsupported mutable SecretRef plus OAuth-profile combinations so restart warnings and policy enforcement match runtime behavior. (#58141) Thanks @joshavant.
 - Telegram/outbound chunking: use static markdown chunking when Telegram runtime state is unavailable so long outbound Telegram messages still split correctly after cold starts. (#57816) Thanks @ForestDengHK.
 - Update/Corepack: disable interactive Corepack download prompts during update preflight install unless `COREPACK_ENABLE_DOWNLOAD_PROMPT` is already explicitly set, so `openclaw update` can fetch the repo-pinned pnpm version non-interactively. (#61456) Thanks @p6l-richard.
+- Config/schema: hoist plugin and channel schema `$defs` to the root with pointer-safe, collision-safe refs so generated config schemas resolve nested manifest definitions correctly. (#60770) Thanks @Bartok9.
 
 ## 2026.4.2
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -234,7 +234,7 @@ describe("config schema", () => {
 
     // $defs should be hoisted to root level with namespaced key
     expect(schema.$defs).toBeDefined();
-    expect(schema.$defs?.["qqbot_account"]).toBeDefined();
+    expect(schema.$defs?.["qqbot__account"]).toBeDefined();
 
     // Plugin config should have rewritten $ref
     const pluginsNode = schema.properties?.plugins as Record<string, unknown> | undefined;
@@ -248,7 +248,7 @@ describe("config schema", () => {
     const accountProp = pluginConfigProps?.account as Record<string, unknown> | undefined;
 
     // $ref should point to namespaced definition at root
-    expect(accountProp?.$ref).toBe("#/$defs/qqbot_account");
+    expect(accountProp?.$ref).toBe("#/$defs/qqbot__account");
 
     // Plugin config should NOT have its own $defs
     expect(pluginConfigSchema?.$defs).toBeUndefined();
@@ -285,7 +285,7 @@ describe("config schema", () => {
 
     // $defs should be hoisted to root level with namespaced key
     expect(schema.$defs).toBeDefined();
-    expect(schema.$defs?.["custom-channel_settings"]).toBeDefined();
+    expect(schema.$defs?.["custom-channel__settings"]).toBeDefined();
 
     // Channel schema should have rewritten $ref
     const channelsNode = schema.properties?.channels as Record<string, unknown> | undefined;
@@ -295,7 +295,7 @@ describe("config schema", () => {
     const settingsProp = channelSchemaProps?.settings as Record<string, unknown> | undefined;
 
     // $ref should point to namespaced definition at root
-    expect(settingsProp?.$ref).toBe("#/$defs/custom-channel_settings");
+    expect(settingsProp?.$ref).toBe("#/$defs/custom-channel__settings");
 
     // Channel schema should NOT have its own $defs
     expect(channelSchema?.$defs).toBeUndefined();
@@ -334,14 +334,14 @@ describe("config schema", () => {
     const schema = res.schema as { $defs?: Record<string, unknown> };
 
     // Both defs should be hoisted
-    expect(schema.$defs?.["nested-plugin_parent"]).toBeDefined();
-    expect(schema.$defs?.["nested-plugin_child"]).toBeDefined();
+    expect(schema.$defs?.["nested-plugin__parent"]).toBeDefined();
+    expect(schema.$defs?.["nested-plugin__child"]).toBeDefined();
 
     // The nested $ref inside parent should also be rewritten
-    const parentDef = schema.$defs?.["nested-plugin_parent"] as Record<string, unknown> | undefined;
+    const parentDef = schema.$defs?.["nested-plugin__parent"] as Record<string, unknown> | undefined;
     const parentProps = parentDef?.properties as Record<string, unknown> | undefined;
     const childRef = parentProps?.child as Record<string, unknown> | undefined;
-    expect(childRef?.$ref).toBe("#/$defs/nested-plugin_child");
+    expect(childRef?.$ref).toBe("#/$defs/nested-plugin__child");
   });
 
   it("adds heartbeat target hints with dynamic channels", () => {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -4,6 +4,24 @@ import { buildConfigSchema, lookupConfigSchema } from "./schema.js";
 import { applyDerivedTags, CONFIG_TAGS, deriveTagsForPath } from "./schema.tags.js";
 import { ToolsSchema } from "./zod-schema.agent-runtime.js";
 
+function resolveJsonPointer(root: Record<string, unknown>, ref: string): unknown {
+  if (!ref.startsWith("#/")) {
+    return undefined;
+  }
+  const segments = ref
+    .slice(2)
+    .split("/")
+    .map((segment) => segment.replaceAll("~1", "/").replaceAll("~0", "~"));
+  let current: unknown = root;
+  for (const segment of segments) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
 describe("config schema", () => {
   type SchemaInput = NonNullable<Parameters<typeof buildConfigSchema>[0]>;
   let baseSchema: ReturnType<typeof buildConfigSchema>;
@@ -232,9 +250,8 @@ describe("config schema", () => {
       properties?: Record<string, unknown>;
     };
 
-    // $defs should be hoisted to root level with namespaced key
     expect(schema.$defs).toBeDefined();
-    expect(schema.$defs?.["qqbot__account"]).toBeDefined();
+    expect(schema.$defs?.["plugin|qqbot|account"]).toBeDefined();
 
     // Plugin config should have rewritten $ref
     const pluginsNode = schema.properties?.plugins as Record<string, unknown> | undefined;
@@ -247,10 +264,7 @@ describe("config schema", () => {
     const pluginConfigProps = pluginConfigSchema?.properties as Record<string, unknown> | undefined;
     const accountProp = pluginConfigProps?.account as Record<string, unknown> | undefined;
 
-    // $ref should point to namespaced definition at root
-    expect(accountProp?.$ref).toBe("#/$defs/qqbot__account");
-
-    // Plugin config should NOT have its own $defs
+    expect(accountProp?.$ref).toBe("#/$defs/plugin|qqbot|account");
     expect(pluginConfigSchema?.$defs).toBeUndefined();
   });
 
@@ -283,9 +297,8 @@ describe("config schema", () => {
       properties?: Record<string, unknown>;
     };
 
-    // $defs should be hoisted to root level with namespaced key
     expect(schema.$defs).toBeDefined();
-    expect(schema.$defs?.["custom-channel__settings"]).toBeDefined();
+    expect(schema.$defs?.["channel|custom-channel|settings"]).toBeDefined();
 
     // Channel schema should have rewritten $ref
     const channelsNode = schema.properties?.channels as Record<string, unknown> | undefined;
@@ -294,10 +307,7 @@ describe("config schema", () => {
     const channelSchemaProps = channelSchema?.properties as Record<string, unknown> | undefined;
     const settingsProp = channelSchemaProps?.settings as Record<string, unknown> | undefined;
 
-    // $ref should point to namespaced definition at root
-    expect(settingsProp?.$ref).toBe("#/$defs/custom-channel__settings");
-
-    // Channel schema should NOT have its own $defs
+    expect(settingsProp?.$ref).toBe("#/$defs/channel|custom-channel|settings");
     expect(channelSchema?.$defs).toBeUndefined();
   });
 
@@ -333,15 +343,140 @@ describe("config schema", () => {
 
     const schema = res.schema as { $defs?: Record<string, unknown> };
 
-    // Both defs should be hoisted
-    expect(schema.$defs?.["nested-plugin__parent"]).toBeDefined();
-    expect(schema.$defs?.["nested-plugin__child"]).toBeDefined();
+    expect(schema.$defs?.["plugin|nested-plugin|parent"]).toBeDefined();
+    expect(schema.$defs?.["plugin|nested-plugin|child"]).toBeDefined();
 
-    // The nested $ref inside parent should also be rewritten
-    const parentDef = schema.$defs?.["nested-plugin__parent"] as Record<string, unknown> | undefined;
+    const parentDef = schema.$defs?.["plugin|nested-plugin|parent"] as
+      | Record<string, unknown>
+      | undefined;
     const parentProps = parentDef?.properties as Record<string, unknown> | undefined;
     const childRef = parentProps?.child as Record<string, unknown> | undefined;
-    expect(childRef?.$ref).toBe("#/$defs/nested-plugin__child");
+    expect(childRef?.$ref).toBe("#/$defs/plugin|nested-plugin|child");
+  });
+
+  it("uses pointer-safe hoisted keys for slash-delimited plugin ids", () => {
+    const res = buildConfigSchema({
+      plugins: [
+        {
+          id: "pack/one",
+          name: "Pack One",
+          configSchema: {
+            type: "object",
+            properties: {
+              account: { $ref: "#/$defs/account" },
+            },
+            $defs: {
+              account: {
+                type: "object",
+                properties: {
+                  token: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const schema = res.schema as {
+      $defs?: Record<string, unknown>;
+      properties?: Record<string, unknown>;
+    };
+    const pluginsNode = schema.properties?.plugins as Record<string, unknown> | undefined;
+    const pluginsProps = pluginsNode?.properties as Record<string, unknown> | undefined;
+    const entriesNode = pluginsProps?.entries as Record<string, unknown> | undefined;
+    const entryProps = entriesNode?.properties as Record<string, unknown> | undefined;
+    const pluginEntry = entryProps?.["pack/one"] as Record<string, unknown> | undefined;
+    const configSchema = (pluginEntry?.properties as Record<string, unknown> | undefined)?.config as
+      | Record<string, unknown>
+      | undefined;
+    const accountProp = (configSchema?.properties as Record<string, unknown> | undefined)
+      ?.account as Record<string, unknown> | undefined;
+
+    expect(schema.$defs?.["plugin|pack%2Fone|account"]).toBeDefined();
+    expect(accountProp?.$ref).toBe("#/$defs/plugin|pack%2Fone|account");
+    expect(
+      resolveJsonPointer(schema as Record<string, unknown>, String(accountProp?.$ref)),
+    ).toEqual(schema.$defs?.["plugin|pack%2Fone|account"]);
+  });
+
+  it("keeps plugin and channel defs distinct when they share an id", () => {
+    const res = buildConfigSchema({
+      plugins: [
+        {
+          id: "shared",
+          name: "Shared Plugin",
+          configSchema: {
+            type: "object",
+            properties: {
+              pluginValue: { $ref: "#/$defs/config" },
+            },
+            $defs: {
+              config: {
+                type: "object",
+                properties: {
+                  from: { const: "plugin" },
+                },
+              },
+            },
+          },
+        },
+      ],
+      channels: [
+        {
+          id: "shared",
+          label: "Shared Channel",
+          configSchema: {
+            type: "object",
+            properties: {
+              channelValue: { $ref: "#/$defs/config" },
+            },
+            $defs: {
+              config: {
+                type: "object",
+                properties: {
+                  from: { const: "channel" },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const schema = res.schema as {
+      $defs?: Record<string, unknown>;
+      properties?: Record<string, unknown>;
+    };
+    const pluginsNode = schema.properties?.plugins as Record<string, unknown> | undefined;
+    const pluginEntries = (
+      (pluginsNode?.properties as Record<string, unknown> | undefined)?.entries as
+        | Record<string, unknown>
+        | undefined
+    )?.properties as Record<string, unknown> | undefined;
+    const pluginConfig = (
+      (pluginEntries?.shared as Record<string, unknown> | undefined)?.properties as
+        | Record<string, unknown>
+        | undefined
+    )?.config as Record<string, unknown> | undefined;
+    const channelsNode = schema.properties?.channels as Record<string, unknown> | undefined;
+    const channelConfig = (channelsNode?.properties as Record<string, unknown> | undefined)
+      ?.shared as Record<string, unknown> | undefined;
+    const pluginRef = (pluginConfig?.properties as Record<string, unknown> | undefined)
+      ?.pluginValue as Record<string, unknown> | undefined;
+    const channelRef = (channelConfig?.properties as Record<string, unknown> | undefined)
+      ?.channelValue as Record<string, unknown> | undefined;
+
+    expect(schema.$defs?.["plugin|shared|config"]).toBeDefined();
+    expect(schema.$defs?.["channel|shared|config"]).toBeDefined();
+    expect(pluginRef?.$ref).toBe("#/$defs/plugin|shared|config");
+    expect(channelRef?.$ref).toBe("#/$defs/channel|shared|config");
+    expect(resolveJsonPointer(schema as Record<string, unknown>, String(pluginRef?.$ref))).toEqual(
+      schema.$defs?.["plugin|shared|config"],
+    );
+    expect(resolveJsonPointer(schema as Record<string, unknown>, String(channelRef?.$ref))).toEqual(
+      schema.$defs?.["channel|shared|config"],
+    );
   });
 
   it("adds heartbeat target hints with dynamic channels", () => {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -203,6 +203,147 @@ describe("config schema", () => {
     });
   });
 
+  it("hoists $defs from plugin schemas to root level with namespaced keys", () => {
+    const res = buildConfigSchema({
+      plugins: [
+        {
+          id: "qqbot",
+          name: "QQBot",
+          configSchema: {
+            type: "object",
+            properties: {
+              account: { $ref: "#/$defs/account" },
+            },
+            $defs: {
+              account: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const schema = res.schema as {
+      $defs?: Record<string, unknown>;
+      properties?: Record<string, unknown>;
+    };
+
+    // $defs should be hoisted to root level with namespaced key
+    expect(schema.$defs).toBeDefined();
+    expect(schema.$defs?.["qqbot_account"]).toBeDefined();
+
+    // Plugin config should have rewritten $ref
+    const pluginsNode = schema.properties?.plugins as Record<string, unknown> | undefined;
+    const entriesNode = pluginsNode?.properties as Record<string, unknown> | undefined;
+    const entriesProps = entriesNode?.entries as Record<string, unknown> | undefined;
+    const entryProps = entriesProps?.properties as Record<string, unknown> | undefined;
+    const pluginEntry = entryProps?.["qqbot"] as Record<string, unknown> | undefined;
+    const pluginConfig = pluginEntry?.properties as Record<string, unknown> | undefined;
+    const pluginConfigSchema = pluginConfig?.config as Record<string, unknown> | undefined;
+    const pluginConfigProps = pluginConfigSchema?.properties as Record<string, unknown> | undefined;
+    const accountProp = pluginConfigProps?.account as Record<string, unknown> | undefined;
+
+    // $ref should point to namespaced definition at root
+    expect(accountProp?.$ref).toBe("#/$defs/qqbot_account");
+
+    // Plugin config should NOT have its own $defs
+    expect(pluginConfigSchema?.$defs).toBeUndefined();
+  });
+
+  it("hoists $defs from channel schemas to root level with namespaced keys", () => {
+    const res = buildConfigSchema({
+      channels: [
+        {
+          id: "custom-channel",
+          label: "Custom Channel",
+          configSchema: {
+            type: "object",
+            properties: {
+              settings: { $ref: "#/$defs/settings" },
+            },
+            $defs: {
+              settings: {
+                type: "object",
+                properties: {
+                  enabled: { type: "boolean" },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const schema = res.schema as {
+      $defs?: Record<string, unknown>;
+      properties?: Record<string, unknown>;
+    };
+
+    // $defs should be hoisted to root level with namespaced key
+    expect(schema.$defs).toBeDefined();
+    expect(schema.$defs?.["custom-channel_settings"]).toBeDefined();
+
+    // Channel schema should have rewritten $ref
+    const channelsNode = schema.properties?.channels as Record<string, unknown> | undefined;
+    const channelProps = channelsNode?.properties as Record<string, unknown> | undefined;
+    const channelSchema = channelProps?.["custom-channel"] as Record<string, unknown> | undefined;
+    const channelSchemaProps = channelSchema?.properties as Record<string, unknown> | undefined;
+    const settingsProp = channelSchemaProps?.settings as Record<string, unknown> | undefined;
+
+    // $ref should point to namespaced definition at root
+    expect(settingsProp?.$ref).toBe("#/$defs/custom-channel_settings");
+
+    // Channel schema should NOT have its own $defs
+    expect(channelSchema?.$defs).toBeUndefined();
+  });
+
+  it("rewrites nested $refs inside $defs definitions", () => {
+    const res = buildConfigSchema({
+      plugins: [
+        {
+          id: "nested-plugin",
+          name: "Nested Plugin",
+          configSchema: {
+            type: "object",
+            properties: {
+              parent: { $ref: "#/$defs/parent" },
+            },
+            $defs: {
+              child: {
+                type: "object",
+                properties: {
+                  value: { type: "string" },
+                },
+              },
+              parent: {
+                type: "object",
+                properties: {
+                  child: { $ref: "#/$defs/child" },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const schema = res.schema as { $defs?: Record<string, unknown> };
+
+    // Both defs should be hoisted
+    expect(schema.$defs?.["nested-plugin_parent"]).toBeDefined();
+    expect(schema.$defs?.["nested-plugin_child"]).toBeDefined();
+
+    // The nested $ref inside parent should also be rewritten
+    const parentDef = schema.$defs?.["nested-plugin_parent"] as Record<string, unknown> | undefined;
+    const parentProps = parentDef?.properties as Record<string, unknown> | undefined;
+    const childRef = parentProps?.child as Record<string, unknown> | undefined;
+    expect(childRef?.$ref).toBe("#/$defs/nested-plugin_child");
+  });
+
   it("adds heartbeat target hints with dynamic channels", () => {
     const res = buildConfigSchema(heartbeatChannelInput);
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -321,7 +321,7 @@ function applyHeartbeatTargetHints(
 
 /**
  * Recursively rewrites `$ref` pointers in a schema object.
- * If the ref matches `#/$defs/<name>`, it is rewritten to `#/$defs/<prefix>_<name>`.
+ * If the ref matches `#/$defs/<name>`, it is rewritten to `#/$defs/<prefix>__<name>`.
  */
 function rewriteDefsRefs(obj: unknown, prefix: string, originalDefNames: Set<string>): unknown {
   if (obj === null || typeof obj !== "object") {
@@ -336,7 +336,7 @@ function rewriteDefsRefs(obj: unknown, prefix: string, originalDefNames: Set<str
     if (key === "$ref" && typeof value === "string") {
       const match = value.match(/^#\/\$defs\/(.+)$/);
       if (match && originalDefNames.has(match[1])) {
-        result[key] = `#/$defs/${prefix}_${match[1]}`;
+        result[key] = `#/$defs/${prefix}__${match[1]}`;
       } else {
         result[key] = value;
       }
@@ -366,7 +366,7 @@ function extractAndNamespaceDefs(
 
   // Namespace each definition by prefixing with plugin id
   for (const [name, def] of Object.entries(defs)) {
-    const namespacedName = `${pluginId}_${name}`;
+    const namespacedName = `${pluginId}__${name}`;
     // Also rewrite any $refs inside the definition itself
     namespacedDefs[namespacedName] = rewriteDefsRefs(def, pluginId, defNames);
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -25,6 +25,7 @@ type JsonSchemaObject = JsonSchemaNode & {
   required?: string[];
   additionalProperties?: JsonSchemaObject | boolean;
   items?: JsonSchemaObject | JsonSchemaObject[];
+  $defs?: Record<string, unknown>;
 };
 
 const asJsonSchemaObject = (value: unknown): JsonSchemaObject | null =>
@@ -318,18 +319,84 @@ function applyHeartbeatTargetHints(
   return next;
 }
 
+/**
+ * Recursively rewrites `$ref` pointers in a schema object.
+ * If the ref matches `#/$defs/<name>`, it is rewritten to `#/$defs/<prefix>_<name>`.
+ */
+function rewriteDefsRefs(obj: unknown, prefix: string, originalDefNames: Set<string>): unknown {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map((item) => rewriteDefsRefs(item, prefix, originalDefNames));
+  }
+  const record = obj as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "$ref" && typeof value === "string") {
+      const match = value.match(/^#\/\$defs\/(.+)$/);
+      if (match && originalDefNames.has(match[1])) {
+        result[key] = `#/$defs/${prefix}_${match[1]}`;
+      } else {
+        result[key] = value;
+      }
+    } else {
+      result[key] = rewriteDefsRefs(value, prefix, originalDefNames);
+    }
+  }
+  return result;
+}
+
+/**
+ * Extracts $defs from a plugin schema, namespaces them by plugin id,
+ * rewrites $ref pointers, and returns the processed schema along with
+ * the namespaced definitions to hoist to root.
+ */
+function extractAndNamespaceDefs(
+  pluginSchema: JsonSchemaObject,
+  pluginId: string,
+): { schema: JsonSchemaObject; defs: Record<string, unknown> } {
+  const defs = pluginSchema.$defs;
+  if (!defs || typeof defs !== "object" || Array.isArray(defs)) {
+    return { schema: pluginSchema, defs: {} };
+  }
+
+  const defNames = new Set(Object.keys(defs));
+  const namespacedDefs: Record<string, unknown> = {};
+
+  // Namespace each definition by prefixing with plugin id
+  for (const [name, def] of Object.entries(defs)) {
+    const namespacedName = `${pluginId}_${name}`;
+    // Also rewrite any $refs inside the definition itself
+    namespacedDefs[namespacedName] = rewriteDefsRefs(def, pluginId, defNames);
+  }
+
+  // Clone schema without $defs and rewrite all $refs
+  const { $defs: _removed, ...schemaWithoutDefs } = pluginSchema;
+  const rewrittenSchema = rewriteDefsRefs(
+    schemaWithoutDefs,
+    pluginId,
+    defNames,
+  ) as JsonSchemaObject;
+
+  return { schema: rewrittenSchema, defs: namespacedDefs };
+}
+
 function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): ConfigSchema {
   const next = cloneSchema(schema);
   const root = asJsonSchemaObject(next);
   const pluginsNode = asJsonSchemaObject(root?.properties?.plugins);
   const entriesNode = asJsonSchemaObject(pluginsNode?.properties?.entries);
-  if (!entriesNode) {
+  if (!entriesNode || !root) {
     return next;
   }
 
   const entryBase = asJsonSchemaObject(entriesNode.additionalProperties);
   const entryProperties = entriesNode.properties ?? {};
   entriesNode.properties = entryProperties;
+
+  // Collect all hoisted $defs from plugins
+  const hoistedDefs: Record<string, unknown> = {};
 
   for (const plugin of plugins) {
     if (!plugin.configSchema) {
@@ -340,20 +407,37 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
       : ({ type: "object" } as JsonSchemaObject);
     const entryObject = asJsonSchemaObject(entrySchema) ?? ({ type: "object" } as JsonSchemaObject);
     const baseConfigSchema = asJsonSchemaObject(entryObject.properties?.config);
-    const pluginSchema = asJsonSchemaObject(plugin.configSchema);
+    const rawPluginSchema = asJsonSchemaObject(plugin.configSchema);
+
+    // Extract and namespace $defs from plugin schema
+    const { schema: processedPluginSchema, defs } = rawPluginSchema
+      ? extractAndNamespaceDefs(rawPluginSchema, plugin.id)
+      : { schema: rawPluginSchema, defs: {} };
+
+    // Merge hoisted definitions
+    Object.assign(hoistedDefs, defs);
+
     const nextConfigSchema =
       baseConfigSchema &&
-      pluginSchema &&
+      processedPluginSchema &&
       isObjectSchema(baseConfigSchema) &&
-      isObjectSchema(pluginSchema)
-        ? mergeObjectSchema(baseConfigSchema, pluginSchema)
-        : cloneSchema(plugin.configSchema);
+      isObjectSchema(processedPluginSchema)
+        ? mergeObjectSchema(baseConfigSchema, processedPluginSchema)
+        : processedPluginSchema
+          ? cloneSchema(processedPluginSchema)
+          : cloneSchema(plugin.configSchema);
 
     entryObject.properties = {
       ...entryObject.properties,
       config: nextConfigSchema,
     };
     entryProperties[plugin.id] = entryObject;
+  }
+
+  // Hoist all collected $defs to root level
+  if (Object.keys(hoistedDefs).length > 0) {
+    const existingDefs = (root.$defs as Record<string, unknown>) ?? {};
+    root.$defs = { ...existingDefs, ...hoistedDefs };
   }
 
   return next;
@@ -363,23 +447,48 @@ function applyChannelSchemas(schema: ConfigSchema, channels: ChannelUiMetadata[]
   const next = cloneSchema(schema);
   const root = asJsonSchemaObject(next);
   const channelsNode = asJsonSchemaObject(root?.properties?.channels);
-  if (!channelsNode) {
+  if (!channelsNode || !root) {
     return next;
   }
   const channelProps = channelsNode.properties ?? {};
   channelsNode.properties = channelProps;
+
+  // Collect all hoisted $defs from channels
+  const hoistedDefs: Record<string, unknown> = {};
 
   for (const channel of channels) {
     if (!channel.configSchema) {
       continue;
     }
     const existing = asJsonSchemaObject(channelProps[channel.id]);
-    const incoming = asJsonSchemaObject(channel.configSchema);
-    if (existing && incoming && isObjectSchema(existing) && isObjectSchema(incoming)) {
-      channelProps[channel.id] = mergeObjectSchema(existing, incoming);
+    const rawIncoming = asJsonSchemaObject(channel.configSchema);
+
+    // Extract and namespace $defs from channel schema
+    const { schema: processedIncoming, defs } = rawIncoming
+      ? extractAndNamespaceDefs(rawIncoming, channel.id)
+      : { schema: rawIncoming, defs: {} };
+
+    // Merge hoisted definitions
+    Object.assign(hoistedDefs, defs);
+
+    if (
+      existing &&
+      processedIncoming &&
+      isObjectSchema(existing) &&
+      isObjectSchema(processedIncoming)
+    ) {
+      channelProps[channel.id] = mergeObjectSchema(existing, processedIncoming);
+    } else if (processedIncoming) {
+      channelProps[channel.id] = cloneSchema(processedIncoming);
     } else {
       channelProps[channel.id] = cloneSchema(channel.configSchema);
     }
+  }
+
+  // Hoist all collected $defs to root level
+  if (Object.keys(hoistedDefs).length > 0) {
+    const existingDefs = (root.$defs as Record<string, unknown>) ?? {};
+    root.$defs = { ...existingDefs, ...hoistedDefs };
   }
 
   return next;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import { CHANNEL_IDS } from "../channels/ids.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
@@ -30,6 +31,11 @@ type JsonSchemaObject = JsonSchemaNode & {
 
 const asJsonSchemaObject = (value: unknown): JsonSchemaObject | null =>
   asSchemaObject<JsonSchemaObject>(value);
+
+const asJsonSchemaDefs = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 
 const FORBIDDEN_LOOKUP_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
 const LOOKUP_SCHEMA_STRING_KEYS = new Set([
@@ -319,16 +325,54 @@ function applyHeartbeatTargetHints(
   return next;
 }
 
+type HoistedDefSource = "plugin" | "channel";
+
+function encodeHoistedDefPart(value: string): string {
+  return encodeURIComponent(value).replaceAll("~", "%7E");
+}
+
+function buildHoistedDefKey(source: HoistedDefSource, ownerId: string, defName: string): string {
+  return `${source}|${encodeHoistedDefPart(ownerId)}|${encodeHoistedDefPart(defName)}`;
+}
+
+function mergeHoistedDefs(
+  rootSchema: JsonSchemaObject,
+  hoistedDefs: Record<string, unknown>,
+): void {
+  if (Object.keys(hoistedDefs).length === 0) {
+    return;
+  }
+
+  const rootDefs = { ...asJsonSchemaDefs(rootSchema.$defs) };
+  for (const [key, value] of Object.entries(hoistedDefs)) {
+    const current = rootDefs[key];
+    if (current !== undefined && !isDeepStrictEqual(current, value)) {
+      throw new Error(`Conflicting config schema $defs entry: ${key}`);
+    }
+    if (current === undefined) {
+      rootDefs[key] = cloneSchema(value);
+    }
+  }
+  rootSchema.$defs = rootDefs;
+}
+
 /**
  * Recursively rewrites `$ref` pointers in a schema object.
- * If the ref matches `#/$defs/<name>`, it is rewritten to `#/$defs/<prefix>__<name>`.
+ * If the ref matches `#/$defs/<name>`, it is rewritten to a pointer-safe
+ * root-level def key that also encodes whether the source came from a plugin
+ * or a channel schema.
  */
-function rewriteDefsRefs(obj: unknown, prefix: string, originalDefNames: Set<string>): unknown {
+function rewriteDefsRefs(
+  obj: unknown,
+  source: HoistedDefSource,
+  ownerId: string,
+  originalDefNames: Set<string>,
+): unknown {
   if (obj === null || typeof obj !== "object") {
     return obj;
   }
   if (Array.isArray(obj)) {
-    return obj.map((item) => rewriteDefsRefs(item, prefix, originalDefNames));
+    return obj.map((item) => rewriteDefsRefs(item, source, ownerId, originalDefNames));
   }
   const record = obj as Record<string, unknown>;
   const result: Record<string, unknown> = {};
@@ -336,25 +380,26 @@ function rewriteDefsRefs(obj: unknown, prefix: string, originalDefNames: Set<str
     if (key === "$ref" && typeof value === "string") {
       const match = value.match(/^#\/\$defs\/(.+)$/);
       if (match && originalDefNames.has(match[1])) {
-        result[key] = `#/$defs/${prefix}__${match[1]}`;
+        result[key] = `#/$defs/${buildHoistedDefKey(source, ownerId, match[1])}`;
       } else {
         result[key] = value;
       }
     } else {
-      result[key] = rewriteDefsRefs(value, prefix, originalDefNames);
+      result[key] = rewriteDefsRefs(value, source, ownerId, originalDefNames);
     }
   }
   return result;
 }
 
 /**
- * Extracts $defs from a plugin schema, namespaces them by plugin id,
- * rewrites $ref pointers, and returns the processed schema along with
- * the namespaced definitions to hoist to root.
+ * Extracts $defs from a plugin or channel schema, namespaces them safely,
+ * rewrites local $ref pointers, and returns the processed schema along with
+ * the hoisted definitions for the root schema.
  */
 function extractAndNamespaceDefs(
   pluginSchema: JsonSchemaObject,
-  pluginId: string,
+  source: HoistedDefSource,
+  ownerId: string,
 ): { schema: JsonSchemaObject; defs: Record<string, unknown> } {
   const defs = pluginSchema.$defs;
   if (!defs || typeof defs !== "object" || Array.isArray(defs)) {
@@ -364,18 +409,17 @@ function extractAndNamespaceDefs(
   const defNames = new Set(Object.keys(defs));
   const namespacedDefs: Record<string, unknown> = {};
 
-  // Namespace each definition by prefixing with plugin id
+  // Namespace each definition with its source surface and a pointer-safe id.
   for (const [name, def] of Object.entries(defs)) {
-    const namespacedName = `${pluginId}__${name}`;
-    // Also rewrite any $refs inside the definition itself
-    namespacedDefs[namespacedName] = rewriteDefsRefs(def, pluginId, defNames);
+    const namespacedName = buildHoistedDefKey(source, ownerId, name);
+    namespacedDefs[namespacedName] = rewriteDefsRefs(def, source, ownerId, defNames);
   }
 
-  // Clone schema without $defs and rewrite all $refs
   const { $defs: _removed, ...schemaWithoutDefs } = pluginSchema;
   const rewrittenSchema = rewriteDefsRefs(
     schemaWithoutDefs,
-    pluginId,
+    source,
+    ownerId,
     defNames,
   ) as JsonSchemaObject;
 
@@ -395,9 +439,6 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
   const entryProperties = entriesNode.properties ?? {};
   entriesNode.properties = entryProperties;
 
-  // Collect all hoisted $defs from plugins
-  const hoistedDefs: Record<string, unknown> = {};
-
   for (const plugin of plugins) {
     if (!plugin.configSchema) {
       continue;
@@ -411,11 +452,10 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
 
     // Extract and namespace $defs from plugin schema
     const { schema: processedPluginSchema, defs } = rawPluginSchema
-      ? extractAndNamespaceDefs(rawPluginSchema, plugin.id)
+      ? extractAndNamespaceDefs(rawPluginSchema, "plugin", plugin.id)
       : { schema: rawPluginSchema, defs: {} };
 
-    // Merge hoisted definitions
-    Object.assign(hoistedDefs, defs);
+    mergeHoistedDefs(root, defs);
 
     const nextConfigSchema =
       baseConfigSchema &&
@@ -434,12 +474,6 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
     entryProperties[plugin.id] = entryObject;
   }
 
-  // Hoist all collected $defs to root level
-  if (Object.keys(hoistedDefs).length > 0) {
-    const existingDefs = (root.$defs as Record<string, unknown>) ?? {};
-    root.$defs = { ...existingDefs, ...hoistedDefs };
-  }
-
   return next;
 }
 
@@ -453,9 +487,6 @@ function applyChannelSchemas(schema: ConfigSchema, channels: ChannelUiMetadata[]
   const channelProps = channelsNode.properties ?? {};
   channelsNode.properties = channelProps;
 
-  // Collect all hoisted $defs from channels
-  const hoistedDefs: Record<string, unknown> = {};
-
   for (const channel of channels) {
     if (!channel.configSchema) {
       continue;
@@ -465,11 +496,10 @@ function applyChannelSchemas(schema: ConfigSchema, channels: ChannelUiMetadata[]
 
     // Extract and namespace $defs from channel schema
     const { schema: processedIncoming, defs } = rawIncoming
-      ? extractAndNamespaceDefs(rawIncoming, channel.id)
+      ? extractAndNamespaceDefs(rawIncoming, "channel", channel.id)
       : { schema: rawIncoming, defs: {} };
 
-    // Merge hoisted definitions
-    Object.assign(hoistedDefs, defs);
+    mergeHoistedDefs(root, defs);
 
     if (
       existing &&
@@ -483,12 +513,6 @@ function applyChannelSchemas(schema: ConfigSchema, channels: ChannelUiMetadata[]
     } else {
       channelProps[channel.id] = cloneSchema(channel.configSchema);
     }
-  }
-
-  // Hoist all collected $defs to root level
-  if (Object.keys(hoistedDefs).length > 0) {
-    const existingDefs = (root.$defs as Record<string, unknown>) ?? {};
-    root.$defs = { ...existingDefs, ...hoistedDefs };
   }
 
   return next;


### PR DESCRIPTION
## Summary

Fixes #60759

When plugins or channels provide JSON schemas with `$defs` blocks (e.g., from Zod's `toJSONSchema()`), these definitions were being nested inside the plugin's config object instead of at the schema root level. This caused all `$ref` references to fail resolution since they point to `#/$defs/<name>` (root level).

## Changes

- Extract `$defs` from plugin/channel schemas during schema merging
- Namespace definition names by plugin/channel ID to avoid conflicts (e.g., `qqbot_account`)
- Rewrite all `$ref` pointers to use namespaced names
- Hoist the namespaced definitions to the root schema's `$defs`

## Example

A qqbot plugin with `$defs.account` now becomes `$defs.qqbot_account` at root level, and all `$ref: "#/$defs/account"` in the plugin schema become `$ref: "#/$defs/qqbot_account"`.

## Testing

Added 3 new tests:
- Plugin schema `$defs` hoisting
- Channel schema `$defs` hoisting  
- Nested `$refs` inside definitions are also rewritten

All existing tests continue to pass.