### PR TITLE
fix(status): trust live gateway memory provider

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -235,6 +235,7 @@ export async function statusCommand(
       updateChannelSource: channelInfo.source,
       memory,
       memoryPlugin,
+      gatewayMemoryStatus,
       gateway: {
         mode: gatewayMode,
         url: gatewayConnection.url,

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,4 +1,5 @@
 import { withProgress } from "../cli/progress.js";
+import type { DoctorMemoryStatusPayload } from "../gateway/server-methods/doctor.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import { normalizeUpdateChannel, resolveUpdateChannelDisplay } from "../infra/update-channels.js";
 import type { Tone } from "../plugin-sdk/memory-core-host-status.js";
@@ -194,6 +195,18 @@ export async function statusCommand(
             callGateway<HeartbeatEventPayload | null>({
               method: "last-heartbeat",
               params: {},
+              timeoutMs: opts.timeoutMs,
+              config: scan.cfg,
+            }),
+          )
+          .catch(() => null)
+      : null;
+  const gatewayMemoryStatus =
+    opts.deep && gatewayReachable && memoryPlugin.enabled && !memory
+      ? await loadGatewayCallModule()
+          .then(({ callGateway }) =>
+            callGateway<DoctorMemoryStatusPayload>({
+              method: "doctor.memory.status",
               timeoutMs: opts.timeoutMs,
               config: scan.cfg,
             }),
@@ -448,6 +461,14 @@ export async function statusCommand(
     }
     if (!memory) {
       const slot = memoryPlugin.slot ? `plugin ${memoryPlugin.slot}` : "plugin";
+      const gatewayMemoryProvider =
+        typeof gatewayMemoryStatus?.provider === "string" &&
+        gatewayMemoryStatus.provider.trim().length > 0
+          ? gatewayMemoryStatus.provider.trim()
+          : null;
+      if (gatewayMemoryProvider) {
+        return `${muted(`enabled (${slot})`)} · ${ok("gateway active")} · provider ${gatewayMemoryProvider}`;
+      }
       return muted(`enabled (${slot}) · unavailable`);
     }
     const parts: string[] = [];

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -978,6 +978,55 @@ describe("statusCommand", () => {
     expect(joined).not.toContain("enabled (plugin openclaw-honcho) · unavailable");
   });
 
+  it("includes gateway memory status in deep JSON output when local memory is unavailable", async () => {
+    mocks.loadConfig.mockReturnValue({
+      session: {},
+      plugins: {
+        slots: { memory: "openclaw-honcho" },
+      },
+    });
+    const memoryRuntime = await import("../plugins/memory-runtime.js");
+    vi.mocked(memoryRuntime.getActiveMemorySearchManager).mockResolvedValueOnce({
+      manager: null,
+      error: "memory plugin unavailable",
+    } as never);
+    mockProbeGatewayResult({
+      ok: true,
+      connectLatencyMs: 10,
+      error: null,
+      health: {},
+      status: {},
+      presence: [],
+    });
+    mocks.callGateway.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "last-heartbeat") {
+        return null;
+      }
+      if (method === "doctor.memory.status") {
+        return {
+          agentId: "main",
+          provider: "openclaw-honcho",
+          embedding: { ok: false, error: "irrelevant for external plugin" },
+        };
+      }
+      return {};
+    });
+
+    await statusCommand({ json: true, deep: true }, runtime as never);
+    const payload = JSON.parse(String(runtimeLogMock.mock.calls.at(-1)?.[0]));
+
+    expect(payload.memory).toBeNull();
+    expect(payload.memoryPlugin.enabled).toBe(true);
+    expect(payload.memoryPlugin.slot).toBe("openclaw-honcho");
+    expect(payload.gatewayMemoryStatus).toEqual(
+      expect.objectContaining({
+        agentId: "main",
+        provider: "openclaw-honcho",
+        embedding: expect.objectContaining({ ok: false }),
+      }),
+    );
+  });
+
   it("warns instead of crashing when gateway auth SecretRef is unresolved for probe auth", async () => {
     mocks.loadConfig.mockReturnValue({
       session: {},

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -937,6 +937,47 @@ describe("statusCommand", () => {
     });
   });
 
+  it("uses live gateway memory provider when local status cannot materialize the plugin", async () => {
+    mocks.loadConfig.mockReturnValue({
+      session: {},
+      plugins: {
+        slots: { memory: "openclaw-honcho" },
+      },
+    });
+    const memoryRuntime = await import("../plugins/memory-runtime.js");
+    vi.mocked(memoryRuntime.getActiveMemorySearchManager).mockResolvedValueOnce({
+      manager: null,
+      error: "memory plugin unavailable",
+    } as never);
+    mockProbeGatewayResult({
+      ok: true,
+      connectLatencyMs: 10,
+      error: null,
+      health: {},
+      status: {},
+      presence: [],
+    });
+    mocks.callGateway.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === "last-heartbeat") {
+        return null;
+      }
+      if (method === "doctor.memory.status") {
+        return {
+          agentId: "main",
+          provider: "openclaw-honcho",
+          embedding: { ok: false, error: "irrelevant for external plugin" },
+        };
+      }
+      return {};
+    });
+
+    const joined = await runStatusAndGetJoinedLogs({ deep: true });
+
+    expect(joined).toContain("gateway active");
+    expect(joined).toContain("provider openclaw-honcho");
+    expect(joined).not.toContain("enabled (plugin openclaw-honcho) · unavailable");
+  });
+
   it("warns instead of crashing when gateway auth SecretRef is unresolved for probe auth", async () => {
     mocks.loadConfig.mockReturnValue({
       session: {},


### PR DESCRIPTION
Closes #57256

This is a surgical fix for the `openclaw status --deep` false-negative when:

- a memory plugin is enabled
- the local status path cannot materialize the plugin runtime
- the live gateway is already running the memory plugin successfully

Instead of treating that as simply unavailable, the status command now checks `doctor.memory.status` and, when the gateway reports a non-empty `provider`, surfaces that provider on both output surfaces:

- human-readable `status --deep`
- machine-readable `status --json --deep`

Why this scope:
- no plugin loader/runtime changes
- no doctor payload shape changes
- no new runtime/embedding split
- minimal surface area for easier review

This directly addresses the Honcho/self-host case confirmed by @pdurlej:
https://github.com/openclaw/openclaw/issues/57256#issuecomment-4165336414

Validation:
- `pnpm lint` ✅
- commit hooks/checks ✅
- attempted targeted `status.test.ts` run, but the suite is currently blocked in this checkout by a pre-existing `telegram command config contract surface is unavailable` harness failure before the touched path executes
