### PR TITLE
fix(models): clear stale fallbacks when configure leaves selection empty

### DIFF
--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -279,8 +279,8 @@ export async function modelsScanCommand(
     throw new Error("Non-interactive scan: pass --yes to apply defaults.");
   }
 
-  if (selected.length === 0) {
-    throw new Error("No models selected for fallbacks.");
+  if (opts.setDefault && selected.length === 0) {
+    throw new Error("No models selected for primary model.");
   }
   if (opts.setImage && selectedImages.length === 0) {
     throw new Error("No image-capable models selected for image model.");
@@ -312,7 +312,7 @@ export async function modelsScanCommand(
       ...cfg.agents?.defaults,
       model: {
         ...(existingModel?.primary ? { primary: existingModel.primary } : undefined),
-        fallbacks: selected,
+        ...(selected.length > 0 ? { fallbacks: selected } : {}),
         ...(opts.setDefault ? { primary: selected[0] } : {}),
       },
       ...(nextImageModel ? { imageModel: nextImageModel } : {}),

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -202,7 +202,11 @@ export function mergePrimaryFallbackConfig(
     next.primary = patch.primary;
   }
   if (patch.fallbacks !== undefined) {
-    next.fallbacks = patch.fallbacks;
+    if (patch.fallbacks.length === 0) {
+      delete next.fallbacks;
+    } else {
+      next.fallbacks = patch.fallbacks;
+    }
   }
   return next;
 }


### PR DESCRIPTION
## Problem

When a user runs `openclaw configure` → Model → leaves fallback selection empty (or selects "Skip for now"), the **previous fallback list persists** in `openclaw.json`. When the primary model then fails, the runtime attempts the stale fallback (e.g. `ollama/glm-4.7-flash`) and gets a 404 cascade.

Reported in #60769.

## Root Cause

Two issues:

1. **`scan.ts` line 282**: when `selected.length === 0`, it threw `"No models selected for fallbacks."` instead of treating the empty selection as "clear the fallback list". This blocked any wizard path that tried to write zero fallbacks.

2. **`shared.ts` `mergePrimaryFallbackConfig`**: when called with `fallbacks: []`, it wrote `fallbacks: []` to the config object instead of deleting the key. An empty array still looks like a configured-but-empty fallback list, which can confuse some runtime paths.

## Fix

1. **`scan.ts`**: narrow the empty-selection guard to only apply when `--set-default` is passed (where a primary model selection is actually required). Empty fallback selection is now treated as "clear fallbacks".

2. **`shared.ts`**: when `patch.fallbacks` is an empty array, `delete next.fallbacks` instead of assigning `[]`. This ensures the field is fully removed from `openclaw.json` when cleared.

Fixes #60769