### PR TITLE
refactor(plugin-sdk): centralize private-network opt-in semantics

### DIFF
--- a/extensions/bluebubbles/src/account-resolve.ts
+++ b/extensions/bluebubbles/src/account-resolve.ts
@@ -1,4 +1,7 @@
-import { isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  isBlockedHostnameOrIp,
+  isPrivateNetworkOptInEnabled,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveBlueBubblesAccount } from "./accounts.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { normalizeResolvedSecretInputString } from "./secret-input.js";
@@ -58,6 +61,6 @@ export function resolveBlueBubblesServerAccount(params: BlueBubblesAccountResolv
     baseUrl,
     password,
     accountId: account.accountId,
-    allowPrivateNetwork: account.config.allowPrivateNetwork === true || autoAllowPrivateNetwork,
+    allowPrivateNetwork: isPrivateNetworkOptInEnabled(account.config) || autoAllowPrivateNetwork,
   };
 }

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -1,4 +1,7 @@
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromPrivateNetworkOptIn,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { z } from "openclaw/plugin-sdk/zod";
 
 export type MattermostFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -116,7 +119,7 @@ export function createMattermostClient(params: {
       url,
       init,
       auditContext: "mattermost-api",
-      policy: params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+      policy: ssrfPolicyFromPrivateNetworkOptIn(params.allowPrivateNetwork),
     });
     try {
       const bodyBytes = NULL_BODY_STATUSES.has(response.status)

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -1,4 +1,7 @@
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromPrivateNetworkOptIn,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeMattermostBaseUrl, readMattermostError, type MattermostUser } from "./client.js";
 import type { BaseProbeResult } from "./runtime-api.js";
 
@@ -33,7 +36,7 @@ export async function probeMattermost(
         signal: controller?.signal,
       },
       auditContext: "mattermost-probe",
-      policy: allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+      policy: ssrfPolicyFromPrivateNetworkOptIn(allowPrivateNetwork),
     });
     try {
       const elapsedMs = Date.now() - start;

--- a/extensions/nextcloud-talk/src/room-info.ts
+++ b/extensions/nextcloud-talk/src/room-info.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { ssrfPolicyFromPrivateNetworkOptIn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { fetchWithSsrFGuard, type RuntimeEnv } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { normalizeResolvedSecretInputString } from "./secret-input.js";
@@ -111,7 +112,7 @@ export async function resolveNextcloudTalkRoomKind(params: {
         },
       },
       auditContext: "nextcloud-talk.room-info",
-      policy: account.config?.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+      policy: ssrfPolicyFromPrivateNetworkOptIn(account.config),
     });
     try {
       if (!response.ok) {

--- a/extensions/nextcloud-talk/src/send.runtime.ts
+++ b/extensions/nextcloud-talk/src/send.runtime.ts
@@ -1,4 +1,5 @@
 export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
+export { ssrfPolicyFromPrivateNetworkOptIn } from "openclaw/plugin-sdk/ssrf-runtime";
 export { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 export { fetchWithSsrFGuard } from "../runtime-api.js";
 export { resolveNextcloudTalkAccount } from "./accounts.js";

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -6,6 +6,7 @@ import {
   getNextcloudTalkRuntime,
   resolveMarkdownTableMode,
   resolveNextcloudTalkAccount,
+  ssrfPolicyFromPrivateNetworkOptIn,
 } from "./send.runtime.js";
 import type { CoreConfig, NextcloudTalkSendResult } from "./types.js";
 
@@ -130,7 +131,7 @@ export async function sendMessageNextcloudTalk(
       body: bodyStr,
     },
     auditContext: "nextcloud-talk-send",
-    policy: account.config?.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+    policy: ssrfPolicyFromPrivateNetworkOptIn(account.config),
   });
 
   try {
@@ -218,7 +219,7 @@ export async function sendReactionNextcloudTalk(
       body,
     },
     auditContext: "nextcloud-talk-reaction",
-    policy: account.config?.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+    policy: ssrfPolicyFromPrivateNetworkOptIn(account.config),
   });
 
   try {

--- a/src/plugin-sdk/ssrf-policy.test.ts
+++ b/src/plugin-sdk/ssrf-policy.test.ts
@@ -3,9 +3,11 @@ import type { LookupFn } from "../infra/net/ssrf.js";
 import {
   assertHttpUrlTargetsPrivateNetwork,
   buildHostnameAllowlistPolicyFromSuffixAllowlist,
+  isPrivateNetworkOptInEnabled,
   isHttpsUrlAllowedByHostnameSuffixAllowlist,
   normalizeHostnameSuffixAllowlist,
   ssrfPolicyFromAllowPrivateNetwork,
+  ssrfPolicyFromPrivateNetworkOptIn,
 } from "./ssrf-policy.js";
 
 function createLookupFn(addresses: Array<{ address: string; family: number }>): LookupFn {
@@ -36,6 +38,70 @@ describe("ssrfPolicyFromAllowPrivateNetwork", () => {
     },
   ])("$name", ({ input, expected }) => {
     expect(ssrfPolicyFromAllowPrivateNetwork(input)).toEqual(expected);
+  });
+});
+
+describe("isPrivateNetworkOptInEnabled", () => {
+  it.each([
+    {
+      name: "returns false for missing input",
+      input: undefined,
+      expected: false,
+    },
+    {
+      name: "returns false for explicit false",
+      input: false,
+      expected: false,
+    },
+    {
+      name: "returns true for explicit boolean true",
+      input: true,
+      expected: true,
+    },
+    {
+      name: "returns true for flat allowPrivateNetwork config",
+      input: { allowPrivateNetwork: true },
+      expected: true,
+    },
+    {
+      name: "returns true for flat dangerous opt-in config",
+      input: { dangerouslyAllowPrivateNetwork: true },
+      expected: true,
+    },
+    {
+      name: "returns true for nested network dangerous opt-in config",
+      input: { network: { dangerouslyAllowPrivateNetwork: true } },
+      expected: true,
+    },
+    {
+      name: "returns false for nested false values",
+      input: { network: { dangerouslyAllowPrivateNetwork: false } },
+      expected: false,
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(isPrivateNetworkOptInEnabled(input)).toBe(expected);
+  });
+});
+
+describe("ssrfPolicyFromPrivateNetworkOptIn", () => {
+  it.each([
+    {
+      name: "returns undefined for unset input",
+      input: undefined,
+      expected: undefined,
+    },
+    {
+      name: "returns undefined for explicit false input",
+      input: { allowPrivateNetwork: false },
+      expected: undefined,
+    },
+    {
+      name: "returns the compat policy for nested dangerous input",
+      input: { network: { dangerouslyAllowPrivateNetwork: true } },
+      expected: { allowPrivateNetwork: true },
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(ssrfPolicyFromPrivateNetworkOptIn(input)).toEqual(expected);
   });
 });
 

--- a/src/plugin-sdk/ssrf-policy.ts
+++ b/src/plugin-sdk/ssrf-policy.ts
@@ -9,10 +9,45 @@ import {
 export { isPrivateIpAddress };
 export type { SsrFPolicy };
 
+export type PrivateNetworkOptInInput =
+  | boolean
+  | null
+  | undefined
+  | Pick<SsrFPolicy, "allowPrivateNetwork" | "dangerouslyAllowPrivateNetwork">
+  | {
+      allowPrivateNetwork?: boolean | null;
+      dangerouslyAllowPrivateNetwork?: boolean | null;
+      network?:
+        | Pick<SsrFPolicy, "allowPrivateNetwork" | "dangerouslyAllowPrivateNetwork">
+        | null
+        | undefined;
+    };
+
+export function isPrivateNetworkOptInEnabled(input: PrivateNetworkOptInInput): boolean {
+  if (input === true) {
+    return true;
+  }
+  if (!input || typeof input !== "object") {
+    return false;
+  }
+  return (
+    input.allowPrivateNetwork === true ||
+    input.dangerouslyAllowPrivateNetwork === true ||
+    input.network?.allowPrivateNetwork === true ||
+    input.network?.dangerouslyAllowPrivateNetwork === true
+  );
+}
+
+export function ssrfPolicyFromPrivateNetworkOptIn(
+  input: PrivateNetworkOptInInput,
+): SsrFPolicy | undefined {
+  return isPrivateNetworkOptInEnabled(input) ? { allowPrivateNetwork: true } : undefined;
+}
+
 export function ssrfPolicyFromAllowPrivateNetwork(
   allowPrivateNetwork: boolean | null | undefined,
 ): SsrFPolicy | undefined {
-  return allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined;
+  return ssrfPolicyFromPrivateNetworkOptIn(allowPrivateNetwork);
 }
 
 export async function assertHttpUrlTargetsPrivateNetwork(

--- a/src/plugin-sdk/ssrf-runtime.ts
+++ b/src/plugin-sdk/ssrf-runtime.ts
@@ -15,6 +15,8 @@ export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export {
   assertHttpUrlTargetsPrivateNetwork,
   buildHostnameAllowlistPolicyFromSuffixAllowlist,
+  isPrivateNetworkOptInEnabled,
+  ssrfPolicyFromPrivateNetworkOptIn,
   ssrfPolicyFromAllowPrivateNetwork,
 } from "./ssrf-policy.js";
 export { isPrivateOrLoopbackHost } from "../gateway/net.js";


### PR DESCRIPTION
## Summary
- add a shared Plugin SDK helper for current private-network opt-in semantics
- keep the emitted SSRF policy compat-shaped as `{ allowPrivateNetwork: true }`
- reuse the helper in Mattermost, Nextcloud Talk, and BlueBubbles account resolution without renaming any public config keys or changing existing opt-in behavior

## Design boundary
- no public config rename in this PR
- no security-posture change in this PR
- `false` and unset continue to avoid adding any extra private-network opt-in
- BlueBubbles loopback/private-host auto-detection stays intact

## Verification
- `pnpm exec oxlint src/plugin-sdk/ssrf-policy.ts src/plugin-sdk/ssrf-policy.test.ts src/plugin-sdk/ssrf-runtime.ts extensions/mattermost/src/mattermost/client.ts extensions/mattermost/src/mattermost/probe.ts extensions/nextcloud-talk/src/send.runtime.ts extensions/nextcloud-talk/src/send.ts extensions/nextcloud-talk/src/room-info.ts extensions/bluebubbles/src/account-resolve.ts`
- `git diff --check`
- `node --import tsx -e "import { ssrfPolicyFromPrivateNetworkOptIn } from "./src/plugin-sdk/ssrf-policy.ts"; console.log(JSON.stringify({ nested: ssrfPolicyFromPrivateNetworkOptIn({ network: { dangerouslyAllowPrivateNetwork: true } }), flatFalse: ssrfPolicyFromPrivateNetworkOptIn({ allowPrivateNetwork: false }) }))"`
- `pnpm plugin-sdk:api:gen`

## Local caveat
- local Vitest wrapper runs and local `scripts/generate-plugin-sdk-api-baseline.ts --check` both stalled in this low-disk worktree, so I am relying on CI for those lanes rather than overstating a local pass