### PR TITLE
fix(plugins): complete vllm facade fix in provider-vllm-setup

### DIFF
--- a/src/plugins/provider-vllm-setup.ts
+++ b/src/plugins/provider-vllm-setup.ts
@@ -1,10 +1,10 @@
-import type { OpenClawConfig } from "../config/config.js";
 import {
   VLLM_DEFAULT_API_KEY_ENV_VAR,
   VLLM_DEFAULT_BASE_URL,
   VLLM_MODEL_PLACEHOLDER,
   VLLM_PROVIDER_LABEL,
-} from "../plugin-sdk/vllm.js";
+} from "../../extensions/vllm/defaults.js";
+import type { OpenClawConfig } from "../config/config.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import {
   applyProviderDefaultModel,
@@ -14,7 +14,7 @@ import {
   promptAndConfigureOpenAICompatibleSelfHostedProvider,
 } from "./provider-self-hosted-setup.js";
 
-export { VLLM_DEFAULT_BASE_URL } from "../plugin-sdk/vllm.js";
+export { VLLM_DEFAULT_BASE_URL } from "../../extensions/vllm/defaults.js";
 export const VLLM_DEFAULT_CONTEXT_WINDOW = SELF_HOSTED_DEFAULT_CONTEXT_WINDOW;
 export const VLLM_DEFAULT_MAX_TOKENS = SELF_HOSTED_DEFAULT_MAX_TOKENS;
 export const VLLM_DEFAULT_COST = SELF_HOSTED_DEFAULT_COST;


### PR DESCRIPTION
## Summary

- `provider-vllm-setup.ts` was missed in 8109195ad (fix(plugin-sdk): avoid recursive bundled facade loads). It still imported VLLM constants from `plugin-sdk/vllm.js` (the generated facade).
- In source checkouts, the facade evaluates primitive constants eagerly at module init time, causing infinite recursion: sglang/vllm plugin load → `provider-setup` → `provider-vllm-setup` → vllm facade (eager `loadFacadeModule()`) → `extensions/vllm/api.ts` → `vllm/models.ts` → `provider-setup` → ∞
- Fix imports the constants directly from `extensions/vllm/defaults.ts`, where they are defined as plain primitive exports with no side effects.

## Test plan

- [ ] Run gateway from source checkout — sglang and vllm plugins load without `RangeError: Maximum call stack size exceeded`
- [ ] `pnpm test` green