### PR TITLE
Fix: status shows unavailable for third-party memory plugins

### DIFF
--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -138,6 +138,23 @@ export async function resolveSharedMemoryStatusSnapshot(params: {
     return null;
   }
   const agentId = agentStatus.defaultId ?? "main";
+
+  // For third-party plugins (not memory-core), skip built-in config checks
+  // and directly use the plugin's memory manager
+  if (memoryPlugin.slot !== "memory-core") {
+    const { manager } = await params.getMemorySearchManager({ cfg, agentId, purpose: "status" });
+    if (!manager) {
+      return null;
+    }
+    try {
+      await manager.probeVectorAvailability();
+    } catch {}
+    const status = manager.status();
+    await manager.close?.().catch(() => {});
+    return { agentId, ...status };
+  }
+
+  // Existing logic for memory-core (built-in)
   const defaultStorePath = params.requireDefaultStore?.(agentId);
   if (
     defaultStorePath &&


### PR DESCRIPTION
- Add handling for third-party memory plugins (e.g., memory-lancedb-pro)
- Skip built-in config checks when using non-core memory plugins
- Directly use the plugin's memory manager for status checks

Fixes #56968
