### PR TITLE
fix(canvas-host): add baseline security headers to standalone server

### DIFF
--- a/src/canvas-host/server.test.ts
+++ b/src/canvas-host/server.test.ts
@@ -445,4 +445,37 @@ describe("canvas host", () => {
       }
     }
   });
+
+  it("includes baseline security headers on responses", async () => {
+    const dir = await createCaseDir();
+    await fs.writeFile(path.join(dir, "index.html"), "<html><body>sec</body></html>", "utf8");
+    let server: Awaited<ReturnType<typeof startFixtureCanvasHost>>;
+    try {
+      server = await startFixtureCanvasHost(dir);
+    } catch (error) {
+      if (isLoopbackBindDenied(error)) {
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      const res = await realFetch(`http://127.0.0.1:${server.port}${CANVAS_HOST_PATH}/`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(res.headers.get("x-frame-options")).toBe("DENY");
+
+      // 404 responses should also carry security headers.
+      const notFound = await realFetch(
+        `http://127.0.0.1:${server.port}${CANVAS_HOST_PATH}/does-not-exist.txt`,
+      );
+      expect(notFound.status).toBe(404);
+      expect(notFound.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(notFound.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(notFound.headers.get("x-frame-options")).toBe("DENY");
+    } finally {
+      await server.close();
+    }
+  });
 });

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -464,6 +464,14 @@ export async function startCanvasHost(opts: CanvasHostServerOpts): Promise<Canva
 
   const bindHost = opts.listenHost?.trim() || "127.0.0.1";
   const server: Server = http.createServer((req, res) => {
+    // Baseline security headers for all responses served by the standalone
+    // canvas host (defense-in-depth even though it typically binds to
+    // loopback).  The gateway HTTP handler applies its own set; these cover
+    // the standalone server path that the gateway does not wrap.
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader("X-Frame-Options", "DENY");
+
     if (String(req.headers.upgrade ?? "").toLowerCase() === "websocket") {
       return;
     }


### PR DESCRIPTION
## Summary

The standalone canvas host HTTP server (used by `canvas present` and the canvas development server) serves user-generated content without any security headers. While the gateway HTTP handler applies its own baseline headers when proxying requests, the standalone canvas host server path was unprotected.

## Changes

- Add `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and `X-Frame-Options: DENY` headers to all responses from the standalone canvas host server
- Headers are applied early in the request handler before any routing, ensuring they cover all response paths including 404s and error responses
- Provides defense-in-depth even though the server typically binds to loopback

## Testing

- Added test verifying security headers are present on both successful (200) and not-found (404) responses from the standalone server
- All existing canvas host tests continue to pass