### PR TITLE
Browser: headless fallback on Linux without display

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -44,6 +44,9 @@ openclaw browser --browser-profile openclaw reset-profile
 
 Notes:
 
+- On Linux hosts without a display server (`$DISPLAY` / `$WAYLAND_DISPLAY` unset), managed browser launches now fall back to headless mode automatically unless you explicitly force headed mode.
+- To force headless mode for a launch without editing config, use `OPENCLAW_BROWSER_HEADLESS=1 openclaw browser start`.
+- To force headed mode, use `OPENCLAW_BROWSER_HEADLESS=0 openclaw browser start`. If no display server is available, OpenClaw returns an actionable error suggesting headless mode or Xvfb.
 - For `attachOnly` and remote CDP profiles, `openclaw browser stop` closes the
   active control session and clears temporary emulation overrides even when
   OpenClaw did not launch the browser process itself.

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -37,9 +37,14 @@ import {
 } from "./chrome.profile-decoration.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import {
+  getManagedBrowserMissingDisplayError,
+  resolveManagedBrowserHeadlessMode,
+} from "./config.js";
+import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "./constants.js";
+import { BrowserProfileUnavailableError } from "./errors.js";
 
 const log = createSubsystemLogger("browser").child("chrome");
 
@@ -91,6 +96,7 @@ export function buildOpenClawChromeLaunchArgs(params: {
   userDataDir: string;
 }): string[] {
   const { resolved, profile, userDataDir } = params;
+  const { headless } = resolveManagedBrowserHeadlessMode(resolved);
   const args: string[] = [
     `--remote-debugging-port=${profile.cdpPort}`,
     `--user-data-dir=${userDataDir}`,
@@ -105,7 +111,7 @@ export function buildOpenClawChromeLaunchArgs(params: {
     "--password-store=basic",
   ];
 
-  if (resolved.headless) {
+  if (headless) {
     args.push("--headless=new");
     args.push("--disable-gpu");
   }
@@ -299,6 +305,10 @@ export async function launchOpenClawChrome(
 ): Promise<RunningChrome> {
   if (!profile.cdpIsLoopback) {
     throw new Error(`Profile "${profile.name}" is remote; cannot launch local Chrome.`);
+  }
+  const missingDisplayError = getManagedBrowserMissingDisplayError(resolved, profile.name);
+  if (missingDisplayError) {
+    throw new BrowserProfileUnavailableError(missingDisplayError);
   }
   await ensurePortAvailable(profile.cdpPort);
 

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { BrowserConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveBrowserConfig, resolveProfile, shouldStartLocalBrowserServer } from "./config.js";
+import {
+  getManagedBrowserMissingDisplayError,
+  OPENCLAW_BROWSER_HEADLESS_ENV,
+  resolveBrowserConfig,
+  resolveManagedBrowserHeadlessMode,
+  resolveProfile,
+  shouldStartLocalBrowserServer,
+} from "./config.js";
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
 
 function withEnv<T>(env: Record<string, string | undefined>, fn: () => T): T {
@@ -437,6 +444,77 @@ describe("browser config", () => {
         },
       });
       expect(resolved.defaultProfile).toBe("custom");
+    });
+  });
+
+  describe("managed browser headless mode", () => {
+    it("falls back to headless on Linux when no display server is available", () => {
+      const resolved = resolveBrowserConfig({});
+      expect(
+        resolveManagedBrowserHeadlessMode(resolved, {
+          platform: "linux",
+          env: {
+            ...process.env,
+            DISPLAY: "",
+            WAYLAND_DISPLAY: "",
+            [OPENCLAW_BROWSER_HEADLESS_ENV]: undefined,
+          },
+        }),
+      ).toEqual({
+        headless: true,
+        source: "linux-display-fallback",
+      });
+    });
+
+    it("keeps prior headed default when a display server is available", () => {
+      const resolved = resolveBrowserConfig({});
+      expect(
+        resolveManagedBrowserHeadlessMode(resolved, {
+          platform: "linux",
+          env: {
+            ...process.env,
+            DISPLAY: ":0",
+            WAYLAND_DISPLAY: undefined,
+            [OPENCLAW_BROWSER_HEADLESS_ENV]: undefined,
+          },
+        }),
+      ).toEqual({
+        headless: false,
+        source: "default",
+      });
+    });
+
+    it("ignores invalid OPENCLAW_BROWSER_HEADLESS values safely", () => {
+      const resolved = resolveBrowserConfig({});
+      expect(
+        resolveManagedBrowserHeadlessMode(resolved, {
+          platform: "linux",
+          env: {
+            ...process.env,
+            DISPLAY: ":0",
+            WAYLAND_DISPLAY: undefined,
+            [OPENCLAW_BROWSER_HEADLESS_ENV]: "maybe",
+          },
+        }),
+      ).toEqual({
+        headless: false,
+        source: "default",
+      });
+    });
+
+    it("treats explicit config headed mode without a display as an actionable error", () => {
+      const resolved = resolveBrowserConfig({ headless: false });
+      expect(
+        getManagedBrowserMissingDisplayError(resolved, "openclaw", {
+          platform: "linux",
+          env: {
+            ...process.env,
+            DISPLAY: "",
+            WAYLAND_DISPLAY: "",
+            [OPENCLAW_BROWSER_HEADLESS_ENV]: undefined,
+          },
+        }),
+      ).toContain(`Set ${OPENCLAW_BROWSER_HEADLESS_ENV}=1`);
     });
   });
 });

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -8,6 +8,7 @@ import {
 import { isLoopbackHost } from "../gateway/net.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { resolveUserPath } from "../utils.js";
+import { parseBooleanValue } from "../utils/boolean.js";
 import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_ENABLED,
@@ -31,12 +32,20 @@ export type ResolvedBrowserConfig = {
   color: string;
   executablePath?: string;
   headless: boolean;
+  headlessConfigured?: boolean;
   noSandbox: boolean;
   attachOnly: boolean;
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
   ssrfPolicy?: SsrFPolicy;
   extraArgs: string[];
+};
+
+export const OPENCLAW_BROWSER_HEADLESS_ENV = "OPENCLAW_BROWSER_HEADLESS";
+
+export type ManagedBrowserHeadlessMode = {
+  headless: boolean;
+  source: "env" | "config" | "linux-display-fallback" | "default";
 };
 
 export type ResolvedBrowserProfile = {
@@ -250,6 +259,7 @@ export function resolveBrowserConfig(
     };
   }
 
+  const headlessConfigured = typeof cfg?.headless === "boolean";
   const headless = cfg?.headless === true;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
@@ -297,6 +307,7 @@ export function resolveBrowserConfig(
     color: defaultColor,
     executablePath,
     headless,
+    headlessConfigured,
     noSandbox,
     attachOnly,
     defaultProfile,
@@ -304,6 +315,59 @@ export function resolveBrowserConfig(
     ssrfPolicy,
     extraArgs,
   };
+}
+
+function hasEnvDisplay(env: NodeJS.ProcessEnv): boolean {
+  const display = env.DISPLAY?.trim();
+  const waylandDisplay = env.WAYLAND_DISPLAY?.trim();
+  return Boolean(display || waylandDisplay);
+}
+
+export function resolveManagedBrowserHeadlessMode(
+  resolved: ResolvedBrowserConfig,
+  params: {
+    env?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+  } = {},
+): ManagedBrowserHeadlessMode {
+  const env = params.env ?? process.env;
+  const platform = params.platform ?? process.platform;
+  const envHeadless = parseBooleanValue(env[OPENCLAW_BROWSER_HEADLESS_ENV]);
+
+  if (envHeadless !== undefined) {
+    return { headless: envHeadless, source: "env" };
+  }
+  if (resolved.headlessConfigured === true) {
+    return { headless: resolved.headless, source: "config" };
+  }
+  if (platform === "linux" && !hasEnvDisplay(env)) {
+    return { headless: true, source: "linux-display-fallback" };
+  }
+  return { headless: resolved.headless, source: "default" };
+}
+
+export function getManagedBrowserMissingDisplayError(
+  resolved: ResolvedBrowserConfig,
+  profileName: string,
+  params: {
+    env?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+  } = {},
+): string | null {
+  const env = params.env ?? process.env;
+  const platform = params.platform ?? process.platform;
+  if (platform !== "linux" || hasEnvDisplay(env)) {
+    return null;
+  }
+  const mode = resolveManagedBrowserHeadlessMode(resolved, { env, platform });
+  if (mode.headless) {
+    return null;
+  }
+  return (
+    `Headed browser start requested for profile "${profileName}", but no Linux display server was detected ` +
+    `($DISPLAY/$WAYLAND_DISPLAY unset). Set ${OPENCLAW_BROWSER_HEADLESS_ENV}=1, set browser.headless=true, ` +
+    `or launch under Xvfb if you need a visible browser.`
+  );
 }
 
 /**

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -1,5 +1,6 @@
 import { getChromeMcpPid } from "../chrome-mcp.js";
 import { resolveBrowserExecutableForPlatform } from "../chrome.executables.js";
+import { resolveManagedBrowserHeadlessMode } from "../config.js";
 import { toBrowserErrorResponse } from "../errors.js";
 import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
 import { createBrowserProfilesService } from "../profiles-service.js";
@@ -95,6 +96,8 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
         detectError = String(err);
       }
 
+      const managedHeadlessMode = resolveManagedBrowserHeadlessMode(current.resolved);
+
       res.json({
         enabled: current.resolved.enabled,
         profile: profileCtx.profile.name,
@@ -114,7 +117,7 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
         detectError,
         userDataDir: profileState?.running?.userDataDir ?? profileCtx.profile.userDataDir ?? null,
         color: profileCtx.profile.color,
-        headless: current.resolved.headless,
+        headless: managedHeadlessMode.headless,
         noSandbox: current.resolved.noSandbox,
         executablePath: current.resolved.executablePath ?? null,
         attachOnly: profileCtx.profile.attachOnly,


### PR DESCRIPTION
Fixes headless-host failures for `openclaw browser start`.

Problem
- On Linux hosts without a display server (`$DISPLAY` / `$WAYLAND_DISPLAY` unset), managed Chrome launch fails with:
  - "Missing X server or $DISPLAY" / platform init failure
- This blocks CommsOps jobs that rely on browser automation.

Changes
- Adds `OPENCLAW_BROWSER_HEADLESS` env override (parsed via existing boolean parser).
- If no explicit env override and `browser.headless` is not explicitly configured, OpenClaw now **falls back to headless mode on Linux** when no display server is detected.
- If headed mode is explicitly requested on Linux without a display, returns an actionable error suggesting:
  - `OPENCLAW_BROWSER_HEADLESS=1`, or
  - `browser.headless=true`, or
  - launching under Xvfb.
- Status route now reports the effective managed headless mode.

Tests
- Added/updated browser config tests for:
  - Linux display fallback
  - headed default when display exists
  - invalid env values ignored safely
  - actionable error when headed-without-display

How to use
- Force headless: `OPENCLAW_BROWSER_HEADLESS=1 openclaw browser start`
- Force headed: `OPENCLAW_BROWSER_HEADLESS=0 openclaw browser start`

Notes
- Headed behavior is unchanged when a display server is present.