### PR TITLE
fix: strip /openai suffix in resolveGoogleBaseUrl for native Gemini image API

### DIFF
--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -53,7 +53,10 @@ type GoogleGenerateImageResponse = {
 };
 
 function resolveGoogleBaseUrl(cfg: Parameters<typeof resolveApiKeyForProvider>[0]["cfg"]): string {
-  return normalizeGoogleApiBaseUrl(cfg?.models?.providers?.google?.baseUrl);
+  // Strip the /openai suffix if present: native Gemini image API does not use
+  // the OpenAI-compatible endpoint and returns HTTP 404 when it is included.
+  const raw = normalizeGoogleApiBaseUrl(cfg?.models?.providers?.google?.baseUrl);
+  return raw.replace(/\/openai$/, "");
 }
 
 function normalizeGoogleImageModel(model: string | undefined): string {


### PR DESCRIPTION
## Summary

Fixes #60959.

When a user configures a Google provider `baseUrl` that includes the `/openai` suffix (e.g. for OpenAI-compatible routing such as `https://generativelanguage.googleapis.com/v1beta/openai`), the `resolveGoogleBaseUrl()` function was passing that suffix through unchanged to the native Gemini `generateContent` endpoint. This caused HTTP 404 errors because the native Gemini image API does not live under the `/openai` path.

- In `extensions/google/image-generation-provider.ts`, updated `resolveGoogleBaseUrl()` to strip a trailing `/openai` segment from the URL returned by `normalizeGoogleApiBaseUrl()` before it is used to construct the `generateContent` request URL.
- This is a targeted, minimal fix — no changes to `normalizeGoogleApiBaseUrl` itself (which is shared with other providers/flows that may legitimately need the `/openai` suffix).

## Test plan

- [x] Existing unit tests in `extensions/google/image-generation-provider.test.ts` continue to pass (`pnpm test -- extensions/google/image-generation-provider.test.ts`)
- [x] Manually verify that configuring `models.providers.google.baseUrl` with an `/openai` suffix no longer produces HTTP 404 on image generation requests
- [x] Verify that a baseUrl without `/openai` is unaffected

