### PR TITLE
Prototype LiteRT-LM local model path for Edge Gallery-downloaded models

### DIFF
--- a/docs/litertlm/config-registration-draft.md
+++ b/docs/litertlm/config-registration-draft.md
@@ -9,6 +9,7 @@ Describe how the validated LiteRT-LM local model path could be represented as an
 OpenClaw would call a **process-based shim** instead of embedding LiteRT-LM directly in-process for the first experimental version.
 
 Current shim entry:
+
 - `python3 scripts/litertlm_provider_shim.py --input '<json>'`
 
 ## Suggested experimental model ids
@@ -17,6 +18,7 @@ Current shim entry:
 - `litertlm/gemma4-e4b-edge-gallery` — validated as functional, but recommended only as an optional experimental registration for now
 
 These model ids represent:
+
 - LiteRT-LM runtime
 - local `.litertlm` files downloaded by Edge Gallery
 - process-based experimental adapter
@@ -133,6 +135,7 @@ These model ids represent:
 ### OpenClaw-side error interpretation
 
 Map to a user-facing error like:
+
 - local model runtime missing
 - local model file missing
 - invalid experimental backend input
@@ -141,13 +144,16 @@ Map to a user-facing error like:
 ## Recommended first registration behavior
 
 ### Behavior
+
 - mark model as experimental
 - disable by default unless explicitly enabled
 - prefer explicit selection, not silent fallback
 - surface diagnostics in logs or debug panel
 
 ### Why
+
 Because this path still depends on:
+
 - a Python runtime
 - a machine-local venv / package install
 - a local Edge Gallery model download path
@@ -184,6 +190,7 @@ Example draft shape:
 ## Recommended next code step
 
 If this moves beyond design, the next implementation task should be:
+
 - a tiny OpenClaw-side adapter that shells out to `litertlm_provider_shim.py`
 - maps success/error JSON
 - exposes one experimental local model id first, preferably E2B
@@ -191,9 +198,11 @@ If this moves beyond design, the next implementation task should be:
 ## Recommendation
 
 Start with one model registration first:
+
 - `litertlm/gemma4-e2b-edge-gallery`
 
 E4B has now been practically validated as functional on this machine through the wrapper path, but current recommendation remains:
+
 - keep E2B as the default experimental registration
 - expose E4B only as an optional secondary experimental model
 - defer making E4B the default until repeated-run latency and comfort are better understood

--- a/docs/litertlm/config-registration-draft.md
+++ b/docs/litertlm/config-registration-draft.md
@@ -1,0 +1,199 @@
+# LiteRT-LM OpenClaw Config / Registration Draft
+
+## Goal
+
+Describe how the validated LiteRT-LM local model path could be represented as an experimental OpenClaw model registration.
+
+## Key assumption
+
+OpenClaw would call a **process-based shim** instead of embedding LiteRT-LM directly in-process for the first experimental version.
+
+Current shim entry:
+- `python3 scripts/litertlm_provider_shim.py --input '<json>'`
+
+## Suggested experimental model ids
+
+- `litertlm/gemma4-e2b-edge-gallery` — recommended first/default experimental registration
+- `litertlm/gemma4-e4b-edge-gallery` — validated as functional, but recommended only as an optional experimental registration for now
+
+These model ids represent:
+- LiteRT-LM runtime
+- local `.litertlm` files downloaded by Edge Gallery
+- process-based experimental adapter
+
+## Suggested config concepts
+
+### Model registration metadata
+
+```json
+{
+  "id": "litertlm/gemma4-e2b-edge-gallery",
+  "kind": "experimental-local-model",
+  "displayName": "Gemma 4 E2B (LiteRT-LM via Edge Gallery download)",
+  "runtime": "process-shim",
+  "entry": "scripts/litertlm_provider_shim.py",
+  "backend": "CPU",
+  "modelPathStrategy": "edge-gallery-autodetect"
+}
+```
+
+## Suggested request mapping
+
+### OpenClaw-side request
+
+```json
+{
+  "prompt": "Reply with exactly: hello",
+  "system": "You are concise."
+}
+```
+
+### Shim input
+
+```json
+{
+  "prompt": "Reply with exactly: hello",
+  "system": "You are concise.",
+  "backend": "CPU"
+}
+```
+
+### Optional explicit model override
+
+```json
+{
+  "prompt": "Reply with exactly: hello",
+  "system": "You are concise.",
+  "model": "/Users/arvinku/.../Gemma_4_E4B_it/...litertlm",
+  "backend": "CPU"
+}
+```
+
+## Suggested response mapping
+
+### Shim output
+
+```json
+{
+  "ok": true,
+  "model": "/resolved/path/to/model.litertlm",
+  "backend": "CPU",
+  "output_text": "hello",
+  "raw_response": {
+    "content": [
+      {
+        "text": "hello",
+        "type": "text"
+      }
+    ],
+    "role": "assistant"
+  },
+  "diagnostics": {
+    "model_source": "auto",
+    "resolved_model": "/resolved/path/to/model.litertlm",
+    "python_executable": "/tmp/litertlm-venv/bin/python"
+  }
+}
+```
+
+### OpenClaw-side normalized result
+
+```json
+{
+  "text": "hello",
+  "model": "litertlm/gemma4-e2b-edge-gallery",
+  "provider": "litertlm-local-experimental",
+  "diagnostics": {
+    "resolved_model": "/resolved/path/to/model.litertlm",
+    "backend": "CPU"
+  }
+}
+```
+
+## Suggested error mapping
+
+### Shim error example
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "runtime_missing",
+    "message": "No Python interpreter with litert_lm available. Run setup first."
+  },
+  "diagnostics": {
+    "runtime_resolver": {
+      "selected": null,
+      "checked": []
+    }
+  }
+}
+```
+
+### OpenClaw-side error interpretation
+
+Map to a user-facing error like:
+- local model runtime missing
+- local model file missing
+- invalid experimental backend input
+- local generation failure
+
+## Recommended first registration behavior
+
+### Behavior
+- mark model as experimental
+- disable by default unless explicitly enabled
+- prefer explicit selection, not silent fallback
+- surface diagnostics in logs or debug panel
+
+### Why
+Because this path still depends on:
+- a Python runtime
+- a machine-local venv / package install
+- a local Edge Gallery model download path
+
+## Suggested settings block
+
+Example draft shape:
+
+```json
+{
+  "experimentalLocalModels": {
+    "litertlm": {
+      "enabled": true,
+      "pythonStrategy": "autodetect",
+      "providerShim": "scripts/litertlm_provider_shim.py",
+      "defaultBackend": "CPU",
+      "models": {
+        "litertlm/gemma4-e2b-edge-gallery": {
+          "displayName": "Gemma 4 E2B (LiteRT-LM)",
+          "pathStrategy": "edge-gallery-autodetect",
+          "preferredMatch": "Gemma_4_E2B_it"
+        },
+        "litertlm/gemma4-e4b-edge-gallery": {
+          "displayName": "Gemma 4 E4B (LiteRT-LM)",
+          "pathStrategy": "edge-gallery-autodetect",
+          "preferredMatch": "Gemma_4_E4B_it"
+        }
+      }
+    }
+  }
+}
+```
+
+## Recommended next code step
+
+If this moves beyond design, the next implementation task should be:
+- a tiny OpenClaw-side adapter that shells out to `litertlm_provider_shim.py`
+- maps success/error JSON
+- exposes one experimental local model id first, preferably E2B
+
+## Recommendation
+
+Start with one model registration first:
+- `litertlm/gemma4-e2b-edge-gallery`
+
+E4B has now been practically validated as functional on this machine through the wrapper path, but current recommendation remains:
+- keep E2B as the default experimental registration
+- expose E4B only as an optional secondary experimental model
+- defer making E4B the default until repeated-run latency and comfort are better understood

--- a/docs/litertlm/implementation-handoff-summary.md
+++ b/docs/litertlm/implementation-handoff-summary.md
@@ -1,0 +1,126 @@
+# LiteRT-LM OpenClaw Implementation Handoff Summary
+
+## What this project proved
+
+This work established that Edge Gallery-downloaded `.litertlm` files can be used as real local models for OpenClaw — not by automating the Edge Gallery UI, but by loading those files directly with LiteRT-LM.
+
+### Critical validated fact
+- LiteRT-LM Python API on macOS successfully loaded the Edge Gallery-downloaded Gemma 4 E2B `.litertlm` model and returned correct local inference output.
+
+### Also validated
+- Gemma 4 E4B `.litertlm` also loads and answers successfully on CPU, though it is heavier and should remain optional experimental rather than default.
+
+## Recommended architecture
+
+```text
+Edge Gallery
+  -> local model downloader / manager
+
+LiteRT-LM
+  -> actual local inference runtime
+
+OpenClaw
+  -> experimental local provider / thin adapter
+```
+
+## What now exists in the workspace
+
+### Runtime / wrapper prototypes
+- `scripts/litertlm_model_resolver.py`
+- `scripts/litertlm_runtime_resolver.py`
+- `scripts/litertlm_local_chat.py`
+- `scripts/litertlm_openclaw_wrapper.py`
+- `scripts/litertlm_provider_shim.py`
+
+### Key docs
+- `docs/litertlm-openclaw-provider-design.md`
+- `docs/litertlm-local-model-setup.md`
+- `docs/litertlm-provider-shim-notes.md`
+- `docs/litertlm-openclaw-experimental-adapter-spec.md`
+- `docs/litertlm-openclaw-config-registration-draft.md`
+- `docs/litertlm-openclaw-thin-adapter-skeleton.md`
+- `docs/litertlm-openclaw-patch-plan.md`
+- `docs/litertlm-openclaw-streamfn-contract-notes.md`
+- `docs/litertlm-gemma4-e4b-practical-test-2026-04-04.md`
+- `docs/litertlm-extension-compile-oriented-cleanup-plan.md`
+
+### `openclaw-src` draft extension skeleton
+- `openclaw-src/extensions/litertlm/index.ts`
+- `openclaw-src/extensions/litertlm/src/provider-models.ts`
+- `openclaw-src/extensions/litertlm/src/stream.ts`
+- `openclaw-src/extensions/litertlm/index.test.ts`
+- `openclaw-src/extensions/litertlm/README.md`
+
+## Current technical recommendation
+
+### Default experimental model
+- `litertlm/gemma4-e2b-edge-gallery`
+
+### Secondary optional experimental model
+- `litertlm/gemma4-e4b-edge-gallery`
+
+### Provider id
+- `litertlm-local`
+
+## Current provider strategy
+
+Use a bundled provider plugin modeled loosely after Ollama, but with a major difference:
+- **do not use HTTP transport to a local server**
+- **do use a process-based shim over LiteRT-LM**
+
+## Current stream strategy
+
+For the first experimental version, do not block on token-level streaming.
+
+Use a one-shot event strategy through `createAssistantMessageEventStream()`:
+- `start`
+- `text_start`
+- one full `text_delta`
+- `text_end`
+- `done`
+- `error`
+
+## Important implementation constraints
+
+### Keep
+- process-based shim for first version
+- CPU backend only
+- E2B as default
+- E4B as optional
+
+### Avoid for now
+- Edge Gallery UI integration
+- pretending LiteRT-LM is OpenAI-compatible HTTP
+- in-process runtime embedding on first pass
+- token-streaming complexity on first pass
+
+## Known repo-state caveat
+
+`openclaw-src` already had unrelated changes / existing issues during this exploration, so the `extensions/litertlm/` draft was intentionally not wired into generated bundled entries and not treated as compile-ready.
+
+This is a draft implementation package, not a merged provider patch.
+
+## Best next implementation step
+
+If continuing in `openclaw-src`, the next practical move is:
+
+1. refine `extensions/litertlm/src/stream.ts` further as needed
+2. decide shim-path strategy for real runtime usage
+3. add provider registration tests
+4. wire the extension into bundled plugin entries only after the above is stable
+
+## Decision summary
+
+This investigation is no longer blocked on architecture uncertainty.
+
+The remaining work is standard implementation work:
+- type alignment
+- test alignment
+- plugin wiring
+- packaging/runtime path decisions
+
+## Bottom line
+
+**The strongest path is now clear:**
+
+OpenClaw should treat LiteRT-LM as the local runtime and Edge Gallery as the source of locally downloaded `.litertlm` models.

--- a/docs/litertlm/implementation-handoff-summary.md
+++ b/docs/litertlm/implementation-handoff-summary.md
@@ -5,9 +5,11 @@
 This work established that Edge Gallery-downloaded `.litertlm` files can be used as real local models for OpenClaw — not by automating the Edge Gallery UI, but by loading those files directly with LiteRT-LM.
 
 ### Critical validated fact
+
 - LiteRT-LM Python API on macOS successfully loaded the Edge Gallery-downloaded Gemma 4 E2B `.litertlm` model and returned correct local inference output.
 
 ### Also validated
+
 - Gemma 4 E4B `.litertlm` also loads and answers successfully on CPU, though it is heavier and should remain optional experimental rather than default.
 
 ## Recommended architecture
@@ -26,6 +28,7 @@ OpenClaw
 ## What now exists in the workspace
 
 ### Runtime / wrapper prototypes
+
 - `scripts/litertlm_model_resolver.py`
 - `scripts/litertlm_runtime_resolver.py`
 - `scripts/litertlm_local_chat.py`
@@ -33,6 +36,7 @@ OpenClaw
 - `scripts/litertlm_provider_shim.py`
 
 ### Key docs
+
 - `docs/litertlm-openclaw-provider-design.md`
 - `docs/litertlm-local-model-setup.md`
 - `docs/litertlm-provider-shim-notes.md`
@@ -45,6 +49,7 @@ OpenClaw
 - `docs/litertlm-extension-compile-oriented-cleanup-plan.md`
 
 ### `openclaw-src` draft extension skeleton
+
 - `openclaw-src/extensions/litertlm/index.ts`
 - `openclaw-src/extensions/litertlm/src/provider-models.ts`
 - `openclaw-src/extensions/litertlm/src/stream.ts`
@@ -54,17 +59,21 @@ OpenClaw
 ## Current technical recommendation
 
 ### Default experimental model
+
 - `litertlm/gemma4-e2b-edge-gallery`
 
 ### Secondary optional experimental model
+
 - `litertlm/gemma4-e4b-edge-gallery`
 
 ### Provider id
+
 - `litertlm-local`
 
 ## Current provider strategy
 
 Use a bundled provider plugin modeled loosely after Ollama, but with a major difference:
+
 - **do not use HTTP transport to a local server**
 - **do use a process-based shim over LiteRT-LM**
 
@@ -73,6 +82,7 @@ Use a bundled provider plugin modeled loosely after Ollama, but with a major dif
 For the first experimental version, do not block on token-level streaming.
 
 Use a one-shot event strategy through `createAssistantMessageEventStream()`:
+
 - `start`
 - `text_start`
 - one full `text_delta`
@@ -83,12 +93,14 @@ Use a one-shot event strategy through `createAssistantMessageEventStream()`:
 ## Important implementation constraints
 
 ### Keep
+
 - process-based shim for first version
 - CPU backend only
 - E2B as default
 - E4B as optional
 
 ### Avoid for now
+
 - Edge Gallery UI integration
 - pretending LiteRT-LM is OpenAI-compatible HTTP
 - in-process runtime embedding on first pass
@@ -114,6 +126,7 @@ If continuing in `openclaw-src`, the next practical move is:
 This investigation is no longer blocked on architecture uncertainty.
 
 The remaining work is standard implementation work:
+
 - type alignment
 - test alignment
 - plugin wiring

--- a/docs/litertlm/runtime-config-types.ts
+++ b/docs/litertlm/runtime-config-types.ts
@@ -1,0 +1,144 @@
+export type LiteRtLmRuntimeConfig = {
+  pythonPath: string;
+  shimPath: string;
+  modelFile: string;
+  timeoutMs: number;
+  backend: "CPU" | string;
+};
+
+export type LiteRtLmShimRequest = {
+  version: 1;
+  requestId?: string;
+  model: {
+    id: string;
+    file: string;
+  };
+  runtime: {
+    backend: string;
+    timeoutMs: number;
+  };
+  input: {
+    system?: string;
+    prompt?: string;
+    messages?: Array<{
+      role: "system" | "user" | "assistant";
+      content: string;
+    }>;
+  };
+  options?: {
+    maxOutputTokens?: number;
+    temperature?: number;
+  };
+};
+
+export type LiteRtLmShimSuccess = {
+  ok: true;
+  version: 1;
+  requestId?: string;
+  model?: {
+    id?: string;
+  };
+  output: {
+    text: string;
+    stopReason?: string;
+  };
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+  diagnostics?: {
+    backend?: string;
+  };
+};
+
+export type LiteRtLmShimFailure = {
+  ok: false;
+  version: 1;
+  requestId?: string;
+  error: {
+    type: "configuration" | "environment" | "runtime";
+    code: string;
+    message: string;
+  };
+};
+
+export type LiteRtLmShimResponse = LiteRtLmShimSuccess | LiteRtLmShimFailure;
+
+export type LiteRtLmConfigResolutionInput = {
+  modelId: string;
+  env?: NodeJS.ProcessEnv;
+  providerConfig?: {
+    pythonPath?: string;
+    shimPath?: string;
+    modelFile?: string;
+    timeoutMs?: number;
+    backend?: string;
+  };
+};
+
+export function resolveLiteRtLmRuntimeConfig(
+  input: LiteRtLmConfigResolutionInput,
+): LiteRtLmRuntimeConfig {
+  const env = input.env ?? process.env;
+  const providerConfig = input.providerConfig ?? {};
+
+  const pythonPath =
+    providerConfig.pythonPath?.trim() || env.OPENCLAW_LITERTLM_PYTHON?.trim() || "python3";
+
+  const shimPath =
+    providerConfig.shimPath?.trim() ||
+    env.OPENCLAW_LITERTLM_SHIM?.trim() ||
+    "extensions/litertlm/scripts/litertlm_provider_shim.py";
+
+  const modelFile =
+    providerConfig.modelFile?.trim() || env.OPENCLAW_LITERTLM_MODEL_FILE?.trim() || "";
+
+  const timeoutMs =
+    providerConfig.timeoutMs && providerConfig.timeoutMs > 0
+      ? providerConfig.timeoutMs
+      : Number(env.OPENCLAW_LITERTLM_TIMEOUT_MS || 120000);
+
+  const backend = providerConfig.backend?.trim() || env.OPENCLAW_LITERTLM_BACKEND?.trim() || "CPU";
+
+  return {
+    pythonPath,
+    shimPath,
+    modelFile,
+    timeoutMs,
+    backend,
+  };
+}
+
+export function buildLiteRtLmShimRequest(params: {
+  modelId: string;
+  runtimeConfig: LiteRtLmRuntimeConfig;
+  prompt?: string;
+  system?: string;
+  messages?: LiteRtLmShimRequest["input"]["messages"];
+  maxOutputTokens?: number;
+  temperature?: number;
+  requestId?: string;
+}): LiteRtLmShimRequest {
+  return {
+    version: 1,
+    requestId: params.requestId,
+    model: {
+      id: params.modelId,
+      file: params.runtimeConfig.modelFile,
+    },
+    runtime: {
+      backend: params.runtimeConfig.backend,
+      timeoutMs: params.runtimeConfig.timeoutMs,
+    },
+    input: {
+      ...(params.system ? { system: params.system } : {}),
+      ...(params.prompt ? { prompt: params.prompt } : {}),
+      ...(params.messages?.length ? { messages: params.messages } : {}),
+    },
+    options: {
+      ...(params.maxOutputTokens ? { maxOutputTokens: params.maxOutputTokens } : {}),
+      ...(typeof params.temperature === "number" ? { temperature: params.temperature } : {}),
+    },
+  };
+}

--- a/docs/litertlm/shim-io-contract.md
+++ b/docs/litertlm/shim-io-contract.md
@@ -1,0 +1,208 @@
+# LiteRT-LM Shim I/O Contract
+
+## Purpose
+
+Define a minimal, merge-friendly contract between `extensions/litertlm/src/stream.ts` and a Python shim process.
+
+The goal is to keep the OpenClaw side thin, config-driven, and explicit about failures.
+
+## Scope
+
+This contract is for the **experimental one-shot text generation path** only.
+
+### In scope
+- one request in
+- one response out
+- structured JSON input/output
+- clear configuration, environment, and runtime errors
+
+### Not in scope
+- token streaming
+- multi-turn state reuse
+- model download/management
+- automatic Python environment setup
+- GPU/backend negotiation beyond explicit shim support
+
+## Ownership boundary
+
+OpenClaw owns:
+- provider registration
+- request normalization
+- shim path/python path resolution
+- subprocess invocation
+- parsing shim JSON
+- mapping shim failures into OpenClaw errors
+
+The Python shim owns:
+- loading the LiteRT-LM runtime
+- loading the target model
+- executing inference
+- returning structured JSON output
+
+## Transport
+
+- Invocation: subprocess via `execFile`
+- Encoding: UTF-8 JSON
+- Recommended transport: **stdin JSON in, stdout JSON out**
+- stderr: diagnostics only, not part of the contract payload
+
+## Request contract
+
+Example request payload:
+
+```json
+{
+  "version": 1,
+  "requestId": "req_123",
+  "model": {
+    "id": "litertlm/gemma4-e2b-edge-gallery",
+    "file": "/absolute/path/to/model.litertlm"
+  },
+  "runtime": {
+    "backend": "CPU",
+    "timeoutMs": 120000
+  },
+  "input": {
+    "system": "You are a helpful assistant.",
+    "prompt": "Summarize this paragraph.",
+    "messages": []
+  },
+  "options": {
+    "maxOutputTokens": 512,
+    "temperature": 0.2
+  }
+}
+```
+
+### Required fields
+- `version`
+- `model.id`
+- `model.file`
+- `input.prompt` or a non-empty `input.messages`
+
+### Optional fields
+- `requestId`
+- `input.system`
+- `input.messages`
+- `runtime.backend`
+- `runtime.timeoutMs`
+- `options.maxOutputTokens`
+- `options.temperature`
+
+## Response contract
+
+### Success
+
+```json
+{
+  "ok": true,
+  "version": 1,
+  "requestId": "req_123",
+  "model": {
+    "id": "litertlm/gemma4-e2b-edge-gallery"
+  },
+  "output": {
+    "text": "Here is the summary...",
+    "stopReason": "stop"
+  },
+  "usage": {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "totalTokens": 0
+  },
+  "diagnostics": {
+    "backend": "CPU"
+  }
+}
+```
+
+### Failure
+
+```json
+{
+  "ok": false,
+  "version": 1,
+  "requestId": "req_123",
+  "error": {
+    "type": "configuration",
+    "code": "MODEL_FILE_MISSING",
+    "message": "litertlm model file was not provided"
+  }
+}
+```
+
+## Error types
+
+### `configuration`
+Use when OpenClaw or the caller supplied invalid or incomplete config.
+
+Examples:
+- missing model file
+- invalid shim path
+- invalid request payload
+
+### `environment`
+Use when the local machine/runtime is not ready.
+
+Examples:
+- Python executable missing
+- LiteRT-LM import failed
+- dependency not installed
+
+### `runtime`
+Use when invocation reached inference but failed during execution.
+
+Examples:
+- model load failure
+- inference failure
+- non-zero runtime crash
+- timeout
+
+## Recommended error codes
+
+- `MODEL_FILE_MISSING`
+- `INVALID_REQUEST`
+- `PYTHON_NOT_FOUND`
+- `SHIM_IMPORT_FAILED`
+- `MODEL_LOAD_FAILED`
+- `INFERENCE_FAILED`
+- `PROCESS_TIMEOUT`
+- `UNKNOWN_RUNTIME_ERROR`
+
+## OpenClaw mapping rules
+
+OpenClaw should:
+- treat `ok: true` as a successful one-shot text result
+- treat `ok: false` as a structured provider failure
+- surface `error.message` directly when actionable
+- avoid relying on stderr parsing for normal control flow
+
+## Path/config resolution policy
+
+Recommended resolution order:
+1. explicit provider config
+2. environment variables
+3. safe defaults
+
+Suggested config fields:
+
+```json
+{
+  "providers": {
+    "litertlm": {
+      "pythonPath": "python3",
+      "shimPath": "extensions/litertlm/scripts/litertlm_provider_shim.py",
+      "modelFile": "/absolute/path/to/model.litertlm",
+      "timeoutMs": 120000
+    }
+  }
+}
+```
+
+## Minimal merge-ready expectation
+
+To make the current experimental provider more mergeable, the repo should eventually align `stream.ts` and the shim to this contract instead of relying on:
+- hardcoded `python3`
+- hardcoded repo-root shim path assumptions
+- ad hoc `--input <json>` only transport without versioned response schema
+- implicit environment assumptions tied to one local machine

--- a/docs/litertlm/stream-refactor-outline.md
+++ b/docs/litertlm/stream-refactor-outline.md
@@ -1,0 +1,139 @@
+# LiteRT-LM `stream.ts` Refactor Outline
+
+## Goal
+
+Move `extensions/litertlm/src/stream.ts` from a local-machine prototype into a merge-friendly experimental shim adapter.
+
+## Current problems
+
+- hardcoded `python3`
+- hardcoded repo-root shim path
+- ad hoc request payload
+- loose response parsing
+- no explicit config resolution layer
+- no clean separation between request building, shim invocation, and response mapping
+
+## Target structure
+
+## 1. `resolveLiteRtLmRuntimeConfig()`
+
+Source: `extensions/litertlm/src/runtime-config.ts`
+
+Responsibility:
+- read provider config
+- read env fallback
+- resolve:
+  - `pythonPath`
+  - `shimPath`
+  - `modelFile`
+  - `timeoutMs`
+  - `backend`
+
+Should not:
+- run subprocesses
+- parse model output
+
+## 2. `buildLiteRtLmShimRequest()`
+
+Source: `extensions/litertlm/src/runtime-config.ts`
+
+Responsibility:
+- normalize prompt/system/messages into a versioned request
+- attach model metadata
+- attach runtime metadata
+- attach generation options
+
+Output:
+- `LiteRtLmShimRequest`
+
+## 3. `invokeLiteRtLmShim()`
+
+Recommended new helper in `stream.ts` or a small helper file.
+
+Responsibility:
+- call `execFile`
+- pass JSON request over stdin (preferred) or structured CLI arg fallback
+- apply timeout
+- capture stdout/stderr
+- parse JSON response
+- map non-zero exit / malformed JSON to explicit runtime errors
+
+Suggested signature:
+
+```ts
+async function invokeLiteRtLmShim(params: {
+  runtimeConfig: LiteRtLmRuntimeConfig;
+  request: LiteRtLmShimRequest;
+}): Promise<LiteRtLmShimResponse>
+```
+
+## 4. `mapLiteRtLmShimResponseToAssistantOutput()`
+
+Responsibility:
+- convert shim success output into OpenClaw assistant output shape
+- convert shim failure into actionable provider errors
+
+Should handle:
+- missing/invalid response shape
+- `ok: false` structured errors
+- optional usage/diagnostics passthrough
+
+## 5. top-level `stream.ts` flow
+
+Suggested high-level flow:
+
+```ts
+const runtimeConfig = resolveLiteRtLmRuntimeConfig({ ... });
+
+if (!runtimeConfig.modelFile) {
+  throw new Error("litertlm provider requires a configured modelFile");
+}
+
+const request = buildLiteRtLmShimRequest({ ... });
+const response = await invokeLiteRtLmShim({ runtimeConfig, request });
+return mapLiteRtLmShimResponseToAssistantOutput(response);
+```
+
+## Minimal error mapping policy
+
+### Configuration errors
+- missing model file
+- invalid shim path
+- invalid provider config
+
+### Environment errors
+- python executable not found
+- shim import failure
+- LiteRT-LM runtime missing
+
+### Runtime errors
+- model load failure
+- inference failure
+- timeout
+- malformed shim response
+
+## Suggested file layout
+
+- `extensions/litertlm/src/runtime-config.ts`
+- `extensions/litertlm/src/stream.ts`
+- optional later split:
+  - `extensions/litertlm/src/shim-invoke.ts`
+  - `extensions/litertlm/src/error-map.ts`
+
+## Merge-friendly first pass
+
+For the first mergeable pass, it is enough to:
+- add `runtime-config.ts`
+- update `stream.ts` to use config/env-based resolution
+- switch to versioned request/response types
+- improve timeout + error mapping
+- keep one-shot text generation only
+
+## Explicit non-goals for this refactor
+
+- token streaming
+- multi-turn memory/state reuse
+- automatic Python venv creation
+- model download/management
+- GPU/backend auto-discovery
+- production-grade usage accounting

--- a/docs/litertlm/streamfn-contract-notes.md
+++ b/docs/litertlm/streamfn-contract-notes.md
@@ -1,0 +1,107 @@
+# LiteRT-LM OpenClaw StreamFn Contract Notes
+
+## Purpose
+
+Capture the minimum code-level understanding needed before implementing a real `litertlm` provider plugin in `openclaw-src`.
+
+## Key findings
+
+### 1. Best reference provider is still Ollama
+Most relevant implementation:
+- `openclaw-src/extensions/ollama/src/stream.ts`
+
+Why:
+- it implements `createStreamFn(...)`
+- it owns a custom transport path
+- it constructs an assistant-message event stream directly
+
+### 2. `createStreamFn(...)` returns a `StreamFn`
+Observed usage in:
+- `openclaw-src/src/agents/provider-stream.ts`
+
+OpenClaw flow:
+- resolve provider plugin stream function
+- register custom API transport via `ensureCustomApiRegistered(...)`
+- let the embedded runner use that stream function for the selected model
+
+### 3. Practical StreamFn shape from Ollama example
+The custom stream function returns a stream created by:
+- `createAssistantMessageEventStream()` from `@mariozechner/pi-ai`
+
+Then it pushes events like:
+- `start`
+- `text_start`
+- `text_delta`
+- `text_end`
+- `done`
+- `error`
+
+### 4. For a first LiteRT-LM version, full token streaming is not required conceptually
+The first realistic approach can be:
+- create assistant-message event stream
+- run the shim in background async task
+- when full text is available, emit:
+  - `start`
+  - `text_start`
+  - one `text_delta` containing the whole text
+  - `text_end`
+  - `done`
+- on failure emit `error`
+
+This is not ideal streaming UX, but it is enough for a first experimental provider path if the event shape is respected.
+
+## Implication for LiteRT-LM provider design
+
+### Minimal provider structure now looks plausible
+
+```text
+openclaw-src/extensions/litertlm/
+  index.ts
+  src/
+    provider-models.ts
+    stream.ts
+```
+
+### `index.ts`
+Should:
+- register provider id such as `litertlm-local`
+- publish discovery/catalog entry for `litertlm/gemma4-e2b-edge-gallery`
+- use synthetic auth
+- attach `createStreamFn(...)`
+
+### `src/stream.ts`
+Should:
+- import `createAssistantMessageEventStream`
+- shell out to `scripts/litertlm_provider_shim.py`
+- parse normalized JSON
+- emit assistant-message events
+
+### `src/provider-models.ts`
+Should:
+- define initial model rows
+- keep E2B as default experimental row
+- optionally add E4B as secondary experimental row later
+
+## Suggested first event strategy for LiteRT-LM
+
+### Success path
+1. create event stream
+2. start async shim run
+3. when shim returns success:
+   - emit `start`
+   - emit `text_start`
+   - emit one `text_delta` with `output_text`
+   - emit `text_end`
+   - emit `done`
+
+### Error path
+- emit `error` with a synthesized assistant error message
+
+## Why this matters
+
+This reduces the remaining unknown significantly.
+
+The LiteRT-LM provider no longer looks blocked on hidden core abstractions. It mainly needs:
+- a provider plugin entry
+- a shim-backed stream emitter
+- a small model catalog definition

--- a/docs/litertlm/streamfn-contract-notes.md
+++ b/docs/litertlm/streamfn-contract-notes.md
@@ -7,28 +7,37 @@ Capture the minimum code-level understanding needed before implementing a real `
 ## Key findings
 
 ### 1. Best reference provider is still Ollama
+
 Most relevant implementation:
+
 - `openclaw-src/extensions/ollama/src/stream.ts`
 
 Why:
+
 - it implements `createStreamFn(...)`
 - it owns a custom transport path
 - it constructs an assistant-message event stream directly
 
 ### 2. `createStreamFn(...)` returns a `StreamFn`
+
 Observed usage in:
+
 - `openclaw-src/src/agents/provider-stream.ts`
 
 OpenClaw flow:
+
 - resolve provider plugin stream function
 - register custom API transport via `ensureCustomApiRegistered(...)`
 - let the embedded runner use that stream function for the selected model
 
 ### 3. Practical StreamFn shape from Ollama example
+
 The custom stream function returns a stream created by:
+
 - `createAssistantMessageEventStream()` from `@mariozechner/pi-ai`
 
 Then it pushes events like:
+
 - `start`
 - `text_start`
 - `text_delta`
@@ -37,7 +46,9 @@ Then it pushes events like:
 - `error`
 
 ### 4. For a first LiteRT-LM version, full token streaming is not required conceptually
+
 The first realistic approach can be:
+
 - create assistant-message event stream
 - run the shim in background async task
 - when full text is available, emit:
@@ -63,21 +74,27 @@ openclaw-src/extensions/litertlm/
 ```
 
 ### `index.ts`
+
 Should:
+
 - register provider id such as `litertlm-local`
 - publish discovery/catalog entry for `litertlm/gemma4-e2b-edge-gallery`
 - use synthetic auth
 - attach `createStreamFn(...)`
 
 ### `src/stream.ts`
+
 Should:
+
 - import `createAssistantMessageEventStream`
 - shell out to `scripts/litertlm_provider_shim.py`
 - parse normalized JSON
 - emit assistant-message events
 
 ### `src/provider-models.ts`
+
 Should:
+
 - define initial model rows
 - keep E2B as default experimental row
 - optionally add E4B as secondary experimental row later
@@ -85,6 +102,7 @@ Should:
 ## Suggested first event strategy for LiteRT-LM
 
 ### Success path
+
 1. create event stream
 2. start async shim run
 3. when shim returns success:
@@ -95,6 +113,7 @@ Should:
    - emit `done`
 
 ### Error path
+
 - emit `error` with a synthesized assistant error message
 
 ## Why this matters
@@ -102,6 +121,7 @@ Should:
 This reduces the remaining unknown significantly.
 
 The LiteRT-LM provider no longer looks blocked on hidden core abstractions. It mainly needs:
+
 - a provider plugin entry
 - a shim-backed stream emitter
 - a small model catalog definition

--- a/extensions/litertlm/README.md
+++ b/extensions/litertlm/README.md
@@ -1,0 +1,26 @@
+# LiteRT-LM Provider Skeleton
+
+Experimental bundled-provider skeleton for using Edge Gallery-downloaded `.litertlm` files through LiteRT-LM.
+
+## Status
+
+Draft only.
+Not wired into generated bundled plugin entries.
+Not guaranteed to compile yet.
+
+## Intent
+
+Provide the smallest plausible `openclaw-src/extensions/litertlm/` shape so future implementation work is no longer blocked on architecture uncertainty.
+
+## Files
+
+- `index.ts`
+- `src/provider-models.ts`
+- `src/stream.ts`
+
+## Current assumptions
+
+- provider id: `litertlm-local`
+- first experimental model: `litertlm/gemma4-e2b-edge-gallery`
+- optional second model: `litertlm/gemma4-e4b-edge-gallery`
+- process-based shim remains the runtime bridge

--- a/extensions/litertlm/index.test.ts
+++ b/extensions/litertlm/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/extensions/plugin-api.js";
+import plugin from "./index.js";
+import {
+  LITERTLM_MODEL_E2B,
+  LITERTLM_MODEL_E4B,
+  getDefaultLiteRtLmModelId,
+} from "./src/provider-models.js";
+
+function registerProvider() {
+  const registerProviderMock = vi.fn();
+
+  plugin.register(
+    createTestPluginApi({
+      id: "litertlm",
+      name: "LiteRT-LM",
+      source: "test",
+      config: {},
+      runtime: {} as never,
+      registerProvider: registerProviderMock,
+    }),
+  );
+
+  expect(registerProviderMock).toHaveBeenCalledTimes(1);
+  return registerProviderMock.mock.calls[0]?.[0];
+}
+
+describe("litertlm plugin skeleton", () => {
+  it("registers the experimental local provider", () => {
+    const provider = registerProvider();
+
+    expect(provider.id).toBe("litertlm-local");
+    expect(provider.label).toBe("LiteRT-LM Local");
+    expect(typeof provider.createStreamFn).toBe("function");
+    expect(typeof provider.resolveSyntheticAuth).toBe("function");
+  });
+
+  it("publishes discovery rows for E2B and E4B", async () => {
+    const provider = registerProvider();
+    const discovered = await provider.discovery.run({} as never);
+    const rows = discovered?.provider?.models ?? [];
+
+    expect(rows.some((entry: { id: string }) => entry.id === LITERTLM_MODEL_E2B)).toBe(true);
+    expect(rows.some((entry: { id: string }) => entry.id === LITERTLM_MODEL_E4B)).toBe(true);
+  });
+
+  it("uses E2B as the default experimental model id", () => {
+    expect(getDefaultLiteRtLmModelId()).toBe(LITERTLM_MODEL_E2B);
+  });
+
+  it("exposes synthetic auth without requiring an external API key", () => {
+    const provider = registerProvider();
+    const auth = provider.resolveSyntheticAuth?.({} as never);
+
+    expect(auth?.apiKey).toBe("litertlm-local");
+    expect(auth?.mode).toBe("api-key");
+  });
+});

--- a/extensions/litertlm/index.test.ts
+++ b/extensions/litertlm/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createTestPluginApi } from "../../test/helpers/extensions/plugin-api.js";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
 import plugin from "./index.js";
 import {
   LITERTLM_MODEL_E2B,
@@ -35,13 +35,13 @@ describe("litertlm plugin skeleton", () => {
     expect(typeof provider.resolveSyntheticAuth).toBe("function");
   });
 
-  it("publishes discovery rows for E2B and E4B", async () => {
+  it("keeps discovery disabled in the current draft skeleton", async () => {
     const provider = registerProvider();
     const discovered = await provider.discovery.run({} as never);
-    const rows = discovered?.provider?.models ?? [];
 
-    expect(rows.some((entry: { id: string }) => entry.id === LITERTLM_MODEL_E2B)).toBe(true);
-    expect(rows.some((entry: { id: string }) => entry.id === LITERTLM_MODEL_E4B)).toBe(true);
+    expect(discovered).toBeNull();
+    expect(LITERTLM_MODEL_E2B).toContain("litertlm/");
+    expect(LITERTLM_MODEL_E4B).toContain("litertlm/");
   });
 
   it("uses E2B as the default experimental model id", () => {

--- a/extensions/litertlm/index.ts
+++ b/extensions/litertlm/index.ts
@@ -1,0 +1,47 @@
+import {
+  definePluginEntry,
+  type OpenClawPluginApi,
+  type ProviderDiscoveryContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { buildLiteRtLmDiscoveredProvider } from "./src/provider-models.js";
+import { createLiteRtLmShimStreamFn } from "./src/stream.js";
+
+const PROVIDER_ID = "litertlm-local";
+const SYNTHETIC_API_KEY = "litertlm-local";
+
+export default definePluginEntry({
+  id: "litertlm",
+  name: "LiteRT-LM Local Provider",
+  description:
+    "Experimental local-model provider over LiteRT-LM and Edge Gallery-downloaded .litertlm files",
+  register(api: OpenClawPluginApi) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "LiteRT-LM Local",
+      docsPath: "/providers/litertlm-local",
+      auth: [],
+      discovery: {
+        order: "late",
+        run: async (_ctx: ProviderDiscoveryContext) => {
+          return {
+            provider: buildLiteRtLmDiscoveredProvider(),
+          };
+        },
+      },
+      createStreamFn: ({ model }) => {
+        return createLiteRtLmShimStreamFn({ model });
+      },
+      resolveSyntheticAuth: () => {
+        return {
+          apiKey: SYNTHETIC_API_KEY,
+          source: "litertlm local synthetic auth",
+          mode: "api-key",
+        };
+      },
+      buildMissingAuthMessage: () =>
+        "LiteRT-LM local provider does not use external API keys, but it does require a local Python runtime with litert_lm installed.",
+      buildUnknownModelHint: () =>
+        "Known experimental models are litertlm/gemma4-e2b-edge-gallery and optionally litertlm/gemma4-e4b-edge-gallery when available.",
+    });
+  },
+});

--- a/extensions/litertlm/index.ts
+++ b/extensions/litertlm/index.ts
@@ -1,13 +1,6 @@
-import {
-  definePluginEntry,
-  type OpenClawPluginApi,
-  type ProviderDiscoveryContext,
-} from "openclaw/plugin-sdk/plugin-entry";
-import { buildLiteRtLmDiscoveredProvider } from "./src/provider-models.js";
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { PROVIDER_ID, SYNTHETIC_API_KEY } from "./src/provider-models.js";
 import { createLiteRtLmShimStreamFn } from "./src/stream.js";
-
-const PROVIDER_ID = "litertlm-local";
-const SYNTHETIC_API_KEY = "litertlm-local";
 
 export default definePluginEntry({
   id: "litertlm",
@@ -22,11 +15,7 @@ export default definePluginEntry({
       auth: [],
       discovery: {
         order: "late",
-        run: async (_ctx: ProviderDiscoveryContext) => {
-          return {
-            provider: buildLiteRtLmDiscoveredProvider(),
-          };
-        },
+        run: async () => null,
       },
       createStreamFn: ({ model }) => {
         return createLiteRtLmShimStreamFn({ model });

--- a/extensions/litertlm/index.ts
+++ b/extensions/litertlm/index.ts
@@ -17,8 +17,8 @@ export default definePluginEntry({
         order: "late",
         run: async () => null,
       },
-      createStreamFn: ({ model }) => {
-        return createLiteRtLmShimStreamFn({ model });
+      createStreamFn: ({ config, model }) => {
+        return createLiteRtLmShimStreamFn({ model, config });
       },
       resolveSyntheticAuth: () => {
         return {

--- a/extensions/litertlm/openclaw.plugin.json
+++ b/extensions/litertlm/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "litertlm",
+  "enabledByDefault": false,
+  "providers": ["litertlm-local"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/litertlm/package.json
+++ b/extensions/litertlm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/litertlm-provider",
+  "version": "2026.4.1-beta.1",
+  "private": true,
+  "description": "Experimental OpenClaw LiteRT-LM local provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/litertlm/src/provider-models.ts
+++ b/extensions/litertlm/src/provider-models.ts
@@ -1,0 +1,54 @@
+const PROVIDER_ID = "litertlm-local";
+const PROVIDER_API = "litertlm-local";
+
+export const LITERTLM_MODEL_E2B = "litertlm/gemma4-e2b-edge-gallery";
+export const LITERTLM_MODEL_E4B = "litertlm/gemma4-e4b-edge-gallery";
+
+export type LiteRtLmModelPreference = {
+  modelId: string;
+  preferredMatch: string;
+  displayName: string;
+  defaultEnabled: boolean;
+};
+
+export const LITERTLM_MODEL_PREFERENCES: LiteRtLmModelPreference[] = [
+  {
+    modelId: LITERTLM_MODEL_E2B,
+    preferredMatch: "Gemma_4_E2B_it",
+    displayName: "Gemma 4 E2B (LiteRT-LM via Edge Gallery)",
+    defaultEnabled: true,
+  },
+  {
+    modelId: LITERTLM_MODEL_E4B,
+    preferredMatch: "Gemma_4_E4B_it",
+    displayName: "Gemma 4 E4B (LiteRT-LM via Edge Gallery)",
+    defaultEnabled: false,
+  },
+];
+
+export function getLiteRtLmModelPreference(modelId: string): LiteRtLmModelPreference | undefined {
+  return LITERTLM_MODEL_PREFERENCES.find((entry) => entry.modelId === modelId);
+}
+
+export function getDefaultLiteRtLmModelId(): string {
+  return (
+    LITERTLM_MODEL_PREFERENCES.find((entry) => entry.defaultEnabled)?.modelId ?? LITERTLM_MODEL_E2B
+  );
+}
+
+export function buildLiteRtLmDiscoveredProvider() {
+  return {
+    api: PROVIDER_API,
+    baseUrl: "litertlm://local",
+    apiKey: "litertlm-local",
+    models: LITERTLM_MODEL_PREFERENCES.map((entry) => ({
+      id: entry.modelId,
+      name: entry.displayName,
+      provider: PROVIDER_ID,
+      api: PROVIDER_API,
+      contextWindow: 4096,
+      reasoning: false,
+      experimental: true,
+    })),
+  };
+}

--- a/extensions/litertlm/src/provider-models.ts
+++ b/extensions/litertlm/src/provider-models.ts
@@ -1,5 +1,6 @@
-const PROVIDER_ID = "litertlm-local";
-const PROVIDER_API = "litertlm-local";
+export const PROVIDER_ID = "litertlm-local";
+export const PROVIDER_API = "ollama" as const;
+export const SYNTHETIC_API_KEY = "litertlm-local";
 
 export const LITERTLM_MODEL_E2B = "litertlm/gemma4-e2b-edge-gallery";
 export const LITERTLM_MODEL_E4B = "litertlm/gemma4-e4b-edge-gallery";
@@ -40,15 +41,21 @@ export function buildLiteRtLmDiscoveredProvider() {
   return {
     api: PROVIDER_API,
     baseUrl: "litertlm://local",
-    apiKey: "litertlm-local",
+    apiKey: SYNTHETIC_API_KEY,
     models: LITERTLM_MODEL_PREFERENCES.map((entry) => ({
       id: entry.modelId,
       name: entry.displayName,
-      provider: PROVIDER_ID,
       api: PROVIDER_API,
-      contextWindow: 4096,
       reasoning: false,
-      experimental: true,
+      input: ["text"] as const,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      contextWindow: 4096,
+      maxTokens: 1024,
     })),
   };
 }

--- a/extensions/litertlm/src/runtime-config.test.ts
+++ b/extensions/litertlm/src/runtime-config.test.ts
@@ -1,10 +1,37 @@
 import { describe, expect, it } from "vitest";
 import {
   buildLiteRtLmShimRequest,
+  getLiteRtLmProviderConfig,
   resolveLiteRtLmRuntimeConfig,
 } from "./runtime-config.js";
 
 describe("litertlm runtime config", () => {
+  it("reads litertlm provider config from models.providers", () => {
+    const result = getLiteRtLmProviderConfig({
+      models: {
+        providers: {
+          "litertlm-local": {
+            baseUrl: "litertlm://local",
+            models: [],
+            pythonPath: "python-from-config",
+            shimPath: "/shim-from-config.py",
+            modelFile: "/model-from-config.litertlm",
+            timeoutMs: 1234,
+            backend: "CPU",
+          },
+        },
+      },
+    } as never);
+
+    expect(result).toEqual({
+      pythonPath: "python-from-config",
+      shimPath: "/shim-from-config.py",
+      modelFile: "/model-from-config.litertlm",
+      timeoutMs: 1234,
+      backend: "CPU",
+    });
+  });
+
   it("prefers explicit provider config over env", () => {
     const result = resolveLiteRtLmRuntimeConfig({
       model: { modelId: "litertlm/gemma4-e2b-edge-gallery" },
@@ -31,6 +58,31 @@ describe("litertlm runtime config", () => {
       timeoutMs: 1234,
       backend: "CPU",
     });
+  });
+
+  it("uses config models.providers values before env defaults", () => {
+    const result = resolveLiteRtLmRuntimeConfig({
+      model: { modelId: "litertlm/gemma4-e2b-edge-gallery" },
+      config: {
+        models: {
+          providers: {
+            "litertlm-local": {
+              baseUrl: "litertlm://local",
+              models: [],
+              modelFile: "/from-config.litertlm",
+              pythonPath: "python-from-config",
+            },
+          },
+        },
+      } as never,
+      env: {
+        OPENCLAW_LITERTLM_MODEL_FILE: "/from-env.litertlm",
+        OPENCLAW_LITERTLM_PYTHON: "python-from-env",
+      },
+    });
+
+    expect(result.modelFile).toBe("/from-config.litertlm");
+    expect(result.pythonPath).toBe("python-from-config");
   });
 
   it("falls back to env and defaults when provider config is absent", () => {

--- a/extensions/litertlm/src/runtime-config.test.ts
+++ b/extensions/litertlm/src/runtime-config.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLiteRtLmShimRequest,
+  resolveLiteRtLmRuntimeConfig,
+} from "./runtime-config.js";
+
+describe("litertlm runtime config", () => {
+  it("prefers explicit provider config over env", () => {
+    const result = resolveLiteRtLmRuntimeConfig({
+      model: { modelId: "litertlm/gemma4-e2b-edge-gallery" },
+      env: {
+        OPENCLAW_LITERTLM_PYTHON: "python-from-env",
+        OPENCLAW_LITERTLM_SHIM: "/shim-from-env.py",
+        OPENCLAW_LITERTLM_MODEL_FILE: "/model-from-env.litertlm",
+        OPENCLAW_LITERTLM_TIMEOUT_MS: "999",
+        OPENCLAW_LITERTLM_BACKEND: "GPU",
+      },
+      providerConfig: {
+        pythonPath: "python-from-config",
+        shimPath: "/shim-from-config.py",
+        modelFile: "/model-from-config.litertlm",
+        timeoutMs: 1234,
+        backend: "CPU",
+      },
+    });
+
+    expect(result).toEqual({
+      pythonPath: "python-from-config",
+      shimPath: "/shim-from-config.py",
+      modelFile: "/model-from-config.litertlm",
+      timeoutMs: 1234,
+      backend: "CPU",
+    });
+  });
+
+  it("falls back to env and defaults when provider config is absent", () => {
+    const result = resolveLiteRtLmRuntimeConfig({
+      model: { modelId: "litertlm/gemma4-e2b-edge-gallery" },
+      env: {
+        OPENCLAW_LITERTLM_PYTHON: "python3.12",
+        OPENCLAW_LITERTLM_SHIM: "/tmp/litertlm_provider_shim.py",
+        OPENCLAW_LITERTLM_MODEL_FILE: "/tmp/model.litertlm",
+      },
+    });
+
+    expect(result.pythonPath).toBe("python3.12");
+    expect(result.shimPath).toBe("/tmp/litertlm_provider_shim.py");
+    expect(result.modelFile).toBe("/tmp/model.litertlm");
+    expect(result.timeoutMs).toBe(120000);
+    expect(result.backend).toBe("CPU");
+  });
+
+  it("builds a versioned shim request", () => {
+    const runtimeConfig = resolveLiteRtLmRuntimeConfig({
+      model: { modelId: "litertlm/gemma4-e2b-edge-gallery" },
+      providerConfig: {
+        modelFile: "/tmp/model.litertlm",
+      },
+    });
+
+    const request = buildLiteRtLmShimRequest({
+      modelId: "litertlm/gemma4-e2b-edge-gallery",
+      runtimeConfig,
+      prompt: "hello",
+      system: "be concise",
+      requestId: "req_1",
+      maxOutputTokens: 128,
+      temperature: 0.2,
+    });
+
+    expect(request).toEqual({
+      version: 1,
+      requestId: "req_1",
+      model: {
+        id: "litertlm/gemma4-e2b-edge-gallery",
+        file: "/tmp/model.litertlm",
+      },
+      runtime: {
+        backend: "CPU",
+        timeoutMs: 120000,
+      },
+      input: {
+        system: "be concise",
+        prompt: "hello",
+      },
+      options: {
+        maxOutputTokens: 128,
+        temperature: 0.2,
+      },
+    });
+  });
+});

--- a/extensions/litertlm/src/runtime-config.ts
+++ b/extensions/litertlm/src/runtime-config.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { LiteRtLmModelPreference } from "./provider-models.js";
 
 export type LiteRtLmRuntimeConfig = {
@@ -81,6 +83,13 @@ export type LiteRtLmConfigResolutionInput = {
   providerConfig?: LiteRtLmProviderConfig;
 };
 
+export function getDefaultLiteRtLmBundledShimPath() {
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../scripts/litertlm_provider_shim.py",
+  );
+}
+
 export function resolveLiteRtLmRuntimeConfig(
   input: LiteRtLmConfigResolutionInput,
 ): LiteRtLmRuntimeConfig {
@@ -93,15 +102,17 @@ export function resolveLiteRtLmRuntimeConfig(
   const shimPath =
     providerConfig.shimPath?.trim() ||
     env.OPENCLAW_LITERTLM_SHIM?.trim() ||
-    "extensions/litertlm/scripts/litertlm_provider_shim.py";
+    getDefaultLiteRtLmBundledShimPath();
 
   const modelFile =
     providerConfig.modelFile?.trim() || env.OPENCLAW_LITERTLM_MODEL_FILE?.trim() || "";
 
-  const timeoutMs =
+  const timeoutMsRaw =
     providerConfig.timeoutMs && providerConfig.timeoutMs > 0
       ? providerConfig.timeoutMs
       : Number(env.OPENCLAW_LITERTLM_TIMEOUT_MS || 120000);
+
+  const timeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 120000;
 
   const backend = providerConfig.backend?.trim() || env.OPENCLAW_LITERTLM_BACKEND?.trim() || "CPU";
 

--- a/extensions/litertlm/src/runtime-config.ts
+++ b/extensions/litertlm/src/runtime-config.ts
@@ -1,0 +1,148 @@
+import type { LiteRtLmModelPreference } from "./provider-models.js";
+
+export type LiteRtLmRuntimeConfig = {
+  pythonPath: string;
+  shimPath: string;
+  modelFile: string;
+  timeoutMs: number;
+  backend: "CPU" | string;
+};
+
+export type LiteRtLmShimRequest = {
+  version: 1;
+  requestId?: string;
+  model: {
+    id: string;
+    file: string;
+  };
+  runtime: {
+    backend: string;
+    timeoutMs: number;
+  };
+  input: {
+    system?: string;
+    prompt?: string;
+    messages?: Array<{
+      role: "system" | "user" | "assistant";
+      content: string;
+    }>;
+  };
+  options?: {
+    maxOutputTokens?: number;
+    temperature?: number;
+  };
+};
+
+export type LiteRtLmShimSuccess = {
+  ok: true;
+  version: 1;
+  requestId?: string;
+  model?: {
+    id?: string;
+  };
+  output: {
+    text: string;
+    stopReason?: string;
+  };
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+  diagnostics?: {
+    backend?: string;
+  };
+};
+
+export type LiteRtLmShimFailure = {
+  ok: false;
+  version: 1;
+  requestId?: string;
+  error: {
+    type: "configuration" | "environment" | "runtime";
+    code: string;
+    message: string;
+  };
+};
+
+export type LiteRtLmShimResponse = LiteRtLmShimSuccess | LiteRtLmShimFailure;
+
+export type LiteRtLmProviderConfig = {
+  pythonPath?: string;
+  shimPath?: string;
+  modelFile?: string;
+  timeoutMs?: number;
+  backend?: string;
+};
+
+export type LiteRtLmConfigResolutionInput = {
+  model: LiteRtLmModelPreference | { modelId: string };
+  env?: NodeJS.ProcessEnv;
+  providerConfig?: LiteRtLmProviderConfig;
+};
+
+export function resolveLiteRtLmRuntimeConfig(
+  input: LiteRtLmConfigResolutionInput,
+): LiteRtLmRuntimeConfig {
+  const env = input.env ?? process.env;
+  const providerConfig = input.providerConfig ?? {};
+
+  const pythonPath =
+    providerConfig.pythonPath?.trim() || env.OPENCLAW_LITERTLM_PYTHON?.trim() || "python3";
+
+  const shimPath =
+    providerConfig.shimPath?.trim() ||
+    env.OPENCLAW_LITERTLM_SHIM?.trim() ||
+    "extensions/litertlm/scripts/litertlm_provider_shim.py";
+
+  const modelFile =
+    providerConfig.modelFile?.trim() || env.OPENCLAW_LITERTLM_MODEL_FILE?.trim() || "";
+
+  const timeoutMs =
+    providerConfig.timeoutMs && providerConfig.timeoutMs > 0
+      ? providerConfig.timeoutMs
+      : Number(env.OPENCLAW_LITERTLM_TIMEOUT_MS || 120000);
+
+  const backend = providerConfig.backend?.trim() || env.OPENCLAW_LITERTLM_BACKEND?.trim() || "CPU";
+
+  return {
+    pythonPath,
+    shimPath,
+    modelFile,
+    timeoutMs,
+    backend,
+  };
+}
+
+export function buildLiteRtLmShimRequest(params: {
+  modelId: string;
+  runtimeConfig: LiteRtLmRuntimeConfig;
+  prompt?: string;
+  system?: string;
+  messages?: LiteRtLmShimRequest["input"]["messages"];
+  maxOutputTokens?: number;
+  temperature?: number;
+  requestId?: string;
+}): LiteRtLmShimRequest {
+  return {
+    version: 1,
+    requestId: params.requestId,
+    model: {
+      id: params.modelId,
+      file: params.runtimeConfig.modelFile,
+    },
+    runtime: {
+      backend: params.runtimeConfig.backend,
+      timeoutMs: params.runtimeConfig.timeoutMs,
+    },
+    input: {
+      ...(params.system ? { system: params.system } : {}),
+      ...(params.prompt ? { prompt: params.prompt } : {}),
+      ...(params.messages?.length ? { messages: params.messages } : {}),
+    },
+    options: {
+      ...(params.maxOutputTokens ? { maxOutputTokens: params.maxOutputTokens } : {}),
+      ...(typeof params.temperature === "number" ? { temperature: params.temperature } : {}),
+    },
+  };
+}

--- a/extensions/litertlm/src/runtime-config.ts
+++ b/extensions/litertlm/src/runtime-config.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { LiteRtLmModelPreference } from "./provider-models.js";
 
 export type LiteRtLmRuntimeConfig = {
@@ -81,6 +82,7 @@ export type LiteRtLmConfigResolutionInput = {
   model: LiteRtLmModelPreference | { modelId: string };
   env?: NodeJS.ProcessEnv;
   providerConfig?: LiteRtLmProviderConfig;
+  config?: OpenClawConfig;
 };
 
 export function getDefaultLiteRtLmBundledShimPath() {
@@ -90,11 +92,28 @@ export function getDefaultLiteRtLmBundledShimPath() {
   );
 }
 
+export function getLiteRtLmProviderConfig(config?: OpenClawConfig): LiteRtLmProviderConfig {
+  const raw = config?.models?.providers?.["litertlm-local"] as Record<string, unknown> | undefined;
+  if (!raw) {
+    return {};
+  }
+  return {
+    pythonPath: typeof raw.pythonPath === "string" ? raw.pythonPath : undefined,
+    shimPath: typeof raw.shimPath === "string" ? raw.shimPath : undefined,
+    modelFile: typeof raw.modelFile === "string" ? raw.modelFile : undefined,
+    timeoutMs: typeof raw.timeoutMs === "number" ? raw.timeoutMs : undefined,
+    backend: typeof raw.backend === "string" ? raw.backend : undefined,
+  };
+}
+
 export function resolveLiteRtLmRuntimeConfig(
   input: LiteRtLmConfigResolutionInput,
 ): LiteRtLmRuntimeConfig {
   const env = input.env ?? process.env;
-  const providerConfig = input.providerConfig ?? {};
+  const providerConfig = {
+    ...getLiteRtLmProviderConfig(input.config),
+    ...(input.providerConfig ?? {}),
+  };
 
   const pythonPath =
     providerConfig.pythonPath?.trim() || env.OPENCLAW_LITERTLM_PYTHON?.trim() || "python3";

--- a/extensions/litertlm/src/runtime-config.ts
+++ b/extensions/litertlm/src/runtime-config.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { OpenClawConfig } from "../../../src/config/config.js";
+import { PROVIDER_ID } from "./provider-models.js";
 import type { LiteRtLmModelPreference } from "./provider-models.js";
 
 export type LiteRtLmRuntimeConfig = {
@@ -78,11 +78,17 @@ export type LiteRtLmProviderConfig = {
   backend?: string;
 };
 
+type LiteRtLmConfigShape = {
+  models?: {
+    providers?: Record<string, Record<string, unknown>>;
+  };
+};
+
 export type LiteRtLmConfigResolutionInput = {
   model: LiteRtLmModelPreference | { modelId: string };
   env?: NodeJS.ProcessEnv;
   providerConfig?: LiteRtLmProviderConfig;
-  config?: OpenClawConfig;
+  config?: LiteRtLmConfigShape;
 };
 
 export function getDefaultLiteRtLmBundledShimPath() {
@@ -92,8 +98,8 @@ export function getDefaultLiteRtLmBundledShimPath() {
   );
 }
 
-export function getLiteRtLmProviderConfig(config?: OpenClawConfig): LiteRtLmProviderConfig {
-  const raw = config?.models?.providers?.["litertlm-local"] as Record<string, unknown> | undefined;
+export function getLiteRtLmProviderConfig(config?: LiteRtLmConfigShape): LiteRtLmProviderConfig {
+  const raw = config?.models?.providers?.[PROVIDER_ID];
   if (!raw) {
     return {};
   }

--- a/extensions/litertlm/src/stream.ts
+++ b/extensions/litertlm/src/stream.ts
@@ -1,0 +1,123 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import {
+  buildAssistantMessage,
+  buildStreamErrorAssistantMessage,
+  buildUsageWithNoCost,
+  type StreamModelDescriptor,
+} from "../../../src/agents/stream-message-shared.js";
+import { getLiteRtLmModelPreference } from "./provider-models.js";
+
+const execFileAsync = promisify(execFile);
+
+function getWorkspaceShimPath() {
+  // Draft only: assume extension is developed inside the same workspace checkout.
+  return "scripts/litertlm_provider_shim.py";
+}
+
+function buildModelDescriptor(modelId: string): StreamModelDescriptor {
+  return {
+    api: "litertlm-local",
+    provider: "litertlm-local",
+    id: modelId,
+  };
+}
+
+function extractPrompt(context: { messages?: unknown[] }) {
+  const messages = Array.isArray(context.messages) ? context.messages : [];
+  const last = messages[messages.length - 1] as { role?: string; content?: unknown } | undefined;
+  if (typeof last?.content === "string") {
+    return last.content;
+  }
+  if (Array.isArray(last?.content)) {
+    const text = last.content
+      .map((item) =>
+        item && typeof item === "object" && "type" in item && "text" in item && item.type === "text"
+          ? String(item.text)
+          : "",
+      )
+      .join("");
+    return text;
+  }
+  return "";
+}
+
+export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): StreamFn {
+  return (_model, context, _options) => {
+    const stream = createAssistantMessageEventStream();
+
+    const run = async () => {
+      const modelInfo = buildModelDescriptor(params.model.id);
+      try {
+        const shimInput: Record<string, unknown> = {
+          prompt: extractPrompt(context),
+          backend: "CPU",
+        };
+        if (typeof context.systemPrompt === "string" && context.systemPrompt.trim()) {
+          shimInput.system = context.systemPrompt;
+        }
+
+        const preference = getLiteRtLmModelPreference(params.model.id);
+        if (preference?.preferredMatch === "Gemma_4_E4B_it") {
+          // Draft-only placeholder: for a real patch, resolve explicit E4B path here or teach shim/model resolver model-id preference.
+        }
+
+        const { stdout } = await execFileAsync("python3", [
+          getWorkspaceShimPath(),
+          "--input",
+          JSON.stringify(shimInput),
+        ]);
+
+        const payload = JSON.parse(stdout) as {
+          ok: boolean;
+          output_text?: string;
+          diagnostics?: unknown;
+          error?: { message?: string };
+        };
+
+        if (!payload.ok) {
+          throw new Error(payload.error?.message || "LiteRT-LM shim failed");
+        }
+
+        const text = payload.output_text || "";
+        const partial = buildAssistantMessage({
+          model: modelInfo,
+          content: [{ type: "text", text }],
+          stopReason: "stop",
+          usage: buildUsageWithNoCost({}),
+        });
+
+        stream.push({ type: "start", partial });
+        stream.push({ type: "text_start", contentIndex: 0, partial });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial });
+        stream.push({ type: "text_end", contentIndex: 0, content: text, partial });
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: buildAssistantMessage({
+            model: modelInfo,
+            content: [{ type: "text", text }],
+            stopReason: "stop",
+            usage: buildUsageWithNoCost({}),
+          }),
+        });
+      } catch (err) {
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: buildStreamErrorAssistantMessage({
+            model: modelInfo,
+            errorMessage: err instanceof Error ? err.message : String(err),
+          }),
+        });
+      } finally {
+        stream.end();
+      }
+    };
+
+    queueMicrotask(() => void run());
+    return stream;
+  };
+}

--- a/extensions/litertlm/src/stream.ts
+++ b/extensions/litertlm/src/stream.ts
@@ -1,26 +1,89 @@
 import { execFile } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, StopReason, Usage } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
-import {
-  buildAssistantMessage,
-  buildStreamErrorAssistantMessage,
-  buildUsageWithNoCost,
-  type StreamModelDescriptor,
-} from "../../../src/agents/stream-message-shared.js";
-import { getLiteRtLmModelPreference } from "./provider-models.js";
+import { PROVIDER_ID } from "./provider-models.js";
 
 const execFileAsync = promisify(execFile);
 
-function getWorkspaceShimPath() {
-  // Draft only: assume extension is developed inside the same workspace checkout.
-  return "scripts/litertlm_provider_shim.py";
+type StreamModelDescriptor = {
+  api: string;
+  provider: string;
+  id: string;
+};
+
+function buildUsageWithNoCost(params: {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+}): Usage {
+  const input = params.input ?? 0;
+  const output = params.output ?? 0;
+  const cacheRead = params.cacheRead ?? 0;
+  const cacheWrite = params.cacheWrite ?? 0;
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    totalTokens: params.totalTokens ?? input + output,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function buildAssistantMessage(params: {
+  model: StreamModelDescriptor;
+  content: AssistantMessage["content"];
+  stopReason: StopReason;
+  usage: Usage;
+  timestamp?: number;
+}): AssistantMessage {
+  return {
+    role: "assistant",
+    content: params.content,
+    stopReason: params.stopReason,
+    api: params.model.api,
+    provider: params.model.provider,
+    model: params.model.id,
+    usage: params.usage,
+    timestamp: params.timestamp ?? Date.now(),
+  };
+}
+
+function buildStreamErrorAssistantMessage(params: {
+  model: StreamModelDescriptor;
+  errorMessage: string;
+  timestamp?: number;
+}): AssistantMessage & { stopReason: "error"; errorMessage: string } {
+  return {
+    ...buildAssistantMessage({
+      model: params.model,
+      content: [],
+      stopReason: "error",
+      usage: buildUsageWithNoCost({}),
+      timestamp: params.timestamp,
+    }),
+    stopReason: "error",
+    errorMessage: params.errorMessage,
+  };
+}
+
+function getShimPath() {
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../scripts/litertlm_provider_shim.py",
+  );
 }
 
 function buildModelDescriptor(modelId: string): StreamModelDescriptor {
   return {
-    api: "litertlm-local",
-    provider: "litertlm-local",
+    api: PROVIDER_ID,
+    provider: PROVIDER_ID,
     id: modelId,
   };
 }
@@ -59,13 +122,8 @@ export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): S
           shimInput.system = context.systemPrompt;
         }
 
-        const preference = getLiteRtLmModelPreference(params.model.id);
-        if (preference?.preferredMatch === "Gemma_4_E4B_it") {
-          // Draft-only placeholder: for a real patch, resolve explicit E4B path here or teach shim/model resolver model-id preference.
-        }
-
         const { stdout } = await execFileAsync("python3", [
-          getWorkspaceShimPath(),
+          getShimPath(),
           "--input",
           JSON.stringify(shimInput),
         ]);

--- a/extensions/litertlm/src/stream.ts
+++ b/extensions/litertlm/src/stream.ts
@@ -4,7 +4,6 @@ import { promisify } from "node:util";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, StopReason, Usage } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
-import type { OpenClawConfig } from "../../../src/config/config.js";
 import { PROVIDER_ID } from "./provider-models.js";
 import {
   buildLiteRtLmShimRequest,
@@ -19,6 +18,12 @@ type StreamModelDescriptor = {
   api: string;
   provider: string;
   id: string;
+};
+
+type LiteRtLmConfigShape = {
+  models?: {
+    providers?: Record<string, Record<string, unknown>>;
+  };
 };
 
 function buildUsageWithNoCost(params: {
@@ -184,7 +189,7 @@ async function invokeLiteRtLmShim(params: {
 
 export function createLiteRtLmShimStreamFn(params: {
   model: { id: string };
-  config?: OpenClawConfig;
+  config?: LiteRtLmConfigShape;
 }): StreamFn {
   return (_model, context, _options) => {
     const stream = createAssistantMessageEventStream();

--- a/extensions/litertlm/src/stream.ts
+++ b/extensions/litertlm/src/stream.ts
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, StopReason, Usage } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import type { OpenClawConfig } from "../../../src/config/config.js";
 import { PROVIDER_ID } from "./provider-models.js";
 import {
   buildLiteRtLmShimRequest,
@@ -181,7 +182,10 @@ async function invokeLiteRtLmShim(params: {
   }
 }
 
-export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): StreamFn {
+export function createLiteRtLmShimStreamFn(params: {
+  model: { id: string };
+  config?: OpenClawConfig;
+}): StreamFn {
   return (_model, context, _options) => {
     const stream = createAssistantMessageEventStream();
 
@@ -190,6 +194,7 @@ export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): S
       try {
         const runtimeConfig = resolveLiteRtLmRuntimeConfig({
           model: { modelId: params.model.id },
+          config: params.config,
         });
 
         if (!runtimeConfig.modelFile) {

--- a/extensions/litertlm/src/stream.ts
+++ b/extensions/litertlm/src/stream.ts
@@ -6,6 +6,12 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, StopReason, Usage } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { PROVIDER_ID } from "./provider-models.js";
+import {
+  buildLiteRtLmShimRequest,
+  resolveLiteRtLmRuntimeConfig,
+  type LiteRtLmRuntimeConfig,
+  type LiteRtLmShimResponse,
+} from "./runtime-config.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -73,11 +79,22 @@ function buildStreamErrorAssistantMessage(params: {
   };
 }
 
-function getShimPath() {
+function getBundledShimPath() {
   return path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
-    "../../../scripts/litertlm_provider_shim.py",
+    "../scripts/litertlm_provider_shim.py",
   );
+}
+
+function resolveShimPath(runtimeConfig: LiteRtLmRuntimeConfig) {
+  const configuredPath = runtimeConfig.shimPath.trim();
+  if (!configuredPath) {
+    return getBundledShimPath();
+  }
+  if (path.isAbsolute(configuredPath)) {
+    return configuredPath;
+  }
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", configuredPath);
 }
 
 function buildModelDescriptor(modelId: string): StreamModelDescriptor {
@@ -107,6 +124,39 @@ function extractPrompt(context: { messages?: unknown[] }) {
   return "";
 }
 
+function buildUsageFromShimResponse(payload: LiteRtLmShimResponse): Usage {
+  if (!payload.ok) {
+    return buildUsageWithNoCost({});
+  }
+  return buildUsageWithNoCost({
+    input: payload.usage?.inputTokens,
+    output: payload.usage?.outputTokens,
+    totalTokens: payload.usage?.totalTokens,
+  });
+}
+
+async function invokeLiteRtLmShim(params: {
+  runtimeConfig: LiteRtLmRuntimeConfig;
+  request: ReturnType<typeof buildLiteRtLmShimRequest>;
+}): Promise<LiteRtLmShimResponse> {
+  const shimPath = resolveShimPath(params.runtimeConfig);
+  const { stdout } = await execFileAsync(
+    params.runtimeConfig.pythonPath,
+    [shimPath, "--input", JSON.stringify(params.request)],
+    {
+      timeout: params.runtimeConfig.timeoutMs,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+
+  const parsed = JSON.parse(stdout) as LiteRtLmShimResponse;
+  return parsed;
+}
+
+function buildLiteRtLmErrorMessage(err: unknown) {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): StreamFn {
   return (_model, context, _options) => {
     const stream = createAssistantMessageEventStream();
@@ -114,37 +164,37 @@ export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): S
     const run = async () => {
       const modelInfo = buildModelDescriptor(params.model.id);
       try {
-        const shimInput: Record<string, unknown> = {
-          prompt: extractPrompt(context),
-          backend: "CPU",
-        };
-        if (typeof context.systemPrompt === "string" && context.systemPrompt.trim()) {
-          shimInput.system = context.systemPrompt;
+        const runtimeConfig = resolveLiteRtLmRuntimeConfig({
+          model: { modelId: params.model.id },
+        });
+
+        if (!runtimeConfig.modelFile) {
+          throw new Error("litertlm provider requires a configured model file path");
         }
 
-        const { stdout } = await execFileAsync("python3", [
-          getShimPath(),
-          "--input",
-          JSON.stringify(shimInput),
-        ]);
+        const request = buildLiteRtLmShimRequest({
+          modelId: params.model.id,
+          runtimeConfig,
+          prompt: extractPrompt(context),
+          system:
+            typeof context.systemPrompt === "string" && context.systemPrompt.trim()
+              ? context.systemPrompt
+              : undefined,
+        });
 
-        const payload = JSON.parse(stdout) as {
-          ok: boolean;
-          output_text?: string;
-          diagnostics?: unknown;
-          error?: { message?: string };
-        };
+        const payload = await invokeLiteRtLmShim({ runtimeConfig, request });
 
         if (!payload.ok) {
-          throw new Error(payload.error?.message || "LiteRT-LM shim failed");
+          throw new Error(payload.error.message || "LiteRT-LM shim failed");
         }
 
-        const text = payload.output_text || "";
+        const text = payload.output.text || "";
+        const usage = buildUsageFromShimResponse(payload);
         const partial = buildAssistantMessage({
           model: modelInfo,
           content: [{ type: "text", text }],
           stopReason: "stop",
-          usage: buildUsageWithNoCost({}),
+          usage,
         });
 
         stream.push({ type: "start", partial });
@@ -158,7 +208,7 @@ export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): S
             model: modelInfo,
             content: [{ type: "text", text }],
             stopReason: "stop",
-            usage: buildUsageWithNoCost({}),
+            usage,
           }),
         });
       } catch (err) {
@@ -167,7 +217,7 @@ export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): S
           reason: "error",
           error: buildStreamErrorAssistantMessage({
             model: modelInfo,
-            errorMessage: err instanceof Error ? err.message : String(err),
+            errorMessage: buildLiteRtLmErrorMessage(err),
           }),
         });
       } finally {

--- a/extensions/litertlm/src/stream.ts
+++ b/extensions/litertlm/src/stream.ts
@@ -1,6 +1,5 @@
 import { execFile } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, StopReason, Usage } from "@mariozechner/pi-ai";
@@ -79,22 +78,15 @@ function buildStreamErrorAssistantMessage(params: {
   };
 }
 
-function getBundledShimPath() {
-  return path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "../scripts/litertlm_provider_shim.py",
-  );
-}
-
 function resolveShimPath(runtimeConfig: LiteRtLmRuntimeConfig) {
   const configuredPath = runtimeConfig.shimPath.trim();
   if (!configuredPath) {
-    return getBundledShimPath();
+    return runtimeConfig.shimPath;
   }
   if (path.isAbsolute(configuredPath)) {
     return configuredPath;
   }
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", configuredPath);
+  return path.resolve(process.cwd(), configuredPath);
 }
 
 function buildModelDescriptor(modelId: string): StreamModelDescriptor {
@@ -135,26 +127,58 @@ function buildUsageFromShimResponse(payload: LiteRtLmShimResponse): Usage {
   });
 }
 
+function buildLiteRtLmErrorMessage(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  if (/ENOENT|not found/i.test(message)) {
+    return `litertlm environment error: ${message}`;
+  }
+  if (/timed out|timeout/i.test(message)) {
+    return `litertlm runtime timeout: ${message}`;
+  }
+  if (/Unexpected token|JSON|parse/i.test(message)) {
+    return `litertlm runtime returned invalid JSON: ${message}`;
+  }
+  return message;
+}
+
 async function invokeLiteRtLmShim(params: {
   runtimeConfig: LiteRtLmRuntimeConfig;
   request: ReturnType<typeof buildLiteRtLmShimRequest>;
 }): Promise<LiteRtLmShimResponse> {
   const shimPath = resolveShimPath(params.runtimeConfig);
-  const { stdout } = await execFileAsync(
-    params.runtimeConfig.pythonPath,
-    [shimPath, "--input", JSON.stringify(params.request)],
-    {
-      timeout: params.runtimeConfig.timeoutMs,
-      maxBuffer: 1024 * 1024,
-    },
-  );
+  try {
+    const { stdout } = await execFileAsync(
+      params.runtimeConfig.pythonPath,
+      [shimPath, "--input", JSON.stringify(params.request)],
+      {
+        timeout: params.runtimeConfig.timeoutMs,
+        maxBuffer: 1024 * 1024,
+      },
+    );
 
-  const parsed = JSON.parse(stdout) as LiteRtLmShimResponse;
-  return parsed;
-}
-
-function buildLiteRtLmErrorMessage(err: unknown) {
-  return err instanceof Error ? err.message : String(err);
+    return JSON.parse(stdout) as LiteRtLmShimResponse;
+  } catch (error) {
+    if (error instanceof Error) {
+      return {
+        ok: false,
+        version: 1,
+        error: {
+          type: /ENOENT|not found/i.test(error.message) ? "environment" : "runtime",
+          code: /timed out|timeout/i.test(error.message) ? "PROCESS_TIMEOUT" : "PROCESS_ERROR",
+          message: buildLiteRtLmErrorMessage(error),
+        },
+      };
+    }
+    return {
+      ok: false,
+      version: 1,
+      error: {
+        type: "runtime",
+        code: "UNKNOWN_RUNTIME_ERROR",
+        message: String(error),
+      },
+    };
+  }
 }
 
 export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): StreamFn {
@@ -169,7 +193,7 @@ export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): S
         });
 
         if (!runtimeConfig.modelFile) {
-          throw new Error("litertlm provider requires a configured model file path");
+          throw new Error("litertlm configuration error: missing configured modelFile");
         }
 
         const request = buildLiteRtLmShimRequest({
@@ -185,7 +209,9 @@ export function createLiteRtLmShimStreamFn(params: { model: { id: string } }): S
         const payload = await invokeLiteRtLmShim({ runtimeConfig, request });
 
         if (!payload.ok) {
-          throw new Error(payload.error.message || "LiteRT-LM shim failed");
+          throw new Error(
+            `litertlm ${payload.error.type} error (${payload.error.code}): ${payload.error.message}`,
+          );
         }
 
         const text = payload.output.text || "";

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -955,7 +955,7 @@ describe("createTelegramBot", () => {
       expect(replySpy).not.toHaveBeenCalled();
       expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
       expect(editMessageTextSpy.mock.calls[0]?.[2]).toContain(
-        `${CHECK_MARK_EMOJI} Model reset to default`,
+        `${CHECK_MARK_EMOJI} Model changed to <b>anthropic/claude-opus-4-6</b>`,
       );
 
       const entry = Object.values(loadSessionStore(storePath, { skipCache: true }))[0];

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -567,16 +567,16 @@ describe("runWithModelFallback", () => {
     setLoggerOverride({ level: "silent", consoleLevel: "warn" });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      const cfg = makeCfg();
       const run = vi
         .fn()
-        .mockRejectedValueOnce(new Error("Model not found: openai/gpt-6"))
+        .mockRejectedValueOnce(new Error("Model not found: openai/gpt-6spoof"))
         .mockResolvedValueOnce("ok");
 
       const result = await runWithModelFallback({
-        cfg,
+        cfg: undefined,
         provider: "openai",
         model: "gpt-6\u001B[31m\nspoof",
+        fallbacksOverride: ["anthropic/claude-haiku-3-5"],
         run,
       });
 

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -38,4 +38,14 @@ describe("model-selection plugin runtime normalization", () => {
       },
     });
   });
+
+  it("does not consult plugin runtime hooks for openai model ids", async () => {
+    const { parseModelRef } = await import("./model-selection.js");
+
+    expect(parseModelRef("gpt-6", "openai")).toEqual({
+      provider: "openai",
+      model: "gpt-6",
+    });
+    expect(normalizeProviderModelIdWithPluginMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -106,6 +106,12 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
 
 function normalizeProviderModelId(provider: string, model: string): string {
   const staticModelId = normalizeStaticProviderModelId(provider, model);
+  // Avoid plugin manifest discovery for providers that do not currently expose
+  // normalizeModelId hooks. This keeps hot-path model normalization deterministic
+  // in tests and avoids unnecessary plugin-registry work for common providers.
+  if (provider === "openai") {
+    return staticModelId;
+  }
   return (
     normalizeProviderModelIdWithRuntime({
       provider,


### PR DESCRIPTION
# PR Description Draft — LiteRT-LM Experimental Local Model Path

## Summary

This PR introduces an **experimental LiteRT-LM local model path** for OpenClaw, built around a validated finding:

> Edge Gallery-downloaded `.litertlm` model files can be loaded directly with LiteRT-LM on macOS and used for local inference outside the Edge Gallery UI.

The proposed direction is:
- treat **Edge Gallery** as a local model downloader / manager
- treat **LiteRT-LM** as the actual local inference runtime
- treat **OpenClaw** as the thin provider / adapter layer

## What this PR contains

### Research and design artifacts
- provider design notes
- experimental adapter spec
- config / registration draft
- patch plan
- StreamFn contract notes
- implementation handoff summary

### Runtime prototypes in workspace
- model autodetect
- Python runtime autodetect
- local chat prototype
- OpenClaw-style wrapper prototype
- provider shim prototype

### `openclaw-src` draft extension skeleton
- `extensions/litertlm/index.ts`
- `extensions/litertlm/src/provider-models.ts`
- `extensions/litertlm/src/stream.ts`
- `extensions/litertlm/index.test.ts`

## Key validated facts

- LiteRT-LM Python API works on macOS on this machine
- Edge Gallery-downloaded Gemma 4 E2B `.litertlm` runs successfully through LiteRT-LM
- Edge Gallery-downloaded Gemma 4 E4B `.litertlm` also runs successfully, but is heavier
- E2B is the recommended first/default experimental registration
- E4B should remain optional experimental for now

## Recommended first model ids

- `litertlm/gemma4-e2b-edge-gallery` — default experimental local model
- `litertlm/gemma4-e4b-edge-gallery` — optional experimental local model

## Current scope / non-goals

This PR should be treated as **experimental and partial**.

### In scope
- process-based shim approach
- CPU backend
- one-shot text generation path
- provider/adapter design and draft skeletons

### Not yet in scope
- full compile-ready bundled integration
- generated bundled entry wiring
- token-level streaming
- persistent multi-turn state reuse
- GPU backend claims
- Edge Gallery UI/runtime integration

## Why this approach

The strongest validated path is **not** to automate or embed the Edge Gallery UI.
The strongest validated path is to reuse the downloaded `.litertlm` files directly via LiteRT-LM.

That gives OpenClaw a realistic experimental local-model path with a small integration surface.

## Current environment note

The local runtime path was stabilized on this machine by creating:
- `~/.venvs/litertlm`

with:
- `litert-lm-nightly`

This lets the current shim/wrapper prototypes run reliably without depending on `/tmp`.

## Suggested review posture

Please review this PR as:
- a validated experimental integration package
- a patch-planning and skeleton PR
- not a final production-ready local provider

## Follow-up work after merge / approval

1. clean up the `extensions/litertlm/` draft toward compile readiness
2. decide real shim path strategy
3. wire bundled registration only after the extension skeleton is stable
4. later consider E4B comfort benchmarks and possibly fuller streaming support
