### PR TITLE
fix(openrouter): add resolveDefaultThinkingLevel hook

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -1,8 +1,26 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const registerRuntimeMocks = vi.hoisted(() => ({
+  getOpenRouterModelCapabilities: vi.fn(),
+}));
+
+vi.mock("./register.runtime.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./register.runtime.js")>("./register.runtime.js");
+  return {
+    ...actual,
+    getOpenRouterModelCapabilities: registerRuntimeMocks.getOpenRouterModelCapabilities,
+  };
+});
+
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import openrouterPlugin from "./index.js";
 
 describe("openrouter provider hooks", () => {
+  beforeEach(() => {
+    registerRuntimeMocks.getOpenRouterModelCapabilities.mockReset();
+    registerRuntimeMocks.getOpenRouterModelCapabilities.mockReturnValue(undefined);
+  });
+
   it("owns passthrough-gemini replay policy for Gemini-backed models", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
 
@@ -52,6 +70,42 @@ describe("openrouter provider hooks", () => {
         modelId: "openai/gpt-5.4",
       } as never),
     ).toBe("native");
+  });
+
+  it("defaults OpenRouter auto to minimal thinking", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "openrouter",
+        modelId: "auto",
+      } as never),
+    ).toBe("minimal");
+  });
+
+  it("defaults cached reasoning-capable OpenRouter models to low thinking", async () => {
+    registerRuntimeMocks.getOpenRouterModelCapabilities.mockReturnValue({
+      reasoning: true,
+    });
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "openrouter",
+        modelId: "stepfun/step-3.5-flash:free",
+      } as never),
+    ).toBe("low");
+  });
+
+  it("keeps non-auto OpenRouter models unset without a reasoning hint", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "openrouter",
+        modelId: "gpt-5-mini",
+      } as never),
+    ).toBeUndefined();
   });
 
   it("injects provider routing into compat before applying stream wrappers", async () => {

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -15,6 +15,7 @@ const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
   "moonshotai/",
   "zai/",
 ] as const;
+const OPENROUTER_AUTO_MODEL_IDS = new Set(["auto", "openrouter/auto"]);
 
 export default definePluginEntry({
   id: "openrouter",
@@ -107,6 +108,18 @@ export default definePluginEntry({
       return OPENROUTER_CACHE_TTL_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
     }
 
+    function resolveOpenRouterDefaultThinkingLevel(modelId: string) {
+      const normalizedModelId = modelId.trim().toLowerCase();
+      if (!normalizedModelId) {
+        return undefined;
+      }
+      if (OPENROUTER_AUTO_MODEL_IDS.has(normalizedModelId)) {
+        return "minimal" as const;
+      }
+      const capabilities = getOpenRouterModelCapabilities(modelId);
+      return capabilities?.reasoning ? ("low" as const) : undefined;
+    }
+
     api.registerProvider({
       id: PROVIDER_ID,
       label: "OpenRouter",
@@ -158,6 +171,7 @@ export default definePluginEntry({
       isModernModelRef: () => true,
       wrapStreamFn: wrapOpenRouterProviderStream,
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
+      resolveDefaultThinkingLevel: ({ modelId }) => resolveOpenRouterDefaultThinkingLevel(modelId),
     });
     api.registerMediaUnderstandingProvider(openrouterMediaUnderstandingProvider);
   },


### PR DESCRIPTION
## Summary

v2026.3.28 refactored thinking level resolution into per-provider plugin hooks
but missed the OpenRouter provider. Without the hook, the core fallback injects
`reasoning: { effort: "none" }` into every non-reasoning OpenRouter model
request, causing "Reasoning is required for this model endpoint" errors.

Adds `resolveDefaultThinkingLevel` to the OpenRouter provider registration:
- `auto` / `openrouter/auto` → `"minimal"`
- reasoning-capable models (per cached capabilities) → `"low"`
- everything else → `undefined` (no reasoning params injected)

Fixes #57430.

## Validation

- `pnpm tsgo extensions/openrouter/` — no type errors
- `pnpm test extensions/openrouter/index.test.ts` — 6/6 pass (3 new)
- `pnpm build` — clean, no ineffective dynamic import warnings