### PR TITLE
fix(discord): avoid duplicate ACP fallback replies

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -16,8 +16,10 @@ const collectDiscordAuditChannelIdsMock = vi.hoisted(() =>
 );
 const sleepWithAbortMock = vi.hoisted(() => vi.fn(async () => undefined));
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
   return {
+    ...actual,
     sleepWithAbort: sleepWithAbortMock,
   };
 });
@@ -132,6 +134,16 @@ describe("discordPlugin outbound", () => {
 
     expect(resolveReplyToMode({ cfg, accountId: "work" })).toBe("first");
     expect(resolveReplyToMode({ cfg, accountId: "default" })).toBe("all");
+  });
+
+  it("treats ACP block replies as already visible", () => {
+    const shouldTreatRoutedTextAsVisible = discordPlugin.outbound?.shouldTreatRoutedTextAsVisible;
+    if (!shouldTreatRoutedTextAsVisible) {
+      throw new Error("Expected discord outbound visibility hook to be defined");
+    }
+
+    expect(shouldTreatRoutedTextAsVisible({ kind: "block", text: "hello" })).toBe(true);
+    expect(shouldTreatRoutedTextAsVisible({ kind: "tool", text: "hello" })).toBe(false);
   });
 
   it("forwards mediaLocalRoots to sendMessageDiscord", async () => {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -151,6 +151,16 @@ function resolveOptionalDiscordRuntime() {
   }
 }
 
+function shouldTreatDiscordRoutedTextAsVisible(params: {
+  kind: "tool" | "block" | "final";
+  text?: string;
+}): boolean {
+  void params.text;
+  // Discord renders streamed ACP block replies directly in-channel, so treating
+  // them as hidden causes the final fallback to replay the same text.
+  return params.kind === "block";
+}
+
 async function resolveDiscordSend(deps?: { [channelId: string]: unknown }): Promise<DiscordSendFn> {
   return (
     resolveOutboundSendDep<DiscordSendFn>(deps, "discord") ??
@@ -819,6 +829,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
             accountId,
             payload,
           }),
+        shouldTreatRoutedTextAsVisible: shouldTreatDiscordRoutedTextAsVisible,
         resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
       },
       attachedResults: {

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -16,9 +16,37 @@ const deliveryMocks = vi.hoisted(() => ({
   runMessageAction: vi.fn(async (_params: unknown) => ({ ok: true as const })),
 }));
 
+const channelPluginMocks = vi.hoisted(() => ({
+  getChannelPlugin: vi.fn((channelId: string) => {
+    if (channelId === "telegram") {
+      return {
+        outbound: {
+          shouldTreatRoutedTextAsVisible: ({ kind }: { kind: string }) => kind !== "final",
+        },
+      };
+    }
+    if (channelId === "discord") {
+      return {
+        outbound: {
+          shouldTreatRoutedTextAsVisible: ({ kind }: { kind: string }) => kind === "block",
+        },
+      };
+    }
+    return undefined;
+  }),
+}));
+
 vi.mock("../../tts/tts.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
 }));
+
+vi.mock("../../channels/plugins/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../channels/plugins/index.js")>();
+  return {
+    ...actual,
+    getChannelPlugin: (channelId: string) => channelPluginMocks.getChannelPlugin(channelId),
+  };
+});
 
 vi.mock("./route-reply.js", () => ({
   routeReply: (params: unknown) => deliveryMocks.routeReply(params),
@@ -61,6 +89,7 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     deliveryMocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock-message" });
     deliveryMocks.runMessageAction.mockClear();
     deliveryMocks.runMessageAction.mockResolvedValue({ ok: true as const });
+    channelPluginMocks.getChannelPlugin.mockClear();
   });
 
   it("bypasses TTS when skipTts is requested", async () => {
@@ -142,8 +171,30 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
   });
 
-  it("does not treat non-telegram direct block text as visible", async () => {
+  it("treats direct discord block text as visible", async () => {
     const coordinator = createCoordinator();
+
+    await coordinator.deliver("block", { text: "hello" }, { skipTts: true });
+    await coordinator.settleVisibleText();
+
+    expect(coordinator.hasDeliveredFinalReply()).toBe(false);
+    expect(coordinator.hasDeliveredVisibleText()).toBe(true);
+    expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
+    expect(coordinator.getRoutedCounts().block).toBe(0);
+  });
+
+  it("does not treat direct block text as visible without a channel visibility hook", async () => {
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "webchat",
+        Surface: "webchat",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher: createDispatcher(),
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+    });
 
     await coordinator.deliver("block", { text: "hello" }, { skipTts: true });
     await coordinator.settleVisibleText();

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -58,6 +58,26 @@ const bindingServiceMocks = vi.hoisted(() => ({
   unbind: vi.fn<(input: unknown) => Promise<SessionBindingRecord[]>>(async () => []),
 }));
 
+const channelPluginMocks = vi.hoisted(() => ({
+  getChannelPlugin: vi.fn((channelId: string) => {
+    if (channelId === "telegram") {
+      return {
+        outbound: {
+          shouldTreatRoutedTextAsVisible: ({ kind }: { kind: string }) => kind !== "final",
+        },
+      };
+    }
+    if (channelId === "discord") {
+      return {
+        outbound: {
+          shouldTreatRoutedTextAsVisible: ({ kind }: { kind: string }) => kind === "block",
+        },
+      };
+    }
+    return undefined;
+  }),
+}));
+
 const sessionKey = "agent:codex-acp:session-1";
 const originalFetch = globalThis.fetch;
 type MockTtsReply = Awaited<ReturnType<typeof ttsMocks.maybeApplyTtsToPayload>>;
@@ -107,6 +127,8 @@ async function runDispatch(params: {
   cfg?: OpenClawConfig;
   dispatcher?: ReplyDispatcher;
   shouldRouteToOriginating?: boolean;
+  originatingChannel?: string;
+  originatingTo?: string;
   onReplyStart?: () => void;
   ctxOverrides?: Record<string, unknown>;
   sessionKeyOverride?: string;
@@ -126,7 +148,10 @@ async function runDispatch(params: {
     inboundAudio: false,
     shouldRouteToOriginating: params.shouldRouteToOriginating ?? false,
     ...(params.shouldRouteToOriginating
-      ? { originatingChannel: "telegram", originatingTo: "telegram:thread-1" }
+      ? {
+          originatingChannel: params.originatingChannel ?? "telegram",
+          originatingTo: params.originatingTo ?? "telegram:thread-1",
+        }
       : {}),
     shouldSendToolSummaries: true,
     bypassForCommand: false,
@@ -199,13 +224,18 @@ function queueTtsReplies(...replies: MockTtsReply[]) {
   }
 }
 
-async function runRoutedAcpTextTurn(text: string) {
+async function runRoutedAcpTextTurn(
+  text: string,
+  params?: { originatingChannel?: string; originatingTo?: string },
+) {
   mockRoutedTextTurn(text);
   const { dispatcher } = createDispatcher();
   const result = await runDispatch({
     bodyForAgent: "run acp",
     dispatcher,
     shouldRouteToOriginating: true,
+    originatingChannel: params?.originatingChannel,
+    originatingTo: params?.originatingTo,
   });
   return { result };
 }
@@ -256,6 +286,13 @@ describe("tryDispatchAcpReply", () => {
         unbind: (input: unknown) => bindingServiceMocks.unbind(input),
       }),
     }));
+    vi.doMock("../../channels/plugins/index.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../../channels/plugins/index.js")>();
+      return {
+        ...actual,
+        getChannelPlugin: (channelId: string) => channelPluginMocks.getChannelPlugin(channelId),
+      };
+    });
     ({ tryDispatchAcpReply } = await import("./dispatch-acp.js"));
     managerMocks.resolveSession.mockReset();
     managerMocks.runTurn.mockReset();
@@ -283,6 +320,24 @@ describe("tryDispatchAcpReply", () => {
     bindingServiceMocks.listBySession.mockReturnValue([]);
     bindingServiceMocks.unbind.mockReset();
     bindingServiceMocks.unbind.mockResolvedValue([]);
+    channelPluginMocks.getChannelPlugin.mockReset();
+    channelPluginMocks.getChannelPlugin.mockImplementation((channelId: string) => {
+      if (channelId === "telegram") {
+        return {
+          outbound: {
+            shouldTreatRoutedTextAsVisible: ({ kind }: { kind: string }) => kind !== "final",
+          },
+        };
+      }
+      if (channelId === "discord") {
+        return {
+          outbound: {
+            shouldTreatRoutedTextAsVisible: ({ kind }: { kind: string }) => kind === "block",
+          },
+        };
+      }
+      return undefined;
+    });
     globalThis.fetch = originalFetch;
   });
 
@@ -906,6 +961,20 @@ describe("tryDispatchAcpReply", () => {
     expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
   });
 
+  it("does not deliver final fallback text when routed discord block text was already visible", async () => {
+    setReadyAcpResolution();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    queueTtsReplies({ text: "CODEX_OK" }, {} as ReturnType<typeof ttsMocks.maybeApplyTtsToPayload>);
+    const { result } = await runRoutedAcpTextTurn("CODEX_OK", {
+      originatingChannel: "discord",
+      originatingTo: "channel:1489996832695386162",
+    });
+
+    expect(result?.counts.block).toBe(1);
+    expect(result?.counts.final).toBe(0);
+    expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
+  });
+
   it("does not deliver final fallback text when direct block text was already visible", async () => {
     setReadyAcpResolution();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
@@ -955,7 +1024,7 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
-  it("preserves final fallback when direct block text is filtered by non-telegram channels", async () => {
+  it("preserves final fallback when direct block text uses a channel without a visibility hook", async () => {
     setReadyAcpResolution();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
     queueTtsReplies({ text: "CODEX_OK" }, {} as ReturnType<typeof ttsMocks.maybeApplyTtsToPayload>);
@@ -965,6 +1034,10 @@ describe("tryDispatchAcpReply", () => {
     const result = await runDispatch({
       bodyForAgent: "reply",
       dispatcher,
+      ctxOverrides: {
+        Provider: "webchat",
+        Surface: "webchat",
+      },
     });
 
     expect(result?.counts.block).toBe(0);

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -478,6 +478,8 @@ describe("tryDispatchAcpReply", () => {
           },
         }),
         ctxOverrides: {
+          Provider: "imessage",
+          Surface: "imessage",
           MediaPath: imagePath,
           MediaType: "image/png",
         },

--- a/src/auto-reply/reply/test-fixtures/acp-runtime.ts
+++ b/src/auto-reply/reply/test-fixtures/acp-runtime.ts
@@ -10,6 +10,7 @@ export function createAcpTestConfig(overrides?: Partial<OpenClawConfig>): OpenCl
         maxChunkChars: 64,
       },
     },
+    channels: {},
     ...overrides,
   } as OpenClawConfig;
 }


### PR DESCRIPTION
AI-assisted: Codex. Testing: `pnpm build`, `pnpm check`, `pnpm test src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/dispatch-acp.test.ts`, and `pnpm test extensions/discord/src/channel.test.ts -t 'treats ACP block replies as already visible'`.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: ACP-backed Discord sessions can replay the same visible reply twice when the turn ends.
- Why it matters: users see duplicate Codex responses in Discord for a single turn.
- What changed: Discord now opts into `shouldTreatRoutedTextAsVisible` for ACP block replies, and ACP regression coverage now exercises Discord-visible block delivery plus no-hook fallback behavior.
- What did NOT change (scope boundary): ACP fallback semantics are still channel-specific; channels without a visibility hook still keep the existing final fallback path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: ACP delivery only treats non-final text as already visible when the target channel opts in via `shouldTreatRoutedTextAsVisible`. Telegram had that hook; Discord did not, so Discord block replies were treated as hidden and the accumulated block text was replayed as a final fallback.
- Missing detection / guardrail: there was no Discord-specific regression test proving that routed ACP block replies should suppress the final text fallback.
- Contributing context (if known): ACP keeps the final fallback intentionally channel-specific because some parent surfaces only expose terminal replies.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/channel.test.ts`, `src/auto-reply/reply/dispatch-acp-delivery.test.ts`, `src/auto-reply/reply/dispatch-acp.test.ts`
- Scenario the test should lock in: Discord block replies emitted by ACP count as already visible output, so the end-of-turn final fallback does not replay the same text.
- Why this is the smallest reliable guardrail: the plugin test proves Discord exposes the visibility contract, and the ACP tests prove that both direct and routed fallback logic honor it while preserving fallback behavior for channels without a hook.
- Existing test that already covers this (if any): none for Discord before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord ACP replies no longer duplicate the same final text after a visible block reply has already been delivered. No config or default changes.

## Diagram (if applicable)

```text
Before:
[Discord ACP turn] -> [block reply sent to Discord] -> [fallback assumes output was hidden] -> [same text sent again as final reply]

After:
[Discord ACP turn] -> [block reply sent to Discord] -> [Discord visibility hook marks it visible] -> [no duplicate final replay]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm 10
- Model/provider: Codex via ACPX
- Integration/channel (if any): Discord
- Relevant config (redacted): persistent ACP Codex session bound to a Discord channel

### Steps

1. Bind a persistent ACP Codex session to a Discord channel.
2. Send a short prompt that produces one visible ACP block reply.
3. Wait for turn completion.

### Expected

- One visible Discord reply for the turn.

### Actual

- The same visible text is posted twice: once as the ACP block reply and again as the final fallback.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm build`, `pnpm check`, the full ACP regression files (`dispatch-acp-delivery.test.ts` and `dispatch-acp.test.ts`), and a focused Discord plugin test for the new visibility hook.
- Edge cases checked: Discord routed block replies suppress the fallback; direct Discord block replies are treated as visible; channels without a visibility hook still keep the fallback.
- What you did **not** verify: a fresh end-to-end Discord round-trip from this source checkout.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: marking the wrong channel output as visible could suppress the fallback where it is still needed.
  - Mitigation: the change is scoped to Discord via the channel-level hook, and the tests keep the no-hook fallback path green.
