### PR TITLE
Browser: improve existing-session attach error for DevToolsActivePort

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.attach-failure-message.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.attach-failure-message.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatChromeMcpAttachFailureMessage } from "./chrome-mcp.js";
+
+describe("chrome-mcp attach failure message", () => {
+  it("adds actionable guidance for DevToolsActivePort failures", () => {
+    const msg = formatChromeMcpAttachFailureMessage({
+      profileName: "chrome-live",
+      userDataDir: "/home/user/.config/google-chrome",
+      details:
+        "Could not connect to Chrome / missing DevToolsActivePort at /home/user/.config/google-chrome/DevToolsActivePort",
+    });
+
+    expect(msg).toContain("DevToolsActivePort");
+    expect(msg).toContain("remote debugging");
+    expect(msg).toContain("--remote-debugging-port=9222");
+  });
+
+  it("keeps generic details for unrelated failures", () => {
+    const msg = formatChromeMcpAttachFailureMessage({
+      profileName: "chrome-live",
+      details: "attach failed",
+    });
+
+    expect(msg).toContain("attach failed");
+    expect(msg).not.toContain("DevToolsActivePort missing");
+  });
+});

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -31,6 +31,34 @@ type ChromeMcpSessionFactory = (
   userDataDir?: string,
 ) => Promise<ChromeMcpSession>;
 
+export function formatChromeMcpAttachFailureMessage(params: {
+  profileName: string;
+  userDataDir?: string;
+  details: string;
+}): string {
+  const details = params.details.trim();
+  const targetLabel = params.userDataDir
+    ? `the configured Chromium user data dir (${params.userDataDir})`
+    : "Google Chrome's default profile";
+
+  const base =
+    `Chrome MCP existing-session attach failed for profile "${params.profileName}". ` +
+    `Make sure ${targetLabel} is running locally with remote debugging enabled.`;
+
+  const lower = details.toLowerCase();
+  if (lower.includes("devtoolsactiveport")) {
+    return (
+      `${base} ` +
+      `Chrome did not expose a DevTools endpoint (DevToolsActivePort missing). ` +
+      `Start/keep Chrome running with remote debugging enabled (e.g. ` +
+      `--remote-debugging-port=9222 or --remote-debugging-port=0) and try again. ` +
+      `Details: ${details}`
+    );
+  }
+
+  return `${base} Details: ${details}`;
+}
+
 const DEFAULT_CHROME_MCP_COMMAND = "npx";
 const DEFAULT_CHROME_MCP_ARGS = [
   "-y",
@@ -246,13 +274,12 @@ async function createRealSession(
       }
     } catch (err) {
       await client.close().catch(() => {});
-      const targetLabel = userDataDir
-        ? `the configured Chromium user data dir (${userDataDir})`
-        : "Google Chrome's default profile";
       throw new BrowserProfileUnavailableError(
-        `Chrome MCP existing-session attach failed for profile "${profileName}". ` +
-          `Make sure ${targetLabel} is running locally with remote debugging enabled. ` +
-          `Details: ${String(err)}`,
+        formatChromeMcpAttachFailureMessage({
+          profileName,
+          userDataDir,
+          details: String(err),
+        }),
       );
     }
   })();


### PR DESCRIPTION
Improves the existing-session (Chrome MCP) attach failure message when Chrome is not exposing DevTools.

Context
- Comms-Ops watchdog hit:
  - "Could not connect to Chrome / missing DevToolsActivePort at ~/.config/google-chrome/DevToolsActivePort"

Change
- Adds a small formatter that detects DevToolsActivePort-related failures and returns an actionable message:
  - explains that Chrome did not expose a DevTools endpoint
  - suggests running Chrome with `--remote-debugging-port=9222` (or `--remote-debugging-port=0`)
  - preserves original error details for debugging

Tests
- Adds unit tests for message formatting:
  - DevToolsActivePort case
  - generic failure case (no misclassification)

QA
- `pnpm install --frozen-lockfile`
- `pnpm vitest run extensions/browser/src/browser/chrome-mcp.attach-failure-message.test.ts --no-file-parallelism --maxWorkers 1`
- repo `pnpm check` ran via git hooks during commit