### PR TITLE
feat(ollama): auto-detect vision models from /api/show metadata

### DIFF
--- a/extensions/ollama/api.ts
+++ b/extensions/ollama/api.ts
@@ -7,11 +7,15 @@ export {
 } from "./src/defaults.js";
 export {
   buildOllamaModelDefinition,
+  detectVisionFromShowResponse,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
   isReasoningModelHeuristic,
+  isVisionModelHeuristic,
   queryOllamaContextWindow,
+  queryOllamaModelMeta,
   resolveOllamaApiBase,
+  type OllamaModelMeta,
   type OllamaModelWithContext,
   type OllamaTagModel,
   type OllamaTagsResponse,

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { jsonResponse, requestBodyText, requestUrl } from "../../../src/test-helpers/http.js";
 import {
+  buildOllamaModelDefinition,
+  detectVisionFromShowResponse,
   enrichOllamaModelsWithContext,
+  isVisionModelHeuristic,
   resolveOllamaApiBase,
   type OllamaTagModel,
 } from "./provider-models.js";
@@ -34,8 +37,145 @@ describe("ollama provider models", () => {
     const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
 
     expect(enriched).toEqual([
-      { name: "llama3:8b", contextWindow: 65536 },
-      { name: "deepseek-r1:14b", contextWindow: undefined },
+      { name: "llama3:8b", contextWindow: 65536, vision: undefined },
+      { name: "deepseek-r1:14b", contextWindow: undefined, vision: undefined },
     ]);
+  });
+
+  it("enriches discovered models with vision capability from /api/show", async () => {
+    const models: OllamaTagModel[] = [
+      { name: "llava:13b" },
+      { name: "llama3:8b" },
+      { name: "llama3.2-vision:11b" },
+    ];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = requestUrl(input);
+      if (!url.endsWith("/api/show")) {
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+      const body = JSON.parse(requestBodyText(init?.body)) as { name?: string };
+      if (body.name === "llava:13b") {
+        return jsonResponse({
+          model_info: {
+            "llama.context_length": 4096,
+            "clip.has_vision_encoder": true,
+            "clip.vision.image_size": 336,
+          },
+          details: { families: ["llama", "clip"] },
+        });
+      }
+      if (body.name === "llama3.2-vision:11b") {
+        return jsonResponse({
+          model_info: {
+            "mllama.context_length": 131072,
+            "mllama.vision.image_size": 560,
+          },
+          details: { families: ["mllama"] },
+        });
+      }
+      return jsonResponse({ model_info: { "llama.context_length": 8192 } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
+
+    expect(enriched).toEqual([
+      { name: "llava:13b", contextWindow: 4096, vision: true },
+      { name: "llama3:8b", contextWindow: 8192, vision: undefined },
+      { name: "llama3.2-vision:11b", contextWindow: 131072, vision: true },
+    ]);
+  });
+});
+
+describe("detectVisionFromShowResponse", () => {
+  it("detects CLIP-based vision models via model_info keys", () => {
+    expect(
+      detectVisionFromShowResponse({
+        model_info: { "clip.has_vision_encoder": true, "clip.vision.image_size": 336 },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects mllama vision models via model_info keys", () => {
+    expect(
+      detectVisionFromShowResponse({
+        model_info: { "mllama.vision.image_size": 560 },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects vision models via details.families", () => {
+    expect(
+      detectVisionFromShowResponse({
+        details: { families: ["llama", "clip"] },
+      }),
+    ).toBe(true);
+
+    expect(
+      detectVisionFromShowResponse({
+        details: { families: ["mllama"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for text-only models", () => {
+    expect(
+      detectVisionFromShowResponse({
+        model_info: { "llama.context_length": 8192, "general.architecture": "llama" },
+        details: { families: ["llama"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for empty response", () => {
+    expect(detectVisionFromShowResponse({})).toBe(false);
+  });
+});
+
+describe("isVisionModelHeuristic", () => {
+  it.each([
+    "llava:13b",
+    "llava-llama3:8b",
+    "bakllava:7b",
+    "llama3.2-vision:11b",
+    "qwen2.5-vl-7b",
+    "qwen2-vl:72b",
+    "moondream:latest",
+    "moondream2:latest",
+    "minicpm-v:8b",
+    "pixtral-12b:latest",
+    "internvl2:26b",
+  ])("identifies %s as a vision model", (modelId) => {
+    expect(isVisionModelHeuristic(modelId)).toBe(true);
+  });
+
+  it.each(["llama3:8b", "deepseek-r1:14b", "qwen3:30b-a3b", "gemma2:9b", "phi3:14b"])(
+    "does not flag %s as a vision model",
+    (modelId) => {
+      expect(isVisionModelHeuristic(modelId)).toBe(false);
+    },
+  );
+});
+
+describe("buildOllamaModelDefinition", () => {
+  it("sets input to text-only for plain text models", () => {
+    const def = buildOllamaModelDefinition("llama3:8b");
+    expect(def.input).toEqual(["text"]);
+  });
+
+  it("sets input to text+image when vision detected by API", () => {
+    const def = buildOllamaModelDefinition("llama3:8b", undefined, { vision: true });
+    expect(def.input).toEqual(["text", "image"]);
+  });
+
+  it("sets input to text+image via name heuristic when no API data", () => {
+    const def = buildOllamaModelDefinition("llava:13b");
+    expect(def.input).toEqual(["text", "image"]);
+  });
+
+  it("uses name heuristic as fallback when API did not detect vision", () => {
+    // Name says vision, API returned no vision data (undefined) → heuristic wins
+    const def = buildOllamaModelDefinition("qwen2.5-vl-7b", undefined, { vision: undefined });
+    expect(def.input).toEqual(["text", "image"]);
   });
 });

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -25,9 +25,50 @@ export type OllamaTagsResponse = {
 
 export type OllamaModelWithContext = OllamaTagModel & {
   contextWindow?: number;
+  vision?: boolean;
+};
+
+type OllamaShowResponse = {
+  model_info?: Record<string, unknown>;
+  details?: {
+    family?: string;
+    families?: string[];
+    parameter_size?: string;
+  };
+};
+
+export type OllamaModelMeta = {
+  contextWindow?: number;
+  vision?: boolean;
 };
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
+
+// Vision models surface a CLIP or cross-attention encoder in /api/show as keys
+// like "clip.has_vision_encoder" or "mllama.vision.image_size", and as "clip" or
+// "mllama" in details.families.
+const VISION_MODEL_INFO_KEY_RE = /^clip\.|\.vision\./;
+const VISION_FAMILIES = new Set(["clip", "mllama"]);
+
+export function detectVisionFromShowResponse(data: OllamaShowResponse): boolean {
+  if (data.model_info) {
+    for (const key of Object.keys(data.model_info)) {
+      if (VISION_MODEL_INFO_KEY_RE.test(key)) {
+        return true;
+      }
+    }
+  }
+  if (Array.isArray(data.details?.families)) {
+    if (data.details.families.some((f) => VISION_FAMILIES.has(f.toLowerCase()))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function isVisionModelHeuristic(modelId: string): boolean {
+  return /\bvl\b|llava|vision|moondream|minicpm-v|pixtral|internvl/i.test(modelId);
+}
 
 export function buildOllamaBaseUrlSsrFPolicy(baseUrl: string): SsrFPolicy | undefined {
   const trimmed = baseUrl.trim();
@@ -56,10 +97,10 @@ export function resolveOllamaApiBase(configuredBaseUrl?: string): string {
   return trimmed.replace(/\/v1$/i, "");
 }
 
-export async function queryOllamaContextWindow(
+export async function queryOllamaModelMeta(
   apiBase: string,
   modelName: string,
-): Promise<number | undefined> {
+): Promise<OllamaModelMeta> {
   try {
     const { response, release } = await fetchWithSsrFGuard({
       url: `${apiBase}/api/show`,
@@ -74,31 +115,42 @@ export async function queryOllamaContextWindow(
     });
     try {
       if (!response.ok) {
-        return undefined;
+        return {};
       }
-      const data = (await response.json()) as { model_info?: Record<string, unknown> };
-      if (!data.model_info) {
-        return undefined;
-      }
-      for (const [key, value] of Object.entries(data.model_info)) {
-        if (
-          key.endsWith(".context_length") &&
-          typeof value === "number" &&
-          Number.isFinite(value)
-        ) {
-          const contextWindow = Math.floor(value);
-          if (contextWindow > 0) {
-            return contextWindow;
+      const data = (await response.json()) as OllamaShowResponse;
+      let contextWindow: number | undefined;
+      if (data.model_info) {
+        for (const [key, value] of Object.entries(data.model_info)) {
+          if (
+            key.endsWith(".context_length") &&
+            typeof value === "number" &&
+            Number.isFinite(value)
+          ) {
+            const ctx = Math.floor(value);
+            if (ctx > 0) {
+              contextWindow = ctx;
+              break;
+            }
           }
         }
       }
-      return undefined;
+      const vision = detectVisionFromShowResponse(data);
+      return { contextWindow, vision: vision || undefined };
     } finally {
       await release();
     }
   } catch {
-    return undefined;
+    return {};
   }
+}
+
+/** @deprecated Use {@link queryOllamaModelMeta} for richer metadata. */
+export async function queryOllamaContextWindow(
+  apiBase: string,
+  modelName: string,
+): Promise<number | undefined> {
+  const meta = await queryOllamaModelMeta(apiBase, modelName);
+  return meta.contextWindow;
 }
 
 export async function enrichOllamaModelsWithContext(
@@ -111,10 +163,14 @@ export async function enrichOllamaModelsWithContext(
   for (let index = 0; index < models.length; index += concurrency) {
     const batch = models.slice(index, index + concurrency);
     const batchResults = await Promise.all(
-      batch.map(async (model) => ({
-        ...model,
-        contextWindow: await queryOllamaContextWindow(apiBase, model.name),
-      })),
+      batch.map(async (model) => {
+        const meta = await queryOllamaModelMeta(apiBase, model.name);
+        return {
+          ...model,
+          contextWindow: meta.contextWindow,
+          vision: meta.vision,
+        };
+      }),
     );
     enriched.push(...batchResults);
   }
@@ -128,12 +184,17 @@ export function isReasoningModelHeuristic(modelId: string): boolean {
 export function buildOllamaModelDefinition(
   modelId: string,
   contextWindow?: number,
+  opts?: { vision?: boolean },
 ): ModelDefinitionConfig {
+  // Combine API-detected vision capability with name heuristic for maximum
+  // coverage: the /api/show metadata is authoritative when available, the
+  // heuristic catches models whose architecture metadata is missing or novel.
+  const vision = opts?.vision || isVisionModelHeuristic(modelId);
   return {
     id: modelId,
     name: modelId,
     reasoning: isReasoningModelHeuristic(modelId),
-    input: ["text"],
+    input: vision ? ["text", "image"] : ["text"],
     cost: OLLAMA_DEFAULT_COST,
     contextWindow: contextWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -245,9 +245,12 @@ function buildOllamaModelsConfig(
   modelNames: string[],
   discoveredModelsByName?: Map<string, OllamaModelWithContext>,
 ) {
-  return modelNames.map((name) =>
-    buildOllamaModelDefinition(name, discoveredModelsByName?.get(name)?.contextWindow),
-  );
+  return modelNames.map((name) => {
+    const discovered = discoveredModelsByName?.get(name);
+    return buildOllamaModelDefinition(name, discovered?.contextWindow, {
+      vision: discovered?.vision,
+    });
+  });
 }
 
 function applyOllamaProviderConfig(
@@ -299,7 +302,9 @@ export async function buildOllamaProvider(
   return {
     baseUrl: apiBase,
     api: "ollama",
-    models: discovered.map((model) => buildOllamaModelDefinition(model.name, model.contextWindow)),
+    models: discovered.map((model) =>
+      buildOllamaModelDefinition(model.name, model.contextWindow, { vision: model.vision }),
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

- Detect vision-capable Ollama models (llava, llama3.2-vision, qwen2-vl, etc.) from `/api/show` metadata (`clip.*`, `mllama.vision.*` keys, `details.families`) and set `input: ["text", "image"]` in auto-discovered model definitions
- Add name-based heuristic fallback (`vl`, `llava`, `vision`, `moondream`, `minicpm-v`, `pixtral`, `internvl`) for models whose architecture metadata is missing or novel
- Combine both detection layers via OR logic for maximum coverage with zero extra API calls (piggybacks on existing `/api/show` call used for context window)

### Problem

`buildOllamaModelDefinition` hardcodes `input: ["text"]` for all auto-discovered models. Vision-capable models like `llava`, `llama3.2-vision`, or `qwen2.5-vl` work fine at the protocol level (image data is already passed through `stream.ts`), but OpenClaw's routing engine never selects them for image tasks because the model definition doesn't declare image support.

### Changes

**`extensions/ollama/src/provider-models.ts`**
- Add `detectVisionFromShowResponse()` — checks `model_info` keys for `clip.*` / `.vision.*` patterns and `details.families` for `clip` / `mllama`
- Add `isVisionModelHeuristic()` — name-based regex fallback
- Add `queryOllamaModelMeta()` — returns both `contextWindow` and `vision` from a single `/api/show` call
- Keep `queryOllamaContextWindow()` as a deprecated backwards-compatible wrapper
- Update `enrichOllamaModelsWithContext()` to thread `vision` through
- Update `buildOllamaModelDefinition()` with optional `opts.vision` parameter

**`extensions/ollama/src/setup.ts`**
- Pass `vision` from enriched models through `buildOllamaModelsConfig` and `buildOllamaProvider`

**`extensions/ollama/api.ts`**
- Export new functions and types

**`extensions/ollama/src/provider-models.test.ts`**
- 28 tests covering vision detection from API metadata, name heuristics, enrichment pipeline, and model definition output

## Test plan

- [x] All 28 tests in `provider-models.test.ts` pass
- [x] Existing SSRF tests unaffected
- [ ] Manual: pull a vision model (`ollama pull llava`), run discovery, verify `input: ["text", "image"]` in model definition
- [ ] Manual: send an image via WhatsApp/Telegram with Ollama as primary provider, verify it routes to the vision model