### PR TITLE
Plugin SDK: export secret-input-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
       "types": "./dist/plugin-sdk/config-runtime.d.ts",
       "default": "./dist/plugin-sdk/config-runtime.js"
     },
+    "./plugin-sdk/secret-input-runtime": {
+      "types": "./dist/plugin-sdk/secret-input-runtime.d.ts",
+      "default": "./dist/plugin-sdk/secret-input-runtime.js"
+    },
     "./plugin-sdk/telegram-command-config": {
       "types": "./dist/plugin-sdk/telegram-command-config.d.ts",
       "default": "./dist/plugin-sdk/telegram-command-config.js"
@@ -511,10 +515,6 @@
       "types": "./dist/plugin-sdk/channel-targets.d.ts",
       "default": "./dist/plugin-sdk/channel-targets.js"
     },
-    "./plugin-sdk/messaging-targets": {
-      "types": "./dist/plugin-sdk/messaging-targets.d.ts",
-      "default": "./dist/plugin-sdk/messaging-targets.js"
-    },
     "./plugin-sdk/feishu": {
       "types": "./dist/plugin-sdk/feishu.d.ts",
       "default": "./dist/plugin-sdk/feishu.js"
@@ -587,17 +587,21 @@
       "types": "./dist/plugin-sdk/reply-history.d.ts",
       "default": "./dist/plugin-sdk/reply-history.js"
     },
-    "./plugin-sdk/realtime-voice": {
-      "types": "./dist/plugin-sdk/realtime-voice.d.ts",
-      "default": "./dist/plugin-sdk/realtime-voice.js"
-    },
     "./plugin-sdk/realtime-transcription": {
       "types": "./dist/plugin-sdk/realtime-transcription.d.ts",
       "default": "./dist/plugin-sdk/realtime-transcription.js"
     },
+    "./plugin-sdk/realtime-voice": {
+      "types": "./dist/plugin-sdk/realtime-voice.d.ts",
+      "default": "./dist/plugin-sdk/realtime-voice.js"
+    },
     "./plugin-sdk/media-understanding": {
       "types": "./dist/plugin-sdk/media-understanding.d.ts",
       "default": "./dist/plugin-sdk/media-understanding.js"
+    },
+    "./plugin-sdk/messaging-targets": {
+      "types": "./dist/plugin-sdk/messaging-targets.d.ts",
+      "default": "./dist/plugin-sdk/messaging-targets.js"
     },
     "./plugin-sdk/request-url": {
       "types": "./dist/plugin-sdk/request-url.d.ts",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -19,6 +19,7 @@
   "approval-reply-runtime",
   "approval-runtime",
   "config-runtime",
+  "secret-input-runtime",
   "telegram-command-config",
   "config-schema",
   "reply-runtime",


### PR DESCRIPTION
Fixes CI failures caused by `openclaw/plugin-sdk/secret-input-runtime` being imported by the Slack extension but not exported publicly.

Changes
- Add `secret-input-runtime` to `scripts/lib/plugin-sdk-entrypoints.json`
- Run `pnpm plugin-sdk:sync-exports` so `package.json` exports include `./plugin-sdk/secret-input-runtime`

QA
- `pnpm install --frozen-lockfile`
- `pnpm lint:plugins:plugin-sdk-subpaths-exported`
- `pnpm plugin-sdk:check-exports`
- `pnpm check` ran via git hooks during commit

Motivation
This unblocks unrelated PRs that were failing `lint:plugins:plugin-sdk-subpaths-exported` / export checks.