### PR TITLE
docs: add islo.dev install guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -260,6 +260,10 @@
     "target": "安装完整性检查"
   },
   {
+    "source": "islo.dev",
+    "target": "islo.dev"
+  },
+  {
     "source": "get unstuck",
     "target": "解决问题"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -972,6 +972,7 @@
                   "install/fly",
                   "install/gcp",
                   "install/hetzner",
+                  "install/islo-dev",
                   "install/kubernetes",
                   "vps",
                   "install/macos-vm",

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -177,6 +177,7 @@ Deploy OpenClaw on a cloud server or VPS:
   <Card title="Railway" href="/install/railway">Railway</Card>
   <Card title="Render" href="/install/render">Render</Card>
   <Card title="Northflank" href="/install/northflank">Northflank</Card>
+  <Card title="islo.dev" href="/install/islo-dev">islo.dev</Card>
 </CardGroup>
 
 ## Update, migrate, or uninstall

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -167,17 +167,17 @@ If you want managed startup after install:
 Deploy OpenClaw on a cloud server or VPS:
 
 <CardGroup cols={3}>
-  <Card title="VPS" href="/vps">Any Linux VPS</Card>
-  <Card title="Docker VM" href="/install/docker-vm-runtime">Shared Docker steps</Card>
-  <Card title="Kubernetes" href="/install/kubernetes">K8s</Card>
-  <Card title="Fly.io" href="/install/fly">Fly.io</Card>
-  <Card title="Hetzner" href="/install/hetzner">Hetzner</Card>
-  <Card title="GCP" href="/install/gcp">Google Cloud</Card>
   <Card title="Azure" href="/install/azure">Azure</Card>
+  <Card title="Docker VM" href="/install/docker-vm-runtime">Shared Docker steps</Card>
+  <Card title="Fly.io" href="/install/fly">Fly.io</Card>
+  <Card title="GCP" href="/install/gcp">Google Cloud</Card>
+  <Card title="Hetzner" href="/install/hetzner">Hetzner</Card>
+  <Card title="islo.dev" href="/install/islo-dev">islo.dev</Card>
+  <Card title="Kubernetes" href="/install/kubernetes">K8s</Card>
+  <Card title="Northflank" href="/install/northflank">Northflank</Card>
   <Card title="Railway" href="/install/railway">Railway</Card>
   <Card title="Render" href="/install/render">Render</Card>
-  <Card title="Northflank" href="/install/northflank">Northflank</Card>
-  <Card title="islo.dev" href="/install/islo-dev">islo.dev</Card>
+  <Card title="VPS" href="/vps">Any Linux VPS</Card>
 </CardGroup>
 
 ## Update, migrate, or uninstall

--- a/docs/install/islo-dev.md
+++ b/docs/install/islo-dev.md
@@ -66,7 +66,7 @@ Pin versions or add dependencies in your project's `islo.yaml`:
 ```yaml
 tools:
   openclaw: "latest"
-  node: "22"
+  node: "22.14"
 ```
 
 OpenClaw requires Node 22.14+. islo installs it automatically as a dependency.

--- a/docs/install/islo-dev.md
+++ b/docs/install/islo-dev.md
@@ -23,7 +23,7 @@ That's it. islo automatically:
 
 ## What you need
 
-- [islo CLI](https://docs.islo.dev) installed and logged in (`islo auth login`)
+- [islo CLI](https://docs.islo.dev) installed and logged in (`islo login`)
 - Anthropic API key — via [islo.dev integrations](https://app.islo.dev/settings/integrations) (recommended) or `--env`
 
 ## Interactive Mode

--- a/docs/install/islo-dev.md
+++ b/docs/install/islo-dev.md
@@ -17,6 +17,7 @@ islo use my-sandbox --agent openclaw --task "Build a REST API with Express"
 ```
 
 That's it. islo automatically:
+
 1. Creates a sandbox VM (Kata Container on bare-metal)
 2. Installs Node.js and OpenClaw via [mise](https://mise.jdx.dev)
 3. Launches `openclaw agent --message "..." --local --thinking high`
@@ -74,12 +75,14 @@ OpenClaw requires Node 22.14+. islo installs it automatically as a dependency.
 ## How it works
 
 islo.dev sandboxes are hardware-isolated VMs (Kata Containers) with:
+
 - Full root access and toolchain (git, gh CLI, docker, etc.)
 - Network isolation via nftables + Envoy transparent proxy
 - GitHub integration for cloning repos and opening PRs
 - Agent-aware lifecycle — sandbox stays alive while the agent runs
 
 When you pass `--agent openclaw`, islo:
+
 1. Installs `node` (dependency) and `openclaw` (via npm)
 2. Injects configured API keys as environment variables
 3. Runs `openclaw agent --message "<task>" --local --thinking high`

--- a/docs/install/islo-dev.md
+++ b/docs/install/islo-dev.md
@@ -1,0 +1,114 @@
+---
+summary: "Run OpenClaw in an islo.dev sandbox with one command"
+read_when:
+  - Setting up OpenClaw in an isolated cloud sandbox
+  - Running OpenClaw with islo.dev for secure AI agent development
+title: "islo.dev"
+---
+
+# islo.dev
+
+Goal: OpenClaw running inside an [islo.dev](https://islo.dev) sandbox — an isolated cloud VM with full toolchain access, one command to launch.
+
+## Quick Start
+
+```bash
+islo use my-sandbox --agent openclaw --task "Build a REST API with Express"
+```
+
+That's it. islo automatically:
+1. Creates a sandbox VM (Kata Container on bare-metal)
+2. Installs Node.js and OpenClaw via [mise](https://mise.jdx.dev)
+3. Launches `openclaw agent --message "..." --local --thinking high`
+
+## What you need
+
+- [islo CLI](https://docs.islo.dev) installed and logged in (`islo auth login`)
+- Anthropic API key — via [islo.dev integrations](https://app.islo.dev/settings/integrations) (recommended) or `--env`
+
+## Interactive Mode
+
+Drop into OpenClaw's interactive agent without a task:
+
+```bash
+islo use my-sandbox --agent openclaw
+```
+
+## With a Source Repo
+
+Clone a GitHub repo into the sandbox and let OpenClaw work on it:
+
+```bash
+islo use my-sandbox \
+  --source "github://myorg/myrepo" \
+  --agent openclaw \
+  --workdir myrepo \
+  --task "Fix the failing tests in src/auth.ts"
+```
+
+## Environment Variables
+
+Pass API keys and config explicitly:
+
+```bash
+islo use my-sandbox \
+  --agent openclaw \
+  --env ANTHROPIC_API_KEY=sk-ant-... \
+  --task "Your task"
+```
+
+Or configure via [islo.dev integrations](https://app.islo.dev/settings/integrations) — keys are injected automatically into every sandbox.
+
+## Configuration via `islo.yaml`
+
+Pin versions or add dependencies in your project's `islo.yaml`:
+
+```yaml
+tools:
+  openclaw: "latest"
+  node: "22"
+```
+
+OpenClaw requires Node 22.14+. islo installs it automatically as a dependency.
+
+## How it works
+
+islo.dev sandboxes are hardware-isolated VMs (Kata Containers) with:
+- Full root access and toolchain (git, gh CLI, docker, etc.)
+- Network isolation via nftables + Envoy transparent proxy
+- GitHub integration for cloning repos and opening PRs
+- Agent-aware lifecycle — sandbox stays alive while the agent runs
+
+When you pass `--agent openclaw`, islo:
+1. Installs `node` (dependency) and `openclaw` (via npm)
+2. Injects configured API keys as environment variables
+3. Runs `openclaw agent --message "<task>" --local --thinking high`
+4. Streams agent output to your terminal
+
+## Multi-repo workflows
+
+Work across multiple repos in a single sandbox:
+
+```bash
+islo use my-sandbox \
+  --source "github://myorg/frontend" \
+  --source "github://myorg/backend" \
+  --agent openclaw \
+  --task "Update the API client in frontend to match the new backend endpoints"
+```
+
+## Updating
+
+OpenClaw is installed fresh in each new sandbox. Existing sandboxes can be updated:
+
+```bash
+islo exec my-sandbox -- npm i -g openclaw@latest
+```
+
+## Cleanup
+
+```bash
+islo rm my-sandbox -f
+```
+
+Guide: [Updating](/install/updating)


### PR DESCRIPTION
## Summary

Adds islo.dev as a hosting/deployment option for OpenClaw, following the same pattern as the [exe.dev guide](https://docs.openclaw.ai/install/exe-dev).

- New file: `docs/install/islo-dev.md` — complete guide for running OpenClaw in islo.dev sandboxes
- Updated: `docs/install/index.md` — added islo.dev card to "Hosting and deployment" section (alphabetically sorted)
- Updated: `docs/docs.json` — registered `install/islo-dev` in the Hosting navigation group

## What is islo.dev?

[islo.dev](https://islo.dev) provides hardware-isolated sandbox VMs (Kata Containers on bare-metal) designed for AI coding agents. OpenClaw is supported as a first-class agent — one command to launch:

```bash
islo use my-sandbox --agent openclaw --task "Build a REST API with Express"
```

islo automatically installs Node.js + OpenClaw, injects API keys, and launches `openclaw agent` in autonomous mode.

## Guide covers

- Quick start (one-liner)
- Interactive mode
- Source repo workflows (clone + work on existing code)
- Environment variables and API key injection
- `islo.yaml` configuration
- Multi-repo workflows
- How it works under the hood

## Test plan

- [ ] Docs page renders correctly in Mintlify preview
- [ ] All code examples are syntactically correct
- [ ] Links to islo.dev docs are valid
- [ ] Card appears in the "Hosting and deployment" section of the install index
- [ ] `install/islo-dev` appears in sidebar navigation via `docs.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)