### PR TITLE
fix: align timeout guidance and sessions_send defaults

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -582,6 +582,56 @@ describe("sessions tools", () => {
     expect(details.error).toMatch(/Session not found|No session found/);
   });
 
+  it("sessions_send defaults to the global agent timeout when timeoutSeconds is omitted", async () => {
+    const calls: Array<{ method?: string; params?: unknown; timeoutMs?: number }> = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown; timeoutMs?: number };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-1", status: "accepted", acceptedAt: 1234 };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    openClawToolsTesting.setDepsForTest({
+      callGateway: (opts: unknown) => callGatewayMock(opts),
+      config: {
+        ...TEST_CONFIG,
+        agents: { defaults: { timeoutSeconds: 123 } },
+      } as OpenClawConfig,
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call-default-timeout", {
+      sessionKey: "main",
+      message: "wait",
+    });
+    expect(waited.details).toMatchObject({ status: "ok" });
+
+    const waitCall = calls.find((call) => call.method === "agent.wait");
+    expect(waitCall).toBeDefined();
+    expect(waitCall?.timeoutMs).toBe(125_000);
+  });
+
   it("sessions_send supports fire-and-forget and wait", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     let agentCallCount = 0;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -85,6 +85,7 @@ import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { resolveEffectiveRuntimeModel, resolveHookModelSelection } from "./run/setup.js";
+import { buildNoResponseTimeoutMessage } from "./run/timeout-message.js";
 import {
   sessionLikelyHasOversizedToolResults,
   truncateOversizedToolResultsInSession,
@@ -1308,9 +1309,7 @@ export async function runEmbeddedPiAgent(
             return {
               payloads: [
                 {
-                  text:
-                    "Request timed out before a response was generated. " +
-                    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+                  text: buildNoResponseTimeoutMessage(),
                   isError: true,
                 },
               ],

--- a/src/agents/pi-embedded-runner/run/timeout-message.test.ts
+++ b/src/agents/pi-embedded-runner/run/timeout-message.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { buildNoResponseTimeoutMessage } from "./timeout-message.js";
+
+describe("buildNoResponseTimeoutMessage", () => {
+  it("mentions both total turn timeout and LLM idle timeout guidance", () => {
+    const text = buildNoResponseTimeoutMessage();
+    expect(text).toContain("agents.defaults.timeoutSeconds");
+    expect(text).toContain("agents.defaults.llm.idleTimeoutSeconds");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/timeout-message.ts
+++ b/src/agents/pi-embedded-runner/run/timeout-message.ts
@@ -1,0 +1,8 @@
+export function buildNoResponseTimeoutMessage(): string {
+  return (
+    "Request timed out before a response was generated. " +
+    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config. " +
+    "If the model produced no tokens before timing out, also consider increasing " +
+    "`agents.defaults.llm.idleTimeoutSeconds`."
+  );
+}

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -13,6 +13,7 @@ import {
   readLatestAssistantReplySnapshot,
   waitForAgentRunAndReadUpdatedAssistantReply,
 } from "../run-wait.js";
+import { resolveAgentTimeoutMs } from "../timeout.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
@@ -225,7 +226,7 @@ export function createSessionsSendTool(opts?: {
       const timeoutSeconds =
         typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
           ? Math.max(0, Math.floor(params.timeoutSeconds))
-          : 30;
+          : Math.max(1, Math.floor(resolveAgentTimeoutMs({ cfg, minMs: 1000 }) / 1000));
       const timeoutMs = timeoutSeconds * 1000;
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();


### PR DESCRIPTION
## Summary
- make sessions_send inherit the global agent timeout when timeoutSeconds is omitted instead of hardcoding 30s
- move the no-response timeout text into a shared helper and mention both total turn timeout and LLM idle timeout guidance
- add focused tests covering the sessions_send default timeout behavior and timeout guidance message

## Validation
- targeted test: `pnpm exec vitest run src/agents/openclaw-tools.sessions.test.ts -t "sessions_send defaults to the global agent timeout when timeoutSeconds is omitted"`
- targeted test: `pnpm exec vitest run src/agents/pi-embedded-runner/run/timeout-message.test.ts`
- lightweight local commit path used `FAST_COMMIT=1` to avoid repo-wide `pnpm check` on the live server after repeated heavy-run instability; full validation should run in CI
