### PR TITLE
feat(ollama): warn on WSL2 crash loop risk from Ollama systemd autostart

### DIFF
--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -13,6 +13,10 @@ Local is doable, but OpenClaw expects large context + strong defenses against pr
 
 If you want the lowest-friction local setup, start with [Ollama](/providers/ollama) and `openclaw onboard`. This page is the opinionated guide for higher-end local stacks and custom OpenAI-compatible local servers.
 
+<Warning>
+**WSL2 + Ollama users:** Ollama installs with `Restart=always` and auto-starts on WSL2 boot, pinning RAM via CUDA. This conflicts with the Hyper-V `hv_balloon` memory driver and can cause a crash-restart loop. See [WSL2 crash loop](/providers/ollama#wsl2-crash-loop-repeated-reboots) in the Ollama troubleshooting guide.
+</Warning>
+
 ## Recommended: LM Studio + large local model (Responses API)
 
 Best current local stack. Load a large model in LM Studio (for example, a full-size Qwen, DeepSeek, or Llama build), enable the local server (default `http://127.0.0.1:1234`), and use Responses API to keep reasoning separate from final text.

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -401,7 +401,7 @@ See: [ollama/ollama#11317](https://github.com/ollama/ollama/issues/11317)
 2. Disable Hyper-V dynamic memory reclaim. Add the following to `%USERPROFILE%\.wslconfig` on the **Windows** side:
 
    ```ini
-   [wsl2]
+   [experimental]
    autoMemoryReclaim=disabled
    ```
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -372,6 +372,55 @@ ps aux | grep ollama
 ollama serve
 ```
 
+### WSL2 crash loop (repeated reboots)
+
+<Warning>
+**WSL2 users:** If you experience repeated WSL2 reboots (sometimes 10+ per day) shortly after starting the gateway, you may be hitting a Hyper-V balloon memory conflict with Ollama.
+</Warning>
+
+**Root cause:** Ollama installs with `Restart=always` in systemd and loads the last model on boot via `cudaMallocHost`, which **pins physical RAM pages**. The Hyper-V `hv_balloon` dynamic memory driver cannot reclaim pinned pages, so Windows forcibly terminates the WSL2 VM — which then restarts and repeats the cycle.
+
+**Symptoms:**
+
+- Repeated WSL2 reboots (check with `wsl --status` or Event Viewer on Windows)
+- High CPU in `app.slice` at startup (`systemd-cgls` shows Ollama consuming >100% CPU)
+- All terminations are SIGTERM from systemd (not OOM killer)
+
+OpenClaw will log a warning at startup when this risky configuration is detected.
+
+See: [ollama/ollama#11317](https://github.com/ollama/ollama/issues/11317)
+
+**Fix — apply all three steps:**
+
+1. Disable Ollama autostart:
+
+   ```bash
+   sudo systemctl disable ollama
+   ```
+
+2. Disable Hyper-V dynamic memory reclaim. Add the following to `%USERPROFILE%\.wslconfig` on the **Windows** side:
+
+   ```ini
+   [wsl2]
+   autoMemoryReclaim=disabled
+   ```
+
+   Then restart WSL2: `wsl --shutdown`
+
+3. Set a model keep-alive timeout so Ollama releases VRAM when idle:
+
+   ```bash
+   # Add to /etc/systemd/system/ollama.service.d/override.conf
+   # or your shell profile
+   export OLLAMA_KEEP_ALIVE=5m
+   ```
+
+   With autostart disabled, start Ollama manually when you need it:
+
+   ```bash
+   ollama serve &
+   ```
+
 ## See Also
 
 - [Model Providers](/concepts/model-providers) - Overview of all providers

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -24,6 +24,7 @@ import {
   createConfiguredOllamaStreamFn,
 } from "./src/stream.js";
 import { createOllamaWebSearchProvider } from "./src/web-search-provider.js";
+import { checkWsl2CrashLoopRisk } from "./src/wsl2-crash-loop-check.js";
 
 const PROVIDER_ID = "ollama";
 const DEFAULT_API_KEY = "ollama-local";
@@ -40,6 +41,9 @@ export default definePluginEntry({
   name: "Ollama Provider",
   description: "Bundled Ollama provider plugin",
   register(api: OpenClawPluginApi) {
+    if (api.registrationMode === "full") {
+      void checkWsl2CrashLoopRisk(api.logger);
+    }
     api.registerWebSearchProvider(createOllamaWebSearchProvider());
     api.registerProvider({
       id: PROVIDER_ID,

--- a/extensions/ollama/src/wsl2-crash-loop-check.test.ts
+++ b/extensions/ollama/src/wsl2-crash-loop-check.test.ts
@@ -49,7 +49,7 @@ describe("isWsl2", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.clearAllMocks());
 
-  it("returns true when /proc/version contains microsoft and WSL2", async () => {
+  it("returns true when /proc/version contains wsl2 or microsoft-standard", async () => {
     readFileMock.mockResolvedValue(
       "Linux version 5.15.90.1-microsoft-standard-WSL2 (gcc ...)" as never,
     );
@@ -61,9 +61,14 @@ describe("isWsl2", () => {
     expect(await isWsl2()).toBe(false);
   });
 
-  it("returns false on WSL1 (microsoft present but no WSL2)", async () => {
-    readFileMock.mockResolvedValue("Linux version 4.4.0-microsoft-standard (gcc ...)" as never);
+  it("returns false on WSL1 (microsoft present but no WSL2 or microsoft-standard)", async () => {
+    readFileMock.mockResolvedValue("Linux version 4.4.0-microsoft (gcc ...)" as never);
     expect(await isWsl2()).toBe(false);
+  });
+
+  it("returns true when osrelease contains microsoft-standard (no WSL2 suffix)", async () => {
+    readFileMock.mockResolvedValue("Linux version 5.15.0-microsoft-standard (gcc ...)" as never);
+    expect(await isWsl2()).toBe(true);
   });
 
   it("returns false when /proc/version is unreadable", async () => {

--- a/extensions/ollama/src/wsl2-crash-loop-check.test.ts
+++ b/extensions/ollama/src/wsl2-crash-loop-check.test.ts
@@ -1,54 +1,52 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { promisify } from "node:util";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 
-// Mock node:fs/promises and node:child_process BEFORE importing the module under test.
-// Do NOT mock node:util — real promisify must wrap the mocked execFile.
+// Mock node:fs/promises BEFORE importing the module under test.
 vi.mock("node:fs/promises", () => ({
   readFile: vi.fn(),
   access: vi.fn(),
 }));
 
-vi.mock("node:child_process", () => ({
-  execFile: vi.fn(),
-}));
+// Create a mock execFile with util.promisify.custom support.
+// vi.mock factory must not reference outer scope, so we build the mock inline.
+vi.mock("node:child_process", async (importOriginal) => {
+  const { promisify: realPromisify } = await import("node:util");
+  const mockFn = vi.fn();
+  // Attach the promisify.custom symbol so util.promisify returns our async mock
+  const asyncMock = vi.fn();
+  (mockFn as unknown as Record<symbol, unknown>)[realPromisify.custom] = asyncMock;
+  return { execFile: mockFn };
+});
 
 import * as childProcess from "node:child_process";
 import * as fs from "node:fs/promises";
 import {
   checkWsl2CrashLoopRisk,
+  hasCuda,
   isWsl2,
   isOllamaEnabledWithRestartAlways,
 } from "./wsl2-crash-loop-check.js";
 
 const readFileMock = vi.mocked(fs.readFile);
 const accessMock = vi.mocked(fs.access);
-// execFile is callback-based; promisify wraps it, so mock must use the callback style
-const execFileMock = vi.mocked(childProcess.execFile);
+// Access the promisify.custom mock from the mocked execFile
+const execFileMock = childProcess.execFile as unknown as ReturnType<typeof vi.fn> & {
+  [key: symbol]: ReturnType<typeof vi.fn>;
+};
+const execFilePromiseMock = vi.mocked(execFileMock[promisify.custom]);
 
-// Helper: make execFile callback succeed with the given stdout
+// Helper: make execFile resolve with the given stdout
 function mockExecFileOk(stdout: string) {
-  execFileMock.mockImplementation(((
-    _cmd: unknown,
-    _args: unknown,
-    _opts: unknown,
-    cb: (err: null, r: { stdout: string; stderr: string }) => void,
-  ) => {
-    cb(null, { stdout, stderr: "" });
-  }) as never);
+  execFilePromiseMock.mockResolvedValue({ stdout, stderr: "" });
 }
 
-// Helper: make execFile callback fail
+// Helper: make execFile reject
 function mockExecFileFail() {
-  execFileMock.mockImplementation(((
-    _cmd: unknown,
-    _args: unknown,
-    _opts: unknown,
-    cb: (err: Error) => void,
-  ) => {
-    cb(new Error("command not found"));
-  }) as never);
+  execFilePromiseMock.mockRejectedValue(new Error("command not found"));
 }
 
 describe("isWsl2", () => {
+  beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.clearAllMocks());
 
   it("returns true when /proc/version contains microsoft and WSL2", async () => {
@@ -71,6 +69,33 @@ describe("isWsl2", () => {
   it("returns false when /proc/version is unreadable", async () => {
     readFileMock.mockRejectedValue(new Error("ENOENT") as never);
     expect(await isWsl2()).toBe(false);
+  });
+});
+
+describe("hasCuda", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns true when /usr/lib/wsl/lib/nvidia-smi exists", async () => {
+    accessMock.mockResolvedValueOnce(undefined as never);
+    expect(await hasCuda()).toBe(true);
+    expect(accessMock).toHaveBeenCalledTimes(1);
+    expect(accessMock).toHaveBeenCalledWith("/usr/lib/wsl/lib/nvidia-smi");
+  });
+
+  it("returns true via fallback when /usr/local/cuda exists but nvidia-smi does not", async () => {
+    accessMock
+      .mockRejectedValueOnce(new Error("ENOENT") as never) // nvidia-smi fails
+      .mockResolvedValueOnce(undefined as never); // /usr/local/cuda succeeds
+    expect(await hasCuda()).toBe(true);
+    expect(accessMock).toHaveBeenCalledTimes(2);
+    expect(accessMock).toHaveBeenNthCalledWith(1, "/usr/lib/wsl/lib/nvidia-smi");
+    expect(accessMock).toHaveBeenNthCalledWith(2, "/usr/local/cuda");
+  });
+
+  it("returns false when neither path exists", async () => {
+    accessMock.mockRejectedValue(new Error("ENOENT") as never);
+    expect(await hasCuda()).toBe(false);
+    expect(accessMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/extensions/ollama/src/wsl2-crash-loop-check.test.ts
+++ b/extensions/ollama/src/wsl2-crash-loop-check.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+// Mock node:fs/promises and node:child_process BEFORE importing the module under test.
+// Do NOT mock node:util — real promisify must wrap the mocked execFile.
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+  access: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs/promises";
+import {
+  checkWsl2CrashLoopRisk,
+  isWsl2,
+  isOllamaEnabledWithRestartAlways,
+} from "./wsl2-crash-loop-check.js";
+
+const readFileMock = vi.mocked(fs.readFile);
+const accessMock = vi.mocked(fs.access);
+// execFile is callback-based; promisify wraps it, so mock must use the callback style
+const execFileMock = vi.mocked(childProcess.execFile);
+
+// Helper: make execFile callback succeed with the given stdout
+function mockExecFileOk(stdout: string) {
+  execFileMock.mockImplementation(((
+    _cmd: unknown,
+    _args: unknown,
+    _opts: unknown,
+    cb: (err: null, r: { stdout: string; stderr: string }) => void,
+  ) => {
+    cb(null, { stdout, stderr: "" });
+  }) as never);
+}
+
+// Helper: make execFile callback fail
+function mockExecFileFail() {
+  execFileMock.mockImplementation(((
+    _cmd: unknown,
+    _args: unknown,
+    _opts: unknown,
+    cb: (err: Error) => void,
+  ) => {
+    cb(new Error("command not found"));
+  }) as never);
+}
+
+describe("isWsl2", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns true when /proc/version contains microsoft and WSL2", async () => {
+    readFileMock.mockResolvedValue(
+      "Linux version 5.15.90.1-microsoft-standard-WSL2 (gcc ...)" as never,
+    );
+    expect(await isWsl2()).toBe(true);
+  });
+
+  it("returns false on bare Linux (no microsoft)", async () => {
+    readFileMock.mockResolvedValue("Linux version 6.1.0-debian-amd64 (gcc ...)" as never);
+    expect(await isWsl2()).toBe(false);
+  });
+
+  it("returns false on WSL1 (microsoft present but no WSL2)", async () => {
+    readFileMock.mockResolvedValue("Linux version 4.4.0-microsoft-standard (gcc ...)" as never);
+    expect(await isWsl2()).toBe(false);
+  });
+
+  it("returns false when /proc/version is unreadable", async () => {
+    readFileMock.mockRejectedValue(new Error("ENOENT") as never);
+    expect(await isWsl2()).toBe(false);
+  });
+});
+
+describe("isOllamaEnabledWithRestartAlways", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns true when UnitFileState=enabled and Restart=always", async () => {
+    mockExecFileOk("UnitFileState=enabled\nRestart=always\n");
+    expect(await isOllamaEnabledWithRestartAlways()).toBe(true);
+  });
+
+  it("returns false when UnitFileState=disabled", async () => {
+    mockExecFileOk("UnitFileState=disabled\nRestart=always\n");
+    expect(await isOllamaEnabledWithRestartAlways()).toBe(false);
+  });
+
+  it("returns false when Restart=on-failure", async () => {
+    mockExecFileOk("UnitFileState=enabled\nRestart=on-failure\n");
+    expect(await isOllamaEnabledWithRestartAlways()).toBe(false);
+  });
+
+  it("returns false when systemctl fails (not installed)", async () => {
+    mockExecFileFail();
+    expect(await isOllamaEnabledWithRestartAlways()).toBe(false);
+  });
+});
+
+describe("checkWsl2CrashLoopRisk", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("emits warn when WSL2 + enabled + Restart=always", async () => {
+    readFileMock.mockResolvedValue(
+      "Linux version 5.15.90.1-microsoft-standard-WSL2 (gcc ...)" as never,
+    );
+    mockExecFileOk("UnitFileState=enabled\nRestart=always\n");
+    // No CUDA (access throws)
+    accessMock.mockRejectedValue(new Error("ENOENT") as never);
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await checkWsl2CrashLoopRisk(logger);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const msg = logger.warn.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("WSL2 crash loop risk");
+    expect(msg).toContain("sudo systemctl disable ollama");
+    expect(msg).toContain("autoMemoryReclaim=disabled");
+    expect(msg).toContain("OLLAMA_KEEP_ALIVE=5m");
+  });
+
+  it("does NOT emit warn when not on WSL2", async () => {
+    readFileMock.mockResolvedValue("Linux version 6.1.0-debian-amd64 (gcc ...)" as never);
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await checkWsl2CrashLoopRisk(logger);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit warn when WSL2 but ollama not enabled", async () => {
+    readFileMock.mockResolvedValue(
+      "Linux version 5.15.90.1-microsoft-standard-WSL2 (gcc ...)" as never,
+    );
+    mockExecFileOk("UnitFileState=disabled\nRestart=always\n");
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await checkWsl2CrashLoopRisk(logger);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT throw and does NOT warn when readFile fails", async () => {
+    readFileMock.mockRejectedValue(new Error("EACCES") as never);
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await expect(checkWsl2CrashLoopRisk(logger)).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT throw and does NOT warn when execFile fails", async () => {
+    readFileMock.mockResolvedValue(
+      "Linux version 5.15.90.1-microsoft-standard-WSL2 (gcc ...)" as never,
+    );
+    mockExecFileFail();
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await expect(checkWsl2CrashLoopRisk(logger)).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("includes CUDA note when nvidia-smi is present", async () => {
+    readFileMock.mockResolvedValue(
+      "Linux version 5.15.90.1-microsoft-standard-WSL2 (gcc ...)" as never,
+    );
+    mockExecFileOk("UnitFileState=enabled\nRestart=always\n");
+    // Make /usr/lib/wsl/lib/nvidia-smi accessible
+    accessMock.mockResolvedValue(undefined as never);
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    await checkWsl2CrashLoopRisk(logger);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0]?.[0] as string).toContain("CUDA installation detected");
+  });
+});

--- a/extensions/ollama/src/wsl2-crash-loop-check.ts
+++ b/extensions/ollama/src/wsl2-crash-loop-check.ts
@@ -24,7 +24,7 @@ const execFileAsync = promisify(execFile);
 export async function isWsl2(): Promise<boolean> {
   try {
     const content = await readFile("/proc/version", "utf8");
-    return /microsoft/i.test(content) && /WSL2/i.test(content);
+    return /wsl2/i.test(content) || /microsoft-standard/i.test(content);
   } catch {
     return false;
   }

--- a/extensions/ollama/src/wsl2-crash-loop-check.ts
+++ b/extensions/ollama/src/wsl2-crash-loop-check.ts
@@ -1,0 +1,109 @@
+/**
+ * WSL2 crash loop risk detection for Ollama.
+ *
+ * When Ollama is installed with `Restart=always` + `WantedBy=default.target`
+ * on WSL2, it auto-starts at boot and pins physical RAM via cudaMallocHost.
+ * The Hyper-V hv_balloon driver cannot reclaim pinned pages, so Windows
+ * forcibly terminates the WSL2 VM — which then restarts, triggering the
+ * same sequence in an infinite loop.
+ *
+ * See: https://github.com/ollama/ollama/issues/11317
+ *
+ * All checks are wrapped in try/catch — any failure silently skips the
+ * warning and never breaks provider discovery.
+ */
+
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
+
+const execFileAsync = promisify(execFile);
+
+/** Returns true when running inside WSL2 (not WSL1, not bare Linux). */
+export async function isWsl2(): Promise<boolean> {
+  try {
+    const content = await readFile("/proc/version", "utf8");
+    return /microsoft/i.test(content) && /WSL2/i.test(content);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when the ollama.service systemd unit is both:
+ *   - enabled (will start on boot)
+ *   - configured with Restart=always
+ */
+export async function isOllamaEnabledWithRestartAlways(): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      "systemctl",
+      ["show", "ollama.service", "--property=UnitFileState,Restart", "--no-pager"],
+      { timeout: 5000 },
+    );
+    return stdout.includes("UnitFileState=enabled") && stdout.includes("Restart=always");
+  } catch {
+    return false;
+  }
+}
+
+/** Returns true when a CUDA installation is detected. */
+export async function hasCuda(): Promise<boolean> {
+  try {
+    await access("/usr/lib/wsl/lib/nvidia-smi");
+    return true;
+  } catch {
+    // fall through
+  }
+  try {
+    await access("/usr/local/cuda");
+    return true;
+  } catch {
+    // fall through
+  }
+  return false;
+}
+
+/**
+ * Runs a single-shot WSL2 crash loop risk check and logs a warning if the
+ * risky configuration is detected.
+ *
+ * Only call this in daemon context (`api.registrationMode === "full"`).
+ * Never throws.
+ */
+export async function checkWsl2CrashLoopRisk(logger: PluginLogger): Promise<void> {
+  try {
+    const wsl2 = await isWsl2();
+    if (!wsl2) return;
+
+    const risky = await isOllamaEnabledWithRestartAlways();
+    if (!risky) return;
+
+    const cudaDetected = await hasCuda();
+    const cudaNote = cudaDetected
+      ? " CUDA installation detected — pinned RAM pages are likely."
+      : "";
+
+    logger.warn(
+      [
+        `[ollama] ⚠️  WSL2 crash loop risk: Ollama systemd service is enabled with Restart=always.${cudaNote}`,
+        "",
+        "On WSL2, Ollama auto-starts at boot and pins physical RAM via cudaMallocHost.",
+        "The Hyper-V hv_balloon dynamic memory driver cannot reclaim pinned pages,",
+        "so Windows forcibly terminates the WSL2 VM — which restarts and loops.",
+        "",
+        "Evidence: repeated WSL2 reboots, high CPU in app.slice at startup, SIGTERM from systemd.",
+        "See: https://github.com/ollama/ollama/issues/11317",
+        "",
+        "Fix (apply all three):",
+        "  1. sudo systemctl disable ollama",
+        "  2. Add  autoMemoryReclaim=disabled  to %USERPROFILE%\\.wslconfig  (Windows-side)",
+        "  3. Set  OLLAMA_KEEP_ALIVE=5m  in your Ollama environment",
+      ].join("\n"),
+    );
+  } catch {
+    // Never break provider discovery — checks are purely advisory.
+  }
+}

--- a/extensions/ollama/src/wsl2-crash-loop-check.ts
+++ b/extensions/ollama/src/wsl2-crash-loop-check.ts
@@ -14,8 +14,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { access } from "node:fs/promises";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
 


### PR DESCRIPTION
## What changed

- New file `extensions/ollama/src/wsl2-crash-loop-check.ts`: WSL2 crash loop detection logic
- `extensions/ollama/index.ts`: calls `checkWsl2CrashLoopRisk(api.logger)` in `register()` when `api.registrationMode === "full"` (daemon context only)
- New file `extensions/ollama/src/wsl2-crash-loop-check.test.ts`: 18 tests covering all detection paths
- `docs/providers/ollama.md`: new "WSL2 crash loop" troubleshooting section with root cause, symptoms, and three-step fix
- `docs/gateway/local-models.md`: callout warning for WSL2 + Ollama users

## Why

**Production bug:** OpenClaw + Ollama on WSL2 causes a crash loop.

1. Ollama installs with `Restart=always` + `WantedBy=default.target` in systemd
2. On WSL2 boot, Ollama auto-starts and loads the last model via `cudaMallocHost` — **pins physical RAM pages**
3. Hyper-V `hv_balloon` dynamic memory driver tries to reclaim pages → cannot (CUDA pinned) → Windows forcibly terminates the WSL2 VM
4. WSL2 restarts → loop repeats

**Evidence from the field:**
- 14 WSL2 reboots in a single day
- `app.slice: Consumed 21–41s CPU` in 18–56s wall time (>100% CPU = Ollama loading model at startup)
- All terminations are SIGTERM from systemd — not OOM killer
- No `oom_kill` events in kernel log; pure Hyper-V balloon conflict

Relates to: https://github.com/ollama/ollama/issues/11317

## How

Detection runs once in `register()` when `registrationMode === "full"` (daemon startup only):

1. **isWsl2()** — reads `/proc/version`, checks for `wsl2` OR `microsoft-standard` (matches core `isWSL2Sync()` in `src/infra/wsl.ts`)
2. **isOllamaEnabledWithRestartAlways()** — `execFile(systemctl show ollama.service --property=UnitFileState,Restart --no-pager)`, checks for both `UnitFileState=enabled` and `Restart=always`
3. **hasCuda()** — `access()` probes `/usr/lib/wsl/lib/nvidia-smi` and `/usr/local/cuda`
4. If WSL2 + enabled + Restart=always → `api.logger.warn(...)` with the three fix steps

All checks are wrapped in `try/catch`. Any failure silently skips the warning and never throws.

## What could break

Nothing. All detection checks are:
- Purely advisory (warn-only, no behavior change)
- Wrapped in `try/catch` — errors are swallowed silently
- Guarded behind `registrationMode === "full"` — no impact on CLI one-shots, test runs, or setup-only registrations
- Linux-only paths (`/proc/version`, `systemctl`) — harmless on macOS/Windows where these will throw and be caught

## Test evidence

18 tests in `wsl2-crash-loop-check.test.ts`:
- WSL2 + enabled + Restart=always → warning fires ✓
- WSL2 + disabled → no warning ✓
- Non-WSL2 → no warning ✓
- WSL1 (microsoft present, no WSL2 suffix) → no warning ✓
- `microsoft-standard`-only kernel string → detected as WSL2 ✓
- `readFile` failure → no warning, no throw ✓
- `execFile` failure → no warning, no throw ✓
- CUDA present (WSL2 driver path) → warning includes CUDA note ✓
- CUDA present (`/usr/local/cuda` path) → warning includes CUDA note ✓
- `access` failure → CUDA not detected ✓

Phantom-test verified: removing the `logger.warn()` call causes exactly the relevant tests to fail.

All 52 Ollama extension tests pass: `pnpm test:extension ollama`

---

## AI Disclosure 🤖

This PR was AI-assisted (Claude via OpenClaw). The author understands and has reviewed all code changes.

**Testing degree:** Fully tested — see test evidence above.

Fixes #61185