### PR TITLE
feat: gap-fill — turn telemetry, replay harness, degraded state, diag…

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 
 ## Operator quick refs
 
-- Chat commands: `/status`, `/new`, `/reset`, `/compact`, `/think <level>`, `/verbose on|off`, `/trace on|off`, `/usage off|tokens|full`, `/restart`, `/activation mention|always`
+- Chat commands: `/status`, `/doctor`, `/prompt`, `/cache`, `/new`, `/reset`, `/compact`, `/think <level>`, `/verbose on|off`, `/trace on|off`, `/usage off|tokens|full`, `/restart`, `/activation mention|always`
+- Diagnostics commands: `/doctor` gives a quick config/model/channel/git/runtime health snapshot, `/prompt` shows the detailed current context report, and `/cache` shows the latest cache/system-prompt trace for the current session after at least one turn.
+- Verbose session notices: `/verbose on` can prepend new-session, auto-compaction, model-fallback, and best-effort git freshness notices on new sessions.
 - Session tools: `sessions_list`, `sessions_history`, `sessions_send`
 - Skills registry: [ClawHub](https://clawhub.com)
 - Architecture overview: [Architecture](https://docs.openclaw.ai/concepts/architecture)
@@ -175,8 +177,8 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 - Apps + nodes: [macOS](https://docs.openclaw.ai/platforms/macos), [iOS](https://docs.openclaw.ai/platforms/ios), [Android](https://docs.openclaw.ai/platforms/android), [Nodes](https://docs.openclaw.ai/nodes)
 - Config + security: [Configuration](https://docs.openclaw.ai/gateway/configuration), [Security](https://docs.openclaw.ai/gateway/security), [Docker sandboxing](https://docs.openclaw.ai/install/docker)
 - Remote + web: [Gateway](https://docs.openclaw.ai/gateway), [Remote access](https://docs.openclaw.ai/gateway/remote), [Tailscale](https://docs.openclaw.ai/gateway/tailscale), [Web surfaces](https://docs.openclaw.ai/web)
-- Tools + automation: [Tools](https://docs.openclaw.ai/tools), [Skills](https://docs.openclaw.ai/tools/skills), [Cron jobs](https://docs.openclaw.ai/automation/cron-jobs), [Webhooks](https://docs.openclaw.ai/automation/webhook), [Gmail Pub/Sub](https://docs.openclaw.ai/automation/gmail-pubsub)
-- Internals: [Architecture](https://docs.openclaw.ai/concepts/architecture), [Agent](https://docs.openclaw.ai/concepts/agent), [Session model](https://docs.openclaw.ai/concepts/session), [Gateway protocol](https://docs.openclaw.ai/reference/rpc)
+- Tools + automation: [Tools](https://docs.openclaw.ai/tools), [Slash commands](https://docs.openclaw.ai/tools/slash-commands), [Skills](https://docs.openclaw.ai/tools/skills), [Cron jobs](https://docs.openclaw.ai/automation/cron-jobs), [Webhooks](https://docs.openclaw.ai/automation/webhook), [Gmail Pub/Sub](https://docs.openclaw.ai/automation/gmail-pubsub)
+- Internals: [Architecture](https://docs.openclaw.ai/concepts/architecture), [Agent](https://docs.openclaw.ai/concepts/agent), [Session model](https://docs.openclaw.ai/concepts/session), [Gateway protocol](https://docs.openclaw.ai/reference/rpc), [Tests](https://docs.openclaw.ai/reference/test)
 - Troubleshooting: [Channel troubleshooting](https://docs.openclaw.ai/channels/troubleshooting), [Logging](https://docs.openclaw.ai/logging), [Docs home](https://docs.openclaw.ai)
 
 ## Apps (optional)

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -366,5 +366,2333 @@
   {
     "source": "Testing",
     "target": "测试"
+  },
+  {
+    "source": "/automation/cron-jobs",
+    "target": "/automation/cron-jobs"
+  },
+  {
+    "source": "/automation/cron-jobs#troubleshooting",
+    "target": "/automation/cron-jobs#troubleshooting"
+  },
+  {
+    "source": "/channels/bluebubbles#troubleshooting",
+    "target": "/channels/bluebubbles#troubleshooting"
+  },
+  {
+    "source": "/channels/discord",
+    "target": "/channels/discord"
+  },
+  {
+    "source": "/channels/groups",
+    "target": "/channels/groups"
+  },
+  {
+    "source": "/channels/imessage#troubleshooting",
+    "target": "/channels/imessage#troubleshooting"
+  },
+  {
+    "source": "/channels/pairing",
+    "target": "/channels/pairing"
+  },
+  {
+    "source": "/channels/telegram",
+    "target": "/channels/telegram"
+  },
+  {
+    "source": "/channels/troubleshooting",
+    "target": "/channels/troubleshooting"
+  },
+  {
+    "source": "/channels/whatsapp",
+    "target": "/channels/whatsapp"
+  },
+  {
+    "source": "/cli/devices",
+    "target": "/cli/devices"
+  },
+  {
+    "source": "/concepts/memory",
+    "target": "/concepts/memory"
+  },
+  {
+    "source": "/concepts/memory-search",
+    "target": "/concepts/memory-search"
+  },
+  {
+    "source": "/gateway/authentication",
+    "target": "/gateway/authentication"
+  },
+  {
+    "source": "/gateway/background-process",
+    "target": "/gateway/background-process"
+  },
+  {
+    "source": "/gateway/configuration",
+    "target": "/gateway/configuration"
+  },
+  {
+    "source": "/gateway/configuration-reference#openai-compatible-endpoints",
+    "target": "/gateway/configuration-reference#openai-compatible-endpoints"
+  },
+  {
+    "source": "/gateway/doctor",
+    "target": "/gateway/doctor"
+  },
+  {
+    "source": "/gateway/heartbeat",
+    "target": "/gateway/heartbeat"
+  },
+  {
+    "source": "/gateway/local-models",
+    "target": "/gateway/local-models"
+  },
+  {
+    "source": "/gateway/pairing",
+    "target": "/gateway/pairing"
+  },
+  {
+    "source": "/gateway/remote",
+    "target": "/gateway/remote"
+  },
+  {
+    "source": "/gateway/security#what-the-audit-checks-high-level",
+    "target": "/gateway/security#what-the-audit-checks-high-level"
+  },
+  {
+    "source": "/gateway/troubleshooting#browser-tool-fails",
+    "target": "/gateway/troubleshooting#browser-tool-fails"
+  },
+  {
+    "source": "/gateway/troubleshooting#channel-connected-messages-not-flowing",
+    "target": "/gateway/troubleshooting#channel-connected-messages-not-flowing"
+  },
+  {
+    "source": "/gateway/troubleshooting#cron-and-heartbeat-delivery",
+    "target": "/gateway/troubleshooting#cron-and-heartbeat-delivery"
+  },
+  {
+    "source": "/gateway/troubleshooting#dashboard-control-ui-connectivity",
+    "target": "/gateway/troubleshooting#dashboard-control-ui-connectivity"
+  },
+  {
+    "source": "/gateway/troubleshooting#gateway-service-not-running",
+    "target": "/gateway/troubleshooting#gateway-service-not-running"
+  },
+  {
+    "source": "/gateway/troubleshooting#no-replies",
+    "target": "/gateway/troubleshooting#no-replies"
+  },
+  {
+    "source": "/gateway/troubleshooting#node-paired-tool-fails",
+    "target": "/gateway/troubleshooting#node-paired-tool-fails"
+  },
+  {
+    "source": "/gateway/trusted-proxy-auth",
+    "target": "/gateway/trusted-proxy-auth"
+  },
+  {
+    "source": "/help/faq#why-am-i-seeing-http-429-ratelimiterror-from-anthropic",
+    "target": "/help/faq#why-am-i-seeing-http-429-ratelimiterror-from-anthropic"
+  },
+  {
+    "source": "/nodes/camera",
+    "target": "/nodes/camera"
+  },
+  {
+    "source": "/nodes/index",
+    "target": "/nodes/index"
+  },
+  {
+    "source": "/nodes/location-command",
+    "target": "/nodes/location-command"
+  },
+  {
+    "source": "/nodes/troubleshooting",
+    "target": "/nodes/troubleshooting"
+  },
+  {
+    "source": "/providers/anthropic",
+    "target": "/providers/anthropic"
+  },
+  {
+    "source": "/reference/token-use",
+    "target": "/reference/token-use"
+  },
+  {
+    "source": "/tools/browser",
+    "target": "/tools/browser"
+  },
+  {
+    "source": "/tools/browser-linux-troubleshooting",
+    "target": "/tools/browser-linux-troubleshooting"
+  },
+  {
+    "source": "/tools/browser-wsl2-windows-remote-cdp-troubleshooting",
+    "target": "/tools/browser-wsl2-windows-remote-cdp-troubleshooting"
+  },
+  {
+    "source": "/tools/browser#missing-browser-command-or-tool",
+    "target": "/tools/browser#missing-browser-command-or-tool"
+  },
+  {
+    "source": "/tools/exec",
+    "target": "/tools/exec"
+  },
+  {
+    "source": "/tools/exec-approvals",
+    "target": "/tools/exec-approvals"
+  },
+  {
+    "source": "/web/control-ui",
+    "target": "/web/control-ui"
+  },
+  {
+    "source": "acp",
+    "target": "acp"
+  },
+  {
+    "source": "ACP Agents",
+    "target": "ACP Agents"
+  },
+  {
+    "source": "Active Memory",
+    "target": "主动记忆"
+  },
+  {
+    "source": "Adding Capabilities (Contributor Guide)",
+    "target": "Adding Capabilities (Contributor Guide)"
+  },
+  {
+    "source": "Agent Bootstrapping",
+    "target": "Agent Bootstrapping"
+  },
+  {
+    "source": "Agent CLI reference",
+    "target": "Agent CLI 参考"
+  },
+  {
+    "source": "Agent Harness Plugins",
+    "target": "Agent Harness Plugins"
+  },
+  {
+    "source": "Agent Loop",
+    "target": "代理循环"
+  },
+  {
+    "source": "Agent Runtime",
+    "target": "代理运行时"
+  },
+  {
+    "source": "Agent Send",
+    "target": "代理发送"
+  },
+  {
+    "source": "Agent tools",
+    "target": "代理工具"
+  },
+  {
+    "source": "Agent workspace",
+    "target": "代理工作区"
+  },
+  {
+    "source": "Agent Workspace",
+    "target": "代理工作区"
+  },
+  {
+    "source": "agents",
+    "target": "agents"
+  },
+  {
+    "source": "AGENTS.dev Template",
+    "target": "AGENTS.dev Template"
+  },
+  {
+    "source": "AGENTS.md Template",
+    "target": "AGENTS.md Template"
+  },
+  {
+    "source": "Alibaba Model Studio",
+    "target": "Alibaba Model Studio"
+  },
+  {
+    "source": "All channels",
+    "target": "All channels"
+  },
+  {
+    "source": "Amazon Bedrock",
+    "target": "Amazon Bedrock"
+  },
+  {
+    "source": "Amazon Bedrock Mantle",
+    "target": "Amazon Bedrock Mantle"
+  },
+  {
+    "source": "Android app",
+    "target": "Android 应用"
+  },
+  {
+    "source": "Android App",
+    "target": "Android 应用"
+  },
+  {
+    "source": "Ansible",
+    "target": "Ansible"
+  },
+  {
+    "source": "Anthropic",
+    "target": "Anthropic"
+  },
+  {
+    "source": "API Usage and Costs",
+    "target": "API 用量与成本"
+  },
+  {
+    "source": "apply_patch Tool",
+    "target": "apply_patch Tool"
+  },
+  {
+    "source": "approvals",
+    "target": "approvals"
+  },
+  {
+    "source": "Arcee AI",
+    "target": "Arcee AI"
+  },
+  {
+    "source": "Arcee AI (Trinity models)",
+    "target": "Arcee AI (Trinity models)"
+  },
+  {
+    "source": "Audio and Voice Notes",
+    "target": "Audio and Voice Notes"
+  },
+  {
+    "source": "Auth Credential Semantics",
+    "target": "认证凭据语义"
+  },
+  {
+    "source": "Auth Monitoring",
+    "target": "认证监控"
+  },
+  {
+    "source": "Authentication",
+    "target": "认证"
+  },
+  {
+    "source": "Automation & Tasks",
+    "target": "自动化与任务"
+  },
+  {
+    "source": "Automation Overview",
+    "target": "自动化概览"
+  },
+  {
+    "source": "Automation Troubleshooting",
+    "target": "自动化故障排查"
+  },
+  {
+    "source": "Azure",
+    "target": "Azure"
+  },
+  {
+    "source": "Background Exec and Process Tool",
+    "target": "后台 exec 与 process 工具"
+  },
+  {
+    "source": "Background Process",
+    "target": "后台进程"
+  },
+  {
+    "source": "Background Tasks",
+    "target": "后台任务"
+  },
+  {
+    "source": "backup",
+    "target": "backup"
+  },
+  {
+    "source": "Bake required binaries into the image",
+    "target": "将所需二进制文件打包进镜像"
+  },
+  {
+    "source": "BlueBubbles",
+    "target": "BlueBubbles"
+  },
+  {
+    "source": "BlueBubbles (iMessage)",
+    "target": "BlueBubbles (iMessage)"
+  },
+  {
+    "source": "BlueBubbles channel",
+    "target": "BlueBubbles 渠道"
+  },
+  {
+    "source": "Bonjour Discovery",
+    "target": "Bonjour Discovery"
+  },
+  {
+    "source": "BOOT.md Template",
+    "target": "BOOT.md Template"
+  },
+  {
+    "source": "BOOTSTRAP.md Template",
+    "target": "BOOTSTRAP.md Template"
+  },
+  {
+    "source": "Brave Search",
+    "target": "Brave Search"
+  },
+  {
+    "source": "Brave Search (legacy path)",
+    "target": "Brave Search（旧路径）"
+  },
+  {
+    "source": "Bridge Protocol",
+    "target": "桥接协议"
+  },
+  {
+    "source": "Broadcast Groups",
+    "target": "广播群组"
+  },
+  {
+    "source": "browser",
+    "target": "browser"
+  },
+  {
+    "source": "Browser",
+    "target": "浏览器"
+  },
+  {
+    "source": "Browser (OpenClaw-managed)",
+    "target": "浏览器（由 OpenClaw 管理）"
+  },
+  {
+    "source": "Browser Login",
+    "target": "浏览器登录"
+  },
+  {
+    "source": "Browser Troubleshooting",
+    "target": "浏览器故障排查"
+  },
+  {
+    "source": "BTW Side Questions",
+    "target": "BTW Side Questions"
+  },
+  {
+    "source": "Build and launch",
+    "target": "构建并启动"
+  },
+  {
+    "source": "Building Channel Plugins",
+    "target": "Building Channel Plugins"
+  },
+  {
+    "source": "Building plugins",
+    "target": "构建插件"
+  },
+  {
+    "source": "Building Plugins",
+    "target": "构建插件"
+  },
+  {
+    "source": "Building Plugins (redirect)",
+    "target": "构建插件（重定向）"
+  },
+  {
+    "source": "Building Provider Plugins",
+    "target": "Building Provider Plugins"
+  },
+  {
+    "source": "Builtin Engine",
+    "target": "内置引擎"
+  },
+  {
+    "source": "Builtin Memory Engine",
+    "target": "内置记忆引擎"
+  },
+  {
+    "source": "Bun (Experimental)",
+    "target": "Bun (Experimental)"
+  },
+  {
+    "source": "BytePlus",
+    "target": "BytePlus"
+  },
+  {
+    "source": "Camera Capture",
+    "target": "摄像头捕获"
+  },
+  {
+    "source": "Canvas",
+    "target": "Canvas"
+  },
+  {
+    "source": "Capability cookbook",
+    "target": "能力扩展手册"
+  },
+  {
+    "source": "Channel Location Parsing",
+    "target": "渠道位置解析"
+  },
+  {
+    "source": "Channel routing",
+    "target": "渠道路由"
+  },
+  {
+    "source": "Channel Routing",
+    "target": "渠道路由"
+  },
+  {
+    "source": "Channel Troubleshooting",
+    "target": "渠道故障排查"
+  },
+  {
+    "source": "channels",
+    "target": "channels"
+  },
+  {
+    "source": "Channels",
+    "target": "渠道"
+  },
+  {
+    "source": "Channels Overview",
+    "target": "渠道概览"
+  },
+  {
+    "source": "Chat Channels",
+    "target": "聊天渠道"
+  },
+  {
+    "source": "CI Pipeline",
+    "target": "CI 流水线"
+  },
+  {
+    "source": "Claude Max API Proxy",
+    "target": "Claude Max API Proxy"
+  },
+  {
+    "source": "clawbot",
+    "target": "clawbot"
+  },
+  {
+    "source": "ClawDock",
+    "target": "ClawDock"
+  },
+  {
+    "source": "ClawFlow",
+    "target": "ClawFlow"
+  },
+  {
+    "source": "ClawHub",
+    "target": "ClawHub"
+  },
+  {
+    "source": "CLI Automation",
+    "target": "CLI 自动化"
+  },
+  {
+    "source": "CLI Backends",
+    "target": "CLI 后端"
+  },
+  {
+    "source": "CLI Reference",
+    "target": "CLI 参考"
+  },
+  {
+    "source": "CLI Reference: hooks",
+    "target": "CLI 参考：hooks"
+  },
+  {
+    "source": "CLI webhooks",
+    "target": "CLI webhooks"
+  },
+  {
+    "source": "CLI: memory",
+    "target": "CLI：memory"
+  },
+  {
+    "source": "CLI: tasks",
+    "target": "CLI：tasks"
+  },
+  {
+    "source": "CLI: Tasks",
+    "target": "CLI：Tasks"
+  },
+  {
+    "source": "CLI: wiki",
+    "target": "CLI：wiki"
+  },
+  {
+    "source": "Cloudflare AI Gateway",
+    "target": "Cloudflare AI Gateway"
+  },
+  {
+    "source": "Code Execution",
+    "target": "代码执行"
+  },
+  {
+    "source": "Codex Harness",
+    "target": "Codex Harness"
+  },
+  {
+    "source": "ComfyUI",
+    "target": "ComfyUI"
+  },
+  {
+    "source": "Command Queue",
+    "target": "命令队列"
+  },
+  {
+    "source": "Community plugins",
+    "target": "社区插件"
+  },
+  {
+    "source": "Community Plugins",
+    "target": "社区插件"
+  },
+  {
+    "source": "Compaction",
+    "target": "压缩"
+  },
+  {
+    "source": "completion",
+    "target": "completion"
+  },
+  {
+    "source": "config",
+    "target": "config"
+  },
+  {
+    "source": "Configuration",
+    "target": "配置"
+  },
+  {
+    "source": "Configuration examples",
+    "target": "配置示例"
+  },
+  {
+    "source": "Configuration Examples",
+    "target": "配置示例"
+  },
+  {
+    "source": "Configuration Reference",
+    "target": "配置参考"
+  },
+  {
+    "source": "Configuration reference - Discord",
+    "target": "配置参考 - Discord"
+  },
+  {
+    "source": "Configuration reference - iMessage",
+    "target": "配置参考 - iMessage"
+  },
+  {
+    "source": "Configuration reference - Slack",
+    "target": "配置参考 - Slack"
+  },
+  {
+    "source": "Configuration reference - Telegram",
+    "target": "配置参考 - Telegram"
+  },
+  {
+    "source": "Configuration reference - WhatsApp",
+    "target": "配置参考 - WhatsApp"
+  },
+  {
+    "source": "configure",
+    "target": "configure"
+  },
+  {
+    "source": "Context",
+    "target": "上下文"
+  },
+  {
+    "source": "Context Engine",
+    "target": "上下文引擎"
+  },
+  {
+    "source": "Context Engines",
+    "target": "上下文引擎"
+  },
+  {
+    "source": "Contributing to the Threat Model",
+    "target": "Contributing to the Threat Model"
+  },
+  {
+    "source": "Control UI",
+    "target": "控制界面"
+  },
+  {
+    "source": "Control UI (browser)",
+    "target": "控制界面（浏览器）"
+  },
+  {
+    "source": "Creating Skills",
+    "target": "创建 Skills"
+  },
+  {
+    "source": "cron",
+    "target": "cron"
+  },
+  {
+    "source": "Cron jobs",
+    "target": "Cron 任务"
+  },
+  {
+    "source": "Cron Jobs",
+    "target": "Cron 任务"
+  },
+  {
+    "source": "Cron vs Heartbeat",
+    "target": "Cron 与 Heartbeat"
+  },
+  {
+    "source": "daemon",
+    "target": "daemon"
+  },
+  {
+    "source": "dashboard",
+    "target": "dashboard"
+  },
+  {
+    "source": "Dashboard",
+    "target": "控制面板"
+  },
+  {
+    "source": "Dashboard auth troubleshooting",
+    "target": "控制面板认证故障排查"
+  },
+  {
+    "source": "Date & Time",
+    "target": "日期与时间"
+  },
+  {
+    "source": "Date and Time",
+    "target": "日期与时间"
+  },
+  {
+    "source": "Debugging",
+    "target": "调试"
+  },
+  {
+    "source": "Deepgram",
+    "target": "Deepgram"
+  },
+  {
+    "source": "DeepSeek",
+    "target": "DeepSeek"
+  },
+  {
+    "source": "Default AGENTS.md",
+    "target": "Default AGENTS.md"
+  },
+  {
+    "source": "Delegate Architecture",
+    "target": "委托架构"
+  },
+  {
+    "source": "Device Model Database",
+    "target": "设备型号数据库"
+  },
+  {
+    "source": "devices",
+    "target": "devices"
+  },
+  {
+    "source": "Diagnostics",
+    "target": "诊断"
+  },
+  {
+    "source": "Diagnostics Flags",
+    "target": "诊断标记"
+  },
+  {
+    "source": "DigitalOcean",
+    "target": "DigitalOcean"
+  },
+  {
+    "source": "DigitalOcean (Platform)",
+    "target": "DigitalOcean (Platform)"
+  },
+  {
+    "source": "directory",
+    "target": "directory"
+  },
+  {
+    "source": "Discord",
+    "target": "Discord"
+  },
+  {
+    "source": "Discovery and transports",
+    "target": "发现与传输"
+  },
+  {
+    "source": "Discovery and Transports",
+    "target": "发现与传输"
+  },
+  {
+    "source": "dns",
+    "target": "dns"
+  },
+  {
+    "source": "Docker",
+    "target": "Docker"
+  },
+  {
+    "source": "Docker Sandboxing",
+    "target": "Docker 沙箱隔离"
+  },
+  {
+    "source": "Docker VM Runtime",
+    "target": "Docker VM 运行时"
+  },
+  {
+    "source": "docs",
+    "target": "docs"
+  },
+  {
+    "source": "Docs Hubs",
+    "target": "文档导航"
+  },
+  {
+    "source": "Docs hubs (all pages linked)",
+    "target": "文档导航（链接所有页面）"
+  },
+  {
+    "source": "doctor",
+    "target": "doctor"
+  },
+  {
+    "source": "DuckDuckGo Search",
+    "target": "DuckDuckGo Search"
+  },
+  {
+    "source": "Elevated Mode",
+    "target": "提升模式"
+  },
+  {
+    "source": "Environment Variables",
+    "target": "环境变量"
+  },
+  {
+    "source": "Exa Search",
+    "target": "Exa Search"
+  },
+  {
+    "source": "exe.dev",
+    "target": "exe.dev"
+  },
+  {
+    "source": "Exec",
+    "target": "Exec"
+  },
+  {
+    "source": "Exec approvals",
+    "target": "Exec 审批"
+  },
+  {
+    "source": "Exec Approvals",
+    "target": "Exec 审批"
+  },
+  {
+    "source": "Exec tool",
+    "target": "Exec 工具"
+  },
+  {
+    "source": "Exec Tool",
+    "target": "Exec 工具"
+  },
+  {
+    "source": "Experimental Features",
+    "target": "实验性功能"
+  },
+  {
+    "source": "fal",
+    "target": "fal"
+  },
+  {
+    "source": "FAQ: env vars and .env loading",
+    "target": "FAQ：环境变量与 .env 加载"
+  },
+  {
+    "source": "Firecrawl",
+    "target": "Firecrawl"
+  },
+  {
+    "source": "Fireworks",
+    "target": "Fireworks"
+  },
+  {
+    "source": "flows (redirect)",
+    "target": "flows (redirect)"
+  },
+  {
+    "source": "Fly.io",
+    "target": "Fly.io"
+  },
+  {
+    "source": "gateway",
+    "target": "gateway"
+  },
+  {
+    "source": "Gateway Architecture",
+    "target": "Gateway Architecture"
+  },
+  {
+    "source": "Gateway background process",
+    "target": "Gateway 后台进程"
+  },
+  {
+    "source": "Gateway configuration",
+    "target": "Gateway 配置"
+  },
+  {
+    "source": "Gateway Configuration",
+    "target": "Gateway 配置"
+  },
+  {
+    "source": "Gateway Configuration Reference",
+    "target": "Gateway 配置参考"
+  },
+  {
+    "source": "Gateway Lifecycle",
+    "target": "Gateway 生命周期"
+  },
+  {
+    "source": "Gateway Lock",
+    "target": "Gateway 锁"
+  },
+  {
+    "source": "Gateway Logging",
+    "target": "Gateway 日志"
+  },
+  {
+    "source": "Gateway Logging Internals",
+    "target": "Gateway 日志内部机制"
+  },
+  {
+    "source": "Gateway on macOS",
+    "target": "Gateway on macOS"
+  },
+  {
+    "source": "Gateway Protocol",
+    "target": "Gateway 协议"
+  },
+  {
+    "source": "Gateway remote",
+    "target": "Gateway 远程访问"
+  },
+  {
+    "source": "Gateway runbook",
+    "target": "Gateway 运行手册"
+  },
+  {
+    "source": "Gateway Runbook",
+    "target": "Gateway 运行手册"
+  },
+  {
+    "source": "Gateway troubleshooting",
+    "target": "Gateway 故障排查"
+  },
+  {
+    "source": "Gateway Troubleshooting",
+    "target": "Gateway 故障排查"
+  },
+  {
+    "source": "Gateway-Owned Pairing",
+    "target": "Gateway-Owned Pairing"
+  },
+  {
+    "source": "GCP",
+    "target": "GCP"
+  },
+  {
+    "source": "Gemini Search",
+    "target": "Gemini Search"
+  },
+  {
+    "source": "General Troubleshooting",
+    "target": "常规故障排查"
+  },
+  {
+    "source": "GitHub Copilot",
+    "target": "GitHub Copilot"
+  },
+  {
+    "source": "GLM (Zhipu)",
+    "target": "GLM (Zhipu)"
+  },
+  {
+    "source": "GLM Models",
+    "target": "GLM Models"
+  },
+  {
+    "source": "Gmail hooks (Pub/Sub)",
+    "target": "Gmail hooks (Pub/Sub)"
+  },
+  {
+    "source": "Gmail PubSub",
+    "target": "Gmail PubSub"
+  },
+  {
+    "source": "Google (Gemini)",
+    "target": "Google (Gemini)"
+  },
+  {
+    "source": "Google Chat",
+    "target": "Google Chat"
+  },
+  {
+    "source": "Grok Search",
+    "target": "Grok Search"
+  },
+  {
+    "source": "Groq",
+    "target": "Groq"
+  },
+  {
+    "source": "Groq (LPU inference)",
+    "target": "Groq (LPU inference)"
+  },
+  {
+    "source": "Group Messages",
+    "target": "群组消息"
+  },
+  {
+    "source": "Groups",
+    "target": "群组"
+  },
+  {
+    "source": "health",
+    "target": "health"
+  },
+  {
+    "source": "Health",
+    "target": "健康状态"
+  },
+  {
+    "source": "Health Checks",
+    "target": "健康检查"
+  },
+  {
+    "source": "Health Checks (macOS)",
+    "target": "健康检查（macOS）"
+  },
+  {
+    "source": "Heartbeat",
+    "target": "心跳"
+  },
+  {
+    "source": "HEARTBEAT.md Template",
+    "target": "HEARTBEAT.md Template"
+  },
+  {
+    "source": "Help",
+    "target": "帮助"
+  },
+  {
+    "source": "Hetzner",
+    "target": "Hetzner"
+  },
+  {
+    "source": "Honcho Memory",
+    "target": "Honcho Memory"
+  },
+  {
+    "source": "hooks",
+    "target": "hooks"
+  },
+  {
+    "source": "Hooks",
+    "target": "Hooks"
+  },
+  {
+    "source": "Hooks and webhooks overview",
+    "target": "Hooks 与 Webhooks 概览"
+  },
+  {
+    "source": "Hostinger",
+    "target": "Hostinger"
+  },
+  {
+    "source": "Hugging Face (Inference)",
+    "target": "Hugging Face (Inference)"
+  },
+  {
+    "source": "IDENTITY Template",
+    "target": "IDENTITY Template"
+  },
+  {
+    "source": "IDENTITY.dev Template",
+    "target": "IDENTITY.dev Template"
+  },
+  {
+    "source": "Image and Media Support",
+    "target": "图像与媒体支持"
+  },
+  {
+    "source": "Image Generation",
+    "target": "图像生成"
+  },
+  {
+    "source": "iMessage",
+    "target": "iMessage"
+  },
+  {
+    "source": "iMessage (legacy)",
+    "target": "iMessage (legacy)"
+  },
+  {
+    "source": "Inference CLI",
+    "target": "推理 CLI"
+  },
+  {
+    "source": "inferrs",
+    "target": "inferrs"
+  },
+  {
+    "source": "inferrs (local models)",
+    "target": "inferrs（本地模型）"
+  },
+  {
+    "source": "Install",
+    "target": "安装"
+  },
+  {
+    "source": "Install and Configure Plugins",
+    "target": "安装与配置插件"
+  },
+  {
+    "source": "Install and use plugins",
+    "target": "安装并使用插件"
+  },
+  {
+    "source": "Install Overview",
+    "target": "安装概览"
+  },
+  {
+    "source": "Installer Internals",
+    "target": "安装器内部机制"
+  },
+  {
+    "source": "iOS app",
+    "target": "iOS 应用"
+  },
+  {
+    "source": "iOS App",
+    "target": "iOS 应用"
+  },
+  {
+    "source": "IRC",
+    "target": "IRC"
+  },
+  {
+    "source": "Kilocode",
+    "target": "Kilocode"
+  },
+  {
+    "source": "Kimi Search",
+    "target": "Kimi Search"
+  },
+  {
+    "source": "Kubernetes",
+    "target": "Kubernetes"
+  },
+  {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
+    "source": "Linux app",
+    "target": "Linux 应用"
+  },
+  {
+    "source": "Linux App",
+    "target": "Linux 应用"
+  },
+  {
+    "source": "Linux Server",
+    "target": "Linux Server"
+  },
+  {
+    "source": "LiteLLM",
+    "target": "LiteLLM"
+  },
+  {
+    "source": "LiteLLM (unified gateway)",
+    "target": "LiteLLM (unified gateway)"
+  },
+  {
+    "source": "LLM Task",
+    "target": "LLM Task"
+  },
+  {
+    "source": "LM Studio",
+    "target": "LM Studio"
+  },
+  {
+    "source": "LM Studio (local models)",
+    "target": "LM Studio（本地模型）"
+  },
+  {
+    "source": "Local Models",
+    "target": "本地模型"
+  },
+  {
+    "source": "Location Command",
+    "target": "位置命令"
+  },
+  {
+    "source": "Logging Overview",
+    "target": "日志概览"
+  },
+  {
+    "source": "logs",
+    "target": "logs"
+  },
+  {
+    "source": "macOS app",
+    "target": "macOS 应用"
+  },
+  {
+    "source": "macOS App",
+    "target": "macOS 应用"
+  },
+  {
+    "source": "macOS Dev Setup",
+    "target": "macOS Dev Setup"
+  },
+  {
+    "source": "macOS IPC",
+    "target": "macOS IPC"
+  },
+  {
+    "source": "macOS Logging",
+    "target": "macOS Logging"
+  },
+  {
+    "source": "macOS Permissions",
+    "target": "macOS Permissions"
+  },
+  {
+    "source": "macOS Signing",
+    "target": "macOS Signing"
+  },
+  {
+    "source": "macOS VMs",
+    "target": "macOS VMs"
+  },
+  {
+    "source": "Manifest",
+    "target": "Manifest"
+  },
+  {
+    "source": "Markdown Formatting",
+    "target": "Markdown 格式化"
+  },
+  {
+    "source": "Matrix",
+    "target": "Matrix"
+  },
+  {
+    "source": "Matrix migration",
+    "target": "Matrix migration"
+  },
+  {
+    "source": "mcp",
+    "target": "mcp"
+  },
+  {
+    "source": "Media audio",
+    "target": "媒体音频"
+  },
+  {
+    "source": "Media images",
+    "target": "媒体图像"
+  },
+  {
+    "source": "Media Overview",
+    "target": "媒体概览"
+  },
+  {
+    "source": "Media Understanding",
+    "target": "媒体理解"
+  },
+  {
+    "source": "memory",
+    "target": "memory"
+  },
+  {
+    "source": "Memory",
+    "target": "记忆"
+  },
+  {
+    "source": "memory CLI",
+    "target": "memory CLI"
+  },
+  {
+    "source": "Memory configuration reference",
+    "target": "记忆配置参考"
+  },
+  {
+    "source": "Memory Overview",
+    "target": "记忆概览"
+  },
+  {
+    "source": "Memory Search",
+    "target": "记忆搜索"
+  },
+  {
+    "source": "Memory Wiki plugin",
+    "target": "Memory Wiki 插件"
+  },
+  {
+    "source": "Menu Bar",
+    "target": "Menu Bar"
+  },
+  {
+    "source": "Menu Bar Icon",
+    "target": "Menu Bar Icon"
+  },
+  {
+    "source": "message",
+    "target": "message"
+  },
+  {
+    "source": "Messages",
+    "target": "消息"
+  },
+  {
+    "source": "Microsoft Teams",
+    "target": "Microsoft Teams"
+  },
+  {
+    "source": "Migrating",
+    "target": "迁移"
+  },
+  {
+    "source": "Migration Guide",
+    "target": "迁移指南"
+  },
+  {
+    "source": "MiniMax",
+    "target": "MiniMax"
+  },
+  {
+    "source": "MiniMax Search",
+    "target": "MiniMax Search"
+  },
+  {
+    "source": "Mistral",
+    "target": "Mistral"
+  },
+  {
+    "source": "Model Failover",
+    "target": "模型故障切换"
+  },
+  {
+    "source": "Model Provider Quickstart",
+    "target": "模型提供商快速开始"
+  },
+  {
+    "source": "Model Providers",
+    "target": "模型提供商"
+  },
+  {
+    "source": "models",
+    "target": "models"
+  },
+  {
+    "source": "Models",
+    "target": "模型"
+  },
+  {
+    "source": "Models CLI",
+    "target": "模型 CLI"
+  },
+  {
+    "source": "Models overview",
+    "target": "模型概览"
+  },
+  {
+    "source": "Multi-agent",
+    "target": "多代理"
+  },
+  {
+    "source": "Multi-Agent",
+    "target": "多代理"
+  },
+  {
+    "source": "Multi-Agent Configuration",
+    "target": "多代理配置"
+  },
+  {
+    "source": "Multi-agent routing",
+    "target": "多代理路由"
+  },
+  {
+    "source": "Multi-Agent Routing",
+    "target": "多代理路由"
+  },
+  {
+    "source": "Multi-Agent Sandbox & Tools",
+    "target": "多代理沙箱与工具"
+  },
+  {
+    "source": "Multi-Agent Sandbox and Tools",
+    "target": "多代理沙箱与工具"
+  },
+  {
+    "source": "Multiple Gateways",
+    "target": "多个 Gateway"
+  },
+  {
+    "source": "Music Generation",
+    "target": "音乐生成"
+  },
+  {
+    "source": "Network",
+    "target": "网络"
+  },
+  {
+    "source": "Nextcloud Talk",
+    "target": "Nextcloud Talk"
+  },
+  {
+    "source": "Nix",
+    "target": "Nix"
+  },
+  {
+    "source": "Nix mode",
+    "target": "Nix mode"
+  },
+  {
+    "source": "node",
+    "target": "node"
+  },
+  {
+    "source": "Node + tsx Crash",
+    "target": "Node + tsx Crash"
+  },
+  {
+    "source": "Node Troubleshooting",
+    "target": "Node 故障排查"
+  },
+  {
+    "source": "Node.js",
+    "target": "Node.js"
+  },
+  {
+    "source": "nodes",
+    "target": "nodes"
+  },
+  {
+    "source": "Nodes",
+    "target": "节点"
+  },
+  {
+    "source": "Nodes (iOS and Android)",
+    "target": "节点（iOS 和 Android）"
+  },
+  {
+    "source": "Northflank",
+    "target": "Northflank"
+  },
+  {
+    "source": "Nostr",
+    "target": "Nostr"
+  },
+  {
+    "source": "NVIDIA",
+    "target": "NVIDIA"
+  },
+  {
+    "source": "OAuth",
+    "target": "OAuth"
+  },
+  {
+    "source": "Ollama",
+    "target": "Ollama"
+  },
+  {
+    "source": "Ollama (cloud + local models)",
+    "target": "Ollama (cloud + local models)"
+  },
+  {
+    "source": "onboard",
+    "target": "onboard"
+  },
+  {
+    "source": "Onboarding (CLI)",
+    "target": "入门（CLI）"
+  },
+  {
+    "source": "Onboarding (macOS App)",
+    "target": "入门（macOS 应用）"
+  },
+  {
+    "source": "Onboarding Overview",
+    "target": "入门概览"
+  },
+  {
+    "source": "Onboarding Reference",
+    "target": "入门参考"
+  },
+  {
+    "source": "OpenAI",
+    "target": "OpenAI"
+  },
+  {
+    "source": "OpenAI Chat Completions",
+    "target": "OpenAI Chat Completions"
+  },
+  {
+    "source": "OpenClaw assistant setup",
+    "target": "OpenClaw 助手设置"
+  },
+  {
+    "source": "OpenClaw Lore",
+    "target": "OpenClaw 背景设定"
+  },
+  {
+    "source": "OpenClaw Threat Model",
+    "target": "OpenClaw 威胁模型"
+  },
+  {
+    "source": "OpenCode",
+    "target": "OpenCode"
+  },
+  {
+    "source": "OpenCode (Zen + Go)",
+    "target": "OpenCode (Zen + Go)"
+  },
+  {
+    "source": "OpenCode Go",
+    "target": "OpenCode Go"
+  },
+  {
+    "source": "OpenProse",
+    "target": "OpenProse"
+  },
+  {
+    "source": "OpenResponses API",
+    "target": "OpenResponses API"
+  },
+  {
+    "source": "OpenRouter",
+    "target": "OpenRouter"
+  },
+  {
+    "source": "OpenShell",
+    "target": "OpenShell"
+  },
+  {
+    "source": "Oracle Cloud",
+    "target": "Oracle Cloud"
+  },
+  {
+    "source": "Oracle Cloud (Platform)",
+    "target": "Oracle Cloud (Platform)"
+  },
+  {
+    "source": "pairing",
+    "target": "pairing"
+  },
+  {
+    "source": "Pairing",
+    "target": "配对"
+  },
+  {
+    "source": "Pairing (DM and nodes)",
+    "target": "配对（私信与节点）"
+  },
+  {
+    "source": "PDF tool",
+    "target": "PDF 工具"
+  },
+  {
+    "source": "PDF Tool",
+    "target": "PDF 工具"
+  },
+  {
+    "source": "Peekaboo Bridge",
+    "target": "Peekaboo Bridge"
+  },
+  {
+    "source": "Perplexity",
+    "target": "Perplexity"
+  },
+  {
+    "source": "Perplexity (web search)",
+    "target": "Perplexity (web search)"
+  },
+  {
+    "source": "Perplexity Search",
+    "target": "Perplexity Search"
+  },
+  {
+    "source": "Perplexity Search (legacy path)",
+    "target": "Perplexity Search（旧路径）"
+  },
+  {
+    "source": "Personal Assistant Setup",
+    "target": "个人助理设置"
+  },
+  {
+    "source": "Pi Development Workflow",
+    "target": "Pi Development Workflow"
+  },
+  {
+    "source": "Pi Integration Architecture",
+    "target": "Pi Integration Architecture"
+  },
+  {
+    "source": "Platforms",
+    "target": "平台"
+  },
+  {
+    "source": "Plugin Architecture",
+    "target": "插件架构"
+  },
+  {
+    "source": "Plugin bundles",
+    "target": "插件包"
+  },
+  {
+    "source": "Plugin Bundles",
+    "target": "插件包"
+  },
+  {
+    "source": "Plugin Internals",
+    "target": "插件内部机制"
+  },
+  {
+    "source": "Plugin manifest",
+    "target": "插件清单"
+  },
+  {
+    "source": "Plugin Manifest",
+    "target": "插件清单"
+  },
+  {
+    "source": "Plugin Runtime Helpers",
+    "target": "插件运行时辅助工具"
+  },
+  {
+    "source": "Plugin runtime SDK",
+    "target": "插件运行时 SDK"
+  },
+  {
+    "source": "Plugin SDK Migration",
+    "target": "插件 SDK 迁移"
+  },
+  {
+    "source": "Plugin SDK overview",
+    "target": "插件 SDK 概览"
+  },
+  {
+    "source": "Plugin SDK setup",
+    "target": "插件 SDK 设置"
+  },
+  {
+    "source": "Plugin Setup and Config",
+    "target": "插件设置与配置"
+  },
+  {
+    "source": "Plugin Testing",
+    "target": "插件测试"
+  },
+  {
+    "source": "plugins",
+    "target": "plugins"
+  },
+  {
+    "source": "Plugins",
+    "target": "插件"
+  },
+  {
+    "source": "Plugins overview",
+    "target": "插件概览"
+  },
+  {
+    "source": "Podman",
+    "target": "Podman"
+  },
+  {
+    "source": "Presence",
+    "target": "Presence"
+  },
+  {
+    "source": "Prompt Caching",
+    "target": "Prompt Caching"
+  },
+  {
+    "source": "Provider Directory",
+    "target": "提供商目录"
+  },
+  {
+    "source": "Providers",
+    "target": "提供商"
+  },
+  {
+    "source": "QA Channel",
+    "target": "QA 渠道"
+  },
+  {
+    "source": "QA E2E Automation",
+    "target": "QA E2E 自动化"
+  },
+  {
+    "source": "Qianfan",
+    "target": "Qianfan"
+  },
+  {
+    "source": "QMD Engine",
+    "target": "QMD 引擎"
+  },
+  {
+    "source": "QMD Memory Engine",
+    "target": "QMD 记忆引擎"
+  },
+  {
+    "source": "qr",
+    "target": "qr"
+  },
+  {
+    "source": "Queue",
+    "target": "队列"
+  },
+  {
+    "source": "Qwen / Model Studio",
+    "target": "Qwen / Model Studio"
+  },
+  {
+    "source": "Qwen Cloud",
+    "target": "Qwen Cloud"
+  },
+  {
+    "source": "Railway",
+    "target": "Railway"
+  },
+  {
+    "source": "Raspberry Pi",
+    "target": "Raspberry Pi"
+  },
+  {
+    "source": "Raspberry Pi (Platform)",
+    "target": "Raspberry Pi (Platform)"
+  },
+  {
+    "source": "Reactions",
+    "target": "反应"
+  },
+  {
+    "source": "Registering Tools",
+    "target": "注册工具"
+  },
+  {
+    "source": "Release Channels",
+    "target": "发布通道"
+  },
+  {
+    "source": "Remote access",
+    "target": "远程访问"
+  },
+  {
+    "source": "Remote Access",
+    "target": "远程访问"
+  },
+  {
+    "source": "Remote Control",
+    "target": "远程控制"
+  },
+  {
+    "source": "Remote Gateway Setup",
+    "target": "远程 Gateway 设置"
+  },
+  {
+    "source": "Render",
+    "target": "Render"
+  },
+  {
+    "source": "reset",
+    "target": "reset"
+  },
+  {
+    "source": "Retry",
+    "target": "重试"
+  },
+  {
+    "source": "Retry Policy",
+    "target": "重试策略"
+  },
+  {
+    "source": "Routing Configuration",
+    "target": "路由配置"
+  },
+  {
+    "source": "RPC adapters",
+    "target": "RPC 适配器"
+  },
+  {
+    "source": "RPC Adapters",
+    "target": "RPC 适配器"
+  },
+  {
+    "source": "Runtime Helpers",
+    "target": "运行时辅助工具"
+  },
+  {
+    "source": "Runway",
+    "target": "Runway"
+  },
+  {
+    "source": "Sandbox CLI",
+    "target": "沙箱 CLI"
+  },
+  {
+    "source": "Sandbox Configuration",
+    "target": "沙箱配置"
+  },
+  {
+    "source": "Sandbox vs Tool Policy vs Elevated",
+    "target": "沙箱、工具策略与提升模式"
+  },
+  {
+    "source": "Scheduled Tasks",
+    "target": "计划任务"
+  },
+  {
+    "source": "Scripts",
+    "target": "脚本"
+  },
+  {
+    "source": "SDK Channel Plugins",
+    "target": "SDK 渠道插件"
+  },
+  {
+    "source": "SDK Entry Points",
+    "target": "SDK 入口点"
+  },
+  {
+    "source": "SDK Migration",
+    "target": "SDK 迁移"
+  },
+  {
+    "source": "SDK Provider Plugins",
+    "target": "SDK 提供商插件"
+  },
+  {
+    "source": "SDK Runtime",
+    "target": "SDK 运行时"
+  },
+  {
+    "source": "SDK Testing",
+    "target": "SDK 测试"
+  },
+  {
+    "source": "SearXNG Search",
+    "target": "SearXNG Search"
+  },
+  {
+    "source": "SecretRef Credential Surface",
+    "target": "SecretRef 凭据表面"
+  },
+  {
+    "source": "secrets",
+    "target": "secrets"
+  },
+  {
+    "source": "Secrets",
+    "target": "Secrets"
+  },
+  {
+    "source": "Secrets Apply Plan Contract",
+    "target": "Secrets 应用计划契约"
+  },
+  {
+    "source": "Secrets Management",
+    "target": "Secrets 管理"
+  },
+  {
+    "source": "security",
+    "target": "security"
+  },
+  {
+    "source": "Security",
+    "target": "安全"
+  },
+  {
+    "source": "Session",
+    "target": "会话"
+  },
+  {
+    "source": "Session Management",
+    "target": "会话管理"
+  },
+  {
+    "source": "Session Management Deep Dive",
+    "target": "会话管理深度解析"
+  },
+  {
+    "source": "Session Pruning",
+    "target": "会话裁剪"
+  },
+  {
+    "source": "Session Tools",
+    "target": "会话工具"
+  },
+  {
+    "source": "sessions",
+    "target": "sessions"
+  },
+  {
+    "source": "Sessions",
+    "target": "会话"
+  },
+  {
+    "source": "setup",
+    "target": "setup"
+  },
+  {
+    "source": "Setup and Config",
+    "target": "Setup and Config"
+  },
+  {
+    "source": "SGLang",
+    "target": "SGLang"
+  },
+  {
+    "source": "SGLang (local models)",
+    "target": "SGLang（本地模型）"
+  },
+  {
+    "source": "Signal",
+    "target": "Signal"
+  },
+  {
+    "source": "skills",
+    "target": "skills"
+  },
+  {
+    "source": "Skills (macOS)",
+    "target": "Skills (macOS)"
+  },
+  {
+    "source": "Skills reference",
+    "target": "Skills 参考"
+  },
+  {
+    "source": "Slack",
+    "target": "Slack"
+  },
+  {
+    "source": "Slash commands",
+    "target": "斜杠命令"
+  },
+  {
+    "source": "Slash Commands",
+    "target": "斜杠命令"
+  },
+  {
+    "source": "SOUL.dev Template",
+    "target": "SOUL.dev Template"
+  },
+  {
+    "source": "SOUL.md Personality Guide",
+    "target": "SOUL.md Personality Guide"
+  },
+  {
+    "source": "SOUL.md template",
+    "target": "SOUL.md 模板"
+  },
+  {
+    "source": "SOUL.md Template",
+    "target": "SOUL.md Template"
+  },
+  {
+    "source": "Standing Orders",
+    "target": "常驻指令"
+  },
+  {
+    "source": "status",
+    "target": "status"
+  },
+  {
+    "source": "StepFun",
+    "target": "StepFun"
+  },
+  {
+    "source": "Streaming",
+    "target": "流式传输"
+  },
+  {
+    "source": "Streaming and Chunking",
+    "target": "流式传输与分块"
+  },
+  {
+    "source": "Sub-agents",
+    "target": "子代理"
+  },
+  {
+    "source": "Sub-Agents",
+    "target": "子代理"
+  },
+  {
+    "source": "Synology Chat",
+    "target": "Synology Chat"
+  },
+  {
+    "source": "Synthetic",
+    "target": "Synthetic"
+  },
+  {
+    "source": "system",
+    "target": "system"
+  },
+  {
+    "source": "System prompt",
+    "target": "系统提示词"
+  },
+  {
+    "source": "System Prompt",
+    "target": "系统提示词"
+  },
+  {
+    "source": "Talk Mode",
+    "target": "通话模式"
+  },
+  {
+    "source": "Task Flow",
+    "target": "任务流"
+  },
+  {
+    "source": "Tavily",
+    "target": "Tavily"
+  },
+  {
+    "source": "Telegram",
+    "target": "Telegram"
+  },
+  {
+    "source": "Telegram reactionLevel",
+    "target": "Telegram reactionLevel"
+  },
+  {
+    "source": "Tests",
+    "target": "测试"
+  },
+  {
+    "source": "Text-to-Speech",
+    "target": "文本转语音"
+  },
+  {
+    "source": "Thinking",
+    "target": "思考"
+  },
+  {
+    "source": "Thinking Levels",
+    "target": "思考级别"
+  },
+  {
+    "source": "Threat Model (MITRE ATLAS)",
+    "target": "Threat Model (MITRE ATLAS)"
+  },
+  {
+    "source": "Timezone",
+    "target": "时区"
+  },
+  {
+    "source": "Timezones",
+    "target": "时区"
+  },
+  {
+    "source": "Tlon",
+    "target": "Tlon"
+  },
+  {
+    "source": "Together AI",
+    "target": "Together AI"
+  },
+  {
+    "source": "Token Use and Costs",
+    "target": "Token 用量与成本"
+  },
+  {
+    "source": "Tool-loop detection",
+    "target": "工具循环检测"
+  },
+  {
+    "source": "Tools",
+    "target": "工具"
+  },
+  {
+    "source": "Tools and Plugins",
+    "target": "工具与插件"
+  },
+  {
+    "source": "Tools Invoke API",
+    "target": "工具调用 API"
+  },
+  {
+    "source": "Tools overview",
+    "target": "工具概览"
+  },
+  {
+    "source": "Tools Overview",
+    "target": "工具概览"
+  },
+  {
+    "source": "TOOLS.dev Template",
+    "target": "TOOLS.dev Template"
+  },
+  {
+    "source": "TOOLS.md Template",
+    "target": "TOOLS.md Template"
+  },
+  {
+    "source": "Transcript Hygiene",
+    "target": "转录卫生"
+  },
+  {
+    "source": "Troubleshooting",
+    "target": "故障排查"
+  },
+  {
+    "source": "Trusted Proxy Auth",
+    "target": "受信代理认证"
+  },
+  {
+    "source": "tui",
+    "target": "tui"
+  },
+  {
+    "source": "TUI",
+    "target": "TUI"
+  },
+  {
+    "source": "Twitch",
+    "target": "Twitch"
+  },
+  {
+    "source": "TypeBox",
+    "target": "TypeBox"
+  },
+  {
+    "source": "Typing Indicators",
+    "target": "输入指示器"
+  },
+  {
+    "source": "uninstall",
+    "target": "uninstall"
+  },
+  {
+    "source": "Uninstall",
+    "target": "卸载"
+  },
+  {
+    "source": "update",
+    "target": "update"
+  },
+  {
+    "source": "Updates",
+    "target": "更新"
+  },
+  {
+    "source": "Updating",
+    "target": "更新"
+  },
+  {
+    "source": "Updating and rollback",
+    "target": "更新与回滚"
+  },
+  {
+    "source": "Usage Tracking",
+    "target": "用量跟踪"
+  },
+  {
+    "source": "USER Template",
+    "target": "USER Template"
+  },
+  {
+    "source": "USER.dev Template",
+    "target": "USER.dev Template"
+  },
+  {
+    "source": "Venice (Venice AI, privacy-focused)",
+    "target": "Venice (Venice AI, privacy-focused)"
+  },
+  {
+    "source": "Venice (Venice AI)",
+    "target": "Venice (Venice AI)"
+  },
+  {
+    "source": "Venice AI",
+    "target": "Venice AI"
+  },
+  {
+    "source": "Video Generation",
+    "target": "视频生成"
+  },
+  {
+    "source": "vLLM",
+    "target": "vLLM"
+  },
+  {
+    "source": "vLLM (local models)",
+    "target": "vLLM（本地模型）"
+  },
+  {
+    "source": "Voice Call",
+    "target": "Voice Call"
+  },
+  {
+    "source": "Voice call plugin",
+    "target": "Voice call 插件"
+  },
+  {
+    "source": "Voice Call Plugin",
+    "target": "Voice Call 插件"
+  },
+  {
+    "source": "Voice Overlay",
+    "target": "语音浮层"
+  },
+  {
+    "source": "Voice Wake",
+    "target": "语音唤醒"
+  },
+  {
+    "source": "Voice Wake (macOS)",
+    "target": "语音唤醒（macOS）"
+  },
+  {
+    "source": "voicecall",
+    "target": "voicecall"
+  },
+  {
+    "source": "Volcengine (Doubao)",
+    "target": "Volcengine (Doubao)"
+  },
+  {
+    "source": "VPS hosting",
+    "target": "VPS 托管"
+  },
+  {
+    "source": "Vydra",
+    "target": "Vydra"
+  },
+  {
+    "source": "Web",
+    "target": "Web"
+  },
+  {
+    "source": "Web Browser",
+    "target": "Web 浏览器"
+  },
+  {
+    "source": "Web Fetch",
+    "target": "网页抓取"
+  },
+  {
+    "source": "Web Search",
+    "target": "网页搜索"
+  },
+  {
+    "source": "Web Search overview",
+    "target": "网页搜索概览"
+  },
+  {
+    "source": "Web surfaces (Control UI)",
+    "target": "Web 界面（控制界面）"
+  },
+  {
+    "source": "Web tools",
+    "target": "Web 工具"
+  },
+  {
+    "source": "WebChat",
+    "target": "WebChat"
+  },
+  {
+    "source": "WebChat (macOS)",
+    "target": "WebChat (macOS)"
+  },
+  {
+    "source": "webhooks",
+    "target": "webhooks"
+  },
+  {
+    "source": "Webhooks",
+    "target": "Webhooks"
+  },
+  {
+    "source": "Webhooks Plugin",
+    "target": "Webhooks 插件"
+  },
+  {
+    "source": "What persists where",
+    "target": "持久化内容与位置"
+  },
+  {
+    "source": "WhatsApp",
+    "target": "WhatsApp"
+  },
+  {
+    "source": "WhatsApp group messages",
+    "target": "WhatsApp group messages"
+  },
+  {
+    "source": "WhatsApp reactionLevel",
+    "target": "WhatsApp reactionLevel"
+  },
+  {
+    "source": "Windows",
+    "target": "Windows"
+  },
+  {
+    "source": "Windows (WSL2)",
+    "target": "Windows (WSL2)"
+  },
+  {
+    "source": "Workspace templates",
+    "target": "工作区模板"
+  },
+  {
+    "source": "WSL2 + Windows + remote Chrome CDP troubleshooting",
+    "target": "WSL2 + Windows + 远程 Chrome CDP 故障排查"
+  },
+  {
+    "source": "x_search in Web Search",
+    "target": "x_search in Web Search"
+  },
+  {
+    "source": "xAI",
+    "target": "xAI"
+  },
+  {
+    "source": "Xiaomi MiMo",
+    "target": "Xiaomi MiMo"
+  },
+  {
+    "source": "Z.AI",
+    "target": "Z.AI"
+  },
+  {
+    "source": "Zalo",
+    "target": "Zalo"
+  },
+  {
+    "source": "Zalo Personal",
+    "target": "Zalo Personal"
+  },
+  {
+    "source": "Zalo Personal Plugin",
+    "target": "Zalo Personal 插件"
+  },
+  {
+    "source": "Zalo user plugin",
+    "target": "Zalo user 插件"
   }
 ]

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -289,10 +289,15 @@ Notes:
 
 - You can also enable the plugin with `openclaw plugins enable diagnostics-otel`.
 - `protocol` currently supports `http/protobuf` only. `grpc` is ignored.
-- Metrics include token usage, cost, context size, run duration, and message-flow
-  counters/histograms (webhooks, queueing, session state, queue depth/wait).
+- Metrics include token usage, cost, context size, run duration, message-flow
+  counters/histograms (webhooks, queueing, session state, queue depth/wait),
+  tool-loop guard counters, and turn lifecycle metrics.
 - Traces/metrics can be toggled with `traces` / `metrics` (default: on). Traces
-  include model usage spans plus webhook/message processing spans when enabled.
+  include model usage spans plus webhook/message processing, tool-loop, and
+  turn-completion spans when enabled.
+- Turn lifecycle diagnostics emit `turn.started` / `turn.completed` events.
+  The OTel exporter maps those into turn counters, duration histograms,
+  iteration/tool-call counters, and a completion span.
 - Set `headers` when your collector requires auth.
 - Environment variables supported: `OTEL_EXPORTER_OTLP_ENDPOINT`,
   `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_PROTOCOL`.
@@ -337,6 +342,20 @@ Queues + sessions:
 - `openclaw.session.stuck_age_ms` (histogram, attrs: `openclaw.state`)
 - `openclaw.run.attempt` (counter, attrs: `openclaw.attempt`)
 
+Tool loops + turns:
+
+- `openclaw.tool.loop` (counter, attrs: `openclaw.tool`, `openclaw.level`,
+  `openclaw.action`, `openclaw.detector`, `openclaw.count`, optional
+  `openclaw.pairedTool`)
+- `openclaw.turn` (counter, attrs: `openclaw.provider`, `openclaw.model`,
+  `openclaw.phase`, and `openclaw.outcome` on completed turns)
+- `openclaw.turn.duration_ms` (histogram, attrs: `openclaw.provider`,
+  `openclaw.model`, `openclaw.outcome`)
+- `openclaw.turn.tool_calls` (counter, attrs: `openclaw.provider`,
+  `openclaw.model`, `openclaw.outcome`)
+- `openclaw.turn.iterations` (counter, attrs: `openclaw.provider`,
+  `openclaw.model`, `openclaw.outcome`)
+
 ### Exported spans (names + key attributes)
 
 - `openclaw.model.usage`
@@ -355,6 +374,15 @@ Queues + sessions:
 - `openclaw.session.stuck`
   - `openclaw.state`, `openclaw.ageMs`, `openclaw.queueDepth`,
     `openclaw.sessionKey`, `openclaw.sessionId`
+- `openclaw.tool.loop`
+  - `openclaw.tool`, `openclaw.level`, `openclaw.action`,
+    `openclaw.detector`, `openclaw.count`, optional `openclaw.pairedTool`
+  - `openclaw.sessionKey`, `openclaw.sessionId`, `openclaw.message`
+- `openclaw.turn`
+  - `openclaw.provider`, `openclaw.model`, `openclaw.outcome`
+  - `openclaw.turnId`, `openclaw.runId`, `openclaw.sessionKey`
+  - `openclaw.iterations`, `openclaw.toolCalls`, `openclaw.toolErrors`
+  - optional `openclaw.tokens.total`
 
 ### Sampling + flushing
 

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -33,6 +33,17 @@ title: "Tests"
 - `pnpm test:docker:openwebui`: Starts Dockerized OpenClaw + Open WebUI, signs in through Open WebUI, checks `/api/models`, then runs a real proxied chat through `/api/chat/completions`. Requires a usable live model key (for example OpenAI in `~/.profile`), pulls an external Open WebUI image, and is not expected to be CI-stable like the normal unit/e2e suites.
 - `pnpm test:docker:mcp-channels`: Starts a seeded Gateway container and a second client container that spawns `openclaw mcp serve`, then verifies routed conversation discovery, transcript reads, attachment metadata, live event queue behavior, outbound send routing, and Claude-style channel + permission notifications over the real stdio bridge. The Claude notification assertion reads the raw stdio MCP frames directly so the smoke reflects what the bridge actually emits.
 
+## Turn fixtures and replay
+
+- `src/test-utils/turn-recorder.ts` records the agent-event and diagnostic-event stream for a turn into a JSON fixture with `version`, `recordedAt`, and ordered `entries`.
+- `src/test-utils/turn-replayer.ts` replays a saved fixture by re-emitting those events in order, which is useful for regression tests around listeners, telemetry export, and event-stream parity.
+- `src/test-utils/turn-replay.test.ts` is the parity suite for the replay harness.
+- Use the replay harness when you want to lock in control-flow or observability behavior without reconstructing the full live runtime around a scenario.
+
+Targeted run:
+
+- `pnpm exec vitest run src/test-utils/turn-replay.test.ts`
+
 ## Local PR gate
 
 For local PR land/gate checks, run:

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -107,6 +107,9 @@ Built-in commands available today:
 - `/commands` shows the generated command catalog.
 - `/tools [compact|verbose]` shows what the current agent can use right now.
 - `/status` shows runtime status, including provider usage/quota when available.
+- `/doctor` shows a lightweight health summary for config validity, model/context, channel degradation, git/update state, and runtime info.
+- `/prompt` renders the detailed prompt/context report for the current session.
+- `/cache` shows the latest cache/system-prompt trace for the current session once at least one turn has run.
 - `/tasks` lists active/recent background tasks for the current session.
 - `/context [list|detail|json]` explains how context is assembled.
 - `/export-session [path]` exports the current session to HTML. Alias: `/export`.
@@ -177,6 +180,8 @@ Notes:
 - `/allowlist add|remove` requires `commands.config=true` and honors channel `configWrites`.
 - In multi-account channels, config-targeted `/allowlist --account <id>` and `/config set channels.<provider>.accounts.<id>...` also honor the target account's `configWrites`.
 - `/usage` controls the per-response usage footer; `/usage cost` prints a local cost summary from OpenClaw session logs.
+- `/prompt` is the convenience alias for `/context detail`.
+- `/cache` only has data after the current session has produced at least one model turn with a prompt report.
 - `/restart` is enabled by default; set `commands.restart: false` to disable it.
 - `/plugins install <spec>` accepts the same plugin specs as `openclaw plugins install`: local path/archive, npm package, or `clawhub:<pkg>`.
 - `/plugins enable|disable` updates plugin config and may prompt for a restart.
@@ -184,6 +189,7 @@ Notes:
 - Discord thread-binding commands (`/focus`, `/unfocus`, `/agents`, `/session idle`, `/session max-age`) require effective thread bindings to be enabled (`session.threadBindings.enabled` and/or `channels.discord.threadBindings.enabled`).
 - ACP command reference and runtime behavior: [ACP Agents](/tools/acp-agents).
 - `/verbose` is meant for debugging and extra visibility; keep it **off** in normal use.
+- When `/verbose` is on, new sessions can prepend operational notices such as the new session id, auto-compaction completion, model fallback notes, and a best-effort git freshness warning when the workspace is dirty or behind upstream.
 - `/trace` is narrower than `/verbose`: it only reveals plugin-owned trace/debug lines and keeps normal verbose tool chatter off.
 - `/fast on|off` persists a session override. Use the Sessions UI `inherit` option to clear it and fall back to config defaults.
 - `/fast` is provider-specific: OpenAI/OpenAI Codex map it to `service_tier=priority` on native Responses endpoints, while direct public Anthropic requests, including OAuth-authenticated traffic sent to `api.anthropic.com`, map it to `service_tier=auto` or `standard_only`. See [OpenAI](/providers/openai) and [Anthropic](/providers/anthropic).
@@ -226,7 +232,7 @@ of treating `/tools` as a static catalog.
 
 - **Provider usage/quota** (example: “Claude 80% left”) shows up in `/status` for the current model provider when usage tracking is enabled. OpenClaw normalizes provider windows to `% left`; for MiniMax, remaining-only percent fields are inverted before display, and `model_remains` responses prefer the chat-model entry plus a model-tagged plan label.
 - **Token/cache lines** in `/status` can fall back to the latest transcript usage entry when the live session snapshot is sparse. Existing nonzero live values still win, and transcript fallback can also recover the active runtime model label plus a larger prompt-oriented total when stored totals are missing or smaller.
-- **Per-response tokens/cost** is controlled by `/usage off|tokens|full` (appended to normal replies).
+- **Per-response tokens/cost** is controlled by `/usage off|tokens|full` (appended to normal replies and kept on the main assistant payload even when trailing plugin/trace payloads are emitted).
 - `/model status` is about **models/auth/endpoints**, not usage.
 
 ## Model selection (`/model`)

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -232,6 +232,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         unit: "1",
         description: "Run attempts",
       });
+      const toolLoopCounter = meter.createCounter("openclaw.tool.loop", {
+        unit: "1",
+        description: "Tool loop guard events",
+      });
       const turnCounter = meter.createCounter("openclaw.turn", {
         unit: "1",
         description: "Agent turns by outcome",
@@ -619,6 +623,31 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         runAttemptCounter.add(1, { "openclaw.attempt": evt.attempt });
       };
 
+      const recordToolLoop = (evt: Extract<DiagnosticEventPayload, { type: "tool.loop" }>) => {
+        const attrs: Record<string, string | number> = {
+          "openclaw.tool": evt.toolName,
+          "openclaw.level": evt.level,
+          "openclaw.action": evt.action,
+          "openclaw.detector": evt.detector,
+          "openclaw.count": evt.count,
+        };
+        if (evt.pairedToolName) {
+          attrs["openclaw.pairedTool"] = evt.pairedToolName;
+        }
+        toolLoopCounter.add(1, attrs);
+        if (!tracesEnabled) {
+          return;
+        }
+        const spanAttrs: Record<string, string | number> = { ...attrs };
+        addSessionIdentityAttrs(spanAttrs, evt);
+        spanAttrs["openclaw.message"] = redactSensitiveText(evt.message);
+        const span = tracer.startSpan("openclaw.tool.loop", { attributes: spanAttrs });
+        if (evt.level === "critical") {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: redactSensitiveText(evt.message) });
+        }
+        span.end();
+      };
+
       const recordHeartbeat = (
         evt: Extract<DiagnosticEventPayload, { type: "diagnostic.heartbeat" }>,
       ) => {
@@ -705,6 +734,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "run.attempt":
               recordRunAttempt(evt);
+              return;
+            case "tool.loop":
+              recordToolLoop(evt);
               return;
             case "diagnostic.heartbeat":
               recordHeartbeat(evt);

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -232,6 +232,22 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         unit: "1",
         description: "Run attempts",
       });
+      const turnCounter = meter.createCounter("openclaw.turn", {
+        unit: "1",
+        description: "Agent turns by outcome",
+      });
+      const turnDurationHistogram = meter.createHistogram("openclaw.turn.duration_ms", {
+        unit: "ms",
+        description: "Agent turn duration",
+      });
+      const turnToolCallCounter = meter.createCounter("openclaw.turn.tool_calls", {
+        unit: "1",
+        description: "Tool calls per turn",
+      });
+      const turnIterationCounter = meter.createCounter("openclaw.turn.iterations", {
+        unit: "1",
+        description: "Iterations per turn",
+      });
 
       if (logsEnabled) {
         const logExporter = new OTLPLogExporter({
@@ -609,6 +625,51 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         queueDepthHistogram.record(evt.queued, { "openclaw.channel": "heartbeat" });
       };
 
+      const recordTurnStarted = (
+        evt: Extract<DiagnosticEventPayload, { type: "turn.started" }>,
+      ) => {
+        turnCounter.add(1, {
+          "openclaw.provider": evt.provider ?? "unknown",
+          "openclaw.model": evt.model ?? "unknown",
+          "openclaw.phase": "started",
+        });
+      };
+
+      const recordTurnCompleted = (
+        evt: Extract<DiagnosticEventPayload, { type: "turn.completed" }>,
+      ) => {
+        const attrs = {
+          "openclaw.provider": evt.provider ?? "unknown",
+          "openclaw.model": evt.model ?? "unknown",
+          "openclaw.outcome": evt.outcome,
+        };
+        turnCounter.add(1, { ...attrs, "openclaw.phase": "completed" });
+        turnDurationHistogram.record(evt.durationMs, attrs);
+        turnToolCallCounter.add(evt.toolCallCount, attrs);
+        turnIterationCounter.add(evt.iterations, attrs);
+
+        if (!tracesEnabled) {
+          return;
+        }
+        const spanAttrs: Record<string, string | number> = {
+          ...attrs,
+          "openclaw.turnId": evt.turnId,
+          "openclaw.runId": evt.runId,
+          "openclaw.sessionKey": evt.sessionKey ?? "",
+          "openclaw.iterations": evt.iterations,
+          "openclaw.toolCalls": evt.toolCallCount,
+          "openclaw.toolErrors": evt.toolErrors,
+        };
+        if (evt.usage?.total) {
+          spanAttrs["openclaw.tokens.total"] = evt.usage.total;
+        }
+        const span = spanWithDuration("openclaw.turn", spanAttrs, evt.durationMs);
+        if (evt.outcome === "error") {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: evt.error });
+        }
+        span.end();
+      };
+
       unsubscribe = onDiagnosticEvent((evt: DiagnosticEventPayload) => {
         try {
           switch (evt.type) {
@@ -647,6 +708,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "diagnostic.heartbeat":
               recordHeartbeat(evt);
+              return;
+            case "turn.started":
+              recordTurnStarted(evt);
+              return;
+            case "turn.completed":
+              recordTurnCompleted(evt);
               return;
           }
         } catch (err) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2008,7 +2008,13 @@ describe("runReplyAgent fallback reasoning tags", () => {
 });
 
 describe("runReplyAgent response usage footer", () => {
-  function createRun(params: { responseUsage: "tokens" | "full"; sessionKey: string }) {
+  function createRun(params: {
+    responseUsage: "tokens" | "full";
+    sessionKey: string;
+    resolvedVerboseLevel?: "off" | "on";
+    traceAuthorized?: boolean;
+    sessionEntryOverrides?: Partial<SessionEntry>;
+  }) {
     const typing = createMockTypingController();
     const sessionCtx = {
       Provider: "whatsapp",
@@ -2022,6 +2028,7 @@ describe("runReplyAgent response usage footer", () => {
       sessionId: "session",
       updatedAt: Date.now(),
       responseUsage: params.responseUsage,
+      ...params.sessionEntryOverrides,
     };
 
     const followupRun = {
@@ -2038,10 +2045,11 @@ describe("runReplyAgent response usage footer", () => {
         workspaceDir: "/tmp",
         config: createCliBackendTestConfig(),
         skillsSnapshot: {},
+        traceAuthorized: params.traceAuthorized ?? false,
         provider: "anthropic",
         model: "claude",
         thinkLevel: "low",
-        verboseLevel: "off",
+        verboseLevel: params.resolvedVerboseLevel ?? "off",
         elevatedLevel: "off",
         bashElevated: {
           enabled: false,
@@ -2067,7 +2075,7 @@ describe("runReplyAgent response usage footer", () => {
       sessionEntry,
       sessionKey: params.sessionKey,
       defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
+      resolvedVerboseLevel: params.resolvedVerboseLevel ?? "off",
       isNewSession: false,
       blockStreamingEnabled: false,
       resolvedBlockStreamingBreak: "message_end",
@@ -2116,6 +2124,45 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).toContain("Usage:");
     expect(text).toContain("cache 4 cached / 2 new");
     expect(text).not.toContain("· session ");
+  });
+
+  it("keeps the usage footer on the main reply before trailing plugin status payloads", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          usage: { input: 12, output: 3, cacheRead: 4, cacheWrite: 2 },
+        },
+      },
+    });
+
+    const sessionKey = "agent:main:whatsapp:dm:+1000";
+    const res = await createRun({
+      responseUsage: "full",
+      sessionKey,
+      resolvedVerboseLevel: "on",
+      sessionEntryOverrides: {
+        verboseLevel: "on",
+        pluginDebugEntries: [
+          {
+            pluginId: "active-memory",
+            lines: ["🧩 Active Memory: status=ok elapsed=842ms query=recent summary=34 chars"],
+          },
+        ],
+      },
+    });
+
+    expect(Array.isArray(res)).toBe(true);
+    expect((res as { text?: string }[]).map((payload) => payload.text)).toEqual([
+      expect.stringContaining("ok\nUsage:"),
+      "🧩 Active Memory: status=ok elapsed=842ms query=recent summary=34 chars",
+    ]);
+    const firstPayload = (res as { text?: string }[])[0]?.text ?? "";
+    const secondPayload = (res as { text?: string }[])[1]?.text ?? "";
+    expect(firstPayload).toContain(`· session \`${sessionKey}\``);
+    expect(secondPayload).not.toContain("Usage:");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -20,7 +20,6 @@ import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnosti
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { TurnSummaryBuilder } from "../../infra/turn-summary.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
-import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   estimateUsageCost,
@@ -1816,8 +1815,12 @@ export async function runReplyAgent(params: {
     if (prefixPayloads.length > 0) {
       finalPayloads = [...prefixPayloads, ...finalPayloads];
     }
+    if (responseUsageLine) {
+      finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
+    }
     if (trailingPluginStatusPayload) {
       finalPayloads = [...finalPayloads, trailingPluginStatusPayload];
+    }
     return finalizeWithFollowup(
       finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,
       queueKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -18,8 +18,8 @@ import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
-import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { TurnSummaryBuilder } from "../../infra/turn-summary.js";
+import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
@@ -1090,6 +1090,44 @@ export async function runReplyAgent(params: {
   let runFollowupTurn = queuedRunFollowupTurn;
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied = false;
+  let turnId: string | undefined;
+  let turnBuilder: TurnSummaryBuilder | undefined;
+  let didEmitTurnCompleted = false;
+  const emitTurnCompleted = (params?: {
+    provider?: string;
+    model?: string;
+    usage?: NormalizedUsage;
+    outcome?: "success" | "error" | "aborted" | "compaction";
+    error?: string;
+  }) => {
+    if (!isDiagnosticsEnabled(cfg) || didEmitTurnCompleted || !turnId || !turnBuilder) {
+      return;
+    }
+    if (params?.usage) {
+      turnBuilder.setUsage(params.usage);
+    }
+    if (params?.outcome || params?.error) {
+      turnBuilder.setOutcome(params.outcome ?? "error", params.error);
+    }
+    const summary = turnBuilder.freeze();
+    didEmitTurnCompleted = true;
+    emitDiagnosticEvent({
+      type: "turn.completed",
+      turnId,
+      runId: opts?.runId ?? "unknown",
+      sessionKey,
+      sessionId: followupRun.run.sessionId,
+      provider: params?.provider ?? followupRun.run.provider,
+      model: params?.model ?? followupRun.run.model,
+      durationMs: summary.durationMs ?? 0,
+      iterations: summary.iterations,
+      toolCallCount: summary.toolCalls.length,
+      toolErrors: summary.toolCalls.filter((t) => !t.success).length,
+      outcome: summary.outcome,
+      usage: summary.usage,
+      error: summary.error,
+    });
+  };
 
   try {
     await typingSignals.signalRunStart();
@@ -1187,8 +1225,8 @@ export async function runReplyAgent(params: {
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
-    const turnId = crypto.randomUUID();
-    const turnBuilder = new TurnSummaryBuilder({
+    turnId = crypto.randomUUID();
+    turnBuilder = new TurnSummaryBuilder({
       turnId,
       runId: opts?.runId ?? "unknown",
       sessionKey,
@@ -1208,43 +1246,6 @@ export async function runReplyAgent(params: {
         model: followupRun.run.model,
       });
     }
-
-    let didEmitTurnCompleted = false;
-    const emitTurnCompleted = (params?: {
-      provider?: string;
-      model?: string;
-      usage?: NormalizedUsage;
-      outcome?: "success" | "error" | "aborted" | "compaction";
-      error?: string;
-    }) => {
-      if (!isDiagnosticsEnabled(cfg) || didEmitTurnCompleted) {
-        return;
-      }
-      if (params?.usage) {
-        turnBuilder.setUsage(params.usage);
-      }
-      if (params?.outcome || params?.error) {
-        turnBuilder.setOutcome(params.outcome ?? "error", params.error);
-      }
-      const summary = turnBuilder.freeze();
-      didEmitTurnCompleted = true;
-      emitDiagnosticEvent({
-        type: "turn.completed",
-        turnId,
-        runId: opts?.runId ?? "unknown",
-        sessionKey,
-        sessionId: followupRun.run.sessionId,
-        provider: params?.provider ?? followupRun.run.provider,
-        model: params?.model ?? followupRun.run.model,
-        durationMs: summary.durationMs ?? 0,
-        iterations: summary.iterations,
-        toolCallCount: summary.toolCalls.length,
-        toolErrors: summary.toolCalls.filter((t) => !t.success).length,
-        outcome: summary.outcome,
-        usage: summary.usage,
-        error: summary.error,
-      });
-    };
 
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -5,7 +5,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded-runner/runs.js";
-import { hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
+import { hasNonzeroUsage, normalizeUsage, type NormalizedUsage } from "../../agents/usage.js";
 import {
   loadSessionStore,
   resolveSessionPluginStatusLines,
@@ -19,6 +19,8 @@ import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
+import { TurnSummaryBuilder } from "../../infra/turn-summary.js";
+import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   estimateUsageCost,
@@ -1185,6 +1187,65 @@ export async function runReplyAgent(params: {
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
+    const turnId = crypto.randomUUID();
+    const turnBuilder = new TurnSummaryBuilder({
+      turnId,
+      runId: opts?.runId ?? "unknown",
+      sessionKey,
+      sessionId: followupRun.run.sessionId,
+      provider: followupRun.run.provider,
+      model: followupRun.run.model,
+    });
+
+    if (isDiagnosticsEnabled(cfg)) {
+      emitDiagnosticEvent({
+        type: "turn.started",
+        turnId,
+        runId: opts?.runId ?? "unknown",
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        provider: followupRun.run.provider,
+        model: followupRun.run.model,
+      });
+    }
+
+    let didEmitTurnCompleted = false;
+    const emitTurnCompleted = (params?: {
+      provider?: string;
+      model?: string;
+      usage?: NormalizedUsage;
+      outcome?: "success" | "error" | "aborted" | "compaction";
+      error?: string;
+    }) => {
+      if (!isDiagnosticsEnabled(cfg) || didEmitTurnCompleted) {
+        return;
+      }
+      if (params?.usage) {
+        turnBuilder.setUsage(params.usage);
+      }
+      if (params?.outcome || params?.error) {
+        turnBuilder.setOutcome(params.outcome ?? "error", params.error);
+      }
+      const summary = turnBuilder.freeze();
+      didEmitTurnCompleted = true;
+      emitDiagnosticEvent({
+        type: "turn.completed",
+        turnId,
+        runId: opts?.runId ?? "unknown",
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        provider: params?.provider ?? followupRun.run.provider,
+        model: params?.model ?? followupRun.run.model,
+        durationMs: summary.durationMs ?? 0,
+        iterations: summary.iterations,
+        toolCallCount: summary.toolCalls.length,
+        toolErrors: summary.toolCalls.filter((t) => !t.success).length,
+        outcome: summary.outcome,
+        usage: summary.usage,
+        error: summary.error,
+      });
+    };
+
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
       followupRun,
@@ -1214,6 +1275,9 @@ export async function runReplyAgent(params: {
       if (!replyOperation.result) {
         replyOperation.fail("run_failed", new Error("reply operation exited with final payload"));
       }
+      emitTurnCompleted({
+        outcome: replyOperation.result?.kind === "aborted" ? "aborted" : "error",
+      });
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
     }
 
@@ -1337,6 +1401,12 @@ export async function runReplyAgent(params: {
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
     if (payloadArray.length === 0) {
+      emitTurnCompleted({
+        provider: providerUsed,
+        model: modelUsed,
+        usage,
+        outcome: autoCompactionCount > 0 ? "compaction" : "success",
+      });
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 
@@ -1368,6 +1438,12 @@ export async function runReplyAgent(params: {
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
     if (replyPayloads.length === 0) {
+      emitTurnCompleted({
+        provider: providerUsed,
+        model: modelUsed,
+        usage,
+        outcome: autoCompactionCount > 0 ? "compaction" : "success",
+      });
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 
@@ -1431,6 +1507,13 @@ export async function runReplyAgent(params: {
         durationMs: Date.now() - runStartedAt,
       });
     }
+
+    emitTurnCompleted({
+      provider: providerUsed,
+      model: modelUsed,
+      usage,
+      outcome: autoCompactionCount > 0 ? "compaction" : "success",
+    });
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??
@@ -1577,6 +1660,29 @@ export async function runReplyAgent(params: {
         verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
       }
     }
+    // Pre-op branch freshness warning (only on new sessions to avoid overhead)
+    if (verboseEnabled && activeIsNewSession) {
+      try {
+        const { checkGitUpdateStatus } = await import("../../infra/update-check.js");
+        const gitStatus = await checkGitUpdateStatus({
+          root: followupRun.run.workspaceDir,
+          timeoutMs: 3000,
+          fetch: false,
+        });
+        const warnings: string[] = [];
+        if (gitStatus.dirty) {
+          warnings.push("dirty worktree");
+        }
+        if (gitStatus.behind && gitStatus.behind > 0) {
+          warnings.push(`${gitStatus.behind} commit(s) behind upstream`);
+        }
+        if (warnings.length > 0) {
+          verboseNotices.push({ text: `⚠️ Git: ${warnings.join(", ")}` });
+        }
+      } catch {
+        // Best-effort: skip if git check fails
+      }
+    }
     const prefixPayloads = [...verboseNotices];
     const rawUserText =
       runResult.meta?.finalPromptText ??
@@ -1711,17 +1817,21 @@ export async function runReplyAgent(params: {
     }
     if (trailingPluginStatusPayload) {
       finalPayloads = [...finalPayloads, trailingPluginStatusPayload];
-    }
-    if (responseUsageLine) {
-      finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
-    }
-
     return finalizeWithFollowup(
       finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,
       queueKey,
       runFollowupTurn,
     );
   } catch (error) {
+    emitTurnCompleted({
+      outcome:
+        replyOperation.result?.kind === "aborted" ||
+        error instanceof GatewayDrainingError ||
+        error instanceof CommandLaneClearedError
+          ? "aborted"
+          : "error",
+      error: error instanceof Error ? error.message : String(error),
+    });
     if (
       replyOperation.result?.kind === "aborted" &&
       replyOperation.result.code === "aborted_for_restart"

--- a/src/auto-reply/reply/commands-doctor.ts
+++ b/src/auto-reply/reply/commands-doctor.ts
@@ -1,0 +1,207 @@
+import { getUpdateCheckResult } from "../../commands/status.update.js";
+import { loadConfig } from "../../config/io.js";
+import { validateConfigObject } from "../../config/validation.js";
+import { logVerbose } from "../../globals.js";
+import { buildChannelSummary } from "../../infra/channel-summary.js";
+import { buildContextReply } from "./commands-context-report.js";
+import type { CommandHandler } from "./commands-types.js";
+
+// ─── /doctor ──────────────────────────────────────────────────────────
+
+export const handleDoctorCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  if (params.command.commandBodyNormalized !== "/doctor") {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /doctor from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  const lines: string[] = ["🩺 **System Doctor**", ""];
+
+  // 1. Config validation
+  try {
+    const cfg = loadConfig();
+    const result = validateConfigObject(cfg);
+    if (result.ok) {
+      lines.push("✅ Config: valid");
+    } else {
+      lines.push(`⚠️ Config: ${result.issues.length} issue(s)`);
+      for (const issue of result.issues.slice(0, 5)) {
+        lines.push(`  - ${issue.path}: ${issue.message}`);
+      }
+    }
+  } catch (err) {
+    lines.push(`❌ Config: failed to load — ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 2. Model reachability (basic check)
+  lines.push(`✅ Model: ${params.provider}/${params.model}`);
+  lines.push(`   Context: ${params.contextTokens} tokens`);
+
+  // 3. Channel health
+  try {
+    const channelLines = await buildChannelSummary(params.cfg, { colorize: false });
+    if (channelLines.length > 0) {
+      const degradedCount = channelLines.filter((l) => l.includes("degraded")).length;
+      const connectedCount = channelLines.filter(
+        (l) => l.includes("linked") || l.includes("configured"),
+      ).length;
+      if (degradedCount > 0) {
+        lines.push(`⚠️ Channels: ${degradedCount} degraded, ${connectedCount} healthy`);
+      } else {
+        lines.push(`✅ Channels: ${connectedCount} configured`);
+      }
+    } else {
+      lines.push("ℹ️ Channels: none configured");
+    }
+  } catch (err) {
+    lines.push(`❌ Channels: check failed — ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 4. Git / update check
+  try {
+    const updateResult = await getUpdateCheckResult({
+      timeoutMs: 6000,
+      fetchGit: false,
+      includeRegistry: false,
+    });
+    const git = updateResult.git;
+    const gitParts: string[] = [];
+    if (git) {
+      if (git.dirty) {
+        gitParts.push("dirty");
+      }
+      if (git.behind && git.behind > 0) {
+        gitParts.push(`${git.behind} behind`);
+      }
+      if (git.ahead && git.ahead > 0) {
+        gitParts.push(`${git.ahead} ahead`);
+      }
+      if (git.branch) {
+        gitParts.push(`branch: ${git.branch}`);
+      }
+    }
+    if (gitParts.length === 0) {
+      lines.push("✅ Git: clean");
+    } else {
+      const hasIssue = git?.dirty || (git?.behind && git.behind > 0);
+      lines.push(`${hasIssue ? "⚠️" : "✅"} Git: ${gitParts.join(", ")}`);
+    }
+
+    const deps = updateResult.deps;
+    if (deps) {
+      if (deps.status === "ok") {
+        lines.push("✅ Dependencies: up to date");
+      } else {
+        lines.push(`⚠️ Dependencies: ${deps.status}${deps.reason ? ` — ${deps.reason}` : ""}`);
+      }
+    }
+  } catch (err) {
+    lines.push(`❌ Update check: failed — ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 5. Runtime info
+  lines.push("");
+  lines.push(`Node: ${process.version}`);
+  lines.push(`Platform: ${process.platform} ${process.arch}`);
+  lines.push(`Memory: ${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB RSS`);
+
+  return { shouldContinue: false, reply: { text: lines.join("\n") } };
+};
+
+// ─── /prompt ──────────────────────────────────────────────────────────
+
+export const handlePromptReportCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  if (params.command.commandBodyNormalized !== "/prompt") {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /prompt from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  // Reuse the context report — override commandBodyNormalized so parseContextArgs
+  // inside buildContextReply returns "detail" instead of seeing "/prompt".
+  const overridden = {
+    ...params,
+    command: { ...params.command, commandBodyNormalized: "/context detail" },
+  };
+  return { shouldContinue: false, reply: await buildContextReply(overridden) };
+};
+
+// ─── /cache ───────────────────────────────────────────────────────────
+
+export const handleCacheTraceCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  if (params.command.commandBodyNormalized !== "/cache") {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /cache from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  const report = params.sessionEntry?.systemPromptReport;
+  if (!report) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: "ℹ️ No cache trace data available for this session yet. Send a message first, then try again.",
+      },
+    };
+  }
+
+  const lines: string[] = ["📊 **Cache Trace**", ""];
+
+  lines.push(`Session: ${params.sessionKey}`);
+  lines.push(`Model: ${params.provider}/${params.model}`);
+  lines.push(`Context: ${params.contextTokens} tokens`);
+  lines.push("");
+
+  if (report.systemPrompt) {
+    lines.push(
+      `System prompt: ${report.systemPrompt.chars} chars (~${Math.ceil(report.systemPrompt.chars / 4)} tokens)`,
+    );
+    if (report.systemPrompt.projectContextChars) {
+      lines.push(`  Project context: ${report.systemPrompt.projectContextChars} chars`);
+    }
+  }
+
+  if (report.tools && report.tools.entries.length > 0) {
+    lines.push(`Tools: ${report.tools.entries.length} (${report.tools.schemaChars} schema chars)`);
+  }
+
+  if (report.skills && report.skills.entries.length > 0) {
+    lines.push(`Skills: ${report.skills.entries.map((s) => s.name).join(", ")}`);
+  }
+
+  if (report.injectedWorkspaceFiles && report.injectedWorkspaceFiles.length > 0) {
+    const injected = report.injectedWorkspaceFiles.filter((f) => !f.missing);
+    lines.push(`Workspace files: ${injected.length} injected`);
+    for (const file of injected.slice(0, 5)) {
+      lines.push(
+        `  - ${file.name}: ${file.injectedChars ?? 0} chars${file.truncated ? " (truncated)" : ""}`,
+      );
+    }
+    if (injected.length > 5) {
+      lines.push(`  ... and ${injected.length - 5} more`);
+    }
+  }
+
+  return { shouldContinue: false, reply: { text: lines.join("\n") } };
+};

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -7,6 +7,11 @@ import { handleCompactCommand } from "./commands-compact.js";
 import { handleConfigCommand, handleDebugCommand } from "./commands-config.js";
 import { handleContextCommand } from "./commands-context-command.js";
 import {
+  handleDoctorCommand,
+  handlePromptReportCommand,
+  handleCacheTraceCommand,
+} from "./commands-doctor.js";
+import {
   handleCommandsListCommand,
   handleExportSessionCommand,
   handleHelpCommand,
@@ -64,6 +69,9 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleModelsCommand,
     handleStopCommand,
     handleCompactCommand,
+    handleDoctorCommand,
+    handlePromptReportCommand,
+    handleCacheTraceCommand,
     handleAbortTrigger,
   ];
 }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -124,7 +124,7 @@ export type ChannelSetupInput = {
 export type ChannelStatusIssue = {
   channel: ChannelId;
   accountId: string;
-  kind: "intent" | "permissions" | "config" | "auth" | "runtime";
+  kind: "intent" | "permissions" | "config" | "auth" | "runtime" | "degraded";
   message: string;
   fix?: string;
 };
@@ -184,6 +184,8 @@ export type ChannelAccountSnapshot = {
   running?: boolean;
   connected?: boolean;
   restartPending?: boolean;
+  degraded?: boolean;
+  degradedReason?: string;
   reconnectAttempts?: number;
   lastConnectedAt?: number | null;
   lastDisconnect?:

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -526,7 +526,16 @@ describe("GatewayClient connect auth payload", () => {
     failureDetails: Record<string, unknown>;
   }) {
     emitConnectFailure(params.firstWs, params.connectId, params.failureDetails);
-    await vi.waitFor(() => expect(wsInstances.length).toBeGreaterThan(1), { timeout: 3_000 });
+    // The reconnect is scheduled via setTimeout inside scheduleReconnect.
+    // Use fake timers to deterministically advance past the reconnect delay
+    // instead of relying on real timers that can be slow under CI load.
+    vi.useFakeTimers();
+    try {
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(wsInstances.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
     const ws = getLatestWs();
     ws.emitOpen();
     emitConnectChallenge(ws, "nonce-2");

--- a/src/infra/channel-summary.ts
+++ b/src/infra/channel-summary.ts
@@ -58,6 +58,9 @@ const buildAccountDetails = (params: {
   if (snapshot.enabled === false) {
     details.push("disabled");
   }
+  if (snapshot.degraded) {
+    details.push(`degraded${snapshot.degradedReason ? `: ${snapshot.degradedReason}` : ""}`);
+  }
   if (snapshot.dmPolicy) {
     details.push(`dm:${snapshot.dmPolicy}`);
   }
@@ -206,22 +209,27 @@ export async function buildChannelSummary(
         ? summaryRecord.configured
         : configuredEntries.length > 0;
 
+    const hasDegraded = entries.some((entry) => entry.snapshot.degraded);
     const status = !anyEnabled
       ? "disabled"
-      : linked !== null
-        ? linked
-          ? "linked"
-          : "not linked"
-        : configured
-          ? "configured"
-          : "not configured";
+      : hasDegraded
+        ? "degraded"
+        : linked !== null
+          ? linked
+            ? "linked"
+            : "not linked"
+          : configured
+            ? "configured"
+            : "not configured";
 
     const statusColor =
       status === "linked" || status === "configured"
         ? theme.success
-        : status === "not linked"
-          ? theme.error
-          : theme.muted;
+        : status === "degraded"
+          ? theme.warn
+          : status === "not linked"
+            ? theme.error
+            : theme.muted;
     const baseLabel = plugin.meta.label ?? plugin.id;
     let line = `${baseLabel}: ${status}`;
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -152,6 +152,39 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   pairedToolName?: string;
 };
 
+export type DiagnosticTurnStartedEvent = DiagnosticBaseEvent & {
+  type: "turn.started";
+  turnId: string;
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+};
+
+export type DiagnosticTurnCompletedEvent = DiagnosticBaseEvent & {
+  type: "turn.completed";
+  turnId: string;
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  durationMs: number;
+  iterations: number;
+  toolCallCount: number;
+  toolErrors: number;
+  outcome: "success" | "error" | "aborted" | "compaction";
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+  error?: string;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -165,7 +198,9 @@ export type DiagnosticEventPayload =
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent
   | DiagnosticHeartbeatEvent
-  | DiagnosticToolLoopEvent;
+  | DiagnosticToolLoopEvent
+  | DiagnosticTurnStartedEvent
+  | DiagnosticTurnCompletedEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload

--- a/src/infra/turn-summary.ts
+++ b/src/infra/turn-summary.ts
@@ -1,0 +1,111 @@
+import type { CacheTraceEvent } from "../agents/cache-trace.js";
+import type { NormalizedUsage } from "../agents/usage.js";
+
+export type TurnToolCall = {
+  name: string;
+  startedAt: number;
+  completedAt?: number;
+  durationMs?: number;
+  success: boolean;
+  error?: string;
+};
+
+export type TurnSummary = {
+  turnId: string;
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  startedAt: number;
+  completedAt?: number;
+  durationMs?: number;
+  iterations: number;
+  toolCalls: TurnToolCall[];
+  usage?: NormalizedUsage;
+  cacheEvents: CacheTraceEvent[];
+  outcome: "success" | "error" | "aborted" | "compaction";
+  error?: string;
+};
+
+/**
+ * Mutable builder for accumulating turn data during execution.
+ * Call `freeze()` to get the final immutable TurnSummary.
+ */
+export class TurnSummaryBuilder {
+  private summary: TurnSummary;
+  private activeTools = new Map<string, TurnToolCall>();
+
+  constructor(params: {
+    turnId: string;
+    runId: string;
+    sessionKey?: string;
+    sessionId?: string;
+    provider?: string;
+    model?: string;
+  }) {
+    this.summary = {
+      turnId: params.turnId,
+      runId: params.runId,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      provider: params.provider,
+      model: params.model,
+      startedAt: Date.now(),
+      iterations: 0,
+      toolCalls: [],
+      cacheEvents: [],
+      outcome: "success",
+    };
+  }
+
+  incrementIterations(): void {
+    this.summary.iterations += 1;
+  }
+
+  recordToolStart(callId: string, name: string): void {
+    const entry: TurnToolCall = { name, startedAt: Date.now(), success: true };
+    this.activeTools.set(callId, entry);
+    this.summary.toolCalls.push(entry);
+  }
+
+  recordToolEnd(callId: string, success: boolean, error?: string): void {
+    const entry = this.activeTools.get(callId);
+    if (!entry) {
+      return;
+    }
+    entry.completedAt = Date.now();
+    entry.durationMs = entry.completedAt - entry.startedAt;
+    entry.success = success;
+    if (error) {
+      entry.error = error;
+    }
+    this.activeTools.delete(callId);
+  }
+
+  setUsage(usage: NormalizedUsage): void {
+    this.summary.usage = usage;
+  }
+
+  addCacheEvent(event: CacheTraceEvent): void {
+    this.summary.cacheEvents.push(event);
+  }
+
+  setOutcome(outcome: TurnSummary["outcome"], error?: string): void {
+    this.summary.outcome = outcome;
+    if (error) {
+      this.summary.error = error;
+    }
+  }
+
+  freeze(): TurnSummary {
+    const now = Date.now();
+    this.summary.completedAt = now;
+    this.summary.durationMs = now - this.summary.startedAt;
+    return {
+      ...this.summary,
+      toolCalls: [...this.summary.toolCalls],
+      cacheEvents: [...this.summary.cacheEvents],
+    };
+  }
+}

--- a/src/test-utils/turn-recorder.ts
+++ b/src/test-utils/turn-recorder.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { onAgentEvent, type AgentEventPayload } from "../infra/agent-events.js";
+import { onDiagnosticEvent, type DiagnosticEventPayload } from "../infra/diagnostic-events.js";
+
+export type TurnFixtureEntry =
+  | { kind: "agent"; event: AgentEventPayload }
+  | { kind: "diagnostic"; event: DiagnosticEventPayload };
+
+export type TurnFixture = {
+  version: 1;
+  recordedAt: string;
+  entries: TurnFixtureEntry[];
+};
+
+/**
+ * Records all agent and diagnostic events during an active turn into a JSON fixture.
+ * Call `start()` before the turn; call `stop()` after to finalize and write the fixture.
+ */
+export class TurnRecorder {
+  private entries: TurnFixtureEntry[] = [];
+  private disposeAgent: (() => void) | null = null;
+  private disposeDiag: (() => void) | null = null;
+  private startedAt: string | null = null;
+
+  start(): void {
+    this.entries = [];
+    this.startedAt = new Date().toISOString();
+    this.disposeAgent = onAgentEvent((event) => {
+      this.entries.push({ kind: "agent", event });
+    });
+    this.disposeDiag = onDiagnosticEvent((event) => {
+      this.entries.push({ kind: "diagnostic", event });
+    });
+  }
+
+  stop(): TurnFixture {
+    this.disposeAgent?.();
+    this.disposeDiag?.();
+    this.disposeAgent = null;
+    this.disposeDiag = null;
+    const fixture: TurnFixture = {
+      version: 1,
+      recordedAt: this.startedAt ?? new Date().toISOString(),
+      entries: [...this.entries],
+    };
+    this.entries = [];
+    return fixture;
+  }
+
+  writeToFile(fixture: TurnFixture, outputDir: string, label?: string): string {
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const slug = label ? `-${label.replace(/\s+/g, "-").toLowerCase()}` : "";
+    const filename = `turn-fixture${slug}-${ts}.json`;
+    const filePath = path.join(outputDir, filename);
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(fixture, null, 2));
+    return filePath;
+  }
+}

--- a/src/test-utils/turn-replay.test.ts
+++ b/src/test-utils/turn-replay.test.ts
@@ -1,0 +1,529 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { onAgentEvent, resetAgentRunContextForTest } from "../infra/agent-events.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { TurnSummaryBuilder } from "../infra/turn-summary.js";
+import { TurnRecorder, type TurnFixture } from "../test-utils/turn-recorder.js";
+import { replayTurnFixture } from "../test-utils/turn-replayer.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function makeFixture(
+  entries: TurnFixture["entries"],
+  overrides?: Partial<TurnFixture>,
+): TurnFixture {
+  return {
+    version: 1,
+    recordedAt: new Date().toISOString(),
+    entries,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("turn-replay-parity", () => {
+  beforeEach(() => {
+    resetAgentRunContextForTest();
+    resetDiagnosticEventsForTest();
+  });
+
+  // ── Scenario 1: Simple reply (no tool calls) ───────────────────────
+
+  test("scenario 1: simple reply — lifecycle start + assistant + lifecycle end", () => {
+    const fixture = makeFixture([
+      {
+        kind: "agent",
+        event: {
+          runId: "run-1",
+          seq: 1,
+          ts: 1000,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 1000 },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-1",
+          seq: 2,
+          ts: 1050,
+          stream: "assistant",
+          data: { text: "Hello, world!" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-1",
+          seq: 3,
+          ts: 1100,
+          stream: "lifecycle",
+          data: { phase: "end", startedAt: 1000, endedAt: 1100 },
+        },
+      },
+      {
+        kind: "diagnostic",
+        event: {
+          type: "turn.completed",
+          seq: 1,
+          ts: 1100,
+          turnId: "turn-1",
+          runId: "run-1",
+          durationMs: 100,
+          iterations: 1,
+          toolCallCount: 0,
+          toolErrors: 0,
+          outcome: "success",
+        },
+      },
+    ]);
+
+    const agentStreams: string[] = [];
+    const diagTypes: string[] = [];
+    const cleanupA = onAgentEvent((evt) => agentStreams.push(evt.stream));
+    const cleanupD = onDiagnosticEvent((evt) => diagTypes.push(evt.type));
+
+    const result = replayTurnFixture(fixture);
+
+    cleanupA();
+    cleanupD();
+
+    expect(result.entriesReplayed).toBe(4);
+    expect(result.agentEvents).toBe(3);
+    expect(result.diagnosticEvents).toBe(1);
+    expect(agentStreams).toEqual(["lifecycle", "assistant", "lifecycle"]);
+    expect(diagTypes).toEqual(["turn.completed"]);
+  });
+
+  // ── Scenario 2: Single tool call ───────────────────────────────────
+
+  test("scenario 2: single tool call — tool start + tool end + assistant", () => {
+    const fixture = makeFixture([
+      {
+        kind: "agent",
+        event: {
+          runId: "run-2",
+          seq: 1,
+          ts: 2000,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 2000 },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-2",
+          seq: 2,
+          ts: 2010,
+          stream: "tool",
+          data: { phase: "start", tool: "web_search", callId: "call-1" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-2",
+          seq: 3,
+          ts: 2500,
+          stream: "tool",
+          data: { phase: "end", tool: "web_search", callId: "call-1" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-2",
+          seq: 4,
+          ts: 2600,
+          stream: "assistant",
+          data: { text: "I found some results." },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-2",
+          seq: 5,
+          ts: 2700,
+          stream: "lifecycle",
+          data: { phase: "end", startedAt: 2000, endedAt: 2700 },
+        },
+      },
+    ]);
+
+    const toolPhases: string[] = [];
+    const cleanupA = onAgentEvent((evt) => {
+      if (evt.stream === "tool" && typeof evt.data.phase === "string") {
+        toolPhases.push(evt.data.phase);
+      }
+    });
+
+    const result = replayTurnFixture(fixture);
+    cleanupA();
+
+    expect(result.agentEvents).toBe(5);
+    expect(toolPhases).toEqual(["start", "end"]);
+  });
+
+  // ── Scenario 3: Multi-tool chain ──────────────────────────────────
+
+  test("scenario 3: multi-tool chain — three sequential tool calls", () => {
+    const tools = ["read_file", "edit_file", "run_tests"];
+    const entries: TurnFixture["entries"] = [
+      {
+        kind: "agent",
+        event: {
+          runId: "run-3",
+          seq: 1,
+          ts: 3000,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 3000 },
+        },
+      },
+    ];
+    let seq = 2;
+    for (const tool of tools) {
+      entries.push({
+        kind: "agent",
+        event: {
+          runId: "run-3",
+          seq: seq++,
+          ts: 3000 + seq * 100,
+          stream: "tool",
+          data: { phase: "start", tool, callId: `call-${tool}` },
+        },
+      });
+      entries.push({
+        kind: "agent",
+        event: {
+          runId: "run-3",
+          seq: seq++,
+          ts: 3000 + seq * 100,
+          stream: "tool",
+          data: { phase: "end", tool, callId: `call-${tool}` },
+        },
+      });
+    }
+    entries.push({
+      kind: "agent",
+      event: {
+        runId: "run-3",
+        seq: seq++,
+        ts: 4000,
+        stream: "assistant",
+        data: { text: "All done!" },
+      },
+    });
+    entries.push({
+      kind: "agent",
+      event: {
+        runId: "run-3",
+        seq: seq,
+        ts: 4100,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 3000, endedAt: 4100 },
+      },
+    });
+
+    const fixture = makeFixture(entries);
+
+    const toolNames: string[] = [];
+    const cleanupA = onAgentEvent((evt) => {
+      if (
+        evt.stream === "tool" &&
+        evt.data.phase === "start" &&
+        typeof evt.data.tool === "string"
+      ) {
+        toolNames.push(evt.data.tool);
+      }
+    });
+
+    const result = replayTurnFixture(fixture);
+    cleanupA();
+
+    expect(result.agentEvents).toBe(entries.length);
+    expect(toolNames).toEqual(["read_file", "edit_file", "run_tests"]);
+  });
+
+  // ── Scenario 4: Tool error recovery ───────────────────────────────
+
+  test("scenario 4: tool error recovery — first call fails, second succeeds", () => {
+    const fixture = makeFixture([
+      {
+        kind: "agent",
+        event: {
+          runId: "run-4",
+          seq: 1,
+          ts: 4000,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 4000 },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-4",
+          seq: 2,
+          ts: 4010,
+          stream: "tool",
+          data: { phase: "start", tool: "bash", callId: "call-err" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-4",
+          seq: 3,
+          ts: 4200,
+          stream: "tool",
+          data: { phase: "end", tool: "bash", callId: "call-err", error: "exit code 1" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-4",
+          seq: 4,
+          ts: 4300,
+          stream: "tool",
+          data: { phase: "start", tool: "bash", callId: "call-ok" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-4",
+          seq: 5,
+          ts: 4500,
+          stream: "tool",
+          data: { phase: "end", tool: "bash", callId: "call-ok" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-4",
+          seq: 6,
+          ts: 4600,
+          stream: "assistant",
+          data: { text: "Fixed the issue and retried successfully." },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-4",
+          seq: 7,
+          ts: 4700,
+          stream: "lifecycle",
+          data: { phase: "end", startedAt: 4000, endedAt: 4700 },
+        },
+      },
+      {
+        kind: "diagnostic",
+        event: {
+          type: "turn.completed",
+          seq: 1,
+          ts: 4700,
+          turnId: "turn-4",
+          runId: "run-4",
+          durationMs: 700,
+          iterations: 2,
+          toolCallCount: 2,
+          toolErrors: 1,
+          outcome: "success",
+        },
+      },
+    ]);
+
+    const diagEvents: DiagnosticEventPayload[] = [];
+    const cleanupD = onDiagnosticEvent((evt) => diagEvents.push(evt));
+
+    const result = replayTurnFixture(fixture);
+    cleanupD();
+
+    expect(result.diagnosticEvents).toBe(1);
+    const turnEvt = diagEvents.find((e) => e.type === "turn.completed");
+    expect(turnEvt).toBeDefined();
+    if (turnEvt?.type === "turn.completed") {
+      expect(turnEvt.toolErrors).toBe(1);
+      expect(turnEvt.toolCallCount).toBe(2);
+      expect(turnEvt.outcome).toBe("success");
+    }
+  });
+
+  // ── Scenario 5: Context overflow / compaction ─────────────────────
+
+  test("scenario 5: context overflow triggers compaction outcome", () => {
+    const fixture = makeFixture([
+      {
+        kind: "agent",
+        event: {
+          runId: "run-5",
+          seq: 1,
+          ts: 5000,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 5000 },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-5",
+          seq: 2,
+          ts: 5010,
+          stream: "compaction",
+          data: { phase: "start" },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-5",
+          seq: 3,
+          ts: 5500,
+          stream: "compaction",
+          data: { phase: "end", willRetry: false },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-5",
+          seq: 4,
+          ts: 5600,
+          stream: "assistant",
+          data: { text: "Compacted and continuing." },
+        },
+      },
+      {
+        kind: "agent",
+        event: {
+          runId: "run-5",
+          seq: 5,
+          ts: 5700,
+          stream: "lifecycle",
+          data: { phase: "end", startedAt: 5000, endedAt: 5700 },
+        },
+      },
+      {
+        kind: "diagnostic",
+        event: {
+          type: "turn.completed",
+          seq: 1,
+          ts: 5700,
+          turnId: "turn-5",
+          runId: "run-5",
+          durationMs: 700,
+          iterations: 1,
+          toolCallCount: 0,
+          toolErrors: 0,
+          outcome: "compaction",
+        },
+      },
+    ]);
+
+    const diagEvents: DiagnosticEventPayload[] = [];
+    const cleanupD = onDiagnosticEvent((evt) => diagEvents.push(evt));
+
+    replayTurnFixture(fixture);
+    cleanupD();
+
+    const turnEvt = diagEvents.find((e) => e.type === "turn.completed");
+    expect(turnEvt).toBeDefined();
+    if (turnEvt?.type === "turn.completed") {
+      expect(turnEvt.outcome).toBe("compaction");
+      expect(turnEvt.durationMs).toBe(700);
+    }
+  });
+});
+
+// ─── TurnSummaryBuilder unit tests ────────────────────────────────────
+
+describe("TurnSummaryBuilder", () => {
+  test("tracks tool calls and timing", () => {
+    const builder = new TurnSummaryBuilder({
+      turnId: "t-1",
+      runId: "r-1",
+      sessionKey: "sk",
+    });
+    builder.incrementIterations();
+    builder.recordToolStart("c1", "bash");
+    builder.recordToolEnd("c1", true);
+    builder.incrementIterations();
+    builder.recordToolStart("c2", "web_search");
+    builder.recordToolEnd("c2", false, "timeout");
+    builder.setUsage({ input: 100, output: 50 });
+    builder.setOutcome("success");
+    const summary = builder.freeze();
+
+    expect(summary.turnId).toBe("t-1");
+    expect(summary.iterations).toBe(2);
+    expect(summary.toolCalls).toHaveLength(2);
+    expect(summary.toolCalls[0].name).toBe("bash");
+    expect(summary.toolCalls[0].success).toBe(true);
+    expect(summary.toolCalls[1].name).toBe("web_search");
+    expect(summary.toolCalls[1].success).toBe(false);
+    expect(summary.toolCalls[1].error).toBe("timeout");
+    expect(summary.usage?.input).toBe(100);
+    expect(summary.outcome).toBe("success");
+    expect(typeof summary.durationMs).toBe("number");
+    expect(summary.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("freeze returns a snapshot (not a mutable reference)", () => {
+    const builder = new TurnSummaryBuilder({ turnId: "t-2", runId: "r-2" });
+    builder.recordToolStart("c1", "foo");
+    const snap = builder.freeze();
+    builder.recordToolStart("c2", "bar");
+    expect(snap.toolCalls).toHaveLength(1);
+  });
+});
+
+// ─── TurnRecorder unit tests ──────────────────────────────────────────
+
+describe("TurnRecorder", () => {
+  beforeEach(() => {
+    resetAgentRunContextForTest();
+    resetDiagnosticEventsForTest();
+  });
+
+  test("captures and stops cleanly", async () => {
+    const recorder = new TurnRecorder();
+    recorder.start();
+
+    // Simulate some events via the emitters
+    const { emitAgentEvent } = await import("../infra/agent-events.js");
+    const { emitDiagnosticEvent } = await import("../infra/diagnostic-events.js");
+
+    emitAgentEvent({
+      runId: "rec-run-1",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    emitDiagnosticEvent({
+      type: "turn.started",
+      turnId: "rec-turn-1",
+      runId: "rec-run-1",
+    });
+
+    const fixture = recorder.stop();
+
+    expect(fixture.version).toBe(1);
+    expect(fixture.entries).toHaveLength(2);
+    expect(fixture.entries[0].kind).toBe("agent");
+    expect(fixture.entries[1].kind).toBe("diagnostic");
+
+    // After stop, no more events should be captured
+    emitAgentEvent({
+      runId: "rec-run-1",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    expect(fixture.entries).toHaveLength(2);
+  });
+});

--- a/src/test-utils/turn-replayer.ts
+++ b/src/test-utils/turn-replayer.ts
@@ -39,9 +39,11 @@ export function replayTurnFixture(fixture: TurnFixture): ReplayResult {
 function replayEntry(entry: TurnFixtureEntry): void {
   if (entry.kind === "agent") {
     const { seq: _, ts: __, ...rest } = entry.event;
-    emitAgentEvent(rest);
+    const replayEvent: Omit<typeof entry.event, "seq" | "ts"> = rest;
+    emitAgentEvent(replayEvent);
   } else {
     const { seq: _, ts: __, ...rest } = entry.event;
-    emitDiagnosticEvent(rest as unknown as DiagnosticEventInput);
+    const replayEvent: DiagnosticEventInput = rest;
+    emitDiagnosticEvent(replayEvent);
   }
 }

--- a/src/test-utils/turn-replayer.ts
+++ b/src/test-utils/turn-replayer.ts
@@ -1,0 +1,47 @@
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitDiagnosticEvent, type DiagnosticEventInput } from "../infra/diagnostic-events.js";
+import type { TurnFixture, TurnFixtureEntry } from "./turn-recorder.js";
+
+export type ReplayResult = {
+  entriesReplayed: number;
+  agentEvents: number;
+  diagnosticEvents: number;
+  durationMs: number;
+};
+
+/**
+ * Replays a recorded turn fixture by re-emitting all events in order.
+ * Useful for regression testing: listeners attached before replay will
+ * see the same event stream as the original turn.
+ */
+export function replayTurnFixture(fixture: TurnFixture): ReplayResult {
+  const startedAt = Date.now();
+  let agentEvents = 0;
+  let diagnosticEvents = 0;
+
+  for (const entry of fixture.entries) {
+    replayEntry(entry);
+    if (entry.kind === "agent") {
+      agentEvents += 1;
+    } else {
+      diagnosticEvents += 1;
+    }
+  }
+
+  return {
+    entriesReplayed: fixture.entries.length,
+    agentEvents,
+    diagnosticEvents,
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+function replayEntry(entry: TurnFixtureEntry): void {
+  if (entry.kind === "agent") {
+    const { seq: _, ts: __, ...rest } = entry.event;
+    emitAgentEvent(rest);
+  } else {
+    const { seq: _, ts: __, ...rest } = entry.event;
+    emitDiagnosticEvent(rest as unknown as DiagnosticEventInput);
+  }
+}


### PR DESCRIPTION
…nostic commands, branch warning

Rebased onto upstream v2026.4.4. Adapted to lazy-loaded command handler registry, verboseNotices pattern, config/io.ts path changes, try/catch OTel dispatch, and DiagnosticToolLoopEvent union.

## Summary

- Problem: diagnostics and regression tooling had gaps across turn-level telemetry, replay coverage, degraded-state visibility, and operator-facing diagnostic commands.
- Why it matters: these gaps make production diagnosis and regression investigation harder, and they left OTel turn telemetry unbalanced on some execution paths.
- What changed: this branch adds turn-level telemetry plumbing, a replay harness, `/doctor`-style diagnostic commands, degraded-state snapshot support, a branch-freshness warning, follow-up fixes for the review-raised telemetry balance and event export issues, and the latest fix to keep the reply usage footer attached to the main reply payload before trailing plugin/debug payloads.
- What did NOT change (scope boundary): no broad architecture rewrite, no unrelated product behavior changes, and no migration-facing config overhaul beyond the diagnostics-related additions already in this PR.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: turn lifecycle diagnostics and related operator tooling were added across multiple execution paths, but completion/export handling was inconsistent for some paths such as empty or filtered reply payloads.
- Missing detection / guardrail: no regression coverage was locking in balanced telemetry for tool-only, filtered-payload, and exception paths, and there was no focused regression around reply usage footer placement relative to trailing plugin/debug payloads.
- Contributing context (if known): the branch was rebased onto newer upstream changes in handler loading, config paths, and OTel dispatch behavior while this work was in flight.

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: replay/turn-runner coverage around `agent-runner` telemetry emission and diagnostics OTel export, plus `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` for response-usage footer ordering.
- Scenario the test should lock in: every emitted `turn.started` must have a matching `turn.completed`, including tool-only turns, filtered-payload turns, and exception paths, and the usage footer must stay on the primary reply payload even when trailing plugin/debug payloads are appended.
- Why this is the smallest reliable guardrail: the defect spans control-flow boundaries and diagnostics integration, so narrow unit tests are less reliable than turn-level seam coverage.
- Existing test that already covers this (if any): replay harness coverage added in this branch is intended to support this class of regression.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Added `/doctor`, `/prompt`, and `/cache` diagnostic commands.
- Added degraded-state visibility in the channel snapshot.
- Added verbose branch freshness warning on new sessions.
- Added turn-level telemetry export improvements for diagnostics/OTel consumers.
- Kept response usage footers attached to the main reply instead of trailing plugin/debug payloads.

## Diagram

```text
Before:
[user/debug session] -> [partial diagnostics visibility]

After:
[user/debug session] -> [turn telemetry + replay + degraded-state snapshot + diagnostic commands] -> [better diagnosis and regression coverage]
```

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (Yes)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: this adds diagnostic command surface only; risk is limited by keeping scope diagnostic/operator-focused and by existing command handling and review checks.

## Repro + Verification

### Environment

- OS: GitHub Actions matrix + local verification on the updated branch tip
- Runtime/container: repo default CI/runtime targets
- Model/provider: N/A
- Integration/channel (if any): diagnostics-otel and related reply/turn tooling
- Relevant config (redacted): diagnostics enabled for telemetry validation

### Steps

1. Enable diagnostics/OTel path.
2. Run turns that produce normal replies, filtered/empty payloads, tool-only execution, failure paths, and verbose/plugin payload combinations.
3. Confirm telemetry balance, diagnostic event export behavior, and reply usage footer placement.

### Expected

- `turn.started` and `turn.completed` stay balanced across all supported paths.
- Diagnostic commands and degraded-state reporting behave consistently.
- Usage footers remain attached to the primary reply payload.

### Actual

- Addressed in this branch; current branch tip passed local validation.

## Evidence

- [x] Trace/log snippets
- [x] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios: branch contains follow-up fixes for telemetry completion balance, tool-loop OTel export, replay typing cleanup, device-token retry flake prevention, and response-usage footer ordering.
- Edge cases checked: empty/filtered payload and error-path telemetry were the targeted review concerns, plus verbose/plugin trailing payload ordering for usage footers.
- Validation run on the current branch tip: `pnpm check`; `pnpm exec vitest run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts -t "response usage footer"`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: broad PR surface makes review and regression isolation harder.
  - Mitigation: keep follow-up fixes narrowly scoped and rely on replay/telemetry coverage plus CI reruns after conflict resolution.
- Risk: diagnostic command additions could expose inconsistent behavior across paths.
  - Mitigation: validate via seam-level replay coverage and targeted diagnostics checks.
- Risk: reply metadata/debug payload assembly could regress footer placement.
  - Mitigation: lock it with the new focused `runReplyAgent` regression test.
