### PR TITLE
fix(discord): advertise upload-file action so agents can discover file-send capability

### DIFF
--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -90,6 +90,31 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "upload-file") {
+    const to = readStringParam(params, "to", { required: true });
+    const filePath =
+      readStringParam(params, "filePath", { trim: false }) ??
+      readStringParam(params, "path", { trim: false }) ??
+      readStringParam(params, "media", { trim: false });
+    if (!filePath) {
+      throw new Error("upload-file requires filePath, path, or media");
+    }
+    const content = readStringParam(params, "message", { allowEmpty: true });
+    const filename = readStringParam(params, "filename");
+    return await handleDiscordAction(
+      {
+        action: "sendMessage",
+        accountId: accountId ?? undefined,
+        to,
+        content: content ?? "",
+        mediaUrl: filePath,
+        filename: filename ?? undefined,
+      },
+      cfg,
+      actionOptions,
+    );
+  }
+
   if (action === "poll") {
     const to = readStringParam(params, "to", { required: true });
     const question = readStringParam(params, "pollQuestion", {

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -56,6 +56,7 @@ function describeDiscordMessageTool({
     actions.add("read");
     actions.add("edit");
     actions.add("delete");
+    actions.add("upload-file");
   }
   if (discovery.isEnabled("pins")) {
     actions.add("pin");


### PR DESCRIPTION
Closes #60652

## Summary

- Discord message tool now advertises upload-file in its action set, consistent with Slack.
- Added a dedicated upload-file handler in Discord action dispatch that extracts filePath/path/media parameters and delegates to the existing sendMessage backend.

## Root Cause

describeDiscordMessageTool in extensions/discord/src/channel-actions.ts built the action set with send, read, edit, delete, etc. but never included upload-file. The backend capability already existed (the send handler reads media/path/filePath params), but agents could not discover it because the action was not advertised in the tool schema.

Slack correctly adds both download-file and upload-file under its messages feature toggle.

## Changes

extensions/discord/src/channel-actions.ts - added upload-file to the action set under the messages feature toggle.

extensions/discord/src/actions/handle-action.ts - added a dedicated upload-file handler that extracts file params (filePath, path, media) and delegates to sendMessage with the media URL, matching Slack pattern.

## Test Plan

- [x] npx vitest run extensions/discord/src/channel-actions.test.ts - 5/5 pass
- [x] npx vitest run extensions/discord/src/actions/ - 68/68 pass
- [x] npx vitest run src/agents/tools/message-tool.test.ts - 27/27 pass
- [x] No lint errors on touched files

## Risks and Mitigations

- download-file was intentionally not added. Discord file API is different from Slack and would need a dedicated handler with attachment ID resolution. A follow-up PR can add this if needed.
- The upload-file handler delegates to the same sendMessage backend that already handles file attachments via the send action, so no new Discord API surface is involved.

---

[Joel Nishanth](https://offlyn.ai) - [offlyn.AI](https://offlyn.ai)
