### PR TITLE
fix (web-ui): prevent Node-only modules leaking into browser bundle.

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -6,6 +6,7 @@ import {
   defineChatCommand,
 } from "./commands-registry.shared.js";
 import type { ChatCommandDefinition } from "./commands-registry.types.js";
+import { listThinkingLevels } from "./thinking.js";
 
 type ChannelPlugin = ReturnType<typeof listChannelPlugins>[number];
 
@@ -30,7 +31,7 @@ let cachedNativeRegistry: ReturnType<typeof getActivePluginRegistry> | null = nu
 
 function buildChatCommands(): ChatCommandDefinition[] {
   const commands: ChatCommandDefinition[] = [
-    ...buildBuiltinChatCommands(),
+    ...buildBuiltinChatCommands({ listThinkingLevels }),
     ...listChannelPlugins()
       .filter(supportsNativeCommands)
       .map((plugin) => defineDockCommand(plugin)),

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -4,7 +4,14 @@ import type {
   CommandCategory,
   CommandScope,
 } from "./commands-registry.types.js";
-import { listThinkingLevels } from "./thinking.js";
+import { listThinkingLevels as listThinkingLevelsFallback } from "./thinking.shared.js";
+
+type BuildBuiltinChatCommandsDeps = {
+  listThinkingLevels?: (
+    provider?: string | null,
+    model?: string | null,
+  ) => ReturnType<typeof listThinkingLevelsFallback>;
+};
 
 type DefineChatCommandInput = {
   key: string;
@@ -113,7 +120,10 @@ export function assertCommandRegistry(commands: ChatCommandDefinition[]): void {
   }
 }
 
-export function buildBuiltinChatCommands(): ChatCommandDefinition[] {
+export function buildBuiltinChatCommands(
+  deps: BuildBuiltinChatCommandsDeps = {},
+): ChatCommandDefinition[] {
+  const listThinkingLevels = deps.listThinkingLevels ?? listThinkingLevelsFallback;
   const commands: ChatCommandDefinition[] = [
     defineChatCommand({
       key: "help",

--- a/src/sessions/send-policy.ts
+++ b/src/sessions/send-policy.ts
@@ -1,7 +1,13 @@
 import { normalizeChatType } from "../channels/chat-type.js";
+import { getBundledChannelContractSurfaces } from "../channels/plugins/contract-surfaces.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionChatType, SessionEntry } from "../config/sessions.js";
 import { deriveSessionChatType } from "./session-chat-type.js";
+import { setLegacySessionChatTypeSurfacesProvider } from "./session-key-utils.js";
+
+// Register the Node.js-only channel contract surfaces so that deriveSessionChatType
+// can recognise legacy session key formats (WhatsApp @g.us groups, Discord channels, …).
+setLegacySessionChatTypeSurfacesProvider(getBundledChannelContractSurfaces);
 
 export type SessionSendPolicyDecision = "allow" | "deny";
 

--- a/src/sessions/session-chat-type.ts
+++ b/src/sessions/session-chat-type.ts
@@ -1,15 +1,6 @@
-import { getBundledChannelContractSurfaces } from "../channels/plugins/contract-surfaces.js";
-import { parseAgentSessionKey } from "./session-key-utils.js";
+import { listLegacySessionChatTypeSurfaces, parseAgentSessionKey } from "./session-key-utils.js";
 
 export type SessionKeyChatType = "direct" | "group" | "channel" | "unknown";
-
-type LegacySessionChatTypeSurface = {
-  deriveLegacySessionChatType?: (sessionKey: string) => "direct" | "group" | "channel" | undefined;
-};
-
-function listLegacySessionChatTypeSurfaces(): LegacySessionChatTypeSurface[] {
-  return getBundledChannelContractSurfaces() as LegacySessionChatTypeSurface[];
-}
 
 function deriveBuiltInLegacySessionChatType(
   scopedSessionKey: string,

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -15,6 +15,24 @@ export type RawSessionConversationRef = {
   prefix: string;
 };
 
+type LegacySessionChatTypeSurface = {
+  deriveLegacySessionChatType?: (sessionKey: string) => "direct" | "group" | "channel" | undefined;
+};
+
+// Populated at runtime by Node.js entry points (e.g. send-policy.ts).
+// Browser and test contexts that do not register a provider get an empty list,
+// which is safe because legacy WhatsApp/Discord session key detection is
+// server-only behaviour.
+let _legacySurfacesProvider: (() => unknown[]) | null = null;
+
+export function setLegacySessionChatTypeSurfacesProvider(provider: () => unknown[]): void {
+  _legacySurfacesProvider = provider;
+}
+
+function listLegacySessionChatTypeSurfaces(): LegacySessionChatTypeSurface[] {
+  return (_legacySurfacesProvider?.() ?? []) as LegacySessionChatTypeSurface[];
+}
+
 /**
  * Parse agent-scoped session keys in a canonical, case-insensitive way.
  * Returned values are normalized to lowercase for stable comparisons/routing.

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -15,22 +15,14 @@ export type RawSessionConversationRef = {
   prefix: string;
 };
 
-type LegacySessionChatTypeSurface = {
-  deriveLegacySessionChatType?: (sessionKey: string) => "direct" | "group" | "channel" | undefined;
-};
-
 // Populated at runtime by Node.js entry points (e.g. send-policy.ts).
 // Browser and test contexts that do not register a provider get an empty list,
 // which is safe because legacy WhatsApp/Discord session key detection is
-// server-only behaviour.
+// server-only behavior.
 let _legacySurfacesProvider: (() => unknown[]) | null = null;
 
 export function setLegacySessionChatTypeSurfacesProvider(provider: () => unknown[]): void {
   _legacySurfacesProvider = provider;
-}
-
-function listLegacySessionChatTypeSurfaces(): LegacySessionChatTypeSurface[] {
-  return (_legacySurfacesProvider?.() ?? []) as LegacySessionChatTypeSurface[];
 }
 
 /**

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -15,6 +15,14 @@ export type RawSessionConversationRef = {
   prefix: string;
 };
 
+export type LegacySessionChatTypeSurface = {
+  deriveLegacySessionChatType?: (sessionKey: string) => "direct" | "group" | "channel" | undefined;
+};
+
+export function listLegacySessionChatTypeSurfaces(): LegacySessionChatTypeSurface[] {
+  return (_legacySurfacesProvider?.() ?? []) as LegacySessionChatTypeSurface[];
+}
+
 // Populated at runtime by Node.js entry points (e.g. send-policy.ts).
 // Browser and test contexts that do not register a provider get an empty list,
 // which is safe because legacy WhatsApp/Discord session key detection is


### PR DESCRIPTION
## Summary

- Problem: Shared/browser-reachable code paths were coupled to Node-only runtime modules, which could leak Node-only imports into web UI bundles.
- Why it matters: This can break browser builds/runtime and makes shared modules unsafe across environments.
- What changed: Added dependency injection for thinking-level lookup in shared command registry code; moved Node-only wiring to Node runtime entrypoints; added legacy session chat-type surface provider wiring used at runtime.
- What did NOT change (scope boundary): No changes to product features, CLI behavior, config schema, permissions, or external API contracts.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<!-- fill if applicable -->
- Related #<!-- fill if applicable -->
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: A shared module imported Node-only logic directly instead of consuming it via a runtime seam/injected dependency.
- Missing detection / guardrail: No focused test/guardrail specifically enforced browser-safe import boundaries for this path.
- Contributing context (if known): Runtime-specific behavior had grown in shared code over time.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/commands-registry*.test.ts` (or nearest command-registry/browser-safe import test surface).
- Scenario the test should lock in: Building/initializing shared command registry in browser-safe context does not pull Node-only modules.
- Why this is the smallest reliable guardrail: It directly validates the import/runtime seam at the boundary where the regression occurred.
- Existing test that already covers this (if any): None confirmed.
- If no new test is added, why not: Fix was kept minimal and scoped; adding the guardrail can be done as a follow-up if maintainers prefer.

## User-visible / Behavior Changes

None (intended behavior preserved; bug fix is internal boundary correctness).

## Diagram (if applicable)

```text
Before:
[web/shared command registry load] -> [direct Node-only import] -> [browser bundle/runtime risk]

After:
[web/shared command registry load] -> [shared fallback or injected dep] -> [no Node-only import leakage]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (local dev)
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): Web UI / shared command registry path
- Relevant config (redacted): Default local dev config

### Steps

1. Check out branch with fix and rebase onto latest `upstream/main`.
2. Build/load affected shared command/session paths in web UI flow.
3. Verify no Node-only module leakage from shared/browser code paths.

### Expected

- Shared/browser paths do not depend on Node-only modules.
- Legacy session chat-type derivation still works in Node runtime path.

### Actual

- Matches expected after fix.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Rebased cleanly; conflict resolution preserved intended fix; reviewed touched files for runtime boundary correctness.
- Edge cases checked: Legacy session chat-type runtime provider wiring remains Node-entrypoint initialized.
- What you did **not** verify: Full automated suite output is not attached in this PR body; no additional perf/security instrumentation run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Runtime wiring for legacy session chat-type surfaces could be missed if future entrypoints bypass initialization.
  - Mitigation: Wiring is centralized in Node runtime path (`send-policy`), and shared fallback remains safe in browser/test contexts.
- Risk: Boundary regression reintroduced later via new direct imports.
  - Mitigation: Follow-up guardrail test recommended in command registry/browser-safe import surface.
