### PR TITLE
Docs: use --target in README message send example (instead of outdated --to argument)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ openclaw onboard --install-daemon
 openclaw gateway --port 18789 --verbose
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/IRC/Microsoft Teams/Matrix/Feishu/LINE/Mattermost/Nextcloud Talk/Nostr/Synology Chat/Tlon/Twitch/Zalo/Zalo Personal/WeChat/WebChat)
 openclaw agent --message "Ship checklist" --thinking high


### PR DESCRIPTION
## Summary

Problem: The README Quick start showed `openclaw message send --to ...`, but the CLI only documents and accepts `-t / --target` for the recipient (src/cli/program/message/helpers.ts).
Why it matters: Copy-paste from the README fails or confuses new users; official examples already use --target.
What changed: README example updated to use --target instead of --to.
What did NOT change (scope boundary): No CLI, schema, or runtime behavior; no other docs files in this PR.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [X] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [X] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none)
- Related # (none)
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

Root cause: N/A — docs drift vs current CLI flags (README was never updated when --to was removed or was always wrong).
Missing detection / guardrail: N/A (optional: no automated check that README examples match openclaw message send --help).
Contributing context (if known): N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [X] Existing coverage already sufficient
- Target test or file: N/A 
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): CLI help / examples in src/cli/program/register.message.ts already show --target.
- If no new test is added, why not: Documentation-only correction; behavior unchanged.

## User-visible / Behavior Changes

None

## Diagram (if applicable)

NA

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: NA

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Open README.md Quick start block.
2. Confirm the example uses openclaw message send --target ... --message "...".
3. (Optional) Run openclaw message send --help and confirm required recipient flag is --target / -t.

### Expected

- README matches CLI.

### Actual

- README matches CLI after this change.

## Evidence

-  N/A for a one-line README fix — change is visible in the diff.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Compared README example to register.message.ts / message CLI helpers (--target required).
- Edge cases checked: N/A
- What you did not verify: Full pnpm test / CI (optional for you locally; CI will run on the PR).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: NA

## Risks and Mitigations

None
