### PR TITLE
fix(media): remap .aac to .m4a for OpenAI-compatible audio transcription

### DIFF
--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -28,6 +28,63 @@ describe("transcribeOpenAiCompatibleAudio", () => {
     expect(headers.get("user-agent")).toMatch(/^openclaw\//);
   });
 
+  it("remaps .aac extension to .m4a in the uploaded filename", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
+
+    await transcribeOpenAiCompatibleAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.aac",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      fetchFn,
+      provider: "openai",
+      defaultBaseUrl: "https://api.openai.com/v1",
+      defaultModel: "gpt-4o-mini-transcribe",
+    });
+
+    const body = getRequest().init?.body as FormData;
+    const file = body.get("file") as File;
+    expect(file.name).toBe("voice.m4a");
+  });
+
+  it("remaps .AAC extension case-insensitively", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
+
+    await transcribeOpenAiCompatibleAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.AAC",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      fetchFn,
+      provider: "openai",
+      defaultBaseUrl: "https://api.openai.com/v1",
+      defaultModel: "gpt-4o-mini-transcribe",
+    });
+
+    const body = getRequest().init?.body as FormData;
+    const file = body.get("file") as File;
+    expect(file.name).toBe("voice.m4a");
+  });
+
+  it("leaves non-.aac extensions unchanged", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
+
+    await transcribeOpenAiCompatibleAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      fetchFn,
+      provider: "openai",
+      defaultBaseUrl: "https://api.openai.com/v1",
+      defaultModel: "gpt-4o-mini-transcribe",
+    });
+
+    const body = getRequest().init?.body as FormData;
+    const file = body.get("file") as File;
+    expect(file.name).toBe("note.mp3");
+  });
+
   it("does not add hidden attribution headers on custom OpenAI-compatible hosts", async () => {
     const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
 

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -40,7 +40,11 @@ export async function transcribeOpenAiCompatibleAudio(
 
   const model = resolveModel(params.model, params.defaultModel);
   const form = new FormData();
-  const fileName = params.fileName?.trim() || path.basename(params.fileName) || "audio";
+  const rawFileName = params.fileName?.trim() || path.basename(params.fileName) || "audio";
+  // OpenAI-compatible Whisper APIs validate file extension, not content.
+  // .aac is valid AAC audio but not in the accepted list; remap to .m4a
+  // which is the same codec in an MPEG-4 container that APIs accept.
+  const fileName = rawFileName.endsWith(".aac") ? rawFileName.slice(0, -4) + ".m4a" : rawFileName;
   const bytes = new Uint8Array(params.buffer);
   const blob = new Blob([bytes], {
     type: params.mime ?? "application/octet-stream",

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -44,7 +44,7 @@ export async function transcribeOpenAiCompatibleAudio(
   // OpenAI-compatible Whisper APIs validate file extension, not content.
   // .aac is valid AAC audio but not in the accepted list; remap to .m4a
   // which is the same codec in an MPEG-4 container that APIs accept.
-  const fileName = rawFileName.endsWith(".aac") ? rawFileName.slice(0, -4) + ".m4a" : rawFileName;
+  const fileName = rawFileName.replace(/\.aac$/i, ".m4a");
   const bytes = new Uint8Array(params.buffer);
   const blob = new Blob([bytes], {
     type: params.mime ?? "application/octet-stream",


### PR DESCRIPTION
## Summary

- Groq (and other OpenAI-compatible Whisper endpoints) reject `.aac` file extensions with a 400 error, even though the audio content is valid AAC
- Signal saves voice messages with a `.aac` extension, while iMessage/BlueBubbles uses `.m4a` — causing transcription to silently fail for Signal
- Remaps `.aac` → `.m4a` in the multipart upload filename since both use the same AAC codec and `.m4a` is in the accepted extension list

Accepted extensions per Groq/OpenAI Whisper API: `flac, mp3, mp4, mpeg, mpga, m4a, ogg, opus, wav, webm`

## Test plan

- [x] Existing media-understanding tests pass (117/117)
- [x] Type-check clean
- [x] Manually verified: same Signal `.aac` file returns 400 from Groq, but succeeds when renamed to `.m4a`
- [x] Send a voice message via Signal and confirm transcription works end-to-end
