### PR TITLE
fix: normalize legacy plain-array cron stores on load

### DIFF
--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -89,6 +89,56 @@ describe("cron store", () => {
     });
   });
 
+  it("loads legacy plain-array cron stores", async () => {
+    const store = await makeStorePath();
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify([
+        {
+          id: "job-1",
+          name: "Job 1",
+          enabled: true,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "tick-job-1" },
+          state: {},
+        },
+      ]),
+      "utf-8",
+    );
+
+    await expect(loadCronStore(store.storePath)).resolves.toMatchObject({
+      version: 1,
+      jobs: [{ id: "job-1", enabled: true }],
+    });
+  });
+
+  it("preserves legacy plain-array jobs when loading then saving", async () => {
+    const store = await makeStorePath();
+    const legacyJob = makeStore("job-legacy", true).jobs[0];
+    const newJob = makeStore("job-new", false).jobs[0];
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(store.storePath, JSON.stringify([legacyJob]), "utf-8");
+
+    const loaded = await loadCronStore(store.storePath);
+    await saveCronStore(store.storePath, {
+      ...loaded,
+      jobs: [...loaded.jobs, newJob],
+    });
+
+    await expect(loadCronStore(store.storePath)).resolves.toMatchObject({
+      version: 1,
+      jobs: [
+        { id: "job-legacy", enabled: true },
+        { id: "job-new", enabled: false },
+      ],
+    });
+  });
+
   it("does not create a backup file when saving unchanged content", async () => {
     const store = await makeStorePath();
     const payload = makeStore("job-1", true);

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -26,21 +26,30 @@ function stripRuntimeOnlyCronFields(store: CronStoreFile): unknown {
   };
 }
 
-function parseCronStoreForBackupComparison(raw: string): CronStoreFile | null {
-  try {
-    const parsed = parseJsonWithJson5Fallback(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
-    }
-    const version = (parsed as { version?: unknown }).version;
-    const jobs = (parsed as { jobs?: unknown }).jobs;
-    if (version !== 1 || !Array.isArray(jobs)) {
-      return null;
-    }
+function normalizeCronStore(parsed: unknown): CronStoreFile | null {
+  if (Array.isArray(parsed)) {
     return {
       version: 1,
-      jobs: jobs.filter(Boolean) as CronStoreFile["jobs"],
+      jobs: parsed.filter(Boolean) as CronStoreFile["jobs"],
     };
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+  const version = (parsed as { version?: unknown }).version;
+  const jobs = (parsed as { jobs?: unknown }).jobs;
+  if (version !== 1 || !Array.isArray(jobs)) {
+    return null;
+  }
+  return {
+    version: 1,
+    jobs: jobs.filter(Boolean) as CronStoreFile["jobs"],
+  };
+}
+
+function parseCronStoreForBackupComparison(raw: string): CronStoreFile | null {
+  try {
+    return normalizeCronStore(parseJsonWithJson5Fallback(raw));
   } catch {
     return null;
   }
@@ -85,15 +94,7 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
         cause: err,
       });
     }
-    const parsedRecord =
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {};
-    const jobs = Array.isArray(parsedRecord.jobs) ? (parsedRecord.jobs as never[]) : [];
-    const store = {
-      version: 1 as const,
-      jobs: jobs.filter(Boolean) as never as CronStoreFile["jobs"],
-    };
+    const store = normalizeCronStore(parsed) ?? { version: 1 as const, jobs: [] };
     serializedStoreCache.set(storePath, JSON.stringify(store, null, 2));
     return store;
   } catch (err) {


### PR DESCRIPTION
Fixes #60799

**Root cause:** `parseCronStoreForBackupComparison()` rejects top-level arrays and `loadCronStore()` converts them to empty objects, so legacy plain-array `jobs.json` files load as `{ version: 1, jobs: [] }`. First cron write then overwrites the store with only newly-added jobs, dropping all existing ones.

**Fix:** Extract a `normalizeCronStore(parsed)` helper that accepts both legacy top-level arrays and the current `{ version: 1, jobs: [...] }` envelope. Used in both `parseCronStoreForBackupComparison()` and `loadCronStore()`.

**Tests:** Two new regression tests in `store.test.ts`:
- Loads a legacy plain-array store correctly
- Preserves legacy jobs through a load-add-save round trip

2 files changed, 72 insertions, 21 deletions.