### PR TITLE
UI: localize connect command labels

### DIFF
--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -110,6 +110,10 @@ export const de: TranslationMap = {
       stayHttp: "Wenn Sie bei HTTP bleiben müssen, setzen Sie {config} (nur Token).",
     },
   },
+  connectCommand: {
+    copyTitle: "Befehl kopieren",
+    copyAriaLabel: "Befehl kopieren: {command}",
+  },
   chat: {
     disconnected: "Verbindung zum Gateway getrennt.",
     refreshTitle: "Chat-Daten aktualisieren",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -155,6 +155,10 @@ export const en: TranslationMap = {
       noResults: "No results",
     },
   },
+  connectCommand: {
+    copyTitle: "Copy command",
+    copyAriaLabel: "Copy command: {command}",
+  },
   usage: {
     page: {
       subtitle: "See where tokens go, when sessions spike, and what drives cost.",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -127,6 +127,10 @@ export const es: TranslationMap = {
     de: "Deutsch (Alemán)",
     es: "Español",
   },
+  connectCommand: {
+    copyTitle: "Copiar comando",
+    copyAriaLabel: "Copiar comando: {command}",
+  },
   cron: {
     summary: {
       enabled: "Habilitado",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -158,6 +158,10 @@ export const pt_BR: TranslationMap = {
     subtitle: "Painel do Gateway",
     passwordPlaceholder: "opcional",
   },
+  connectCommand: {
+    copyTitle: "Copiar comando",
+    copyAriaLabel: "Copiar comando: {command}",
+  },
   chat: {
     disconnected: "Desconectado do gateway.",
     refreshTitle: "Atualizar dados do chat",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -155,6 +155,10 @@ export const zh_CN: TranslationMap = {
     subtitle: "网关仪表盘",
     passwordPlaceholder: "可选",
   },
+  connectCommand: {
+    copyTitle: "复制命令",
+    copyAriaLabel: "复制命令：{command}",
+  },
   chat: {
     disconnected: "已断开与网关的连接。",
     refreshTitle: "刷新聊天数据",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -155,6 +155,10 @@ export const zh_TW: TranslationMap = {
     subtitle: "閘道儀表板",
     passwordPlaceholder: "可選",
   },
+  connectCommand: {
+    copyTitle: "複製指令",
+    copyAriaLabel: "複製指令：{command}",
+  },
   chat: {
     disconnected: "已斷開與網關的連接。",
     refreshTitle: "刷新聊天數據",

--- a/ui/src/ui/views/connect-command.ts
+++ b/ui/src/ui/views/connect-command.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { t } from "../../i18n/index.ts";
 import { renderCopyButton } from "../chat/copy-as-markdown.ts";
 
 async function copyCommand(command: string) {
@@ -15,8 +16,8 @@ export function renderConnectCommand(command: string) {
       class="login-gate__command"
       role="button"
       tabindex="0"
-      title="Copy command"
-      aria-label=${`Copy command: ${command}`}
+      title=${t("connectCommand.copyTitle")}
+      aria-label=${t("connectCommand.copyAriaLabel", { command })}
       @click=${async (e: Event) => {
         if ((e.target as HTMLElement | null)?.closest(".chat-copy-btn")) {
           return;
@@ -32,7 +33,7 @@ export function renderConnectCommand(command: string) {
       }}
     >
       <code>${command}</code>
-      ${renderCopyButton(command, "Copy command")}
+      ${renderCopyButton(command, t("connectCommand.copyTitle"))}
     </div>
   `;
 }


### PR DESCRIPTION
## Summary

- Problem: `connect-command.ts` still had hardcoded English copy for the tooltip and accessibility label used by the command-copy affordance.
- Why it matters: this control is reused in onboarding/connect flows, so those English labels leak into otherwise localized UI.
- What changed: moved the connect-command tooltip and aria-label into locale keys and wired the view through `t(...)`.
- What did NOT change (scope boundary): no clipboard behavior changes and no command execution changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61036
- Related #61054
- Related #61062
- Related #61073
- Related #61080
- Related #61092
- Related #61104
- Related #61112

## Root Cause (if applicable)

- Root cause: the connect-command surface still embedded a few user-facing labels directly in the view instead of locale files.
- Missing detection / guardrail: locale infrastructure exists, but this helper view still carried hardcoded copy.
- Contributing context (if known): this PR intentionally keeps the cleanup to one tiny reusable surface.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/i18n/test/translate.test.ts`
- Scenario the test should lock in:
  - locale lookups for the new `connectCommand.*` keys resolve correctly.
- Why this is the smallest reliable guardrail:
  - the change is isolated to locale keys plus one tiny helper view.
- Existing test that already covers this (if any):
  - `ui/src/i18n/test/translate.test.ts`
- If no new test is added, why not:
  - existing i18n coverage plus successful UI build were sufficient for this scoped change.

## User-visible / Behavior Changes

- The command-copy affordance now uses locale-backed tooltip and accessibility text.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: local Node/pnpm dev environment
- Model/provider: N/A
- Integration/channel (if any): Control UI connect command helper
- Relevant config (redacted): N/A

### Steps

1. Switch the Control UI locale away from English.
2. View a connect/onboarding command helper.
3. Inspect the tooltip and aria-label around the copy affordance.

### Expected

- Those labels should come from locale files instead of staying hardcoded in English.

### Actual

- The connect-command helper now uses locale-backed strings for those labels.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation:

```text
pnpm --dir ui build
pnpm test ui/src/i18n/test/translate.test.ts -- --project ui
```

## Human Verification (required)

- Verified scenarios:
  - reviewed the connect-command diff to ensure only labels were moved to locale keys
  - confirmed local build passes
  - confirmed targeted UI translation test passes
- Edge cases checked:
  - preserved clipboard copy behavior
  - added real translations in all supported locales for this tiny surface
- What you did **not** verify:
  - full browser walkthrough of every locale using the helper

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Risks and Mitigations

- Risk: other tiny helper views may still contain hardcoded labels.
  - Mitigation: this PR intentionally scopes the cleanup to `connect-command.ts` only.