### PR TITLE
fix(reply): prefer inbound provider for elevated auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Prefer the current inbound provider over persisted session provider when resolving elevated allow-from auth, so webchat/control-ui senders are authorized against the correct `allowFrom` list. (#61099) thanks @bradgroux
+
 - Channels/context visibility: add configurable `contextVisibility` per channel (`all`, `allowlist`, `allowlist_quote`) so supplemental quote, thread, and fetched history context can be filtered by sender allowlists instead of always passing through as received.
 - Matrix/exec approvals: add Matrix-native exec approval prompts with account-scoped approvers, channel-or-DM delivery, and room-thread aware resolution handling. (#58635) Thanks @gumadeiras.
 - Providers/StepFun: add the bundled StepFun provider plugin with standard and Step Plan endpoints, China/global onboarding choices, `step-3.5-flash` on both catalogs, and `step-3.5-flash-2603` currently exposed on Step Plan. (#60032) Thanks @hengm3467.

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -345,7 +345,7 @@ export async function resolveReplyDirectives(params: {
   sessionCtx.BodyStripped = cleanedBody;
 
   const messageProviderKey =
-    sessionCtx.Provider?.trim().toLowerCase() ?? ctx.Provider?.trim().toLowerCase() ?? "";
+    ctx.Provider?.trim().toLowerCase() ?? sessionCtx.Provider?.trim().toLowerCase() ?? "";
   const elevated = resolveElevatedPermissions({
     cfg,
     agentId,

--- a/src/auto-reply/reply/reply-elevated.test.ts
+++ b/src/auto-reply/reply/reply-elevated.test.ts
@@ -3,12 +3,12 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 import { resolveElevatedPermissions } from "./reply-elevated.js";
 
-function buildConfig(allowFrom: string[]): OpenClawConfig {
+function buildConfig(provider: string, allowFrom: string[]): OpenClawConfig {
   return {
     tools: {
       elevated: {
         allowFrom: {
-          whatsapp: allowFrom,
+          [provider]: allowFrom,
         },
       },
     },
@@ -28,14 +28,16 @@ function buildContext(overrides?: Partial<MsgContext>): MsgContext {
 }
 
 function expectAllowFromDecision(params: {
+  provider?: string;
   allowFrom: string[];
   ctx?: Partial<MsgContext>;
   allowed: boolean;
 }) {
+  const provider = params.provider ?? "whatsapp";
   const result = resolveElevatedPermissions({
-    cfg: buildConfig(params.allowFrom),
+    cfg: buildConfig(provider, params.allowFrom),
     agentId: "main",
-    provider: "whatsapp",
+    provider,
     ctx: buildContext(params.ctx),
   });
 
@@ -48,7 +50,7 @@ function expectAllowFromDecision(params: {
 
   expect(result.failures).toContainEqual({
     gate: "allowFrom",
-    key: "tools.elevated.allowFrom.whatsapp",
+    key: `tools.elevated.allowFrom.${provider}`,
   });
 }
 
@@ -85,6 +87,23 @@ describe("resolveElevatedPermissions", () => {
       allowed: true,
       ctx: {
         SenderUsername: "owner_username",
+      },
+    });
+  });
+
+  it("authorizes webchat sender ids via plain allowFrom entries", () => {
+    expectAllowFromDecision({
+      provider: "webchat",
+      allowFrom: ["openclaw-control-ui"],
+      allowed: true,
+      ctx: {
+        Provider: "webchat",
+        Surface: "webchat",
+        SenderId: "openclaw-control-ui",
+        SenderName: "OpenClaw Control UI",
+        SenderUsername: "OpenClaw Control UI",
+        From: "webchat:openclaw-control-ui",
+        SenderE164: undefined,
       },
     });
   });


### PR DESCRIPTION
## Summary
- prefer the current inbound `ctx.Provider` over persisted `sessionCtx.Provider` when resolving elevated auth
- keep `allowFrom` authorization keyed to the live inbound provider instead of stale session state
- add webchat coverage for `openclaw-control-ui`

## Problem
Elevated authorization could use a persisted session provider before the current inbound provider. In mixed-session flows, that lets stale session state drive `allowFrom` lookup, so valid webchat/control-ui senders can be evaluated against the wrong provider-specific allowlist.

## Fix
In `src/auto-reply/reply/get-reply-directives.ts`, prefer `ctx.Provider` before `sessionCtx.Provider` when calling `resolveElevatedPermissions(...)`.

## Testing
- `pnpm exec vitest run --config tmp/elevated-webchat.scoped.config.ts src/auto-reply/reply/reply-elevated.test.ts src/auto-reply/reply/commands.test.ts`
