### PR TITLE
fix(signal): resolve contentType for voice notes when signal-cli omits it

### DIFF
--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -297,9 +297,9 @@ async function fetchAttachment(params: {
   // Resolve contentType: prefer signal-cli's value, then sniff from buffer + filename.
   // signal-cli omits contentType for voice notes on some platforms/versions,
   // leaving saveMediaBuffer unable to classify the audio (no filePath, sniff
-  // fails for ADTS AAC). Detect here so the downstream transcription pipeline
-  // sees a usable MIME. Requires attachment.filename for the extension-based
-  // fallback to work. See #48614.
+  // fails for ADTS AAC). Pre-resolve here because saveMediaBuffer's internal
+  // detectMime only receives headerMime (no filePath), so without this the
+  // extension-based fallback is unreachable. See #48614.
   const filename = attachment.filename ?? undefined;
   const resolvedContentType =
     attachment.contentType ?? (await detectMime({ buffer, filePath: filename }));

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -7,7 +7,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/config-runtime";
 import { waitForTransportReady } from "openclaw/plugin-sdk/infra-runtime";
-import { estimateBase64DecodedBytes, saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
+import { detectMime, estimateBase64DecodedBytes, saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import {
   deliverTextOrMediaReply,
@@ -294,11 +294,21 @@ async function fetchAttachment(params: {
     );
   }
   const buffer = Buffer.from(result.data, "base64");
+  // Resolve contentType: prefer signal-cli's value, then sniff from buffer + filename.
+  // signal-cli omits contentType for voice notes on some platforms/versions,
+  // leaving saveMediaBuffer unable to classify the audio (no filePath, sniff
+  // fails for ADTS AAC). Detect here so the downstream transcription pipeline
+  // sees a usable MIME. Requires attachment.filename for the extension-based
+  // fallback to work. See #48614.
+  const filename = attachment.filename ?? undefined;
+  const resolvedContentType =
+    attachment.contentType ?? (await detectMime({ buffer, filePath: filename }));
   const saved = await saveMediaBuffer(
     buffer,
-    attachment.contentType ?? undefined,
+    resolvedContentType,
     "inbound",
     params.maxBytes,
+    filename,
   );
   return { path: saved.path, contentType: saved.contentType };
 }

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -280,6 +280,52 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(capture.ctx?.MediaTypes).toEqual(["image/jpeg", "application/octet-stream"]);
   });
 
+  it("resolves audio contentType via filename when signal-cli omits contentType (#48614)", async () => {
+    // fetchAttachment is private in monitor.ts, so we simulate the fixed behavior:
+    // when contentType is missing, detectMime resolves MIME from the filename extension.
+    // The detectMime unit test below proves that mechanism; this test proves the event
+    // handler threads the resolved contentType into MsgContext correctly.
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        },
+        ignoreAttachments: false,
+        fetchAttachment: async ({ attachment }) => ({
+          path: `/tmp/${String(attachment.id)}.aac`,
+          contentType: "audio/aac",
+        }),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "",
+          attachments: [{ id: "voice1", contentType: undefined, filename: "voice.aac" }],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.MediaPath).toBe("/tmp/voice1.aac");
+    expect(capture.ctx?.MediaType).toBe("audio/aac");
+    expect(capture.ctx?.MediaTypes).toEqual(["audio/aac"]);
+  });
+
+  it("detectMime resolves audio/aac from bare filename when buffer sniff fails (#48614)", async () => {
+    // Core assertion: detectMime with a bare filename (no full path) returns the
+    // correct MIME from the extension, even when the buffer is not sniffable.
+    // This is what fetchAttachment relies on after the fix.
+    const { detectMime } = await import("openclaw/plugin-sdk/media-runtime");
+    // 16 bytes of zeroes — not valid AAC, so fileTypeFromBuffer returns undefined.
+    const unsniffableBuffer = Buffer.alloc(16);
+    const mime = await detectMime({ buffer: unsniffableBuffer, filePath: "voice.aac" });
+    expect(mime).toBe("audio/aac");
+  });
+
   it("drops own UUID inbound messages when only accountUuid is configured", async () => {
     const ownUuid = "123e4567-e89b-12d3-a456-426614174000";
     const handler = createSignalEventHandler(


### PR DESCRIPTION
## Summary

- **Problem:** Signal voice notes are saved to disk but the transcription pipeline never runs. signal-cli on Linux omits `contentType` on voice note attachments, leaving `saveMediaBuffer` unable to classify the audio (`fileTypeFromBuffer` fails on ADTS AAC, no `filePath` fallback). The file is saved without extension, `MediaTypes` falls back to `application/octet-stream`, `isAudioAttachment()` returns false, and `selectAttachments` exits with `outcome: no-attachment` — silently.
- **Why it matters:** Completely blocks voice memo transcription on Signal for Linux deployments. `tools.media.audio` is configured but never triggers.
- **What changed:** In `fetchAttachment`, run `detectMime({ buffer, filePath: filename })` before calling `saveMediaBuffer` so the extension-based MIME lookup resolves `audio/aac` from the attachment filename. Also forward `attachment.filename` as `originalFilename` so saved files preserve the original extension on disk.
- **What did NOT change:** No core media pipeline changes. No other channel adapters touched. No config schema changes.

**AI-assisted:** This fix was developed with Claude Code (Opus 4.6). Fully tested — see evidence below.

**Dependency:** This fix is necessary but not sufficient for end-to-end Signal voice transcription. OpenAI rejects `.aac` file extensions (returns 400 "Unsupported file format aac"), which is addressed by #61094. Both PRs must land for transcription to work. We verified the full chain locally with both fixes applied — see evidence.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48614
- Related #61094 (`.aac` → `.m4a` remap — required for OpenAI provider acceptance)
- Related #60421 (transcription errors silently swallowed at default log level)
- Related #56010, #55052 (similar symptoms on Telegram)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `fetchAttachment` in `extensions/signal/src/monitor.ts` passes `attachment.contentType ?? undefined` to `saveMediaBuffer`. When signal-cli omits `contentType` (observed on Linux with signal-cli 0.14.1), `saveMediaBuffer` calls `detectMime({ buffer, headerMime: undefined })` — no `filePath`, so the extension-based MIME fallback is impossible. `fileTypeFromBuffer` cannot detect ADTS-format AAC. Result: `mime = undefined`, file saved as bare UUID without extension, `ctx.MediaTypes = ["application/octet-stream"]`, `isAudioAttachment()` returns false.
- **Missing detection / guardrail:** No fallback to `attachment.filename` for MIME resolution. Matrix got this fix in v2026.3.28 (#55692 — forwarding `originalFilename` to `saveMediaBuffer`), but Signal was missed.
- **Contributing context:** signal-cli on macOS consistently provides `contentType: "audio/aac"` on voice note attachments; Linux signal-cli 0.14.1 sometimes omits it. The `SignalAttachment` type already includes `filename?: string` but it was never used.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/signal/src/monitor/event-handler.inbound-context.test.ts`
- Scenario the test should lock in:
  1. Event handler threads resolved `audio/aac` contentType into `MsgContext` when `fetchAttachment` returns it (integration wiring test)
  2. `detectMime({ buffer, filePath: "voice.aac" })` returns `"audio/aac"` when buffer sniffing fails (core mechanism test — proves bare filename is sufficient for `getFileExtension`/`MIME_BY_EXT` lookup)
- Why this is the smallest reliable guardrail: `fetchAttachment` is private, so we test the two halves separately — the event handler's contentType threading (existing test pattern) and the `detectMime` filename-based resolution (new direct test).
- Existing test that already covers this (if any): The existing "forwards all fetched attachments via MediaPaths/MediaTypes" test at line 255 covers the happy path but explicitly expects `"application/octet-stream"` for attachments without contentType — confirming the bug was baked into test expectations.

## Evidence

**Unit tests:**
```
pnpm test:extension signal — 19 files, 169/169 passed
pnpm check — clean (lint, format, typecheck)
pnpm build — clean
```

**Live end-to-end verification (with #61094 applied on test branch):**
- Built v2026.4.2 + this fix + #61094's `.aac` → `.m4a` remap
- Started gateway from fork against production workspace (`~/.openclaw/`)
- Sent Signal voice note from phone
- OpenClaw transcribed: *"Signal audio transcription test with Ben Z's fix. Time is 10:15 p.m."*
- `echoTranscript` delivered transcript back to Signal chat

**curl verification of the `.aac` rejection (why #61094 is needed):**
```
$ curl https://api.openai.com/v1/audio/transcriptions -F file="@voice.aac" -F model="gpt-4o-mini-transcribe"
→ 400: "Unsupported file format aac"

$ curl https://api.openai.com/v1/audio/transcriptions -F "file=@voice.aac;filename=voice.m4a" -F model="gpt-4o-mini-transcribe"
→ 200: {"text": "Signal audio transcription test..."}
```

## Human Verification (required)

- **Verified scenarios:** Full Signal voice note → transcription → echo reply chain on Linux (Ubuntu, signal-cli 0.14.1, OpenAI gpt-4o-mini-transcribe). Sent 3 voice notes across test runs.
- **Edge cases checked:** Attachment with `contentType: undefined` + `filename: "voice.aac"` (primary fix path). Verified `detectMime` resolves correctly with bare filename (no full path).
- **What I did not verify:** Voice notes where both `contentType` AND `filename` are missing (falls back to pre-fix behavior — `application/octet-stream`). Other channels (Telegram, WhatsApp, Discord).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** `detectMime` called with bare filename instead of full path — `getFileExtension` uses `path.extname` which handles bare filenames correctly, verified by unit test.
  - Mitigation: Direct unit test for `detectMime({ buffer, filePath: "voice.aac" })` → `"audio/aac"`.
- **Risk:** When both `contentType` and `filename` are missing, behavior is unchanged (falls through to `undefined`). No regression, but also no improvement for that edge case.
  - Mitigation: Documented in PR; would require adding `voiceNote?: boolean` to `SignalAttachment` type as a future enhancement.