### PR TITLE
fix: guard sanitizeChatSendMessageInput against non-string message objects

### DIFF
--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -35,7 +35,7 @@ export const ChatHistoryParamsSchema = Type.Object(
 export const ChatSendParamsSchema = Type.Object(
   {
     sessionKey: ChatSendSessionKeyString,
-    message: Type.String(),
+    message: Type.Union([Type.String(), Type.Record(Type.String(), Type.Unknown())]),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     originatingChannel: Type.Optional(Type.String()),

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -35,7 +35,7 @@ export const ChatHistoryParamsSchema = Type.Object(
 export const ChatSendParamsSchema = Type.Object(
   {
     sessionKey: ChatSendSessionKeyString,
-    message: Type.Union([Type.String(), Type.Record(Type.String(), Type.Unknown())]),
+    message: Type.String(),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     originatingChannel: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -308,7 +308,7 @@ export function sanitizeChatSendMessageInput(
       (typeof obj.body === "string" ? obj.body : undefined) ??
       (typeof obj.conversation === "string" ? obj.conversation : undefined) ??
       (typeof obj.content === "string" ? obj.content : undefined);
-    if (!extracted) {
+    if (extracted === undefined) {
       return { ok: false, error: "message must be a string (received unsupported object)" };
     }
     text = extracted;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -292,9 +292,31 @@ function stripDisallowedChatControlChars(message: string): string {
 }
 
 export function sanitizeChatSendMessageInput(
-  message: string,
+  message: unknown,
 ): { ok: true; message: string } | { ok: false; error: string } {
-  const normalized = message.normalize("NFC");
+  // Guard: if message is not a string, attempt to extract text from common
+  // channel object shapes (Telegram caption objects, WhatsApp/Baileys raw
+  // message structures, etc.) before falling back to rejection.
+  let text: string;
+  if (typeof message === "string") {
+    text = message;
+  } else if (message != null && typeof message === "object") {
+    const obj = message as Record<string, unknown>;
+    const extracted =
+      (typeof obj.text === "string" ? obj.text : undefined) ??
+      (typeof obj.caption === "string" ? obj.caption : undefined) ??
+      (typeof obj.body === "string" ? obj.body : undefined) ??
+      (typeof obj.conversation === "string" ? obj.conversation : undefined) ??
+      (typeof obj.content === "string" ? obj.content : undefined);
+    if (!extracted) {
+      return { ok: false, error: "message must be a string (received unsupported object)" };
+    }
+    text = extracted;
+  } else {
+    return { ok: false, error: "message must be a string" };
+  }
+
+  const normalized = text.normalize("NFC");
   if (normalized.includes("\u0000")) {
     return { ok: false, error: "message must not contain null bytes" };
   }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -310,6 +310,47 @@ describe("sanitizeChatSendMessageInput", () => {
   ])("$name", ({ input, expected }) => {
     expect(sanitizeChatSendMessageInput(input)).toEqual(expected);
   });
+
+  it("extracts text from object with .text property", () => {
+    expect(sanitizeChatSendMessageInput({ text: "hello", entities: [] } as unknown as string)).toEqual({
+      ok: true,
+      message: "hello",
+    });
+  });
+
+  it("extracts caption from object with .caption property", () => {
+    expect(sanitizeChatSendMessageInput({ caption: "photo caption" } as unknown as string)).toEqual({
+      ok: true,
+      message: "photo caption",
+    });
+  });
+
+  it("extracts body from WhatsApp/Baileys object", () => {
+    expect(sanitizeChatSendMessageInput({ body: "whatsapp msg" } as unknown as string)).toEqual({
+      ok: true,
+      message: "whatsapp msg",
+    });
+  });
+
+  it("extracts conversation from Baileys raw message", () => {
+    expect(
+      sanitizeChatSendMessageInput({ conversation: "baileys text" } as unknown as string),
+    ).toEqual({ ok: true, message: "baileys text" });
+  });
+
+  it("rejects object with no extractable text fields", () => {
+    expect(sanitizeChatSendMessageInput({ foo: "bar" } as unknown as string)).toEqual({
+      ok: false,
+      error: "message must be a string (received unsupported object)",
+    });
+  });
+
+  it("rejects non-string non-object values", () => {
+    expect(sanitizeChatSendMessageInput(42 as unknown as string)).toEqual({
+      ok: false,
+      error: "message must be a string",
+    });
+  });
 });
 
 describe("gateway chat transcript writes (guardrail)", () => {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -312,21 +312,21 @@ describe("sanitizeChatSendMessageInput", () => {
   });
 
   it("extracts text from object with .text property", () => {
-    expect(sanitizeChatSendMessageInput({ text: "hello", entities: [] } as unknown as string)).toEqual({
+    expect(sanitizeChatSendMessageInput({ text: "hello", entities: [] })).toEqual({
       ok: true,
       message: "hello",
     });
   });
 
   it("extracts caption from object with .caption property", () => {
-    expect(sanitizeChatSendMessageInput({ caption: "photo caption" } as unknown as string)).toEqual({
+    expect(sanitizeChatSendMessageInput({ caption: "photo caption" })).toEqual({
       ok: true,
       message: "photo caption",
     });
   });
 
   it("extracts body from WhatsApp/Baileys object", () => {
-    expect(sanitizeChatSendMessageInput({ body: "whatsapp msg" } as unknown as string)).toEqual({
+    expect(sanitizeChatSendMessageInput({ body: "whatsapp msg" })).toEqual({
       ok: true,
       message: "whatsapp msg",
     });
@@ -334,19 +334,19 @@ describe("sanitizeChatSendMessageInput", () => {
 
   it("extracts conversation from Baileys raw message", () => {
     expect(
-      sanitizeChatSendMessageInput({ conversation: "baileys text" } as unknown as string),
+      sanitizeChatSendMessageInput({ conversation: "baileys text" }),
     ).toEqual({ ok: true, message: "baileys text" });
   });
 
   it("rejects object with no extractable text fields", () => {
-    expect(sanitizeChatSendMessageInput({ foo: "bar" } as unknown as string)).toEqual({
+    expect(sanitizeChatSendMessageInput({ foo: "bar" })).toEqual({
       ok: false,
       error: "message must be a string (received unsupported object)",
     });
   });
 
   it("rejects non-string non-object values", () => {
-    expect(sanitizeChatSendMessageInput(42 as unknown as string)).toEqual({
+    expect(sanitizeChatSendMessageInput(42)).toEqual({
       ok: false,
       error: "message must be a string",
     });


### PR DESCRIPTION
## Summary

Fixes the `[object Object]` bug where Telegram photo captions and WhatsApp/Baileys raw messages arrive as `[object Object]` instead of the actual text.

## Root Cause

`sanitizeChatSendMessageInput()` assumes its `message` parameter is always a string. When channel integrations pass an object (e.g. Telegram caption with entities, Baileys raw message structure), calling `.normalize('NFC')` triggers `.toString()` → `"[object Object]"`.

## Fix

Add a type guard at the top of `sanitizeChatSendMessageInput()` that:
1. Passes strings through unchanged (existing behavior)
2. Extracts text from common channel object shapes: `.text`, `.caption`, `.body`, `.conversation`, `.content`
3. Returns a clear error if the object has no extractable text field
4. Rejects non-string/non-object values explicitly

## Tests Added

6 new test cases covering:
- Object with `.text` (Telegram text messages)
- Object with `.caption` (Telegram photo captions)
- Object with `.body` (WhatsApp)
- Object with `.conversation` (Baileys)
- Object with no extractable fields (error case)
- Non-string non-object values (error case)

## Related Issues

- Fixes #61142 — Telegram photo captions arrive as `[object Object]`
- Fixes #52464 — WhatsApp messages arrive as `[object Object]` (same root cause)
- Related to #45999 — Telegram `[object Object]` regression