### PR TITLE
fix(discord): pass accountId and token to ack reaction handlers

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -171,11 +171,15 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
         rest: discordRest,
+        token,
+        accountId,
       });
     },
     removeReaction: async (emoji) => {
       await removeReactionDiscord(messageChannelId, message.id, emoji, {
         rest: discordRest,
+        token,
+        accountId,
       });
     },
   };


### PR DESCRIPTION
## Summary

- Passes `accountId` and `token` to `reactMessageDiscord()` and `removeReactionDiscord()` in the Discord status reaction adapter
- Without these, `createDiscordRestClient` falls back to `accountId = "default"`, which throws when only named accounts are configured
- The failure was completely silent at debug log level — only visible with `--verbose`

## Root Cause

In `processDiscordMessage`, the `statusReactionController` adapter calls `reactMessageDiscord` without passing `accountId` or `token`:

```ts
setReaction: async (emoji) => {
  await reactMessageDiscord(messageChannelId, message.id, emoji, {
    rest: discordRest,
    // accountId and token missing here
  });
},
```

This causes `createDiscordRestClient` to resolve `accountId` as `"default"`, then fail with:
```
Discord bot token missing for account "default" (set discord.accounts.default.token or DISCORD_BOT_TOKEN for default).
```

The error is caught in `applyEmoji`'s try/catch and forwarded to `onError` → `logAckFailure` → `logVerbose`, which only writes to the file logger — invisible in Docker logs at any level.

## Fix

Both `accountId` and `token` are already destructured from `ctx` (line 75-76) and used elsewhere in the same function. This change passes them through to the reaction adapter opts.

## Validation

- `accountId` is already in scope and used in the same function
- `token` is already in scope and used in the same function
- `DiscordReactOpts` type already accepts both `accountId?: string` and `token?: string`
- Tested with a multi-account Discord setup (named account `riven67`, no default token) — reactions now appear correctly

## Scope

XS — 4-line addition in one file

Revives #22938 / #22973 (both auto-closed by stale bot)