### PR TITLE
CLI: fix Docker gateway startup hang

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -402,6 +402,8 @@ describe("argv helpers", () => {
     { argv: ["node", "openclaw", "status"], expected: false },
     { argv: ["node", "openclaw", "health"], expected: false },
     { argv: ["node", "openclaw", "sessions"], expected: false },
+    { argv: ["node", "openclaw", "gateway", "run"], expected: false },
+    { argv: ["node", "openclaw", "cron", "run", "job-123"], expected: false },
     { argv: ["node", "openclaw", "config", "get", "update"], expected: false },
     { argv: ["node", "openclaw", "config", "unset", "update"], expected: false },
     { argv: ["node", "openclaw", "models", "list"], expected: false },
@@ -416,6 +418,8 @@ describe("argv helpers", () => {
 
   it.each([
     { path: ["status"], expected: false },
+    { path: ["gateway", "run"], expected: false },
+    { path: ["cron", "run"], expected: false },
     { path: ["update", "status"], expected: false },
     { path: ["config", "get"], expected: false },
     { path: ["models", "status"], expected: false },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -305,7 +305,13 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
     return true;
   }
   const [primary, secondary] = path;
-  if (primary === "health" || primary === "status" || primary === "sessions") {
+  if (
+    primary === "health" ||
+    primary === "status" ||
+    primary === "sessions" ||
+    primary === "gateway" ||
+    primary === "cron"
+  ) {
     return false;
   }
   if (primary === "update" && secondary === "status") {

--- a/src/cli/banner-config-lite.test.ts
+++ b/src/cli/banner-config-lite.test.ts
@@ -163,4 +163,49 @@ describe("readCliBannerTaglineMode", () => {
 
     expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: configPath })).toBe("off");
   });
+
+  it("hydrates dotenv before resolving banner env substitutions for process.env", () => {
+    const root = makeTempDir("openclaw-banner-dotenv-");
+    const configPath = path.join(root, "openclaw.json");
+    const envPath = path.join(root, ".env");
+    fs.writeFileSync(
+      configPath,
+      `{
+        cli: {
+          banner: {
+            taglineMode: "\${TAGLINE_MODE}",
+          },
+        },
+      }
+      `,
+      "utf-8",
+    );
+    fs.writeFileSync(envPath, "TAGLINE_MODE=off\n", "utf-8");
+
+    const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousTaglineMode = process.env.TAGLINE_MODE;
+    delete process.env.TAGLINE_MODE;
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    process.env.OPENCLAW_STATE_DIR = root;
+    try {
+      expect(readCliBannerTaglineMode()).toBe("off");
+    } finally {
+      if (previousConfigPath === undefined) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+      }
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      if (previousTaglineMode === undefined) {
+        delete process.env.TAGLINE_MODE;
+      } else {
+        process.env.TAGLINE_MODE = previousTaglineMode;
+      }
+    }
+  });
 });

--- a/src/cli/banner-config-lite.test.ts
+++ b/src/cli/banner-config-lite.test.ts
@@ -68,4 +68,50 @@ describe("readCliBannerTaglineMode", () => {
     expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: missingPath })).toBeUndefined();
     expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: invalidPath })).toBeUndefined();
   });
+
+  it("resolves tagline mode from process env substitution", () => {
+    const root = makeTempDir("openclaw-banner-process-env-");
+    const configPath = path.join(root, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      `{
+        cli: {
+          banner: {
+            taglineMode: "\${TAGLINE_MODE}",
+          },
+        },
+      }
+      `,
+      "utf-8",
+    );
+
+    expect(
+      readCliBannerTaglineMode({
+        OPENCLAW_CONFIG_PATH: configPath,
+        TAGLINE_MODE: "off",
+      }),
+    ).toBe("off");
+  });
+
+  it("resolves tagline mode from config env substitution", () => {
+    const root = makeTempDir("openclaw-banner-config-env-");
+    const configPath = path.join(root, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      `{
+        env: {
+          TAGLINE_MODE: "default",
+        },
+        cli: {
+          banner: {
+            taglineMode: "\${TAGLINE_MODE}",
+          },
+        },
+      }
+      `,
+      "utf-8",
+    );
+
+    expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: configPath })).toBe("default");
+  });
 });

--- a/src/cli/banner-config-lite.test.ts
+++ b/src/cli/banner-config-lite.test.ts
@@ -114,4 +114,53 @@ describe("readCliBannerTaglineMode", () => {
 
     expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: configPath })).toBe("default");
   });
+
+  it("prefers the OPENCLAW_STATE_DIR config path over legacy home fallbacks", () => {
+    const homeRoot = makeTempDir("openclaw-banner-home-");
+    const stateDir = makeTempDir("openclaw-banner-state-");
+    const legacyConfigDir = path.join(homeRoot, ".openclaw");
+    const legacyConfigPath = path.join(legacyConfigDir, "openclaw.json");
+    fs.mkdirSync(legacyConfigDir, { recursive: true });
+    fs.writeFileSync(
+      legacyConfigPath,
+      `{
+        cli: {
+          banner: {
+            taglineMode: "off",
+          },
+        },
+      }
+      `,
+      "utf-8",
+    );
+
+    expect(
+      readCliBannerTaglineMode({
+        HOME: homeRoot,
+        OPENCLAW_STATE_DIR: stateDir,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps a valid banner mode when unrelated env vars are missing", () => {
+    const root = makeTempDir("openclaw-banner-missing-env-");
+    const configPath = path.join(root, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      `{
+        features: {
+          extra: "\${MISSING_VALUE}",
+        },
+        cli: {
+          banner: {
+            taglineMode: "off",
+          },
+        },
+      }
+      `,
+      "utf-8",
+    );
+
+    expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: configPath })).toBe("off");
+  });
 });

--- a/src/cli/banner-config-lite.test.ts
+++ b/src/cli/banner-config-lite.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readCliBannerTaglineMode } from "./banner-config-lite.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("readCliBannerTaglineMode", () => {
+  it("reads tagline mode from the active config file", () => {
+    const root = makeTempDir("openclaw-banner-config-");
+    const configPath = path.join(root, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      `{
+        cli: {
+          banner: {
+            taglineMode: "off",
+          },
+        },
+      }
+      `,
+      "utf-8",
+    );
+
+    expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: configPath })).toBe("off");
+  });
+
+  it("resolves tagline mode from included config files", () => {
+    const root = makeTempDir("openclaw-banner-include-");
+    const configPath = path.join(root, "openclaw.json");
+    const includePath = path.join(root, "banner.json5");
+    fs.writeFileSync(configPath, `{ "$include": "./banner.json5" }\n`, "utf-8");
+    fs.writeFileSync(
+      includePath,
+      `{
+        cli: {
+          banner: {
+            taglineMode: "default",
+          },
+        },
+      }
+      `,
+      "utf-8",
+    );
+
+    expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: configPath })).toBe("default");
+  });
+
+  it("returns undefined when the config is missing or invalid", () => {
+    const root = makeTempDir("openclaw-banner-missing-");
+    const missingPath = path.join(root, "missing.json");
+    const invalidPath = path.join(root, "invalid.json");
+    fs.writeFileSync(invalidPath, "{ not valid json5", "utf-8");
+
+    expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: missingPath })).toBeUndefined();
+    expect(readCliBannerTaglineMode({ OPENCLAW_CONFIG_PATH: invalidPath })).toBeUndefined();
+  });
+});

--- a/src/cli/banner-config-lite.ts
+++ b/src/cli/banner-config-lite.ts
@@ -5,6 +5,7 @@ import { applyConfigEnvVars } from "../config/env-vars.js";
 import { resolveConfigIncludes } from "../config/includes.js";
 import { resolveConfigPath } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { loadDotEnv } from "../infra/dotenv.js";
 import type { TaglineMode } from "./tagline.js";
 
 function parseTaglineMode(value: unknown): TaglineMode | undefined {
@@ -34,6 +35,9 @@ export function readCliBannerTaglineMode(
     // Keep banner startup cheap, but still honor config.env and ${VAR} substitution.
     if (parsed && typeof parsed === "object" && "env" in parsed) {
       applyConfigEnvVars(parsed as OpenClawConfig, env);
+    }
+    if (env === process.env) {
+      loadDotEnv({ quiet: true });
     }
     const resolved = resolveConfigEnvVars(parsed, env, {
       onMissing: () => {

--- a/src/cli/banner-config-lite.ts
+++ b/src/cli/banner-config-lite.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import JSON5 from "json5";
+import { resolveConfigEnvVars } from "../config/env-substitution.js";
+import { applyConfigEnvVars } from "../config/env-vars.js";
 import { resolveConfigIncludes } from "../config/includes.js";
 import { resolveConfigPathCandidate } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.js";
 import type { TaglineMode } from "./tagline.js";
 
 function parseTaglineMode(value: unknown): TaglineMode | undefined {
@@ -28,7 +31,12 @@ export function readCliBannerTaglineMode(
       JSON5.parse(fs.readFileSync(configPath, "utf-8")),
       configPath,
     ) as BannerConfigShape;
-    return parseTaglineMode(parsed.cli?.banner?.taglineMode);
+    // Keep banner startup cheap, but still honor config.env and ${VAR} substitution.
+    if (parsed && typeof parsed === "object" && "env" in parsed) {
+      applyConfigEnvVars(parsed as OpenClawConfig, env);
+    }
+    const resolved = resolveConfigEnvVars(parsed, env) as BannerConfigShape;
+    return parseTaglineMode(resolved.cli?.banner?.taglineMode);
   } catch {
     return undefined;
   }

--- a/src/cli/banner-config-lite.ts
+++ b/src/cli/banner-config-lite.ts
@@ -3,7 +3,7 @@ import JSON5 from "json5";
 import { resolveConfigEnvVars } from "../config/env-substitution.js";
 import { applyConfigEnvVars } from "../config/env-vars.js";
 import { resolveConfigIncludes } from "../config/includes.js";
-import { resolveConfigPathCandidate } from "../config/paths.js";
+import { resolveConfigPath } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { TaglineMode } from "./tagline.js";
 
@@ -22,7 +22,7 @@ export function readCliBannerTaglineMode(
   env: NodeJS.ProcessEnv = process.env,
 ): TaglineMode | undefined {
   try {
-    const configPath = resolveConfigPathCandidate(env);
+    const configPath = resolveConfigPath(env);
     if (!fs.existsSync(configPath)) {
       return undefined;
     }
@@ -35,7 +35,11 @@ export function readCliBannerTaglineMode(
     if (parsed && typeof parsed === "object" && "env" in parsed) {
       applyConfigEnvVars(parsed as OpenClawConfig, env);
     }
-    const resolved = resolveConfigEnvVars(parsed, env) as BannerConfigShape;
+    const resolved = resolveConfigEnvVars(parsed, env, {
+      onMissing: () => {
+        // Match the full config loader by tolerating unrelated missing env vars.
+      },
+    }) as BannerConfigShape;
     return parseTaglineMode(resolved.cli?.banner?.taglineMode);
   } catch {
     return undefined;

--- a/src/cli/banner-config-lite.ts
+++ b/src/cli/banner-config-lite.ts
@@ -1,4 +1,7 @@
-import { createConfigIO } from "../config/config.js";
+import fs from "node:fs";
+import JSON5 from "json5";
+import { resolveConfigIncludes } from "../config/includes.js";
+import { resolveConfigPathCandidate } from "../config/paths.js";
 import type { TaglineMode } from "./tagline.js";
 
 function parseTaglineMode(value: unknown): TaglineMode | undefined {
@@ -8,13 +11,23 @@ function parseTaglineMode(value: unknown): TaglineMode | undefined {
   return undefined;
 }
 
+type BannerConfigShape = {
+  cli?: { banner?: { taglineMode?: unknown } };
+};
+
 export function readCliBannerTaglineMode(
   env: NodeJS.ProcessEnv = process.env,
 ): TaglineMode | undefined {
   try {
-    const parsed = createConfigIO({ env }).loadConfig() as {
-      cli?: { banner?: { taglineMode?: unknown } };
-    };
+    const configPath = resolveConfigPathCandidate(env);
+    if (!fs.existsSync(configPath)) {
+      return undefined;
+    }
+    // Keep banner startup cheap: only read the raw config path and resolve includes.
+    const parsed = resolveConfigIncludes(
+      JSON5.parse(fs.readFileSync(configPath, "utf-8")),
+      configPath,
+    ) as BannerConfigShape;
     return parseTaglineMode(parsed.cli?.banner?.taglineMode);
   } catch {
     return undefined;

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -84,6 +84,16 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for gateway commands that need to bind quickly",
+      commandPath: ["gateway", "run"],
+      expectedDoctorCalls: 0,
+    },
+    {
+      name: "skips doctor flow for cron commands that should not stall scheduled work",
+      commandPath: ["cron", "run"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "skips doctor flow for update status",
       commandPath: ["update", "status"],
       expectedDoctorCalls: 0,

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -236,7 +236,7 @@ describe("registerPreActionHooks", () => {
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
-      commandPath: ["agent"],
+      commandPath: ["agent", "hi"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
   });

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -8,10 +8,6 @@ import { defaultRuntime } from "../../runtime.js";
 import { getCommandPathWithRootOptions, getVerboseFlag, hasHelpOrVersion } from "../argv.js";
 import { emitCliBanner } from "../banner.js";
 import { resolveCliName } from "../cli-name.js";
-import {
-  resolvePluginInstallInvalidConfigPolicy,
-  resolvePluginInstallPreactionRequest,
-} from "../plugin-install-config-policy.js";
 import { isCommandJsonOutputMode } from "./json-mode.js";
 
 function setProcessTitleForCommand(actionCommand: Command) {
@@ -41,6 +37,9 @@ const PLUGIN_REQUIRED_COMMANDS = new Set([
 const CONFIG_GUARD_BYPASS_COMMANDS = new Set(["backup", "doctor", "completion", "secrets"]);
 let configGuardModulePromise: Promise<typeof import("./config-guard.js")> | undefined;
 let pluginRegistryModulePromise: Promise<typeof import("../plugin-registry.js")> | undefined;
+let pluginInstallConfigPolicyModulePromise:
+  | Promise<typeof import("../plugin-install-config-policy.js")>
+  | undefined;
 
 function shouldBypassConfigGuard(commandPath: string[]): boolean {
   const [primary, secondary] = commandPath;
@@ -66,6 +65,11 @@ function loadPluginRegistryModule() {
   return pluginRegistryModulePromise;
 }
 
+function loadPluginInstallConfigPolicyModule() {
+  pluginInstallConfigPolicyModulePromise ??= import("../plugin-install-config-policy.js");
+  return pluginInstallConfigPolicyModulePromise;
+}
+
 function resolvePluginRegistryScope(commandPath: string[]): "channels" | "all" {
   return commandPath[0] === "status" || commandPath[0] === "health" ? "channels" : "all";
 }
@@ -84,7 +88,15 @@ function shouldLoadPluginsForCommand(commandPath: string[], jsonOutputMode: bool
   }
   return true;
 }
-function shouldAllowInvalidConfigForAction(actionCommand: Command, commandPath: string[]): boolean {
+async function shouldAllowInvalidConfigForAction(
+  actionCommand: Command,
+  commandPath: string[],
+): Promise<boolean> {
+  if (commandPath[0] !== "plugins" || commandPath[1] !== "install") {
+    return false;
+  }
+  const { resolvePluginInstallInvalidConfigPolicy, resolvePluginInstallPreactionRequest } =
+    await loadPluginInstallConfigPolicyModule();
   return (
     resolvePluginInstallInvalidConfigPolicy(
       resolvePluginInstallPreactionRequest({
@@ -148,7 +160,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (shouldBypassConfigGuard(commandPath)) {
       return;
     }
-    const allowInvalid = shouldAllowInvalidConfigForAction(actionCommand, commandPath);
+    const allowInvalid = await shouldAllowInvalidConfigForAction(actionCommand, commandPath);
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,


### PR DESCRIPTION
## What
Fix Docker-hosted gateway and cron CLI startup hangs.

## Why
In the Docker workflow, some CLI entry points were doing more startup work than they needed. That made `gateway`, `cron`, and related invocations slow and, in some cases, hang before doing any useful work.

## Included
- skip state-migration work for `gateway` and `cron` commands
- read banner config through a lightweight path instead of loading the full config stack
- lazy-load plugin install config policy in preaction hooks
- make `openclaw/plugin-sdk/google` a direct re-export so the Docker runtime does not stall on the sync facade path
- add regression coverage for the CLI startup path

## Notes
This PR is scoped to CLI/runtime startup behavior only.
