### PR TITLE
fix(secrets): skip env variable references in audit --check

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -224,7 +224,7 @@ describe("secrets audit", () => {
     expect(hasFinding(report, (entry) => entry.code === "PLAINTEXT_FOUND")).toBe(true);
   });
 
-  it("ignores env variable references in .env while still flagging real plaintext values", async () => {
+  it("flags all values including env variable references in .env as plaintext", async () => {
     await writeJsonFile(fixture.authStorePath, {
       version: 1,
       profiles: {},
@@ -232,8 +232,8 @@ describe("secrets audit", () => {
     await fs.writeFile(
       fixture.envPath,
       [
-        `${OPENAI_API_KEY_MARKER}=\${OPENAI_API_KEY}`,
-        `${OPENAI_API_KEY_MARKER}=$OPENAI_API_KEY`,
+        `${OPENAI_API_KEY_MARKER}=\${OPENAI_API_KEY}`, // pragma: allowlist secret
+        `${OPENAI_API_KEY_MARKER}=$OPENAI_API_KEY`, // pragma: allowlist secret
         `${OPENAI_API_KEY_MARKER}=sk-openai-plaintext`, // pragma: allowlist secret
       ].join("\n"),
       "utf8",
@@ -247,7 +247,7 @@ describe("secrets audit", () => {
         entry.jsonPath === `$env.${OPENAI_API_KEY_MARKER}`,
     );
 
-    expect(envPlaintextFindings).toHaveLength(1);
+    expect(envPlaintextFindings).toHaveLength(3);
   });
 
   it("does not mutate legacy auth.json during audit", async () => {

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -224,6 +224,32 @@ describe("secrets audit", () => {
     expect(hasFinding(report, (entry) => entry.code === "PLAINTEXT_FOUND")).toBe(true);
   });
 
+  it("ignores env variable references in .env while still flagging real plaintext values", async () => {
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(
+      fixture.envPath,
+      [
+        `${OPENAI_API_KEY_MARKER}=\${OPENAI_API_KEY}`,
+        `${OPENAI_API_KEY_MARKER}=$OPENAI_API_KEY`,
+        `${OPENAI_API_KEY_MARKER}=sk-openai-plaintext`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    const envPlaintextFindings = report.findings.filter(
+      (entry) =>
+        entry.code === "PLAINTEXT_FOUND" &&
+        entry.file === fixture.envPath &&
+        entry.jsonPath === `$env.${OPENAI_API_KEY_MARKER}`,
+    );
+
+    expect(envPlaintextFindings).toHaveLength(1);
+  });
+
   it("does not mutate legacy auth.json during audit", async () => {
     await fs.rm(fixture.authStorePath, { force: true });
     await writeJsonFile(fixture.authJsonPath, {

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -234,7 +234,7 @@ describe("secrets audit", () => {
       [
         `${OPENAI_API_KEY_MARKER}=\${OPENAI_API_KEY}`,
         `${OPENAI_API_KEY_MARKER}=$OPENAI_API_KEY`,
-        `${OPENAI_API_KEY_MARKER}=sk-openai-plaintext`,
+        `${OPENAI_API_KEY_MARKER}=sk-openai-plaintext`, // pragma: allowlist secret
       ].join("\n"),
       "utf8",
     );

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -196,9 +196,6 @@ function collectEnvPlaintext(params: { envPath: string; collector: AuditCollecto
     if (!value) {
       continue;
     }
-    if (/^\$\{[A-Za-z_][A-Za-z0-9_]*\}$|^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
-      continue;
-    }
     addFinding(params.collector, {
       code: "PLAINTEXT_FOUND",
       severity: "warn",

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -196,6 +196,9 @@ function collectEnvPlaintext(params: { envPath: string; collector: AuditCollecto
     if (!value) {
       continue;
     }
+    if (/^\$\{[A-Za-z_][A-Za-z0-9_]*\}$|^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+      continue;
+    }
     addFinding(params.collector, {
       code: "PLAINTEXT_FOUND",
       severity: "warn",


### PR DESCRIPTION
## Summary

- Problem: `openclaw secrets audit --check` flags env variable references like `${OPENAI_API_KEY}` in `.env` files as `PLAINTEXT_FOUND`, same severity as hardcoded secrets.
- Why it matters: audit output is unusable when every env reference triggers a false positive. Operators can't distinguish real findings from safe references.
- What changed: added a regex guard in `collectEnvPlaintext()` to skip values matching `$VAR` or `${VAR}` patterns before generating a finding.
- What did NOT change: actual plaintext secrets are still flagged. No changes to the config file scanning path or any other audit logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61058
- [x] This PR fixes a bug or regression

## Root Cause

`collectEnvPlaintext()` in `src/secrets/audit.ts` calls `parseEnvAssignmentValue()` which strips quotes via `parseEnvValue()` but never checks if the resulting value is an env variable reference. The regex `/^\$\{[A-Za-z_][A-Za-z0-9_]*\}$|^\$[A-Za-z_][A-Za-z0-9_]*$/` now skips those values before the `PLAINTEXT_FOUND` finding is emitted.

This contribution was developed with AI assistance (Codex).