### PR TITLE
fix(exec): support bare command patterns in approvals allowlist

### DIFF
--- a/src/infra/exec-allowlist-matching.test.ts
+++ b/src/infra/exec-allowlist-matching.test.ts
@@ -46,6 +46,18 @@ describe("exec allowlist matching", () => {
     expect(
       matchAllowlist([{ pattern: "python3" }], winResolution, undefined, "win32")?.pattern,
     ).toBe("python3");
+    expect(
+      matchAllowlist([{ pattern: "python3.exe" }], winResolution, undefined, "win32")?.pattern,
+    ).toBe("python3.exe");
+
+    const winCmdResolution = {
+      rawExecutable: "deploy",
+      resolvedPath: "C:\\tools\\deploy.cmd",
+      executableName: "deploy.cmd",
+    };
+    expect(
+      matchAllowlist([{ pattern: "deploy" }], winCmdResolution, undefined, "win32")?.pattern,
+    ).toBe("deploy");
 
     // On a Linux host evaluating a Windows target, case-insensitive matching
     // should use the target platform, not the host platform.

--- a/src/infra/exec-allowlist-matching.test.ts
+++ b/src/infra/exec-allowlist-matching.test.ts
@@ -36,6 +36,22 @@ describe("exec allowlist matching", () => {
 
     // Bare name does not match a different executable
     expect(matchAllowlist([{ pattern: "node" }], pythonResolution)?.pattern ?? null).toBe(null);
+
+    // On Windows, bare pattern strips .exe before matching
+    const winResolution = {
+      rawExecutable: "python3",
+      resolvedPath: "C:\\Python39\\python3.exe",
+      executableName: "python3.exe",
+    };
+    expect(
+      matchAllowlist([{ pattern: "python3" }], winResolution, undefined, "win32")?.pattern,
+    ).toBe("python3");
+  });
+
+  it("does not widen wildcard+argPattern entries into global allows", () => {
+    // { pattern: "*", argPattern: "..." } should NOT match without argv on non-Windows
+    const wildArgEntry = { pattern: "*", argPattern: "--safe-flag" };
+    expect(matchAllowlist([wildArgEntry], baseResolution)?.pattern ?? null).toBe(null);
   });
 
   it("matches bare wildcard patterns against arbitrary resolved executables", () => {

--- a/src/infra/exec-allowlist-matching.test.ts
+++ b/src/infra/exec-allowlist-matching.test.ts
@@ -10,7 +10,6 @@ describe("exec allowlist matching", () => {
 
   it("handles wildcard and path matching semantics", () => {
     const cases: Array<{ entries: ExecAllowlistEntry[]; expectedPattern: string | null }> = [
-      { entries: [{ pattern: "RG" }], expectedPattern: null },
       { entries: [{ pattern: "/opt/**/rg" }], expectedPattern: "/opt/**/rg" },
       { entries: [{ pattern: "/opt/*/rg" }], expectedPattern: null },
     ];
@@ -18,6 +17,25 @@ describe("exec allowlist matching", () => {
       const match = matchAllowlist(entries, baseResolution);
       expect(match?.pattern ?? null).toBe(expectedPattern);
     }
+  });
+
+  it("matches bare executable name patterns without path separators", () => {
+    // Exact bare name match
+    expect(matchAllowlist([{ pattern: "rg" }], baseResolution)?.pattern).toBe("rg");
+
+    // Bare name should be case-sensitive (no match for wrong case)
+    expect(matchAllowlist([{ pattern: "RG" }], baseResolution)?.pattern ?? null).toBe(null);
+
+    // Bare name matches regardless of resolved path
+    const pythonResolution = {
+      rawExecutable: "python3",
+      resolvedPath: "/usr/bin/python3",
+      executableName: "python3",
+    };
+    expect(matchAllowlist([{ pattern: "python3" }], pythonResolution)?.pattern).toBe("python3");
+
+    // Bare name does not match a different executable
+    expect(matchAllowlist([{ pattern: "node" }], pythonResolution)?.pattern ?? null).toBe(null);
   });
 
   it("matches bare wildcard patterns against arbitrary resolved executables", () => {

--- a/src/infra/exec-allowlist-matching.test.ts
+++ b/src/infra/exec-allowlist-matching.test.ts
@@ -46,6 +46,17 @@ describe("exec allowlist matching", () => {
     expect(
       matchAllowlist([{ pattern: "python3" }], winResolution, undefined, "win32")?.pattern,
     ).toBe("python3");
+
+    // On a Linux host evaluating a Windows target, case-insensitive matching
+    // should use the target platform, not the host platform.
+    expect(
+      matchAllowlist(
+        [{ pattern: "RG" }],
+        { ...baseResolution, executableName: "rg" },
+        undefined,
+        "win32",
+      )?.pattern,
+    ).toBe("RG");
   });
 
   it("does not widen wildcard+argPattern entries into global allows", () => {

--- a/src/infra/exec-allowlist-pattern.ts
+++ b/src/infra/exec-allowlist-pattern.ts
@@ -4,8 +4,8 @@ import { expandHomePrefix } from "./home-dir.js";
 const GLOB_REGEX_CACHE_LIMIT = 512;
 const globRegexCache = new Map<string, RegExp>();
 
-function normalizeMatchTarget(value: string): string {
-  if (process.platform === "win32") {
+function normalizeMatchTarget(value: string, platform?: NodeJS.Platform): string {
+  if ((platform ?? process.platform) === "win32") {
     const stripped = value.replace(/^\\\\[?.]\\/, "");
     return stripped.replace(/\\/g, "/").toLowerCase();
   }
@@ -24,8 +24,9 @@ function escapeRegExpLiteral(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function compileGlobRegex(pattern: string): RegExp {
-  const cacheKey = `${process.platform}:${pattern}`;
+function compileGlobRegex(pattern: string, platform?: NodeJS.Platform): RegExp {
+  const effectivePlatform = platform ?? process.platform;
+  const cacheKey = `${effectivePlatform}:${pattern}`;
   const cached = globRegexCache.get(cacheKey);
   if (cached) {
     return cached;
@@ -56,7 +57,7 @@ function compileGlobRegex(pattern: string): RegExp {
   }
   regex += "$";
 
-  const compiled = new RegExp(regex, process.platform === "win32" ? "i" : "");
+  const compiled = new RegExp(regex, effectivePlatform === "win32" ? "i" : "");
   if (globRegexCache.size >= GLOB_REGEX_CACHE_LIMIT) {
     globRegexCache.clear();
   }
@@ -64,21 +65,26 @@ function compileGlobRegex(pattern: string): RegExp {
   return compiled;
 }
 
-export function matchesExecAllowlistPattern(pattern: string, target: string): boolean {
+export function matchesExecAllowlistPattern(
+  pattern: string,
+  target: string,
+  platform?: NodeJS.Platform,
+): boolean {
   const trimmed = pattern.trim();
   if (!trimmed) {
     return false;
   }
 
+  const effectivePlatform = platform ?? process.platform;
   const expanded = trimmed.startsWith("~") ? expandHomePrefix(trimmed) : trimmed;
   const hasWildcard = /[*?]/.test(expanded);
   let normalizedPattern = expanded;
   let normalizedTarget = target;
-  if (process.platform === "win32" && !hasWildcard) {
+  if (effectivePlatform === "win32" && !hasWildcard) {
     normalizedPattern = tryRealpath(expanded) ?? expanded;
     normalizedTarget = tryRealpath(target) ?? target;
   }
-  normalizedPattern = normalizeMatchTarget(normalizedPattern);
-  normalizedTarget = normalizeMatchTarget(normalizedTarget);
-  return compileGlobRegex(normalizedPattern).test(normalizedTarget);
+  normalizedPattern = normalizeMatchTarget(normalizedPattern, effectivePlatform);
+  normalizedTarget = normalizeMatchTarget(normalizedTarget, effectivePlatform);
+  return compileGlobRegex(normalizedPattern, effectivePlatform).test(normalizedTarget);
 }

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -342,8 +342,9 @@ export function matchAllowlist(
   // preserves the pre-existing behaviour.
   // Use the caller-supplied target platform rather than process.platform so that
   // a Linux gateway evaluating a Windows node command applies argPattern correctly.
-  const effectivePlatform = platform ?? process.platform;
-  const useArgPattern = String(effectivePlatform).trim().toLowerCase().startsWith("win");
+  const effectivePlatform = (platform ?? process.platform) as NodeJS.Platform;
+  const normalizedPlatform = String(effectivePlatform).trim().toLowerCase();
+  const useArgPattern = normalizedPlatform.startsWith("win");
   let pathOnlyMatch: ExecAllowlistEntry | null = null;
   for (const entry of entries) {
     const pattern = entry.pattern?.trim();
@@ -355,12 +356,21 @@ export function matchAllowlist(
       // Bare patterns (no path separators) match against the executable name
       // rather than the full resolved path.  This allows patterns like
       // "python3" or "node" to work regardless of where the binary lives.
-      // On Windows, strip the .exe suffix so "python3" matches "python3.exe".
-      let bareTarget = resolution.executableName;
-      if (useArgPattern && bareTarget.toLowerCase().endsWith(".exe")) {
-        bareTarget = bareTarget.slice(0, -4);
+      // On win32, also test a stripped extension form so patterns like
+      // "python3" match "python3.exe" while explicit extension patterns
+      // ("python3.exe") still match via the original executable name.
+      const bareTargets = [resolution.executableName];
+      if (normalizedPlatform === "win32") {
+        const strippedBareTarget = path.parse(resolution.executableName).name;
+        if (strippedBareTarget && strippedBareTarget !== resolution.executableName) {
+          bareTargets.push(strippedBareTarget);
+        }
       }
-      if (matchesExecAllowlistPattern(pattern, bareTarget, effectivePlatform)) {
+      if (
+        bareTargets.some((target) =>
+          matchesExecAllowlistPattern(pattern, target, effectivePlatform),
+        )
+      ) {
         if (!entry.argPattern) {
           if (!useArgPattern) {
             return entry;

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -355,11 +355,16 @@ export function matchAllowlist(
       // Bare patterns (no path separators) match against the executable name
       // rather than the full resolved path.  This allows patterns like
       // "python3" or "node" to work regardless of where the binary lives.
-      if (matchesExecAllowlistPattern(pattern, resolution.executableName)) {
-        if (!useArgPattern) {
-          return entry;
-        }
+      // On Windows, strip the .exe suffix so "python3" matches "python3.exe".
+      let bareTarget = resolution.executableName;
+      if (useArgPattern && bareTarget.toLowerCase().endsWith(".exe")) {
+        bareTarget = bareTarget.slice(0, -4);
+      }
+      if (matchesExecAllowlistPattern(pattern, bareTarget)) {
         if (!entry.argPattern) {
+          if (!useArgPattern) {
+            return entry;
+          }
           if (!pathOnlyMatch) {
             pathOnlyMatch = entry;
           }

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -352,6 +352,23 @@ export function matchAllowlist(
     }
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
     if (!hasPath) {
+      // Bare patterns (no path separators) match against the executable name
+      // rather than the full resolved path.  This allows patterns like
+      // "python3" or "node" to work regardless of where the binary lives.
+      if (matchesExecAllowlistPattern(pattern, resolution.executableName)) {
+        if (!useArgPattern) {
+          return entry;
+        }
+        if (!entry.argPattern) {
+          if (!pathOnlyMatch) {
+            pathOnlyMatch = entry;
+          }
+          continue;
+        }
+        if (argv && matchArgPattern(entry.argPattern, argv, platform)) {
+          return entry;
+        }
+      }
       continue;
     }
     if (!matchesExecAllowlistPattern(pattern, resolvedPath)) {

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -360,7 +360,7 @@ export function matchAllowlist(
       if (useArgPattern && bareTarget.toLowerCase().endsWith(".exe")) {
         bareTarget = bareTarget.slice(0, -4);
       }
-      if (matchesExecAllowlistPattern(pattern, bareTarget)) {
+      if (matchesExecAllowlistPattern(pattern, bareTarget, effectivePlatform)) {
         if (!entry.argPattern) {
           if (!useArgPattern) {
             return entry;
@@ -376,7 +376,7 @@ export function matchAllowlist(
       }
       continue;
     }
-    if (!matchesExecAllowlistPattern(pattern, resolvedPath)) {
+    if (!matchesExecAllowlistPattern(pattern, resolvedPath, effectivePlatform)) {
       continue;
     }
     if (!useArgPattern) {


### PR DESCRIPTION
## Summary

- Problem: exec approvals allowlist silently skips patterns without path separators (`/`, `\`, `~`). Patterns like `python3` or `node` are accepted by `openclaw approvals allowlist add` but never matched during command evaluation.
- Why it matters: users configure allowlist rules expecting `python3` to match `/usr/bin/python3`, but the pattern is silently ignored. Commands that should be auto-approved still require manual approval.
- What changed: when a pattern has no path separators, `matchAllowlist()` now matches it against `executableName` (the basename) instead of skipping it entirely.
- What did NOT change: path-based patterns still match against `resolvedPath` as before. The bare `*` wildcard shortcut is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61193
- [x] This PR fixes a bug or regression

## Root Cause

`matchAllowlist()` in `src/infra/exec-command-resolution.ts:353-355` has a guard that checks `hasPath` and skips any pattern without `/`, `\`, or `~`. Bare executable names like `python3` fail this check and are silently dropped from evaluation. The fix routes bare patterns through `matchesExecAllowlistPattern()` with `executableName` as the target instead of `resolvedPath`, preserving argPattern semantics on Windows.

This contribution was developed with AI assistance (Claude Code).