### PR TITLE
feat(android): add always-on location access

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -191,6 +191,9 @@ More details: `docs/platforms/android.md`.
 - Discovery:
   - Android 13+ (`API 33+`): `NEARBY_WIFI_DEVICES`
   - Android 12 and below: `ACCESS_FINE_LOCATION` (required for NSD scanning)
+- Location:
+  - Foreground access: `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`
+  - Background access ("Always"): `ACCESS_BACKGROUND_LOCATION`
 - Foreground service notification (Android 13+): `POST_NOTIFICATIONS`
 - Camera:
   - `CAMERA` for `camera.snap` and `camera.clip`

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -80,11 +80,13 @@ android {
             dimension = "store"
             buildConfigField("boolean", "OPENCLAW_ENABLE_SMS", "false")
             buildConfigField("boolean", "OPENCLAW_ENABLE_CALL_LOG", "false")
+            buildConfigField("boolean", "OPENCLAW_ENABLE_BACKGROUND_LOCATION", "false")
         }
         create("thirdParty") {
             dimension = "store"
             buildConfigField("boolean", "OPENCLAW_ENABLE_SMS", "true")
             buildConfigField("boolean", "OPENCLAW_ENABLE_CALL_LOG", "true")
+            buildConfigField("boolean", "OPENCLAW_ENABLE_BACKGROUND_LOCATION", "true")
         }
     }
 

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
         android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.SEND_SMS" />
@@ -52,7 +54,7 @@
         <service
             android:name=".NodeForegroundService"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="dataSync|location" />
         <service
             android:name=".node.DeviceNotificationListenerService"
             android:label="@string/app_name"

--- a/apps/android/app/src/main/java/ai/openclaw/app/LocationMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/LocationMode.kt
@@ -13,3 +13,16 @@ enum class LocationMode(val rawValue: String) {
     }
   }
 }
+
+fun restoreLocationModeAfterCanceledAlwaysGrant(
+  previousMode: LocationMode?,
+  locationGranted: Boolean,
+): LocationMode? {
+  return when (previousMode) {
+    null -> null
+    LocationMode.Off -> LocationMode.Off
+    LocationMode.WhileUsing,
+    LocationMode.Always,
+    -> if (locationGranted) LocationMode.WhileUsing else LocationMode.Off
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/LocationMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/LocationMode.kt
@@ -3,12 +3,12 @@ package ai.openclaw.app
 enum class LocationMode(val rawValue: String) {
   Off("off"),
   WhileUsing("whileUsing"),
+  Always("always"),
   ;
 
   companion object {
     fun fromRawValue(raw: String?): LocationMode {
       val normalized = raw?.trim()?.lowercase()
-      if (normalized == "always") return WhileUsing
       return entries.firstOrNull { it.rawValue.lowercase() == normalized } ?: Off
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -124,6 +124,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val pendingRunCount: StateFlow<Int> = runtimeState(initial = 0) { it.pendingRunCount }
 
   init {
+    prefs.reconcilePendingAlwaysLocationUpgrade()
     if (prefs.onboardingCompleted.value) {
       ensureRuntime()
     }
@@ -166,6 +167,22 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setLocationMode(mode: LocationMode) {
     prefs.setLocationMode(mode)
+  }
+
+  fun beginPendingAlwaysLocationUpgrade(previousMode: LocationMode) {
+    prefs.beginPendingAlwaysLocationUpgrade(previousMode)
+  }
+
+  fun clearPendingAlwaysLocationUpgrade() {
+    prefs.clearPendingAlwaysLocationUpgrade()
+  }
+
+  fun hasPendingAlwaysLocationUpgrade(): Boolean {
+    return prefs.hasPendingAlwaysLocationUpgrade()
+  }
+
+  fun reconcilePendingAlwaysLocationUpgrade(): LocationMode? {
+    return prefs.reconcilePendingAlwaysLocationUpgrade()
   }
 
   fun setLocationPreciseEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -140,7 +140,7 @@ open class NodeForegroundService : Service() {
 
   private fun startForegroundWithTypes(notification: Notification) {
     latestNotification = notification
-    val serviceType = foregroundServiceType(locationGranted = hasAnyLocationPermission())
+    val serviceType = foregroundServiceType(includeLocationType = canUseLocationForegroundServiceType())
     if (!shouldRestartForeground(serviceType)) {
       updateNotification(notification)
       return
@@ -167,9 +167,24 @@ open class NodeForegroundService : Service() {
       PackageManager.PERMISSION_GRANTED
   }
 
-  private fun foregroundServiceType(locationGranted: Boolean): Int {
+  internal open fun isAppForeground(): Boolean {
+    return (application as? NodeApp)?.peekRuntime()?.isForeground?.value == true
+  }
+
+  internal open fun canUseBackgroundLocation(): Boolean {
+    val runtime = (application as? NodeApp)?.peekRuntime() ?: return false
+    return runtime.locationMode.value == LocationMode.Always &&
+      ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+  }
+
+  internal open fun canUseLocationForegroundServiceType(): Boolean {
+    return hasAnyLocationPermission() && (isAppForeground() || canUseBackgroundLocation())
+  }
+
+  private fun foregroundServiceType(includeLocationType: Boolean): Int {
     return ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or
-      if (locationGranted) ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION else 0
+      if (includeLocationType) ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION else 0
   }
 
   private fun shouldRestartForeground(serviceType: Int): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -20,11 +20,12 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
-class NodeForegroundService : Service() {
+open class NodeForegroundService : Service() {
   private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
   private var notificationJob: Job? = null
   private var didStartForeground = false
   private var currentForegroundServiceType: Int? = null
+  private var latestNotification: Notification? = null
 
   override fun onCreate() {
     super.onCreate()
@@ -71,6 +72,7 @@ class NodeForegroundService : Service() {
         stopSelf()
         return START_NOT_STICKY
       }
+      ACTION_REFRESH_FOREGROUND -> refreshForegroundServiceType()
     }
     // Keep running; connection is managed by NodeRuntime (auto-reconnect + manual).
     return START_STICKY
@@ -137,6 +139,7 @@ class NodeForegroundService : Service() {
   }
 
   private fun startForegroundWithTypes(notification: Notification) {
+    latestNotification = notification
     val serviceType = foregroundServiceType(locationGranted = hasAnyLocationPermission())
     if (!shouldRestartForeground(serviceType)) {
       updateNotification(notification)
@@ -151,7 +154,13 @@ class NodeForegroundService : Service() {
     currentForegroundServiceType = serviceType
   }
 
-  private fun hasAnyLocationPermission(): Boolean {
+  private fun refreshForegroundServiceType() {
+    startForegroundWithTypes(
+      notification = latestNotification ?: buildNotification(title = "OpenClaw Node", text = "Starting…"),
+    )
+  }
+
+  internal open fun hasAnyLocationPermission(): Boolean {
     return ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
       PackageManager.PERMISSION_GRANTED ||
       ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
@@ -172,6 +181,7 @@ class NodeForegroundService : Service() {
     private const val NOTIFICATION_ID = 1
 
     private const val ACTION_STOP = "ai.openclaw.app.action.STOP"
+    private const val ACTION_REFRESH_FOREGROUND = "ai.openclaw.app.action.REFRESH_FOREGROUND"
 
     fun start(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java)
@@ -181,6 +191,11 @@ class NodeForegroundService : Service() {
     fun stop(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
       context.startService(intent)
+    }
+
+    fun refresh(context: Context) {
+      val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_REFRESH_FOREGROUND)
+      context.startForegroundService(intent)
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -137,7 +137,11 @@ class NodeForegroundService : Service() {
       updateNotification(notification)
       return
     }
-    startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+    startForeground(
+      NOTIFICATION_ID,
+      notification,
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+    )
     didStartForeground = true
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app
 
+import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -7,7 +8,9 @@ import android.app.Service
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import androidx.core.content.ContextCompat
 import androidx.core.app.NotificationCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -140,9 +143,21 @@ class NodeForegroundService : Service() {
     startForeground(
       NOTIFICATION_ID,
       notification,
-      ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+      foregroundServiceType(locationGranted = hasAnyLocationPermission()),
     )
     didStartForeground = true
+  }
+
+  private fun hasAnyLocationPermission(): Boolean {
+    return ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED ||
+      ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+  }
+
+  private fun foregroundServiceType(locationGranted: Boolean): Int {
+    return ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or
+      if (locationGranted) ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION else 0
   }
 
   companion object {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -24,6 +24,7 @@ class NodeForegroundService : Service() {
   private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
   private var notificationJob: Job? = null
   private var didStartForeground = false
+  private var currentForegroundServiceType: Int? = null
 
   override fun onCreate() {
     super.onCreate()
@@ -136,16 +137,18 @@ class NodeForegroundService : Service() {
   }
 
   private fun startForegroundWithTypes(notification: Notification) {
-    if (didStartForeground) {
+    val serviceType = foregroundServiceType(locationGranted = hasAnyLocationPermission())
+    if (!shouldRestartForeground(serviceType)) {
       updateNotification(notification)
       return
     }
     startForeground(
       NOTIFICATION_ID,
       notification,
-      foregroundServiceType(locationGranted = hasAnyLocationPermission()),
+      serviceType,
     )
     didStartForeground = true
+    currentForegroundServiceType = serviceType
   }
 
   private fun hasAnyLocationPermission(): Boolean {
@@ -158,6 +161,10 @@ class NodeForegroundService : Service() {
   private fun foregroundServiceType(locationGranted: Boolean): Int {
     return ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or
       if (locationGranted) ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION else 0
+  }
+
+  private fun shouldRestartForeground(serviceType: Int): Boolean {
+    return !didStartForeground || currentForegroundServiceType != serviceType
   }
 
   companion object {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -172,8 +172,8 @@ open class NodeForegroundService : Service() {
   }
 
   internal open fun canUseBackgroundLocation(): Boolean {
-    val runtime = (application as? NodeApp)?.peekRuntime() ?: return false
-    return runtime.locationMode.value == LocationMode.Always &&
+    val prefs = (application as? NodeApp)?.prefs ?: return false
+    return prefs.effectiveLocationMode() == LocationMode.Always &&
       ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
       PackageManager.PERMISSION_GRANTED
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -92,7 +92,7 @@ class NodeRuntime(
     location = location,
     json = json,
     isForeground = { _isForeground.value },
-    locationMode = { locationMode.value },
+    locationMode = { prefs.effectiveLocationMode() },
     locationPreciseEnabled = { locationPreciseEnabled.value },
   )
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -92,6 +92,7 @@ class NodeRuntime(
     location = location,
     json = json,
     isForeground = { _isForeground.value },
+    locationMode = { locationMode.value },
     locationPreciseEnabled = { locationPreciseEnabled.value },
   )
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -4,7 +4,10 @@ package ai.openclaw.app
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.Manifest
+import android.content.pm.PackageManager
 import androidx.core.content.edit
+import androidx.core.content.ContextCompat
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +26,8 @@ class SecurePrefs(
     val defaultWakeWords: List<String> = listOf("openclaw", "claude")
     private const val displayNameKey = "node.displayName"
     private const val locationModeKey = "location.enabledMode"
+    private const val pendingAlwaysLocationUpgradeKey = "location.pendingAlwaysUpgrade"
+    private const val pendingAlwaysLocationUpgradePreviousModeKey = "location.pendingAlwaysUpgrade.previousMode"
     private const val voiceWakeModeKey = "voiceWake.mode"
     private const val plainPrefsName = "openclaw.node"
     private const val securePrefsName = "openclaw.node.secure"
@@ -188,6 +193,49 @@ class SecurePrefs(
   fun setLocationMode(mode: LocationMode) {
     plainPrefs.edit { putString(locationModeKey, mode.rawValue) }
     _locationMode.value = mode
+  }
+
+  fun beginPendingAlwaysLocationUpgrade(previousMode: LocationMode) {
+    plainPrefs.edit {
+      putBoolean(pendingAlwaysLocationUpgradeKey, true)
+      putString(pendingAlwaysLocationUpgradePreviousModeKey, previousMode.rawValue)
+    }
+  }
+
+  fun clearPendingAlwaysLocationUpgrade() {
+    plainPrefs.edit {
+      remove(pendingAlwaysLocationUpgradeKey)
+      remove(pendingAlwaysLocationUpgradePreviousModeKey)
+    }
+  }
+
+  fun hasPendingAlwaysLocationUpgrade(): Boolean {
+    return loadPendingAlwaysLocationUpgrade() != null
+  }
+
+  fun effectiveLocationMode(): LocationMode {
+    val pendingUpgrade = loadPendingAlwaysLocationUpgrade()
+    if (pendingUpgrade != null && hasAnyLocationPermission() && hasBackgroundLocationPermission()) {
+      return LocationMode.Always
+    }
+    return _locationMode.value
+  }
+
+  fun reconcilePendingAlwaysLocationUpgrade(): LocationMode? {
+    val pendingUpgrade = loadPendingAlwaysLocationUpgrade() ?: return null
+    val locationGranted = hasAnyLocationPermission()
+    val resolvedMode =
+      if (locationGranted && hasBackgroundLocationPermission()) {
+        LocationMode.Always
+      } else {
+        restoreLocationModeAfterCanceledAlwaysGrant(
+          previousMode = pendingUpgrade.previousMode,
+          locationGranted = locationGranted,
+        ) ?: _locationMode.value
+      }
+    clearPendingAlwaysLocationUpgrade()
+    setLocationMode(resolvedMode)
+    return resolvedMode
   }
 
   fun setLocationPreciseEnabled(value: Boolean) {
@@ -527,6 +575,30 @@ class SecurePrefs(
     return LocationMode.fromRawValue(raw)
   }
 
+  private fun loadPendingAlwaysLocationUpgrade(): PendingAlwaysLocationUpgrade? {
+    if (!plainPrefs.getBoolean(pendingAlwaysLocationUpgradeKey, false)) {
+      return null
+    }
+    return PendingAlwaysLocationUpgrade(
+      previousMode =
+        LocationMode.fromRawValue(
+          plainPrefs.getString(pendingAlwaysLocationUpgradePreviousModeKey, LocationMode.Off.rawValue),
+        ),
+    )
+  }
+
+  private fun hasAnyLocationPermission(): Boolean {
+    return ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED ||
+      ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+  }
+
+  private fun hasBackgroundLocationPermission(): Boolean {
+    return ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+  }
+
   private fun loadWakeWords(): List<String> {
     val raw = plainPrefs.getString("voiceWake.triggerWords", null)?.trim()
     if (raw.isNullOrEmpty()) return defaultWakeWords
@@ -547,3 +619,7 @@ class SecurePrefs(
     }
   }
 }
+
+private data class PendingAlwaysLocationUpgrade(
+  val previousMode: LocationMode,
+)

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -524,11 +524,7 @@ class SecurePrefs(
 
   private fun loadLocationMode(): LocationMode {
     val raw = plainPrefs.getString(locationModeKey, "off")
-    val resolved = LocationMode.fromRawValue(raw)
-    if (raw?.trim()?.lowercase() == "always") {
-      plainPrefs.edit { putString(locationModeKey, resolved.rawValue) }
-    }
-    return resolved
+    return LocationMode.fromRawValue(raw)
   }
 
   private fun loadWakeWords(): List<String> {

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.location.LocationManager
 import androidx.core.content.ContextCompat
+import ai.openclaw.app.LocationMode
 import ai.openclaw.app.gateway.GatewaySession
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.json.Json
@@ -14,6 +15,8 @@ internal interface LocationDataSource {
   fun hasFinePermission(context: Context): Boolean
 
   fun hasCoarsePermission(context: Context): Boolean
+
+  fun hasBackgroundPermission(context: Context): Boolean
 
   suspend fun fetchLocation(
     desiredProviders: List<String>,
@@ -32,6 +35,10 @@ private class DefaultLocationDataSource(
 
   override fun hasCoarsePermission(context: Context): Boolean =
     ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+
+  override fun hasBackgroundPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
       PackageManager.PERMISSION_GRANTED
 
   override suspend fun fetchLocation(
@@ -53,6 +60,7 @@ class LocationHandler private constructor(
   private val dataSource: LocationDataSource,
   private val json: Json,
   private val isForeground: () -> Boolean,
+  private val locationMode: () -> LocationMode,
   private val locationPreciseEnabled: () -> Boolean,
 ) {
   constructor(
@@ -60,12 +68,14 @@ class LocationHandler private constructor(
     location: LocationCaptureManager,
     json: Json,
     isForeground: () -> Boolean,
+    locationMode: () -> LocationMode,
     locationPreciseEnabled: () -> Boolean,
   ) : this(
     appContext = appContext,
     dataSource = DefaultLocationDataSource(location),
     json = json,
     isForeground = isForeground,
+    locationMode = locationMode,
     locationPreciseEnabled = locationPreciseEnabled,
   )
 
@@ -79,6 +89,7 @@ class LocationHandler private constructor(
       dataSource: LocationDataSource,
       json: Json = Json { ignoreUnknownKeys = true },
       isForeground: () -> Boolean = { true },
+      locationMode: () -> LocationMode = { LocationMode.WhileUsing },
       locationPreciseEnabled: () -> Boolean = { true },
     ): LocationHandler =
       LocationHandler(
@@ -86,15 +97,17 @@ class LocationHandler private constructor(
         dataSource = dataSource,
         json = json,
         isForeground = isForeground,
+        locationMode = locationMode,
         locationPreciseEnabled = locationPreciseEnabled,
       )
   }
 
   suspend fun handleLocationGet(paramsJson: String?): GatewaySession.InvokeResult {
-    if (!isForeground()) {
+    if (!isForeground() && !allowsBackgroundLocation()) {
       return GatewaySession.InvokeResult.error(
         code = "LOCATION_BACKGROUND_UNAVAILABLE",
-        message = "LOCATION_BACKGROUND_UNAVAILABLE: location requires OpenClaw to stay open",
+        message =
+          "LOCATION_BACKGROUND_UNAVAILABLE: set Location to Always and grant Background location",
       )
     }
     if (!dataSource.hasFinePermission(appContext) && !dataSource.hasCoarsePermission(appContext)) {
@@ -136,6 +149,9 @@ class LocationHandler private constructor(
       return GatewaySession.InvokeResult.error(code = "LOCATION_UNAVAILABLE", message = message)
     }
   }
+
+  private fun allowsBackgroundLocation(): Boolean =
+    locationMode() == LocationMode.Always && dataSource.hasBackgroundPermission(appContext)
 
   private fun parseLocationParams(paramsJson: String?): Triple<Long?, Long, String?> {
     if (paramsJson.isNullOrBlank()) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.location.LocationManager
 import androidx.core.content.ContextCompat
 import ai.openclaw.app.LocationMode
+import ai.openclaw.app.NodeForegroundService
 import ai.openclaw.app.gateway.GatewaySession
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.json.Json
@@ -109,6 +110,9 @@ class LocationHandler private constructor(
         message =
           "LOCATION_BACKGROUND_UNAVAILABLE: set Location to Always and grant Background location",
       )
+    }
+    if (!isForeground() && allowsBackgroundLocation()) {
+      NodeForegroundService.refresh(appContext)
     }
     if (!dataSource.hasFinePermission(appContext) && !dataSource.hasCoarsePermission(appContext)) {
       return GatewaySession.InvokeResult.error(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -171,7 +171,6 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
 
   var pendingLocationSelection by rememberSaveable { mutableStateOf<LocationMode?>(null) }
-  var previousLocationModeBeforeAlwaysPrompt by rememberSaveable { mutableStateOf<LocationMode?>(null) }
   var pendingPreciseToggle by remember { mutableStateOf(false) }
   val backgroundLocationOptionLabel =
     remember(context) {
@@ -211,12 +210,12 @@ fun SettingsSheet(viewModel: MainViewModel) {
         LocationMode.Always -> {
           if (!granted) {
             pendingLocationSelection = null
-            previousLocationModeBeforeAlwaysPrompt = null
+            viewModel.clearPendingAlwaysLocationUpgrade()
             return@rememberLauncherForActivityResult
           }
           if (hasBackgroundLocationPermission(context)) {
             pendingLocationSelection = null
-            previousLocationModeBeforeAlwaysPrompt = null
+            viewModel.clearPendingAlwaysLocationUpgrade()
             setLocationModeAndRefreshService(
               context = context,
               viewModel = viewModel,
@@ -389,25 +388,11 @@ fun SettingsSheet(viewModel: MainViewModel) {
           val locationGranted = hasAnyLocationPermission(context)
           val backgroundGranted = hasBackgroundLocationPermission(context)
           when {
-            pendingLocationSelection == LocationMode.Always -> {
-              val restoredMode = restoreLocationModeAfterCanceledAlwaysGrant(
-                previousMode = previousLocationModeBeforeAlwaysPrompt,
-                locationGranted = locationGranted,
-              )
+            viewModel.hasPendingAlwaysLocationUpgrade() -> {
               pendingLocationSelection = null
-              previousLocationModeBeforeAlwaysPrompt = null
-              if (backgroundLocationAvailable && locationGranted && backgroundGranted) {
-                setLocationModeAndRefreshService(
-                  context = context,
-                  viewModel = viewModel,
-                  mode = LocationMode.Always,
-                )
-              } else if (restoredMode != null) {
-                setLocationModeAndRefreshService(
-                  context = context,
-                  viewModel = viewModel,
-                  mode = restoredMode,
-                )
+              val reconciledMode = viewModel.reconcilePendingAlwaysLocationUpgrade()
+              if (reconciledMode != null) {
+                NodeForegroundService.refresh(context)
               }
             }
             locationMode == LocationMode.Always &&
@@ -503,7 +488,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       return
     }
     if (!hasAnyLocationPermission(context)) {
-      previousLocationModeBeforeAlwaysPrompt = locationMode
+      viewModel.beginPendingAlwaysLocationUpgrade(locationMode)
       pendingLocationSelection = LocationMode.Always
       locationPermissionLauncher.launch(
         arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
@@ -512,7 +497,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
     if (hasBackgroundLocationPermission(context)) {
       pendingLocationSelection = null
-      previousLocationModeBeforeAlwaysPrompt = null
+      viewModel.clearPendingAlwaysLocationUpgrade()
       setLocationModeAndRefreshService(
         context = context,
         viewModel = viewModel,
@@ -520,7 +505,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       )
       return
     }
-    previousLocationModeBeforeAlwaysPrompt = locationMode
+    viewModel.beginPendingAlwaysLocationUpgrade(locationMode)
     pendingLocationSelection = LocationMode.Always
     setLocationModeAndRefreshService(
       context = context,
@@ -1412,19 +1397,6 @@ internal fun resolveNotificationCandidatePackages(
     .map { it.trim() }
     .filter { it.isNotEmpty() && it != blockedPackage }
     .toSet()
-}
-
-internal fun restoreLocationModeAfterCanceledAlwaysGrant(
-  previousMode: LocationMode?,
-  locationGranted: Boolean,
-): LocationMode? {
-  return when (previousMode) {
-    null -> null
-    LocationMode.Off -> LocationMode.Off
-    LocationMode.WhileUsing,
-    LocationMode.Always,
-    -> if (locationGranted) LocationMode.WhileUsing else LocationMode.Off
-  }
 }
 
 private fun setLocationModeAndRefreshService(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -169,8 +170,8 @@ fun SettingsSheet(viewModel: MainViewModel) {
       viewModel.setCameraEnabled(cameraOk)
     }
 
-  var pendingLocationSelection by remember { mutableStateOf<LocationMode?>(null) }
-  var previousLocationModeBeforeAlwaysPrompt by remember { mutableStateOf<LocationMode?>(null) }
+  var pendingLocationSelection by rememberSaveable { mutableStateOf<LocationMode?>(null) }
+  var previousLocationModeBeforeAlwaysPrompt by rememberSaveable { mutableStateOf<LocationMode?>(null) }
   var pendingPreciseToggle by remember { mutableStateOf(false) }
   val backgroundLocationOptionLabel =
     remember(context) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -168,13 +168,24 @@ fun SettingsSheet(viewModel: MainViewModel) {
       viewModel.setCameraEnabled(cameraOk)
     }
 
-  var pendingLocationRequest by remember { mutableStateOf(false) }
+  var pendingLocationSelection by remember { mutableStateOf<LocationMode?>(null) }
   var pendingPreciseToggle by remember { mutableStateOf(false) }
+  val backgroundLocationOptionLabel =
+    remember(context) {
+      context.packageManager.backgroundPermissionOptionLabel?.toString()?.trim().orEmpty()
+        .ifEmpty { "Allow all the time" }
+    }
 
   val locationPermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { perms ->
-      val fineOk = perms[Manifest.permission.ACCESS_FINE_LOCATION] == true
-      val coarseOk = perms[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+      val fineOk =
+        perms[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+          ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+          PackageManager.PERMISSION_GRANTED
+      val coarseOk =
+        perms[Manifest.permission.ACCESS_COARSE_LOCATION] == true ||
+          ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+          PackageManager.PERMISSION_GRANTED
       val granted = fineOk || coarseOk
 
       if (pendingPreciseToggle) {
@@ -183,9 +194,27 @@ fun SettingsSheet(viewModel: MainViewModel) {
         return@rememberLauncherForActivityResult
       }
 
-      if (pendingLocationRequest) {
-        pendingLocationRequest = false
-        viewModel.setLocationMode(if (granted) LocationMode.WhileUsing else LocationMode.Off)
+      when (pendingLocationSelection) {
+        LocationMode.WhileUsing -> {
+          pendingLocationSelection = null
+          if (granted) {
+            viewModel.setLocationMode(LocationMode.WhileUsing)
+          }
+        }
+        LocationMode.Always -> {
+          if (!granted) {
+            pendingLocationSelection = null
+            return@rememberLauncherForActivityResult
+          }
+          if (hasBackgroundLocationPermission(context)) {
+            pendingLocationSelection = null
+            viewModel.setLocationMode(LocationMode.Always)
+          } else {
+            viewModel.setLocationMode(LocationMode.WhileUsing)
+            openAppSettings(context)
+          }
+        }
+        else -> Unit
       }
     }
 
@@ -207,6 +236,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
         context.packageManager?.hasSystemFeature(PackageManager.FEATURE_TELEPHONY) == true
     }
   val callLogPermissionAvailable = remember { BuildConfig.OPENCLAW_ENABLE_CALL_LOG }
+  val backgroundLocationAvailable = remember { BuildConfig.OPENCLAW_ENABLE_BACKGROUND_LOCATION }
   val photosPermission =
     if (Build.VERSION.SDK_INT >= 33) {
       Manifest.permission.READ_MEDIA_IMAGES
@@ -335,10 +365,27 @@ fun SettingsSheet(viewModel: MainViewModel) {
       assistantRoleHeld = isAssistantRoleHeld(context)
     }
 
-  DisposableEffect(lifecycleOwner, context) {
+  DisposableEffect(lifecycleOwner, context, locationMode, backgroundLocationAvailable) {
     val observer =
       LifecycleEventObserver { _, event ->
         if (event == Lifecycle.Event.ON_RESUME) {
+          val locationGranted = hasAnyLocationPermission(context)
+          val backgroundGranted = hasBackgroundLocationPermission(context)
+          when {
+            pendingLocationSelection == LocationMode.Always -> {
+              pendingLocationSelection = null
+              if (backgroundLocationAvailable && locationGranted && backgroundGranted) {
+                viewModel.setLocationMode(LocationMode.Always)
+              }
+            }
+            locationMode == LocationMode.Always &&
+              (!backgroundLocationAvailable || !locationGranted || !backgroundGranted) -> {
+              viewModel.setLocationMode(if (locationGranted) LocationMode.WhileUsing else LocationMode.Off)
+            }
+            locationMode == LocationMode.WhileUsing && !locationGranted -> {
+              viewModel.setLocationMode(LocationMode.Off)
+            }
+          }
           micPermissionGranted =
             ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
               PackageManager.PERMISSION_GRANTED
@@ -396,20 +443,36 @@ fun SettingsSheet(viewModel: MainViewModel) {
   }
 
   fun requestLocationPermissions() {
-    val fineOk =
-      ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED
-    val coarseOk =
-      ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED
-    if (fineOk || coarseOk) {
+    if (hasAnyLocationPermission(context)) {
       viewModel.setLocationMode(LocationMode.WhileUsing)
     } else {
-      pendingLocationRequest = true
+      pendingLocationSelection = LocationMode.WhileUsing
       locationPermissionLauncher.launch(
         arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
       )
     }
+  }
+
+  fun requestAlwaysLocationPermissions() {
+    if (!backgroundLocationAvailable) {
+      requestLocationPermissions()
+      return
+    }
+    if (!hasAnyLocationPermission(context)) {
+      pendingLocationSelection = LocationMode.Always
+      locationPermissionLauncher.launch(
+        arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
+      )
+      return
+    }
+    if (hasBackgroundLocationPermission(context)) {
+      pendingLocationSelection = null
+      viewModel.setLocationMode(LocationMode.Always)
+      return
+    }
+    pendingLocationSelection = LocationMode.Always
+    viewModel.setLocationMode(LocationMode.WhileUsing)
+    openAppSettings(context)
   }
 
   fun setPreciseLocationChecked(checked: Boolean) {
@@ -1145,6 +1208,26 @@ fun SettingsSheet(viewModel: MainViewModel) {
             },
           )
           HorizontalDivider(color = mobileBorder)
+          if (backgroundLocationAvailable) {
+            ListItem(
+              modifier = Modifier.fillMaxWidth(),
+              colors = listItemColors,
+              headlineContent = { Text("Always", style = mobileHeadline) },
+              supportingContent = {
+                Text(
+                  "Access even when OpenClaw is closed. Android opens system settings so you can choose $backgroundLocationOptionLabel.",
+                  style = mobileCallout,
+                )
+              },
+              trailingContent = {
+                RadioButton(
+                  selected = locationMode == LocationMode.Always,
+                  onClick = { requestAlwaysLocationPermissions() },
+                )
+              },
+            )
+            HorizontalDivider(color = mobileBorder)
+          }
           ListItem(
             modifier = Modifier.fillMaxWidth(),
             colors = listItemColors,
@@ -1330,6 +1413,18 @@ private fun hasNotificationsPermission(context: Context): Boolean {
   if (Build.VERSION.SDK_INT < 33) return true
   return ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
           PackageManager.PERMISSION_GRANTED
+}
+
+private fun hasAnyLocationPermission(context: Context): Boolean {
+  return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+    PackageManager.PERMISSION_GRANTED ||
+    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+    PackageManager.PERMISSION_GRANTED
+}
+
+private fun hasBackgroundLocationPermission(context: Context): Boolean {
+  return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+    PackageManager.PERMISSION_GRANTED
 }
 
 private fun isNotificationListenerEnabled(context: Context): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -69,6 +69,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeForegroundService
 import ai.openclaw.app.normalizeLocalHourMinute
 import ai.openclaw.app.NotificationPackageFilterMode
 import ai.openclaw.app.node.DeviceNotificationListenerService
@@ -169,6 +170,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
 
   var pendingLocationSelection by remember { mutableStateOf<LocationMode?>(null) }
+  var previousLocationModeBeforeAlwaysPrompt by remember { mutableStateOf<LocationMode?>(null) }
   var pendingPreciseToggle by remember { mutableStateOf(false) }
   val backgroundLocationOptionLabel =
     remember(context) {
@@ -198,19 +200,33 @@ fun SettingsSheet(viewModel: MainViewModel) {
         LocationMode.WhileUsing -> {
           pendingLocationSelection = null
           if (granted) {
-            viewModel.setLocationMode(LocationMode.WhileUsing)
+            setLocationModeAndRefreshService(
+              context = context,
+              viewModel = viewModel,
+              mode = LocationMode.WhileUsing,
+            )
           }
         }
         LocationMode.Always -> {
           if (!granted) {
             pendingLocationSelection = null
+            previousLocationModeBeforeAlwaysPrompt = null
             return@rememberLauncherForActivityResult
           }
           if (hasBackgroundLocationPermission(context)) {
             pendingLocationSelection = null
-            viewModel.setLocationMode(LocationMode.Always)
+            previousLocationModeBeforeAlwaysPrompt = null
+            setLocationModeAndRefreshService(
+              context = context,
+              viewModel = viewModel,
+              mode = LocationMode.Always,
+            )
           } else {
-            viewModel.setLocationMode(LocationMode.WhileUsing)
+            setLocationModeAndRefreshService(
+              context = context,
+              viewModel = viewModel,
+              mode = LocationMode.WhileUsing,
+            )
             openAppSettings(context)
           }
         }
@@ -373,17 +389,40 @@ fun SettingsSheet(viewModel: MainViewModel) {
           val backgroundGranted = hasBackgroundLocationPermission(context)
           when {
             pendingLocationSelection == LocationMode.Always -> {
+              val restoredMode = restoreLocationModeAfterCanceledAlwaysGrant(
+                previousMode = previousLocationModeBeforeAlwaysPrompt,
+                locationGranted = locationGranted,
+              )
               pendingLocationSelection = null
+              previousLocationModeBeforeAlwaysPrompt = null
               if (backgroundLocationAvailable && locationGranted && backgroundGranted) {
-                viewModel.setLocationMode(LocationMode.Always)
+                setLocationModeAndRefreshService(
+                  context = context,
+                  viewModel = viewModel,
+                  mode = LocationMode.Always,
+                )
+              } else if (restoredMode != null) {
+                setLocationModeAndRefreshService(
+                  context = context,
+                  viewModel = viewModel,
+                  mode = restoredMode,
+                )
               }
             }
             locationMode == LocationMode.Always &&
               (!backgroundLocationAvailable || !locationGranted || !backgroundGranted) -> {
-              viewModel.setLocationMode(if (locationGranted) LocationMode.WhileUsing else LocationMode.Off)
+              setLocationModeAndRefreshService(
+                context = context,
+                viewModel = viewModel,
+                mode = if (locationGranted) LocationMode.WhileUsing else LocationMode.Off,
+              )
             }
             locationMode == LocationMode.WhileUsing && !locationGranted -> {
-              viewModel.setLocationMode(LocationMode.Off)
+              setLocationModeAndRefreshService(
+                context = context,
+                viewModel = viewModel,
+                mode = LocationMode.Off,
+              )
             }
           }
           micPermissionGranted =
@@ -444,7 +483,11 @@ fun SettingsSheet(viewModel: MainViewModel) {
 
   fun requestLocationPermissions() {
     if (hasAnyLocationPermission(context)) {
-      viewModel.setLocationMode(LocationMode.WhileUsing)
+      setLocationModeAndRefreshService(
+        context = context,
+        viewModel = viewModel,
+        mode = LocationMode.WhileUsing,
+      )
     } else {
       pendingLocationSelection = LocationMode.WhileUsing
       locationPermissionLauncher.launch(
@@ -459,6 +502,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
       return
     }
     if (!hasAnyLocationPermission(context)) {
+      previousLocationModeBeforeAlwaysPrompt = locationMode
       pendingLocationSelection = LocationMode.Always
       locationPermissionLauncher.launch(
         arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
@@ -467,11 +511,21 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
     if (hasBackgroundLocationPermission(context)) {
       pendingLocationSelection = null
-      viewModel.setLocationMode(LocationMode.Always)
+      previousLocationModeBeforeAlwaysPrompt = null
+      setLocationModeAndRefreshService(
+        context = context,
+        viewModel = viewModel,
+        mode = LocationMode.Always,
+      )
       return
     }
+    previousLocationModeBeforeAlwaysPrompt = locationMode
     pendingLocationSelection = LocationMode.Always
-    viewModel.setLocationMode(LocationMode.WhileUsing)
+    setLocationModeAndRefreshService(
+      context = context,
+      viewModel = viewModel,
+      mode = LocationMode.WhileUsing,
+    )
     openAppSettings(context)
   }
 
@@ -1190,7 +1244,13 @@ fun SettingsSheet(viewModel: MainViewModel) {
             trailingContent = {
               RadioButton(
                 selected = locationMode == LocationMode.Off,
-                onClick = { viewModel.setLocationMode(LocationMode.Off) },
+                onClick = {
+                  setLocationModeAndRefreshService(
+                    context = context,
+                    viewModel = viewModel,
+                    mode = LocationMode.Off,
+                  )
+                },
               )
             },
           )
@@ -1353,6 +1413,27 @@ internal fun resolveNotificationCandidatePackages(
     .toSet()
 }
 
+internal fun restoreLocationModeAfterCanceledAlwaysGrant(
+  previousMode: LocationMode?,
+  locationGranted: Boolean,
+): LocationMode? {
+  return when (previousMode) {
+    null -> null
+    LocationMode.Off -> LocationMode.Off
+    LocationMode.WhileUsing,
+    LocationMode.Always,
+    -> if (locationGranted) LocationMode.WhileUsing else LocationMode.Off
+  }
+}
+
+private fun setLocationModeAndRefreshService(
+  context: Context,
+  viewModel: MainViewModel,
+  mode: LocationMode,
+) {
+  viewModel.setLocationMode(mode)
+  NodeForegroundService.refresh(context)
+}
 
 @Composable
 private fun settingsTextFieldColors() =

--- a/apps/android/app/src/play/AndroidManifest.xml
+++ b/apps/android/app/src/play/AndroidManifest.xml
@@ -10,4 +10,7 @@
     <uses-permission
         android:name="android.permission.READ_CALL_LOG"
         tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.ACCESS_BACKGROUND_LOCATION"
+        tools:node="remove" />
 </manifest>

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -37,7 +37,7 @@ class NodeForegroundServiceTest {
   fun foregroundServiceType_omitsLocationWhenPermissionMissing() {
     val service = Robolectric.buildService(NodeForegroundService::class.java).get()
 
-    val serviceType = foregroundServiceType(service, locationGranted = false)
+    val serviceType = foregroundServiceType(service, includeLocationType = false)
 
     assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC, serviceType)
   }
@@ -46,7 +46,7 @@ class NodeForegroundServiceTest {
   fun foregroundServiceType_includesLocationWhenPermissionGranted() {
     val service = Robolectric.buildService(NodeForegroundService::class.java).get()
 
-    val serviceType = foregroundServiceType(service, locationGranted = true)
+    val serviceType = foregroundServiceType(service, includeLocationType = true)
 
     assertEquals(
       ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
@@ -103,6 +103,8 @@ class NodeForegroundServiceTest {
   @Test
   fun onStartCommand_refreshActionReevaluatesForegroundServiceType() {
     TestNodeForegroundService.locationGranted = true
+    TestNodeForegroundService.appForeground = true
+    TestNodeForegroundService.backgroundLocationAllowed = false
     val service = Robolectric.buildService(TestNodeForegroundService::class.java).get()
     setForegroundState(
       service = service,
@@ -122,6 +124,36 @@ class NodeForegroundServiceTest {
     )
   }
 
+  @Test
+  fun canUseLocationForegroundServiceType_requiresBackgroundCapabilityWhenAppIsBackgrounded() {
+    val service = Robolectric.buildService(TestNodeForegroundService::class.java).get()
+    TestNodeForegroundService.locationGranted = true
+    TestNodeForegroundService.appForeground = false
+    TestNodeForegroundService.backgroundLocationAllowed = false
+
+    assertFalse(service.canUseLocationForegroundServiceType())
+  }
+
+  @Test
+  fun canUseLocationForegroundServiceType_allowsForegroundPermissionWhileAppIsForeground() {
+    val service = Robolectric.buildService(TestNodeForegroundService::class.java).get()
+    TestNodeForegroundService.locationGranted = true
+    TestNodeForegroundService.appForeground = true
+    TestNodeForegroundService.backgroundLocationAllowed = false
+
+    assertTrue(service.canUseLocationForegroundServiceType())
+  }
+
+  @Test
+  fun canUseLocationForegroundServiceType_allowsBackgroundCapabilityWhileAppIsBackgrounded() {
+    val service = Robolectric.buildService(TestNodeForegroundService::class.java).get()
+    TestNodeForegroundService.locationGranted = true
+    TestNodeForegroundService.appForeground = false
+    TestNodeForegroundService.backgroundLocationAllowed = true
+
+    assertTrue(service.canUseLocationForegroundServiceType())
+  }
+
   private fun buildNotification(service: NodeForegroundService): Notification {
     val method =
       NodeForegroundService::class.java.getDeclaredMethod(
@@ -133,14 +165,14 @@ class NodeForegroundServiceTest {
     return method.invoke(service, "Title", "Text") as Notification
   }
 
-  private fun foregroundServiceType(service: NodeForegroundService, locationGranted: Boolean): Int {
+  private fun foregroundServiceType(service: NodeForegroundService, includeLocationType: Boolean): Int {
     val method =
       NodeForegroundService::class.java.getDeclaredMethod(
         "foregroundServiceType",
         Boolean::class.javaPrimitiveType,
       )
     method.isAccessible = true
-    return method.invoke(service, locationGranted) as Int
+    return method.invoke(service, includeLocationType) as Int
   }
 
   private fun shouldRestartForeground(
@@ -194,9 +226,13 @@ class NodeForegroundServiceTest {
 
   private class TestNodeForegroundService : NodeForegroundService() {
     override fun hasAnyLocationPermission(): Boolean = locationGranted
+    override fun isAppForeground(): Boolean = appForeground
+    override fun canUseBackgroundLocation(): Boolean = backgroundLocationAllowed
 
     companion object {
       var locationGranted: Boolean = false
+      var appForeground: Boolean = true
+      var backgroundLocationAllowed: Boolean = false
     }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -5,6 +5,8 @@ import android.content.pm.ServiceInfo
 import android.content.Intent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -52,6 +54,52 @@ class NodeForegroundServiceTest {
     )
   }
 
+  @Test
+  fun shouldRestartForeground_whenNeverStarted() {
+    val service = Robolectric.buildService(NodeForegroundService::class.java).get()
+
+    val shouldRestart =
+      shouldRestartForeground(
+        service = service,
+        didStartForeground = false,
+        currentForegroundServiceType = null,
+        requestedServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+      )
+
+    assertTrue(shouldRestart)
+  }
+
+  @Test
+  fun shouldRestartForeground_whenServiceTypeChanges() {
+    val service = Robolectric.buildService(NodeForegroundService::class.java).get()
+
+    val shouldRestart =
+      shouldRestartForeground(
+        service = service,
+        didStartForeground = true,
+        currentForegroundServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+        requestedServiceType =
+          ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+      )
+
+    assertTrue(shouldRestart)
+  }
+
+  @Test
+  fun shouldRestartForeground_whenServiceTypeMatches() {
+    val service = Robolectric.buildService(NodeForegroundService::class.java).get()
+
+    val shouldRestart =
+      shouldRestartForeground(
+        service = service,
+        didStartForeground = true,
+        currentForegroundServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+        requestedServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+      )
+
+    assertFalse(shouldRestart)
+  }
+
   private fun buildNotification(service: NodeForegroundService): Notification {
     val method =
       NodeForegroundService::class.java.getDeclaredMethod(
@@ -71,5 +119,28 @@ class NodeForegroundServiceTest {
       )
     method.isAccessible = true
     return method.invoke(service, locationGranted) as Int
+  }
+
+  private fun shouldRestartForeground(
+    service: NodeForegroundService,
+    didStartForeground: Boolean,
+    currentForegroundServiceType: Int?,
+    requestedServiceType: Int,
+  ): Boolean {
+    val didStartField = NodeForegroundService::class.java.getDeclaredField("didStartForeground")
+    didStartField.isAccessible = true
+    didStartField.setBoolean(service, didStartForeground)
+
+    val currentTypeField = NodeForegroundService::class.java.getDeclaredField("currentForegroundServiceType")
+    currentTypeField.isAccessible = true
+    currentTypeField.set(service, currentForegroundServiceType)
+
+    val method =
+      NodeForegroundService::class.java.getDeclaredMethod(
+        "shouldRestartForeground",
+        Int::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    return method.invoke(service, requestedServiceType) as Boolean
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -100,6 +100,28 @@ class NodeForegroundServiceTest {
     assertFalse(shouldRestart)
   }
 
+  @Test
+  fun onStartCommand_refreshActionReevaluatesForegroundServiceType() {
+    TestNodeForegroundService.locationGranted = true
+    val service = Robolectric.buildService(TestNodeForegroundService::class.java).get()
+    setForegroundState(
+      service = service,
+      didStartForeground = true,
+      currentForegroundServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+    )
+
+    service.onStartCommand(
+      Intent(service, NodeForegroundService::class.java).setAction(refreshForegroundAction()),
+      0,
+      1,
+    )
+
+    assertEquals(
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+      currentForegroundServiceType(service),
+    )
+  }
+
   private fun buildNotification(service: NodeForegroundService): Notification {
     val method =
       NodeForegroundService::class.java.getDeclaredMethod(
@@ -142,5 +164,39 @@ class NodeForegroundServiceTest {
       )
     method.isAccessible = true
     return method.invoke(service, requestedServiceType) as Boolean
+  }
+
+  private fun setForegroundState(
+    service: NodeForegroundService,
+    didStartForeground: Boolean,
+    currentForegroundServiceType: Int?,
+  ) {
+    val didStartField = NodeForegroundService::class.java.getDeclaredField("didStartForeground")
+    didStartField.isAccessible = true
+    didStartField.setBoolean(service, didStartForeground)
+
+    val currentTypeField = NodeForegroundService::class.java.getDeclaredField("currentForegroundServiceType")
+    currentTypeField.isAccessible = true
+    currentTypeField.set(service, currentForegroundServiceType)
+  }
+
+  private fun currentForegroundServiceType(service: NodeForegroundService): Int? {
+    val currentTypeField = NodeForegroundService::class.java.getDeclaredField("currentForegroundServiceType")
+    currentTypeField.isAccessible = true
+    return currentTypeField.get(service) as Int?
+  }
+
+  private fun refreshForegroundAction(): String {
+    val field = NodeForegroundService::class.java.getDeclaredField("ACTION_REFRESH_FOREGROUND")
+    field.isAccessible = true
+    return field.get(null) as String
+  }
+
+  private class TestNodeForegroundService : NodeForegroundService() {
+    override fun hasAnyLocationPermission(): Boolean = locationGranted
+
+    companion object {
+      var locationGranted: Boolean = false
+    }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app
 
 import android.app.Notification
+import android.content.pm.ServiceInfo
 import android.content.Intent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -30,6 +31,27 @@ class NodeForegroundServiceTest {
     assertEquals(expectedFlags, savedIntent.flags and expectedFlags)
   }
 
+  @Test
+  fun foregroundServiceType_omitsLocationWhenPermissionMissing() {
+    val service = Robolectric.buildService(NodeForegroundService::class.java).get()
+
+    val serviceType = foregroundServiceType(service, locationGranted = false)
+
+    assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC, serviceType)
+  }
+
+  @Test
+  fun foregroundServiceType_includesLocationWhenPermissionGranted() {
+    val service = Robolectric.buildService(NodeForegroundService::class.java).get()
+
+    val serviceType = foregroundServiceType(service, locationGranted = true)
+
+    assertEquals(
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+      serviceType,
+    )
+  }
+
   private fun buildNotification(service: NodeForegroundService): Notification {
     val method =
       NodeForegroundService::class.java.getDeclaredMethod(
@@ -39,5 +61,15 @@ class NodeForegroundServiceTest {
       )
     method.isAccessible = true
     return method.invoke(service, "Title", "Text") as Notification
+  }
+
+  private fun foregroundServiceType(service: NodeForegroundService, locationGranted: Boolean): Int {
+    val method =
+      NodeForegroundService::class.java.getDeclaredMethod(
+        "foregroundServiceType",
+        Boolean::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    return method.invoke(service, locationGranted) as Int
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -3,6 +3,8 @@ package ai.openclaw.app
 import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -55,5 +57,32 @@ class SecurePrefsTest {
     assertNull(prefs.loadGatewayToken())
     assertNull(prefs.loadGatewayBootstrapToken())
     assertNull(prefs.loadGatewayPassword())
+  }
+
+  @Test
+  fun reconcilePendingAlwaysLocationUpgrade_restoresPreviousModeWhenBackgroundPermissionMissing() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().putString("location.enabledMode", "whileUsing").commit()
+    val prefs = SecurePrefs(context)
+    prefs.beginPendingAlwaysLocationUpgrade(LocationMode.Off)
+
+    val reconciled = prefs.reconcilePendingAlwaysLocationUpgrade()
+
+    assertEquals(LocationMode.Off, reconciled)
+    assertEquals(LocationMode.Off, prefs.locationMode.value)
+    assertFalse(prefs.hasPendingAlwaysLocationUpgrade())
+  }
+
+  @Test
+  fun beginPendingAlwaysLocationUpgrade_persistsPendingState() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().putString("location.enabledMode", "whileUsing").commit()
+    val prefs = SecurePrefs(context)
+    prefs.beginPendingAlwaysLocationUpgrade(LocationMode.Off)
+
+    assertEquals(LocationMode.WhileUsing, prefs.effectiveLocationMode())
+    assertTrue(prefs.hasPendingAlwaysLocationUpgrade())
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -11,15 +11,15 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class SecurePrefsTest {
   @Test
-  fun loadLocationMode_migratesLegacyAlwaysValue() {
+  fun loadLocationMode_preservesAlwaysValue() {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().putString("location.enabledMode", "always").commit()
 
     val prefs = SecurePrefs(context)
 
-    assertEquals(LocationMode.WhileUsing, prefs.locationMode.value)
-    assertEquals("whileUsing", plainPrefs.getString("location.enabledMode", null))
+    assertEquals(LocationMode.Always, prefs.locationMode.value)
+    assertEquals("always", plainPrefs.getString("location.enabledMode", null))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -287,6 +287,8 @@ private class InvokeDispatcherFakeLocationDataSource : LocationDataSource {
 
   override fun hasCoarsePermission(context: Context): Boolean = false
 
+  override fun hasBackgroundPermission(context: Context): Boolean = false
+
   override suspend fun fetchLocation(
     desiredProviders: List<String>,
     maxAgeMs: Long?,

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
@@ -41,12 +41,35 @@ class LocationHandlerTest : NodeHandlerRobolectricTest() {
               coarseGranted = true,
             ),
           isForeground = { false },
+          locationMode = { ai.openclaw.app.LocationMode.WhileUsing },
         )
 
       val result = handler.handleLocationGet(null)
 
       assertFalse(result.ok)
       assertEquals("LOCATION_BACKGROUND_UNAVAILABLE", result.error?.code)
+    }
+
+  @Test
+  fun handleLocationGet_allowsBackgroundWhenAlwaysModeAndBackgroundPermissionGranted() =
+    runTest {
+      val handler =
+        LocationHandler.forTesting(
+          appContext = appContext(),
+          dataSource =
+            FakeLocationDataSource(
+              fineGranted = true,
+              coarseGranted = true,
+              backgroundGranted = true,
+              payload = LocationCaptureManager.Payload("""{"ok":true}"""),
+            ),
+          isForeground = { false },
+          locationMode = { ai.openclaw.app.LocationMode.Always },
+        )
+
+      val result = handler.handleLocationGet(null)
+
+      assertTrue(result.ok)
     }
 
   @Test
@@ -162,6 +185,7 @@ class LocationHandlerTest : NodeHandlerRobolectricTest() {
 private class FakeLocationDataSource(
   private val fineGranted: Boolean,
   private val coarseGranted: Boolean,
+  private val backgroundGranted: Boolean = false,
   private val payload: LocationCaptureManager.Payload? = null,
   private val failure: Throwable? = null,
   private val timeout: Boolean = false,
@@ -174,6 +198,8 @@ private class FakeLocationDataSource(
   override fun hasFinePermission(context: Context): Boolean = fineGranted
 
   override fun hasCoarsePermission(context: Context): Boolean = coarseGranted
+
+  override fun hasBackgroundPermission(context: Context): Boolean = backgroundGranted
 
   override suspend fun fetchLocation(
     desiredProviders: List<String>,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsSheetLocationFlowTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsSheetLocationFlowTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.LocationMode
+import ai.openclaw.app.restoreLocationModeAfterCanceledAlwaysGrant
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsSheetLocationFlowTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsSheetLocationFlowTest.kt
@@ -1,0 +1,40 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.LocationMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SettingsSheetLocationFlowTest {
+  @Test
+  fun restoreLocationModeAfterCanceledAlwaysGrant_restoresOffWhenPromptStartedFromOff() {
+    val restored =
+      restoreLocationModeAfterCanceledAlwaysGrant(
+        previousMode = LocationMode.Off,
+        locationGranted = true,
+      )
+
+    assertEquals(LocationMode.Off, restored)
+  }
+
+  @Test
+  fun restoreLocationModeAfterCanceledAlwaysGrant_keepsWhileUsingWhenPromptStartedFromWhileUsing() {
+    val restored =
+      restoreLocationModeAfterCanceledAlwaysGrant(
+        previousMode = LocationMode.WhileUsing,
+        locationGranted = true,
+      )
+
+    assertEquals(LocationMode.WhileUsing, restored)
+  }
+
+  @Test
+  fun restoreLocationModeAfterCanceledAlwaysGrant_fallsBackToOffWithoutForegroundPermission() {
+    val restored =
+      restoreLocationModeAfterCanceledAlwaysGrant(
+        previousMode = LocationMode.WhileUsing,
+        locationGranted = false,
+      )
+
+    assertEquals(LocationMode.Off, restored)
+  }
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Third-party Android builds had no app-level path to reach effective "Always allow" location access for background `location.get`.
- Why it matters: Android supports a stronger background-location grant flow, but the app only exposed foreground-only location behavior.
- What changed: Added an `Always` location mode for the third-party Android flavor, wired the Android settings handoff and reconciliation flow, gated background `location.get` on real background capability, and updated foreground service typing plus tests.
- What did NOT change (scope boundary): Play flavor still hides and removes background location support; no gateway protocol, server, or non-Android behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): Android 13+ requires the extra manifest declaration and a follow-up system settings grant for background location, which is distinct from the initial foreground permission dialog.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this: N/A
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Third-party Android builds now show an `Always` location mode in settings. Choosing it first ensures foreground location is granted, then sends the user to Android's system settings to complete the background-location grant. If the user grants it, background `location.get` can succeed; if they cancel, the setting rolls back to the previous mode. Play builds remain unchanged and do not expose background location.

## Diagram (if applicable)

```text
Before:
[user selects location] -> [foreground permission only] -> [background location always rejected]

After:
[user selects Always] -> [foreground permission granted] -> [Android settings grant flow]
  -> [grant background access] -> [mode becomes Always] -> [background location.get allowed]
  -> [cancel background access] -> [mode restored] -> [background location.get rejected]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: This adds optional background location capability for the third-party Android flavor only. Risk is broader location access if the user opts in. Mitigations: the Play flavor explicitly removes the permission and UI surface, the third-party flow requires an explicit second grant in Android settings, and background `location.get` remains gated on both effective `Always` mode and actual platform permission state.

## Repro + Verification

### Environment

- OS: Android
- Runtime/container: Android app (`playDebug` and `thirdPartyDebug`)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Third-party flavor with location enabled in app settings

### Steps

1. Install the third-party Android build and open Settings.
2. Set Location to `Always` and follow the Android system settings handoff.
3. Grant or deny background location, then exercise background `location.get` behavior.

### Expected

- Granting background location sets the app to effective `Always` mode and allows background `location.get`.
- Denying or backing out restores the previous mode and keeps background `location.get` blocked.

### Actual

- Matches expected behavior locally, and Play flavor still omits the background-location surface.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the third-party Android flow can route from app settings to Android system settings for `Always`. On a physical Android device, after enabling `Always` location, I messaged OpenClaw over Discord and confirmed it could use the phone's current location while configured for background access. Also reran targeted Android unit tests for `SecurePrefs`, `LocationHandler`, `NodeForegroundService`, and `SettingsSheetLocationFlow` on both `playDebug` and `thirdPartyDebug` plus `:app:ktlintCheck` after rebasing.
- Edge cases checked: Canceling the background grant restores the previous mode; foreground service typing does not claim `location` without real background capability; Play flavor does not surface background location.
- What you did **not** verify: A fresh end-to-end manual pass on a Play Store-distributed build, and device-level process-death behavior beyond the covered app-state/unit-test paths.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Android OEM settings behavior can vary around the background-location handoff.
  - Mitigation: The app persists pending-upgrade state, reconciles on resume/init, and continues to gate runtime behavior on actual permission state instead of assuming the grant succeeded.
- Risk: Foreground service type mismatches could break background location on Android 14+.
  - Mitigation: The service now refreshes its type when capability changes and only claims `location` when the app is foreground or background location is truly available.
