### PR TITLE
fix(polls): add missing test coverage for resolvePollMaxSelections

### DIFF
--- a/src/polls.test.ts
+++ b/src/polls.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizePollDurationHours, normalizePollInput } from "./polls.js";
+import {
+  normalizePollDurationHours,
+  normalizePollInput,
+  resolvePollMaxSelections,
+} from "./polls.js";
 
 describe("polls", () => {
   it("normalizes question/options and validates maxSelections", () => {
@@ -43,5 +47,28 @@ describe("polls", () => {
         durationHours: 1,
       }),
     ).toThrow(/mutually exclusive/);
+  });
+
+  describe("resolvePollMaxSelections", () => {
+    it("returns 1 when multiselect is false", () => {
+      expect(resolvePollMaxSelections(5, false)).toBe(1);
+    });
+
+    it("returns 1 when multiselect is undefined", () => {
+      expect(resolvePollMaxSelections(5, undefined)).toBe(1);
+    });
+
+    it("returns optionCount when multiselect is true and options >= 2", () => {
+      expect(resolvePollMaxSelections(5, true)).toBe(5);
+    });
+
+    it("returns at least 2 when multiselect is true", () => {
+      expect(resolvePollMaxSelections(1, true)).toBe(2);
+      expect(resolvePollMaxSelections(0, true)).toBe(2);
+    });
+
+    it("returns optionCount for exactly 2 options with multiselect", () => {
+      expect(resolvePollMaxSelections(2, true)).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
resolvePollMaxSelections is the only exported function in polls.ts without test coverage. It is exposed through the plugin SDK (channel-actions.ts) and called by message-action-runner.ts.

## Summary

Add unit tests for `resolvePollMaxSelections` covering all branches:
- `allowMultiselect=false` → returns 1
- `allowMultiselect=undefined` → returns 1
- `allowMultiselect=true` → returns `optionCount`
- `Math.max(2, n)` floor when `optionCount < 2`

- Problem: SDK-exported function with zero test coverage
- Why it matters: Behavior changes cannot be regression-detected
- What changed: Added 5 test cases in `src/polls.test.ts`
- What did NOT change (scope boundary): No production code changes

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #36547
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — test coverage gap, not a runtime bug.

## Testing

- Added `describe("resolvePollMaxSelections")` block in `src/polls.test.ts`
- All 5 new test cases pass locally
