### PR TITLE
fix(polls): remove unused Telegram-specific poll param exports

### DIFF
--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -1,6 +1,6 @@
 import { readSnakeCaseParamRaw } from "./param-key.js";
 
-export type PollCreationParamKind = "string" | "stringArray" | "number" | "boolean";
+type PollCreationParamKind = "string" | "stringArray" | "number" | "boolean";
 
 export type PollCreationParamDef = {
   kind: PollCreationParamKind;
@@ -25,16 +25,12 @@ export const POLL_CREATION_PARAM_DEFS: Record<string, PollCreationParamDef> = {
 };
 
 export type SharedPollCreationParamName = keyof typeof SHARED_POLL_CREATION_PARAM_DEFS;
-export type TelegramPollCreationParamName = keyof typeof TELEGRAM_POLL_CREATION_PARAM_DEFS;
 export type PollCreationParamName = keyof typeof POLL_CREATION_PARAM_DEFS;
 
 export const POLL_CREATION_PARAM_NAMES = Object.keys(POLL_CREATION_PARAM_DEFS);
 export const SHARED_POLL_CREATION_PARAM_NAMES = Object.keys(
   SHARED_POLL_CREATION_PARAM_DEFS,
 ) as SharedPollCreationParamName[];
-export const TELEGRAM_POLL_CREATION_PARAM_NAMES = Object.keys(
-  TELEGRAM_POLL_CREATION_PARAM_DEFS,
-) as TelegramPollCreationParamName[];
 
 function readPollParamRaw(params: Record<string, unknown>, key: string): unknown {
   return readSnakeCaseParamRaw(params, key);


### PR DESCRIPTION
`TELEGRAM_POLL_CREATION_PARAM_NAMES`, `TelegramPollCreationParamName`, and `PollCreationParamKind` are exported from `src/poll-params.ts` but never imported anywhere else in the entire repo (including extensions/).

## Summary

Remove unused Telegram-specific exports from core `poll-params.ts` to reduce the public API surface.

- Problem: Three exports in `src/poll-params.ts` have zero consumers outside the file
- Why it matters: Unused exports mislead plugin authors into thinking they are public API; per AGENTS.md, Telegram-specific config should live in the owning plugin, not core
- What changed: Removed `export` from `PollCreationParamKind`, `TelegramPollCreationParamName`, and `TELEGRAM_POLL_CREATION_PARAM_NAMES`; deleted the latter two entirely since they had no in-file usage either
- What did NOT change (scope boundary): `POLL_CREATION_PARAM_DEFS`, `POLL_CREATION_PARAM_NAMES`, `SHARED_POLL_CREATION_PARAM_NAMES`, and all runtime logic remain unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #36547
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Dead exports left behind after poll-params centralization in #36547
- Missing detection / guardrail: No unused-export lint rule

## Testing

- Verified via repo-wide grep: zero imports of the removed symbols outside `src/poll-params.ts`
- Existing `src/poll-params.test.ts` unchanged and still passes
