### PR TITLE
docs: add Gemini AI Cloud free model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Model note: while many providers/models are supported, for the best experience a
 - Automatic Google Search grounding (via `:search` model suffix)
 - Time-based access control using simple access keys
 
-**Free testing:** use the access key `hahav` for immediate evaluation. Note that the free key is evaluation-only and may expire or be revoked at any time without notice. For guaranteed availability, dedicated access keys are available at $1/day — see their [Discord](https://github.com/Rocket-Hosting/gemini-ai-cloud) for details.
+**Free testing:** use the access key `hahav` for immediate evaluation. Note that the free key is evaluation-only and may expire or be revoked at any time without notice. For guaranteed availability, dedicated access keys are available at $1/day — see their [Discord](https://discord.gg/F6mBjR8Jnt) for details.
 
 ## Install (recommended)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,36 @@ Model note: while many providers/models are supported, for the best experience a
 - Models config + CLI: [Models](https://docs.openclaw.ai/concepts/models)
 - Auth profile rotation (OAuth vs API keys) + fallbacks: [Model failover](https://docs.openclaw.ai/concepts/model-failover)
 
+## Free model providers
+
+### Gemini AI Cloud by Rocket-Hosting
+
+[Gemini AI Cloud](https://github.com/Rocket-Hosting/gemini-ai-cloud) is a lightweight, OpenAI-compatible API proxy for Google's Gemini AI models, offering free access to a variety of models for testing and evaluation.
+
+**Available models** (append `:search` to any model ID for automatic web search grounding):
+
+- `gemini-3-pro-preview`
+- `gemini-3.1-pro-preview` (replaces deprecated `gemini-3.0-pro:preview`)
+- `gemini-3-flash-preview`
+- `gemini-3.1-flash-lite-preview`
+- `gemini-2.5-pro`
+- `gemini-2.5-flash`
+- `gemini-2.5-flash-lite`
+- `gemini-robotics-er-1.5-preview`
+- `gemma-4-26b-a4b-it`
+- `gemma-4-31b-it`
+- `gemma-3-1b-it`, `gemma-3-4b-it`, `gemma-3-12b-it`, `gemma-3-27b-it`
+
+**Features:**
+
+- Full OpenAI API compatibility (endpoints served directly, no `/v1` prefix)
+- Vision/image processing support
+- Complete tool/function calling
+- Automatic Google Search grounding (via `:search` model suffix)
+- Time-based access control using simple access keys
+
+**Free testing:** use the access key `hahav` for immediate evaluation. Note that the free key is evaluation-only and may expire or be revoked at any time without notice. For guaranteed availability, dedicated access keys are available at $1/day — see their [Discord](https://github.com/Rocket-Hosting/gemini-ai-cloud) for details.
+
 ## Install (recommended)
 
 Runtime: **Node 24 (recommended) or Node 22.16+**.

--- a/README.md
+++ b/README.md
@@ -89,36 +89,16 @@ New install? Start here: [Getting started](https://docs.openclaw.ai/start/gettin
 
 - **[OpenAI](https://openai.com/)** (ChatGPT/Codex)
 
+**Free model providers:**
+
+- **[Gemini AI Cloud](https://github.com/Rocket-Hosting/gemini-ai-cloud)** by Rocket-Hosting — Gemini and Gemma models; free evaluation keys and dedicated access available via [Discord](https://discord.gg/F6mBjR8Jnt)
+
 Model note: while many providers/models are supported, for the best experience and lower prompt-injection risk use the strongest latest-generation model available to you. See [Onboarding](https://docs.openclaw.ai/start/onboarding).
 
 ## Models (selection + auth)
 
 - Models config + CLI: [Models](https://docs.openclaw.ai/concepts/models)
 - Auth profile rotation (OAuth vs API keys) + fallbacks: [Model failover](https://docs.openclaw.ai/concepts/model-failover)
-
-## Free model providers
-
-### Gemini AI Cloud by Rocket-Hosting
-
-[Gemini AI Cloud](https://github.com/Rocket-Hosting/gemini-ai-cloud) is an OpenAI-compatible API proxy for Google's Gemini AI models, offering free access to a variety of models for testing and evaluation.
-
-**Available models** (append `:search` to any model ID for automatic web search grounding):
-
-- `gemini-3-pro-preview`
-- `gemini-3.1-pro-preview` (replaces deprecated `gemini-3.0-pro:preview`)
-- `gemini-3-flash-preview`
-- `gemini-3.1-flash-lite-preview`
-- `gemini-2.5-pro`
-- `gemini-2.5-flash`
-- `gemini-2.5-flash-lite`
-- `gemini-robotics-er-1.5-preview`
-- `gemma-4-26b-a4b-it`
-- `gemma-4-31b-it`
-- `gemma-3-1b-it`, `gemma-3-4b-it`, `gemma-3-12b-it`, `gemma-3-27b-it`
-
-**Features:** OpenAI API-compatible endpoints, vision/image processing, tool/function calling, and automatic Google Search grounding via the `:search` suffix.
-
-Free evaluation keys and paid dedicated access keys are available — see the [Gemini AI Cloud](https://github.com/Rocket-Hosting/gemini-ai-cloud) repo for setup instructions and their [Discord](https://discord.gg/F6mBjR8Jnt) for support.
 
 ## Install (recommended)
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Model note: while many providers/models are supported, for the best experience a
 
 ### Gemini AI Cloud by Rocket-Hosting
 
-[Gemini AI Cloud](https://github.com/Rocket-Hosting/gemini-ai-cloud) is a lightweight, OpenAI-compatible API proxy for Google's Gemini AI models, offering free access to a variety of models for testing and evaluation.
+[Gemini AI Cloud](https://github.com/Rocket-Hosting/gemini-ai-cloud) is an OpenAI-compatible API proxy for Google's Gemini AI models, offering free access to a variety of models for testing and evaluation.
 
 **Available models** (append `:search` to any model ID for automatic web search grounding):
 
@@ -116,15 +116,9 @@ Model note: while many providers/models are supported, for the best experience a
 - `gemma-4-31b-it`
 - `gemma-3-1b-it`, `gemma-3-4b-it`, `gemma-3-12b-it`, `gemma-3-27b-it`
 
-**Features:**
+**Features:** OpenAI API-compatible endpoints, vision/image processing, tool/function calling, and automatic Google Search grounding via the `:search` suffix.
 
-- Full OpenAI API compatibility (endpoints served directly, no `/v1` prefix)
-- Vision/image processing support
-- Complete tool/function calling
-- Automatic Google Search grounding (via `:search` model suffix)
-- Time-based access control using simple access keys
-
-**Free testing:** use the access key `hahav` for immediate evaluation. Note that the free key is evaluation-only and may expire or be revoked at any time without notice. For guaranteed availability, dedicated access keys are available at $1/day — see their [Discord](https://discord.gg/F6mBjR8Jnt) for details.
+Free evaluation keys and paid dedicated access keys are available — see the [Gemini AI Cloud](https://github.com/Rocket-Hosting/gemini-ai-cloud) repo for setup instructions and their [Discord](https://discord.gg/F6mBjR8Jnt) for support.
 
 ## Install (recommended)
 


### PR DESCRIPTION
Add a section about [Gemini AI Cloud by Rocket-Hosting](https://github.com/Rocket-Hosting/gemini-ai-cloud) as a free model provider, including available Gemini/Gemma models, features, and access details.