### PR TITLE
fix(android): allow onboarding finish when operator is offline

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -229,7 +229,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   var manualTls by rememberSaveable { mutableStateOf(false) }
   var gatewayError by rememberSaveable { mutableStateOf<String?>(null) }
   var attemptedConnect by rememberSaveable { mutableStateOf(false) }
-  val canFinishOnboarding = canFinishOnboarding(isConnected = isConnected, isNodeConnected = isNodeConnected)
+  val canFinishOnboarding = canFinishOnboarding(isNodeConnected = isNodeConnected)
 
   val lifecycleOwner = LocalLifecycleOwner.current
   val qrScannerOptions =
@@ -927,8 +927,10 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   }
 }
 
-internal fun canFinishOnboarding(isConnected: Boolean, isNodeConnected: Boolean): Boolean {
-  return isConnected && isNodeConnected
+internal fun canFinishOnboarding(isNodeConnected: Boolean): Boolean {
+  // Operator connectivity can legitimately lag or be offline after pairing.
+  // Finishing onboarding only needs to prove this device node reached the gateway.
+  return isNodeConnected
 }
 
 @Composable

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -6,22 +6,12 @@ import org.junit.Test
 
 class OnboardingFlowLogicTest {
   @Test
-  fun blocksFinishWhenOnlyOperatorIsConnected() {
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = false))
+  fun blocksFinishWhenNodeIsDisconnected() {
+    assertFalse(canFinishOnboarding(isNodeConnected = false))
   }
 
   @Test
-  fun blocksFinishWhenDisconnected() {
-    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = false))
-  }
-
-  @Test
-  fun blocksFinishWhenOnlyNodeIsConnected() {
-    assertFalse(canFinishOnboarding(isConnected = false, isNodeConnected = true))
-  }
-
-  @Test
-  fun allowsFinishOnlyWhenOperatorAndNodeAreConnected() {
-    assertTrue(canFinishOnboarding(isConnected = true, isNodeConnected = true))
+  fun allowsFinishWhenNodeIsConnected() {
+    assertTrue(canFinishOnboarding(isNodeConnected = true))
   }
 }


### PR DESCRIPTION
## Summary

- Problem: Android onboarding could get stuck on the final Connect step when the node was paired and connected but the operator session was still offline.
- Why it matters: `Connected (operator offline)` is a normal post-pairing state, but onboarding treated it like a hard failure and never exposed Finish.
- What changed: onboarding now finishes based on node connectivity to the gateway, and the logic test locks that behavior in.
- What did NOT change (scope boundary): this does not change operator session auth, reconnect timing, or gateway pairing flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61005
- Related #61005
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the onboarding finish gate required both operator and node sessions to be connected, even though the UI already models `Connected (operator offline)` as a normal connected state.
- Missing detection / guardrail: the existing unit test encoded the stricter behavior, so the regression was effectively blessed instead of caught.
- Contributing context (if known): recent Android runtime changes can legitimately leave the node connected while the operator session is still offline or delayed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt`
- Scenario the test should lock in: onboarding can finish once the node is connected, even if the operator session is offline.
- Why this is the smallest reliable guardrail: the bug is in the pure finish-gate decision, so a focused unit test is enough to pin the contract.
- Existing test that already covers this (if any): the same file covered the finish gate, but with the wrong expectation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Android onboarding now allows Finish when the device node is connected to the gateway, even if the operator session still shows offline.

## Diagram (if applicable)

```text
Before:
[node paired + connected] -> [operator offline] -> [Connect step stuck]

After:
[node paired + connected] -> [operator offline] -> [Finish enabled] -> [onboarding completes]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: Android Gradle unit tests
- Model/provider: N/A
- Integration/channel (if any): Android onboarding
- Relevant config (redacted): `ANDROID_HOME` / `ANDROID_SDK_ROOT` pointed at the local Android SDK

### Steps

1. Pair an Android node to a gateway.
2. Reach the final onboarding Connect step while the node is connected but the operator session remains offline.
3. Try to complete onboarding.

### Expected

- Onboarding can finish because node connectivity to the gateway is already established.

### Actual

- Finish never appears because the flow waits for operator connectivity too.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: updated the onboarding finish gate and ran `ANDROID_HOME=$HOME/Library/Android/sdk ANDROID_SDK_ROOT=$HOME/Library/Android/sdk ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest` successfully.
- Edge cases checked: finish still stays blocked when the node is not connected.
- What you did **not** verify: I did not run the full Android unit suite or a device/manual onboarding pass.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: onboarding could allow Finish in a state that is too permissive if future logic stops requiring node connectivity for actual readiness.
  - Mitigation: the gate still requires `isNodeConnected`, and the unit test now documents that exact contract.
