### PR TITLE
fix(bedrock-mantle): add missing configSchema to plugin manifest

### DIFF
--- a/extensions/amazon-bedrock-mantle/openclaw.plugin.json
+++ b/extensions/amazon-bedrock-mantle/openclaw.plugin.json
@@ -1,5 +1,10 @@
 {
   "id": "amazon-bedrock-mantle",
   "enabledByDefault": true,
-  "providers": ["amazon-bedrock-mantle"]
+  "providers": ["amazon-bedrock-mantle"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
 }


### PR DESCRIPTION
## Problem

The `amazon-bedrock-mantle` plugin manifest (added in #61296) is missing the required `configSchema` field. This causes gateway startup to fail when running from source:

```
Config invalid
File: ~/.openclaw/openclaw.json
Problem:
  - plugins: plugin: plugin manifest requires configSchema
```

## Fix

Add the standard empty object schema to match every other bundled plugin:

```json
"configSchema": {
  "type": "object",
  "additionalProperties": false,
  "properties": {}
}
```

## Verification

- Confirmed this is the only bundled plugin missing `configSchema` (checked all 90+ manifests)
- Gateway starts successfully after the fix