### PR TITLE
fix(transcript): disable OpenAI tool-use pairing repair

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,8 @@ importers:
         specifier: 3.1022.0
         version: 3.1022.0
 
+  extensions/amazon-bedrock-mantle: {}
+
   extensions/anthropic: {}
 
   extensions/anthropic-vertex: {}
@@ -391,6 +393,8 @@ importers:
         version: link:../..
 
   extensions/firecrawl: {}
+
+  extensions/fireworks: {}
 
   extensions/github-copilot: {}
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -106,6 +106,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
               sanitizeMode: "images-only",
               sanitizeToolCallIds: context?.modelApi === "openai-completions",
               ...(context?.modelApi === "openai-completions" ? { toolCallIdMode: "strict" } : {}),
+              repairToolUseResultPairing: false,
               applyAssistantFirstOrderingFix: false,
               validateGeminiTurns: false,
               validateAnthropicTurns: false,
@@ -225,6 +226,24 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.applyGoogleTurnOrdering).toBe(false);
     expect(policy.validateGeminiTurns).toBe(false);
     expect(policy.validateAnthropicTurns).toBe(false);
+  });
+
+  it("disables tool-use/result pairing repair for OpenAI-compatible replay", () => {
+    const openAiResponsesPolicy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+    });
+    const codexResponsesPolicy = resolveTranscriptPolicy({
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      modelApi: "openai-codex-responses",
+    });
+
+    expect(openAiResponsesPolicy.repairToolUseResultPairing).toBe(false);
+    expect(openAiResponsesPolicy.allowSyntheticToolResults).toBe(false);
+    expect(codexResponsesPolicy.repairToolUseResultPairing).toBe(false);
+    expect(codexResponsesPolicy.allowSyntheticToolResults).toBe(false);
   });
 
   it("enables strict tool call id sanitization for openai-completions APIs", () => {

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -22,6 +22,7 @@ export function buildOpenAICompatibleReplayPolicy(
   return {
     sanitizeToolCallIds: true,
     toolCallIdMode: "strict",
+    repairToolUseResultPairing: false,
     ...(modelApi === "openai-completions"
       ? {
           applyAssistantFirstOrderingFix: true,


### PR DESCRIPTION
## Summary
- disable `repairToolUseResultPairing` for OpenAI-compatible replay policy
- keep `allowSyntheticToolResults` false for OpenAI-compatible models
- add transcript-policy coverage for `openai-responses` and `openai-codex-responses`

## Why
For OpenAI/Codex response sessions, replay-time tool-use/result pairing repair can synthesize missing tool results into the transcript. In the harness flow this poisoned resumed sessions after gateway restart/turn interruption and broke checkpoint recovery with synthetic error tool results.

Observed live symptom locally before the fix:
- `harness_execute` resumed flows were getting replay-poisoned by synthetic missing tool results
- current-session recovery only became stable after disabling OpenAI pairing repair locally

## Verification
- targeted source test passed:
  - `pnpm exec vitest run --config vitest.config.ts --project agents src/agents/transcript-policy.test.ts`
- live local validation after equivalent runtime patch:
  - `harness_execute` returned `Run: resumed from checkpoint` for a recoverable checkpoint smoke in an OpenAI session

## Scope
This change is intentionally narrow:
- Anthropic/Google pairing repair behavior remains unchanged
- OpenAI-compatible replay still keeps its existing sanitization and tool-call-id handling
