### PR TITLE
fix: resolve intermittent 'unknown channel' errors for plugin channels in sessions_spawn

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,4 +1,7 @@
-import { getActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginChannelRegistry,
+} from "../plugins/runtime.js";
 import { getChatChannelMeta, listChatChannels, type ChatChannelMeta } from "./chat-meta.js";
 import {
   CHANNEL_IDS,
@@ -19,7 +22,21 @@ type RegisteredChannelPluginEntry = {
   };
 };
 
+/**
+ * List registered channel plugin entries.
+ *
+ * Uses the pinned channel registry (stable after gateway startup) as the primary
+ * source, falling back to the mutable active registry. This prevents intermittent
+ * "unknown channel" errors when the active registry is temporarily empty during
+ * plugin reload cycles.
+ *
+ * Fixes: https://github.com/openclaw/openclaw/issues/61358
+ */
 function listRegisteredChannelPluginEntries(): RegisteredChannelPluginEntry[] {
+  const pinned = getActivePluginChannelRegistry();
+  if (pinned && pinned.channels && pinned.channels.length > 0) {
+    return pinned.channels;
+  }
   return getActivePluginRegistry()?.channels ?? [];
 }
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -36,6 +36,7 @@ import {
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
+  isDeliverableMessageChannel,
   isGatewayMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
@@ -402,6 +403,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     const isKnownGatewayChannel = (value: string): boolean => isGatewayMessageChannel(value);
+    const isSubagentSpawn = request.deliver === false && request.lane === "subagent";
     const channelHints = [request.channel, request.replyChannel]
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
@@ -409,6 +411,16 @@ export const agentHandlers: GatewayRequestHandlers = {
     for (const rawChannel of channelHints) {
       const normalized = normalizeMessageChannel(rawChannel);
       if (normalized && normalized !== "last" && !isKnownGatewayChannel(normalized)) {
+        // Subagent spawns use channel only as metadata context for routing
+        // announcement results. The spawned agent communicates internally via
+        // the spawn mechanism, not through the channel directly. Skip strict
+        // validation to avoid rejecting valid plugin channels that may not be
+        // registered in the active plugin channel registry (split-brain state)
+        // or when the registry is temporarily empty during a swap cycle.
+        // Refs: #61358, #59181, #48790, #55338
+        if (isSubagentSpawn) {
+          continue;
+        }
         respond(
           false,
           undefined,


### PR DESCRIPTION
## Summary

Fixes #61358
Closes #59181 (supersedes the suggested fixes there)
Related: #48790, #55338

## Problem

 intermittently fails with  for all third-party channel plugins (openclaw-weixin, qqbot, feishu, wecom, lightclawbot, etc.). This has **two root causes**:

### Root Cause 1: Mutable registry swap (#61358, #48790)

 reads from the mutable , which can be temporarily empty during plugin reload cycles. Bundled channels (telegram, discord, etc.) are unaffected because they are hardcoded in .

### Root Cause 2: Split-brain registration (#59181)

Plugin channels may not be registered in the channel plugin registry at all, even though they are fully functional for message sending/receiving. The channel field in a spawn request comes from the parent session and is metadata-only — the subagent does not communicate through the channel directly.

## Changes

### 1.  (primary fix)

Skip strict channel validation for subagent spawn requests (). The channel is only used as metadata for routing announcement results, not for actual channel communication.



Non-spawn requests (chat.send, direct agent calls, etc.) still receive strict channel validation.

### 2.  (defense-in-depth)

Use the pinned channel registry () as the primary source in , falling back to the mutable active registry. This prevents registry swap from affecting all callers of the channel plugin list.

## Why this is safe

- Subagent spawns communicate entirely through the internal spawn mechanism (task input → agent execution → announcement message)
- The channel field is metadata for routing the announcement back to the requester session
- If the channel is truly invalid, the announcement routing will gracefully degrade (no delivery), but the spawn itself succeeds
- Non-spawn agent calls still validate channels strictly

## Testing

- Verified against OpenClaw 2026.4.2 source code
- The  combination is only set by  in 
- Regular agent calls via chat.send always have  or no lane