### PR TITLE
fix(ssrf): add fake-ip proxy compatibility to web_fetch ssrf policy

### DIFF
--- a/docs/config/web-fetch-ssrf-policy.md
+++ b/docs/config/web-fetch-ssrf-policy.md
@@ -1,0 +1,73 @@
+# Web Fetch SSRF policy: fake-ip proxy compatibility
+
+OpenClaw `web_fetch` supports an SSRF policy override for fake-ip proxy environments.
+
+## Configuration
+
+```yaml
+tools:
+  web:
+    fetch:
+      ssrfPolicy:
+        assumeProxyEnvironment: true
+```
+
+## When to use this
+
+Enable this when `web_fetch` runs behind a fake-ip proxy environment (for example Clash or Surge fake-ip mode) and public hosts resolve to RFC2544 benchmark addresses such as:
+
+- `198.18.x.x`
+- `198.19.x.x`
+
+Without this setting, `web_fetch` can block such requests as private/internal/special-use IPs even though the destination site is public.
+
+## Behavior
+
+### Disabled / unset
+
+- RFC2544 fake-ip results are blocked by SSRF protection
+- hostname blocklist remains enforced
+- RFC2544 block errors include a fake-ip compatibility hint
+
+### Enabled
+
+- the `web_fetch` SSRF path assumes a fake-ip proxy environment
+- IP range checks are skipped for that path
+- hostname blocklist remains enforced
+
+## Scope
+
+This setting only affects the `web_fetch` SSRF path.
+It is intentionally scoped under `tools.web.fetch.ssrfPolicy` instead of a global top-level network section.
+
+## Difference from `dangerouslyAllowPrivateNetwork`
+
+OpenClaw already supports:
+
+```yaml
+tools:
+  web:
+    fetch:
+      ssrfPolicy:
+        dangerouslyAllowPrivateNetwork: true
+```
+
+That setting is broader and more dangerous:
+
+- it is an explicit private-network bypass
+
+`assumeProxyEnvironment` is narrower:
+
+- it is intended for fake-ip proxy compatibility for public web fetches
+
+If the goal is to make `web_fetch` work behind fake-ip proxy environments, prefer:
+
+- `tools.web.fetch.ssrfPolicy.assumeProxyEnvironment: true`
+
+Use `dangerouslyAllowPrivateNetwork` only when you explicitly want the broader private-network bypass.
+
+## CLI example
+
+```bash
+openclaw config set tools.web.fetch.ssrfPolicy.assumeProxyEnvironment true
+```

--- a/src/agents/tools/web-fetch.config-bridge.test.ts
+++ b/src/agents/tools/web-fetch.config-bridge.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchWithWebToolsNetworkGuardMock: vi.fn(),
+  readResponseTextMock: vi.fn(async () => ({ text: "ok", truncated: false })),
+}));
+
+vi.mock("./web-guarded-fetch.js", () => ({
+  fetchWithWebToolsNetworkGuard: mocks.fetchWithWebToolsNetworkGuardMock,
+}));
+
+vi.mock("./web-fetch-utils.js", () => ({
+  extractBasicHtmlContent: vi.fn(),
+  extractReadableContent: vi.fn(),
+  htmlToMarkdown: vi.fn(),
+  markdownToText: vi.fn((value: string) => value),
+  truncateText: vi.fn((value: string) => ({ text: value, truncated: false })),
+}));
+
+vi.mock("../../security/external-content.js", () => ({
+  wrapExternalContent: (value: string) => value,
+  wrapWebContent: (value: string) => value,
+}));
+
+vi.mock("../../logger.js", () => ({
+  logDebug: vi.fn(),
+}));
+
+vi.mock("../../web-fetch/runtime.js", () => ({
+  resolveWebFetchDefinition: vi.fn(() => null),
+}));
+
+vi.mock("./web-shared.js", () => ({
+  CacheEntry: class {},
+  DEFAULT_CACHE_TTL_MINUTES: 0,
+  DEFAULT_TIMEOUT_SECONDS: 30,
+  normalizeCacheKey: (value: string) => value,
+  readCache: vi.fn(() => null),
+  readResponseText: mocks.readResponseTextMock,
+  resolveCacheTtlMs: vi.fn(() => 0),
+  resolveTimeoutSeconds: vi.fn((_value: unknown, fallback: number) => fallback),
+  writeCache: vi.fn(),
+}));
+
+import { createWebFetchTool } from "./web-fetch.js";
+
+describe("web_fetch config bridge", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes assumeProxyEnvironment from tools.web.fetch.ssrfPolicy to guarded fetch", async () => {
+    mocks.fetchWithWebToolsNetworkGuardMock.mockResolvedValue({
+      response: new Response("ok", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+      finalUrl: "https://example.com",
+      release: async () => {},
+    });
+
+    const tool = createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 0,
+              ssrfPolicy: {
+                assumeProxyEnvironment: true,
+              },
+            },
+          },
+        },
+      },
+      sandboxed: false,
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com" });
+
+    expect(mocks.fetchWithWebToolsNetworkGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy: expect.objectContaining({ assumeProxyEnvironment: true }),
+      }),
+    );
+  });
+
+  it("does not pass assumeProxyEnvironment when config is unset", async () => {
+    mocks.fetchWithWebToolsNetworkGuardMock.mockResolvedValue({
+      response: new Response("ok", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+      finalUrl: "https://example.com",
+      release: async () => {},
+    });
+
+    const tool = createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 0,
+            },
+          },
+        },
+      },
+      sandboxed: false,
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com" });
+
+    const call = mocks.fetchWithWebToolsNetworkGuardMock.mock.calls[0]?.[0];
+    expect(call?.policy).toBeUndefined();
+  });
+
+  it("passes dangerouslyAllowPrivateNetwork from tools.web.fetch.ssrfPolicy to guarded fetch", async () => {
+    mocks.fetchWithWebToolsNetworkGuardMock.mockResolvedValue({
+      response: new Response("ok", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+      finalUrl: "https://example.com",
+      release: async () => {},
+    });
+
+    const tool = createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 0,
+              ssrfPolicy: {
+                dangerouslyAllowPrivateNetwork: true,
+              },
+            },
+          },
+        },
+      },
+      sandboxed: false,
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com" });
+
+    expect(mocks.fetchWithWebToolsNetworkGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy: expect.objectContaining({ dangerouslyAllowPrivateNetwork: true }),
+      }),
+    );
+  });
+});

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -147,4 +147,55 @@ describe("web_fetch SSRF protection", () => {
       extractor: "raw",
     });
   });
+
+  it("does not share cache entries across different SSRF policy states", async () => {
+    const { createWebFetchTool } = await import("./web-tools.js");
+
+    lookupMock.mockImplementation(async (hostname: string) => {
+      if (hostname === "public.test") {
+        return [{ address: "93.184.216.34", family: 4 }];
+      }
+      return [{ address: "127.0.0.1", family: 4 }];
+    });
+
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("strict-ok"));
+
+    const relaxedTool = createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 1,
+              ssrfPolicy: {
+                dangerouslyAllowPrivateNetwork: true,
+              },
+            },
+          },
+        },
+      },
+      lookupFn: lookupMock as unknown as LookupFn,
+    });
+
+    const strictTool = createWebFetchTool({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 1,
+            },
+          },
+        },
+      },
+      lookupFn: lookupMock as unknown as LookupFn,
+    });
+
+    const relaxedResult = await relaxedTool?.execute?.("call", { url: "http://127.0.0.1/test" });
+    expect(relaxedResult?.details).toMatchObject({ status: 200 });
+
+    await expect(strictTool?.execute?.("call", { url: "http://127.0.0.1/test" })).rejects.toThrow(
+      /private|internal|blocked/i,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -246,6 +246,8 @@ type WebFetchRuntimeParams = {
   readabilityEnabled: boolean;
   lookupFn?: LookupFn;
   resolveProviderFallback: () => ReturnType<typeof resolveWebFetchDefinition>;
+  dangerouslyAllowPrivateNetwork?: boolean;
+  assumeProxyEnvironment?: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -364,8 +366,12 @@ async function maybeFetchProviderWebFetchPayload(
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
+  const cachePolicyKey = JSON.stringify({
+    dangerouslyAllowPrivateNetwork: params.dangerouslyAllowPrivateNetwork === true,
+    assumeProxyEnvironment: params.assumeProxyEnvironment === true,
+  });
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}:${cachePolicyKey}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {
@@ -387,11 +393,21 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
   try {
+    const policy =
+      params.dangerouslyAllowPrivateNetwork || params.assumeProxyEnvironment
+        ? {
+            ...(params.dangerouslyAllowPrivateNetwork
+              ? { dangerouslyAllowPrivateNetwork: true }
+              : {}),
+            ...(params.assumeProxyEnvironment ? { assumeProxyEnvironment: true } : {}),
+          }
+        : undefined;
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
       lookupFn: params.lookupFn,
+      ...(policy ? { policy } : {}),
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -595,6 +611,10 @@ export function createWebFetchTool(options?: {
     }
     return providerFallbackCache;
   };
+  const assumeProxyEnvironment =
+    options?.config?.tools?.web?.fetch?.ssrfPolicy?.assumeProxyEnvironment === true;
+  const dangerouslyAllowPrivateNetwork =
+    options?.config?.tools?.web?.fetch?.ssrfPolicy?.dangerouslyAllowPrivateNetwork === true;
   return {
     label: "Web Fetch",
     name: "web_fetch",
@@ -623,6 +643,8 @@ export function createWebFetchTool(options?: {
         readabilityEnabled,
         lookupFn: options?.lookupFn,
         resolveProviderFallback,
+        dangerouslyAllowPrivateNetwork,
+        assumeProxyEnvironment,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-guarded-fetch.test.ts
+++ b/src/agents/tools/web-guarded-fetch.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../../infra/net/fetch-guard.js";
-import { withStrictWebToolsEndpoint, withTrustedWebToolsEndpoint } from "./web-guarded-fetch.js";
+import {
+  fetchWithWebToolsNetworkGuard,
+  withStrictWebToolsEndpoint,
+  withTrustedWebToolsEndpoint,
+} from "./web-guarded-fetch.js";
 
 vi.mock("../../infra/net/fetch-guard.js", () => {
   const GUARDED_FETCH_MODE = {
@@ -64,5 +68,45 @@ describe("web-guarded-fetch", () => {
     const call = vi.mocked(fetchWithSsrFGuard).mock.calls[0]?.[0];
     expect(call?.policy).toBeUndefined();
     expect(call?.mode).toBe(GUARDED_FETCH_MODE.STRICT);
+  });
+
+  it("propagates assumeProxyEnvironment when explicitly set on policy", async () => {
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response: new Response("ok", { status: 200 }),
+      finalUrl: "https://example.com",
+      release: async () => {},
+    });
+
+    await fetchWithWebToolsNetworkGuard({
+      url: "https://example.com",
+      policy: { assumeProxyEnvironment: true },
+    });
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy: expect.objectContaining({ assumeProxyEnvironment: true }),
+      }),
+    );
+  });
+
+  it("does not add assumeProxyEnvironment unless explicitly configured", async () => {
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response: new Response("ok", { status: 200 }),
+      finalUrl: "https://example.com",
+      release: async () => {},
+    });
+
+    await fetchWithWebToolsNetworkGuard({
+      url: "https://example.com",
+      policy: { allowRfc2544BenchmarkRange: true },
+    });
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy: expect.objectContaining({ allowRfc2544BenchmarkRange: true }),
+      }),
+    );
+    const call = vi.mocked(fetchWithSsrFGuard).mock.calls[0]?.[0];
+    expect(call?.policy).not.toHaveProperty("assumeProxyEnvironment");
   });
 });

--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -38,6 +38,7 @@ export async function fetchWithWebToolsNetworkGuard(
   params: WebToolGuardedFetchOptions,
 ): Promise<GuardedFetchResult> {
   const { timeoutSeconds, useEnvProxy, ...rest } = params;
+
   const resolved = {
     ...rest,
     timeoutMs: resolveTimeoutMs({ timeoutMs: rest.timeoutMs, timeoutSeconds }),

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -149,6 +149,54 @@ describe("plugins.entries.*.subagent", () => {
   });
 });
 
+describe("web fetch ssrf policy config", () => {
+  it("accepts tools.web.fetch.ssrfPolicy.assumeProxyEnvironment=true", () => {
+    const result = OpenClawSchema.safeParse({
+      tools: {
+        web: {
+          fetch: {
+            ssrfPolicy: {
+              assumeProxyEnvironment: true,
+            },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts tools.web.fetch.ssrfPolicy.assumeProxyEnvironment=false", () => {
+    const result = OpenClawSchema.safeParse({
+      tools: {
+        web: {
+          fetch: {
+            ssrfPolicy: {
+              assumeProxyEnvironment: false,
+            },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts tools.web.fetch.ssrfPolicy with both assumeProxyEnvironment and dangerouslyAllowPrivateNetwork", () => {
+    const result = OpenClawSchema.safeParse({
+      tools: {
+        web: {
+          fetch: {
+            ssrfPolicy: {
+              assumeProxyEnvironment: true,
+              dangerouslyAllowPrivateNetwork: false,
+            },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("web search provider config", () => {
   it("accepts kimi provider and config", () => {
     const res = validateConfigObject(

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -7010,6 +7010,18 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     description:
                       "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
                   },
+                  ssrfPolicy: {
+                    type: "object",
+                    properties: {
+                      dangerouslyAllowPrivateNetwork: {
+                        type: "boolean",
+                      },
+                      assumeProxyEnvironment: {
+                        type: "boolean",
+                      },
+                    },
+                    additionalProperties: false,
+                  },
                   firecrawl: {
                     type: "object",
                     properties: {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -542,6 +542,13 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /** SSRF policy overrides for web fetch. */
+      ssrfPolicy?: {
+        /** Dangerous private-network bypass for web fetch. */
+        dangerouslyAllowPrivateNetwork?: boolean;
+        /** Assume fake-ip proxy environment and skip IP range checks while keeping hostname blocking. */
+        assumeProxyEnvironment?: boolean;
+      };
     };
   };
   media?: MediaToolsConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -325,6 +325,13 @@ export const ToolsWebFetchSchema = z
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
     readability: z.boolean().optional(),
+    ssrfPolicy: z
+      .object({
+        dangerouslyAllowPrivateNetwork: z.boolean().optional(),
+        assumeProxyEnvironment: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     // Keep the legacy Firecrawl fetch shape loadable so existing installs can
     // start and then migrate cleanly through doctor.
     firecrawl: z

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -208,18 +208,160 @@ describe("ssrf pinning", () => {
     expect(lookup).toHaveBeenCalledTimes(1);
   });
 
-  it("accepts dangerouslyAllowPrivateNetwork as an allowPrivateNetwork alias", async () => {
+  it("accepts dangerouslyAllowPrivateNetwork as an allowPrivateNetwork alias for DNS results", async () => {
     const lookup = vi.fn(async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
 
     await expect(
-      resolvePinnedHostnameWithPolicy("localhost", {
+      resolvePinnedHostnameWithPolicy("example.com", {
         lookupFn: lookup,
         policy: { dangerouslyAllowPrivateNetwork: true },
       }),
     ).resolves.toMatchObject({
-      hostname: "localhost",
+      hostname: "example.com",
       addresses: ["127.0.0.1"],
     });
     expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors allowPrivateNetwork for blocked hostname literals", async () => {
+    const lookup = createPublicLookupMock();
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("localhost", {
+        lookupFn: lookup,
+        policy: { allowPrivateNetwork: true },
+      }),
+    ).resolves.toMatchObject({
+      hostname: "localhost",
+      addresses: ["93.184.216.34"],
+    });
+    expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors hostnameAllowlist for blocked hostnames when private network is explicitly enabled", async () => {
+    const lookup = createPublicLookupMock();
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("localhost", {
+        lookupFn: lookup,
+        policy: {
+          allowPrivateNetwork: true,
+          hostnameAllowlist: ["localhost"],
+        },
+      }),
+    ).resolves.toMatchObject({
+      hostname: "localhost",
+      addresses: ["93.184.216.34"],
+    });
+    expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows RFC2544 fake-ip results when assumeProxyEnvironment is enabled", async () => {
+    const lookup = vi.fn(async () => [
+      { address: "198.18.0.153", family: 4 },
+    ]) as unknown as LookupFn;
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("api.telegram.org", {
+        lookupFn: lookup,
+        policy: { assumeProxyEnvironment: true },
+      }),
+    ).resolves.toMatchObject({
+      hostname: "api.telegram.org",
+      addresses: ["198.18.0.153"],
+    });
+  });
+
+  it("allows 198.19.x.x fake-ip results when assumeProxyEnvironment is enabled", async () => {
+    const lookup = vi.fn(async () => [{ address: "198.19.0.1", family: 4 }]) as unknown as LookupFn;
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("api.telegram.org", {
+        lookupFn: lookup,
+        policy: { assumeProxyEnvironment: true },
+      }),
+    ).resolves.toMatchObject({
+      hostname: "api.telegram.org",
+      addresses: ["198.19.0.1"],
+    });
+  });
+
+  it("still blocks non-RFC2544 private DNS results when assumeProxyEnvironment is enabled", async () => {
+    const lookup = vi.fn(async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("api.telegram.org", {
+        lookupFn: lookup,
+        policy: { assumeProxyEnvironment: true },
+      }),
+    ).rejects.toThrow(/private|internal/i);
+  });
+
+  it("still blocks literal RFC2544 fake-ip addresses when assumeProxyEnvironment is enabled", async () => {
+    const lookup = createPublicLookupMock();
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("198.18.1.2", {
+        lookupFn: lookup,
+        policy: { assumeProxyEnvironment: true },
+      }),
+    ).rejects.toThrow(SsrFBlockedError);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("still blocks disallowed hostnames when assumeProxyEnvironment is enabled", async () => {
+    const lookup = createPublicLookupMock();
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("localhost", {
+        lookupFn: lookup,
+        policy: { assumeProxyEnvironment: true },
+      }),
+    ).rejects.toThrow(SsrFBlockedError);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("adds a fake-ip proxy hint when RFC2544 resolved addresses are blocked", async () => {
+    const lookup = vi.fn(async () => [{ address: "198.18.0.1", family: 4 }]) as unknown as LookupFn;
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("example.com", {
+        lookupFn: lookup,
+      }),
+    ).rejects.toThrow(/fake-ip compatibility/i);
+  });
+
+  it("does not add a fake-ip proxy hint for non-RFC2544 private IP blocks", async () => {
+    const lookup = vi.fn(async () => [{ address: "10.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+    try {
+      await resolvePinnedHostnameWithPolicy("example.com", {
+        lookupFn: lookup,
+      });
+      expect.unreachable("expected SSRF block");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SsrFBlockedError);
+      expect((error as Error).message).not.toMatch(/assumeProxyEnvironment/i);
+    }
+  });
+
+  it("still blocks non-RFC2544 private IP literals when assumeProxyEnvironment is enabled", async () => {
+    const lookup = createPublicLookupMock();
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("127.0.0.1", {
+        lookupFn: lookup,
+        policy: { assumeProxyEnvironment: true },
+      }),
+    ).rejects.toThrow(SsrFBlockedError);
+
+    await expect(
+      resolvePinnedHostnameWithPolicy("10.0.0.1", {
+        lookupFn: lookup,
+        policy: { assumeProxyEnvironment: true },
+      }),
+    ).rejects.toThrow(SsrFBlockedError);
+
+    expect(lookup).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -36,6 +36,13 @@ export type SsrFPolicy = {
   allowRfc2544BenchmarkRange?: boolean;
   allowedHostnames?: string[];
   hostnameAllowlist?: string[];
+  /**
+   * When true, skip IP range checks after DNS resolution while keeping
+   * hostname blocklist protection.  Useful for transparent proxies with
+   * fake-ip mode (Surge, Clash) where DNS returns synthetic addresses
+   * such as 198.18.x.x (RFC 2544).
+   */
+  assumeProxyEnvironment?: boolean;
 };
 
 const BLOCKED_HOSTNAMES = new Set([
@@ -181,11 +188,18 @@ export function isBlockedHostnameOrIp(hostname: string, policy?: SsrFPolicy): bo
 
 const BLOCKED_HOST_OR_IP_MESSAGE = "Blocked hostname or private/internal/special-use IP address";
 const BLOCKED_RESOLVED_IP_MESSAGE = "Blocked: resolves to private/internal/special-use IP address";
+const BLOCKED_RESOLVED_IP_PROXY_HINT =
+  "Hint: If you use a proxy with fake-ip mode (Surge, Clash, etc.), enable fake-ip compatibility on the specific caller or runtime that is performing this fetch.";
 
 function assertAllowedHostOrIpOrThrow(hostnameOrIp: string, policy?: SsrFPolicy): void {
   if (isBlockedHostnameOrIp(hostnameOrIp, policy)) {
     throw new SsrFBlockedError(BLOCKED_HOST_OR_IP_MESSAGE);
   }
+}
+
+function isRfc2544Address(address: string): boolean {
+  const trimmed = address.trim();
+  return trimmed.startsWith("198.18.") || trimmed.startsWith("198.19.");
 }
 
 function assertAllowedResolvedAddressesOrThrow(
@@ -195,6 +209,23 @@ function assertAllowedResolvedAddressesOrThrow(
   for (const entry of results) {
     // Reuse the exact same host/IP classifier as the pre-DNS check to avoid drift.
     if (isBlockedHostnameOrIp(entry.address, policy)) {
+      const hint = isRfc2544Address(entry.address) ? ` ${BLOCKED_RESOLVED_IP_PROXY_HINT}` : "";
+      throw new SsrFBlockedError(`${BLOCKED_RESOLVED_IP_MESSAGE}${hint}`);
+    }
+  }
+}
+
+function assertResolvedAddressesAllowedForProxyEnvironmentOrThrow(
+  results: readonly LookupAddress[],
+): void {
+  for (const entry of results) {
+    if (isBlockedHostname(entry.address)) {
+      throw new SsrFBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
+    }
+    if (isRfc2544Address(entry.address)) {
+      continue;
+    }
+    if (isPrivateIpAddress(entry.address)) {
       throw new SsrFBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
     }
   }
@@ -320,13 +351,23 @@ export async function resolvePinnedHostnameWithPolicy(
 
   const hostnameAllowlist = normalizeHostnameAllowlist(params.policy?.hostnameAllowlist);
   const skipPrivateNetworkChecks = shouldSkipPrivateNetworkChecks(normalized, params.policy);
+  const skipIpRangeChecks = params.policy?.assumeProxyEnvironment === true;
 
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
     throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
   }
 
-  if (!skipPrivateNetworkChecks) {
+  // Preserve explicit private-network overrides for trusted callers.
+  if (!skipPrivateNetworkChecks && isBlockedHostnameNormalized(normalized)) {
+    throw new SsrFBlockedError(BLOCKED_HOST_OR_IP_MESSAGE);
+  }
+
+  if (!skipPrivateNetworkChecks && !skipIpRangeChecks) {
     // Phase 1: fail fast for literal hosts/IPs before any DNS lookup side-effects.
+    assertAllowedHostOrIpOrThrow(normalized, params.policy);
+  } else if (!skipPrivateNetworkChecks && skipIpRangeChecks) {
+    // In proxy-environment mode, phase-1 literal host/IP blocking stays intact.
+    // Only phase-2 DNS answers get the narrow RFC2544 fake-ip compatibility.
     assertAllowedHostOrIpOrThrow(normalized, params.policy);
   }
 
@@ -336,9 +377,13 @@ export async function resolvePinnedHostnameWithPolicy(
     throw new Error(`Unable to resolve hostname: ${hostname}`);
   }
 
-  if (!skipPrivateNetworkChecks) {
+  if (!skipPrivateNetworkChecks && !skipIpRangeChecks) {
     // Phase 2: re-check DNS answers so public hostnames cannot pivot to private targets.
     assertAllowedResolvedAddressesOrThrow(results, params.policy);
+  } else if (!skipPrivateNetworkChecks && skipIpRangeChecks) {
+    // Proxy-environment mode is intentionally narrow: allow RFC2544 fake-ip answers
+    // while continuing to block other private/special-use destinations.
+    assertResolvedAddressesAllowedForProxyEnvironmentOrThrow(results);
   }
 
   // Prefer addresses returned as IPv4 by DNS family metadata before other


### PR DESCRIPTION
## Summary

This PR fixes the fake-ip proxy environment issue affecting `web_fetch`.

Instead of introducing a global top-level network setting, the new config is scoped to the feature it actually affects:

- `tools.web.fetch.ssrfPolicy.assumeProxyEnvironment`

This keeps the behavior local to `web_fetch` SSRF handling and avoids introducing a broader global `network` config surface.

---

## What changed

### Config
Added:

- `tools.web.fetch.ssrfPolicy.assumeProxyEnvironment`

This is intentionally scoped under `tools.web.fetch.ssrfPolicy` because the current change only affects the `web_fetch` SSRF path.

### Behavior
When `assumeProxyEnvironment` is enabled:

- RFC2544 fake-ip proxy results (for example `198.18.x.x` / `198.19.x.x`) are no longer treated as blocking IP-range failures in the `web_fetch` SSRF path
- hostname blocklist protection remains enforced

When disabled / unset:

- the previous blocking behavior remains unchanged
- RFC2544 block errors include a fake-ip compatibility hint

### Tests
Added / updated coverage for:

- SSRF pinning behavior
- `web_fetch` guarded-fetch policy propagation
- config → runtime policy bridging
- config schema acceptance for `tools.web.fetch.ssrfPolicy.assumeProxyEnvironment`

### Documentation
Added documentation content for the new `web_fetch` SSRF policy setting.

Docs entry-point / navigation integration remains a follow-up item and is not treated as a blocker for this PR.

---

## Manual verification

Validated in a release-like local flow after linking the current repo build into the local `openclaw` command.

Confirmed:

- `tools.web.fetch.ssrfPolicy.assumeProxyEnvironment = false`
  - `web_fetch` blocked RFC2544 fake-ip resolution
  - fake-ip hint was shown

- `tools.web.fetch.ssrfPolicy.assumeProxyEnvironment = true`
  - the same request succeeded

---

## Why not use `dangerouslyAllowPrivateNetwork`?

That existing setting is broader and semantically different:

- `dangerouslyAllowPrivateNetwork` is an explicit private-network bypass
- `assumeProxyEnvironment` is a narrower compatibility control for fake-ip proxy environments affecting public web fetches

If both are set, both policy relaxations apply. `assumeProxyEnvironment` does not replace or override `dangerouslyAllowPrivateNetwork`.

---

## Follow-up

A separate historical test integrity / merge-gate issue discovered during this work is tracked in:

- #61272

That cleanup is intentionally kept out of this PR to keep scope focused.

---

## Note on local commit checks

`git commit --amend` was blocked by unrelated existing `pnpm tsgo` failures in:

- `extensions/openrouter/index.ts`
- `extensions/openrouter/index.test.ts`

Those files are outside the scope of this PR. This PR was validated with focused tests and manual runtime verification for the `web_fetch` fake-ip proxy flow.

---

## Closure note

This PR is being closed because the original fake-IP compatibility problem is now resolved on `main` through a different scoped configuration design.

Current `main` behavior:
- `web_fetch` supports `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange`
- runtime, config schema, and tests are aligned with that option

Validation after upgrading local OpenClaw:
- with default config, `web_fetch` remained blocked in a proxy environment resolving public domains to `198.18.x.x`
- after enabling `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange: true`, `web_fetch https://example.com` succeeded with `status: 200`

Because the original issue is covered by current `main`, this PR's older design (`assumeProxyEnvironment` / `dangerouslyAllowPrivateNetwork`) is no longer needed.

