### PR TITLE
feat(tts): add Inworld as a native TTS provider

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -173,9 +173,11 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 
 `apiKey`, `modelId`, and `voiceId` are all required — the provider will not report itself
 as configured if any of them is missing. `baseUrl` defaults to `https://api.inworld.ai`.
+`apiKey` can also be supplied via the `INWORLD_API_KEY` environment variable.
 
 **V1 scope**: non-streaming synthesis only. Telephony/talk paths, voice discovery, and
-streaming are not supported in V1. Only `voiceId` can be overridden via model directives.
+streaming are not supported in V1. Use `inworld_voice` / `inworldvoice` to override the
+voice for a single reply via model directives.
 
 ### MiniMax primary
 
@@ -333,8 +335,8 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (registered speech provider id, for example `openai`, `elevenlabs`, `minimax`, or `microsoft`; requires `allowProvider: true`)
-- `voice` (OpenAI voice) or `voiceId` (ElevenLabs / MiniMax)
+- `provider` (registered speech provider id, for example `openai`, `elevenlabs`, `inworld`, `minimax`, or `microsoft`; requires `allowProvider: true`)
+- `voice` (OpenAI voice) or `voiceId` (ElevenLabs / MiniMax) or `inworld_voice` / `inworldvoice` (Inworld)
 - `model` (OpenAI TTS model, ElevenLabs model id, or MiniMax model)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
 - `vol` / `volume` (MiniMax volume, 0-10)

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,12 +9,13 @@ title: "Text-to-Speech (legacy path)"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, Microsoft, MiniMax, or OpenAI.
+OpenClaw can convert outbound replies into audio using ElevenLabs, Inworld, Microsoft, MiniMax, or OpenAI.
 It works anywhere OpenClaw can send audio.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
+- **Inworld** (primary or fallback provider; uses the Inworld Voice API)
 - **Microsoft** (primary or fallback provider; current bundled implementation uses `node-edge-tts`)
 - **MiniMax** (primary or fallback provider; uses the T2A v2 API)
 - **OpenAI** (primary or fallback provider; also used for summaries)
@@ -34,9 +35,10 @@ or ElevenLabs.
 
 ## Optional keys
 
-If you want OpenAI, ElevenLabs, or MiniMax:
+If you want OpenAI, ElevenLabs, Inworld, or MiniMax:
 
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
+- `INWORLD_API_KEY`
 - `MINIMAX_API_KEY`
 - `OPENAI_API_KEY`
 
@@ -52,6 +54,8 @@ so that provider must also be authenticated if you enable summaries.
 - [OpenAI Audio API reference](https://platform.openai.com/docs/api-reference/audio)
 - [ElevenLabs Text to Speech](https://elevenlabs.io/docs/api-reference/text-to-speech)
 - [ElevenLabs Authentication](https://elevenlabs.io/docs/api-reference/authentication)
+- [Inworld Voice API](https://docs.inworld.ai/docs/tts-api/getting-started/)
+- [Inworld Voice API Reference](https://docs.inworld.ai/docs/tts-api/reference/)
 - [MiniMax T2A v2 API](https://platform.minimaxi.com/document/T2A%20V2)
 - [node-edge-tts](https://github.com/SchneeHertz/node-edge-tts)
 - [Microsoft Speech output formats](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech#audio-outputs)
@@ -145,6 +149,33 @@ Full schema is in [Gateway configuration](/gateway/configuration).
   },
 }
 ```
+
+### Inworld primary
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "inworld",
+      providers: {
+        inworld: {
+          // Base64 API key copied from the Inworld Portal — do not re-encode.
+          apiKey: "your-base64-key-from-inworld-portal",
+          modelId: "inworld-tts-1.5-max",
+          voiceId: "Ashley",
+        },
+      },
+    },
+  },
+}
+```
+
+`apiKey`, `modelId`, and `voiceId` are all required — the provider will not report itself
+as configured if any of them is missing. `baseUrl` defaults to `https://api.inworld.ai`.
+
+**V1 scope**: non-streaming synthesis only. Telephony/talk paths, voice discovery, and
+streaming are not supported in V1. Only `voiceId` can be overridden via model directives.
 
 ### MiniMax primary
 

--- a/extensions/inworld/index.ts
+++ b/extensions/inworld/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { buildInworldSpeechProvider } from "./speech-provider.js";
+
+export default definePluginEntry({
+  id: "inworld",
+  name: "Inworld Speech",
+  description: "Bundled Inworld speech provider",
+  register(api) {
+    api.registerSpeechProvider(buildInworldSpeechProvider());
+  },
+});

--- a/extensions/inworld/openclaw.plugin.json
+++ b/extensions/inworld/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "inworld",
+  "contracts": {
+    "speechProviders": ["inworld"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/inworld/package.json
+++ b/extensions/inworld/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/inworld-speech",
+  "version": "2026.4.4",
+  "private": true,
+  "description": "OpenClaw Inworld speech plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/inworld/speech-provider.test.ts
+++ b/extensions/inworld/speech-provider.test.ts
@@ -94,7 +94,7 @@ describe("buildInworldSpeechProvider", () => {
       allowSeed: false,
     };
 
-    it("handles voiceid key", () => {
+    it("does not handle generic voiceid key (let earlier providers claim it)", () => {
       const result = provider.parseDirectiveToken!({
         key: "voiceid",
         value: "Michael",
@@ -102,11 +102,10 @@ describe("buildInworldSpeechProvider", () => {
         providerConfig: BASE_CONFIG,
         currentOverrides: undefined,
       });
-      expect(result.handled).toBe(true);
-      expect(result.overrides?.voiceId).toBe("Michael");
+      expect(result.handled).toBe(false);
     });
 
-    it("handles voice_id key", () => {
+    it("does not handle generic voice_id key (let earlier providers claim it)", () => {
       const result = provider.parseDirectiveToken!({
         key: "voice_id",
         value: "Michael",
@@ -114,7 +113,7 @@ describe("buildInworldSpeechProvider", () => {
         providerConfig: BASE_CONFIG,
         currentOverrides: undefined,
       });
-      expect(result.handled).toBe(true);
+      expect(result.handled).toBe(false);
     });
 
     it("handles inworld_voice key", () => {
@@ -126,11 +125,24 @@ describe("buildInworldSpeechProvider", () => {
         currentOverrides: undefined,
       });
       expect(result.handled).toBe(true);
+      expect(result.overrides?.voiceId).toBe("Michael");
+    });
+
+    it("handles inworldvoice key", () => {
+      const result = provider.parseDirectiveToken!({
+        key: "inworldvoice",
+        value: "Michael",
+        policy,
+        providerConfig: BASE_CONFIG,
+        currentOverrides: undefined,
+      });
+      expect(result.handled).toBe(true);
+      expect(result.overrides?.voiceId).toBe("Michael");
     });
 
     it("returns handled:true but no overrides when allowVoice is false", () => {
       const result = provider.parseDirectiveToken!({
-        key: "voiceid",
+        key: "inworld_voice",
         value: "Michael",
         policy: { ...policy, allowVoice: false },
         providerConfig: BASE_CONFIG,

--- a/extensions/inworld/speech-provider.test.ts
+++ b/extensions/inworld/speech-provider.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { buildInworldSpeechProvider } from "./speech-provider.js";
+
+const provider = buildInworldSpeechProvider();
+
+const BASE_CONFIG = {
+  apiKey: "test-api-key",
+  baseUrl: "https://api.inworld.ai",
+  modelId: "inworld-tts-1.5-max",
+  voiceId: "Ashley",
+};
+
+describe("buildInworldSpeechProvider", () => {
+  describe("provider metadata", () => {
+    it("has correct id and label", () => {
+      expect(provider.id).toBe("inworld");
+      expect(provider.label).toBe("Inworld");
+    });
+
+    it("has autoSelectOrder 50", () => {
+      expect(provider.autoSelectOrder).toBe(50);
+    });
+  });
+
+  describe("resolveConfig", () => {
+    it("returns undefined modelId and voiceId when not set", () => {
+      const config = provider.resolveConfig!({ rawConfig: {} });
+      expect(config.modelId).toBeUndefined();
+      expect(config.voiceId).toBeUndefined();
+    });
+
+    it("reads from providers.inworld path", () => {
+      const config = provider.resolveConfig!({
+        rawConfig: {
+          providers: {
+            inworld: { modelId: "inworld-tts-1.5-mini", voiceId: "Michael" },
+          },
+        },
+      });
+      expect(config.modelId).toBe("inworld-tts-1.5-mini");
+      expect(config.voiceId).toBe("Michael");
+    });
+
+    it("defaults baseUrl", () => {
+      const config = provider.resolveConfig!({ rawConfig: {} });
+      expect(config.baseUrl).toBe("https://api.inworld.ai");
+    });
+  });
+
+  describe("isConfigured", () => {
+    it("returns false when apiKey missing", () => {
+      expect(
+        provider.isConfigured({ providerConfig: { ...BASE_CONFIG, apiKey: undefined } }),
+      ).toBe(false);
+    });
+
+    it("returns false when modelId missing", () => {
+      expect(
+        provider.isConfigured({ providerConfig: { ...BASE_CONFIG, modelId: undefined } }),
+      ).toBe(false);
+    });
+
+    it("returns false when voiceId missing", () => {
+      expect(
+        provider.isConfigured({ providerConfig: { ...BASE_CONFIG, voiceId: undefined } }),
+      ).toBe(false);
+    });
+
+    it("returns true when all three present", () => {
+      expect(provider.isConfigured({ providerConfig: BASE_CONFIG })).toBe(true);
+    });
+
+    it("returns true when INWORLD_API_KEY env is set", () => {
+      const original = process.env.INWORLD_API_KEY;
+      process.env.INWORLD_API_KEY = "env-key";
+      try {
+        expect(
+          provider.isConfigured({
+            providerConfig: { ...BASE_CONFIG, apiKey: undefined },
+          }),
+        ).toBe(true);
+      } finally {
+        process.env.INWORLD_API_KEY = original;
+      }
+    });
+  });
+
+  describe("parseDirectiveToken", () => {
+    const policy = {
+      allowVoice: true,
+      allowModelId: false,
+      allowVoiceSettings: false,
+      allowNormalization: false,
+      allowSeed: false,
+    };
+
+    it("handles voiceid key", () => {
+      const result = provider.parseDirectiveToken!({
+        key: "voiceid",
+        value: "Michael",
+        policy,
+        providerConfig: BASE_CONFIG,
+        currentOverrides: undefined,
+      });
+      expect(result.handled).toBe(true);
+      expect(result.overrides?.voiceId).toBe("Michael");
+    });
+
+    it("handles voice_id key", () => {
+      const result = provider.parseDirectiveToken!({
+        key: "voice_id",
+        value: "Michael",
+        policy,
+        providerConfig: BASE_CONFIG,
+        currentOverrides: undefined,
+      });
+      expect(result.handled).toBe(true);
+    });
+
+    it("handles inworld_voice key", () => {
+      const result = provider.parseDirectiveToken!({
+        key: "inworld_voice",
+        value: "Michael",
+        policy,
+        providerConfig: BASE_CONFIG,
+        currentOverrides: undefined,
+      });
+      expect(result.handled).toBe(true);
+    });
+
+    it("returns handled:true but no overrides when allowVoice is false", () => {
+      const result = provider.parseDirectiveToken!({
+        key: "voiceid",
+        value: "Michael",
+        policy: { ...policy, allowVoice: false },
+        providerConfig: BASE_CONFIG,
+        currentOverrides: undefined,
+      });
+      expect(result.handled).toBe(true);
+      expect(result.overrides).toBeUndefined();
+    });
+
+    it("returns handled:false for unknown keys", () => {
+      const result = provider.parseDirectiveToken!({
+        key: "unknown",
+        value: "something",
+        policy,
+        providerConfig: BASE_CONFIG,
+        currentOverrides: undefined,
+      });
+      expect(result.handled).toBe(false);
+    });
+  });
+
+  describe("synthesize", () => {
+    beforeEach(() => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ audioContent: Buffer.from("fake-audio").toString("base64") }),
+        }),
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("throws when apiKey missing", async () => {
+      const original = process.env.INWORLD_API_KEY;
+      delete process.env.INWORLD_API_KEY;
+      try {
+        await expect(
+          provider.synthesize({
+            text: "hello",
+            providerConfig: { ...BASE_CONFIG, apiKey: undefined },
+            providerOverrides: undefined,
+            target: "audio-file",
+            timeoutMs: 10000,
+          }),
+        ).rejects.toThrow("Inworld API key missing");
+      } finally {
+        if (original !== undefined) {
+          process.env.INWORLD_API_KEY = original;
+        }
+      }
+    });
+
+    it("throws when modelId missing", async () => {
+      await expect(
+        provider.synthesize({
+          text: "hello",
+          providerConfig: { ...BASE_CONFIG, modelId: undefined },
+          providerOverrides: undefined,
+          target: "audio-file",
+          timeoutMs: 10000,
+        }),
+      ).rejects.toThrow("modelId missing");
+    });
+
+    it("throws when voiceId missing", async () => {
+      await expect(
+        provider.synthesize({
+          text: "hello",
+          providerConfig: { ...BASE_CONFIG, voiceId: undefined },
+          providerOverrides: undefined,
+          target: "audio-file",
+          timeoutMs: 10000,
+        }),
+      ).rejects.toThrow("voiceId missing");
+    });
+
+    it("calls fetch with correct params", async () => {
+      await provider.synthesize({
+        text: "hello world",
+        providerConfig: BASE_CONFIG,
+        providerOverrides: undefined,
+        target: "audio-file",
+        timeoutMs: 10000,
+      });
+
+      expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.inworld.ai/tts/v1/voice");
+      expect(init.method).toBe("POST");
+      expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+        "Basic test-api-key",
+      );
+      const body = JSON.parse(init.body as string);
+      expect(body).toEqual({
+        text: "hello world",
+        voiceId: "Ashley",
+        modelId: "inworld-tts-1.5-max",
+      });
+    });
+
+    it("applies voiceId override", async () => {
+      await provider.synthesize({
+        text: "hello",
+        providerConfig: BASE_CONFIG,
+        providerOverrides: { voiceId: "Michael" },
+        target: "audio-file",
+        timeoutMs: 10000,
+      });
+
+      const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.voiceId).toBe("Michael");
+    });
+
+    it("returns Buffer with mp3 metadata", async () => {
+      const result = await provider.synthesize({
+        text: "hello",
+        providerConfig: BASE_CONFIG,
+        providerOverrides: undefined,
+        target: "audio-file",
+        timeoutMs: 10000,
+      });
+
+      expect(result.audioBuffer).toBeInstanceOf(Buffer);
+      expect(result.outputFormat).toBe("mp3");
+      expect(result.fileExtension).toBe(".mp3");
+      expect(result.voiceCompatible).toBe(false);
+    });
+  });
+});

--- a/extensions/inworld/speech-provider.ts
+++ b/extensions/inworld/speech-provider.ts
@@ -77,8 +77,6 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
   warnings?: string[];
 } {
   switch (ctx.key) {
-    case "voiceid":
-    case "voice_id":
     case "inworld_voice":
     case "inworldvoice":
       if (!ctx.policy.allowVoice) {

--- a/extensions/inworld/speech-provider.ts
+++ b/extensions/inworld/speech-provider.ts
@@ -1,0 +1,140 @@
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import type {
+  SpeechDirectiveTokenParseContext,
+  SpeechProviderConfig,
+  SpeechProviderOverrides,
+  SpeechProviderPlugin,
+} from "openclaw/plugin-sdk/speech-core";
+import { DEFAULT_INWORLD_BASE_URL, INWORLD_TTS_MODELS, inworldTTS } from "./tts.js";
+
+type InworldTtsProviderConfig = {
+  apiKey?: string;
+  baseUrl: string;
+  modelId?: string;
+  voiceId?: string;
+};
+
+type InworldTtsProviderOverrides = {
+  voiceId?: string;
+};
+
+function trimToUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function normalizeInworldBaseUrl(baseUrl: string | undefined): string {
+  const trimmed = baseUrl?.trim();
+  return trimmed?.replace(/\/+$/, "") || DEFAULT_INWORLD_BASE_URL;
+}
+
+function normalizeInworldProviderConfig(
+  rawConfig: Record<string, unknown>,
+): InworldTtsProviderConfig {
+  const providers = asObject(rawConfig.providers);
+  // silent legacy tolerance for rawConfig.inworld — no docs/tests for this path
+  const raw = asObject(providers?.inworld) ?? asObject(rawConfig.inworld);
+  return {
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw?.apiKey,
+      path: "messages.tts.providers.inworld.apiKey",
+    }),
+    baseUrl: normalizeInworldBaseUrl(trimToUndefined(raw?.baseUrl)),
+    modelId: trimToUndefined(raw?.modelId),
+    voiceId: trimToUndefined(raw?.voiceId),
+  };
+}
+
+function readInworldProviderConfig(config: SpeechProviderConfig): InworldTtsProviderConfig {
+  const defaults = normalizeInworldProviderConfig({});
+  return {
+    apiKey: trimToUndefined(config.apiKey) ?? defaults.apiKey,
+    baseUrl: normalizeInworldBaseUrl(trimToUndefined(config.baseUrl) ?? defaults.baseUrl),
+    modelId: trimToUndefined(config.modelId) ?? defaults.modelId,
+    voiceId: trimToUndefined(config.voiceId) ?? defaults.voiceId,
+  };
+}
+
+function readInworldOverrides(
+  overrides: SpeechProviderOverrides | undefined,
+): InworldTtsProviderOverrides {
+  if (!overrides) {
+    return {};
+  }
+  return {
+    voiceId: trimToUndefined(overrides.voiceId),
+  };
+}
+
+function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
+  handled: boolean;
+  overrides?: SpeechProviderOverrides;
+  warnings?: string[];
+} {
+  switch (ctx.key) {
+    case "voiceid":
+    case "voice_id":
+    case "inworld_voice":
+    case "inworldvoice":
+      if (!ctx.policy.allowVoice) {
+        return { handled: true };
+      }
+      return {
+        handled: true,
+        overrides: { ...(ctx.currentOverrides ?? {}), voiceId: ctx.value },
+      };
+    default:
+      return { handled: false };
+  }
+}
+
+export function buildInworldSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "inworld",
+    label: "Inworld",
+    autoSelectOrder: 50,
+    models: INWORLD_TTS_MODELS,
+    resolveConfig: ({ rawConfig }) => normalizeInworldProviderConfig(rawConfig),
+    parseDirectiveToken,
+    isConfigured: ({ providerConfig }) => {
+      const config = readInworldProviderConfig(providerConfig);
+      const hasApiKey = Boolean(config.apiKey || process.env.INWORLD_API_KEY);
+      return hasApiKey && Boolean(config.modelId) && Boolean(config.voiceId);
+    },
+    synthesize: async (req) => {
+      const config = readInworldProviderConfig(req.providerConfig);
+      const overrides = readInworldOverrides(req.providerOverrides);
+      const apiKey = config.apiKey || process.env.INWORLD_API_KEY;
+      if (!apiKey) {
+        throw new Error("Inworld API key missing");
+      }
+      const modelId = config.modelId;
+      if (!modelId) {
+        throw new Error("Inworld modelId missing — set messages.tts.providers.inworld.modelId");
+      }
+      const voiceId = overrides.voiceId ?? config.voiceId;
+      if (!voiceId) {
+        throw new Error("Inworld voiceId missing — set messages.tts.providers.inworld.voiceId");
+      }
+      const audioBuffer = await inworldTTS({
+        text: req.text,
+        apiKey,
+        baseUrl: config.baseUrl,
+        modelId,
+        voiceId,
+        timeoutMs: req.timeoutMs,
+      });
+      return {
+        audioBuffer,
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
+        voiceCompatible: false,
+      };
+    },
+  };
+}

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -1,0 +1,54 @@
+export const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
+
+export const INWORLD_TTS_MODELS = ["inworld-tts-1.5-max", "inworld-tts-1.5-mini"] as const;
+
+function normalizeInworldBaseUrl(baseUrl?: string): string {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return DEFAULT_INWORLD_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+export async function inworldTTS(params: {
+  text: string;
+  apiKey: string;
+  baseUrl: string;
+  modelId: string;
+  voiceId: string;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const { text, apiKey, baseUrl, modelId, voiceId, timeoutMs } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${normalizeInworldBaseUrl(baseUrl)}/tts/v1/voice`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ text, voiceId, modelId }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      throw new Error(
+        `Inworld TTS API error (${response.status})${errBody.trim() ? `: ${errBody.trim()}` : ""}`,
+      );
+    }
+
+    const body = (await response.json()) as { audioContent?: string };
+    const audioContent = body?.audioContent;
+    if (!audioContent) {
+      throw new Error("Inworld TTS API returned no audio data");
+    }
+
+    return Buffer.from(audioContent, "base64");
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -2,14 +2,6 @@ export const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
 
 export const INWORLD_TTS_MODELS = ["inworld-tts-1.5-max", "inworld-tts-1.5-mini"] as const;
 
-function normalizeInworldBaseUrl(baseUrl?: string): string {
-  const trimmed = baseUrl?.trim();
-  if (!trimmed) {
-    return DEFAULT_INWORLD_BASE_URL;
-  }
-  return trimmed.replace(/\/+$/, "");
-}
-
 export async function inworldTTS(params: {
   text: string;
   apiKey: string;
@@ -24,7 +16,7 @@ export async function inworldTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${normalizeInworldBaseUrl(baseUrl)}/tts/v1/voice`, {
+    const response = await fetch(`${baseUrl}/tts/v1/voice`, {
       method: "POST",
       headers: {
         Authorization: `Basic ${apiKey}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,8 @@ importers:
 
   extensions/imessage: {}
 
+  extensions/inworld: {}
+
   extensions/irc: {}
 
   extensions/kilocode: {}

--- a/vitest.extension-provider-paths.mjs
+++ b/vitest.extension-provider-paths.mjs
@@ -12,6 +12,7 @@ export const providerExtensionIds = [
   "google",
   "groq",
   "huggingface",
+  "inworld",
   "kimi-coding",
   "microsoft",
   "microsoft-foundry",


### PR DESCRIPTION
## Summary
- Adds `inworld` as a bundled speech provider following the existing plugin architecture (mirrors the current speech-provider pattern used by other bundled providers)
- Sync non-streaming endpoint (`POST /tts/v1/voice`), MP3 output via base64 `audioContent`
- `apiKey`, `modelId`, and `voiceId` are required; `apiKey` also supports the `INWORLD_API_KEY` env-var fallback
- Inworld voice override is supported via provider-specific directives: `[[tts:inworld_voice=...]]` / `[[tts:inworldvoice=...]]`
- `autoSelectOrder: 50` (after MiniMax=40)
- Includes unit tests and docs updates for Inworld-specific directive keys

## Config example
```yaml
messages.tts.providers.inworld:
  apiKey: your-base64-key-from-inworld-portal
  modelId: inworld-tts-1.5-max
  voiceId: Ashley