### PR TITLE
fix(heartbeat): clamp setTimeout delay to prevent 32-bit overflow

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -257,6 +257,38 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("clamps setTimeout delay to prevent 32-bit overflow for large intervals", async () => {
+    useFakeHeartbeatTime();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    // 30 days = 2_592_000_000 ms, which exceeds the 32-bit signed int max
+    // (2_147_483_647 ms). Without clamping, Node.js sets the timeout to 1 ms.
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30d" } },
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    const delays = (timeoutSpy.mock.calls as Array<[unknown, unknown, ...unknown[]]>)
+      .map(([, delay]) => delay)
+      .filter((d): d is number => typeof d === "number");
+
+    // Every delay passed to setTimeout must be ≤ 2^31 - 1.
+    for (const d of delays) {
+      expect(d).toBeLessThanOrEqual(2_147_483_647);
+    }
+    // The interval should have been clamped, not left at the raw 30-day value.
+    expect(delays.some((d) => d > 0)).toBe(true);
+
+    timeoutSpy.mockRestore();
+    runner.stop();
+  });
+
   it("does not fan out to unrelated agents for session-scoped exec wakes", async () => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -91,6 +91,12 @@ export type HeartbeatDeps = OutboundSendDeps &
 
 const log = createSubsystemLogger("gateway/heartbeat");
 
+/** Node.js setTimeout uses a 32-bit signed integer internally; values above
+ *  this threshold are clamped to 1 ms, causing a runaway hot-loop.  Cap any
+ *  computed delay to this value — the timer will re-arm and recompute on wake.
+ */
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
+
 export { areHeartbeatsEnabled, setHeartbeatsEnabled };
 export {
   isHeartbeatEnabledForAgent,
@@ -1009,7 +1015,7 @@ export function startHeartbeatRunner(opts: {
     if (!Number.isFinite(nextDue)) {
       return;
     }
-    const delay = Math.max(0, nextDue - now);
+    const delay = Math.min(Math.max(0, nextDue - now), MAX_SAFE_TIMEOUT_MS);
     state.timer = setTimeout(() => {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });


### PR DESCRIPTION
## Summary

- Clamp the `setTimeout` delay in `scheduleNext` to `2^31 - 1` (2,147,483,647 ms) to prevent Node.js from clamping it to 1 ms and causing a runaway hot-loop
- Add test verifying setTimeout delays never exceed the 32-bit signed integer limit

When the heartbeat interval exceeds ~24.8 days, Node.js internally uses a 32-bit signed integer for timer delays and clamps overflowing values to 1 ms. This causes the heartbeat callback to fire thousands of times per second, generating 500 MB+ of `TimeoutOverflowWarning` log spam.

The timer naturally re-arms and recomputes the remaining delay on wake, so large intervals still fire at the correct time.

## Test plan

- [x] New test: `"clamps setTimeout delay to prevent 32-bit overflow for large intervals"` — configures a 30-day heartbeat interval and asserts all `setTimeout` delays are ≤ 2^31-1
- [x] Full `heartbeat-runner.scheduler.test.ts` suite passes (9/9)

Fixes #41240