### PR TITLE
fix(config): tighten min constraints for channelStaleEventThresholdMinutes and channelMaxRestartsPerHour

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -728,8 +728,8 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
-        channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
-        channelMaxRestartsPerHour: z.number().int().min(1).optional(),
+        channelStaleEventThresholdMinutes: z.number().int().min(5).optional(),
+        channelMaxRestartsPerHour: z.number().int().min(0).optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),


### PR DESCRIPTION
## Summary

- `channelMaxRestartsPerHour: min(1)` → `min(0)`: allows `0` as "no restart limit / disabled". Users who want unlimited restarts currently have no valid value.
- `channelStaleEventThresholdMinutes: min(1)` → `min(5)`: the default `channelHealthCheckMinutes` is 5. Allowing values below 5 creates a confusing state where the stale threshold fires before a health check can complete.

## Change

```diff
- channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
- channelMaxRestartsPerHour: z.number().int().min(1).optional(),
+ channelStaleEventThresholdMinutes: z.number().int().min(5).optional(),
+ channelMaxRestartsPerHour: z.number().int().min(0).optional(),
```

`src/config/zod-schema.ts` only — no logic changes.

Closes #61389

---
*AI-assisted PR — filed via Claude Code on behalf of [@Arry8](https://github.com/Arry8).*