### PR TITLE
UI: refresh chat history after remote runs

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -579,6 +579,23 @@ describe("connectGateway", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not reload chat history for lifecycle completion of the UI own active run", () => {
+    const { host, client } = connectHostGateway();
+    (host as typeof host & { chatRunId: string | null }).chatRunId = "run-ui-1";
+
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-ui-1",
+        sessionKey: "main",
+        stream: "lifecycle",
+        data: { phase: "end" },
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
   it("does not reload chat history for lifecycle events in other sessions", () => {
     const { client } = connectHostGateway();
 

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -563,6 +563,38 @@ describe("connectGateway", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
+  it("reloads chat history when another client finishes a run in the same session", () => {
+    const { client } = connectHostGateway();
+
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "remote-run-1",
+        sessionKey: "main",
+        stream: "lifecycle",
+        data: { phase: "end" },
+      },
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload chat history for lifecycle events in other sessions", () => {
+    const { client } = connectHostGateway();
+
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "remote-run-1",
+        sessionKey: "agent:main:openresponses:abc",
+        stream: "lifecycle",
+        data: { phase: "end" },
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
   it("routes plugin.approval.requested into execApprovalQueue with kind plugin", () => {
     const host = createHost();
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -371,10 +371,24 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     if (host.onboarding) {
       return;
     }
+    const payload = evt.payload as AgentEventPayload | undefined;
     handleAgentEvent(
       host as unknown as Parameters<typeof handleAgentEvent>[0],
-      evt.payload as AgentEventPayload | undefined,
+      payload,
     );
+    // Some non-UI clients (for example /v1/responses callers) finish runs without
+    // going through the local chat controller, so refresh the current transcript
+    // when the active session receives a lifecycle completion event.
+    if (
+      payload?.sessionKey === host.sessionKey &&
+      payload.runId !== host.chatRunId &&
+      payload.stream === "lifecycle"
+    ) {
+      const phase = typeof payload.data?.phase === "string" ? payload.data.phase : "";
+      if (phase === "end" || phase === "error") {
+        void loadChatHistory(host as unknown as OpenClawApp);
+      }
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- reload chat history when a non-UI client finishes a lifecycle run in the active session
- add node UI tests for same-session and other-session lifecycle completion events

## Testing
- syntax-checked the updated TypeScript files with `typescript` `transpileModule`
- unable to run the full Vitest target against official `main` locally because GitHub clone/archive transfers were repeatedly reset in this environment
