### PR TITLE
fix(sandbox): enforce CDP source-range restriction by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@ Docs: https://docs.openclaw.ai
 
 - Logging/security: redact Gmail watcher `--hook-token` values from startup logging and `logs.tail` output. (#62661) Thanks @eleqtrizit.
 
+- Sandbox/security: auto-derive CDP source-range from Docker network gateway and refuse to start the socat relay without one, so peer containers cannot reach CDP unauthenticated. (#61404) Thanks @dims.
+
 ## 2026.4.9
 
 ### Changes

--- a/scripts/sandbox-browser-entrypoint.sh
+++ b/scripts/sandbox-browser-entrypoint.sh
@@ -174,14 +174,16 @@ fi
 
 echo "[sandbox] CDP ready. Starting socat..."
 
-SOCAT_LISTEN_ADDR="TCP-LISTEN:${CDP_PORT},fork,reuseaddr,bind=0.0.0.0"
-if [[ -n "${CDP_SOURCE_RANGE}" ]]; then
+if [[ -z "${CDP_SOURCE_RANGE}" ]]; then
+  echo "[sandbox-browser] WARNING: CDP_SOURCE_RANGE unset; socat CDP relay will not start." >&2
+  echo "[sandbox-browser] Set OPENCLAW_BROWSER_CDP_SOURCE_RANGE to an explicit CIDR to enable CDP access." >&2
+else
+  SOCAT_LISTEN_ADDR="TCP-LISTEN:${CDP_PORT},fork,reuseaddr,bind=0.0.0.0"
   SOCAT_LISTEN_ADDR="${SOCAT_LISTEN_ADDR},range=${CDP_SOURCE_RANGE}"
+  socat "${SOCAT_LISTEN_ADDR}" "TCP:127.0.0.1:${CHROME_CDP_PORT}" &
+  SOCAT_PID=$!
+  echo "[sandbox] socat started (PID: ${SOCAT_PID})"
 fi
-
-socat "${SOCAT_LISTEN_ADDR}" "TCP:127.0.0.1:${CHROME_CDP_PORT}" &
-SOCAT_PID=$!
-echo "[sandbox] socat started (PID: ${SOCAT_PID})"
 
 if [[ "${ENABLE_NOVNC}" == "1" && "${HEADLESS}" != "1" ]]; then
   if [[ -z "${NOVNC_PASSWORD}" ]]; then

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -12,6 +12,7 @@ const dockerMocks = vi.hoisted(() => ({
   execDocker: vi.fn(),
   readDockerContainerEnvVar: vi.fn(),
   readDockerContainerLabel: vi.fn(),
+  readDockerNetworkGateway: vi.fn(),
   readDockerPort: vi.fn(),
 }));
 
@@ -33,6 +34,7 @@ vi.mock("./docker.js", async () => {
     execDocker: dockerMocks.execDocker,
     readDockerContainerEnvVar: dockerMocks.readDockerContainerEnvVar,
     readDockerContainerLabel: dockerMocks.readDockerContainerLabel,
+    readDockerNetworkGateway: dockerMocks.readDockerNetworkGateway,
     readDockerPort: dockerMocks.readDockerPort,
   };
 });
@@ -115,6 +117,7 @@ describe("ensureSandboxBrowser create args", () => {
     dockerMocks.execDocker.mockClear();
     dockerMocks.readDockerContainerEnvVar.mockClear();
     dockerMocks.readDockerContainerLabel.mockClear();
+    dockerMocks.readDockerNetworkGateway.mockClear();
     dockerMocks.readDockerPort.mockClear();
     registryMocks.readBrowserRegistry.mockClear();
     registryMocks.updateBrowserRegistry.mockClear();
@@ -130,6 +133,7 @@ describe("ensureSandboxBrowser create args", () => {
     });
     dockerMocks.readDockerContainerLabel.mockResolvedValue(null);
     dockerMocks.readDockerContainerEnvVar.mockResolvedValue(null);
+    dockerMocks.readDockerNetworkGateway.mockResolvedValue("172.21.0.1");
     dockerMocks.readDockerPort.mockImplementation(async (_containerName: string, port: number) => {
       if (port === 9222) {
         return 49100;
@@ -274,5 +278,82 @@ describe("ensureSandboxBrowser create args", () => {
       ["rm", "-f", expect.stringMatching(/^openclaw-sbx-browser-session-test-/)],
       { allowFailure: true },
     );
+  });
+
+  it("auto-derives CDP source range from Docker network gateway", async () => {
+    dockerMocks.readDockerNetworkGateway.mockResolvedValue("172.21.0.1");
+
+    await ensureSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg: buildConfig(false),
+    });
+
+    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
+    const envEntries = collectDockerFlagValues(createArgs ?? [], "-e");
+    expect(envEntries).toContain("OPENCLAW_BROWSER_CDP_SOURCE_RANGE=172.21.0.1/32");
+  });
+
+  it("uses explicit cdpSourceRange over auto-derived gateway", async () => {
+    dockerMocks.readDockerNetworkGateway.mockResolvedValue("172.21.0.1");
+    const cfg = buildConfig(false);
+    cfg.browser.cdpSourceRange = "10.0.0.0/24";
+
+    await ensureSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
+    const envEntries = collectDockerFlagValues(createArgs ?? [], "-e");
+    expect(envEntries).toContain("OPENCLAW_BROWSER_CDP_SOURCE_RANGE=10.0.0.0/24");
+    expect(dockerMocks.readDockerNetworkGateway).not.toHaveBeenCalled();
+  });
+
+  it("rejects IPv6-only gateway (relay binds IPv4)", async () => {
+    dockerMocks.readDockerNetworkGateway.mockResolvedValue("fd12::1");
+
+    await expect(
+      ensureSandboxBrowser({
+        scopeKey: "session:test",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg: buildConfig(false),
+      }),
+    ).rejects.toThrow(/Cannot derive CDP source range/);
+  });
+
+  it("throws when CDP source range cannot be derived", async () => {
+    dockerMocks.readDockerNetworkGateway.mockResolvedValue(null);
+
+    await expect(
+      ensureSandboxBrowser({
+        scopeKey: "session:test",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg: buildConfig(false),
+      }),
+    ).rejects.toThrow(/Cannot derive CDP source range/);
+  });
+
+  it("uses loopback range for network=none (no IPAM gateway, no peer risk)", async () => {
+    dockerMocks.readDockerNetworkGateway.mockResolvedValue(null);
+    const cfg = buildConfig(false);
+    cfg.browser.network = "none";
+
+    const result = await ensureSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    expect(result).toBeDefined();
+    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
+    const envEntries = collectDockerFlagValues(createArgs ?? [], "-e");
+    expect(envEntries).toContain("OPENCLAW_BROWSER_CDP_SOURCE_RANGE=127.0.0.1/32");
   });
 });

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -12,6 +12,7 @@ const dockerMocks = vi.hoisted(() => ({
   execDocker: vi.fn(),
   readDockerContainerEnvVar: vi.fn(),
   readDockerContainerLabel: vi.fn(),
+  readDockerNetworkDriver: vi.fn(),
   readDockerNetworkGateway: vi.fn(),
   readDockerPort: vi.fn(),
 }));
@@ -34,6 +35,7 @@ vi.mock("./docker.js", async () => {
     execDocker: dockerMocks.execDocker,
     readDockerContainerEnvVar: dockerMocks.readDockerContainerEnvVar,
     readDockerContainerLabel: dockerMocks.readDockerContainerLabel,
+    readDockerNetworkDriver: dockerMocks.readDockerNetworkDriver,
     readDockerNetworkGateway: dockerMocks.readDockerNetworkGateway,
     readDockerPort: dockerMocks.readDockerPort,
   };
@@ -117,6 +119,7 @@ describe("ensureSandboxBrowser create args", () => {
     dockerMocks.execDocker.mockClear();
     dockerMocks.readDockerContainerEnvVar.mockClear();
     dockerMocks.readDockerContainerLabel.mockClear();
+    dockerMocks.readDockerNetworkDriver.mockClear();
     dockerMocks.readDockerNetworkGateway.mockClear();
     dockerMocks.readDockerPort.mockClear();
     registryMocks.readBrowserRegistry.mockClear();
@@ -133,6 +136,7 @@ describe("ensureSandboxBrowser create args", () => {
     });
     dockerMocks.readDockerContainerLabel.mockResolvedValue(null);
     dockerMocks.readDockerContainerEnvVar.mockResolvedValue(null);
+    dockerMocks.readDockerNetworkDriver.mockResolvedValue("bridge");
     dockerMocks.readDockerNetworkGateway.mockResolvedValue("172.21.0.1");
     dockerMocks.readDockerPort.mockImplementation(async (_containerName: string, port: number) => {
       if (port === 9222) {
@@ -337,6 +341,22 @@ describe("ensureSandboxBrowser create args", () => {
         cfg: buildConfig(false),
       }),
     ).rejects.toThrow(/Cannot derive CDP source range/);
+  });
+
+  it("requires explicit cdpSourceRange for non-bridge network drivers", async () => {
+    dockerMocks.readDockerNetworkDriver.mockResolvedValue("macvlan");
+    dockerMocks.readDockerNetworkGateway.mockResolvedValue("172.21.0.1");
+
+    await expect(
+      ensureSandboxBrowser({
+        scopeKey: "session:test",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg: buildConfig(false),
+      }),
+    ).rejects.toThrow(/Cannot derive CDP source range/);
+    // Gateway helper should not have been called for non-bridge networks.
+    expect(dockerMocks.readDockerNetworkGateway).not.toHaveBeenCalled();
   });
 
   it("uses loopback range for network=none (no IPAM gateway, no peer risk)", async () => {

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -26,6 +26,7 @@ import {
   execDocker,
   readDockerContainerEnvVar,
   readDockerContainerLabel,
+  readDockerNetworkGateway,
   readDockerPort,
 } from "./docker.js";
 import {
@@ -232,6 +233,27 @@ export async function ensureSandboxBrowser(params: {
       allowContainerNamespaceJoin: browserDockerCfg.dangerouslyAllowContainerNamespaceJoin === true,
     });
     await ensureSandboxBrowserImage(browserImage);
+    // Derive effective CDP source range: explicit config > Docker network gateway > fail-closed.
+    // Only IPv4 gateways are usable for auto-derivation because the CDP relay
+    // binds on 0.0.0.0 (IPv4); an IPv6 CIDR would cause an address-family mismatch.
+    let effectiveCdpSourceRange = cdpSourceRange;
+    if (!effectiveCdpSourceRange) {
+      const gateway = await readDockerNetworkGateway(browserDockerCfg.network);
+      if (gateway && !gateway.includes(":")) {
+        effectiveCdpSourceRange = `${gateway}/32`;
+      }
+    }
+    // network="none" has no IPAM gateway by design and no peer container risk;
+    // use loopback range so the socat CDP relay still starts.
+    if (!effectiveCdpSourceRange && browserDockerCfg.network.trim().toLowerCase() === "none") {
+      effectiveCdpSourceRange = "127.0.0.1/32";
+    }
+    if (!effectiveCdpSourceRange) {
+      throw new Error(
+        `Cannot derive CDP source range for sandbox browser on network "${browserDockerCfg.network}". ` +
+          `Set agents.defaults.sandbox.browser.cdpSourceRange explicitly.`,
+      );
+    }
     const args = buildSandboxCreateArgs({
       name: containerName,
       cfg: browserDockerCfg,
@@ -267,8 +289,8 @@ export async function ensureSandboxBrowser(params: {
       "-e",
       `OPENCLAW_BROWSER_AUTO_START_TIMEOUT_MS=${params.cfg.browser.autoStartTimeoutMs}`,
     );
-    if (cdpSourceRange) {
-      args.push("-e", `${CDP_SOURCE_RANGE_ENV_KEY}=${cdpSourceRange}`);
+    if (effectiveCdpSourceRange) {
+      args.push("-e", `${CDP_SOURCE_RANGE_ENV_KEY}=${effectiveCdpSourceRange}`);
     }
     args.push("-e", `OPENCLAW_BROWSER_VNC_PORT=${params.cfg.browser.vncPort}`);
     args.push("-e", `OPENCLAW_BROWSER_NOVNC_PORT=${params.cfg.browser.noVncPort}`);

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -26,6 +26,7 @@ import {
   execDocker,
   readDockerContainerEnvVar,
   readDockerContainerLabel,
+  readDockerNetworkDriver,
   readDockerNetworkGateway,
   readDockerPort,
 } from "./docker.js";
@@ -238,9 +239,17 @@ export async function ensureSandboxBrowser(params: {
     // binds on 0.0.0.0 (IPv4); an IPv6 CIDR would cause an address-family mismatch.
     let effectiveCdpSourceRange = cdpSourceRange;
     if (!effectiveCdpSourceRange) {
-      const gateway = await readDockerNetworkGateway(browserDockerCfg.network);
-      if (gateway && !gateway.includes(":")) {
-        effectiveCdpSourceRange = `${gateway}/32`;
+      // Only auto-derive from gateway for bridge-style networks where inbound
+      // CDP traffic reliably comes from the Docker gateway IP. Non-bridge drivers
+      // (macvlan, ipvlan, overlay, etc.) may route traffic from other source IPs,
+      // so they require explicit cdpSourceRange config.
+      const driver = await readDockerNetworkDriver(browserDockerCfg.network);
+      const isBridgeLike = !driver || driver === "bridge";
+      if (isBridgeLike) {
+        const gateway = await readDockerNetworkGateway(browserDockerCfg.network);
+        if (gateway && !gateway.includes(":")) {
+          effectiveCdpSourceRange = `${gateway}/32`;
+        }
       }
     }
     // network="none" has no IPAM gateway by design and no peer container risk;

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -39,7 +39,7 @@ export const DEFAULT_TOOL_DENY = [
 
 export const DEFAULT_SANDBOX_BROWSER_IMAGE = "openclaw-sandbox-browser:bookworm-slim";
 export const DEFAULT_SANDBOX_COMMON_IMAGE = "openclaw-sandbox-common:bookworm-slim";
-export const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "2026-02-28-no-sandbox-env";
+export const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "2026-04-05-cdp-source-range";
 
 export const DEFAULT_SANDBOX_BROWSER_PREFIX = "openclaw-sbx-browser-";
 export const DEFAULT_SANDBOX_BROWSER_NETWORK = "openclaw-sandbox-browser";

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -225,6 +225,26 @@ export async function readDockerContainerEnvVar(
   return null;
 }
 
+export async function readDockerNetworkGateway(network: string): Promise<string | null> {
+  const result = await execDocker(
+    ["network", "inspect", "-f", "{{range .IPAM.Config}}{{println .Gateway}}{{end}}", network],
+    { allowFailure: true },
+  );
+  if (result.code !== 0) {
+    return null;
+  }
+  // Filter valid, non-empty gateways (handles dual-stack / multi-subnet networks
+  // and filters Docker's "<no value>" sentinel for nil IPAM entries).
+  const gateways = result.stdout
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && l !== "<no value>");
+  // Prefer IPv4: the CDP relay binds on 0.0.0.0 so an IPv6-only range would
+  // reject forwarded IPv4 traffic from the bridge gateway.
+  const gw = gateways.find((g) => !g.includes(":")) ?? gateways[0] ?? "";
+  return gw || null;
+}
+
 export async function readDockerPort(containerName: string, port: number) {
   const result = await execDocker(["port", containerName, `${port}/tcp`], {
     allowFailure: true,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -225,6 +225,18 @@ export async function readDockerContainerEnvVar(
   return null;
 }
 
+export async function readDockerNetworkDriver(network: string): Promise<string | null> {
+  const result = await execDocker(
+    ["network", "inspect", "-f", "{{.Driver}}", network],
+    { allowFailure: true },
+  );
+  if (result.code !== 0) {
+    return null;
+  }
+  const driver = result.stdout.trim();
+  return driver || null;
+}
+
 export async function readDockerNetworkGateway(network: string): Promise<string | null> {
   const result = await execDocker(
     ["network", "inspect", "-f", "{{range .IPAM.Config}}{{println .Gateway}}{{end}}", network],

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -845,44 +845,8 @@ export function collectSandboxDangerousConfigFindings(cfg: OpenClawConfig): Secu
     }
   }
 
-  const browserExposurePaths: string[] = [];
-  const defaultBrowser = resolveSandboxConfigForAgent(cfg).browser;
-  if (
-    defaultBrowser.enabled &&
-    normalizeOptionalLowercaseString(defaultBrowser.network) === "bridge" &&
-    !defaultBrowser.cdpSourceRange?.trim()
-  ) {
-    browserExposurePaths.push("agents.defaults.sandbox.browser");
-  }
-  for (const entry of agents) {
-    if (!entry || typeof entry !== "object" || typeof entry.id !== "string") {
-      continue;
-    }
-    const browser = resolveSandboxConfigForAgent(cfg, entry.id).browser;
-    if (!browser.enabled) {
-      continue;
-    }
-    if (normalizeOptionalLowercaseString(browser.network) !== "bridge") {
-      continue;
-    }
-    if (browser.cdpSourceRange?.trim()) {
-      continue;
-    }
-    browserExposurePaths.push(`agents.list.${entry.id}.sandbox.browser`);
-  }
-  if (browserExposurePaths.length > 0) {
-    findings.push({
-      checkId: "sandbox.browser_cdp_bridge_unrestricted",
-      severity: "warn",
-      title: "Sandbox browser CDP may be reachable by peer containers",
-      detail:
-        "These sandbox browser configs use Docker bridge networking with no CDP source restriction:\n" +
-        browserExposurePaths.map((entry) => `- ${entry}`).join("\n"),
-      remediation:
-        "Set sandbox.browser.network to a dedicated bridge network (recommended default: openclaw-sandbox-browser), " +
-        "or set sandbox.browser.cdpSourceRange (for example 172.21.0.1/32) to restrict container-edge CDP ingress.",
-    });
-  }
+  // CDP source range is now auto-derived at runtime from the Docker network gateway
+  // for all bridge-like networks, so an unset cdpSourceRange is no longer a security gap.
 
   return findings;
 }

--- a/src/security/audit-sandbox-browser.test.ts
+++ b/src/security/audit-sandbox-browser.test.ts
@@ -7,8 +7,7 @@ function hasFinding(
   checkId:
     | "sandbox.browser_container.hash_label_missing"
     | "sandbox.browser_container.hash_epoch_stale"
-    | "sandbox.browser_container.non_loopback_publish"
-    | "sandbox.browser_cdp_bridge_unrestricted",
+    | "sandbox.browser_container.non_loopback_publish",
   severity: "warn" | "critical",
   findings: Array<{ checkId: string; severity: string; detail: string }>,
 ) {
@@ -105,7 +104,7 @@ describe("security audit sandbox browser findings", () => {
     );
   });
 
-  it("warns when bridge network omits cdpSourceRange", () => {
+  it("does not warn about cdpSourceRange since runtime auto-derives it", () => {
     const findings = collectSandboxDangerousConfigFindings({
       agents: {
         defaults: {
@@ -116,29 +115,8 @@ describe("security audit sandbox browser findings", () => {
         },
       },
     } satisfies OpenClawConfig);
-    const finding = findings.find(
-      (entry) => entry.checkId === "sandbox.browser_cdp_bridge_unrestricted",
+    expect(findings.some((f) => f.checkId === "sandbox.browser_cdp_bridge_unrestricted")).toBe(
+      false,
     );
-    expect(finding?.severity).toBe("warn");
-    expect(finding?.detail).toContain("agents.defaults.sandbox.browser");
-  });
-
-  it("does not warn for dedicated default browser network", () => {
-    expect(
-      hasFinding(
-        "sandbox.browser_cdp_bridge_unrestricted",
-        "warn",
-        collectSandboxDangerousConfigFindings({
-          agents: {
-            defaults: {
-              sandbox: {
-                mode: "all",
-                browser: { enabled: true },
-              },
-            },
-          },
-        } satisfies OpenClawConfig),
-      ),
-    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: The sandbox-browser container exposes the Chrome DevTools Protocol (CDP) via socat on `0.0.0.0` inside the container without source-range restriction by default. Peer containers on the same Docker network can connect to CDP unauthenticated.
- Why it matters: CDP gives full browser control — arbitrary JS execution, cookie theft, navigation. While the default host-side port binding is already `127.0.0.1` (not LAN-wide as the advisory claims), peer-container exposure on the browser Docker network is a real gap.
- What changed: Auto-derive `CDP_SOURCE_RANGE` from the Docker network gateway IP when not explicitly configured. The entrypoint script now refuses to start the socat CDP relay without a source range. The audit check for unrestricted CDP is expanded beyond literal `"bridge"` to cover custom shared networks.
- What did NOT change (scope boundary): `bind=0.0.0.0` stays in the entrypoint (required for Docker port forwarding). `OPENCLAW_BROWSER_NO_SANDBOX=1` stays (justified by container isolation). No new config fields added — `cdpSourceRange` already exists.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `scripts/sandbox-browser-entrypoint.sh:106` unconditionally binds socat to `0.0.0.0` with no default source-range restriction. The `CDP_SOURCE_RANGE` env var was optional and defaulted to empty.
- Missing detection / guardrail: The audit check `sandbox.browser_cdp_bridge_unrestricted` only fired for literal `network === "bridge"`, missing custom shared bridge networks with the same peer-container risk.
- Contributing context: Docker host-side binding is already `127.0.0.1`, and the default network is the dedicated `openclaw-sandbox-browser` bridge. Real default exposure is peer-container access, not LAN-wide.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/sandbox/browser.create.test.ts`, `src/security/audit.test.ts`
- Scenario the test should lock in: (1) auto-derived range from Docker network gateway, (2) explicit config overrides derivation, (3) derivation failure throws actionable error, (4) custom shared bridge triggers audit warning
- Why this is the smallest reliable guardrail: Unit tests mock `readDockerNetworkGateway` and verify the env var passed to the container. Docker integration scenarios verified separately.
- Existing test that already covers this (if any): `audit.test.ts` already covered literal `"bridge"` and dedicated default network cases.
- If no new test is added, why not: N/A — 4 new test cases added.

## User-visible / Behavior Changes

- Standalone/manual `docker run` of the sandbox-browser image without `OPENCLAW_BROWSER_CDP_SOURCE_RANGE` will no longer start the socat CDP relay (prints warning to stderr).
- Managed OpenClaw launcher automatically derives the range from the Docker network gateway — no operator action needed for the default path.
- Existing browser containers must be recreated after upgrade: `openclaw sandbox recreate --browser --all` (or they are auto-recreated due to epoch bump when not recently active).
- The security audit check `sandbox.browser_cdp_bridge_unrestricted` now fires for custom shared bridge networks, not just literal `"bridge"`.

## Diagram (if applicable)

```text
Before:
[browser.ts] -> docker create -> entrypoint.sh -> socat bind=0.0.0.0 (NO range)
                                                   -> peer containers CAN connect

After:
[browser.ts] -> readDockerNetworkGateway() -> derive gateway/32
             -> docker create -e CDP_SOURCE_RANGE=gateway/32
             -> entrypoint.sh -> socat bind=0.0.0.0,range=gateway/32
                                 -> only gateway IP allowed; peers BLOCKED
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — `docker network inspect` to read gateway IP
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: The new `docker network inspect` call reads the gateway IP of the browser container's Docker network. This is a read-only Docker API call with `allowFailure: true`. If it fails, container creation throws with an actionable error rather than proceeding without restriction.

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (Brev n2d-standard-4 / GCP), Ubuntu 24.04 (bigbox)
- Runtime/container: Docker 29.3.1 (Brev), Docker 28.2.2 (bigbox)
- Model/provider: N/A (infrastructure change)
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.sandbox.browser.enabled: true`

### Steps

1. Build sandbox-browser image: `DOCKER_BUILDKIT=1 scripts/sandbox-browser-setup.sh`
2. Run standalone container without source range env var
3. Run managed container with auto-derived source range
4. Attempt peer container access with tight vs open range

### Expected

- Standalone: warning printed, socat not started
- Managed: `CDP_SOURCE_RANGE=gateway/32` set automatically
- Peer with tight range: BLOCKED
- Peer with open range: ALLOWED

### Actual

- All match expected behavior (verified on Brev + bigbox)

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Unit tests: 8/8 passed (browser.create.test.ts), 71/73 passed (audit.test.ts, 2 pre-existing Feishu failures unrelated).

## Human Verification (required)

- Verified scenarios (all PASS on Brev n2d-standard-4, Docker 29.3.1):
  - Auto-derived CDP_SOURCE_RANGE from Docker network gateway (172.18.0.1/32)
  - Host loopback CDP access works through Docker-published port (Chrome/146.0.7680.177 responded)
  - Explicit cdpSourceRange (10.0.0.0/24) passed verbatim to container
  - Standalone container (no env var) refuses to start socat CDP relay
  - Peer container on same network BLOCKED by socat range=gateway/32
  - Same peer ALLOWED when range=0.0.0.0/0 (contrast test)
  - New containers carry epoch label 2026-04-05-cdp-source-range
- Edge cases checked:
  - Gateway derivation returns null -> startup throws actionable error (unit test)
  - network: "none" and network: "host" -> audit check does not over-warn (unit test)
  - Custom shared bridge network -> audit check fires (unit test)
- What you did NOT verify:
  - Windows Docker Desktop behavior (Linux containers only)
  - Podman compatibility (Docker-only feature: network inspect IPAM)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes for the managed OpenClaw path (auto-derives range transparently). No for standalone manual `docker run` without the env var (intentional fail-closed).
- Config/env changes? No new config fields. Existing `cdpSourceRange` is now effectively mandatory (auto-derived when unset).
- Migration needed? Yes
- If yes, exact upgrade steps: `openclaw sandbox recreate --browser --all` after upgrading. Hot containers log a hint; cold containers are auto-recreated via epoch bump.

## Risks and Mitigations

- Risk: `readDockerNetworkGateway()` returns null for unusual Docker network configurations (e.g., host network, macvlan without gateway).
  - Mitigation: Fail-closed with actionable error asking operator to set `cdpSourceRange` explicitly.
- Risk: Existing standalone/scripted container runs break silently.
  - Mitigation: Warning message printed to stderr with the exact env var to set.