### PR TITLE
feat(searxng): pass through img_src from image search results

### DIFF
--- a/extensions/searxng/src/searxng-client.test.ts
+++ b/extensions/searxng/src/searxng-client.test.ts
@@ -39,6 +39,41 @@ describe("searxng client", () => {
     ).toEqual([{ title: "One", url: "https://example.com/1", content: "A" }]);
   });
 
+  it("preserves img_src from image search results", () => {
+    expect(
+      __testing.parseSearxngResponseText(
+        JSON.stringify({
+          results: [
+            {
+              title: "Kitten",
+              url: "https://example.com/kitten",
+              content: "A cute kitten",
+              img_src: "https://cdn.example.com/kitten.jpg",
+            },
+            {
+              title: "No Image",
+              url: "https://example.com/text",
+              content: "Text only",
+            },
+          ],
+        }),
+        10,
+      ),
+    ).toEqual([
+      {
+        title: "Kitten",
+        url: "https://example.com/kitten",
+        content: "A cute kitten",
+        img_src: "https://cdn.example.com/kitten.jpg",
+      },
+      {
+        title: "No Image",
+        url: "https://example.com/text",
+        content: "Text only",
+      },
+    ]);
+  });
+
   it("drops malformed result rows instead of failing the whole response", () => {
     expect(
       __testing.parseSearxngResponseText(

--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -35,6 +35,7 @@ type SearxngResult = {
   url: string;
   title: string;
   content?: string;
+  img_src?: string;
 };
 
 type SearxngResponse = {
@@ -46,7 +47,7 @@ function normalizeSearxngResult(value: unknown): SearxngResult | null {
     return null;
   }
 
-  const candidate = value as { url?: unknown; title?: unknown; content?: unknown };
+  const candidate = value as { url?: unknown; title?: unknown; content?: unknown; img_src?: unknown };
   if (typeof candidate.url !== "string" || typeof candidate.title !== "string") {
     return null;
   }
@@ -55,6 +56,7 @@ function normalizeSearxngResult(value: unknown): SearxngResult | null {
     url: candidate.url,
     title: candidate.title,
     content: typeof candidate.content === "string" ? candidate.content : undefined,
+    img_src: typeof candidate.img_src === "string" ? candidate.img_src : undefined,
   };
 }
 
@@ -220,6 +222,7 @@ export async function runSearxngSearch(params: {
       url: result.url,
       snippet: result.content ? wrapWebContent(result.content, "web_search") : "",
       siteName: resolveSiteName(result.url) || undefined,
+      img_src: result.img_src || undefined,
     })),
   } satisfies Record<string, unknown>;
 


### PR DESCRIPTION
## Summary

- SearXNG returns an `img_src` field for image category results containing direct CDN image URLs
- `normalizeSearxngResult` currently strips this field, so agents cannot obtain direct image URLs from SearXNG image searches
- This adds `img_src` passthrough in the normalizer and results mapper, following the same optional-string pattern used for `content`

## Changes

- Added `img_src?: string` to `SearxngResult` type
- Added `img_src` extraction in `normalizeSearxngResult`
- Added `img_src` to the results payload mapper in `runSearxngSearch`
- Added test case covering `img_src` preservation for image results and absence for text-only results

## Test plan

- [ ] Existing SearXNG tests pass (no breaking changes — `img_src` is optional)
- [ ] New test validates `img_src` is preserved when present and omitted when absent
- [ ] Manual: configure `categories: "images"` or `categories: "general,images"` and verify `img_src` appears in search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)