### PR TITLE
Docs: add WSL proxy guidance for Windows (AI-assisted: Codex)

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -235,6 +235,43 @@ openclaw onboard
 
 Full guide: [Getting Started](/start/getting-started)
 
+## WSL2 with Windows proxy
+
+If Windows uses a system or application proxy, WSL2 may not automatically use
+the same settings. In that case, the CLI and Gateway inside WSL can fail to
+reach external APIs or the internet.
+
+You can configure `.wslconfig` in your Windows user directory, for example
+`C:\Users\<YourName>\.wslconfig`, so WSL networking follows Windows more
+closely:
+
+```ini
+[wsl2]
+networkingMode=mirrored
+autoProxy=true
+dnsTunneling=true
+```
+
+- `networkingMode=mirrored`: when supported (Windows 11 22H2 or later with WSL
+  2.0.0+), WSL2 shares the Windows network stack more directly, which can make
+  proxy and port behavior match Windows more closely. Mirrored networking is not
+  available on Windows 10.
+- `autoProxy=true`: asks WSL to use the proxy configuration from Windows
+  (Windows 11 only; not supported on Windows 10).
+- `dnsTunneling=true`: routes DNS resolution through Windows so name lookup
+  matches Windows proxy and VPN behavior more closely (Windows 11 22H2 or later;
+  not supported on Windows 10).
+
+**Windows 10:** the options above are not available in `.wslconfig`. Configure
+`http_proxy`, `https_proxy`, and `no_proxy` inside the distro instead (for
+example in `~/.bashrc`), pointed at the same proxy your Windows session uses.
+
+After saving `.wslconfig`, run `wsl --shutdown` in PowerShell, then reopen your
+WSL terminal. If Windows does not use a proxy and WSL2 already has working
+internet access, you usually do not need these settings. See [Advanced settings
+configuration in WSL](https://learn.microsoft.com/windows/wsl/wsl-config)
+(Microsoft Learn) for version details.
+
 ## Windows companion app
 
 We do not have a Windows companion app yet. Contributions are welcome if you want


### PR DESCRIPTION
## Summary

- Problem: the Windows docs explain WSL2 install and startup, but they do not mention the common case where Windows has a proxy configured and WSL networking does not follow it automatically.
- Why it matters: users on Windows + WSL can end up with a working host proxy and a non-working OpenClaw CLI/Gateway inside WSL, which makes onboarding and debugging harder.
- What changed: added a focused `WSL2 with Windows proxy` section to `docs/platforms/windows.md` with `.wslconfig` settings and restart guidance.
- What did NOT change (scope boundary): no runtime, build, installer, or networking code changed.

## Change Type (select all)

- [x] Docs
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] UI / DX
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #31840
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- Windows WSL2 docs now explain how to make WSL follow Windows proxy settings when proxy access is required.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows with WSL2
- Runtime/container: Docs-only change
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `.wslconfig`

### Steps

1. Read `docs/platforms/windows.md` on `main`.
2. Find the Windows WSL2 install section.
3. Confirm there is no guidance for WSL inheriting Windows proxy settings.

### Expected

- Windows users running OpenClaw inside WSL can find a short, actionable note for the common proxy mismatch case.

### Actual

- The docs now include a dedicated `WSL2 with Windows proxy` section with `.wslconfig` settings and restart guidance.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: checked the final diff and placement in `docs/platforms/windows.md`.
- Edge cases checked: wording avoids claiming these settings are always required and keeps scope to Windows proxy-backed WSL setups.
- What you did **not** verify: did not live-test `.wslconfig` behavior on a fresh Windows machine in this PR.

## AI-assisted

- AI-assisted: Codex
- Testing: lightly tested (manual docs review only)
- Prompts/logs: requested a standalone docs PR for Windows WSL proxy guidance and refined the wording to keep claims precise.
- Understanding: this PR only adds Windows WSL proxy guidance to the docs; it does not change OpenClaw runtime behavior.
- `codex review --base origin/main`: not run locally in this environment

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the documented `.wslconfig` settings may not be necessary for every WSL setup.
  - Mitigation: the wording scopes them to the proxy case and explicitly says users usually do not need them if WSL already has internet access.