### PR TITLE
config: export browser-safe OpenClawSchema via plugin-sdk/config-schema

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { z } from "zod";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import {
@@ -18,7 +17,7 @@ const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
 
 function isAbsolutePath(value: string): boolean {
   return (
-    path.isAbsolute(value) ||
+    value.startsWith("/") ||
     WINDOWS_ABS_PATH_PATTERN.test(value) ||
     WINDOWS_UNC_PATH_PATTERN.test(value)
   );

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { z } from "zod";
 import { InstallRecordShape } from "./zod-schema.installs.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -10,7 +9,7 @@ function isSafeRelativeModulePath(raw: string): boolean {
   }
   // Hook modules are loaded via file-path resolution + dynamic import().
   // Keep this strictly relative to a configured base dir to avoid path traversal and surprises.
-  if (path.isAbsolute(value)) {
+  if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value)) {
     return false;
   }
   if (value.startsWith("~")) {


### PR DESCRIPTION
## Summary

- **Problem:** `zod-schema.core.ts` and `zod-schema.hooks.ts` import `node:path`, making the config schema non-importable in browser environments.
- **Why it matters:** External tools (config validators, hosted dashboards) need to validate OpenClaw config objects client-side without pulling in Node.js builtins.
- **What changed:** Removed `import path from "node:path"` from both files, replacing `path.isAbsolute(value)` with portable string checks (`value.startsWith("/")` plus Windows drive-letter regex where needed). The `plugin-sdk/config-schema` barrel and `package.json` export already existed on `main`.
- **What did NOT change (scope boundary):** No behavioral change to validation logic. On POSIX, `path.isAbsolute` returns `true` iff the string starts with `/` — the replacement is identical. In `zod-schema.core.ts`, `WINDOWS_ABS_PATH_PATTERN` and `WINDOWS_UNC_PATH_PATTERN` already handle Windows paths. In `zod-schema.hooks.ts`, the function already rejects strings containing `:` on a later line, so `value.startsWith("/")` alone is sufficient for absolute-path rejection; the explicit `^[A-Za-z]:[\\\/]` check is included for defense-in-depth.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — this is a new capability, not a bug fix.

## Regression Test Plan (if applicable)

N/A — no behavioral change. Existing config validation tests cover the same paths.

## User-visible / Behavior Changes

None. The subpath export already existed; this PR only makes its transitive imports browser-safe.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun

### Steps

1. `pnpm build` — passes (hard gate: published surface change)
2. Verify `dist/plugin-sdk/config-schema.js` contains no `node:path` reference
3. Config tests pass (`pnpm test -- src/config/`)

### Expected

- Build succeeds with no `node:path` in the config-schema output bundle

### Actual

- Build succeeds; `node:path` removed from both zod-schema files

## Evidence

- [x] `pnpm build` passes cleanly
- [x] `git diff` shows only `path.isAbsolute(value)` → `value.startsWith("/")` (plus Windows regex in hooks)

## Human Verification (required)

- Verified scenarios: `pnpm build` passes; diff reviewed for semantic equivalence
- Edge cases checked: Windows absolute paths still covered by existing regex patterns; hooks file `:` rejection covers drive-letter paths independently
- What you did **not** verify: full `pnpm test` suite (pre-existing failures on `upstream/main` in unrelated contract tests)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `value.startsWith("/")` does not match `path.isAbsolute` for edge cases like `//foo` (POSIX double-slash).
  - Mitigation: `path.isAbsolute("//foo")` returns `true`, and `"//foo".startsWith("/")` also returns `true`. No difference.