### PR TITLE
fix(update): Suppress Corepack prompts during update preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -693,6 +693,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/OpenAI HTTP: restore default operator scopes for bearer-authenticated requests that omit `x-openclaw-scopes`, so headless `/v1/chat/completions` and session-history callers work again after the recent method-scope hardening. (#57596) Thanks @openperf.
 - Gateway/attachments: offload large inbound images without leaking `media://` markers into text-only runs, preserve mixed attachment order for model input/transcripts, and fail closed when model image capability cannot be resolved. (#55513) Thanks @Syysean.
 - Telegram/outbound chunking: use static markdown chunking when Telegram runtime state is unavailable so long outbound Telegram messages still split correctly after cold starts. (#57816) Thanks @ForestDengHK.
+- Update/Corepack: disable interactive Corepack download prompts during update preflight install unless `COREPACK_ENABLE_DOWNLOAD_PROMPT` is already explicitly set, so `openclaw update` can fetch the repo-pinned pnpm version non-interactively. (#61456) Thanks @p6l-richard.
 
 ## 2026.4.2
 

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -11,6 +11,7 @@ import {
   cleanupGlobalRenameDirs,
   detectGlobalInstallManagerByPresence,
   detectGlobalInstallManagerForRoot,
+  createGlobalInstallEnv,
   globalInstallArgs,
   globalInstallFallbackArgs,
   isExplicitPackageInstallSpec,
@@ -87,6 +88,20 @@ describe("update global helpers", () => {
         tag: "https://example.com/openclaw-main.tgz",
       }),
     ).toBe("https://example.com/openclaw-main.tgz");
+  });
+
+  it("defaults corepack download prompts off for global install env", async () => {
+    await expect(createGlobalInstallEnv({})).resolves.toMatchObject({
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+    });
+
+    await expect(
+      createGlobalInstallEnv({
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: "1",
+      }),
+    ).resolves.toMatchObject({
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "1",
+    });
   });
 
   it("classifies main and raw install specs separately from registry selectors", () => {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -171,10 +171,19 @@ export function resolveGlobalInstallSpec(params: {
 
 export async function createGlobalInstallEnv(
   env?: NodeJS.ProcessEnv,
-): Promise<Record<string, string>> {
+): Promise<NodeJS.ProcessEnv | undefined> {
   const pathPrepend = await resolvePortableGitPathPrepend(env);
+  const sourceEnv = env ?? process.env;
+  const hasCorepackDownloadPromptSetting = Boolean(
+    sourceEnv.COREPACK_ENABLE_DOWNLOAD_PROMPT?.trim(),
+  );
+  const requiresMergedEnv =
+    pathPrepend.length > 0 || process.platform === "win32" || !hasCorepackDownloadPromptSetting;
+  if (!requiresMergedEnv) {
+    return env;
+  }
   const merged = Object.fromEntries(
-    Object.entries(env ?? process.env)
+    Object.entries(sourceEnv)
       .filter(([, value]) => value != null)
       .map(([key, value]) => [key, String(value)]),
   ) as Record<string, string>;

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -29,6 +29,7 @@ const PRIMARY_PACKAGE_NAME = "openclaw";
 const ALL_PACKAGE_NAMES = [PRIMARY_PACKAGE_NAME] as const;
 const GLOBAL_RENAME_PREFIX = ".";
 export const OPENCLAW_MAIN_PACKAGE_SPEC = "github:openclaw/openclaw#main";
+const COREPACK_ENABLE_DOWNLOAD_PROMPT_DEFAULT = "0";
 const NPM_GLOBAL_INSTALL_QUIET_FLAGS = ["--no-fund", "--no-audit", "--loglevel=error"] as const;
 const NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS = [
   "--omit=optional",
@@ -140,6 +141,13 @@ function applyWindowsPackageInstallEnv(env: Record<string, string>) {
   env.NODE_LLAMA_CPP_SKIP_DOWNLOAD = "1";
 }
 
+function applyCorepackDownloadPromptEnv(env: Record<string, string>) {
+  const current = env.COREPACK_ENABLE_DOWNLOAD_PROMPT?.trim();
+  if (!current) {
+    env.COREPACK_ENABLE_DOWNLOAD_PROMPT = COREPACK_ENABLE_DOWNLOAD_PROMPT_DEFAULT;
+  }
+}
+
 export function resolveGlobalInstallSpec(params: {
   packageName: string;
   tag: string;
@@ -165,9 +173,6 @@ export async function createGlobalInstallEnv(
   env?: NodeJS.ProcessEnv,
 ): Promise<NodeJS.ProcessEnv | undefined> {
   const pathPrepend = await resolvePortableGitPathPrepend(env);
-  if (pathPrepend.length === 0 && process.platform !== "win32") {
-    return env;
-  }
   const merged = Object.fromEntries(
     Object.entries(env ?? process.env)
       .filter(([, value]) => value != null)
@@ -175,6 +180,7 @@ export async function createGlobalInstallEnv(
   ) as Record<string, string>;
   applyPathPrepend(merged, pathPrepend);
   applyWindowsPackageInstallEnv(merged);
+  applyCorepackDownloadPromptEnv(merged);
   return merged;
 }
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -171,7 +171,7 @@ export function resolveGlobalInstallSpec(params: {
 
 export async function createGlobalInstallEnv(
   env?: NodeJS.ProcessEnv,
-): Promise<NodeJS.ProcessEnv | undefined> {
+): Promise<Record<string, string>> {
   const pathPrepend = await resolvePortableGitPathPrepend(env);
   const merged = Object.fromEntries(
     Object.entries(env ?? process.env)


### PR DESCRIPTION
## Issue

When running `pnpm openclaw update` on a different pnpm version compared to the pinned one inside the root's package.json (`packageManager`), the update script fails during the `preflight deps install` step when it shells out `pnpm install` as Corepack attempts to download the pinned pnpm version first. 

Corepack's default setting is to prompt for approval before downloading the version, which leads to the script being unable to finish the preflight step and thereby not updating:

<img width="1422" height="2032" alt="openclaw-update-issue-corepack-setting" src="https://github.com/user-attachments/assets/63ce624d-0755-4dc8-9e3f-730f7c3e8c17" />

This may happen for all 10 upstream candidates.

## Changes

In `src/infra/update-global.ts/#133-173` -> `createGlobalInstallEnv()` now always applies `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` unless the env already sets it, so the preflight install path stays non-interactive and installs the pinned pnpm version.

## Other solutions considered

I'm actually unsure if changing Corepack's default behavior here is the right approach. It does allow for an agent-first usage (it also works in non-interactive envs like CI)

If the `preflight deps install` should continue to respect Corepack's default setting, an alternative way is:

- allow Corepack prompts only when stdin is a TTY and the user did not ask for non-interactive mode
- keep suppression for --json, CI, and other non-interactive paths
- optionally add an explicit flag like `--prompt-corepack` or `--interactive-preflight`

## Current (previous) behavior
- `openclaw update` is non-interactive
- It fetches upstream and resolves @{upstream}.
- It runs `git rev-list --max-count=10 upstreamSha`, so it collects up to 10 candidate SHAs (`src/infra/update-runner.ts#611-635`)
- It creates a detached temp worktree at the upstream tip, then for each candidate SHA it checks out that SHA and runs the preflight install/build/lint there (`src/infra/update-runner.ts/#647-710`)
- If one candidate passes, it rebases your current branch onto that selected SHA.


## Tests

This has been tested via running `COREPACK_HOME="$(mktemp -d)" COREPACK_ENABLE_DOWNLOAD_PROMPT=1 node scripts/run-node.mjs update`

<img width="2696" height="1216" alt="CleanShot 2026-04-05 at 20 47 09@2x" src="https://github.com/user-attachments/assets/558f9ccf-9e8a-440d-a826-6f9ef902c7cd" />

It also adds a tests:
- `pnpm vitest run src/infra/update-global.test.ts` (default becomes "0", explicit "1" is preserved)
