### PR TITLE
fix(discord): persist model picker override fallback

### DIFF
--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -84,9 +84,14 @@ export type DispatchDiscordCommandInteractionParams = {
   suppressReplies?: boolean;
 };
 
+export type DispatchDiscordCommandInteractionResult = {
+  accepted: boolean;
+  effectiveRoute?: ResolvedAgentRoute;
+};
+
 export type DispatchDiscordCommandInteraction = (
   params: DispatchDiscordCommandInteractionParams,
-) => Promise<boolean>;
+) => Promise<DispatchDiscordCommandInteractionResult>;
 
 export type SafeDiscordInteractionCall = <T>(
   label: string,
@@ -800,7 +805,7 @@ export async function handleDiscordModelPickerInteraction(params: {
     }
 
     try {
-      const dispatchAccepted = await withTimeout(
+      const dispatchResult = await withTimeout(
         params.dispatchCommandInteraction({
           interaction,
           prompt: selectionCommand.prompt,
@@ -816,7 +821,7 @@ export async function handleDiscordModelPickerInteraction(params: {
         }),
         12000,
       );
-      if (!dispatchAccepted) {
+      if (!dispatchResult.accepted) {
         await params.safeInteractionCall("model picker follow-up", () =>
           interaction.followUp({
             ...buildDiscordModelPickerNoticePayload(
@@ -827,6 +832,74 @@ export async function handleDiscordModelPickerInteraction(params: {
         );
         return;
       }
+      const fallbackRoute = dispatchResult.effectiveRoute ?? route;
+
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      let effectiveModelRef = resolveDiscordModelPickerCurrentModel({
+        cfg: ctx.cfg,
+        route: fallbackRoute,
+        data: pickerData,
+      });
+      let persisted = effectiveModelRef === resolvedModelRef;
+
+      if (!persisted) {
+        logVerbose(
+          `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${fallbackRoute.sessionKey}; attempting direct session override persist`,
+        );
+        try {
+          const directlyPersisted = await persistDiscordModelPickerOverride({
+            cfg: ctx.cfg,
+            route: fallbackRoute,
+            provider: parsedModelRef.provider,
+            model: parsedModelRef.model,
+            isDefault:
+              parsedModelRef.provider === pickerData.resolvedDefault.provider &&
+              parsedModelRef.model === pickerData.resolvedDefault.model,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          effectiveModelRef = resolveDiscordModelPickerCurrentModel({
+            cfg: ctx.cfg,
+            route: fallbackRoute,
+            data: pickerData,
+          });
+          persisted = effectiveModelRef === resolvedModelRef;
+          if (!persisted) {
+            logVerbose(
+              `discord: direct session override persist failed — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${fallbackRoute.sessionKey}`,
+            );
+          } else if (!directlyPersisted) {
+            logVerbose(
+              `discord: direct session override persist became a no-op because ${resolvedModelRef} was already present on re-read for session key ${fallbackRoute.sessionKey}`,
+            );
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          logVerbose(
+            `discord: direct session override persist threw for session key ${fallbackRoute.sessionKey}: ${message}`,
+          );
+        }
+      }
+
+      if (persisted) {
+        await recordDiscordModelPickerRecentModel({
+          scope: preferenceScope,
+          modelRef: resolvedModelRef,
+          limit: 5,
+        }).catch(() => undefined);
+      }
+
+      await params.safeInteractionCall("model picker follow-up", () =>
+        interaction.followUp({
+          ...buildDiscordModelPickerNoticePayload(
+            persisted
+              ? `✅ Model set to ${resolvedModelRef}.`
+              : `⚠️ Tried to set ${resolvedModelRef}, but current model is ${effectiveModelRef}.`,
+          ),
+          ephemeral: true,
+        }),
+      );
+      return;
     } catch (error) {
       if (error instanceof Error && error.message === "timeout") {
         await params.safeInteractionCall("model picker follow-up", () =>
@@ -850,73 +923,6 @@ export async function handleDiscordModelPickerInteraction(params: {
       );
       return;
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 250));
-
-    let effectiveModelRef = resolveDiscordModelPickerCurrentModel({
-      cfg: ctx.cfg,
-      route,
-      data: pickerData,
-    });
-    let persisted = effectiveModelRef === resolvedModelRef;
-
-    if (!persisted) {
-      logVerbose(
-        `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}; attempting direct session override persist`,
-      );
-      try {
-        const directlyPersisted = await persistDiscordModelPickerOverride({
-          cfg: ctx.cfg,
-          route,
-          provider: parsedModelRef.provider,
-          model: parsedModelRef.model,
-          isDefault:
-            parsedModelRef.provider === pickerData.resolvedDefault.provider &&
-            parsedModelRef.model === pickerData.resolvedDefault.model,
-        });
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        effectiveModelRef = resolveDiscordModelPickerCurrentModel({
-          cfg: ctx.cfg,
-          route,
-          data: pickerData,
-        });
-        persisted = effectiveModelRef === resolvedModelRef;
-        if (!persisted) {
-          logVerbose(
-            `discord: direct session override persist failed — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
-          );
-        } else if (!directlyPersisted) {
-          logVerbose(
-            `discord: direct session override persist became a no-op because ${resolvedModelRef} was already present on re-read for session key ${route.sessionKey}`,
-          );
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        logVerbose(
-          `discord: direct session override persist threw for session key ${route.sessionKey}: ${message}`,
-        );
-      }
-    }
-
-    if (persisted) {
-      await recordDiscordModelPickerRecentModel({
-        scope: preferenceScope,
-        modelRef: resolvedModelRef,
-        limit: 5,
-      }).catch(() => undefined);
-    }
-
-    await params.safeInteractionCall("model picker follow-up", () =>
-      interaction.followUp({
-        ...buildDiscordModelPickerNoticePayload(
-          persisted
-            ? `✅ Model set to ${resolvedModelRef}.`
-            : `⚠️ Tried to set ${resolvedModelRef}, but current model is ${effectiveModelRef}.`,
-        ),
-        ephemeral: true,
-      }),
-    );
-    return;
   }
 
   if (parsed.action === "cancel") {

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -869,10 +869,14 @@ export async function handleDiscordModelPickerInteraction(params: {
           route,
           data: pickerData,
         });
-        persisted = directlyPersisted && effectiveModelRef === resolvedModelRef;
+        persisted = effectiveModelRef === resolvedModelRef;
         if (!persisted) {
           logVerbose(
             `discord: direct session override persist failed — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
+          );
+        } else if (!directlyPersisted) {
+          logVerbose(
+            `discord: direct session override persist became a no-op because ${resolvedModelRef} was already present on re-read for session key ${route.sessionKey}`,
           );
         }
       } catch (error) {

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -86,7 +86,7 @@ export type DispatchDiscordCommandInteractionParams = {
 
 export type DispatchDiscordCommandInteraction = (
   params: DispatchDiscordCommandInteractionParams,
-) => Promise<void>;
+) => Promise<boolean>;
 
 export type SafeDiscordInteractionCall = <T>(
   label: string,
@@ -800,7 +800,7 @@ export async function handleDiscordModelPickerInteraction(params: {
     }
 
     try {
-      await withTimeout(
+      const dispatchAccepted = await withTimeout(
         params.dispatchCommandInteraction({
           interaction,
           prompt: selectionCommand.prompt,
@@ -816,6 +816,17 @@ export async function handleDiscordModelPickerInteraction(params: {
         }),
         12000,
       );
+      if (!dispatchAccepted) {
+        await params.safeInteractionCall("model picker follow-up", () =>
+          interaction.followUp({
+            ...buildDiscordModelPickerNoticePayload(
+              `❌ Failed to apply ${resolvedModelRef}. Try /model ${resolvedModelRef} directly.`,
+            ),
+            ephemeral: true,
+          }),
+        );
+        return;
+      }
     } catch (error) {
       if (error instanceof Error && error.message === "timeout") {
         await params.safeInteractionCall("model picker follow-up", () =>

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -26,7 +26,11 @@ import {
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  updateSessionStore,
+} from "openclaw/plugin-sdk/config-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";
@@ -371,6 +375,32 @@ function resolveDiscordModelPickerCurrentModel(params: {
   } catch {
     return fallback;
   }
+}
+
+async function persistDiscordModelPickerOverride(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  route: ResolvedAgentRoute;
+  provider: string;
+  model: string;
+}): Promise<boolean> {
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.route.agentId,
+  });
+  let persisted = false;
+  await updateSessionStore(storePath, (store) => {
+    const entry = store[params.route.sessionKey];
+    if (!entry) {
+      return;
+    }
+    entry.providerOverride = params.provider;
+    entry.modelOverride = params.model;
+    delete entry.model;
+    delete entry.modelProvider;
+    delete entry.contextTokens;
+    entry.updatedAt = Date.now();
+    persisted = true;
+  });
+  return persisted;
 }
 
 export async function replyWithDiscordModelPickerProviders(params: {
@@ -808,17 +838,35 @@ export async function handleDiscordModelPickerInteraction(params: {
 
     await new Promise((resolve) => setTimeout(resolve, 250));
 
-    const effectiveModelRef = resolveDiscordModelPickerCurrentModel({
+    let effectiveModelRef = resolveDiscordModelPickerCurrentModel({
       cfg: ctx.cfg,
       route,
       data: pickerData,
     });
-    const persisted = effectiveModelRef === resolvedModelRef;
+    let persisted = effectiveModelRef === resolvedModelRef;
 
     if (!persisted) {
       logVerbose(
-        `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
+        `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}; attempting direct session override persist`,
       );
+      const directlyPersisted = await persistDiscordModelPickerOverride({
+        cfg: ctx.cfg,
+        route,
+        provider: parsedModelRef.provider,
+        model: parsedModelRef.model,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      effectiveModelRef = resolveDiscordModelPickerCurrentModel({
+        cfg: ctx.cfg,
+        route,
+        data: pickerData,
+      });
+      persisted = directlyPersisted && effectiveModelRef === resolvedModelRef;
+      if (!persisted) {
+        logVerbose(
+          `discord: direct session override persist failed — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
+        );
+      }
     }
 
     if (persisted) {

--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -27,6 +27,7 @@ import {
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
+  applyModelOverrideToSessionEntry,
   loadSessionStore,
   resolveStorePath,
   updateSessionStore,
@@ -382,6 +383,7 @@ async function persistDiscordModelPickerOverride(params: {
   route: ResolvedAgentRoute;
   provider: string;
   model: string;
+  isDefault: boolean;
 }): Promise<boolean> {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.route.agentId,
@@ -392,13 +394,15 @@ async function persistDiscordModelPickerOverride(params: {
     if (!entry) {
       return;
     }
-    entry.providerOverride = params.provider;
-    entry.modelOverride = params.model;
-    delete entry.model;
-    delete entry.modelProvider;
-    delete entry.contextTokens;
-    entry.updatedAt = Date.now();
-    persisted = true;
+    persisted =
+      applyModelOverrideToSessionEntry({
+        entry,
+        selection: {
+          provider: params.provider,
+          model: params.model,
+          isDefault: params.isDefault,
+        },
+      }).updated || persisted;
   });
   return persisted;
 }
@@ -849,22 +853,32 @@ export async function handleDiscordModelPickerInteraction(params: {
       logVerbose(
         `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}; attempting direct session override persist`,
       );
-      const directlyPersisted = await persistDiscordModelPickerOverride({
-        cfg: ctx.cfg,
-        route,
-        provider: parsedModelRef.provider,
-        model: parsedModelRef.model,
-      });
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      effectiveModelRef = resolveDiscordModelPickerCurrentModel({
-        cfg: ctx.cfg,
-        route,
-        data: pickerData,
-      });
-      persisted = directlyPersisted && effectiveModelRef === resolvedModelRef;
-      if (!persisted) {
+      try {
+        const directlyPersisted = await persistDiscordModelPickerOverride({
+          cfg: ctx.cfg,
+          route,
+          provider: parsedModelRef.provider,
+          model: parsedModelRef.model,
+          isDefault:
+            parsedModelRef.provider === pickerData.resolvedDefault.provider &&
+            parsedModelRef.model === pickerData.resolvedDefault.model,
+        });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        effectiveModelRef = resolveDiscordModelPickerCurrentModel({
+          cfg: ctx.cfg,
+          route,
+          data: pickerData,
+        });
+        persisted = directlyPersisted && effectiveModelRef === resolvedModelRef;
+        if (!persisted) {
+          logVerbose(
+            `discord: direct session override persist failed — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
+          );
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
         logVerbose(
-          `discord: direct session override persist failed — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
+          `discord: direct session override persist threw for session key ${route.sessionKey}: ${message}`,
         );
       }
     }

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -11,6 +11,7 @@ import {
   saveSessionStore,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/config-runtime";
+import * as configRuntimeModule from "openclaw/plugin-sdk/config-runtime";
 import * as dispatcherModule from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import * as globalsModule from "openclaw/plugin-sdk/runtime-env";
 import * as commandTextModule from "openclaw/plugin-sdk/text-runtime";
@@ -648,6 +649,78 @@ describe("Discord model picker interactions", () => {
     expect(
       store["agent:worker:subagent:bound"]?.authProfileOverrideCompactionCount,
     ).toBeUndefined();
+  });
+
+  it("accepts the selected model when the fallback re-read matches after a no-op persist", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const pickerData = createDefaultModelPickerData();
+    const modelCommand = createModelCommandDefinition();
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    await saveSessionStore(storePath, {
+      "agent:worker:subagent:bound": {
+        updatedAt: Date.now(),
+        sessionId: "bound-session",
+      },
+    });
+
+    const realUpdateSessionStore = configRuntimeModule.updateSessionStore;
+    let rewroteBeforeFallback = false;
+    vi.spyOn(configRuntimeModule, "updateSessionStore").mockImplementation(
+      async (targetStorePath, mutator) => {
+        if (!rewroteBeforeFallback && targetStorePath === storePath) {
+          rewroteBeforeFallback = true;
+          await realUpdateSessionStore(storePath, (store) => {
+            const entry = store["agent:worker:subagent:bound"];
+            if (!entry) {
+              return;
+            }
+            entry.providerOverride = "openai";
+            entry.modelOverride = "gpt-4o";
+          });
+        }
+        return await realUpdateSessionStore(targetStorePath, mutator);
+      },
+    );
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+    createDispatchSpy();
+
+    const select = createDiscordModelPickerFallbackSelect(context);
+    const selectInteraction = createInteraction({
+      userId: "owner",
+      values: ["gpt-4o"],
+    });
+    selectInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+    await select.run(
+      selectInteraction as unknown as PickerSelectInteraction,
+      createModelsViewSelectData(),
+    );
+
+    const button = createDiscordModelPickerFallbackButton(context);
+    const submitInteraction = createInteraction({ userId: "owner" });
+    submitInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+
+    await button.run(
+      submitInteraction as unknown as PickerButtonInteraction,
+      createModelsViewSubmitData(),
+    );
+
+    expect(JSON.stringify(submitInteraction.followUp.mock.calls[0]?.[0])).toContain(
+      "✅ Model set to openai/gpt-4o.",
+    );
   });
 
   it("loads model picker data from the effective bound route", async () => {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -1,8 +1,16 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { ChannelType } from "discord-api-types/v10";
 import * as commandRegistryModule from "openclaw/plugin-sdk/command-auth";
 import type { ChatCommandDefinition, CommandArgsParsing } from "openclaw/plugin-sdk/command-auth";
 import type { ModelsProviderData } from "openclaw/plugin-sdk/command-auth";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  saveSessionStore,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
 import * as dispatcherModule from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import * as globalsModule from "openclaw/plugin-sdk/runtime-env";
 import * as commandTextModule from "openclaw/plugin-sdk/text-runtime";
@@ -39,6 +47,8 @@ type MockInteraction = {
   client: object;
 };
 
+let tempDir: string;
+
 function createModelsProviderData(entries: Record<string, string[]>): ModelsProviderData {
   return createBaseModelsProviderData(entries, { defaultProviderOrder: "sorted" });
 }
@@ -60,6 +70,9 @@ async function waitForCondition(
 
 function createModelPickerContext(): ModelPickerContext {
   const cfg = {
+    session: {
+      store: path.join(tempDir, "sessions.json"),
+    },
     channels: {
       discord: {
         dm: {
@@ -247,7 +260,8 @@ function createDispatchSpy() {
 }
 
 describe("Discord model picker interactions", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-discord-model-picker-"));
     vi.useRealTimers();
     vi.restoreAllMocks();
     nativeCommandTesting.setDispatchReplyWithDispatcher(
@@ -255,8 +269,9 @@ describe("Discord model picker interactions", () => {
     );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
+    await rm(tempDir, { recursive: true, force: true });
   });
 
   it("registers distinct fallback ids for button and select handlers", () => {
@@ -469,6 +484,63 @@ describe("Discord model picker interactions", () => {
       String(call[0] ?? "").includes("model picker override mismatch"),
     )?.[0];
     expect(mismatchLog).toContain("session key agent:worker:subagent:bound");
+  });
+
+  it("persists the routed session override when dispatch leaves the session store stale", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const pickerData = createDefaultModelPickerData();
+    const modelCommand = createModelCommandDefinition();
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    await saveSessionStore(storePath, {
+      "agent:worker:subagent:bound": {
+        updatedAt: Date.now(),
+        sessionId: "bound-session",
+      },
+    });
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+    createDispatchSpy();
+
+    const select = createDiscordModelPickerFallbackSelect(context);
+    const selectInteraction = createInteraction({
+      userId: "owner",
+      values: ["gpt-4o"],
+    });
+    selectInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+    await select.run(
+      selectInteraction as unknown as PickerSelectInteraction,
+      createModelsViewSelectData(),
+    );
+
+    const button = createDiscordModelPickerFallbackButton(context);
+    const submitInteraction = createInteraction({ userId: "owner" });
+    submitInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+
+    await button.run(
+      submitInteraction as unknown as PickerButtonInteraction,
+      createModelsViewSubmitData(),
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store["agent:worker:subagent:bound"]?.providerOverride).toBe("openai");
+    expect(store["agent:worker:subagent:bound"]?.modelOverride).toBe("gpt-4o");
+    expect(submitInteraction.followUp).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(submitInteraction.followUp.mock.calls[0]?.[0])).toContain(
+      "✅ Model set to openai/gpt-4o.",
+    );
   });
 
   it("loads model picker data from the effective bound route", async () => {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -20,6 +20,7 @@ import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
 import { replyWithDiscordModelPickerProviders } from "./native-command-ui.js";
+import { handleDiscordModelPickerInteraction } from "./native-command-ui.js";
 import {
   __testing as nativeCommandTesting,
   createDiscordModelPickerFallbackButton,
@@ -720,6 +721,47 @@ describe("Discord model picker interactions", () => {
 
     expect(JSON.stringify(submitInteraction.followUp.mock.calls[0]?.[0])).toContain(
       "✅ Model set to openai/gpt-4o.",
+    );
+  });
+
+  it("does not write a fallback override when hidden /model dispatch is rejected", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const pickerData = createDefaultModelPickerData();
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    await saveSessionStore(storePath, {
+      "agent:worker:subagent:bound": {
+        updatedAt: Date.now(),
+        sessionId: "bound-session",
+      },
+    });
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+
+    const interaction = createInteraction({ userId: "owner" });
+    interaction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+
+    await handleDiscordModelPickerInteraction({
+      interaction: interaction as unknown as PickerButtonInteraction,
+      data: createModelsViewSubmitData(),
+      ctx: context,
+      safeInteractionCall: async (_label, fn) => await fn(),
+      dispatchCommandInteraction: async () => false,
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store["agent:worker:subagent:bound"]?.providerOverride).toBeUndefined();
+    expect(store["agent:worker:subagent:bound"]?.modelOverride).toBeUndefined();
+    expect(JSON.stringify(interaction.followUp.mock.calls[0]?.[0])).toContain(
+      "❌ Failed to apply openai/gpt-4o.",
     );
   });
 

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -543,6 +543,113 @@ describe("Discord model picker interactions", () => {
     );
   });
 
+  it("clears routed overrides when reset selects the default model through the fallback path", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const pickerData = createDefaultModelPickerData();
+    const modelCommand = createModelCommandDefinition();
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    await saveSessionStore(storePath, {
+      "agent:worker:subagent:bound": {
+        updatedAt: Date.now(),
+        sessionId: "bound-session",
+        providerOverride: "openai",
+        modelOverride: "gpt-4o",
+      },
+    });
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+    createDispatchSpy();
+
+    const button = createDiscordModelPickerFallbackButton(context);
+    const submitInteraction = createInteraction({ userId: "owner" });
+    submitInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+
+    await button.run(submitInteraction as unknown as PickerButtonInteraction, {
+      cmd: "model",
+      act: "reset",
+      view: "models",
+      u: "owner",
+      p: "openai",
+      pg: "1",
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store["agent:worker:subagent:bound"]?.providerOverride).toBeUndefined();
+    expect(store["agent:worker:subagent:bound"]?.modelOverride).toBeUndefined();
+    expect(JSON.stringify(submitInteraction.followUp.mock.calls[0]?.[0])).toContain(
+      "✅ Model set to anthropic/claude-sonnet-4-5.",
+    );
+  });
+
+  it("clears stale auth profile state when fallback persists a routed model override", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const pickerData = createDefaultModelPickerData();
+    const modelCommand = createModelCommandDefinition();
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    await saveSessionStore(storePath, {
+      "agent:worker:subagent:bound": {
+        updatedAt: Date.now(),
+        sessionId: "bound-session",
+        authProfileOverride: "openai:legacy",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 3,
+      },
+    });
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+    createDispatchSpy();
+
+    const select = createDiscordModelPickerFallbackSelect(context);
+    const selectInteraction = createInteraction({
+      userId: "owner",
+      values: ["gpt-4o"],
+    });
+    selectInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+    await select.run(
+      selectInteraction as unknown as PickerSelectInteraction,
+      createModelsViewSelectData(),
+    );
+
+    const button = createDiscordModelPickerFallbackButton(context);
+    const submitInteraction = createInteraction({ userId: "owner" });
+    submitInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+
+    await button.run(
+      submitInteraction as unknown as PickerButtonInteraction,
+      createModelsViewSubmitData(),
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store["agent:worker:subagent:bound"]?.authProfileOverride).toBeUndefined();
+    expect(store["agent:worker:subagent:bound"]?.authProfileOverrideSource).toBeUndefined();
+    expect(
+      store["agent:worker:subagent:bound"]?.authProfileOverrideCompactionCount,
+    ).toBeUndefined();
+  });
+
   it("loads model picker data from the effective bound route", async () => {
     const context = createModelPickerContext();
     context.threadBindings = createBoundThreadBindingManager({

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -733,6 +733,7 @@ describe("Discord model picker interactions", () => {
       agentId: "worker",
     });
     const pickerData = createDefaultModelPickerData();
+    const modelCommand = createModelCommandDefinition();
     const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
     await saveSessionStore(storePath, {
       "agent:worker:subagent:bound": {
@@ -742,6 +743,7 @@ describe("Discord model picker interactions", () => {
     });
 
     vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
 
     const interaction = createInteraction({ userId: "owner" });
     interaction.channel = {
@@ -754,7 +756,7 @@ describe("Discord model picker interactions", () => {
       data: createModelsViewSubmitData(),
       ctx: context,
       safeInteractionCall: async (_label, fn) => await fn(),
-      dispatchCommandInteraction: async () => false,
+      dispatchCommandInteraction: async () => ({ accepted: false }),
     });
 
     const store = loadSessionStore(storePath, { skipCache: true });
@@ -762,6 +764,66 @@ describe("Discord model picker interactions", () => {
     expect(store["agent:worker:subagent:bound"]?.modelOverride).toBeUndefined();
     expect(JSON.stringify(interaction.followUp.mock.calls[0]?.[0])).toContain(
       "❌ Failed to apply openai/gpt-4o.",
+    );
+  });
+
+  it("persists the fallback override to the effective route returned by dispatch", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:stale",
+      agentId: "worker",
+    });
+    const pickerData = createDefaultModelPickerData();
+    const modelCommand = createModelCommandDefinition();
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    await saveSessionStore(storePath, {
+      "agent:worker:subagent:stale": {
+        updatedAt: Date.now(),
+        sessionId: "stale-session",
+      },
+      "agent:worker:subagent:fresh": {
+        updatedAt: Date.now(),
+        sessionId: "fresh-session",
+      },
+    });
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+
+    const interaction = createInteraction({ userId: "owner" });
+    interaction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+
+    await handleDiscordModelPickerInteraction({
+      interaction: interaction as unknown as PickerButtonInteraction,
+      data: createModelsViewSubmitData(),
+      ctx: context,
+      safeInteractionCall: async (_label, fn) => await fn(),
+      dispatchCommandInteraction: async () => ({
+        accepted: true,
+        effectiveRoute: {
+          accountId: "default",
+          agentId: "worker",
+          channel: "discord",
+          sessionKey: "agent:worker:subagent:fresh",
+          mainSessionKey: "agent:worker:subagent:fresh",
+          lastRoutePolicy: "main",
+          matchedBy: "binding.channel",
+        },
+      }),
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store["agent:worker:subagent:stale"]?.providerOverride).toBeUndefined();
+    expect(store["agent:worker:subagent:stale"]?.modelOverride).toBeUndefined();
+    expect(store["agent:worker:subagent:fresh"]?.providerOverride).toBe("openai");
+    expect(store["agent:worker:subagent:fresh"]?.modelOverride).toBe("gpt-4o");
+    expect(JSON.stringify(interaction.followUp.mock.calls[0]?.[0])).toContain(
+      "✅ Model set to openai/gpt-4o.",
     );
   });
 

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -719,7 +719,7 @@ async function dispatchDiscordCommandInteraction(params: {
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
   const user = interaction.user;
   if (!user) {
-    return;
+    return false;
   }
   const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
   const channel = interaction.channel;
@@ -803,11 +803,11 @@ async function dispatchDiscordCommandInteraction(params: {
     : null;
   if (channelConfig?.enabled === false) {
     await respond("This channel is disabled.");
-    return;
+    return false;
   }
   if (interaction.guild && channelConfig?.allowed === false) {
     await respond("This channel is not allowed.");
-    return;
+    return false;
   }
   if (useAccessGroups && interaction.guild) {
     const channelAllowlistConfigured =
@@ -826,7 +826,7 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     if (!allowByPolicy) {
       await respond("This channel is not allowed.");
-      return;
+      return false;
     }
   }
   const dmEnabled = discordConfig?.dm?.enabled ?? true;
@@ -835,7 +835,7 @@ async function dispatchDiscordCommandInteraction(params: {
   if (isDirectMessage) {
     if (!dmEnabled || dmPolicy === "disabled") {
       await respond("Discord DMs are disabled.");
-      return;
+      return false;
     }
     const dmAccess = await resolveDiscordDmCommandAccess({
       accountId,
@@ -873,7 +873,7 @@ async function dispatchDiscordCommandInteraction(params: {
           await respond("You are not authorized to use this command.", { ephemeral: true });
         },
       });
-      return;
+      return false;
     }
   }
   const groupDmAccess = resolveDiscordNativeGroupDmAccess({
@@ -890,7 +890,7 @@ async function dispatchDiscordCommandInteraction(params: {
         ? "Discord group DMs are disabled."
         : "This group DM is not allowed.",
     );
-    return;
+    return false;
   }
   if (!isDirectMessage) {
     const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
@@ -923,7 +923,7 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     if (!commandAuthorized) {
       await respond("You are not authorized to use this command.", { ephemeral: true });
-      return;
+      return false;
     }
   }
 
@@ -955,7 +955,7 @@ async function dispatchDiscordCommandInteraction(params: {
           ephemeral: true,
         }),
       );
-      return;
+      return true;
     }
     await safeDiscordInteractionCall("interaction reply", () =>
       interaction.reply({
@@ -964,7 +964,7 @@ async function dispatchDiscordCommandInteraction(params: {
         ephemeral: true,
       }),
     );
-    return;
+    return true;
   }
 
   const pluginMatch = matchPluginCommandImpl(prompt);
@@ -989,7 +989,7 @@ async function dispatchDiscordCommandInteraction(params: {
     }));
   if (pluginMatch) {
     if (suppressReplies) {
-      return;
+      return true;
     }
     const channelId = rawChannelId || "unknown";
     const isThreadChannel =
@@ -1022,7 +1022,7 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     if (!hasRenderableReplyPayload(pluginReply)) {
       await respond("Done.");
-      return;
+      return true;
     }
     await deliverDiscordInteractionReply({
       interaction,
@@ -1034,7 +1034,7 @@ async function dispatchDiscordCommandInteraction(params: {
       preferFollowUp,
       chunkMode: resolveChunkMode(cfg, "discord", accountId),
     });
-    return;
+    return true;
   }
 
   const pickerCommandContext = shouldOpenDiscordModelPickerFromCommand({
@@ -1052,7 +1052,7 @@ async function dispatchDiscordCommandInteraction(params: {
       preferFollowUp,
       safeInteractionCall: safeDiscordInteractionCall,
     });
-    return;
+    return true;
   }
 
   const isGuild = Boolean(interaction.guild);
@@ -1066,7 +1066,7 @@ async function dispatchDiscordCommandInteraction(params: {
         `discord native command: configured ACP binding unavailable for channel ${configuredBinding.record.conversation.conversationId}: ${routeState.bindingReadiness.error}`,
       );
       await respond("Configured ACP binding is unavailable right now. Please try again.");
-      return;
+      return false;
     }
   }
   const boundSessionKey = routeState.boundSessionKey;
@@ -1182,6 +1182,7 @@ async function dispatchDiscordCommandInteraction(params: {
       await interaction.reply(payload);
     });
   }
+  return true;
 }
 
 export function createDiscordCommandArgFallbackButton(params: DiscordCommandArgContext): Button {

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -76,6 +76,7 @@ import {
   resolveDiscordNativeChoiceContext,
   shouldOpenDiscordModelPickerFromCommand,
   type DiscordCommandArgContext,
+  type DispatchDiscordCommandInteractionResult,
   type DiscordModelPickerContext,
 } from "./native-command-ui.js";
 import { resolveDiscordSenderIdentity } from "./sender-identity.js";
@@ -688,7 +689,7 @@ async function dispatchDiscordCommandInteraction(params: {
   preferFollowUp: boolean;
   threadBindings: ThreadBindingManager;
   suppressReplies?: boolean;
-}) {
+}): Promise<DispatchDiscordCommandInteractionResult> {
   const {
     interaction,
     prompt,
@@ -719,7 +720,7 @@ async function dispatchDiscordCommandInteraction(params: {
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
   const user = interaction.user;
   if (!user) {
-    return false;
+    return { accepted: false };
   }
   const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
   const channel = interaction.channel;
@@ -803,11 +804,11 @@ async function dispatchDiscordCommandInteraction(params: {
     : null;
   if (channelConfig?.enabled === false) {
     await respond("This channel is disabled.");
-    return false;
+    return { accepted: false };
   }
   if (interaction.guild && channelConfig?.allowed === false) {
     await respond("This channel is not allowed.");
-    return false;
+    return { accepted: false };
   }
   if (useAccessGroups && interaction.guild) {
     const channelAllowlistConfigured =
@@ -826,7 +827,7 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     if (!allowByPolicy) {
       await respond("This channel is not allowed.");
-      return false;
+      return { accepted: false };
     }
   }
   const dmEnabled = discordConfig?.dm?.enabled ?? true;
@@ -835,7 +836,7 @@ async function dispatchDiscordCommandInteraction(params: {
   if (isDirectMessage) {
     if (!dmEnabled || dmPolicy === "disabled") {
       await respond("Discord DMs are disabled.");
-      return false;
+      return { accepted: false };
     }
     const dmAccess = await resolveDiscordDmCommandAccess({
       accountId,
@@ -873,7 +874,7 @@ async function dispatchDiscordCommandInteraction(params: {
           await respond("You are not authorized to use this command.", { ephemeral: true });
         },
       });
-      return false;
+      return { accepted: false };
     }
   }
   const groupDmAccess = resolveDiscordNativeGroupDmAccess({
@@ -890,7 +891,7 @@ async function dispatchDiscordCommandInteraction(params: {
         ? "Discord group DMs are disabled."
         : "This group DM is not allowed.",
     );
-    return false;
+    return { accepted: false };
   }
   if (!isDirectMessage) {
     const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
@@ -923,7 +924,7 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     if (!commandAuthorized) {
       await respond("You are not authorized to use this command.", { ephemeral: true });
-      return false;
+      return { accepted: false };
     }
   }
 
@@ -955,7 +956,7 @@ async function dispatchDiscordCommandInteraction(params: {
           ephemeral: true,
         }),
       );
-      return true;
+      return { accepted: true };
     }
     await safeDiscordInteractionCall("interaction reply", () =>
       interaction.reply({
@@ -964,7 +965,7 @@ async function dispatchDiscordCommandInteraction(params: {
         ephemeral: true,
       }),
     );
-    return true;
+    return { accepted: true };
   }
 
   const pluginMatch = matchPluginCommandImpl(prompt);
@@ -989,7 +990,7 @@ async function dispatchDiscordCommandInteraction(params: {
     }));
   if (pluginMatch) {
     if (suppressReplies) {
-      return true;
+      return { accepted: true };
     }
     const channelId = rawChannelId || "unknown";
     const isThreadChannel =
@@ -1022,7 +1023,7 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     if (!hasRenderableReplyPayload(pluginReply)) {
       await respond("Done.");
-      return true;
+      return { accepted: true, effectiveRoute };
     }
     await deliverDiscordInteractionReply({
       interaction,
@@ -1034,7 +1035,7 @@ async function dispatchDiscordCommandInteraction(params: {
       preferFollowUp,
       chunkMode: resolveChunkMode(cfg, "discord", accountId),
     });
-    return true;
+    return { accepted: true, effectiveRoute };
   }
 
   const pickerCommandContext = shouldOpenDiscordModelPickerFromCommand({
@@ -1052,7 +1053,7 @@ async function dispatchDiscordCommandInteraction(params: {
       preferFollowUp,
       safeInteractionCall: safeDiscordInteractionCall,
     });
-    return true;
+    return { accepted: true };
   }
 
   const isGuild = Boolean(interaction.guild);
@@ -1066,7 +1067,7 @@ async function dispatchDiscordCommandInteraction(params: {
         `discord native command: configured ACP binding unavailable for channel ${configuredBinding.record.conversation.conversationId}: ${routeState.bindingReadiness.error}`,
       );
       await respond("Configured ACP binding is unavailable right now. Please try again.");
-      return false;
+      return { accepted: false };
     }
   }
   const boundSessionKey = routeState.boundSessionKey;
@@ -1182,7 +1183,7 @@ async function dispatchDiscordCommandInteraction(params: {
       await interaction.reply(payload);
     });
   }
-  return true;
+  return { accepted: true, effectiveRoute };
 }
 
 export function createDiscordCommandArgFallbackButton(params: DiscordCommandArgContext): Button {


### PR DESCRIPTION
## Summary

- persist the Discord model-picker selection directly into the routed session store when the hidden `/model` dispatch leaves session state stale during the confirmation window
- keep the existing dispatch path intact, but only allow the fallback persist path after the hidden `/model` dispatch is accepted
- treat the post-fallback re-read as authoritative so late `/model` writes do not produce false mismatch warnings
- align the fallback path with the canonical session model-override helper so default-reset and auth-profile cleanup semantics stay consistent
- add regression coverage for stale-session, reset/default, auth-profile cleanup, no-op-reread, and rejected-dispatch cases

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs
- [ ] Test-only

## Scope

This PR is intentionally narrow.

It only changes Discord model-picker confirmation behavior on the fallback path where the picker dispatch completes but the routed session store still does not reflect the selected model.

It does not change:
- `/model` directive parsing rules
- general allowlist behavior for model selection
- provider/model catalog generation for the picker
- runtime model loading behavior after the override is persisted
- any non-Discord channel model-picker behavior

## Linked Issue/PR

- Related #61096
- Overlaps with open PR #53287
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

On current `upstream/main`, the Discord model picker dispatches a hidden `/model <provider/model>` command and then re-reads the routed session state to decide whether the selection persisted.

In the failure mode reproduced locally with LM Studio-backed selections that include an `@` suffix in the model id, such as:
- `lmstudio/unsloth/gemma-4-26b-a4b-it@iq4_xs`
- `lmstudio/unsloth/gemma-4-26b-a4b-it@iq3_xxs`

…the interaction succeeds and the picker reaches the confirmation step, but the routed session store still has no `providerOverride` / `modelOverride` for the target session key. The picker then re-reads the session, sees the default model, and emits the false warning:

`⚠️ Tried to set X, but current model is Y`

The key observed symptom is that the Discord interaction touches the session registry, but the target routed session entry never records the requested override. In local reproduction, the `@...` model-id suffix made this stale-confirmation path reproducible and easy to observe.

The final implementation keeps the existing dispatch path, but if the immediate read-back still shows a mismatch, it only attempts the fallback persist after dispatch has been accepted, then re-checks once before deciding which confirmation to show.

## Behavior Changes

Before:
- the Discord model picker dispatched the hidden `/model` command
- if the routed session store was still stale during the confirmation window, the picker emitted a mismatch warning
- this was reproducible locally with LM Studio selections using suffixed model ids like `...@iq4_xs`
- the selected model could fail to persist even though the interaction itself succeeded

After:
- the picker still dispatches the hidden `/model` command first
- the fallback persist path only runs after the hidden `/model` dispatch is accepted
- if the routed session store is still stale during confirmation, the picker can persist the routed session override directly
- a matching post-fallback re-read now counts as success even if the fallback write itself became a no-op because the hidden `/model` write landed just in time
- fallback writes now reuse the canonical session override helper, so reset-to-default clears overrides and stale auth-profile state is dropped consistently

## Regression Test Plan

Updated:
- `extensions/discord/src/monitor/native-command.model-picker.test.ts`

Coverage:
- creates a bound-thread routed session entry
- reproduces a picker dispatch path that does not update the session store
- verifies the fallback persist writes `providerOverride` and `modelOverride`
- verifies the picker follow-up reports success after the fallback persist path
- verifies reset-to-default clears overrides on the fallback path
- verifies stale `authProfileOverride*` state is cleared on fallback writes
- verifies a no-op fallback persist still reports success when the second read confirms the selected model
- verifies rejected hidden `/model` dispatch does not allow the fallback path to force a session override

## Repro + Verification

Observed locally with a Discord thread bound to a routed subagent session:
- selecting an LM Studio model with an `@` suffix, such as `lmstudio/unsloth/gemma-4-26b-a4b-it@iq4_xs`, could reach the confirmation step without persisting the routed session override
- `sessions.json` for the routed session was touched, but `providerOverride` / `modelOverride` remained unset
- the picker then reported a mismatch even though the user-selected model should have become the active selection for that routed session

With this patch:
- the picker falls back to directly persisting the routed session override only after hidden `/model` dispatch is accepted
- the routed session entry records the selected provider/model when the state is truly stale
- late hidden `/model` writes are treated as success once the post-fallback re-read confirms the model
- reset/default and auth-profile cleanup semantics stay aligned with the shared session override flow

## Tests

Passed locally:
- `pnpm exec oxlint extensions/discord/src/monitor/native-command.ts extensions/discord/src/monitor/native-command-ui.ts extensions/discord/src/monitor/native-command.model-picker.test.ts`

Attempted locally:
- `pnpm check`
  Reached real upstream failures on current `main` and exited with code 2. The blocking errors were unrelated baseline TypeScript issues outside this PR's touched files.
- `node scripts/run-vitest.mjs run --config vitest.config.ts -t "Discord model picker interactions" extensions/discord/src/monitor/native-command.model-picker.test.ts`
  The repo runner remained slow / broad in this environment and was not reliable as a targeted local signal.
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false --incremental false`
  This also follows the broader repo baseline and is currently blocked by unrelated existing type errors on `main`.

## Risks and Mitigations

Risk:
- the fallback persist path could mask a deeper routing / async persistence bug by repairing the routed session entry after dispatch rather than requiring dispatch to finish the write itself

Mitigation:
- the change is limited to the Discord model-picker confirmation path
- the original dispatch path remains unchanged
- the fallback only runs when the immediate routed-session read-back still mismatches the selected model
- the fallback is additionally gated on successful hidden `/model` dispatch
- a regression test now covers the stale-session fallback case directly, plus default reset, stale auth-profile cleanup, no-op reread success, and rejected dispatch behavior

## AI assistance

AI-assisted: drafted and implemented with Codex, then locally reviewed and validated by me.
