### PR TITLE
Heartbeat: treat shipped scaffold as empty

### DIFF
--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -193,13 +193,17 @@ describe("isHeartbeatContentEffectivelyEmpty", () => {
     expect(isHeartbeatContentEffectivelyEmpty("## Subheader\n### Another")).toBe(true);
   });
 
-  it("returns true for default template content (header + comment)", () => {
-    const defaultTemplate = `# HEARTBEAT.md
-
-Keep this file empty unless you want a tiny checklist. Keep it small.
-`;
-    // Note: The template has actual text content, so it's NOT effectively empty
-    expect(isHeartbeatContentEffectivelyEmpty(defaultTemplate)).toBe(false);
+  it("returns true for the shipped markdown-fenced scaffold template", () => {
+    const scaffoldTemplate = [
+      "# HEARTBEAT.md Template",
+      "",
+      "```markdown",
+      "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
+      "",
+      "# Add tasks below when you want the agent to check something periodically.",
+      "```",
+    ].join("\n");
+    expect(isHeartbeatContentEffectivelyEmpty(scaffoldTemplate)).toBe(true);
   });
 
   it("returns true for header with only empty lines", () => {
@@ -218,6 +222,28 @@ Keep this file empty unless you want a tiny checklist. Keep it small.
 - Task 1
 - Task 2
 `;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
+  });
+
+  it("returns false for actionable content inside a markdown fence", () => {
+    const content = [
+      "# HEARTBEAT.md Template",
+      "",
+      "```markdown",
+      "- Check server logs",
+      "- Review pending PRs",
+      "```",
+    ].join("\n");
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
+  });
+
+  it("returns false for unclosed markdown fences", () => {
+    const content = [
+      "# HEARTBEAT.md Template",
+      "",
+      "```markdown",
+      "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
+    ].join("\n");
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
   });
 

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -56,6 +56,9 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
     }
 
     if (isHeartbeatScaffoldLine(trimmed)) {
+      // Treat scaffold-only lines as comments even inside ```markdown fences.
+      // The shipped HEARTBEAT scaffold uses fenced markdown with #-prefixed guidance,
+      // and that wrapper must stay effectively empty for backward compatibility.
       continue;
     }
 

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -8,6 +8,23 @@ export const HEARTBEAT_PROMPT =
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 
+function isHeartbeatScaffoldLine(trimmed: string): boolean {
+  if (!trimmed) {
+    return true;
+  }
+  // Skip markdown header lines (# followed by space or EOL, ## etc)
+  // This intentionally does NOT skip lines like "#TODO" or "#hashtag" which might be content
+  // (Those aren't valid markdown headers - ATX headers require space after #)
+  if (/^#+(\s|$)/.test(trimmed)) {
+    return true;
+  }
+  // Skip empty markdown list items like "- [ ]" or "* [ ]" or just "- "
+  if (/^[-*+]\s*(\[[\sXx]?\]\s*)?$/.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Check if HEARTBEAT.md content is "effectively empty" - meaning it has no actionable tasks.
  * This allows skipping heartbeat API calls when no tasks are configured.
@@ -29,25 +46,31 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
   }
 
   const lines = content.split("\n");
+  let inMarkdownFence = false;
   for (const line of lines) {
     const trimmed = line.trim();
-    // Skip empty lines
-    if (!trimmed) {
+
+    if (/^```(?:markdown|md)?$/i.test(trimmed)) {
+      inMarkdownFence = !inMarkdownFence;
       continue;
     }
-    // Skip markdown header lines (# followed by space or EOL, ## etc)
-    // This intentionally does NOT skip lines like "#TODO" or "#hashtag" which might be content
-    // (Those aren't valid markdown headers - ATX headers require space after #)
-    if (/^#+(\s|$)/.test(trimmed)) {
+
+    if (isHeartbeatScaffoldLine(trimmed)) {
       continue;
     }
-    // Skip empty markdown list items like "- [ ]" or "* [ ]" or just "- "
-    if (/^[-*+]\s*(\[[\sXx]?\]\s*)?$/.test(trimmed)) {
-      continue;
+
+    if (inMarkdownFence) {
+      return false;
     }
+
     // Found a non-empty, non-comment line - there's actionable content
     return false;
   }
+
+  if (inMarkdownFence) {
+    return false;
+  }
+
   // All lines were either empty or comments
   return true;
 }


### PR DESCRIPTION
## Summary

Treat the shipped markdown-fenced `HEARTBEAT.md` scaffold as effectively empty so already deployed workspaces stop running interval heartbeats unless the file contains real tasks.

## Changes

- add a narrow scaffold-aware compatibility check in `isHeartbeatContentEffectivelyEmpty`
- keep fenced blocks with actionable content treated as non-empty
- add regression tests for the shipped fenced scaffold, actionable fenced content, and unclosed fences

## Validation

- `pnpm test -- src/auto-reply/heartbeat.test.ts`

## Issue

Closes https://github.com/openclaw/openclaw/issues/61492
