### PR TITLE
fix(ollama): use SSRF-guarded fetch in streaming path

### DIFF
--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -602,7 +602,7 @@ export function createOllamaStreamFn(
     const stream = createAssistantMessageEventStream();
 
     const run = async () => {
-      let release: (() => void) | undefined;
+      let release: (() => Promise<void>) | undefined;
       try {
         const ollamaMessages = convertToOllamaMessages(
           context.messages ?? [],
@@ -753,7 +753,7 @@ export function createOllamaStreamFn(
           }),
         });
       } finally {
-        release?.();
+        await release?.();
         stream.end();
       }
     };

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -8,6 +8,8 @@ import type {
   Tool,
   Usage,
 } from "@mariozechner/pi-ai";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { buildOllamaBaseUrlSsrFPolicy } from "./provider-models.js";
 import { createAssistantMessageEventStream, streamSimple } from "@mariozechner/pi-ai";
 import type {
   OpenClawConfig,
@@ -600,6 +602,7 @@ export function createOllamaStreamFn(
     const stream = createAssistantMessageEventStream();
 
     const run = async () => {
+      let release: (() => void) | undefined;
       try {
         const ollamaMessages = convertToOllamaMessages(
           context.messages ?? [],
@@ -635,12 +638,19 @@ export function createOllamaStreamFn(
           headers.Authorization = `Bearer ${options.apiKey}`;
         }
 
-        const response = await fetch(chatUrl, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(body),
-          signal: options?.signal,
+        const fetchResult = await fetchWithSsrFGuard({
+          url: chatUrl,
+          init: {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+            signal: options?.signal,
+          },
+          policy: buildOllamaBaseUrlSsrFPolicy(chatUrl),
+          auditContext: "ollama-stream",
         });
+        const response = fetchResult.response;
+        release = fetchResult.release;
 
         if (!response.ok) {
           const errorText = await response.text().catch(() => "unknown error");
@@ -743,6 +753,7 @@ export function createOllamaStreamFn(
           }),
         });
       } finally {
+        release?.();
         stream.end();
       }
     };


### PR DESCRIPTION
The Ollama extension's streaming path at extensions/ollama/src/stream.ts:638 uses raw fetch() with a user-configured baseUrl. The model discovery path in the same extension (provider-models.ts:64) correctly uses fetchWithSsrFGuard with buildOllamaBaseUrlSsrFPolicy.

When baseUrl points to an attacker-controlled server, the streaming path sends the API key in the Authorization header to that server.

Tested: created a local HTTP listener, called createOllamaStreamFn with the listener URL as baseUrl and apiKey "sk-SUPER-SECRET-KEY". The listener received the request with Authorization: Bearer sk-SUPER-SECRET-KEY.

Fix: replaced fetch() with fetchWithSsrFGuard() using the same buildOllamaBaseUrlSsrFPolicy that provider-models.ts already uses. Added release() call in finally block.