### PR TITLE
  Fix vLLM reasoning model response parsing (empty tool_calls array) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI replay: preserve malformed function-call arguments in stored assistant history, avoid double-encoding preserved raw strings on replay, and coerce replayed string args back to objects at Anthropic and Google provider boundaries. (#61956) Thanks @100yenadmin.
 - Heartbeat/config: accept and honor `agents.defaults.heartbeat.timeoutSeconds` and per-agent heartbeat timeout overrides for heartbeat agent turns. (#64491) Thanks @cedillarack.
 - CLI/devices: make implicit `openclaw devices approve` selection preview-only and require approving the exact request ID, preventing latest-request races during device pairing. (#64160) Thanks @coygeek.
+- Media/security: honor sender-scoped `toolsBySender` policy for outbound host-media reads so denied senders cannot trigger host file disclosure via attachment hydration. (#64459) Thanks @eleqtrizit.
+- Browser/security: reject strict-policy hostname navigation unless the hostname is an explicit allowlist exception or IP literal, and route CDP HTTP discovery through the pinned SSRF fetch path. (#64367) Thanks @eleqtrizit.
+- Models/vLLM: ignore empty `tool_calls` arrays from reasoning-model OpenAI-compatible replies, reset false `toolUse` stop reasons when no actual tool calls were parsed, and stop sending `tool_choice` unless tools are present so vLLM reasoning responses no longer hang indefinitely. (#61197, #61534) Thanks @balajisiva.
 
 ## 2026.4.9
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1457,4 +1457,70 @@ describe("openai transport stream", () => {
     expect(functionCall).toBeDefined();
     expect(functionCall?.arguments).toBe("not valid json");
   });
+
+  it("does not send tool_choice when tools are provided but toolChoice option is not set", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "test-model",
+        name: "Test Model",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: "http://localhost:8000/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 2048,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "You are a helpful assistant",
+        messages: [],
+        tools: [
+          {
+            name: "get_weather",
+            description: "Get weather information",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as never,
+      undefined,
+    );
+
+    expect(params).toHaveProperty("tools");
+    expect(params).not.toHaveProperty("tool_choice");
+  });
+
+  it("sends tool_choice when explicitly configured", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "test-model",
+        name: "Test Model",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: "http://localhost:8000/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 2048,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "You are a helpful assistant",
+        messages: [],
+        tools: [
+          {
+            name: "get_weather",
+            description: "Get weather information",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as never,
+      {
+        toolChoice: "required",
+      },
+    );
+
+    expect(params).toHaveProperty("tools");
+    expect(params).toHaveProperty("tool_choice", "required");
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1570,7 +1570,7 @@ describe("openai transport stream", () => {
         choices: [
           {
             index: 0,
-            delta: { role: "assistant", content: "" },
+            delta: { role: "assistant" as const, content: "" },
             logprobs: null,
             finish_reason: null,
           },
@@ -1598,23 +1598,25 @@ describe("openai transport stream", () => {
         choices: [
           {
             index: 0,
-            delta: { tool_calls: [] },
+            delta: { tool_calls: [] as never[] },
             logprobs: null,
-            finish_reason: "tool_calls",
+            finish_reason: "tool_calls" as const,
           },
         ],
       },
-    ];
+    ] as const;
 
     async function* mockStream() {
       for (const chunk of mockChunks) {
-        yield chunk;
+        yield chunk as never;
       }
     }
 
     await __testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
 
     expect(output.stopReason).toBe("stop");
-    expect(output.content.some((block) => block.type === "toolCall")).toBe(false);
+    expect(output.content.some((block) => (block as { type?: string }).type === "toolCall")).toBe(
+      false,
+    );
   });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -6,6 +6,7 @@ import {
   parseTransportChunkUsage,
   resolveAzureOpenAIApiVersion,
   sanitizeTransportPayloadText,
+  __testing,
 } from "./openai-transport-stream.js";
 import { attachModelProviderRequestTransport } from "./provider-request-config.js";
 import {
@@ -1522,5 +1523,98 @@ describe("openai transport stream", () => {
 
     expect(params).toHaveProperty("tools");
     expect(params).toHaveProperty("tool_choice", "required");
+  });
+
+  it("resets stopReason to stop when finish_reason is tool_calls but tool_calls array is empty", async () => {
+    const model = {
+      id: "nemotron-3-super",
+      name: "Nemotron 3 Super",
+      api: "openai-completions",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1000000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = {
+      role: "assistant" as const,
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    const stream = {
+      push: () => {},
+    };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "nemotron-3-super",
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant", content: "" },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "nemotron-3-super",
+        choices: [
+          {
+            index: 0,
+            delta: { content: "4" },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "nemotron-3-super",
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [] },
+            logprobs: null,
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+    ];
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk;
+      }
+    }
+
+    await __testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content.some((block) => block.type === "toolCall")).toBe(false);
   });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1380,3 +1380,7 @@ function mapStopReason(reason: string | null) {
       };
   }
 }
+
+export const __testing = {
+  processOpenAICompletionsStream,
+};

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1093,7 +1093,7 @@ async function processOpenAICompletionsStream(
       });
       continue;
     }
-    if (choice.delta.tool_calls) {
+    if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
       for (const toolCall of choice.delta.tool_calls) {
         if (
           !currentBlock ||
@@ -1134,6 +1134,10 @@ async function processOpenAICompletionsStream(
     }
   }
   finishCurrentBlock();
+  const hasToolCalls = output.content.some((block) => block.type === "toolCall");
+  if (output.stopReason === "toolUse" && !hasToolCalls) {
+    output.stopReason = "stop";
+  }
 }
 
 function detectCompat(model: OpenAIModeModel) {
@@ -1312,11 +1316,11 @@ export function buildOpenAICompletionsParams(
   }
   if (context.tools) {
     params.tools = convertTools(context.tools, compat, model);
+    if (options?.toolChoice) {
+      params.tool_choice = options.toolChoice;
+    }
   } else if (hasToolHistory(context.messages)) {
     params.tools = [];
-  }
-  if (options?.toolChoice) {
-    params.tool_choice = options.toolChoice;
   }
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
   if (compat.thinkingFormat === "openrouter" && model.reasoning && completionsReasoningEffort) {


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  - **Problem:** vLLM reasoning models return `tool_calls: []` (empty array) instead of omitting the field, causing OpenClaw to hang indefinitely on "typing..." when processing responses    
  - **Why it matters:** All vLLM reasoning models (Nemotron, DeepSeek-R1, Qwen3) are completely unusable - responses never complete                                                           
  - **What changed:** Added array length check before processing tool_calls; added post-validation to reset stopReason if no actual tool calls were parsed; moved tool_choice parameter inside
   tools presence check                                                                                                                                                                       
  - **What did NOT change:** No changes to tool calling logic for providers that correctly omit empty tool_calls; no changes to reasoning field handling                                      
                                                                                                                                                                                              
  ## Change Type (select all)                                                                                                                                                                 
                                                                                                                                                                                              
  - [x] Bug fix                                                                                                                                                                               
  - [ ] Feature                                                                                                                                                                               
  - [ ] Refactor required for the fix                                                                                                                                                         
  - [ ] Docs                                                                                                                                                                                  
  - [ ] Security hardening                                                                                                                                                                    
  - [ ] Chore/infra                                                                                                                                                                           
                                                                                                                                                                                              
  ## Scope (select all touched areas)                                                                                                                                                         
                                                                                                                                                                                              
  - [x] Gateway / orchestration                                                                                                                                                               
  - [ ] Skills / tool execution                                                                                                                                                               
  - [ ] Auth / tokens                                                                                                                                                                         
  - [ ] Memory / storage                                                                                                                                                                      
  - [ ] Integrations                                                                                                                                                                          
  - [x] API / contracts                                                                                                                                                                       
  - [ ] UI / DX                                                                                                                                                                               
  - [ ] CI/CD / infra                                                                                                                                                                         
                                                                                                                                                                                              
  ## Linked Issue/PR                                                                                                                                                                          
                                                                                                                                                                                              
  - Closes #61197                                                                                                                                                                             
  - [x] This PR fixes a bug or regression                                                                                                                                                     
                                                                                                                                                                                              
  ## Root Cause (if applicable)                                                                                                                                                               
                                                                                                                                                                                              
  - **Root cause:** vLLM returns `tool_calls: []` instead of omitting the field per OpenAI spec. OpenClaw's response parser checked for truthiness of `tool_calls` array but not its length,  
  causing it to enter tool-call processing state with zero actual tool calls.                                                                                                                 
  - **Missing detection / guardrail:** No validation that parsed tool_calls array actually contains valid tool calls before setting `stopReason = "toolUse"`                                  
  - **Contributing context:** vLLM also returns `tool_choice` errors when sent `"auto"` value without `--enable-auto-tool-choice` flag; OpenClaw was sending tool_choice unconditionally when 
  tools were present                                                                                                                                                                          
                                                                                                                                                                                              
  ## Regression Test Plan (if applicable)                                                                                                                                                     
                                                                                                                                                                                              
  - Coverage level that should have caught this:                                                                                                                                              
    - [x] Unit test                                                                                                                                                                           
    - [ ] Seam / integration test                                                                                                                                                             
    - [ ] End-to-end test                                                                                                                                                                     
    - [ ] Existing coverage already sufficient                                                                                                                                                
  - **Target test or file:** `src/agents/openai-transport-stream.test.ts`                                                                                                                     
  - **Scenario the test should lock in:** Verify tool_choice is only sent when explicitly configured; verify empty tool_calls arrays don't trigger tool-use state                             
  - **Why this is the smallest reliable guardrail:** Unit tests directly validate the request building and response parsing logic without requiring live provider                             
  - **Existing test that already covers this:** None - this is new coverage                                                                                                                   
  - **If no new test is added, why not:** Two new tests added in this PR                                                                                                                      
                                                                                                                                                                                              
  ## User-visible / Behavior Changes                                                                                                                                                          
                                                                                                                                                                                              
  **Before:** vLLM reasoning model responses hang indefinitely with "typing..." indicator                                                                                                     
                                                                                                                                                                                              
  **After:** vLLM reasoning model responses complete normally, showing reasoning content and final answer                                                                                     
                                                                                                                                                                                              
  No config changes required - fix is transparent to users.                                                                                                                                   
                                                                                                                                                                                              
  ## Diagram (if applicable)                                                                                                                                                                  
                                                                                                                                                                                              
  ```text                                                                                                                                                                                     
  Before:                                                                                                                                                                                     
  [vLLM response with tool_calls:[]] -> [parser sees truthy array] -> [enters tool-use state] -> [waits forever for tool results]                                                             
                                                                                                                                                                                              
  After:                                                                                                                                                                                      
  [vLLM response with tool_calls:[]] -> [parser checks length > 0] -> [skips empty array] -> [post-validation resets stopReason] -> [completes normally]                                      
                                                                                                                                                                                              
  Security Impact (required)                                                                                                                                                                  
                                                                                                                                                                                              
  - New permissions/capabilities? No                                                                                                                                                          
  - Secrets/tokens handling changed? No                                                                                                                                                       
  - New/changed network calls? No                                                                                                                                                             
  - Command/tool execution surface changed? No                                                                                                                                                
  - Data access scope changed? No                                                                                                                                                             
                                                                                                                                                                                              
  Repro + Verification                                                                                                                                                                        
                                                                                                                                                                                              
  Environment                                                                                                                                                                                 
                                                                                                                                                                                              
  - OS: macOS (darwin-arm64)                                                                                                                                                                  
  - Runtime/container: vLLM server on local network                                                                                                                                           
  - Model/provider: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 via vLLM                                                                                                                   
  - Integration/channel: Direct model invocation                                                                                                                                              
  - Relevant config:                                                                                                                                                                          
  {                                                                                                                                                                                           
    "models": {                                                                                                                                                                               
      "providers": {                                                                                                                                                                          
        "vllm": {                                                                                                                                                                             
          "baseUrl": "http://sparky:8000/v1",                                                                                                                                                 
          "models": [{"id": "nemotron-3-super"}]                                                                                                                                              
        }                                                                                                                                                                                     
      }                                                                                                                                                                                       
    }                                                                                                                                                                                         
  }                                                                                                                                                                                           
                                                                                                                                                                                              
  Steps                                                                                                                                                                                       
                                                                                                                                                                                              
  1. Start vLLM with reasoning model (Nemotron/DeepSeek-R1/Qwen3)                                                                                                                             
  2. Send message via OpenClaw: openclaw message send -m vllm/model-name "What is 2+2?"                                                                                                       
  3. Observe response                                                                                                                                                                         
                                                                                                                                                                                              
  Expected                                                                                                                                                                                    
                                                                                                                                                                                              
  Response completes with reasoning content and answer                                                                                                                                        
                                                                                                                                                                                              
  Actual                                                                                                                                                                                      
                                                                                                                                                                                              
  Before fix: Response hangs indefinitely on "typing..." indicator                                                                                                                            
                                                                                                                                                                                              
  After fix: Response completes normally                                                                                                                                                      
                                                                                                                                                                                              
  Evidence                                                                                                                                                                                    
                                                                                                                                                                                              
  vLLM response showing the problematic empty array:                                                                                                                                          
  {                                                                                                                                                                                           
    "tool_calls": [],                                                                                                                                                                         
    "reasoning": "The sum of 2 + 2 is 4.",                                                                                                                                                    
    "content": "\n4"                                                                                                                                                                          
  }                                                                                                                                                                                           
                                                                                                                                                                                              
  Streaming response showing reasoning field usage:                                                                                                                                           
  {"delta": {"reasoning": "The"}}                                                                                                                                                             
  {"delta": {"reasoning": " sum"}}                                                                                                                                                            
  {"delta": {"reasoning": " of 2 + 2 is 4."}}                                                                                                                                                 
                                                                                                                                                                                              
  Human Verification (required)                                                                                                                                                               
                                                                                                                                                                                              
  Verified scenarios:                                                                                                                                                                         
  - Tested with live vLLM instance running Nemotron-3-Super-120B                                                                                                                              
  - Confirmed vLLM returns tool_calls: [] in non-streaming responses                                                                                                                          
  - Verified streaming responses use reasoning field in delta chunks                                                                                                                          
  - Code review of response parsing logic                                                                                                                                                     
  - Verified unit tests pass for tool_choice behavior                                                                                                                                         
                                                                                                                                                                                              
  Edge cases checked:                                                                                                                                                                         
  - Empty tool_calls array handling                                                                                                                                                           
  - Reasoning field variants (reasoning, reasoning_content, reasoning_text)                                                                                                                   
  - tool_choice only sent when explicitly configured                                                                                                                                          
                                                                                                                                                                                              
  What you did NOT verify:                                                                                                                                                                    
  - Full integration test with OpenClaw CLI (build dependencies missing on test machine)                                                                                                      
  - Other vLLM reasoning models (only tested Nemotron)                                                                                                                                        
  - Tool calling with vLLM when --enable-auto-tool-choice is enabled                                                                                                                          
                                                                                                                                                                                              
  Review Conversations                                                                                                                                                                        
                                                                                                                                                                                              
  - I replied to or resolved every bot review conversation I addressed in this PR.                                                                                                            
  - I left unresolved only the conversations that still need reviewer or maintainer judgment.                                                                                                 
                                                                                                                                                                                              
  Compatibility / Migration                                                                                                                                                                   
                                                                                                                                                                                              
  - Backward compatible? Yes                                                                                                                                                                  
  - Config/env changes? No                                                                                                                                                                    
  - Migration needed? No                                                                                                                                                                      
                                                                                                                                                                                              
  Existing configurations continue to work. No user action required.                                                                                                                          
                                                                                                                                                                                              
  Risks and Mitigations                                                                                                                                                                       
                                                                                                                                                                                              
  - Risk: Could affect other OpenAI-compatible providers that also return empty tool_calls arrays                                                                                             
    - Mitigation: Fix is conservative - only skips processing when array is empty AND validates stopReason matches actual parsed tool calls. Existing behavior preserved for providers that   
  correctly omit the field.  
