### PR TITLE
feat(memory): add Jina AI embeddings provider

### DIFF
--- a/extensions/memory-core/src/memory/provider-adapters.test.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.test.ts
@@ -39,7 +39,7 @@ describe("registerBuiltInMemoryEmbeddingProviders", () => {
       },
     });
 
-    expect(ids).toEqual(["local", "openai", "gemini", "voyage", "mistral"]);
+    expect(ids).toEqual(["local", "openai", "gemini", "voyage", "jina", "mistral"]);
     expect(mocks.listRegisteredMemoryEmbeddingProviderAdapters).toHaveBeenCalledTimes(1);
     expect(mocks.listMemoryEmbeddingProviders).not.toHaveBeenCalled();
   });
@@ -57,7 +57,7 @@ describe("registerBuiltInMemoryEmbeddingProviders", () => {
       },
     });
 
-    expect(ids).toEqual(["openai", "voyage", "mistral"]);
+    expect(ids).toEqual(["openai", "voyage", "jina", "mistral"]);
     expect(mocks.listMemoryEmbeddingProviders).not.toHaveBeenCalled();
   });
 });

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -282,7 +282,9 @@ const jinaAdapter: MemoryEmbeddingProviderAdapter = {
         id: "jina",
         cacheKeyData: {
           provider: "jina",
+          baseUrl: client.baseUrl,
           model: client.model,
+          headers: sanitizeHeaders(client.headers, ["authorization"]),
         },
       },
     };

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -1,6 +1,7 @@
 import fsSync from "node:fs";
 import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
+  DEFAULT_JINA_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
   DEFAULT_OPENAI_EMBEDDING_MODEL,
@@ -8,6 +9,7 @@ import {
   OPENAI_BATCH_ENDPOINT,
   buildGeminiEmbeddingRequest,
   createGeminiEmbeddingProvider,
+  createJinaEmbeddingProvider,
   createLocalEmbeddingProvider,
   createMistralEmbeddingProvider,
   createOpenAiEmbeddingProvider,
@@ -82,7 +84,7 @@ function formatLocalSetupError(err: unknown): string {
       ? "2) Reinstall OpenClaw (this should install node-llama-cpp): npm i -g openclaw@latest"
       : null,
     "3) If you use pnpm: pnpm approve-builds (select node-llama-cpp), then pnpm rebuild node-llama-cpp",
-    ...["openai", "gemini", "voyage", "mistral"].map(
+    ...["openai", "gemini", "voyage", "jina", "mistral"].map(
       (provider) => `Or set agents.defaults.memorySearch.provider = "${provider}" (remote).`,
     ),
   ]
@@ -261,6 +263,32 @@ const voyageAdapter: MemoryEmbeddingProviderAdapter = {
   },
 };
 
+const jinaAdapter: MemoryEmbeddingProviderAdapter = {
+  id: "jina",
+  defaultModel: DEFAULT_JINA_EMBEDDING_MODEL,
+  transport: "remote",
+  autoSelectPriority: 45,
+  allowExplicitWhenConfiguredAuto: true,
+  shouldContinueAutoSelection: isMissingApiKeyError,
+  create: async (options) => {
+    const { provider, client } = await createJinaEmbeddingProvider({
+      ...options,
+      provider: "jina",
+      fallback: "none",
+    });
+    return {
+      provider,
+      runtime: {
+        id: "jina",
+        cacheKeyData: {
+          provider: "jina",
+          model: client.model,
+        },
+      },
+    };
+  },
+};
+
 const mistralAdapter: MemoryEmbeddingProviderAdapter = {
   id: "mistral",
   defaultModel: DEFAULT_MISTRAL_EMBEDDING_MODEL,
@@ -318,6 +346,7 @@ export const builtinMemoryEmbeddingProviderAdapters = [
   openAiAdapter,
   geminiAdapter,
   voyageAdapter,
+  jinaAdapter,
   mistralAdapter,
 ] as const;
 
@@ -380,6 +409,7 @@ export function listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata(): Ar
 
 export {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
+  DEFAULT_JINA_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
   DEFAULT_OPENAI_EMBEDDING_MODEL,

--- a/packages/memory-host-sdk/src/host/embeddings-jina.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-jina.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as authModule from "../../../../src/agents/model-auth.js";
+import { type FetchMock, withFetchPreconnect } from "../../../../src/test-utils/fetch-mock.js";
+import { mockPublicPinnedHostname } from "./test-helpers/ssrf.js";
+
+vi.mock("../../../../src/infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: async (params: {
+    url: string;
+    init?: RequestInit;
+    fetchImpl?: typeof fetch;
+  }) => {
+    const fetchImpl = params.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+      throw new Error("fetch is not available");
+    }
+    const response = await fetchImpl(params.url, params.init);
+    return {
+      response,
+      finalUrl: params.url,
+      release: async () => {},
+    };
+  },
+}));
+
+vi.mock("../../../../src/agents/model-auth.js", async () => {
+  const { createModelAuthMockModule } =
+    await import("../../../../src/test-utils/model-auth-mock.js");
+  return createModelAuthMockModule();
+});
+
+const createFetchMock = () => {
+  const fetchMock = vi.fn<FetchMock>(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  return withFetchPreconnect(fetchMock);
+};
+
+function installFetchMock(fetchMock: typeof globalThis.fetch) {
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+let createJinaEmbeddingProvider: typeof import("./embeddings-jina.js").createJinaEmbeddingProvider;
+let normalizeJinaModel: typeof import("./embeddings-jina.js").normalizeJinaModel;
+
+beforeAll(async () => {
+  ({ createJinaEmbeddingProvider, normalizeJinaModel } = await import("./embeddings-jina.js"));
+});
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.doUnmock("undici");
+});
+
+function mockJinaApiKey() {
+  vi.mocked(authModule.resolveApiKeyForProvider).mockResolvedValue({
+    apiKey: "jina-key-123",
+    mode: "api-key",
+    source: "test",
+  });
+}
+
+async function createDefaultJinaProvider(
+  model: string,
+  fetchMock: ReturnType<typeof createFetchMock>,
+) {
+  installFetchMock(fetchMock as unknown as typeof globalThis.fetch);
+  mockPublicPinnedHostname();
+  mockJinaApiKey();
+  return createJinaEmbeddingProvider({
+    config: {} as never,
+    provider: "jina",
+    model,
+    fallback: "none",
+  });
+}
+
+describe("jina embedding provider", () => {
+  afterEach(() => {
+    vi.doUnmock("undici");
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("configures client with correct defaults and headers", async () => {
+    const fetchMock = createFetchMock();
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-small", fetchMock);
+
+    await result.provider.embedQuery("test query");
+
+    expect(authModule.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "jina" }),
+    );
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://api.jina.ai/v1/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer jina-key-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "jina-embeddings-v5-text-small",
+      input: ["test query"],
+      task: "retrieval.query",
+    });
+  });
+
+  it("respects remote overrides for baseUrl and apiKey", async () => {
+    const fetchMock = createFetchMock();
+    installFetchMock(fetchMock as unknown as typeof globalThis.fetch);
+    mockPublicPinnedHostname();
+
+    const result = await createJinaEmbeddingProvider({
+      config: {} as never,
+      provider: "jina",
+      model: "jina-embeddings-v5-text-small",
+      fallback: "none",
+      remote: {
+        baseUrl: "https://custom-jina.example.com",
+        apiKey: "remote-override-key",
+        headers: { "X-Custom": "123" },
+      },
+    });
+
+    await result.provider.embedQuery("test");
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://custom-jina.example.com/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer remote-override-key");
+    expect(headers["X-Custom"]).toBe("123");
+  });
+
+  it("passes task=retrieval.passage for embedBatch", async () => {
+    const fetchMock = withFetchPreconnect(
+      vi.fn<FetchMock>(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response(
+            JSON.stringify({
+              data: [{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-small", fetchMock);
+
+    await result.provider.embedBatch(["doc1", "doc2"]);
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "jina-embeddings-v5-text-small",
+      input: ["doc1", "doc2"],
+      task: "retrieval.passage",
+    });
+  });
+
+  it("returns empty array for empty input", async () => {
+    const fetchMock = createFetchMock();
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-small", fetchMock);
+
+    const embeddings = await result.provider.embedBatch([]);
+
+    expect(embeddings).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes model names", () => {
+    expect(normalizeJinaModel("jina/jina-embeddings-v5-text-small")).toBe(
+      "jina-embeddings-v5-text-small",
+    );
+    expect(normalizeJinaModel("jina-embeddings-v5-text-small")).toBe(
+      "jina-embeddings-v5-text-small",
+    );
+    expect(normalizeJinaModel("  jina-embeddings-v5-text-nano  ")).toBe(
+      "jina-embeddings-v5-text-nano",
+    );
+    expect(normalizeJinaModel("")).toBe("jina-embeddings-v5-text-small");
+  });
+});

--- a/packages/memory-host-sdk/src/host/embeddings-jina.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-jina.ts
@@ -1,0 +1,80 @@
+import type { SsrFPolicy } from "../../../../src/infra/net/ssrf.js";
+import { normalizeEmbeddingModelWithPrefixes } from "./embeddings-model-normalize.js";
+import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
+import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
+import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+
+export type JinaEmbeddingClient = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  ssrfPolicy?: SsrFPolicy;
+  model: string;
+};
+
+export const DEFAULT_JINA_EMBEDDING_MODEL = "jina-embeddings-v5-text-small";
+const DEFAULT_JINA_BASE_URL = "https://api.jina.ai/v1";
+const JINA_MAX_INPUT_TOKENS: Record<string, number> = {
+  "jina-embeddings-v5-text-small": 32768,
+  "jina-embeddings-v5-text-nano": 8192,
+};
+
+export function normalizeJinaModel(model: string): string {
+  return normalizeEmbeddingModelWithPrefixes({
+    model,
+    defaultModel: DEFAULT_JINA_EMBEDDING_MODEL,
+    prefixes: ["jina/"],
+  });
+}
+
+export async function createJinaEmbeddingProvider(
+  options: EmbeddingProviderOptions,
+): Promise<{ provider: EmbeddingProvider; client: JinaEmbeddingClient }> {
+  const client = await resolveJinaEmbeddingClient(options);
+  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+
+  const embed = async (
+    input: string[],
+    task?: "retrieval.query" | "retrieval.passage",
+  ): Promise<number[][]> => {
+    if (input.length === 0) {
+      return [];
+    }
+    const body: Record<string, unknown> = { model: client.model, input };
+    if (task) {
+      body.task = task;
+    }
+    return await fetchRemoteEmbeddingVectors({
+      url,
+      headers: client.headers,
+      ssrfPolicy: client.ssrfPolicy,
+      body,
+      errorPrefix: "jina embeddings failed",
+    });
+  };
+
+  return {
+    provider: {
+      id: "jina",
+      model: client.model,
+      maxInputTokens: JINA_MAX_INPUT_TOKENS[client.model],
+      embedQuery: async (text) => {
+        const [vec] = await embed([text], "retrieval.query");
+        return vec ?? [];
+      },
+      embedBatch: async (texts) => embed(texts, "retrieval.passage"),
+    },
+    client,
+  };
+}
+
+export async function resolveJinaEmbeddingClient(
+  options: EmbeddingProviderOptions,
+): Promise<JinaEmbeddingClient> {
+  const { baseUrl, headers, ssrfPolicy } = await resolveRemoteEmbeddingBearerClient({
+    provider: "jina",
+    options,
+    defaultBaseUrl: DEFAULT_JINA_BASE_URL,
+  });
+  const model = normalizeJinaModel(options.model);
+  return { baseUrl, headers, ssrfPolicy, model };
+}

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -4,7 +4,7 @@ import type { EmbeddingProviderOptions } from "./embeddings.js";
 import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
 import { resolveMemorySecretInputString } from "./secret-input.js";
 
-export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral";
+export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral" | "jina";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -11,6 +11,7 @@ import {
   type GeminiEmbeddingClient,
   type GeminiTaskType,
 } from "./embeddings-gemini.js";
+import { createJinaEmbeddingProvider, type JinaEmbeddingClient } from "./embeddings-jina.js";
 import {
   createMistralEmbeddingProvider,
   type MistralEmbeddingClient,
@@ -21,6 +22,7 @@ import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./emb
 import { importNodeLlamaCpp } from "./node-llama.js";
 
 export type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
+export type { JinaEmbeddingClient } from "./embeddings-jina.js";
 export type { MistralEmbeddingClient } from "./embeddings-mistral.js";
 export type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
 export type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
@@ -35,14 +37,21 @@ export type EmbeddingProvider = {
   embedBatchInputs?: (inputs: EmbeddingInput[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+export type EmbeddingProviderId =
+  | "openai"
+  | "local"
+  | "gemini"
+  | "voyage"
+  | "jina"
+  | "mistral"
+  | "ollama";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
 // Remote providers considered for auto-selection when provider === "auto".
 // Ollama is intentionally excluded here so that "auto" mode does not
 // implicitly assume a local Ollama instance is available.
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "jina", "mistral"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -53,6 +62,7 @@ export type EmbeddingProviderResult = {
   openAi?: OpenAiEmbeddingClient;
   gemini?: GeminiEmbeddingClient;
   voyage?: VoyageEmbeddingClient;
+  jina?: JinaEmbeddingClient;
   mistral?: MistralEmbeddingClient;
   ollama?: OllamaEmbeddingClient;
 };
@@ -187,6 +197,10 @@ export async function createEmbeddingProvider(
     if (id === "voyage") {
       const { provider, client } = await createVoyageEmbeddingProvider(options);
       return { provider, voyage: client };
+    }
+    if (id === "jina") {
+      const { provider, client } = await createJinaEmbeddingProvider(options);
+      return { provider, jina: client };
     }
     if (id === "mistral") {
       const { provider, client } = await createMistralEmbeddingProvider(options);

--- a/src/memory-host-sdk/engine-embeddings.ts
+++ b/src/memory-host-sdk/engine-embeddings.ts
@@ -22,6 +22,10 @@ export {
   buildGeminiEmbeddingRequest,
 } from "./host/embeddings-gemini.js";
 export {
+  createJinaEmbeddingProvider,
+  DEFAULT_JINA_EMBEDDING_MODEL,
+} from "./host/embeddings-jina.js";
+export {
   createMistralEmbeddingProvider,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
 } from "./host/embeddings-mistral.js";

--- a/src/memory-host-sdk/host/embeddings-jina.test.ts
+++ b/src/memory-host-sdk/host/embeddings-jina.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as authModule from "../../agents/model-auth.js";
+import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { mockPublicPinnedHostname } from "./test-helpers/ssrf.js";
+
+vi.mock("../../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: async (params: {
+    url: string;
+    init?: RequestInit;
+    fetchImpl?: typeof fetch;
+  }) => {
+    const fetchImpl = params.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+      throw new Error("fetch is not available");
+    }
+    const response = await fetchImpl(params.url, params.init);
+    return {
+      response,
+      finalUrl: params.url,
+      release: async () => {},
+    };
+  },
+}));
+
+vi.mock("../../agents/model-auth.js", async () => {
+  const { createModelAuthMockModule } = await import("../../test-utils/model-auth-mock.js");
+  return createModelAuthMockModule();
+});
+
+const createFetchMock = () => {
+  const fetchMock = vi.fn<FetchMock>(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  return withFetchPreconnect(fetchMock);
+};
+
+function installFetchMock(fetchMock: typeof globalThis.fetch) {
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+let createJinaEmbeddingProvider: typeof import("./embeddings-jina.js").createJinaEmbeddingProvider;
+let normalizeJinaModel: typeof import("./embeddings-jina.js").normalizeJinaModel;
+
+beforeAll(async () => {
+  ({ createJinaEmbeddingProvider, normalizeJinaModel } = await import("./embeddings-jina.js"));
+});
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.doUnmock("undici");
+});
+
+function mockJinaApiKey() {
+  vi.mocked(authModule.resolveApiKeyForProvider).mockResolvedValue({
+    apiKey: "jina-key-123",
+    mode: "api-key",
+    source: "test",
+  });
+}
+
+async function createDefaultJinaProvider(
+  model: string,
+  fetchMock: ReturnType<typeof createFetchMock>,
+) {
+  installFetchMock(fetchMock as unknown as typeof globalThis.fetch);
+  mockPublicPinnedHostname();
+  mockJinaApiKey();
+  return createJinaEmbeddingProvider({
+    config: {} as never,
+    provider: "jina",
+    model,
+    fallback: "none",
+  });
+}
+
+describe("jina embedding provider", () => {
+  afterEach(() => {
+    vi.doUnmock("undici");
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("configures client with correct defaults and headers", async () => {
+    const fetchMock = createFetchMock();
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-small", fetchMock);
+
+    await result.provider.embedQuery("test query");
+
+    expect(authModule.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "jina" }),
+    );
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://api.jina.ai/v1/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer jina-key-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "jina-embeddings-v5-text-small",
+      input: ["test query"],
+      task: "retrieval.query",
+    });
+  });
+
+  it("respects remote overrides for baseUrl and apiKey", async () => {
+    const fetchMock = createFetchMock();
+    installFetchMock(fetchMock as unknown as typeof globalThis.fetch);
+    mockPublicPinnedHostname();
+
+    const result = await createJinaEmbeddingProvider({
+      config: {} as never,
+      provider: "jina",
+      model: "jina-embeddings-v5-text-small",
+      fallback: "none",
+      remote: {
+        baseUrl: "https://custom-jina.example.com",
+        apiKey: "remote-override-key",
+        headers: { "X-Custom": "123" },
+      },
+    });
+
+    await result.provider.embedQuery("test");
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    expect(url).toBe("https://custom-jina.example.com/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer remote-override-key");
+    expect(headers["X-Custom"]).toBe("123");
+  });
+
+  it("passes task=retrieval.passage for embedBatch", async () => {
+    const fetchMock = withFetchPreconnect(
+      vi.fn<FetchMock>(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response(
+            JSON.stringify({
+              data: [{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-small", fetchMock);
+
+    await result.provider.embedBatch(["doc1", "doc2"]);
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [, init] = call as [RequestInfo | URL, RequestInit | undefined];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "jina-embeddings-v5-text-small",
+      input: ["doc1", "doc2"],
+      task: "retrieval.passage",
+    });
+  });
+
+  it("returns empty array for empty input", async () => {
+    const fetchMock = createFetchMock();
+    const result = await createDefaultJinaProvider("jina-embeddings-v5-text-small", fetchMock);
+
+    const embeddings = await result.provider.embedBatch([]);
+
+    expect(embeddings).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes model names", () => {
+    expect(normalizeJinaModel("jina/jina-embeddings-v5-text-small")).toBe(
+      "jina-embeddings-v5-text-small",
+    );
+    expect(normalizeJinaModel("jina-embeddings-v5-text-small")).toBe(
+      "jina-embeddings-v5-text-small",
+    );
+    expect(normalizeJinaModel("  jina-embeddings-v5-text-nano  ")).toBe(
+      "jina-embeddings-v5-text-nano",
+    );
+    expect(normalizeJinaModel("")).toBe("jina-embeddings-v5-text-small");
+  });
+});

--- a/src/memory-host-sdk/host/embeddings-jina.ts
+++ b/src/memory-host-sdk/host/embeddings-jina.ts
@@ -1,0 +1,80 @@
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+import { normalizeEmbeddingModelWithPrefixes } from "./embeddings-model-normalize.js";
+import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
+import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
+import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+
+export type JinaEmbeddingClient = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  ssrfPolicy?: SsrFPolicy;
+  model: string;
+};
+
+export const DEFAULT_JINA_EMBEDDING_MODEL = "jina-embeddings-v5-text-small";
+const DEFAULT_JINA_BASE_URL = "https://api.jina.ai/v1";
+const JINA_MAX_INPUT_TOKENS: Record<string, number> = {
+  "jina-embeddings-v5-text-small": 32768,
+  "jina-embeddings-v5-text-nano": 8192,
+};
+
+export function normalizeJinaModel(model: string): string {
+  return normalizeEmbeddingModelWithPrefixes({
+    model,
+    defaultModel: DEFAULT_JINA_EMBEDDING_MODEL,
+    prefixes: ["jina/"],
+  });
+}
+
+export async function createJinaEmbeddingProvider(
+  options: EmbeddingProviderOptions,
+): Promise<{ provider: EmbeddingProvider; client: JinaEmbeddingClient }> {
+  const client = await resolveJinaEmbeddingClient(options);
+  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+
+  const embed = async (
+    input: string[],
+    task?: "retrieval.query" | "retrieval.passage",
+  ): Promise<number[][]> => {
+    if (input.length === 0) {
+      return [];
+    }
+    const body: Record<string, unknown> = { model: client.model, input };
+    if (task) {
+      body.task = task;
+    }
+    return await fetchRemoteEmbeddingVectors({
+      url,
+      headers: client.headers,
+      ssrfPolicy: client.ssrfPolicy,
+      body,
+      errorPrefix: "jina embeddings failed",
+    });
+  };
+
+  return {
+    provider: {
+      id: "jina",
+      model: client.model,
+      maxInputTokens: JINA_MAX_INPUT_TOKENS[client.model],
+      embedQuery: async (text) => {
+        const [vec] = await embed([text], "retrieval.query");
+        return vec ?? [];
+      },
+      embedBatch: async (texts) => embed(texts, "retrieval.passage"),
+    },
+    client,
+  };
+}
+
+export async function resolveJinaEmbeddingClient(
+  options: EmbeddingProviderOptions,
+): Promise<JinaEmbeddingClient> {
+  const { baseUrl, headers, ssrfPolicy } = await resolveRemoteEmbeddingBearerClient({
+    provider: "jina",
+    options,
+    defaultBaseUrl: DEFAULT_JINA_BASE_URL,
+  });
+  const model = normalizeJinaModel(options.model);
+  return { baseUrl, headers, ssrfPolicy, model };
+}

--- a/src/memory-host-sdk/host/embeddings-remote-client.ts
+++ b/src/memory-host-sdk/host/embeddings-remote-client.ts
@@ -4,7 +4,7 @@ import type { EmbeddingProviderOptions } from "./embeddings.js";
 import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
 import { resolveMemorySecretInputString } from "./secret-input.js";
 
-export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral";
+export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral" | "jina";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/src/memory-host-sdk/host/embeddings.ts
+++ b/src/memory-host-sdk/host/embeddings.ts
@@ -11,6 +11,7 @@ import {
   type GeminiEmbeddingClient,
   type GeminiTaskType,
 } from "./embeddings-gemini.js";
+import { createJinaEmbeddingProvider, type JinaEmbeddingClient } from "./embeddings-jina.js";
 import {
   createMistralEmbeddingProvider,
   type MistralEmbeddingClient,
@@ -21,6 +22,7 @@ import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./emb
 import { importNodeLlamaCpp } from "./node-llama.js";
 
 export type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
+export type { JinaEmbeddingClient } from "./embeddings-jina.js";
 export type { MistralEmbeddingClient } from "./embeddings-mistral.js";
 export type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
 export type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
@@ -35,14 +37,21 @@ export type EmbeddingProvider = {
   embedBatchInputs?: (inputs: EmbeddingInput[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+export type EmbeddingProviderId =
+  | "openai"
+  | "local"
+  | "gemini"
+  | "voyage"
+  | "jina"
+  | "mistral"
+  | "ollama";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
 // Remote providers considered for auto-selection when provider === "auto".
 // Ollama is intentionally excluded here so that "auto" mode does not
 // implicitly assume a local Ollama instance is available.
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "jina", "mistral"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -53,6 +62,7 @@ export type EmbeddingProviderResult = {
   openAi?: OpenAiEmbeddingClient;
   gemini?: GeminiEmbeddingClient;
   voyage?: VoyageEmbeddingClient;
+  jina?: JinaEmbeddingClient;
   mistral?: MistralEmbeddingClient;
   ollama?: OllamaEmbeddingClient;
 };
@@ -187,6 +197,10 @@ export async function createEmbeddingProvider(
     if (id === "voyage") {
       const { provider, client } = await createVoyageEmbeddingProvider(options);
       return { provider, voyage: client };
+    }
+    if (id === "jina") {
+      const { provider, client } = await createJinaEmbeddingProvider(options);
+      return { provider, jina: client };
     }
     if (id === "mistral") {
       const { provider, client } = await createMistralEmbeddingProvider(options);

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 
 const CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
+  jina: ["JINA_API_KEY"],
   voyage: ["VOYAGE_API_KEY"],
   cerebras: ["CEREBRAS_API_KEY"],
   "anthropic-openai": ["ANTHROPIC_API_KEY"],


### PR DESCRIPTION
## Summary

- Add [Jina AI](https://jina.ai/embeddings/) as a memory embedding provider, supporting `jina-embeddings-v5-text-small` (1024d, 32k tokens) and `jina-embeddings-v5-text-nano` (768d, 8k tokens)
- Default model is `jina-embeddings-v5-text-small` for best quality out of the box
- Follows the Voyage provider pattern with asymmetric task-aware embeddings (`retrieval.query` for queries, `retrieval.passage` for documents)
- Supports self-hosted deployments via the standard `remote.baseUrl` config override
- Auto-select priority 45 (between Voyage at 40 and Mistral at 50)

## Changes

**New files:**
- `packages/memory-host-sdk/src/host/embeddings-jina.ts` / `src/memory-host-sdk/host/embeddings-jina.ts` — Jina embedding provider with task-aware query/passage support and custom base URL for self-hosted deployments
- `packages/memory-host-sdk/src/host/embeddings-jina.test.ts` / `src/memory-host-sdk/host/embeddings-jina.test.ts` — Unit tests (defaults, custom baseUrl/apiKey, task parameters, empty input, model normalization)

**Modified files:**
- `embeddings-remote-client.ts` — Add `"jina"` to `RemoteEmbeddingProviderId`
- `embeddings.ts` — Add `"jina"` to `EmbeddingProviderId`, `REMOTE_EMBEDDING_PROVIDER_IDS`, `EmbeddingProviderResult`, and `createProvider`
- `engine-embeddings.ts` — Export `createJinaEmbeddingProvider` and `DEFAULT_JINA_EMBEDDING_MODEL`
- `provider-adapters.ts` — Add Jina adapter with `autoSelectPriority: 45`
- `provider-adapters.test.ts` — Update expected adapter ID lists
- `provider-env-vars.ts` — Add `JINA_API_KEY` to core provider auth env var candidates

## Test plan

- [x] Unit tests: 10 new tests across 2 test files (both `packages/` and `src/` locations), all passing
- [x] Integration: existing `embeddings.test.ts` (19 tests) continues to pass
- [x] Adapter registration: `provider-adapters.test.ts` updated and passing
- [x] Live validation: tested against real Jina API — both `retrieval.query` and `retrieval.passage` tasks produce correct embeddings with proper cosine similarity ranking; both v5-text-small (1024d) and v5-text-nano (768d) models work

🤖 Generated with [Claude Code](https://claude.com/claude-code)