### PR TITLE
fix(reply): preserve text for direct media blocks

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -212,6 +212,7 @@ Behavior details:
 - Content: delivery uses the isolated run's outbound payloads (text/media) with normal chunking and
   channel formatting.
 - Heartbeat-only responses (`HEARTBEAT_OK` with no real content) are not delivered.
+- Exact silent responses (`NO_REPLY`, after trimming) are not delivered.
 - If the isolated run already sent a message to the same target via the message tool, delivery is
   skipped to avoid duplicates.
 - Missing or invalid delivery targets fail the job unless `delivery.bestEffort = true`.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -18,6 +18,8 @@ Tip: run `openclaw cron --help` for the full command surface.
 
 Note: isolated `cron add` jobs default to `--announce` delivery. Use `--no-deliver` to keep
 output internal. `--deliver` remains as a deprecated alias for `--announce`.
+When an announced isolated run replies with exact `NO_REPLY` (after trimming), OpenClaw suppresses
+the outbound delivery.
 
 Note: one-shot (`--at`) jobs delete after success by default. Use `--keep-after-run` to keep them.
 

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -215,4 +215,38 @@ describe("block streaming", () => {
       });
     });
   });
+
+  it("times out a hanging direct media send and still returns the final reply", async () => {
+    await withTempHome(async (home) => {
+      let abortSignal: AbortSignal | undefined;
+      let timeoutMs: number | undefined;
+      const onBlockReply = vi.fn(
+        async (_payload, context?: { abortSignal?: AbortSignal; timeoutMs?: number }) => {
+          abortSignal = context?.abortSignal;
+          timeoutMs = context?.timeoutMs;
+          await new Promise<void>(() => {});
+        },
+      );
+
+      piEmbeddedMock.runEmbeddedPiAgent.mockImplementation(
+        async (params: RunEmbeddedPiAgentParams) => {
+          await params.onBlockReply?.({ text: "Result\nMEDIA: ./image.png" });
+          return createEmbeddedReply("Final fallback reply");
+        },
+      );
+
+      const res = await runTelegramReply({
+        home,
+        messageSid: "msg-130",
+        onBlockReply,
+        disableBlockStreaming: false,
+      });
+
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+      expect(timeoutMs).toBeGreaterThan(0);
+      expect(abortSignal?.aborted).toBe(true);
+      const payload = Array.isArray(res) ? res[0] : res;
+      expect(payload?.text).toBe("Final fallback reply");
+    });
+  });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -93,6 +93,7 @@ export async function runAgentTurnWithFallback(params: {
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
   pendingToolTasks: Set<Promise<void>>;
+  blockReplyTimeoutMs: number;
   resetSessionAfterCompactionFailure: (reason: string) => Promise<boolean>;
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
   isHeartbeat: boolean;
@@ -421,6 +422,7 @@ export async function runAgentTurnWithFallback(params: {
                       typingSignals: params.typingSignals,
                       blockStreamingEnabled: params.blockStreamingEnabled,
                       blockReplyPipeline,
+                      blockReplyTimeoutMs: params.blockReplyTimeoutMs,
                       directlySentBlockKeys,
                     })
                   : undefined,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -580,6 +580,36 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(result).toBeUndefined();
   });
 
+  it("falls back to final delivery when direct media block delivery fails", async () => {
+    const onBlockReply = vi.fn(async () => {
+      throw new Error("transient media send failure");
+    });
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onBlockReply?.({
+        text: "caption",
+        mediaUrls: ["/tmp/output.png"],
+      });
+      return {
+        payloads: [{ text: "caption", mediaUrls: ["/tmp/output.png"] }],
+        meta: {},
+      };
+    });
+
+    const { run } = createMinimalRun({
+      blockStreamingEnabled: false,
+      opts: { onBlockReply },
+    });
+    const result = await run();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      expect.objectContaining({
+        text: "caption",
+        mediaUrls: ["/tmp/output.png"],
+      }),
+    ]);
+  });
+
   it("handles typing for normal and silent tool results", async () => {
     const cases = [
       {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -551,6 +551,35 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("preserves text for direct media delivery when block streaming is disabled", async () => {
+    const onBlockReply = vi.fn();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onBlockReply?.({
+        text: "caption",
+        mediaUrls: ["/tmp/output.png"],
+      });
+      return {
+        payloads: [{ text: "caption", mediaUrls: ["/tmp/output.png"] }],
+        meta: {},
+      };
+    });
+
+    const { run } = createMinimalRun({
+      blockStreamingEnabled: false,
+      opts: { onBlockReply },
+    });
+    const result = await run();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "caption",
+        mediaUrls: ["/tmp/output.png"],
+      }),
+    );
+    expect(result).toBeUndefined();
+  });
+
   it("handles typing for normal and silent tool results", async () => {
     const cases = [
       {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -365,6 +365,7 @@ export async function runReplyAgent(params: {
       shouldEmitToolResult,
       shouldEmitToolOutput,
       pendingToolTasks,
+      blockReplyTimeoutMs,
       resetSessionAfterCompactionFailure,
       resetSessionAfterRoleOrderingConflict,
       isHeartbeat,

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -120,15 +120,17 @@ export function createBlockReplyDeliveryHandler(params: {
       });
     }
 
-    // Use pipeline if available (block streaming enabled), otherwise send directly.
+    // Use the pipeline for regular block streaming when available. If there is no
+    // pipeline, still deliver media-bearing payloads directly so tool-flush media
+    // is not dropped when block streaming is disabled.
     if (params.blockStreamingEnabled && params.blockReplyPipeline) {
       params.blockReplyPipeline.enqueue(blockPayload);
-    } else if (params.blockStreamingEnabled) {
-      // Send directly when flushing before tool execution (no pipeline but streaming enabled).
-      // Track sent key to avoid duplicate in final payloads.
+    } else if (blockHasMedia) {
+      // Track sent key to avoid duplicate delivery from the later final payload pass.
       params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
       await params.onBlockReply(blockPayload);
     }
-    // When streaming is disabled entirely, blocks are accumulated in final text instead.
+    // When streaming is disabled entirely, text-only blocks are accumulated in the
+    // final payload instead of being delivered incrementally.
   };
 }

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -10,6 +10,27 @@ import type { TypingSignaler } from "./typing-mode.js";
 
 export type ReplyDirectiveParseMode = "always" | "auto" | "never";
 
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutError: Error,
+): Promise<T> => {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return promise;
+  }
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
 export function normalizeReplyPayloadDirectives(params: {
   payload: ReplyPayload;
   currentMessageId?: string;
@@ -67,6 +88,7 @@ export function createBlockReplyDeliveryHandler(params: {
   typingSignals: TypingSignaler;
   blockStreamingEnabled: boolean;
   blockReplyPipeline: BlockReplyPipeline | null;
+  blockReplyTimeoutMs: number;
   directlySentBlockKeys: Set<string>;
 }): (payload: ReplyPayload) => Promise<void> {
   return async (payload) => {
@@ -126,11 +148,27 @@ export function createBlockReplyDeliveryHandler(params: {
     if (params.blockStreamingEnabled && params.blockReplyPipeline) {
       params.blockReplyPipeline.enqueue(blockPayload);
     } else if (blockHasMedia) {
+      const timeoutError = new Error(
+        `block reply delivery timed out after ${params.blockReplyTimeoutMs}ms`,
+      );
+      const abortController = new AbortController();
       try {
-        await params.onBlockReply(blockPayload);
+        await withTimeout(
+          Promise.resolve(
+            params.onBlockReply(blockPayload, {
+              abortSignal: abortController.signal,
+              timeoutMs: params.blockReplyTimeoutMs,
+            }),
+          ),
+          params.blockReplyTimeoutMs,
+          timeoutError,
+        );
         // Track sent key to avoid duplicate delivery from the later final payload pass.
         params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
       } catch (err) {
+        if (err === timeoutError) {
+          abortController.abort();
+        }
         logVerbose(`block reply delivery failed: ${String(err)}`);
       }
     }

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -126,9 +126,13 @@ export function createBlockReplyDeliveryHandler(params: {
     if (params.blockStreamingEnabled && params.blockReplyPipeline) {
       params.blockReplyPipeline.enqueue(blockPayload);
     } else if (blockHasMedia) {
-      // Track sent key to avoid duplicate delivery from the later final payload pass.
-      params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
-      await params.onBlockReply(blockPayload);
+      try {
+        await params.onBlockReply(blockPayload);
+        // Track sent key to avoid duplicate delivery from the later final payload pass.
+        params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
+      } catch (err) {
+        logVerbose(`block reply delivery failed: ${String(err)}`);
+      }
     }
     // When streaming is disabled entirely, text-only blocks are accumulated in the
     // final payload instead of being delivered incrementally.

--- a/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
+++ b/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
@@ -262,6 +262,51 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("deletes the direct cron session when last-target text delivery resolves to NO_REPLY", async () => {
+    await withTempHome(async (home) => {
+      const { storePath, deps } = await createTelegramDeliveryFixture(home);
+
+      mockEmbeddedAgentPayloads([{ text: "NO_REPLY" }]);
+
+      vi.mocked(deps.sendMessageTelegram as (...args: unknown[]) => unknown).mockClear();
+      vi.mocked(runSubagentAnnounceFlow).mockClear();
+      vi.mocked(callGateway).mockClear();
+
+      const deleteRes = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: {
+          ...makeJob({
+            kind: "agentTurn",
+            message: "do it",
+          }),
+          deleteAfterRun: true,
+          delivery: { mode: "announce", channel: "last" },
+        },
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(deleteRes.status).toBe("ok");
+      expect(deleteRes.delivered).toBe(false);
+      expect(deleteRes.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "sessions.delete",
+          params: expect.objectContaining({
+            key: "agent:main:cron:job-1",
+            deleteTranscript: true,
+            emitLifecycleHooks: false,
+          }),
+        }),
+      );
+    });
+  });
+
   it("skips structured outbound delivery when timeout abort is already set", async () => {
     await withTempHome(async (home) => {
       const { storePath, deps } = await createTelegramDeliveryFixture(home);

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -61,4 +61,46 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       });
     });
   });
+
+  it('suppresses exact "NO_REPLY" for plain announce delivery', async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it('suppresses exact "NO_REPLY" for forum-topic announce delivery', async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123:topic:42" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -103,4 +103,33 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
     });
   });
+
+  it('delivers forum-topic media payloads even when text is exact "NO_REPLY"', async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY", mediaUrl: "https://example.com/img.png" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123:topic:42" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(1);
+      expect(deps.sendMessageTelegram).toHaveBeenCalledWith(
+        "123",
+        "NO_REPLY",
+        expect.objectContaining({
+          cfg: expect.any(Object),
+          messageThreadId: 42,
+          mediaUrl: "https://example.com/img.png",
+        }),
+      );
+    });
+  });
 });

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -407,6 +407,24 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("skips announce when the agent reply is whitespace-padded NO_REPLY", async () => {
+    await withTelegramAnnounceFixture(async ({ home, storePath, deps }) => {
+      mockAgentPayloads([{ text: "  NO_REPLY \n" }]);
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("fails when structured direct delivery fails and best-effort is disabled", async () => {
     await expectStructuredTelegramFailure({
       payload: { text: "hello from cron", mediaUrl: "https://example.com/img.png" },

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -112,6 +112,24 @@ export type DispatchCronDeliveryState = {
   deliveryPayloads: ReplyPayload[];
 };
 
+function isDirectSilentReplyOnly(payloads: readonly ReplyPayload[]): boolean {
+  if (payloads.length !== 1) {
+    return false;
+  }
+  const [payload] = payloads;
+  if (!payload || !isSilentReplyText(payload.text, SILENT_REPLY_TOKEN)) {
+    return false;
+  }
+  return !(
+    payload.mediaUrl ||
+    (payload.mediaUrls?.length ?? 0) > 0 ||
+    payload.interactive ||
+    payload.btw ||
+    payload.audioAsVoice === true ||
+    Object.keys(payload.channelData ?? {}).length > 0
+  );
+}
+
 const TRANSIENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /\berrorcode=unavailable\b/i,
   /\bstatus\s*[:=]\s*"?unavailable\b/i,
@@ -339,6 +357,18 @@ export async function dispatchCronDelivery(
             : [];
       if (payloadsForDelivery.length === 0) {
         return null;
+      }
+      if (isDirectSilentReplyOnly(payloadsForDelivery)) {
+        deliveryAttempted = true;
+        delivered = false;
+        return params.withRunSession({
+          status: "ok",
+          summary,
+          outputText,
+          delivered: false,
+          deliveryAttempted: true,
+          ...params.telemetry,
+        });
       }
       if (params.isAborted()) {
         return params.withRunSession({

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,5 @@
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -522,7 +522,7 @@ export async function dispatchCronDelivery(
       hadDescendants &&
       synthesizedText.trim() === initialSynthesizedText &&
       isLikelyInterimCronMessage(initialSynthesizedText) &&
-      initialSynthesizedText.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase()
+      !isSilentReplyText(initialSynthesizedText, SILENT_REPLY_TOKEN)
     ) {
       // Descendants existed but no post-orchestration synthesis arrived AND
       // no descendant fallback reply was available. Suppress stale parent
@@ -537,12 +537,13 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+    if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
       return params.withRunSession({
         status: "ok",
         summary,
         outputText,
-        delivered: true,
+        delivered: false,
+        deliveryAttempted: true,
         ...params.telemetry,
       });
     }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -113,21 +113,26 @@ export type DispatchCronDeliveryState = {
 };
 
 function isDirectSilentReplyOnly(payloads: readonly ReplyPayload[]): boolean {
-  if (payloads.length !== 1) {
+  const textOnlyPayloads = payloads.filter((payload) => {
+    if (!payload) {
+      return false;
+    }
+    return !(
+      payload.mediaUrl ||
+      (payload.mediaUrls?.length ?? 0) > 0 ||
+      payload.interactive ||
+      payload.btw ||
+      payload.audioAsVoice === true ||
+      Object.keys(payload.channelData ?? {}).length > 0
+    );
+  });
+  if (textOnlyPayloads.length !== 1 || textOnlyPayloads.length !== payloads.length) {
     return false;
   }
-  const [payload] = payloads;
-  if (!payload || !isSilentReplyText(payload.text, SILENT_REPLY_TOKEN)) {
-    return false;
-  }
-  return !(
-    payload.mediaUrl ||
-    (payload.mediaUrls?.length ?? 0) > 0 ||
-    payload.interactive ||
-    payload.btw ||
-    payload.audioAsVoice === true ||
-    Object.keys(payload.channelData ?? {}).length > 0
-  );
+  // Direct cron suppression is intentionally limited to an exact single
+  // text-only NO_REPLY payload. Anything with media or structured content
+  // must continue through normal delivery.
+  return isSilentReplyText(textOnlyPayloads[0]?.text, SILENT_REPLY_TOKEN);
 }
 
 const TRANSIENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
@@ -568,6 +573,7 @@ export async function dispatchCronDelivery(
       });
     }
     if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
+      await cleanupDirectCronSessionIfNeeded();
       return params.withRunSession({
         status: "ok",
         summary,


### PR DESCRIPTION
## Summary
- preserve text when directly delivering media-bearing block replies while block streaming is disabled
- keep direct-send dedupe intact by recording the same full payload content key before final payload suppression
- add a regression covering text + media direct delivery through `runReplyAgent` with block streaming disabled

## Testing
- attempted: `pnpm test -- src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "preserves text for direct media delivery when block streaming is disabled"`
- local installs/tests were previously blocked by npm registry DNS failures in this environment (`EAI_AGAIN registry.npmjs.org`)

Closes #61535
