### PR TITLE
fix(transport): disable synthetic tool results for OpenAI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,8 @@ importers:
         specifier: 3.1022.0
         version: 3.1022.0
 
+  extensions/amazon-bedrock-mantle: {}
+
   extensions/anthropic: {}
 
   extensions/anthropic-vertex: {}
@@ -391,6 +393,8 @@ importers:
         version: link:../..
 
   extensions/firecrawl: {}
+
+  extensions/fireworks: {}
 
   extensions/github-copilot: {}
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -106,6 +106,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
               sanitizeMode: "images-only",
               sanitizeToolCallIds: context?.modelApi === "openai-completions",
               ...(context?.modelApi === "openai-completions" ? { toolCallIdMode: "strict" } : {}),
+              repairToolUseResultPairing: false,
               applyAssistantFirstOrderingFix: false,
               validateGeminiTurns: false,
               validateAnthropicTurns: false,
@@ -225,6 +226,24 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.applyGoogleTurnOrdering).toBe(false);
     expect(policy.validateGeminiTurns).toBe(false);
     expect(policy.validateAnthropicTurns).toBe(false);
+  });
+
+  it("disables tool-use/result pairing repair for OpenAI-compatible replay", () => {
+    const openAiResponsesPolicy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+    });
+    const codexResponsesPolicy = resolveTranscriptPolicy({
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      modelApi: "openai-codex-responses",
+    });
+
+    expect(openAiResponsesPolicy.repairToolUseResultPairing).toBe(false);
+    expect(openAiResponsesPolicy.allowSyntheticToolResults).toBe(false);
+    expect(codexResponsesPolicy.repairToolUseResultPairing).toBe(false);
+    expect(codexResponsesPolicy.allowSyntheticToolResults).toBe(false);
   });
 
   it("enables strict tool call id sanitization for openai-completions APIs", () => {

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -1,0 +1,57 @@
+import type { Api, Context, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { transformTransportMessages } from "./transport-message-transform.js";
+
+function makeModel(api: Api, provider: string, id: string): Model<Api> {
+  return { api, provider, id, input: [], output: [] } as unknown as Model<Api>;
+}
+
+function assistantToolCall(
+  id: string,
+  name = "read",
+): Extract<Context["messages"][number], { role: "assistant" }> {
+  return {
+    role: "assistant",
+    provider: "openai",
+    api: "openai-responses",
+    model: "gpt-5.4",
+    stopReason: "toolUse",
+    timestamp: Date.now(),
+    content: [{ type: "toolCall", id, name, arguments: {} }],
+  } as Extract<Context["messages"][number], { role: "assistant" }>;
+}
+
+describe("transformTransportMessages synthetic tool-result policy", () => {
+  it("does not synthesize missing tool results for OpenAI-compatible transports", () => {
+    const messages: Context["messages"] = [
+      assistantToolCall("call_openai_1"),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+
+    const result = transformTransportMessages(
+      messages,
+      makeModel("openai-responses", "openai", "gpt-5.4"),
+    );
+
+    expect(result.map((msg) => msg.role)).toEqual(["assistant", "user"]);
+  });
+
+  it("still synthesizes missing tool results for Anthropic transports", () => {
+    const messages: Context["messages"] = [
+      assistantToolCall("call_anthropic_1"),
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ];
+
+    const result = transformTransportMessages(
+      messages,
+      makeModel("anthropic-messages", "anthropic", "claude-opus-4-6"),
+    );
+
+    expect(result.map((msg) => msg.role)).toEqual(["assistant", "toolResult", "user"]);
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call_anthropic_1",
+      isError: true,
+    });
+  });
+});

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -1,5 +1,13 @@
 import type { Api, Context, Model } from "@mariozechner/pi-ai";
 
+function defaultAllowSyntheticToolResults(modelApi: Api): boolean {
+  return (
+    modelApi === "anthropic-messages" ||
+    modelApi === "bedrock-converse-stream" ||
+    modelApi === "google-generative-ai"
+  );
+}
+
 export function transformTransportMessages(
   messages: Context["messages"],
   model: Model<Api>,
@@ -8,7 +16,12 @@ export function transformTransportMessages(
     targetModel: Model<Api>,
     source: { provider: string; api: Api; model: string },
   ) => string,
+  options?: {
+    allowSyntheticToolResults?: boolean;
+  },
 ): Context["messages"] {
+  const allowSyntheticToolResults =
+    options?.allowSyntheticToolResults ?? defaultAllowSyntheticToolResults(model.api);
   const toolCallIdMap = new Map<string, string>();
   const transformed = messages.map((msg) => {
     if (msg.role === "user") {
@@ -75,16 +88,18 @@ export function transformTransportMessages(
   for (const msg of transformed) {
     if (msg.role === "assistant") {
       if (pendingToolCalls.length > 0) {
-        for (const toolCall of pendingToolCalls) {
-          if (!existingToolResultIds.has(toolCall.id)) {
-            result.push({
-              role: "toolResult",
-              toolCallId: toolCall.id,
-              toolName: toolCall.name,
-              content: [{ type: "text", text: "No result provided" }],
-              isError: true,
-              timestamp: Date.now(),
-            });
+        if (allowSyntheticToolResults) {
+          for (const toolCall of pendingToolCalls) {
+            if (!existingToolResultIds.has(toolCall.id)) {
+              result.push({
+                role: "toolResult",
+                toolCallId: toolCall.id,
+                toolName: toolCall.name,
+                content: [{ type: "text", text: "No result provided" }],
+                isError: true,
+                timestamp: Date.now(),
+              });
+            }
           }
         }
         pendingToolCalls = [];
@@ -110,16 +125,18 @@ export function transformTransportMessages(
       continue;
     }
     if (pendingToolCalls.length > 0) {
-      for (const toolCall of pendingToolCalls) {
-        if (!existingToolResultIds.has(toolCall.id)) {
-          result.push({
-            role: "toolResult",
-            toolCallId: toolCall.id,
-            toolName: toolCall.name,
-            content: [{ type: "text", text: "No result provided" }],
-            isError: true,
-            timestamp: Date.now(),
-          });
+      if (allowSyntheticToolResults) {
+        for (const toolCall of pendingToolCalls) {
+          if (!existingToolResultIds.has(toolCall.id)) {
+            result.push({
+              role: "toolResult",
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              content: [{ type: "text", text: "No result provided" }],
+              isError: true,
+              timestamp: Date.now(),
+            });
+          }
         }
       }
       pendingToolCalls = [];

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -22,6 +22,7 @@ export function buildOpenAICompatibleReplayPolicy(
   return {
     sanitizeToolCallIds: true,
     toolCallIdMode: "strict",
+    repairToolUseResultPairing: false,
     ...(modelApi === "openai-completions"
       ? {
           applyAssistantFirstOrderingFix: true,


### PR DESCRIPTION
## Summary
- disable synthetic orphan toolResult insertion for OpenAI-compatible transports by default
- keep synthetic toolResult behavior for Anthropic, Google, and Bedrock Converse transports
- add transport-level regression coverage for both OpenAI and Anthropic behavior

## Why
`resolveTranscriptPolicy()` already disables synthetic tool results for OpenAI-compatible replay, but `transformTransportMessages()` was still unconditionally inserting synthetic `toolResult` messages with "No result provided" when an orphan tool call was encountered.

That mismatch could poison OpenAI session history and lead to downstream pairing/replay failures.

This change aligns transport behavior with transcript policy expectations.

Follow-up / companion to #61337.

## Validation
- `pnpm exec vitest run --config vitest.config.ts --project agents src/agents/transport-message-transform.test.ts src/agents/transcript-policy.test.ts`
