### PR TITLE
fix: honour explicit cacheRetention long TTL for proxy endpoints

### DIFF
--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -74,7 +74,7 @@ describe("anthropic payload policy", () => {
     });
   });
 
-  it("denies proxied Anthropic service tier and omits long-TTL upgrades for custom hosts", () => {
+  it("denies proxied Anthropic service tier but honours explicit long-TTL for custom hosts", () => {
     const policy = resolveAnthropicPayloadPolicy({
       provider: "anthropic",
       api: "anthropic-messages",
@@ -91,16 +91,17 @@ describe("anthropic payload policy", () => {
     applyAnthropicPayloadPolicyToParams(payload, policy);
 
     expect(payload).not.toHaveProperty("service_tier");
+    // Explicit cacheRetention: "long" grants 1h TTL even for proxy endpoints
     expect(payload.system).toEqual([
       {
         type: "text",
         text: "Follow policy.",
-        cache_control: { type: "ephemeral" },
+        cache_control: { type: "ephemeral", ttl: "1h" },
       },
     ]);
     expect(payload.messages[0]).toEqual({
       role: "user",
-      content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral" } }],
+      content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral", ttl: "1h" } }],
     });
   });
 

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -58,7 +58,13 @@ function resolveAnthropicEphemeralCacheControl(
   if (retention === "none") {
     return undefined;
   }
-  const ttl = retention === "long" && isLongTtlEligibleEndpoint(baseUrl) ? "1h" : undefined;
+  // When the user explicitly configures cacheRetention: "long", honour the 1h TTL
+  // regardless of the base URL. The endpoint check is only meaningful for the auto
+  // default — proxy providers that forward to the real Anthropic API benefit from
+  // extended TTL just as much as direct connections.
+  const explicitLong = cacheRetention === "long";
+  const ttl =
+    retention === "long" && (explicitLong || isLongTtlEligibleEndpoint(baseUrl)) ? "1h" : undefined;
   return { type: "ephemeral", ...(ttl ? { ttl } : {}) };
 }
 


### PR DESCRIPTION
## Summary

- When `cacheRetention` is explicitly set to `"long"` in model params, grant the `1h` cache TTL regardless of the provider's base URL
- Previously, `isLongTtlEligibleEndpoint()` silently downgraded proxy providers (e.g. `localhost`, custom domains) to the 5-minute default — even when the user explicitly requested long retention
- Proxy providers that forward to the real Anthropic API benefit from extended TTL just as much as direct connections

## Context

Custom Anthropic-compatible proxy providers (e.g. `api: "anthropic-messages"` with a local base URL) were unable to get `ttl: "1h"` on `cache_control` markers because `isLongTtlEligibleEndpoint()` only allowed `api.anthropic.com` and `aiplatform.googleapis.com`. The endpoint check is meaningful as an auto-default, but should not override an explicit user configuration.

## Test plan

- [x] Updated existing test: "denies proxied Anthropic service tier but honours explicit long-TTL for custom hosts"
- [x] All 6 tests in `anthropic-payload-policy.test.ts` pass
- [x] Verified with a local proxy setup (`cacheRetention: "long"`, `baseUrl: "http://localhost:3456"`) that `cache_control` now includes `ttl: "1h"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)