### PR TITLE
fix(bluebubbles): normalize iMessageLite chatGuid for satellite messages

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { normalizeWebhookMessage, normalizeWebhookReaction } from "./monitor-normalize.js";
+import { normalizeChatGuidService } from "./targets.js";
 
 function createFallbackDmPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -119,6 +120,50 @@ describe("normalizeWebhookMessage", () => {
 
     expect(result).not.toBeNull();
     expect(result?.participants).toEqual([{ id: "+15551234567" }, { id: "+15557654321" }]);
+  });
+
+  it("normalizes iMessageLite chatGuid to iMessage (satellite messages)", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-sat-1",
+        text: "sent via satellite",
+        isGroup: false,
+        isFromMe: false,
+        handle: { address: "+13178204214" },
+        chatGuid: "iMessageLite;-;+13178204214",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.chatGuid).toBe("iMessage;-;+13178204214");
+    expect(result?.senderId).toBe("+13178204214");
+  });
+});
+
+describe("normalizeChatGuidService", () => {
+  it("remaps iMessageLite to iMessage", () => {
+    expect(normalizeChatGuidService("iMessageLite;-;+13178204214")).toBe(
+      "iMessage;-;+13178204214",
+    );
+  });
+
+  it("remaps iMessageLite case-insensitively", () => {
+    expect(normalizeChatGuidService("imessagelite;-;+13178204214")).toBe(
+      "iMessage;-;+13178204214",
+    );
+  });
+
+  it("leaves iMessage unchanged", () => {
+    expect(normalizeChatGuidService("iMessage;-;+15551234567")).toBe("iMessage;-;+15551234567");
+  });
+
+  it("leaves SMS unchanged", () => {
+    expect(normalizeChatGuidService("SMS;-;+15551234567")).toBe("SMS;-;+15551234567");
+  });
+
+  it("handles group chat guids", () => {
+    expect(normalizeChatGuidService("iMessageLite;+;chat123456")).toBe("iMessage;+;chat123456");
   });
 });
 

--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -1,5 +1,9 @@
 import { parseFiniteNumber } from "openclaw/plugin-sdk/infra-runtime";
-import { extractHandleFromChatGuid, normalizeBlueBubblesHandle } from "./targets.js";
+import {
+  extractHandleFromChatGuid,
+  normalizeBlueBubblesHandle,
+  normalizeChatGuidService,
+} from "./targets.js";
 import type { BlueBubblesAttachment } from "./types.js";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -248,7 +252,7 @@ function extractChatContext(message: Record<string, unknown>): {
 } {
   const chat = asRecord(message.chat) ?? asRecord(message.conversation) ?? null;
   const chatFromList = readFirstChatRecord(message);
-  const chatGuid =
+  const rawChatGuid =
     readString(message, "chatGuid") ??
     readString(message, "chat_guid") ??
     readString(chat, "chatGuid") ??
@@ -257,6 +261,9 @@ function extractChatContext(message: Record<string, unknown>): {
     readString(chatFromList, "chatGuid") ??
     readString(chatFromList, "chat_guid") ??
     readString(chatFromList, "guid");
+  // Satellite messages arrive as "iMessageLite;-;…" — normalize to "iMessage"
+  // so downstream send calls use a service type macOS Messages recognizes.
+  const chatGuid = rawChatGuid ? normalizeChatGuidService(rawChatGuid) : rawChatGuid;
   const chatIdentifier =
     readString(message, "chatIdentifier") ??
     readString(message, "chat_identifier") ??

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -56,9 +56,7 @@ function parseRawChatGuid(value: string): string | null {
   if (separator !== "+" && separator !== "-") {
     return null;
   }
-  // Normalize service directly — it's already split out, no need to regex the full string.
-  const normalizedService = service.toLowerCase() === "imessagelite" ? "iMessage" : service;
-  return `${normalizedService};${separator};${identifier}`;
+  return normalizeChatGuidService(`${service};${separator};${identifier}`);
 }
 
 function stripPrefix(value: string, prefix: string): string {

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -28,6 +28,16 @@ const SERVICE_PREFIXES: Array<{ prefix: string; service: BlueBubblesService }> =
 const CHAT_IDENTIFIER_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const CHAT_IDENTIFIER_HEX_RE = /^[0-9a-f]{24,64}$/i;
 
+/**
+ * Normalize the service component of a chat GUID.
+ * Satellite messages use "iMessageLite" but macOS Messages only recognizes
+ * "iMessage", so we remap it to avoid AppleScript send failures.
+ */
+const IMESSAGE_LITE_RE = /^iMessageLite(?=;)/i;
+export function normalizeChatGuidService(chatGuid: string): string {
+  return chatGuid.replace(IMESSAGE_LITE_RE, "iMessage");
+}
+
 function parseRawChatGuid(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -46,7 +56,9 @@ function parseRawChatGuid(value: string): string | null {
   if (separator !== "+" && separator !== "-") {
     return null;
   }
-  return `${service};${separator};${identifier}`;
+  // Normalize service directly — it's already split out, no need to regex the full string.
+  const normalizedService = service.toLowerCase() === "imessagelite" ? "iMessage" : service;
+  return `${normalizedService};${separator};${identifier}`;
 }
 
 function stripPrefix(value: string, prefix: string): string {


### PR DESCRIPTION
## Summary

- Satellite messages (sent via iPhone satellite connectivity) arrive with service type `iMessageLite` in the `chatGuid` (e.g. `iMessageLite;-;+1234567890`), which macOS Messages does not recognize as a valid service, causing AppleScript send failures.
- Normalizes `iMessageLite` to `iMessage` at both webhook ingestion time (`monitor-normalize.ts`) and target parsing time (`targets.ts`), so downstream send calls use a service type macOS Messages recognizes.
- Includes test coverage for the normalization in `monitor-normalize.test.ts`.

## Test plan

- [x] Unit tests added for `normalizeChatGuidService` covering `iMessageLite` -> `iMessage` remapping
- [x] Existing BlueBubbles monitor-normalize tests continue to pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)