### PR TITLE
Harden Discord reads and message targeting

### DIFF
--- a/extensions/discord/src/actions/runtime.messaging.ts
+++ b/extensions/discord/src/actions/runtime.messaging.ts
@@ -40,6 +40,7 @@ import {
 } from "../send.js";
 import type { DiscordSendComponents, DiscordSendEmbeds } from "../send.shared.js";
 import { resolveDiscordChannelId } from "../targets.js";
+import { logDebug, logWarn } from "../../../../src/logger.js";
 
 export const discordMessagingActionRuntime = {
   createThreadDiscord,
@@ -73,6 +74,127 @@ function hasDiscordComponentObjectKeys(value: unknown): value is Record<string, 
     !Array.isArray(value) &&
     Object.keys(value as Record<string, unknown>).length > 0,
   );
+}
+
+const DISCORD_READ_DEFAULT_LIMIT = 20;
+const DISCORD_READ_MAX_LIMIT = 100;
+const DISCORD_READ_TEXT_LIMIT = 500;
+const DISCORD_READ_WARN_CHARS = 10_000;
+
+type DiscordReadDetailMode = "compact" | "raw";
+
+type DiscordCompactMessage = {
+  id: string;
+  timestampUtc?: string;
+  sender: string;
+  text: string;
+};
+
+function readDiscordReadDetailMode(params: Record<string, unknown>): DiscordReadDetailMode {
+  const detail = readStringParam(params, "detail");
+  if (!detail) {
+    return "compact";
+  }
+  if (detail === "compact" || detail === "raw") {
+    return detail;
+  }
+  throw new Error("detail must be compact or raw");
+}
+
+function clampDiscordReadLimit(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DISCORD_READ_DEFAULT_LIMIT;
+  }
+  return Math.min(Math.max(Math.floor(value), 1), DISCORD_READ_MAX_LIMIT);
+}
+
+function truncateDiscordReadText(value: string): string {
+  if (value.length <= DISCORD_READ_TEXT_LIMIT) {
+    return value;
+  }
+  return `${value.slice(0, DISCORD_READ_TEXT_LIMIT - 1)}…`;
+}
+
+function readDiscordSender(message: Record<string, unknown>): string {
+  const member = message.member;
+  if (member && typeof member === "object") {
+    const nick = (member as { nick?: unknown }).nick;
+    if (typeof nick === "string" && nick.trim()) {
+      return nick.trim();
+    }
+  }
+  const author = message.author;
+  if (author && typeof author === "object") {
+    const globalName = (author as { global_name?: unknown }).global_name;
+    if (typeof globalName === "string" && globalName.trim()) {
+      return globalName.trim();
+    }
+    const username = (author as { username?: unknown }).username;
+    if (typeof username === "string" && username.trim()) {
+      return username.trim();
+    }
+    const id = (author as { id?: unknown }).id;
+    if (typeof id === "string" && id.trim()) {
+      return id.trim();
+    }
+  }
+  return "unknown";
+}
+
+function compactDiscordMessage(message: Record<string, unknown>): DiscordCompactMessage {
+  const text = typeof message.content === "string" ? message.content.trim() : "";
+  return {
+    id: typeof message.id === "string" ? message.id : "",
+    timestampUtc:
+      typeof message.timestampUtc === "string"
+        ? message.timestampUtc
+        : typeof message.timestamp === "string"
+          ? message.timestamp
+          : undefined,
+    sender: readDiscordSender(message),
+    text: truncateDiscordReadText(text || "[non-text content omitted]"),
+  };
+}
+
+function orderDiscordMessagesOldestFirst<T extends { timestampUtc?: string; id?: string }>(
+  messages: T[],
+): T[] {
+  return [...messages].toSorted((left, right) => {
+    const leftTime = left.timestampUtc ? Date.parse(left.timestampUtc) : Number.NaN;
+    const rightTime = right.timestampUtc ? Date.parse(right.timestampUtc) : Number.NaN;
+    const leftHasTime = Number.isFinite(leftTime);
+    const rightHasTime = Number.isFinite(rightTime);
+    if (leftHasTime && rightHasTime && leftTime !== rightTime) {
+      return leftTime - rightTime;
+    }
+    if (leftHasTime !== rightHasTime) {
+      return leftHasTime ? -1 : 1;
+    }
+    return String(left.id ?? "").localeCompare(String(right.id ?? ""));
+  });
+}
+
+function logDiscordReadDiagnostics(params: {
+  requestedTarget: string;
+  resolvedTarget: string;
+  detail: DiscordReadDetailMode;
+  limit: number;
+  returnedMessages: number;
+  chars: number;
+}) {
+  const summary = JSON.stringify({
+    requestedTarget: params.requestedTarget,
+    resolvedTarget: params.resolvedTarget,
+    provider: "discord",
+    detail: params.detail,
+    limit: params.limit,
+    returnedMessages: params.returnedMessages,
+    chars: params.chars,
+  });
+  logDebug(`discord-read ${summary}`);
+  if (params.chars > DISCORD_READ_WARN_CHARS) {
+    logWarn(`discord-read large-payload ${summary}`);
+  }
 }
 
 function parseDiscordMessageLink(link: string) {
@@ -275,8 +397,13 @@ export async function handleDiscordMessagingAction(
         throw new Error("Discord message reads are disabled.");
       }
       const channelId = resolveChannelId();
+      const requestedTarget = readStringParam(params, "channelId", {
+        required: true,
+      });
+      const detail = readDiscordReadDetailMode(params);
+      const limit = clampDiscordReadLimit(readNumberParam(params, "limit"));
       const query = {
-        limit: readNumberParam(params, "limit"),
+        limit,
         before: readStringParam(params, "before"),
         after: readStringParam(params, "after"),
         around: readStringParam(params, "around"),
@@ -287,10 +414,33 @@ export async function handleDiscordMessagingAction(
             accountId,
           })
         : await discordMessagingActionRuntime.readMessagesDiscord(channelId, query, cfgOptions);
-      return jsonResult({
-        ok: true,
-        messages: messages.map((message) => normalizeMessage(message)),
+      const normalizedMessages = messages.map((message) => normalizeMessage(message));
+      const payload =
+        detail === "raw"
+          ? {
+              ok: true,
+              messages: normalizedMessages,
+            }
+          : {
+              ok: true,
+              messages: orderDiscordMessagesOldestFirst(
+                normalizedMessages
+                  .filter(
+                    (message): message is Record<string, unknown> =>
+                      Boolean(message) && typeof message === "object",
+                  )
+                  .map((message) => compactDiscordMessage(message)),
+              ),
+            };
+      logDiscordReadDiagnostics({
+        requestedTarget,
+        resolvedTarget: channelId,
+        detail,
+        limit,
+        returnedMessages: payload.messages.length,
+        chars: JSON.stringify(payload).length,
       });
+      return jsonResult(payload);
     }
     case "sendMessage": {
       if (!isActionEnabled("messages")) {

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -246,7 +246,18 @@ describe("handleDiscordMessagingAction", () => {
 
   it("adds normalized timestamps to readMessages payloads", async () => {
     readMessagesDiscord.mockResolvedValueOnce([
-      { id: "1", timestamp: "2026-01-15T10:00:00.000Z" },
+      {
+        id: "2",
+        timestamp: "2026-01-15T10:05:00.000Z",
+        content: "second",
+        author: { username: "Beta" },
+      },
+      {
+        id: "1",
+        timestamp: "2026-01-15T10:00:00.000Z",
+        content: "first",
+        author: { username: "Alpha" },
+      },
     ] as never);
 
     const result = await handleDiscordMessagingAction(
@@ -255,12 +266,100 @@ describe("handleDiscordMessagingAction", () => {
       enableAllActions,
     );
     const payload = result.details as {
-      messages: Array<{ timestampMs?: number; timestampUtc?: string }>;
+      messages: Array<{ id: string; timestampUtc?: string; sender: string; text: string }>;
     };
 
-    const expectedMs = Date.parse("2026-01-15T10:00:00.000Z");
-    expect(payload.messages[0].timestampMs).toBe(expectedMs);
-    expect(payload.messages[0].timestampUtc).toBe(new Date(expectedMs).toISOString());
+    expect(readMessagesDiscord).toHaveBeenCalledWith(
+      "C1",
+      {
+        limit: 20,
+        before: undefined,
+        after: undefined,
+        around: undefined,
+      },
+      {},
+    );
+    expect(payload.messages).toEqual([
+      {
+        id: "1",
+        timestampUtc: "2026-01-15T10:00:00.000Z",
+        sender: "Alpha",
+        text: "first",
+      },
+      {
+        id: "2",
+        timestampUtc: "2026-01-15T10:05:00.000Z",
+        sender: "Beta",
+        text: "second",
+      },
+    ]);
+  });
+
+  it("returns raw Discord read payloads when detail=raw", async () => {
+    readMessagesDiscord.mockResolvedValueOnce([
+      {
+        id: "1",
+        timestamp: "2026-01-15T10:00:00.000Z",
+        content: "hello",
+        author: { username: "Alpha" },
+      },
+    ] as never);
+
+    const result = await handleDiscordMessagingAction(
+      "readMessages",
+      { channelId: "C1", detail: "raw", limit: 50 },
+      enableAllActions,
+    );
+    const payload = result.details as {
+      messages: Array<{
+        timestampMs?: number;
+        timestampUtc?: string;
+        author?: { username?: string };
+      }>;
+    };
+
+    expect(readMessagesDiscord).toHaveBeenCalledWith(
+      "C1",
+      {
+        limit: 50,
+        before: undefined,
+        after: undefined,
+        around: undefined,
+      },
+      {},
+    );
+    expect(payload.messages[0].timestampMs).toBe(Date.parse("2026-01-15T10:00:00.000Z"));
+    expect(payload.messages[0].author?.username).toBe("Alpha");
+  });
+
+  it("truncates long non-text Discord reads into compact placeholders", async () => {
+    readMessagesDiscord.mockResolvedValueOnce([
+      {
+        id: "1",
+        timestamp: "2026-01-15T10:00:00.000Z",
+        content: "",
+        author: { username: "Alpha" },
+      },
+      {
+        id: "2",
+        timestamp: "2026-01-15T10:01:00.000Z",
+        content: "x".repeat(700),
+        author: { username: "Beta" },
+      },
+    ] as never);
+
+    const result = await handleDiscordMessagingAction(
+      "readMessages",
+      { channelId: "C1" },
+      enableAllActions,
+    );
+    const payload = result.details as {
+      messages: Array<{ text: string }>;
+    };
+
+    expect(payload.messages[0].text).toBe("[non-text content omitted]");
+    expect(payload.messages[1].text).toHaveLength(500);
+    expect(payload.messages[1].text.endsWith("…")).toBe(true);
   });
 
   it("threads provided cfg into readMessages calls", async () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -45,8 +45,18 @@ function actionNeedsExplicitTarget(action: ChannelMessageActionName): boolean {
 }
 function buildRoutingSchema() {
   return {
-    channel: Type.Optional(Type.String()),
-    target: Type.Optional(channelTargetSchema({ description: "Target channel/user id or name." })),
+    channel: Type.Optional(
+      Type.String({
+        description:
+          "Message provider to use (for example discord, slack, telegram). Do not put a Discord channel id here; use target.",
+      }),
+    ),
+    target: Type.Optional(
+      channelTargetSchema({
+        description:
+          "Target channel/user/thread id or name within the selected/current provider. Use this for Discord channel ids.",
+      }),
+    ),
     targets: Type.Optional(channelTargetsSchema()),
     accountId: Type.Optional(Type.String()),
     dryRun: Type.Optional(Type.Boolean()),
@@ -165,6 +175,12 @@ function buildFetchSchema() {
     limit: Type.Optional(Type.Number()),
     pageSize: Type.Optional(Type.Number()),
     pageToken: Type.Optional(Type.String()),
+    detail: Type.Optional(
+      stringEnum(["compact", "raw"], {
+        description:
+          "Read payload detail level. compact is the safe default for Discord history; raw keeps the full normalized payload.",
+      }),
+    ),
     before: Type.Optional(Type.String()),
     after: Type.Optional(Type.String()),
     around: Type.Optional(Type.String()),
@@ -564,7 +580,8 @@ function buildMessageToolDescription(options?: {
   agentId?: string;
   requesterSenderId?: string;
 }): string {
-  const baseDescription = "Send, delete, and manage messages via channel plugins.";
+  const baseDescription =
+    "Send, delete, and manage messages via channel plugins. Use `target` for channel/user/thread ids or names; `channel` selects the provider.";
   const resolvedOptions = options ?? {};
   const currentChannel = normalizeMessageChannel(resolvedOptions.currentChannel);
 
@@ -726,8 +743,6 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       if (requireExplicitTarget && actionNeedsExplicitTarget(action)) {
         const explicitTarget =
           (typeof params.target === "string" && params.target.trim().length > 0) ||
-          (typeof params.to === "string" && params.to.trim().length > 0) ||
-          (typeof params.channelId === "string" && params.channelId.trim().length > 0) ||
           (Array.isArray(params.targets) &&
             params.targets.some((value) => typeof value === "string" && value.trim().length > 0));
         if (!explicitTarget) {

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -131,92 +131,80 @@ describe("resolveMessageChannelSelection", () => {
   beforeEach(() => {
     mocks.listChannelPlugins.mockReset();
     mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.resolveOutboundChannelPlugin.mockReset();
+    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) => ({
+      id: channel,
+    }));
   });
 
-  it.each([
-    {
-      params: { cfg: {} as never, channel: "telegram" },
-      expected: {
-        channel: "telegram",
-        configured: [],
-        source: "explicit",
-      },
-    },
-    {
-      setup: () => {
-        const isConfigured = vi.fn(async () => true);
-        mocks.listChannelPlugins.mockReturnValue([makePlugin({ id: "slack", isConfigured })]);
-        return { isConfigured };
-      },
-      params: { cfg: {} as never, channel: "slack" },
-      expected: {
-        channel: "slack",
-        configured: [],
-        source: "explicit",
-      },
-      verify: ({ isConfigured }: { isConfigured?: ReturnType<typeof vi.fn> }) => {
-        expect(isConfigured).not.toHaveBeenCalled();
-      },
-    },
-    {
-      params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "slack" },
-      expected: {
-        channel: "slack",
-        configured: [],
-        source: "tool-context-fallback",
-      },
-    },
-    {
-      params: { cfg: {} as never, fallbackChannel: "signal" },
-      expected: {
-        channel: "signal",
-        configured: [],
-        source: "tool-context-fallback",
-      },
-    },
-    {
-      setup: () => {
-        mocks.listChannelPlugins.mockReturnValue([
-          makePlugin({ id: "discord", isConfigured: async () => true }),
-        ]);
-      },
-      params: { cfg: {} as never },
-      expected: {
+  it("keeps explicit known channels and marks source explicit", async () => {
+    const selection = await resolveMessageChannelSelection({
+      cfg: {} as never,
+      channel: "telegram",
+    });
+
+    expect(selection).toEqual({
+      channel: "telegram",
+      configured: [],
+      source: "explicit",
+    });
+  });
+
+  it("does not fall back when an explicit channel looks like a target id", async () => {
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: {} as never,
+        channel: "1475627489236881568",
+        fallbackChannel: "discord",
+      }),
+    ).rejects.toThrow(/Use `target` for channel\/user\/thread ids or names/);
+  });
+
+  it("does not fall back when an explicit channel is unavailable", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(undefined);
+
+    await expect(
+      resolveMessageChannelSelection({
+        cfg: {} as never,
         channel: "discord",
-        configured: ["discord"],
-        source: "single-configured",
-      },
-    },
-    {
-      setup: () => {
-        mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) =>
-          channel === "slack" ? { id: "slack" } : undefined,
-        );
-      },
-      params: { cfg: {} as never, channel: "discord", fallbackChannel: "slack" },
-      expected: {
-        channel: "slack",
-        configured: [],
-        source: "tool-context-fallback",
-      },
-    },
-  ])("resolves message channel selection for %j", async ({ setup, params, expected, verify }) => {
-    const setupResult = setup?.();
-    await expect(expectResolvedSelection(params)).resolves.toEqual(expected);
-    verify?.(setupResult as never);
+        fallbackChannel: "slack",
+      }),
+    ).rejects.toThrow("Channel is unavailable: discord");
+  });
+
+  it("uses fallback channel when explicit channel is omitted", async () => {
+    const selection = await resolveMessageChannelSelection({
+      cfg: {} as never,
+      fallbackChannel: "signal",
+    });
+
+    expect(selection).toEqual({
+      channel: "signal",
+      configured: [],
+      source: "tool-context-fallback",
+    });
+  });
+
+  it("selects single configured channel when no explicit/fallback channel exists", async () => {
+    mocks.listChannelPlugins.mockReturnValue([
+      makePlugin({ id: "discord", isConfigured: async () => true }),
+    ]);
+
+    const selection = await resolveMessageChannelSelection({
+      cfg: {} as never,
+    });
+
+    expect(selection).toEqual({
+      channel: "discord",
+      configured: ["discord"],
+      source: "single-configured",
+    });
   });
 
   it.each([
     {
-      params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "not-a-channel" },
-      expectedMessage: "Unknown channel: channel:c123",
-    },
-    {
-      setup: () => {
-        mocks.resolveOutboundChannelPlugin.mockReturnValue(undefined);
-      },
-      params: { cfg: {} as never, channel: "discord" },
-      expectedMessage: "Channel is unavailable: discord",
+      params: { cfg: {} as never, channel: "not-a-channel" },
+      expectedMessage: "Unknown channel provider: not-a-channel",
     },
     {
       params: { cfg: {} as never },

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -52,6 +52,28 @@ function resolveAvailableKnownChannel(params: {
     : undefined;
 }
 
+function looksLikeTargetValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return (
+    /^[0-9]{6,}$/.test(trimmed) ||
+    /^[a-z][0-9]{6,}$/i.test(trimmed) ||
+    trimmed.startsWith("channel:") ||
+    trimmed.startsWith("<#") ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("@")
+  );
+}
+
+function formatUnknownChannelError(value: string): string {
+  if (looksLikeTargetValue(value)) {
+    return `Unknown channel provider: ${value}. Use \`target\` for channel/user/thread ids or names; \`channel\` selects the provider (for example \`discord\`).`;
+  }
+  return `Unknown channel provider: ${value}`;
+}
+
 function isAccountEnabled(account: unknown): boolean {
   if (!account || typeof account !== "object") {
     return true;
@@ -153,25 +175,14 @@ export async function resolveMessageChannelSelection(params: {
 }> {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
+    if (!isKnownChannel(normalized)) {
+      throw new Error(formatUnknownChannelError(String(normalized)));
+    }
     const availableExplicit = resolveAvailableKnownChannel({
       cfg: params.cfg,
       value: normalized,
     });
     if (!availableExplicit) {
-      const fallback = resolveAvailableKnownChannel({
-        cfg: params.cfg,
-        value: params.fallbackChannel,
-      });
-      if (fallback) {
-        return {
-          channel: fallback,
-          configured: [],
-          source: "tool-context-fallback",
-        };
-      }
-      if (!isKnownChannel(normalized)) {
-        throw new Error(`Unknown channel: ${String(normalized)}`);
-      }
       throw new Error(`Channel is unavailable: ${String(normalized)}`);
     }
     return {

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -2,170 +2,101 @@ import { describe, expect, it } from "vitest";
 import { normalizeMessageActionInput } from "./message-action-normalization.js";
 
 describe("normalizeMessageActionInput", () => {
-  type NormalizeMessageActionInputCase = {
-    input: Parameters<typeof normalizeMessageActionInput>[0];
-    expectedFields?: Record<string, unknown>;
-    absentFields?: string[];
-  };
-
-  it.each([
-    {
-      input: {
-        action: "send",
-        args: {
-          target: "channel:C1",
-          to: "legacy",
-          channelId: "legacy-channel",
-        },
-      },
-      expectedFields: { target: "channel:C1", to: "channel:C1" },
-      absentFields: ["channelId"],
-    },
-    {
-      input: {
-        action: "send",
-        args: {
-          target: "1214056829",
-          channelId: "",
-          to: "   ",
-        },
-      },
-      expectedFields: { target: "1214056829", to: "1214056829" },
-      absentFields: ["channelId"],
-    },
-    {
-      input: {
+  it("rejects legacy to targets", () => {
+    expect(() =>
+      normalizeMessageActionInput({
         action: "send",
         args: {
           to: "channel:C1",
         },
-      },
-      expectedFields: { target: "channel:C1", to: "channel:C1" },
-    },
-    {
-      input: {
-        action: "send",
-        args: {},
-        toolContext: {
-          currentChannelId: "channel:C1",
-        },
-      },
-      expectedFields: { target: "channel:C1", to: "channel:C1" },
-    },
-    {
-      input: {
-        action: "send",
-        args: {
-          target: "channel:C1",
-        },
-        toolContext: {
-          currentChannelId: "C1",
-          currentChannelProvider: "slack",
-        },
-      },
-      expectedFields: { channel: "slack" },
-    },
-    {
-      input: {
-        action: "broadcast",
-        args: {},
-        toolContext: {
-          currentChannelId: "channel:C1",
-        },
-      },
-      absentFields: ["target", "to"],
-    },
-    {
-      input: {
-        action: "send",
-        args: {
-          target: "channel:C1",
-        },
-        toolContext: {
-          currentChannelProvider: "webchat",
-        },
-      },
-      absentFields: ["channel"],
-    },
-    {
-      input: {
-        action: "edit",
-        args: {
-          messageId: "msg_123",
-        },
-        toolContext: {
-          currentChannelId: "channel:C1",
-        },
-      },
-      expectedFields: { messageId: "msg_123" },
-      absentFields: ["target", "to"],
-    },
-    {
-      input: {
-        action: "pin",
-        args: {
-          channel: "feishu",
-          messageId: "om_123",
-        },
-      },
-      expectedFields: { messageId: "om_123" },
-      absentFields: ["target", "to"],
-    },
-    {
-      input: {
-        action: "list-pins",
-        args: {
-          channel: "feishu",
-          chatId: "oc_123",
-        },
-      },
-      expectedFields: { chatId: "oc_123" },
-      absentFields: ["target", "to"],
-    },
-    {
-      input: {
+      }),
+    ).toThrow(/Use `target` instead of `to`\/`channelId`/);
+  });
+
+  it("rejects legacy channelId targets for target-taking actions", () => {
+    expect(() =>
+      normalizeMessageActionInput({
         action: "read",
         args: {
-          channel: "slack",
-          messageId: "123.456",
+          channelId: "channel:C1",
         },
-        toolContext: {
-          currentChannelId: "C12345678",
-          currentChannelProvider: "slack",
-        },
-      },
-      expectedFields: { target: "C12345678", messageId: "123.456" },
-    },
-    {
-      input: {
+      }),
+    ).toThrow(/Use `target` instead of `to`\/`channelId`/);
+  });
+
+  it("rejects legacy channelId targets for channel actions", () => {
+    expect(() =>
+      normalizeMessageActionInput({
         action: "channel-info",
         args: {
-          channelId: "C123",
+          channelId: "channel:C1",
         },
+      }),
+    ).toThrow(/Use `target` instead of `to`\/`channelId`/);
+  });
+
+  it("infers target from tool context when required", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {},
+      toolContext: {
+        currentChannelId: "channel:C1",
       },
-      expectedFields: { target: "C123", channelId: "C123" },
-      absentFields: ["to"],
-    },
-  ] satisfies NormalizeMessageActionInputCase[])(
-    "normalizes message action input for %j",
-    ({ input, expectedFields, absentFields }) => {
-      const normalized = normalizeMessageActionInput(input);
-      if (expectedFields) {
-        for (const [field, value] of Object.entries(expectedFields)) {
-          expect(normalized[field]).toBe(value);
-        }
-      }
-      for (const field of absentFields ?? []) {
-        expect(field in normalized).toBe(false);
-      }
-    },
-  );
+    });
+
+    expect(normalized.target).toBe("channel:C1");
+    expect(normalized.to).toBe("channel:C1");
+  });
+
+  it("infers channel from tool context provider", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        target: "channel:C1",
+      },
+      toolContext: {
+        currentChannelId: "C1",
+        currentChannelProvider: "slack",
+      },
+    });
+
+    expect(normalized.channel).toBe("slack");
+  });
+
+  it("does not overwrite explicit targets with tool-context fallback", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        target: "channel:C9",
+      },
+      toolContext: {
+        currentChannelId: "channel:C1",
+        currentChannelProvider: "slack",
+      },
+    });
+
+    expect(normalized.target).toBe("channel:C9");
+    expect(normalized.to).toBe("channel:C9");
+  });
 
   it("throws when required target remains unresolved", () => {
     expect(() =>
       normalizeMessageActionInput({
         action: "send",
         args: {},
+      }),
+    ).toThrow(/requires a target/);
+  });
+
+  it("does not infer read targets from tool context", () => {
+    expect(() =>
+      normalizeMessageActionInput({
+        action: "read",
+        args: {},
+        toolContext: {
+          currentChannelId: "channel:C1",
+          currentChannelProvider: "discord",
+        },
       }),
     ).toThrow(/requires a target/);
   });

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -21,40 +21,20 @@ export function normalizeMessageActionInput(params: {
   const inferredChannel =
     explicitChannel || normalizeMessageChannel(toolContext?.currentChannelProvider) || "";
 
-  const explicitTarget =
-    typeof normalizedArgs.target === "string" ? normalizedArgs.target.trim() : "";
   const hasLegacyTargetFields =
     typeof normalizedArgs.to === "string" || typeof normalizedArgs.channelId === "string";
-  const hasLegacyTarget =
-    (typeof normalizedArgs.to === "string" && normalizedArgs.to.trim().length > 0) ||
-    (typeof normalizedArgs.channelId === "string" && normalizedArgs.channelId.trim().length > 0);
-
-  if (explicitTarget && hasLegacyTargetFields) {
-    delete normalizedArgs.to;
-    delete normalizedArgs.channelId;
+  if (actionRequiresTarget(action) && hasLegacyTargetFields) {
+    throw new Error("Use `target` instead of `to`/`channelId`.");
   }
 
   if (
-    !explicitTarget &&
-    !hasLegacyTarget &&
+    action !== "read" &&
     actionRequiresTarget(action) &&
     !actionHasTarget(action, normalizedArgs, { channel: inferredChannel })
   ) {
     const inferredTarget = toolContext?.currentChannelId?.trim();
     if (inferredTarget) {
       normalizedArgs.target = inferredTarget;
-    }
-  }
-
-  if (!explicitTarget && actionRequiresTarget(action) && hasLegacyTarget) {
-    const legacyTo = typeof normalizedArgs.to === "string" ? normalizedArgs.to.trim() : "";
-    const legacyChannelId =
-      typeof normalizedArgs.channelId === "string" ? normalizedArgs.channelId.trim() : "";
-    const legacyTarget = legacyTo || legacyChannelId;
-    if (legacyTarget) {
-      normalizedArgs.target = legacyTarget;
-      delete normalizedArgs.to;
-      delete normalizedArgs.channelId;
     }
   }
 

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -236,15 +236,6 @@ describe("runMessageAction context isolation", () => {
       toolContext: { currentChannelId: "C12345678" },
     },
     {
-      name: "accepts legacy to parameter for send",
-      cfg: slackConfig,
-      actionParams: {
-        channel: "slack",
-        to: "#C12345678",
-        message: "hi",
-      },
-    },
-    {
       name: "defaults to current channel when target is omitted",
       cfg: slackConfig,
       actionParams: {
@@ -284,6 +275,19 @@ describe("runMessageAction context isolation", () => {
     });
 
     expect(result.kind).toBe("send");
+  });
+
+  it("rejects legacy to parameter for send", async () => {
+    await expect(
+      runDrySend({
+        cfg: slackConfig,
+        actionParams: {
+          channel: "slack",
+          to: "#C12345678",
+          message: "hi",
+        },
+      }),
+    ).rejects.toThrow(/Use `target` instead of `to`\/`channelId`/);
   });
 
   it.each([
@@ -389,32 +393,6 @@ describe("runMessageAction context isolation", () => {
       expectedKind: "send",
       expectedChannel: "slack",
     },
-    {
-      name: "falls back to tool-context provider when channel param is an id",
-      cfg: slackConfig,
-      action: "send" as const,
-      actionParams: {
-        channel: "C12345678",
-        target: "#C12345678",
-        message: "hi",
-      },
-      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },
-      expectedKind: "send",
-      expectedChannel: "slack",
-    },
-    {
-      name: "falls back to tool-context provider for broadcast channel ids",
-      cfg: slackConfig,
-      action: "broadcast" as const,
-      actionParams: {
-        targets: ["channel:C12345678"],
-        channel: "C12345678",
-        message: "hi",
-      },
-      toolContext: { currentChannelProvider: "slack" },
-      expectedKind: "broadcast",
-      expectedChannel: "slack",
-    },
   ])("$name", async ({ cfg, action, actionParams, toolContext, expectedKind, expectedChannel }) => {
     const result = await runDryAction({
       cfg,
@@ -425,6 +403,38 @@ describe("runMessageAction context isolation", () => {
 
     expect(result.kind).toBe(expectedKind);
     expect(result.channel).toBe(expectedChannel);
+  });
+
+  it.each([
+    {
+      name: "send when channel param is a target-like id",
+      action: "send" as const,
+      actionParams: {
+        channel: "C12345678",
+        target: "#C12345678",
+        message: "hi",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },
+    },
+    {
+      name: "broadcast when channel param is a target-like id",
+      action: "broadcast" as const,
+      actionParams: {
+        targets: ["channel:C12345678"],
+        channel: "C12345678",
+        message: "hi",
+      },
+      toolContext: { currentChannelProvider: "slack" },
+    },
+  ])("rejects $name", async ({ action, actionParams, toolContext }) => {
+    await expect(
+      runDryAction({
+        cfg: slackConfig,
+        action,
+        actionParams,
+        toolContext,
+      }),
+    ).rejects.toThrow(/Use `target` for channel\/user\/thread ids or names/);
   });
 
   it.each([

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -108,6 +108,10 @@ export function actionHasTarget(
   params: Record<string, unknown>,
   options?: { channel?: string },
 ): boolean {
+  const target = typeof params.target === "string" ? params.target.trim() : "";
+  if (target) {
+    return true;
+  }
   const to = typeof params.to === "string" ? params.to.trim() : "";
   if (to) {
     return true;


### PR DESCRIPTION
## Summary\n- require explicit provider/target separation for message actions\n- remove legacy target aliases and current-thread fallback for read\n- default Discord reads to compact 20-message payloads with diagnostics\n\n## Testing\n- export PATH="/opt/homebrew/opt/node@22/bin:/Users/jamesdugle/.nvm/versions/node/v18.20.2/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/jamesdugle/.codex/tmp/arg0/codex-arg0iL3mXJ:/Users/jamesdugle/.bun/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/jamesdugle/.local/bin:/Users/jamesdugle/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk@11/bin:/Users/jamesdugle/.nvm/versions/node/v18.20.2/bin:/Applications/Codex.app/Contents/Resources"\n- corepack pnpm exec vitest run src/infra/outbound/channel-selection.test.ts src/infra/outbound/message-action-normalization.test.ts src/infra/outbound/message-action-runner.test.ts src/agents/tools/discord-actions.test.ts\n- export PATH="/opt/homebrew/opt/node@22/bin:/Users/jamesdugle/.nvm/versions/node/v18.20.2/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/jamesdugle/.codex/tmp/arg0/codex-arg0iL3mXJ:/Users/jamesdugle/.bun/bin:/opt/homebrew/share/google-cloud-sdk/bin:/Users/jamesdugle/.local/bin:/Users/jamesdugle/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk@11/bin:/Users/jamesdugle/.nvm/versions/node/v18.20.2/bin:/Applications/Codex.app/Contents/Resources" && corepack pnpm build