### PR TITLE
feat(venice): add video generation provider

### DIFF
--- a/extensions/venice/api.ts
+++ b/extensions/venice/api.ts
@@ -6,3 +6,4 @@ export {
   VENICE_MODEL_CATALOG,
 } from "./models.js";
 export { buildVeniceProvider } from "./provider-catalog.js";
+export { buildVeniceVideoGenerationProvider } from "./video-generation-provider.js";

--- a/extensions/venice/index.ts
+++ b/extensions/venice/index.ts
@@ -2,6 +2,7 @@ import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-en
 import { applyXaiModelCompat } from "openclaw/plugin-sdk/provider-tools";
 import { applyVeniceConfig, VENICE_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildVeniceProvider } from "./provider-catalog.js";
+import { buildVeniceVideoGenerationProvider } from "./video-generation-provider.js";
 
 const PROVIDER_ID = "venice";
 
@@ -43,5 +44,8 @@ export default defineSingleProviderPluginEntry({
     },
     normalizeResolvedModel: ({ modelId, model }) =>
       isXaiBackedVeniceModel(modelId) ? applyXaiModelCompat(model) : undefined,
+  },
+  register(api) {
+    api.registerVideoGenerationProvider(buildVeniceVideoGenerationProvider());
   },
 });

--- a/extensions/venice/video-generation-provider.test.ts
+++ b/extensions/venice/video-generation-provider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildVeniceVideoGenerationProvider } from "./video-generation-provider.js";
+
+describe("Venice video generation provider", () => {
+  const provider = buildVeniceVideoGenerationProvider();
+
+  it("has expected id and aliases", () => {
+    expect(provider.id).toBe("venice");
+    expect(provider.aliases).toContain("veniceai");
+  });
+
+  it("has a default model", () => {
+    expect(provider.defaultModel).toBe("wan-2.5-preview-image-to-video");
+  });
+
+  it("lists expected models", () => {
+    expect(provider.models).toContain("wan-2.5-preview-image-to-video");
+    expect(provider.models).toContain("kling-2.1-master-text-to-video");
+    expect(provider.models).toContain("minimax-image-to-video");
+    expect(provider.models).toContain("luma-ray-2-text-to-video");
+  });
+
+  it("has expected capabilities", () => {
+    expect(provider.capabilities.maxVideos).toBe(1);
+    expect(provider.capabilities.maxInputImages).toBe(1);
+    expect(provider.capabilities.maxInputVideos).toBe(0);
+    expect(provider.capabilities.maxDurationSeconds).toBe(10);
+    expect(provider.capabilities.supportedDurationSeconds).toEqual([5, 10]);
+    expect(provider.capabilities.supportsResolution).toBe(true);
+    expect(provider.capabilities.supportsAspectRatio).toBe(true);
+    expect(provider.capabilities.supportsAudio).toBe(true);
+  });
+
+  it("has isConfigured function", () => {
+    expect(typeof provider.isConfigured).toBe("function");
+  });
+
+  it("has generateVideo function", () => {
+    expect(typeof provider.generateVideo).toBe("function");
+  });
+});

--- a/extensions/venice/video-generation-provider.test.ts
+++ b/extensions/venice/video-generation-provider.test.ts
@@ -13,17 +13,37 @@ describe("Venice video generation provider", () => {
     expect(provider.defaultModel).toBe("wan-2.5-preview-image-to-video");
   });
 
-  it("lists expected models", () => {
+  it("lists expected image-to-video models", () => {
     expect(provider.models).toContain("wan-2.5-preview-image-to-video");
-    expect(provider.models).toContain("kling-2.1-master-text-to-video");
+    expect(provider.models).toContain("wan-2.6-720p-image-to-video");
+    expect(provider.models).toContain("wan-2.6-1080p-image-to-video");
+    expect(provider.models).toContain("kling-2.1-master-image-to-video");
+    expect(provider.models).toContain("kling-2.1-pro-image-to-video");
+    expect(provider.models).toContain("hunyuan-image-to-video");
     expect(provider.models).toContain("minimax-image-to-video");
+    expect(provider.models).toContain("luma-ray-2-image-to-video");
+    expect(provider.models).toContain("seedance-1-image-to-video");
+    expect(provider.models).toContain("vidu-2-image-to-video");
+  });
+
+  it("lists expected text-to-video models", () => {
+    expect(provider.models).toContain("kling-2.1-master-text-to-video");
+    expect(provider.models).toContain("kling-2.1-pro-text-to-video");
+    expect(provider.models).toContain("minimax-text-to-video");
     expect(provider.models).toContain("luma-ray-2-text-to-video");
+    expect(provider.models).toContain("seedance-1-text-to-video");
+    expect(provider.models).toContain("vidu-2-text-to-video");
+  });
+
+  it("lists video upscale models", () => {
+    expect(provider.models).toContain("video-upscale-topaz");
+    expect(provider.models).toContain("video-upscale-standard");
   });
 
   it("has expected capabilities", () => {
     expect(provider.capabilities.maxVideos).toBe(1);
     expect(provider.capabilities.maxInputImages).toBe(1);
-    expect(provider.capabilities.maxInputVideos).toBe(0);
+    expect(provider.capabilities.maxInputVideos).toBe(1);
     expect(provider.capabilities.maxDurationSeconds).toBe(10);
     expect(provider.capabilities.supportedDurationSeconds).toEqual([5, 10]);
     expect(provider.capabilities.supportsResolution).toBe(true);

--- a/extensions/venice/video-generation-provider.test.ts
+++ b/extensions/venice/video-generation-provider.test.ts
@@ -10,34 +10,34 @@ describe("Venice video generation provider", () => {
   });
 
   it("has a default model", () => {
-    expect(provider.defaultModel).toBe("wan-2.5-preview-image-to-video");
+    expect(provider.defaultModel).toBe("wan-2.7-image-to-video");
   });
 
-  it("lists expected image-to-video models", () => {
+  it("lists WAN models", () => {
+    expect(provider.models).toContain("wan-2.7-image-to-video");
+    expect(provider.models).toContain("wan-2.7-text-to-video");
+    expect(provider.models).toContain("wan-2.6-image-to-video");
     expect(provider.models).toContain("wan-2.5-preview-image-to-video");
-    expect(provider.models).toContain("wan-2.6-720p-image-to-video");
-    expect(provider.models).toContain("wan-2.6-1080p-image-to-video");
-    expect(provider.models).toContain("kling-2.1-master-image-to-video");
-    expect(provider.models).toContain("kling-2.1-pro-image-to-video");
-    expect(provider.models).toContain("hunyuan-image-to-video");
-    expect(provider.models).toContain("minimax-image-to-video");
-    expect(provider.models).toContain("luma-ray-2-image-to-video");
-    expect(provider.models).toContain("seedance-1-image-to-video");
-    expect(provider.models).toContain("vidu-2-image-to-video");
   });
 
-  it("lists expected text-to-video models", () => {
-    expect(provider.models).toContain("kling-2.1-master-text-to-video");
-    expect(provider.models).toContain("kling-2.1-pro-text-to-video");
-    expect(provider.models).toContain("minimax-text-to-video");
-    expect(provider.models).toContain("luma-ray-2-text-to-video");
-    expect(provider.models).toContain("seedance-1-text-to-video");
-    expect(provider.models).toContain("vidu-2-text-to-video");
+  it("lists Kling models", () => {
+    expect(provider.models).toContain("kling-2.6-pro-image-to-video");
+    expect(provider.models).toContain("kling-2.6-pro-text-to-video");
+    expect(provider.models).toContain("kling-2.5-turbo-pro-image-to-video");
+    expect(provider.models).toContain("kling-2.5-turbo-pro-text-to-video");
   });
 
-  it("lists video upscale models", () => {
-    expect(provider.models).toContain("video-upscale-topaz");
-    expect(provider.models).toContain("video-upscale-standard");
+  it("lists Seedance models", () => {
+    expect(provider.models).toContain("seedance-2-0-image-to-video");
+    expect(provider.models).toContain("seedance-2-0-text-to-video");
+    expect(provider.models).toContain("seedance-1-5-pro-image-to-video");
+    expect(provider.models).toContain("seedance-1-5-pro-text-to-video");
+  });
+
+  it("lists Vidu and OVI models", () => {
+    expect(provider.models).toContain("vidu-q3-image-to-video");
+    expect(provider.models).toContain("vidu-q3-text-to-video");
+    expect(provider.models).toContain("ovi-image-to-video");
   });
 
   it("has expected capabilities", () => {

--- a/extensions/venice/video-generation-provider.ts
+++ b/extensions/venice/video-generation-provider.ts
@@ -1,0 +1,303 @@
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  assertOkOrThrowHttpError,
+  fetchWithTimeout,
+  postJsonRequest,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+import type {
+  GeneratedVideoAsset,
+  VideoGenerationProvider,
+  VideoGenerationRequest,
+  VideoGenerationResolution,
+} from "openclaw/plugin-sdk/video-generation";
+import { VENICE_BASE_URL } from "./models.js";
+
+const DEFAULT_VENICE_VIDEO_MODEL = "wan-2.5-preview-image-to-video";
+const DEFAULT_TIMEOUT_MS = 180_000;
+const POLL_INTERVAL_MS = 5_000;
+const MAX_POLL_ATTEMPTS = 180;
+
+type VeniceQueueVideoResponse = {
+  model?: string;
+  queue_id?: string;
+  error?: string;
+};
+
+type VeniceRetrieveVideoResponse = {
+  status?: "PROCESSING";
+  average_execution_time?: number;
+  execution_duration?: number;
+  error?: string;
+};
+
+function resolveVeniceVideoBaseUrl(req: VideoGenerationRequest): string {
+  return req.cfg?.models?.providers?.venice?.baseUrl?.trim() || VENICE_BASE_URL;
+}
+
+function toDataUrl(buffer: Buffer, mimeType: string): string {
+  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+}
+
+function normalizeResolution(resolution?: VideoGenerationResolution): string | undefined {
+  if (!resolution) return undefined;
+  // Venice uses lowercase: 480p, 720p, 1080p
+  return resolution.toLowerCase();
+}
+
+function normalizeDuration(durationSeconds?: number): string | undefined {
+  if (typeof durationSeconds !== "number" || !Number.isFinite(durationSeconds)) {
+    return undefined;
+  }
+  // Venice supports 5s and 10s
+  if (durationSeconds <= 5) return "5s";
+  return "10s";
+}
+
+async function pollVeniceVideo(params: {
+  queueId: string;
+  model: string;
+  headers: Headers;
+  timeoutMs?: number;
+  baseUrl: string;
+  fetchFn: typeof fetch;
+}): Promise<Buffer> {
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
+    const body = {
+      model: params.model,
+      queue_id: params.queueId,
+      delete_media_on_completion: true,
+    };
+    const { response, release } = await postJsonRequest({
+      url: `${params.baseUrl}/video/retrieve`,
+      headers: params.headers,
+      body,
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      fetchFn: params.fetchFn,
+      allowPrivateNetwork: false,
+    });
+    try {
+      // Venice returns video/mp4 when complete, application/json when processing
+      const contentType = response.headers.get("content-type") || "";
+
+      if (contentType.includes("video/") || contentType.includes("application/octet-stream")) {
+        // Video is ready - download it
+        const arrayBuffer = await response.arrayBuffer();
+        return Buffer.from(arrayBuffer);
+      }
+
+      if (!response.ok) {
+        const errorBody = (await response.json()) as VeniceRetrieveVideoResponse;
+        if (errorBody.error) {
+          throw new Error(errorBody.error);
+        }
+        throw new Error(`Venice video retrieve failed: HTTP ${response.status}`);
+      }
+
+      // Still processing
+      const statusBody = (await response.json()) as VeniceRetrieveVideoResponse;
+      if (statusBody.status === "PROCESSING") {
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        continue;
+      }
+
+      // Unknown status
+      if (statusBody.error) {
+        throw new Error(statusBody.error);
+      }
+    } finally {
+      await release();
+    }
+  }
+  throw new Error(`Venice video generation task ${params.queueId} did not finish in time`);
+}
+
+export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
+  return {
+    id: "venice",
+    aliases: ["veniceai"],
+    label: "Venice",
+    defaultModel: DEFAULT_VENICE_VIDEO_MODEL,
+    models: [
+      // Image-to-video models
+      "wan-2.5-preview-image-to-video",
+      "wan-2.6-720p-image-to-video",
+      "wan-2.6-1080p-image-to-video",
+      "kling-2.1-master-image-to-video",
+      "kling-2.1-pro-image-to-video",
+      "kling-2.1-standard-image-to-video",
+      "kling-1.6-pro-image-to-video",
+      "kling-1.6-standard-image-to-video",
+      "kling-1.5-pro-image-to-video",
+      "hunyuan-image-to-video",
+      "minimax-image-to-video",
+      "luma-ray-2-image-to-video",
+      "luma-ray-flash-2-image-to-video",
+      "seedance-1-image-to-video",
+      "vidu-2-image-to-video",
+      // Text-to-video models
+      "kling-2.1-master-text-to-video",
+      "kling-2.1-pro-text-to-video",
+      "kling-2.1-standard-text-to-video",
+      "kling-1.6-pro-text-to-video",
+      "kling-1.6-standard-text-to-video",
+      "minimax-text-to-video",
+      "luma-ray-2-text-to-video",
+      "luma-ray-flash-2-text-to-video",
+      "seedance-1-text-to-video",
+      "vidu-2-text-to-video",
+    ],
+    isConfigured: ({ agentDir }) =>
+      isProviderApiKeyConfigured({
+        provider: "venice",
+        agentDir,
+      }),
+    capabilities: {
+      maxVideos: 1,
+      maxInputImages: 1,
+      maxInputVideos: 0,
+      maxDurationSeconds: 10,
+      supportedDurationSeconds: [5, 10],
+      supportsResolution: true,
+      supportsAspectRatio: true,
+      supportsAudio: true,
+    },
+    async generateVideo(req) {
+      if ((req.inputVideos?.length ?? 0) > 0) {
+        throw new Error("Venice video generation does not support video reference inputs.");
+      }
+
+      const auth = await resolveApiKeyForProvider({
+        provider: "venice",
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      if (!auth.apiKey) {
+        throw new Error("Venice API key missing");
+      }
+
+      const fetchFn = fetch;
+      const { baseUrl, headers } = resolveProviderHttpRequestConfig({
+        baseUrl: resolveVeniceVideoBaseUrl(req),
+        defaultBaseUrl: VENICE_BASE_URL,
+        allowPrivateNetwork: false,
+        defaultHeaders: {
+          Authorization: `Bearer ${auth.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        provider: "venice",
+        capability: "video",
+        transport: "http",
+      });
+
+      // Determine model - use image-to-video if image provided, otherwise text-to-video
+      const hasInputImage = (req.inputImages?.length ?? 0) > 0;
+      let model = req.model?.trim() || DEFAULT_VENICE_VIDEO_MODEL;
+
+      // Auto-select appropriate model type based on input
+      if (!req.model) {
+        if (!hasInputImage) {
+          // Switch to text-to-video model if no image provided
+          model = "kling-2.1-pro-text-to-video";
+        }
+      }
+
+      // Build request body per Venice API spec
+      const body: Record<string, unknown> = {
+        model,
+        prompt: req.prompt,
+        duration: normalizeDuration(req.durationSeconds) || "5s",
+      };
+
+      // Add resolution if provided
+      if (req.resolution) {
+        body.resolution = normalizeResolution(req.resolution);
+      }
+
+      // Add aspect ratio if provided
+      if (req.aspectRatio) {
+        body.aspect_ratio = req.aspectRatio;
+      }
+
+      // Add audio toggle if specified
+      if (typeof req.audio === "boolean") {
+        body.audio = req.audio;
+      }
+
+      // Add reference image for image-to-video models
+      if (hasInputImage && req.inputImages?.[0]) {
+        const input = req.inputImages[0];
+        const imageUrl = input.url?.trim()
+          ? input.url.trim()
+          : input.buffer
+            ? toDataUrl(input.buffer, input.mimeType?.trim() || "image/png")
+            : undefined;
+        if (!imageUrl) {
+          throw new Error("Venice reference image is missing image data.");
+        }
+        body.image_url = imageUrl;
+      }
+
+      // Queue the video generation
+      const { response, release } = await postJsonRequest({
+        url: `${baseUrl}/video/queue`,
+        headers,
+        body,
+        timeoutMs: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        fetchFn,
+        allowPrivateNetwork: false,
+      });
+
+      let queueId: string;
+      let returnedModel: string;
+
+      try {
+        await assertOkOrThrowHttpError(response, "Venice video queue failed");
+        const queueResponse = (await response.json()) as VeniceQueueVideoResponse;
+
+        if (queueResponse.error) {
+          throw new Error(queueResponse.error);
+        }
+
+        queueId = queueResponse.queue_id?.trim() || "";
+        returnedModel = queueResponse.model?.trim() || model;
+
+        if (!queueId) {
+          throw new Error("Venice video queue response missing queue_id");
+        }
+      } finally {
+        await release();
+      }
+
+      // Poll for completion
+      const videoBuffer = await pollVeniceVideo({
+        queueId,
+        model: returnedModel,
+        headers,
+        timeoutMs: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        baseUrl,
+        fetchFn,
+      });
+
+      const video: GeneratedVideoAsset = {
+        buffer: videoBuffer,
+        mimeType: "video/mp4",
+        fileName: `video-1.mp4`,
+      };
+
+      return {
+        videos: [video],
+        model: returnedModel,
+        metadata: {
+          queueId,
+          provider: "venice",
+          normalizedDurationSeconds: normalizeDuration(req.durationSeconds) === "10s" ? 10 : 5,
+          requestedDurationSeconds: req.durationSeconds,
+          supportedDurationSeconds: [5, 10],
+        },
+      };
+    },
+  };
+}

--- a/extensions/venice/video-generation-provider.ts
+++ b/extensions/venice/video-generation-provider.ts
@@ -2,7 +2,6 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
-  fetchWithTimeout,
   postJsonRequest,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
@@ -26,7 +25,7 @@ type VeniceQueueVideoResponse = {
 };
 
 type VeniceRetrieveVideoResponse = {
-  status?: "PROCESSING";
+  status?: "PROCESSING" | "QUEUED" | "PENDING";
   average_execution_time?: number;
   execution_duration?: number;
   error?: string;
@@ -55,6 +54,11 @@ function normalizeDuration(durationSeconds?: number): string | undefined {
   return "10s";
 }
 
+function isImageToVideoModel(model: string): boolean {
+  const normalized = model.toLowerCase();
+  return normalized.includes("image-to-video") || normalized.includes("i2v");
+}
+
 async function pollVeniceVideo(params: {
   queueId: string;
   model: string;
@@ -63,7 +67,15 @@ async function pollVeniceVideo(params: {
   baseUrl: string;
   fetchFn: typeof fetch;
 }): Promise<Buffer> {
+  const effectiveTimeout = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + effectiveTimeout;
+
   for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
+    // Check if we've exceeded the total timeout
+    if (Date.now() >= deadline) {
+      break;
+    }
+
     const body = {
       model: params.model,
       queue_id: params.queueId,
@@ -73,7 +85,7 @@ async function pollVeniceVideo(params: {
       url: `${params.baseUrl}/video/retrieve`,
       headers: params.headers,
       body,
-      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      timeoutMs: Math.min(DEFAULT_TIMEOUT_MS, deadline - Date.now()),
       fetchFn: params.fetchFn,
       allowPrivateNetwork: false,
     });
@@ -95,17 +107,25 @@ async function pollVeniceVideo(params: {
         throw new Error(`Venice video retrieve failed: HTTP ${response.status}`);
       }
 
-      // Still processing
+      // Parse status
       const statusBody = (await response.json()) as VeniceRetrieveVideoResponse;
-      if (statusBody.status === "PROCESSING") {
+
+      if (statusBody.error) {
+        throw new Error(statusBody.error);
+      }
+
+      // Handle known processing states - wait before retrying
+      if (
+        statusBody.status === "PROCESSING" ||
+        statusBody.status === "QUEUED" ||
+        statusBody.status === "PENDING"
+      ) {
         await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
         continue;
       }
 
-      // Unknown status
-      if (statusBody.error) {
-        throw new Error(statusBody.error);
-      }
+      // Unknown status - still wait before retrying to avoid tight loops
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     } finally {
       await release();
     }
@@ -120,33 +140,44 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
     label: "Venice",
     defaultModel: DEFAULT_VENICE_VIDEO_MODEL,
     models: [
-      // Image-to-video models
+      // WAN models (Image-to-Video)
       "wan-2.5-preview-image-to-video",
       "wan-2.6-720p-image-to-video",
       "wan-2.6-1080p-image-to-video",
+      // Kling models (Image-to-Video)
       "kling-2.1-master-image-to-video",
       "kling-2.1-pro-image-to-video",
       "kling-2.1-standard-image-to-video",
       "kling-1.6-pro-image-to-video",
       "kling-1.6-standard-image-to-video",
       "kling-1.5-pro-image-to-video",
+      // Kling O3 models (Reference-to-Video with elements support)
+      "kling-o3-r2v",
+      // Hunyuan (Image-to-Video)
       "hunyuan-image-to-video",
+      // MiniMax (Image-to-Video and Text-to-Video)
       "minimax-image-to-video",
+      "minimax-text-to-video",
+      // Luma Ray models (Image-to-Video and Text-to-Video)
       "luma-ray-2-image-to-video",
+      "luma-ray-2-text-to-video",
       "luma-ray-flash-2-image-to-video",
+      "luma-ray-flash-2-text-to-video",
+      // Seedance (Image-to-Video and Text-to-Video)
       "seedance-1-image-to-video",
+      "seedance-1-text-to-video",
+      // Vidu (Image-to-Video and Text-to-Video)
       "vidu-2-image-to-video",
-      // Text-to-video models
+      "vidu-2-text-to-video",
+      // Kling models (Text-to-Video)
       "kling-2.1-master-text-to-video",
       "kling-2.1-pro-text-to-video",
       "kling-2.1-standard-text-to-video",
       "kling-1.6-pro-text-to-video",
       "kling-1.6-standard-text-to-video",
-      "minimax-text-to-video",
-      "luma-ray-2-text-to-video",
-      "luma-ray-flash-2-text-to-video",
-      "seedance-1-text-to-video",
-      "vidu-2-text-to-video",
+      // Video upscale models
+      "video-upscale-topaz",
+      "video-upscale-standard",
     ],
     isConfigured: ({ agentDir }) =>
       isProviderApiKeyConfigured({
@@ -156,7 +187,7 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
     capabilities: {
       maxVideos: 1,
       maxInputImages: 1,
-      maxInputVideos: 0,
+      maxInputVideos: 1,
       maxDurationSeconds: 10,
       supportedDurationSeconds: [5, 10],
       supportsResolution: true,
@@ -164,10 +195,6 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
       supportsAudio: true,
     },
     async generateVideo(req) {
-      if ((req.inputVideos?.length ?? 0) > 0) {
-        throw new Error("Venice video generation does not support video reference inputs.");
-      }
-
       const auth = await resolveApiKeyForProvider({
         provider: "venice",
         cfg: req.cfg,
@@ -194,14 +221,17 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
 
       // Determine model - use image-to-video if image provided, otherwise text-to-video
       const hasInputImage = (req.inputImages?.length ?? 0) > 0;
+      const hasInputVideo = (req.inputVideos?.length ?? 0) > 0;
       let model = req.model?.trim() || DEFAULT_VENICE_VIDEO_MODEL;
 
-      // Auto-select appropriate model type based on input
-      if (!req.model) {
-        if (!hasInputImage) {
-          // Switch to text-to-video model if no image provided
-          model = "kling-2.1-pro-text-to-video";
-        }
+      // Validate: if an I2V model is explicitly chosen but no image is provided, error early
+      if (!req.model && !hasInputImage && !hasInputVideo) {
+        // Auto-select text-to-video model if no image/video provided
+        model = "kling-2.1-pro-text-to-video";
+      } else if (req.model && isImageToVideoModel(req.model) && !hasInputImage) {
+        throw new Error(
+          `Model "${req.model}" requires a reference image. Either provide an image via inputImages or use a text-to-video model.`,
+        );
       }
 
       // Build request body per Venice API spec
@@ -238,6 +268,20 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
           throw new Error("Venice reference image is missing image data.");
         }
         body.image_url = imageUrl;
+      }
+
+      // Add reference video for video-to-video/upscale models
+      if (hasInputVideo && req.inputVideos?.[0]) {
+        const input = req.inputVideos[0];
+        const videoUrl = input.url?.trim()
+          ? input.url.trim()
+          : input.buffer
+            ? toDataUrl(input.buffer, input.mimeType?.trim() || "video/mp4")
+            : undefined;
+        if (!videoUrl) {
+          throw new Error("Venice reference video is missing video data.");
+        }
+        body.video_url = videoUrl;
       }
 
       // Queue the video generation
@@ -293,9 +337,6 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
         metadata: {
           queueId,
           provider: "venice",
-          normalizedDurationSeconds: normalizeDuration(req.durationSeconds) === "10s" ? 10 : 5,
-          requestedDurationSeconds: req.durationSeconds,
-          supportedDurationSeconds: [5, 10],
         },
       };
     },

--- a/extensions/venice/video-generation-provider.ts
+++ b/extensions/venice/video-generation-provider.ts
@@ -13,7 +13,7 @@ import type {
 } from "openclaw/plugin-sdk/video-generation";
 import { VENICE_BASE_URL } from "./models.js";
 
-const DEFAULT_VENICE_VIDEO_MODEL = "wan-2.5-preview-image-to-video";
+const DEFAULT_VENICE_VIDEO_MODEL = "wan-2.7-image-to-video";
 const DEFAULT_TIMEOUT_MS = 180_000;
 const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 180;
@@ -140,44 +140,34 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
     label: "Venice",
     defaultModel: DEFAULT_VENICE_VIDEO_MODEL,
     models: [
-      // WAN models (Image-to-Video)
+      // WAN models (Image-to-Video and Text-to-Video)
+      "wan-2.7-image-to-video",
+      "wan-2.7-text-to-video",
+      "wan-2.6-image-to-video",
       "wan-2.5-preview-image-to-video",
-      "wan-2.6-720p-image-to-video",
-      "wan-2.6-1080p-image-to-video",
-      // Kling models (Image-to-Video)
-      "kling-2.1-master-image-to-video",
-      "kling-2.1-pro-image-to-video",
-      "kling-2.1-standard-image-to-video",
-      "kling-1.6-pro-image-to-video",
-      "kling-1.6-standard-image-to-video",
-      "kling-1.5-pro-image-to-video",
-      // Kling O3 models (Reference-to-Video with elements support)
-      "kling-o3-r2v",
-      // Hunyuan (Image-to-Video)
-      "hunyuan-image-to-video",
-      // MiniMax (Image-to-Video and Text-to-Video)
-      "minimax-image-to-video",
-      "minimax-text-to-video",
-      // Luma Ray models (Image-to-Video and Text-to-Video)
-      "luma-ray-2-image-to-video",
-      "luma-ray-2-text-to-video",
-      "luma-ray-flash-2-image-to-video",
-      "luma-ray-flash-2-text-to-video",
-      // Seedance (Image-to-Video and Text-to-Video)
-      "seedance-1-image-to-video",
-      "seedance-1-text-to-video",
-      // Vidu (Image-to-Video and Text-to-Video)
-      "vidu-2-image-to-video",
-      "vidu-2-text-to-video",
-      // Kling models (Text-to-Video)
-      "kling-2.1-master-text-to-video",
-      "kling-2.1-pro-text-to-video",
-      "kling-2.1-standard-text-to-video",
-      "kling-1.6-pro-text-to-video",
-      "kling-1.6-standard-text-to-video",
-      // Video upscale models
-      "video-upscale-topaz",
-      "video-upscale-standard",
+
+      // Kling 2.6 models
+      "kling-2.6-pro-image-to-video",
+      "kling-2.6-pro-text-to-video",
+
+      // Kling 2.5 Turbo models
+      "kling-2.5-turbo-pro-image-to-video",
+      "kling-2.5-turbo-pro-text-to-video",
+
+      // Seedance 2.0 models (Pro users)
+      "seedance-2-0-image-to-video",
+      "seedance-2-0-text-to-video",
+
+      // Seedance 1.5 Pro models
+      "seedance-1-5-pro-image-to-video",
+      "seedance-1-5-pro-text-to-video",
+
+      // Vidu Q3 models
+      "vidu-q3-image-to-video",
+      "vidu-q3-text-to-video",
+
+      // OVI (MiniMax) model
+      "ovi-image-to-video",
     ],
     isConfigured: ({ agentDir }) =>
       isProviderApiKeyConfigured({
@@ -227,7 +217,7 @@ export function buildVeniceVideoGenerationProvider(): VideoGenerationProvider {
       // Validate: if an I2V model is explicitly chosen but no image is provided, error early
       if (!req.model && !hasInputImage && !hasInputVideo) {
         // Auto-select text-to-video model if no image/video provided
-        model = "kling-2.1-pro-text-to-video";
+        model = "wan-2.7-text-to-video";
       } else if (req.model && isImageToVideoModel(req.model) && !hasInputImage) {
         throw new Error(
           `Model "${req.model}" requires a reference image. Either provide an image via inputImages or use a text-to-video model.`,


### PR DESCRIPTION
## Summary

Add Venice AI as a `video_generate` provider, enabling video generation through Venice's async queue-based API.

## Features

- **Image-to-video models**: WAN 2.7/2.6/2.5, Kling 2.6/2.5, Seedance 2.0/1.5, Vidu Q3, OVI
- **Text-to-video models**: WAN 2.7, Kling 2.6/2.5, Seedance 2.0/1.5, Vidu Q3
- **Duration support**: 5s and 10s options
- **Resolution options**: 480p, 720p, 1080p
- **Aspect ratio support**: Standard ratios (16:9, 9:16, 1:1, etc.)
- **Audio toggle**: Enable/disable generated audio for supported models
- **Automatic model selection**: Chooses T2V vs I2V based on whether a reference image is provided
- **Input validation**: Clear error when I2V model is used without a reference image

## Implementation Details

Venice uses an async queue-based API for video generation:

1. `POST /video/queue` - Submit generation request, receive `queue_id`
2. `POST /video/retrieve` - Poll with `queue_id` until response content-type is `video/mp4`

The provider handles:
- Queue submission with all supported parameters
- Deadline-based polling with configurable timeout (default 3 min)
- Graceful handling of unknown status values
- Automatic video buffer download when complete
- Error handling for failed generations

## Files Changed

- `extensions/venice/video-generation-provider.ts` - Main provider implementation (~320 lines)
- `extensions/venice/video-generation-provider.test.ts` - Unit tests
- `extensions/venice/index.ts` - Register provider via `api.registerVideoGenerationProvider()`
- `extensions/venice/api.ts` - Export provider builder

## Usage

```json5
{
  agents: {
    defaults: {
      videoGenerationModel: {
        primary: "venice/wan-2.7-image-to-video",
      },
    },
  },
}
```

Or use text-to-video:

```json5
{
  agents: {
    defaults: {
      videoGenerationModel: {
        primary: "venice/wan-2.7-text-to-video",
      },
    },
  },
}
```

## Supported Models

All models verified against Venice API `/video/quote` endpoint.

### WAN (Alibaba)
| Model | Type | Price (5s) |
|-------|------|------------|
| `wan-2.7-image-to-video` | I2V | $0.39 |
| `wan-2.7-text-to-video` | T2V | $0.39 |
| `wan-2.6-image-to-video` | I2V | $0.83 |
| `wan-2.5-preview-image-to-video` | I2V | $0.55 |

### Kling (Kuaishou)
| Model | Type | Price (5s) |
|-------|------|------------|
| `kling-2.6-pro-image-to-video` | I2V | $0.77 |
| `kling-2.6-pro-text-to-video` | T2V | $0.77 |
| `kling-2.5-turbo-pro-image-to-video` | I2V | $0.39 |
| `kling-2.5-turbo-pro-text-to-video` | T2V | $0.39 |

### Seedance (ByteDance)
| Model | Type | Price (5s) |
|-------|------|------------|
| `seedance-2-0-image-to-video` | I2V | Pro only |
| `seedance-2-0-text-to-video` | T2V | Pro only |
| `seedance-1-5-pro-image-to-video` | I2V | $0.38 |
| `seedance-1-5-pro-text-to-video` | T2V | $0.29 |

### Vidu (Shengshu)
| Model | Type | Price (5s) |
|-------|------|------------|
| `vidu-q3-image-to-video` | I2V | $0.97 |
| `vidu-q3-text-to-video` | T2V | $0.97 |

### OVI (MiniMax)
| Model | Type | Price (5s) |
|-------|------|------------|
| `ovi-image-to-video` | I2V | $0.22 |

## API Reference

- [Video Queue](https://docs.venice.ai/api-reference/endpoint/video/queue)
- [Video Retrieve](https://docs.venice.ai/api-reference/endpoint/video/retrieve)
- [Video Models](https://docs.venice.ai/models/video)