### PR TITLE
fix(block-streaming): content-aware dedup prevents double sends when chunks don't match final payload

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -159,11 +159,23 @@ export async function buildReplyPayloads(params: {
   const silentFilteredPayloads = params.silentExpected ? [] : replyTaggedPayloads;
 
   // Drop final payloads only when block streaming succeeded end-to-end.
-  // If streaming aborted (e.g., timeout), fall back to final payloads.
+  // If streaming aborted (e.g., timeout), fall through to per-payload
+  // content-coverage dedup (hasSentPayload) instead of blanket drop.
+  const pipelineDidStream = Boolean(params.blockReplyPipeline?.didStream());
+  const pipelineAborted = Boolean(params.blockReplyPipeline?.isAborted());
   const shouldDropFinalPayloads =
-    params.blockStreamingEnabled &&
-    Boolean(params.blockReplyPipeline?.didStream()) &&
-    !params.blockReplyPipeline?.isAborted();
+    params.blockStreamingEnabled && pipelineDidStream && !pipelineAborted;
+  if (params.blockStreamingEnabled && pipelineDidStream) {
+    if (pipelineAborted) {
+      logVerbose(
+        `block streaming aborted; falling back to per-payload content dedup for ${silentFilteredPayloads.length} final payload(s)`,
+      );
+    } else {
+      logVerbose(
+        `block streaming completed successfully; suppressing ${silentFilteredPayloads.length} final payload(s)`,
+      );
+    }
+  }
   const messagingToolSentTexts = params.messagingToolSentTexts ?? [];
   const messagingToolSentTargets = params.messagingToolSentTargets ?? [];
   const shouldCheckMessagingToolDedupe =

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -77,3 +77,145 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(pipeline.hasSentPayload({ text: "response text", replyToId: "other-id" })).toBe(true);
   });
 });
+
+describe("createBlockReplyPipeline content coverage dedup", () => {
+  it("detects when streamed chunks cover final assembled payload", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    // Simulate block streaming sending two paragraph chunks
+    pipeline.enqueue({ text: "First paragraph." });
+    pipeline.enqueue({ text: "Second paragraph." });
+    await pipeline.flush();
+
+    // Final assembled payload combines both paragraphs
+    expect(pipeline.hasSentPayload({ text: "First paragraph.\n\nSecond paragraph." })).toBe(true);
+  });
+
+  it("detects when streamed chunks cover final payload with different whitespace", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "Hello world." });
+    pipeline.enqueue({ text: "How are you?" });
+    await pipeline.flush();
+
+    // Final payload with newlines between chunks
+    expect(pipeline.hasSentPayload({ text: "Hello world.\nHow are you?" })).toBe(true);
+  });
+
+  it("returns false when final payload has new content not streamed", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "First paragraph." });
+    await pipeline.flush();
+
+    // Final payload has extra content that was never streamed
+    expect(pipeline.hasSentPayload({ text: "First paragraph. Extra content not streamed." })).toBe(
+      false,
+    );
+  });
+
+  it("does not suppress media payloads via content coverage", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "Description" });
+    await pipeline.flush();
+
+    // Even though text matches, media payload should not be suppressed
+    expect(pipeline.hasSentPayload({ text: "Description", mediaUrl: "file:///photo.jpg" })).toBe(
+      false,
+    );
+  });
+
+  it("detects single chunk covering single final payload", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "Short reply" });
+    await pipeline.flush();
+
+    // Exact content key match should work
+    expect(pipeline.hasSentPayload({ text: "Short reply" })).toBe(true);
+  });
+
+  it("detects subset match when final payload is part of streamed content", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "Message one." });
+    pipeline.enqueue({ text: "Message two." });
+    pipeline.enqueue({ text: "Message three." });
+    await pipeline.flush();
+
+    // Final payload is a subset of what was streamed
+    expect(pipeline.hasSentPayload({ text: "Message one." })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "Message one. Message two." })).toBe(true);
+  });
+
+  it("returns false when nothing was streamed", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    // No chunks enqueued, so nothing streamed
+    expect(pipeline.hasSentPayload({ text: "Some text" })).toBe(false);
+  });
+
+  it("handles empty final payload text as covered", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "Some content" });
+    await pipeline.flush();
+
+    // Empty text with no media is vacuously covered
+    expect(pipeline.hasSentPayload({ text: "" })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "   " })).toBe(true);
+  });
+});
+
+describe("createBlockReplyPipeline timeout abort with content coverage", () => {
+  it("detects content coverage even after pipeline aborts from timeout", async () => {
+    let callCount = 0;
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {
+        callCount++;
+        if (callCount >= 2) {
+          // Simulate slow delivery that causes timeout
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+      },
+      timeoutMs: 50,
+    });
+
+    // First chunk succeeds quickly
+    pipeline.enqueue({ text: "First paragraph." });
+    // Second chunk will timeout
+    pipeline.enqueue({ text: "Second paragraph." });
+    await pipeline.flush();
+
+    // Pipeline should have streamed at least the first chunk
+    expect(pipeline.didStream()).toBe(true);
+
+    // hasSentPayload should detect that the first chunk covers part of the final
+    expect(pipeline.hasSentPayload({ text: "First paragraph." })).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -90,6 +90,11 @@ export function createBlockReplyPipeline(params: {
   const bufferedKeys = new Set<string>();
   const bufferedPayloadKeys = new Set<string>();
   const bufferedPayloads: ReplyPayload[] = [];
+  // Track trimmed text of each successfully sent payload for content coverage detection.
+  // When block streaming sends chunks (paragraph/sentence splits) that together equal
+  // the final assembled payload, this allows hasSentPayload to detect the match even
+  // though individual chunk content keys differ from the assembled content key.
+  const streamedTexts: string[] = [];
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
   let didStream = false;
@@ -138,6 +143,10 @@ export function createBlockReplyPipeline(params: {
         sentKeys.add(payloadKey);
         sentContentKeys.add(contentKey);
         didStream = true;
+        const sentText = resolveSendableOutboundReplyParts(payload).trimmedText;
+        if (sentText) {
+          streamedTexts.push(sentText);
+        }
       })
       .catch((err) => {
         if (err === timeoutError) {
@@ -245,8 +254,53 @@ export function createBlockReplyPipeline(params: {
     didStream: () => didStream,
     isAborted: () => aborted,
     hasSentPayload: (payload) => {
-      const payloadKey = createBlockReplyContentKey(payload);
-      return sentContentKeys.has(payloadKey);
+      // Exact content key match (handles identical single-chunk payloads).
+      const contentKey = createBlockReplyContentKey(payload);
+      if (sentContentKeys.has(contentKey)) {
+        return true;
+      }
+      // Content coverage: when block streaming delivered chunks that together
+      // contain the same text as the final assembled payload, treat it as sent.
+      // This handles the mismatch between chunked delivery (paragraph/newline/
+      // sentence splits) and the final assembled payload text.
+      if (!didStream || streamedTexts.length === 0) {
+        return false;
+      }
+      const reply = resolveSendableOutboundReplyParts(payload);
+      // Don't suppress payloads with media unless exact content key matched above;
+      // media dedup requires exact key matching to avoid dropping unique attachments.
+      if (reply.hasMedia) {
+        return false;
+      }
+      const finalText = reply.trimmedText;
+      if (!finalText) {
+        // Empty text with no media is vacuously covered.
+        return true;
+      }
+      // Normalize by stripping all whitespace so "para1\n\npara2" and
+      // "para1" + "para2" (joined) compare as equal regardless of how
+      // the block splitter divided the content.
+      const strip = (s: string) => s.replace(/\s+/g, "");
+      const finalStripped = strip(finalText);
+      if (!finalStripped) {
+        return true;
+      }
+      const streamedStripped = strip(streamedTexts.join(""));
+      if (finalStripped === streamedStripped) {
+        logVerbose(
+          `block streaming content dedup: final payload text matches ${streamedTexts.length} streamed chunk(s)`,
+        );
+        return true;
+      }
+      // Final payload text is a subset of what was streamed (e.g. multi-message
+      // response where each message was streamed separately).
+      if (streamedStripped.length > 0 && streamedStripped.includes(finalStripped)) {
+        logVerbose(
+          `block streaming content dedup: final payload text is subset of streamed content`,
+        );
+        return true;
+      }
+      return false;
     },
   };
 }


### PR DESCRIPTION
## Problem

When `blockStreaming` is enabled for a channel (like BlueBubbles), messages get sent twice:

1. The block reply pipeline sends content in chunks (paragraphs/sentences) during LLM streaming
2. After generation finishes, the final payload delivery path sends the complete assembled message again
3. The existing content key dedup (`hasSentPayload`) fails because chunked text (`"para1"` + `"para2"`) produces different content keys than the assembled final text (`"para1\n\npara2"`)

BlueBubbles server API confirmed different GUIDs for the duplicates with 1 to 9 second gaps between them.

## Root Cause

`createBlockReplyContentKey` produces a JSON key from `{ text: trimmedText, mediaList: mediaUrls }`. When block streaming sends "First paragraph." and "Second paragraph." as separate chunks, neither chunk's content key matches the final assembled payload "First paragraph.\n\nSecond paragraph.".

The existing `shouldDropFinalPayloads` blanket drop works when streaming completes successfully (`didStream() && !isAborted()`), but when streaming partially fails or times out, it falls through to per-payload dedup which hits this exact content key mismatch.

## Fix

**Content-aware dedup in the block reply pipeline:**

1. **Track streamed text**: Each successfully sent chunk's trimmed text is recorded in a `streamedTexts` array
2. **Content coverage matching**: When exact content key match fails, `hasSentPayload` now checks whether the concatenated streamed chunks (whitespace-normalized) match or contain the final payload text
3. **Media safety**: Content coverage only applies to text-only payloads; media payloads still require exact key matching to avoid dropping unique attachments
4. **Diagnostic logging**: Added verbose logging for content dedup decisions and pipeline abort state

**Delivery state logging in buildReplyPayloads:**

- Logs whether block streaming completed successfully (blanket drop) or aborted (content dedup fallback)
- Includes payload count for debugging

## Test Coverage

Added 9 new tests covering:
- Chunked content covering assembled final payload
- Different whitespace between chunks and final text  
- New content not covered by streamed chunks (correctly not suppressed)
- Media payloads excluded from content coverage
- Single chunk exact match
- Subset detection (final is part of streamed)
- Empty payload handling
- Timeout abort with partial delivery

## Files Changed

- `src/auto-reply/reply/block-reply-pipeline.ts`: Content coverage dedup in `hasSentPayload`, `streamedTexts` tracking
- `src/auto-reply/reply/block-reply-pipeline.test.ts`: 9 new tests for content coverage dedup
- `src/auto-reply/reply/agent-runner-payloads.ts`: Diagnostic logging for pipeline state