### PR TITLE
fix(control-ui): keep approval buttons visible on mobile

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2897,6 +2897,9 @@ td.data-table-key-col {
 
 .exec-approval-card {
   width: min(540px, 100%);
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -2941,6 +2944,9 @@ td.data-table-key-col {
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
+  overflow-y: auto;
+  flex-shrink: 1;
+  min-height: 0;
 }
 
 .exec-approval-meta {


### PR DESCRIPTION
## Summary

On small mobile viewports (~375-400px), long shell commands in the exec approval card push the Approve/Deny buttons below the visible area, making them inaccessible without scrolling. Users must resort to typing `/approve <ID> allow-once` manually.

## Changes

`ui/src/styles/components.css`:
- `.exec-approval-card`: Add `display: flex; flex-direction: column; max-height: calc(100vh - 48px)` so the card never exceeds the viewport
- `.exec-approval-command`: Add `overflow-y: auto; flex-shrink: 1; min-height: 0` so the command preview scrolls within its space while action buttons remain visible at the bottom

## Before / After

**Before:** Long commands expand the card beyond the viewport, buttons are unreachable on mobile.
**After:** Command preview becomes scrollable, buttons stay pinned at the bottom of the card.

## Test Plan

- [ ] Open control-ui on a ~375px viewport
- [ ] Trigger a long shell command approval (100+ lines)
- [ ] Verify buttons remain visible and accessible
- [ ] Verify desktop layout is unaffected

Fixes #61425

🤖 Generated with [Claude Code](https://claude.com/claude-code)