### PR TITLE
fix(win): re-enable native jiti loading for dist .js to prevent dual module instances

### DIFF
--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -662,7 +662,7 @@ describe("plugin sdk alias helpers", () => {
     }
   });
 
-  it("disables native Jiti loads on Windows even for built JavaScript entries", () => {
+  it("enables native Jiti loads on Windows for built JavaScript entries to prevent dual module instances", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
       configurable: true,
@@ -670,10 +670,14 @@ describe("plugin sdk alias helpers", () => {
     });
 
     try {
-      expect(shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(false);
+      expect(shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(true);
       expect(shouldPreferNativeJiti(`/repo/${bundledDistPluginFile("browser", "index.js")}`)).toBe(
-        false,
+        true,
       );
+      // TypeScript source entries still use jiti transpilation on Windows
+      expect(
+        shouldPreferNativeJiti(`/repo/${bundledPluginFile("discord", "src/channel.runtime.ts")}`),
+      ).toBe(false);
     } finally {
       Object.defineProperty(process, "platform", {
         configurable: true,

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -438,9 +438,13 @@ export function shouldPreferNativeJiti(modulePath: string): boolean {
   if (typeof versions.bun === "string") {
     return false;
   }
-  if (process.platform === "win32") {
-    return false;
-  }
+  // Windows previously disabled native Jiti unconditionally but this causes
+  // dual module instances: jiti evaluates dist chunks in its own cache while
+  // dynamic `import()` inside those chunks loads the same file through Node's
+  // native ESM loader, creating a second runtime-store closure.  The actual
+  // Windows issue was backslash alias paths, which is handled by
+  // `normalizeJitiAliasTargetPath`.  Re-enable native loading for compiled
+  // JavaScript so the dist chunk graph stays on a single module identity.
   switch (path.extname(modulePath).toLowerCase()) {
     case ".js":
     case ".mjs":


### PR DESCRIPTION
## Summary

- Fixes #61614 — Feishu channel crash loop on Windows due to dual jiti/ESM module identity for the plugin runtime store
- Removes the blanket `win32` guard from `shouldPreferNativeJiti()` that was introduced in 3a4b96bf, which forced jiti to evaluate all dist `.js` chunks via `vm.runInThisContext` instead of Node's native ESM loader
- The actual Windows issue (backslash paths in jiti alias maps) is already handled by `normalizeJitiAliasTargetPath()`

## Root Cause

When `tryNative` is `false` on Windows, jiti creates its own module cache separate from Node's native ESM registry. Dynamic `import()` inside jiti-evaluated code escapes back to Node's ESM loader, creating a second instance of `runtime-BAUYLedo.js` with its own `createPluginRuntimeStore` closure. `setFeishuRuntime()` writes to jiti's closure during `register()`, but `getFeishuRuntime()` reads from the ESM closure when the monitor runs — which is still `null`.

## Testing

- `pnpm test src/plugins/sdk-alias.test.ts` — 27/27 pass
- `pnpm test src/plugins/loader.test.ts` — 134/134 pass
- `pnpm build` — clean
- Gateway startup verified: all 3 Feishu accounts start without "Feishu runtime not initialized" error