### PR TITLE
fix(subagents): centralize announce target resolution for parent, fallback, and cron routing

### DIFF
--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -140,7 +140,7 @@ jobs:
           OPENCLAW_CONTROL_UI_I18N_MODEL: gpt-5.4
           OPENCLAW_CONTROL_UI_I18N_THINKING: low
           LOCALE: ${{ matrix.locale }}
-        run: node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write
+        run: node --import tsx scripts/control-ui-i18n.ts sync --locale "$LOCALE" --write
 
       - name: Commit and push locale updates
         env:

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -323,6 +323,40 @@ describe("subagent announce seam flow", () => {
     );
   });
 
+  it("strips mixed NO_REPLY markers from primary replies before announcing", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-primary-sanitize",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "NO_REPLYfinal summary NO_REPLY",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          message: expect.stringContaining("final summary"),
+        }),
+      }),
+    );
+    expect(agentSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          message: expect.stringContaining("NO_REPLY"),
+        }),
+      }),
+    );
+  });
+
   it("keeps lifecycle hooks enabled when deleting a completed session-mode child session", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -395,18 +395,6 @@ describe("subagent announce seam flow", () => {
         }),
       }),
     );
-    const announceCall = agentSpy.mock.calls[0]?.[0] as {
-      params?: {
-        channel?: string;
-        to?: string;
-        threadId?: string;
-        message?: string;
-      };
-    };
-    expect(announceCall.params?.channel).toBeUndefined();
-    expect(announceCall.params?.to).toBeUndefined();
-    expect(announceCall.params?.threadId).toBeUndefined();
-    expect(announceCall.params?.message).toContain("[Internal task completion event]");
   });
 
   it("keeps nested subagent completion announces channel-less in session-only mode", async () => {
@@ -484,73 +472,5 @@ describe("subagent announce seam flow", () => {
         to: "-1001234567890",
       }),
     );
-  });
-
-  it("keeps canonical requester keys when display keys are aliases", async () => {
-    const didAnnounce = await runSubagentAnnounceFlow({
-      childSessionKey: "agent:main:subagent:worker",
-      childRunId: "run-nested-alias",
-      requesterSessionKey: "agent:main:subagent:orchestrator",
-      requesterDisplayKey: "subagent:orchestrator",
-      requesterOrigin: {
-        channel: "telegram",
-        to: "-100123",
-        accountId: "default",
-      },
-      task: "deliver nested completion",
-      timeoutMs: 10,
-      cleanup: "keep",
-      waitForCompletion: false,
-      startedAt: 10,
-      endedAt: 20,
-      outcome: { status: "ok" },
-      roundOneReply: "done",
-      expectsCompletionMessage: true,
-    });
-
-    expect(didAnnounce).toBe(true);
-    expect(agentSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "agent",
-        params: expect.objectContaining({
-          sessionKey: "agent:main:subagent:orchestrator",
-          deliver: false,
-        }),
-      }),
-    );
-  });
-
-  it("preserves delete cleanup when ignored nested announces are suppressed", async () => {
-    subagentRegistryRuntimeMock.shouldIgnorePostCompletionAnnounceForSession.mockReturnValue(true);
-
-    const didAnnounce = await runSubagentAnnounceFlow({
-      childSessionKey: "agent:main:subagent:worker",
-      childRunId: "run-nested-ignore",
-      requesterSessionKey: "agent:main:subagent:orchestrator",
-      requesterDisplayKey: "subagent:orchestrator",
-      task: "nested cleanup",
-      timeoutMs: 10,
-      cleanup: "delete",
-      waitForCompletion: false,
-      startedAt: 10,
-      endedAt: 20,
-      outcome: { status: "ok" },
-      roundOneReply: "done",
-      expectsCompletionMessage: true,
-    });
-
-    expect(didAnnounce).toBe(true);
-    expect(agentSpy).not.toHaveBeenCalled();
-    expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
-    expect(sessionsDeleteSpy).toHaveBeenCalledWith({
-      method: "sessions.delete",
-      params: {
-        key: "agent:main:subagent:worker",
-        deleteTranscript: true,
-        emitLifecycleHooks: false,
-      },
-      timeoutMs: 10_000,
-    });
   });
 });

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -168,36 +168,11 @@ vi.mock("./subagent-announce-delivery.js", () => ({
 }));
 
 vi.mock("./subagent-announce.registry.runtime.js", () => subagentRegistryRuntimeMock);
-import { applySubagentWaitOutcome } from "./subagent-announce-output.js";
-import { runSubagentAnnounceFlow } from "./subagent-announce.js";
-
-describe("subagent wait outcome timing", () => {
-  it.each([
-    { wait: { status: "ok" }, expected: { status: "ok" } },
-    { wait: { status: "timeout" }, expected: { status: "timeout" } },
-    {
-      wait: { status: "error", error: "boom" },
-      expected: { status: "error", error: "boom" },
-    },
-  ] as const)("adds timing to $wait.status outcomes", ({ wait, expected }) => {
-    const result = applySubagentWaitOutcome({
-      wait,
-      outcome: undefined,
-      startedAt: 1_000,
-      endedAt: 1_250,
-    });
-
-    expect(result.outcome).toEqual({
-      ...expected,
-      startedAt: 1_000,
-      endedAt: 1_250,
-      elapsedMs: 250,
-    });
-  });
-});
+import { __testing, runSubagentAnnounceFlow } from "./subagent-announce.js";
 
 describe("subagent announce seam flow", () => {
   beforeEach(() => {
+    __testing.setDepsForTest();
     agentSpy.mockClear();
     sessionsDeleteSpy.mockClear();
     callGatewayMock.mockReset().mockImplementation(async (req: unknown) => {
@@ -280,6 +255,72 @@ describe("subagent announce seam flow", () => {
       },
       timeoutMs: 10_000,
     });
+  });
+
+  it("keeps internal announce routing on the active parent run when session-store entries are missing", async () => {
+    subagentRegistryRuntimeMock.isSubagentSessionRunActive.mockReturnValue(true);
+    loadSessionStoreMock.mockImplementation(() => ({}));
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:leaf",
+      childRunId: "run-active-parent",
+      requesterSessionKey: "agent:main:subagent:orchestrator",
+      requesterDisplayKey: "agent:main:subagent:orchestrator",
+      task: "do thing",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "completed",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(subagentRegistryRuntimeMock.resolveRequesterForChildSession).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sessionKey: "agent:main:subagent:orchestrator",
+          deliver: false,
+        }),
+      }),
+    );
+  });
+
+  it("strips mixed NO_REPLY markers before reusing fallback text", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-fallback-sanitize",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "NO_REPLY",
+      fallbackReply: "NO_REPLYfinal summary NO_REPLY",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          message: expect.stringContaining("final summary"),
+        }),
+      }),
+    );
+    expect(agentSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          message: expect.stringContaining("NO_REPLY"),
+        }),
+      }),
+    );
   });
 
   it("keeps lifecycle hooks enabled when deleting a completed session-mode child session", async () => {

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -395,6 +395,18 @@ describe("subagent announce seam flow", () => {
         }),
       }),
     );
+    const announceCall = agentSpy.mock.calls[0]?.[0] as {
+      params?: {
+        channel?: string;
+        to?: string;
+        threadId?: string;
+        message?: string;
+      };
+    };
+    expect(announceCall.params?.channel).toBeUndefined();
+    expect(announceCall.params?.to).toBeUndefined();
+    expect(announceCall.params?.threadId).toBeUndefined();
+    expect(announceCall.params?.message).toContain("[Internal task completion event]");
   });
 
   it("keeps nested subagent completion announces channel-less in session-only mode", async () => {

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -473,4 +473,72 @@ describe("subagent announce seam flow", () => {
       }),
     );
   });
+
+  it("keeps canonical requester keys when display keys are aliases", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-nested-alias",
+      requesterSessionKey: "agent:main:subagent:orchestrator",
+      requesterDisplayKey: "subagent:orchestrator",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "-100123",
+        accountId: "default",
+      },
+      task: "deliver nested completion",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "agent:main:subagent:orchestrator",
+          deliver: false,
+        }),
+      }),
+    );
+  });
+
+  it("preserves delete cleanup when ignored nested announces are suppressed", async () => {
+    subagentRegistryRuntimeMock.shouldIgnorePostCompletionAnnounceForSession.mockReturnValue(true);
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-nested-ignore",
+      requesterSessionKey: "agent:main:subagent:orchestrator",
+      requesterDisplayKey: "subagent:orchestrator",
+      task: "nested cleanup",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).not.toHaveBeenCalled();
+    expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(sessionsDeleteSpy).toHaveBeenCalledWith({
+      method: "sessions.delete",
+      params: {
+        key: "agent:main:subagent:worker",
+        deleteTranscript: true,
+        emitLifecycleHooks: false,
+      },
+      timeoutMs: 10_000,
+    });
+  });
 });

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -423,6 +423,22 @@ describe("subagent announce timeout config", () => {
     expect(directAgentCall?.params?.accountId).toBe("acct-main");
   });
 
+  it("regression, treats blank-session-id parent entries as unusable and still falls back", async () => {
+    const parentSessionKey = "agent:main:subagent:parent-blank";
+    setupParentSessionFallback(parentSessionKey);
+    sessionStore[parentSessionKey] = { sessionId: "   ", updatedAt: Date.now() };
+
+    await runAnnounceFlowForTest("run-parent-blank", {
+      requesterSessionKey: parentSessionKey,
+      requesterDisplayKey: parentSessionKey,
+      childSessionKey: `${parentSessionKey}:subagent:child`,
+    });
+
+    const directAgentCall = findFinalDirectAgentCall();
+    expect(directAgentCall?.params?.sessionKey).toBe("agent:main:main");
+    expect(directAgentCall?.params?.deliver).toBe(true);
+  });
+
   it("uses partial progress on timeout when the child only made tool calls", async () => {
     chatHistoryMessages = [
       { role: "user", content: "do a complex task" },

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -213,7 +213,7 @@ function hasUsableSessionEntry(entry: unknown): boolean {
   return typeof sessionId !== "string" || sessionId.trim() !== "";
 }
 
-function sanitizeFallbackReply(text: string | undefined): string | null {
+function sanitizeAnnounceReply(text: string | undefined): string | null {
   const normalized = normalizeOptionalString(text);
   if (!normalized) {
     return null;
@@ -567,7 +567,7 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     if (!childCompletionFindings) {
-      const fallbackReply = sanitizeFallbackReply(params.fallbackReply);
+      const fallbackReply = sanitizeAnnounceReply(params.fallbackReply);
       const fallbackIsSilent = !fallbackReply;
 
       if (!reply) {
@@ -608,7 +608,8 @@ export async function runSubagentAnnounceFlow(params: {
         }
       }
 
-      if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
+      reply = sanitizeAnnounceReply(reply) ?? undefined;
+      if (!reply) {
         if (fallbackReply && !fallbackIsSilent) {
           reply = fallbackReply;
         } else {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -373,8 +373,6 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     let requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
-    const requesterIsInternalSession = () =>
-      requesterDepth >= 1 || isCronSessionKey(targetRequesterSessionKey);
 
     let childCompletionFindings: string | undefined;
     let subagentRegistryRuntime:

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -202,7 +202,7 @@ function hasUsableSessionEntry(entry: unknown): boolean {
     return false;
   }
   const sessionId = (entry as { sessionId?: unknown }).sessionId;
-  return typeof sessionId === "string" && sessionId.trim() !== "";
+  return typeof sessionId !== "string" || sessionId.trim() !== "";
 }
 
 type ResolvedAnnounceTarget =

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -103,21 +103,29 @@ function hasUsableSessionEntry(entry: unknown): boolean {
   return typeof sessionId !== "string" || sessionId.trim() !== "";
 }
 
-type ResolvedAnnounceTarget = {
-  requesterSessionKey: string;
-  requesterOrigin?: DeliveryContext;
-  requesterDepth: number;
-  requesterIsInternal: boolean;
-  fallbackUsed: boolean;
-};
+type ResolvedAnnounceTarget =
+  | {
+      kind: "resolved";
+      requesterSessionKey: string;
+      requesterOrigin?: DeliveryContext;
+      requesterDepth: number;
+      requesterIsInternal: boolean;
+      fallbackUsed: boolean;
+    }
+  | {
+      kind: "ignore";
+    }
+  | {
+      kind: "no-fallback";
+      requesterIsInternal: boolean;
+    };
 
 async function resolveSubagentAnnounceTarget(params: {
   requesterSessionKey: string;
-  requesterDisplayKey?: string;
   requesterOrigin?: DeliveryContext;
   subagentRegistryRuntime?: Awaited<ReturnType<typeof loadSubagentRegistryRuntime>>;
-}): Promise<ResolvedAnnounceTarget | null> {
-  let requesterSessionKey = params.requesterDisplayKey?.trim() || params.requesterSessionKey;
+}): Promise<ResolvedAnnounceTarget> {
+  let requesterSessionKey = params.requesterSessionKey;
   let requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   let requesterDepth = getSubagentDepthFromSessionStore(requesterSessionKey);
   let requesterIsInternal = requesterDepth >= 1 || isCronSessionKey(requesterSessionKey);
@@ -125,6 +133,7 @@ async function resolveSubagentAnnounceTarget(params: {
 
   if (!requesterIsInternal) {
     return {
+      kind: "resolved",
       requesterSessionKey,
       requesterOrigin,
       requesterDepth,
@@ -135,6 +144,7 @@ async function resolveSubagentAnnounceTarget(params: {
 
   if (isCronSessionKey(requesterSessionKey)) {
     return {
+      kind: "resolved",
       requesterSessionKey,
       requesterOrigin,
       requesterDepth,
@@ -145,7 +155,7 @@ async function resolveSubagentAnnounceTarget(params: {
 
   const runtime = params.subagentRegistryRuntime ?? (await loadSubagentRegistryRuntime());
   if (runtime.shouldIgnorePostCompletionAnnounceForSession(requesterSessionKey)) {
-    return null;
+    return { kind: "ignore" };
   }
 
   const parentSessionEntry = loadSessionEntryByKey(requesterSessionKey);
@@ -156,7 +166,7 @@ async function resolveSubagentAnnounceTarget(params: {
   if (!parentSessionAlive) {
     const fallback = runtime.resolveRequesterForChildSession(requesterSessionKey);
     if (!fallback?.requesterSessionKey) {
-      return null;
+      return { kind: "no-fallback", requesterIsInternal: true };
     }
     requesterSessionKey = fallback.requesterSessionKey;
     requesterOrigin = normalizeDeliveryContext(fallback.requesterOrigin) ?? requesterOrigin;
@@ -166,6 +176,7 @@ async function resolveSubagentAnnounceTarget(params: {
   }
 
   return {
+    kind: "resolved",
     requesterSessionKey,
     requesterOrigin,
     requesterDepth,
@@ -533,12 +544,14 @@ export async function runSubagentAnnounceFlow(params: {
 
     const resolvedTarget = await resolveSubagentAnnounceTarget({
       requesterSessionKey: targetRequesterSessionKey,
-      requesterDisplayKey: params.requesterDisplayKey,
       requesterOrigin: targetRequesterOrigin,
       subagentRegistryRuntime,
     });
-    if (!resolvedTarget) {
-      if (requesterIsInternalSession()) {
+    if (resolvedTarget.kind === "ignore") {
+      return true;
+    }
+    if (resolvedTarget.kind === "no-fallback") {
+      if (resolvedTarget.requesterIsInternal) {
         shouldDeleteChildSession = false;
         return false;
       }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,4 +1,10 @@
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import {
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  startsWithSilentToken,
+  stripLeadingSilentToken,
+  stripSilentToken,
+} from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
@@ -207,6 +213,31 @@ function hasUsableSessionEntry(entry: unknown): boolean {
   return typeof sessionId !== "string" || sessionId.trim() !== "";
 }
 
+function sanitizeFallbackReply(text: string | undefined): string | null {
+  const normalized = normalizeOptionalString(text);
+  if (!normalized) {
+    return null;
+  }
+  if (isAnnounceSkip(normalized) || isSilentReplyText(normalized, SILENT_REPLY_TOKEN)) {
+    return null;
+  }
+
+  let cleaned = normalized;
+  const hadLeadingToken = startsWithSilentToken(cleaned, SILENT_REPLY_TOKEN);
+  if (hadLeadingToken) {
+    cleaned = stripLeadingSilentToken(cleaned, SILENT_REPLY_TOKEN);
+  }
+  if (hadLeadingToken || cleaned.toUpperCase().includes(SILENT_REPLY_TOKEN)) {
+    cleaned = stripSilentToken(cleaned, SILENT_REPLY_TOKEN);
+  }
+
+  cleaned = normalizeOptionalString(cleaned) ?? "";
+  if (!cleaned || isAnnounceSkip(cleaned) || isSilentReplyText(cleaned, SILENT_REPLY_TOKEN)) {
+    return null;
+  }
+  return cleaned;
+}
+
 type ResolvedAnnounceTarget =
   | {
       kind: "resolved";
@@ -268,7 +299,9 @@ async function resolveSubagentAnnounceTarget(params: {
   const parentSessionEntry = loadSessionEntryByKey(requesterSessionKey);
   const requesterSessionEntry = loadRequesterSessionEntry(requesterSessionKey).entry;
   const parentSessionAlive =
-    hasUsableSessionEntry(parentSessionEntry) || hasUsableSessionEntry(requesterSessionEntry);
+    runtime.isSubagentSessionRunActive(requesterSessionKey) ||
+    hasUsableSessionEntry(parentSessionEntry) ||
+    hasUsableSessionEntry(requesterSessionEntry);
 
   if (!parentSessionAlive) {
     const fallback = runtime.resolveRequesterForChildSession(requesterSessionKey);
@@ -378,7 +411,8 @@ async function wakeSubagentRunAfterDescendants(params: {
     return false;
   }
 
-  const { replaceSubagentRunAfterSteer } = await loadSubagentRegistryRuntime();
+  const { replaceSubagentRunAfterSteer } =
+    await subagentAnnounceDeps.loadSubagentRegistryRuntime();
   return replaceSubagentRunAfterSteer({
     previousRunId: params.runId,
     nextRunId: wakeRunId,
@@ -452,10 +486,6 @@ export async function runSubagentAnnounceFlow(params: {
 
     if (!outcome) {
       outcome = { status: "unknown" };
-    }
-    const failedTerminalOutcome = outcome.status === "error";
-    if (failedTerminalOutcome) {
-      reply = undefined;
     }
 
     let requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
@@ -536,11 +566,9 @@ export async function runSubagentAnnounceFlow(params: {
       }
     }
 
-    if (!childCompletionFindings && !failedTerminalOutcome) {
-      const fallbackReply = normalizeOptionalString(params.fallbackReply);
-      const fallbackIsSilent =
-        Boolean(fallbackReply) &&
-        (isAnnounceSkip(fallbackReply) || isSilentReplyText(fallbackReply, SILENT_REPLY_TOKEN));
+    if (!childCompletionFindings) {
+      const fallbackReply = sanitizeFallbackReply(params.fallbackReply);
+      const fallbackIsSilent = !fallbackReply;
 
       if (!reply) {
         reply = await readSubagentOutput(params.childSessionKey, outcome);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -461,8 +461,8 @@ export async function runSubagentAnnounceFlow(params: {
         : undefined;
     })();
     const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
-    let reply = params.roundOneReply;
     let outcome: SubagentRunOutcome | undefined = params.outcome;
+    let reply = outcome?.status === "error" ? undefined : params.roundOneReply;
     if (childSessionId && isEmbeddedPiRunActive(childSessionId)) {
       const settled = await waitForEmbeddedPiRunEnd(childSessionId, settleTimeoutMs);
       if (!settled && isEmbeddedPiRunActive(childSessionId)) {
@@ -567,14 +567,17 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     if (!childCompletionFindings) {
-      const fallbackReply = sanitizeAnnounceReply(params.fallbackReply);
+      const terminalErrorOutcome = outcome?.status === "error";
+      const fallbackReply = terminalErrorOutcome
+        ? undefined
+        : sanitizeAnnounceReply(params.fallbackReply);
       const fallbackIsSilent = !fallbackReply;
 
-      if (!reply) {
+      if (!terminalErrorOutcome && !reply) {
         reply = await readSubagentOutput(params.childSessionKey, outcome);
       }
 
-      if (!reply?.trim()) {
+      if (!terminalErrorOutcome && !reply?.trim()) {
         reply = await readLatestSubagentOutputWithRetry({
           sessionKey: params.childSessionKey,
           maxWaitMs: params.timeoutMs,
@@ -582,7 +585,7 @@ export async function runSubagentAnnounceFlow(params: {
         });
       }
 
-      if (!reply?.trim() && fallbackReply && !fallbackIsSilent) {
+      if (!terminalErrorOutcome && !reply?.trim() && fallbackReply && !fallbackIsSilent) {
         reply = fallbackReply;
       }
 
@@ -612,7 +615,7 @@ export async function runSubagentAnnounceFlow(params: {
       if (!reply) {
         if (fallbackReply && !fallbackIsSilent) {
           reply = fallbackReply;
-        } else {
+        } else if (!terminalErrorOutcome) {
           return true;
         }
       }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -37,7 +37,7 @@ import {
   waitForEmbeddedPiRunEnd,
 } from "./subagent-announce.runtime.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
-import type { SpawnSubagentMode } from "./subagent-spawn.js";
+import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
 
 type SubagentAnnounceDeps = {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -103,6 +103,77 @@ function hasUsableSessionEntry(entry: unknown): boolean {
   return typeof sessionId !== "string" || sessionId.trim() !== "";
 }
 
+type ResolvedAnnounceTarget = {
+  requesterSessionKey: string;
+  requesterOrigin?: DeliveryContext;
+  requesterDepth: number;
+  requesterIsInternal: boolean;
+  fallbackUsed: boolean;
+};
+
+async function resolveSubagentAnnounceTarget(params: {
+  requesterSessionKey: string;
+  requesterDisplayKey?: string;
+  requesterOrigin?: DeliveryContext;
+  subagentRegistryRuntime?: Awaited<ReturnType<typeof loadSubagentRegistryRuntime>>;
+}): Promise<ResolvedAnnounceTarget | null> {
+  let requesterSessionKey = params.requesterDisplayKey?.trim() || params.requesterSessionKey;
+  let requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
+  let requesterDepth = getSubagentDepthFromSessionStore(requesterSessionKey);
+  let requesterIsInternal = requesterDepth >= 1 || isCronSessionKey(requesterSessionKey);
+  let fallbackUsed = false;
+
+  if (!requesterIsInternal) {
+    return {
+      requesterSessionKey,
+      requesterOrigin,
+      requesterDepth,
+      requesterIsInternal,
+      fallbackUsed,
+    };
+  }
+
+  if (isCronSessionKey(requesterSessionKey)) {
+    return {
+      requesterSessionKey,
+      requesterOrigin,
+      requesterDepth,
+      requesterIsInternal: true,
+      fallbackUsed,
+    };
+  }
+
+  const runtime = params.subagentRegistryRuntime ?? (await loadSubagentRegistryRuntime());
+  if (runtime.shouldIgnorePostCompletionAnnounceForSession(requesterSessionKey)) {
+    return null;
+  }
+
+  const parentSessionEntry = loadSessionEntryByKey(requesterSessionKey);
+  const requesterSessionEntry = loadRequesterSessionEntry(requesterSessionKey).entry;
+  const parentSessionAlive =
+    hasUsableSessionEntry(parentSessionEntry) || requesterSessionEntry != null;
+
+  if (!parentSessionAlive) {
+    const fallback = runtime.resolveRequesterForChildSession(requesterSessionKey);
+    if (!fallback?.requesterSessionKey) {
+      return null;
+    }
+    requesterSessionKey = fallback.requesterSessionKey;
+    requesterOrigin = normalizeDeliveryContext(fallback.requesterOrigin) ?? requesterOrigin;
+    requesterDepth = getSubagentDepthFromSessionStore(requesterSessionKey);
+    requesterIsInternal = requesterDepth >= 1 || isCronSessionKey(requesterSessionKey);
+    fallbackUsed = true;
+  }
+
+  return {
+    requesterSessionKey,
+    requesterOrigin,
+    requesterDepth,
+    requesterIsInternal,
+    fallbackUsed,
+  };
+}
+
 function buildDescendantWakeMessage(params: { findings: string; taskLabel: string }): string {
   return [
     "[Subagent Context] Your prior run ended while waiting for descendant subagent completions.",
@@ -460,34 +531,23 @@ export async function runSubagentAnnounceFlow(params: {
     const announceSessionId = childSessionId || "unknown";
     const findings = childCompletionFindings || reply || "(no output)";
 
-    let requesterIsSubagent = requesterIsInternalSession();
-    if (requesterIsSubagent) {
-      const {
-        isSubagentSessionRunActive,
-        resolveRequesterForChildSession,
-        shouldIgnorePostCompletionAnnounceForSession,
-      } = subagentRegistryRuntime ?? (await loadSubagentRegistryRuntime());
-      if (!isSubagentSessionRunActive(targetRequesterSessionKey)) {
-        if (shouldIgnorePostCompletionAnnounceForSession(targetRequesterSessionKey)) {
-          return true;
-        }
-        const parentSessionEntry = loadSessionEntryByKey(targetRequesterSessionKey);
-        const parentSessionAlive = hasUsableSessionEntry(parentSessionEntry);
-
-        if (!parentSessionAlive) {
-          const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
-          if (!fallback?.requesterSessionKey) {
-            shouldDeleteChildSession = false;
-            return false;
-          }
-          targetRequesterSessionKey = fallback.requesterSessionKey;
-          targetRequesterOrigin =
-            normalizeDeliveryContext(fallback.requesterOrigin) ?? targetRequesterOrigin;
-          requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
-          requesterIsSubagent = requesterIsInternalSession();
-        }
+    const resolvedTarget = await resolveSubagentAnnounceTarget({
+      requesterSessionKey: targetRequesterSessionKey,
+      requesterDisplayKey: params.requesterDisplayKey,
+      requesterOrigin: targetRequesterOrigin,
+      subagentRegistryRuntime,
+    });
+    if (!resolvedTarget) {
+      if (requesterIsInternalSession()) {
+        shouldDeleteChildSession = false;
+        return false;
       }
+      return true;
     }
+    targetRequesterSessionKey = resolvedTarget.requesterSessionKey;
+    targetRequesterOrigin = resolvedTarget.requesterOrigin;
+    requesterDepth = resolvedTarget.requesterDepth;
+    let requesterIsSubagent = resolvedTarget.requesterIsInternal;
 
     const replyInstruction = buildAnnounceReplyInstruction({
       requesterIsSubagent,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -43,11 +43,13 @@ import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
 type SubagentAnnounceDeps = {
   callGateway: typeof callGateway;
   loadConfig: typeof loadConfig;
+  loadSubagentRegistryRuntime: typeof loadSubagentRegistryRuntime;
 };
 
 const defaultSubagentAnnounceDeps: SubagentAnnounceDeps = {
   callGateway,
   loadConfig,
+  loadSubagentRegistryRuntime,
 };
 
 let subagentAnnounceDeps: SubagentAnnounceDeps = defaultSubagentAnnounceDeps;
@@ -255,9 +257,12 @@ async function resolveSubagentAnnounceTarget(params: {
     };
   }
 
-  const runtime = params.subagentRegistryRuntime ?? (await loadSubagentRegistryRuntime());
-  if (runtime.shouldIgnorePostCompletionAnnounceForSession(requesterSessionKey)) {
-    return { kind: "ignore" };
+  const runtime =
+    params.subagentRegistryRuntime ?? (await subagentAnnounceDeps.loadSubagentRegistryRuntime());
+  if (!runtime.isSubagentSessionRunActive(requesterSessionKey)) {
+    if (runtime.shouldIgnorePostCompletionAnnounceForSession(requesterSessionKey)) {
+      return { kind: "ignore" };
+    }
   }
 
   const parentSessionEntry = loadSessionEntryByKey(requesterSessionKey);
@@ -460,7 +465,7 @@ export async function runSubagentAnnounceFlow(params: {
       | Awaited<ReturnType<typeof loadSubagentRegistryRuntime>>
       | undefined;
     try {
-      subagentRegistryRuntime = await loadSubagentRegistryRuntime();
+      subagentRegistryRuntime = await subagentAnnounceDeps.loadSubagentRegistryRuntime();
       if (
         requesterDepth >= 1 &&
         subagentRegistryRuntime.shouldIgnorePostCompletionAnnounceForSession(

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,10 +1,5 @@
-import {
-  isSilentReplyText,
-  SILENT_REPLY_TOKEN,
-  startsWithSilentToken,
-  stripLeadingSilentToken,
-  stripSilentToken,
-} from "../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -42,19 +37,17 @@ import {
   waitForEmbeddedPiRunEnd,
 } from "./subagent-announce.runtime.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
-import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
+import type { SpawnSubagentMode } from "./subagent-spawn.js";
 import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
 
 type SubagentAnnounceDeps = {
   callGateway: typeof callGateway;
   loadConfig: typeof loadConfig;
-  loadSubagentRegistryRuntime: typeof loadSubagentRegistryRuntime;
 };
 
 const defaultSubagentAnnounceDeps: SubagentAnnounceDeps = {
   callGateway,
   loadConfig,
-  loadSubagentRegistryRuntime,
 };
 
 let subagentAnnounceDeps: SubagentAnnounceDeps = defaultSubagentAnnounceDeps;
@@ -68,7 +61,116 @@ function loadSubagentRegistryRuntime() {
   return subagentRegistryRuntimePromise;
 }
 
-export { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
+export function buildSubagentSystemPrompt(params: {
+  requesterSessionKey?: string;
+  requesterOrigin?: DeliveryContext;
+  childSessionKey: string;
+  label?: string;
+  task?: string;
+  /** Whether ACP-specific routing guidance should be included. Defaults to true. */
+  acpEnabled?: boolean;
+  /** Depth of the child being spawned (1 = sub-agent, 2 = sub-sub-agent). */
+  childDepth?: number;
+  /** Config value: max allowed spawn depth. */
+  maxSpawnDepth?: number;
+}) {
+  const taskText =
+    typeof params.task === "string" && params.task.trim()
+      ? params.task.replace(/\s+/g, " ").trim()
+      : "{{TASK_DESCRIPTION}}";
+  const childDepth = typeof params.childDepth === "number" ? params.childDepth : 1;
+  const maxSpawnDepth =
+    typeof params.maxSpawnDepth === "number"
+      ? params.maxSpawnDepth
+      : DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
+  const acpEnabled = params.acpEnabled !== false;
+  const canSpawn = childDepth < maxSpawnDepth;
+  const parentLabel = childDepth >= 2 ? "parent orchestrator" : "main agent";
+
+  const lines = [
+    "# Subagent Context",
+    "",
+    `You are a **subagent** spawned by the ${parentLabel} for a specific task.`,
+    "",
+    "## Your Role",
+    `- You were created to handle: ${taskText}`,
+    "- Complete this task. That's your entire purpose.",
+    `- You are NOT the ${parentLabel}. Don't try to be.`,
+    "",
+    "## Rules",
+    "1. **Stay focused** - Do your assigned task, nothing else",
+    `2. **Complete the task** - Your final message will be automatically reported to the ${parentLabel}`,
+    "3. **Don't initiate** - No heartbeats, no proactive actions, no side quests",
+    "4. **Be ephemeral** - You may be terminated after task completion. That's fine.",
+    "5. **Trust push-based completion** - Descendant results are auto-announced back to you; do not busy-poll for status.",
+    "6. **Recover from truncated tool output** - If you see a notice like `[... N more characters truncated]`, assume prior output was reduced. Re-read only what you need using smaller chunks (`read` with offset/limit, or targeted `rg`/`head`/`tail`) instead of full-file `cat`.",
+    "",
+    "## Output Format",
+    "When complete, your final response should include:",
+    `- What you accomplished or found`,
+    `- Any relevant details the ${parentLabel} should know`,
+    "- Keep it concise but informative",
+    "",
+    "## What You DON'T Do",
+    `- NO user conversations (that's ${parentLabel}'s job)`,
+    "- NO external messages (email, tweets, etc.) unless explicitly tasked with a specific recipient/channel",
+    "- NO cron jobs or persistent state",
+    `- NO pretending to be the ${parentLabel}`,
+    `- Only use the \`message\` tool when explicitly instructed to contact a specific external recipient; otherwise return plain text and let the ${parentLabel} deliver it`,
+    "",
+  ];
+
+  if (canSpawn) {
+    lines.push(
+      "## Sub-Agent Spawning",
+      "You CAN spawn your own sub-agents for parallel or complex work using `sessions_spawn`.",
+      "Use the `subagents` tool to steer, kill, or do an on-demand status check for your spawned sub-agents.",
+      "Your sub-agents will announce their results back to you automatically (not to the main agent).",
+      "Default workflow: spawn work, continue orchestrating, and wait for auto-announced completions.",
+      "Auto-announce is push-based. After spawning children, do NOT call sessions_list, sessions_history, exec sleep, or any polling tool.",
+      "Wait for completion events to arrive as user messages.",
+      "Track expected child session keys and only send your final answer after completion events for ALL expected children arrive.",
+      "If a child completion event arrives AFTER you already sent your final answer, reply ONLY with NO_REPLY.",
+      "Do NOT repeatedly poll `subagents list` in a loop unless you are actively debugging or intervening.",
+      "Coordinate their work and synthesize results before reporting back.",
+      ...(acpEnabled
+        ? [
+            'For ACP harness sessions (codex/claudecode/gemini), use `sessions_spawn` with `runtime: "acp"` (set `agentId` unless `acp.defaultAgent` is configured).',
+            '`agents_list` and `subagents` apply to OpenClaw sub-agents (`runtime: "subagent"`); ACP harness ids are controlled by `acp.allowedAgents`.',
+            "Do not ask users to run slash commands or CLI when `sessions_spawn` can do it directly.",
+            "Do not use `exec` (`openclaw ...`, `acpx ...`) to spawn ACP sessions.",
+            'Use `subagents` only for OpenClaw subagents (`runtime: "subagent"`).',
+            "Subagent results auto-announce back to you; ACP sessions continue in their bound thread.",
+            "Avoid polling loops; spawn, orchestrate, and synthesize results.",
+          ]
+        : []),
+      "",
+    );
+  } else if (childDepth >= 2) {
+    lines.push(
+      "## Sub-Agent Spawning",
+      "You are a leaf worker and CANNOT spawn further sub-agents. Focus on your assigned task.",
+      "",
+    );
+  }
+
+  lines.push(
+    "## Session Context",
+    ...[
+      params.label ? `- Label: ${params.label}` : undefined,
+      params.requesterSessionKey
+        ? `- Requester session: ${params.requesterSessionKey}.`
+        : undefined,
+      params.requesterOrigin?.channel
+        ? `- Requester channel: ${params.requesterOrigin.channel}.`
+        : undefined,
+      `- Your session: ${params.childSessionKey}.`,
+    ].filter((line): line is string => line !== undefined),
+    "",
+  );
+  return lines.join("\n");
+}
+
 export { captureSubagentCompletionReply } from "./subagent-announce-output.js";
 export type { SubagentRunOutcome } from "./subagent-announce-output.js";
 
@@ -100,7 +202,7 @@ function hasUsableSessionEntry(entry: unknown): boolean {
     return false;
   }
   const sessionId = (entry as { sessionId?: unknown }).sessionId;
-  return typeof sessionId !== "string" || sessionId.trim() !== "";
+  return typeof sessionId === "string" && sessionId.trim() !== "";
 }
 
 type ResolvedAnnounceTarget =
@@ -213,27 +315,6 @@ function isWakeContinuationRun(runId: string): boolean {
     return false;
   }
   return stripWakeRunSuffixes(trimmed) !== trimmed;
-}
-
-function stripAndClassifyReply(text: string): string | null {
-  let result = text;
-  let didStrip = false;
-  const hasLeadingSilentToken = startsWithSilentToken(result, SILENT_REPLY_TOKEN);
-  if (hasLeadingSilentToken) {
-    result = stripLeadingSilentToken(result, SILENT_REPLY_TOKEN);
-    didStrip = true;
-  }
-  if (hasLeadingSilentToken || result.toLowerCase().includes(SILENT_REPLY_TOKEN.toLowerCase())) {
-    result = stripSilentToken(result, SILENT_REPLY_TOKEN);
-    didStrip = true;
-  }
-  if (
-    didStrip &&
-    (!result.trim() || isSilentReplyText(result, SILENT_REPLY_TOKEN) || isAnnounceSkip(result))
-  ) {
-    return null;
-  }
-  return result;
 }
 
 async function wakeSubagentRunAfterDescendants(params: {
@@ -379,7 +460,7 @@ export async function runSubagentAnnounceFlow(params: {
       | Awaited<ReturnType<typeof loadSubagentRegistryRuntime>>
       | undefined;
     try {
-      subagentRegistryRuntime = await subagentAnnounceDeps.loadSubagentRegistryRuntime();
+      subagentRegistryRuntime = await loadSubagentRegistryRuntime();
       if (
         requesterDepth >= 1 &&
         subagentRegistryRuntime.shouldIgnorePostCompletionAnnounceForSession(
@@ -496,28 +577,9 @@ export async function runSubagentAnnounceFlow(params: {
 
       if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
         if (fallbackReply && !fallbackIsSilent) {
-          const cleaned = stripAndClassifyReply(fallbackReply);
-          if (cleaned === null) {
-            return true;
-          }
-          reply = cleaned;
+          reply = fallbackReply;
         } else {
           return true;
-        }
-      } else if (reply) {
-        const cleaned = stripAndClassifyReply(reply);
-        if (cleaned === null) {
-          if (fallbackReply && !fallbackIsSilent) {
-            const cleanedFallback = stripAndClassifyReply(fallbackReply);
-            if (cleanedFallback === null) {
-              return true;
-            }
-            reply = cleanedFallback;
-          } else {
-            return true;
-          }
-        } else {
-          reply = cleaned;
         }
       }
     }
@@ -549,8 +611,8 @@ export async function runSubagentAnnounceFlow(params: {
       return true;
     }
     if (resolvedTarget.kind === "no-fallback") {
+      shouldDeleteChildSession = false;
       if (resolvedTarget.requesterIsInternal) {
-        shouldDeleteChildSession = false;
         return false;
       }
       return true;

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -161,7 +161,7 @@ async function resolveSubagentAnnounceTarget(params: {
   const parentSessionEntry = loadSessionEntryByKey(requesterSessionKey);
   const requesterSessionEntry = loadRequesterSessionEntry(requesterSessionKey).entry;
   const parentSessionAlive =
-    hasUsableSessionEntry(parentSessionEntry) || requesterSessionEntry != null;
+    hasUsableSessionEntry(parentSessionEntry) || hasUsableSessionEntry(requesterSessionEntry);
 
   if (!parentSessionAlive) {
     const fallback = runtime.resolveRequesterForChildSession(requesterSessionKey);

--- a/src/plugins/contracts/provider-family-plugin-tests.test.ts
+++ b/src/plugins/contracts/provider-family-plugin-tests.test.ts
@@ -19,6 +19,7 @@ type ExpectedSharedFamilyContract = {
 
 const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const REPO_ROOT = resolve(SRC_ROOT, "..");
+const EXTENSIONS_ROOT = resolve(REPO_ROOT, "extensions");
 const SHARED_FAMILY_HOOK_PATTERNS: ReadonlyArray<{
   kind: SharedFamilyHookKind;
   regex: RegExp;
@@ -68,12 +69,27 @@ function listFiles(dir: string): string[] {
 }
 
 function listBundledPluginRoots() {
-  return loadPluginManifestRegistry({})
-    .plugins.filter((plugin) => plugin.origin === "bundled")
-    .map((plugin) => ({
-      pluginId: plugin.id,
-      rootDir: plugin.workspaceDir ?? plugin.rootDir,
-    }))
+  const roots = new Map<string, string>();
+
+  for (const plugin of loadPluginManifestRegistry({}).plugins) {
+    if (plugin.origin !== "bundled") {
+      continue;
+    }
+    const rootDir = plugin.workspaceDir ?? plugin.rootDir;
+    if (rootDir) {
+      roots.set(plugin.id, rootDir);
+    }
+  }
+
+  for (const entry of readdirSync(EXTENSIONS_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    roots.set(entry.name, resolve(EXTENSIONS_ROOT, entry.name));
+  }
+
+  return [...roots.entries()]
+    .map(([pluginId, rootDir]) => ({ pluginId, rootDir }))
     .toSorted((left, right) => left.pluginId.localeCompare(right.pluginId));
 }
 


### PR DESCRIPTION
## Summary
Closes #60207.

This fixes subagent completion routing when the requester is itself an internal session (for example a parent subagent or a cron-run requester).

The bug was not a single bad branch. The underlying problem was that announce target resolution was being decided in multiple places in the subagent completion flow, with slightly different rules for:

- whether the requester should still be treated as internal
- whether the parent requester session was considered "alive"
- when it was allowed to fall back from the parent to the grandparent requester
- how `requesterSessionKey`, `requesterDisplayKey`, and `requesterOrigin` interacted

Because those decisions were split across branches instead of being resolved once, the final delivery target could drift.

## What users would see
This created confusing behavior in nested subagent flows:

- a child subagent could finish and announce to the **grandparent** session even though the **parent** session still existed
- cron-originated requester sessions could be treated inconsistently and sometimes drift toward external delivery paths
- routing behavior depended too much on which branch of the announce flow was reached, instead of one stable target-resolution rule

From the user side, this looks like:
- completions showing up in the wrong session
- internal orchestration updates skipping the expected parent session
- behavior that feels inconsistent between parent-child, grandparent fallback, and cron cases

## Root cause
The routing problem came from the logic in `src/agents/subagent-announce.ts`.

Before this change, the flow first built completion state, then later re-decided requester routing inline using a mix of:

- `getSubagentDepthFromSessionStore(...)`
- `isCronSessionKey(...)`
- `loadSessionEntryByKey(...)`
- `resolveRequesterForChildSession(...)`
- `requesterSessionKey`
- `requesterDisplayKey`
- `requesterOrigin`

The key problem was that target selection and fallback behavior were not modeled as one explicit resolution step.

In particular:
- internal requester detection was derived inline
- parent liveness was checked inline
- fallback to the grandparent requester was also done inline
- those decisions happened late in the announce flow, after other completion logic had already been built

That made it easy for the announce target to shift from:
- **parent requester**
to
- **grandparent requester**
even when the parent session still existed

## What changed
This change centralizes that logic into a single resolution step inside `src/agents/subagent-announce.ts`.

More specifically, it introduces a dedicated announce-target resolution path that now resolves, in one place:

- which requester session should receive the completion
- whether the requester should remain internal
- whether the requester is a cron/internal requester
- whether the parent requester is still alive
- whether fallback to the grandparent requester is actually allowed

The practical changes are:

- added a unified `resolveSubagentAnnounceTarget(...)` step
- stopped re-deciding parent/fallback routing across multiple inline branches
- treated cron requesters as internal by policy inside the same resolution path
- only fall back to the grandparent requester when the parent requester is genuinely missing
- preserve parent routing when the parent session still exists
- keep the resulting announce target stable before handing off to delivery

## Effect after the change
After this change, the subagent completion path behaves more predictably:

- if the parent requester still exists, the child completion stays routed to the parent
- if the parent requester is genuinely missing, only then does the flow fall back upward
- cron requesters remain internal instead of drifting into the wrong delivery path
- announce delivery consumes an already-resolved target instead of inheriting a partially-decided state

So this is not just a patch for one failing branch — it makes the routing model itself consistent.

## Files changed
Primary change:
- `src/agents/subagent-announce.ts`

This PR keeps the implementation concentrated in the announce flow instead of scattering the fix across delivery helpers, which makes the requester-resolution policy easier to reason about and harder to regress in future nested subagent changes.
