### PR TITLE
fix: clean up seqByRun entries when agent runs end

### DIFF
--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,4 +1,5 @@
 import type { HealthSummary } from "../commands/health.js";
+import { pruneStaleAgentEventState } from "../infra/agent-events.js";
 import { cleanOldMedia } from "../media/store.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ChatRunEntry } from "./server-chat.js";
@@ -102,6 +103,10 @@ export function startGatewayMaintenanceTimers(params: {
         }
       }
     }
+
+    // Safety-net: prune module-level seqByRun / runContextById in agent-events
+    // that may leak if lifecycle cleanup is missed (e.g. dropped events).
+    pruneStaleAgentEventState(AGENT_RUN_SEQ_MAX);
 
     for (const [runId, entry] of params.chatAbortControllers) {
       if (now <= entry.expiresAtMs) {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, test } from "vitest";
 import {
   clearAgentRunContext,
   emitAgentEvent,
+  getAgentEventStateSize,
   getAgentRunContext,
   onAgentEvent,
+  pruneStaleAgentEventState,
   registerAgentRunContext,
   resetAgentEventsForTest,
   resetAgentRunContextForTest,
@@ -132,6 +134,64 @@ describe("agent-events sequencing", () => {
     stop();
 
     expect(receivedSessionKey).toBe("session-main");
+  });
+
+  test("clearAgentRunContext also cleans seqByRun entries", async () => {
+    resetAgentRunContextForTest();
+    registerAgentRunContext("run-seq", { sessionKey: "main" });
+
+    // Emit events to populate seqByRun
+    emitAgentEvent({ runId: "run-seq", stream: "lifecycle", data: {} });
+    emitAgentEvent({ runId: "run-seq", stream: "lifecycle", data: {} });
+    expect(getAgentEventStateSize().seqByRun).toBeGreaterThanOrEqual(1);
+
+    // Clear should remove both context and seq
+    clearAgentRunContext("run-seq");
+    expect(getAgentRunContext("run-seq")).toBeUndefined();
+
+    // Next emit for same runId should restart at seq=1
+    const seqs: number[] = [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-seq") {
+        seqs.push(evt.seq);
+      }
+    });
+    emitAgentEvent({ runId: "run-seq", stream: "lifecycle", data: {} });
+    stop();
+    expect(seqs).toEqual([1]);
+  });
+
+  test("pruneStaleAgentEventState removes oldest entries beyond limit", async () => {
+    resetAgentRunContextForTest();
+
+    // Populate 5 runs
+    for (let i = 0; i < 5; i++) {
+      registerAgentRunContext(`prune-${i}`, { sessionKey: `s-${i}` });
+      emitAgentEvent({ runId: `prune-${i}`, stream: "lifecycle", data: {} });
+    }
+    expect(getAgentEventStateSize().seqByRun).toBe(5);
+    expect(getAgentEventStateSize().runContextById).toBe(5);
+
+    // Prune to max 3 — should remove the 2 oldest (FIFO)
+    const removed = pruneStaleAgentEventState(3);
+    expect(removed).toBe(2);
+    expect(getAgentEventStateSize().seqByRun).toBe(3);
+    expect(getAgentEventStateSize().runContextById).toBe(3);
+
+    // The first two should be gone
+    expect(getAgentRunContext("prune-0")).toBeUndefined();
+    expect(getAgentRunContext("prune-1")).toBeUndefined();
+    // The last three should still exist
+    expect(getAgentRunContext("prune-2")).toBeDefined();
+    expect(getAgentRunContext("prune-3")).toBeDefined();
+    expect(getAgentRunContext("prune-4")).toBeDefined();
+  });
+
+  test("pruneStaleAgentEventState is a no-op when under limit", async () => {
+    resetAgentRunContextForTest();
+    emitAgentEvent({ runId: "small-run", stream: "lifecycle", data: {} });
+    const removed = pruneStaleAgentEventState(1000);
+    expect(removed).toBe(0);
   });
 
   test("keeps notifying later listeners when one throws", async () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -158,11 +158,46 @@ export function getAgentRunContext(runId: string) {
 }
 
 export function clearAgentRunContext(runId: string) {
-  getAgentEventState().runContextById.delete(runId);
+  const state = getAgentEventState();
+  state.runContextById.delete(runId);
+  state.seqByRun.delete(runId);
+}
+
+/**
+ * Safety-net pruning for `seqByRun` — keeps only the most recent entries when
+ * the map grows beyond `maxEntries`. Called from the gateway maintenance timer
+ * so stale run-IDs cannot accumulate indefinitely even if lifecycle cleanup is
+ * missed. Because entries lack timestamps, pruning is FIFO (Map insertion
+ * order).
+ */
+export function pruneStaleAgentEventState(maxEntries: number): number {
+  const state = getAgentEventState();
+  if (state.seqByRun.size <= maxEntries) {
+    return 0;
+  }
+  const excess = state.seqByRun.size - maxEntries;
+  let removed = 0;
+  for (const runId of state.seqByRun.keys()) {
+    state.seqByRun.delete(runId);
+    state.runContextById.delete(runId);
+    removed += 1;
+    if (removed >= excess) {
+      break;
+    }
+  }
+  return removed;
+}
+
+/** Returns the current size of internal agent-event state maps (for instrumentation). */
+export function getAgentEventStateSize(): { seqByRun: number; runContextById: number } {
+  const state = getAgentEventState();
+  return { seqByRun: state.seqByRun.size, runContextById: state.runContextById.size };
 }
 
 export function resetAgentRunContextForTest() {
-  getAgentEventState().runContextById.clear();
+  const state = getAgentEventState();
+  state.runContextById.clear();
+  state.seqByRun.clear();
 }
 
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {


### PR DESCRIPTION
## Summary

Fixes a real gateway memory leak in `src/infra/agent-events.ts` where `seqByRun` grows without bound for completed runs. The leak was confirmed on a long-running local `2026.4.2` install during a Mac Mini memory-ballooning investigation.

## Changes

- delete `seqByRun` entries when `clearAgentRunContext()` runs
- add regression coverage proving the sequence entry is removed and restarts at `1` for reused run IDs
- add a maintenance safety-net that prunes stale agent-event state if cleanup is ever missed

## Testing

- `pnpm vitest run src/infra/agent-events.test.ts`

Fixes #51819
