### PR TITLE
voice-call: make agent ID configurable instead of hardcoding main

### DIFF
--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -361,7 +361,7 @@ export const VoiceCallConfigSchema = z
     /** Store path for call logs */
     store: z.string().optional(),
 
-    /** Agent ID to use for voice call sessions. Defaults to the default agent. */
+    /** Agent ID to use for voice call sessions. Defaults to `"main"`. */
     agent: z.string().optional(),
 
     /** Optional model override for generating voice responses. */

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -361,6 +361,9 @@ export const VoiceCallConfigSchema = z
     /** Store path for call logs */
     store: z.string().optional(),
 
+    /** Agent ID to use for voice call sessions. Defaults to the default agent. */
+    agent: z.string().optional(),
+
     /** Optional model override for generating voice responses. */
     responseModel: z.string().optional(),
 

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -187,7 +187,7 @@ export async function generateVoiceResponse(
   // Build voice-specific session key based on phone number
   const normalizedPhone = from.replace(/\D/g, "");
   const sessionKey = `voice:${normalizedPhone}`;
-  const agentId = "main";
+  const agentId = voiceConfig.agent ?? "main";
 
   // Resolve paths
   const storePath = agentRuntime.session.resolveStorePath(cfg.session?.store, { agentId });


### PR DESCRIPTION
## Summary

The voice call response generator hardcodes `agentId = "main"` in `response-generator.ts:190`, ignoring any agent configuration. This prevents users from routing voice calls through a dedicated lightweight agent optimized for real-time conversation.

**Changes:**
- Add optional `agent` field to `VoiceCallConfigSchema` in `config.ts`
- Replace hardcoded `"main"` with `voiceConfig.agent ?? "main"` in `response-generator.ts`

**Backward compatible** — defaults to `"main"` when not configured.

## Motivation

Voice calls require sub-3-second response times. Using the default main agent loads the full workspace bootstrap (skills, tools, large session history), adding significant latency. A dedicated voice agent with a minimal workspace, `thinkingDefault: "off"`, and `tools.profile: "minimal"` can cut gateway overhead substantially.

## Usage

```json
{
  "voiceCall": {
    "agent": "voice"
  }
}
```

Combined with a lightweight agent definition:

```json
{
  "id": "voice",
  "name": "Voice Agent",
  "workspace": "/path/to/minimal-workspace",
  "model": { "primary": "ollama/nemotron-3-super:cloud" },
  "thinkingDefault": "off",
  "tools": { "profile": "minimal" }
}
```