### PR TITLE
fix(agents): export normalizeDeliveryContext and mergeDeliveryContext from announce-origin helper

### DIFF
--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -30,7 +30,12 @@ import {
   runSubagentAnnounceDispatch,
   type SubagentAnnounceDeliveryResult,
 } from "./subagent-announce-dispatch.js";
-import { resolveAnnounceOrigin, type DeliveryContext } from "./subagent-announce-origin.js";
+import {
+  mergeDeliveryContext,
+  normalizeDeliveryContext,
+  resolveAnnounceOrigin,
+  type DeliveryContext,
+} from "./subagent-announce-origin.js";
 import { type AnnounceQueueItem, enqueueAnnounce } from "./subagent-announce-queue.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";

--- a/src/agents/subagent-announce-origin.ts
+++ b/src/agents/subagent-announce-origin.ts
@@ -42,7 +42,7 @@ function normalizeThreadId(raw?: string | number): string | number | undefined {
   return undefined;
 }
 
-function normalizeDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
+export function normalizeDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
   if (!context) {
     return undefined;
   }
@@ -66,7 +66,7 @@ function normalizeDeliveryContext(context?: DeliveryContext): DeliveryContext | 
   return normalized;
 }
 
-function mergeDeliveryContext(
+export function mergeDeliveryContext(
   primary?: DeliveryContext,
   fallback?: DeliveryContext,
 ): DeliveryContext | undefined {


### PR DESCRIPTION
## Summary

`c45f1ac8ce` (*perf(agents): isolate subagent announce origin helper*) extracted `normalizeDeliveryContext` and `mergeDeliveryContext` into `subagent-announce-origin.ts` but left them unexported. `subagent-announce-delivery.ts` calls them directly, causing a build failure:

```
src/agents/subagent-announce-delivery.ts: error TS2304: Cannot find name 'normalizeDeliveryContext'.
src/agents/subagent-announce-delivery.ts: error TS2304: Cannot find name 'mergeDeliveryContext'.
```

This is currently breaking `build-artifacts` on `main` CI.

## Fix

- `export` both functions from `subagent-announce-origin.ts`
- Add them to the import in `subagent-announce-delivery.ts`

No logic changes — the behaviour is identical.

> 🤖 AI-assisted (Cursor). Confirmed build error from CI logs on `main` run 24016118702.

Made with [Cursor](https://cursor.com)