### PR TITLE
Build: harden A2UI bundle for Windows WSL (AI-assisted: Codex)

### DIFF
--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -2,6 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,6 +34,439 @@ async function pathExists(targetPath) {
   } catch {
     return false;
   }
+}
+
+function isWindowsUncPath(filePath) {
+  return process.platform === "win32" && filePath.startsWith("\\\\");
+}
+
+function resolveCommandCwd(useShell) {
+  if (useShell && isWindowsUncPath(rootDir)) {
+    const drive = process.env.SystemDrive || "C:";
+    return `${drive}\\`;
+  }
+  return rootDir;
+}
+
+function resolveExecutables(command) {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+  if (command === "pnpm") {
+    const executables = [];
+    if (process.env.OPENCLAW_PNPM_CMD) {
+      executables.push(process.env.OPENCLAW_PNPM_CMD);
+    }
+    executables.push("pnpm.cmd", "pnpm");
+    return executables;
+  }
+  if (command === "rolldown") {
+    return ["rolldown.cmd", "rolldown"];
+  }
+  return [command];
+}
+
+function resolveLocalBin(name) {
+  const ext = process.platform === "win32" ? ".cmd" : "";
+  return path.join(rootDir, "node_modules", ".bin", `${name}${ext}`);
+}
+
+/**
+ * Windows `node.exe` (including WSL-invoked) expects `tsc.cmd`; Linux pnpm installs
+ * in WSL often leave only a shell `tsc` shim. Prefer `.cmd` when present; otherwise use
+ * `pnpm exec tsc` so resolution matches mixed WSL/Windows installs.
+ * @returns {{ kind: "path"; executable: string } | { kind: "pnpm-exec" } | null}
+ */
+function resolveLocalTscCommand() {
+  const binDir = path.join(rootDir, "node_modules", ".bin");
+  const tscCmd = path.join(binDir, "tsc.cmd");
+  const tscShim = path.join(binDir, "tsc");
+  if (process.platform === "win32") {
+    if (existsSync(tscCmd)) {
+      return { kind: "path", executable: tscCmd };
+    }
+    if (existsSync(tscShim)) {
+      return { kind: "pnpm-exec" };
+    }
+    return null;
+  }
+  if (existsSync(tscShim)) {
+    return { kind: "path", executable: tscShim };
+  }
+  return null;
+}
+
+function resolvePnpmStoreRolldownBin() {
+  const candidates = [
+    path.join(rootDir, "node_modules", ".pnpm", "node_modules", "rolldown", "bin", "cli.mjs"),
+  ];
+  const pnpmDir = path.join(rootDir, "node_modules", ".pnpm");
+  if (existsSync(pnpmDir)) {
+    for (const entry of readdirSync(pnpmDir)) {
+      if (!entry.startsWith("rolldown@")) {
+        continue;
+      }
+      candidates.push(path.join(pnpmDir, entry, "node_modules", "rolldown", "bin", "cli.mjs"));
+    }
+  }
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+/**
+ * Entry point for running pnpm without `pnpm.cmd`/`cmd.exe`. Needed when `cwd` is a UNC path,
+ * because cmd.exe cannot use a UNC working directory and would drop repo context.
+ * @returns {string | null}
+ */
+function isPnpmNodeEntrypoint(filePath) {
+  const lower = filePath.toLowerCase();
+  return (
+    existsSync(filePath) &&
+    (lower.endsWith("pnpm.cjs") || lower.endsWith("pnpm.js") || lower.endsWith("pnpm.mjs"))
+  );
+}
+
+function resolvePnpmEntrypoint() {
+  const fromEnv = process.env.npm_execpath || process.env.NPM_EXECPATH;
+  if (fromEnv && isPnpmNodeEntrypoint(fromEnv)) {
+    const lower = fromEnv.toLowerCase();
+    if (!lower.endsWith(".cmd")) {
+      return fromEnv;
+    }
+  }
+  const direct = path.join(rootDir, "node_modules", "pnpm", "bin", "pnpm.cjs");
+  if (existsSync(direct)) {
+    return direct;
+  }
+  const pnpmDir = path.join(rootDir, "node_modules", ".pnpm");
+  if (existsSync(pnpmDir)) {
+    for (const entry of readdirSync(pnpmDir)) {
+      if (!entry.startsWith("pnpm@")) {
+        continue;
+      }
+      const candidate = path.join(pnpmDir, entry, "node_modules", "pnpm", "bin", "pnpm.cjs");
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return resolvePnpmEntrypointFromPath();
+}
+
+/** Use a drive-letter cwd for `where` when the repo root is UNC (Windows). */
+function whereCommandCwd() {
+  if (isWindowsUncPath(rootDir)) {
+    const drive = process.env.SystemDrive || "C:";
+    return `${drive}\\`;
+  }
+  return rootDir;
+}
+
+/**
+ * Parse a Node-runnable pnpm entrypoint from a Windows `pnpm.cmd` wrapper.
+ * @param {string} cmdPath
+ * @returns {string | null}
+ */
+function readPnpmEntrypointFromCmdWrapper(cmdPath) {
+  try {
+    const text = readFileSync(cmdPath, "utf8");
+    const matches = text.matchAll(/["']([^"'\r\n]+pnpm\.(?:cjs|mjs|js))["']/gi);
+    for (const match of matches) {
+      const rawPath = match[1];
+      if (!rawPath) {
+        continue;
+      }
+      const expandedPath = rawPath.replace(/%~?dp0%?/gi, `${path.dirname(cmdPath)}\\`);
+      const candidate = path.isAbsolute(expandedPath)
+        ? path.normalize(expandedPath)
+        : path.resolve(path.dirname(cmdPath), expandedPath);
+      if (isPnpmNodeEntrypoint(candidate)) {
+        return candidate;
+      }
+    }
+  } catch {
+    // unreadable or missing
+  }
+  return null;
+}
+
+/**
+ * Resolve a Node-runnable pnpm entrypoint from PATH shims (`pnpm.cmd`, direct `pnpm.js`, etc.).
+ * Needed when `npm_execpath` is a WSL path (invisible to win32 `existsSync`) and the repo
+ * does not vendor pnpm under `node_modules`.
+ * @returns {string | null}
+ */
+function resolvePnpmEntrypointFromPath() {
+  const cwd = whereCommandCwd();
+  for (const name of ["pnpm.cmd", "pnpm"]) {
+    const whereResult = spawnSync("where", [name], {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    });
+    if (whereResult.error || whereResult.status !== 0) {
+      continue;
+    }
+    const lines = whereResult.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    for (const line of lines) {
+      const lower = line.toLowerCase();
+      if (isPnpmNodeEntrypoint(line)) {
+        return line;
+      }
+      if (lower.endsWith(".cmd")) {
+        const npmLayout = path.join(path.dirname(line), "node_modules", "pnpm", "bin", "pnpm.cjs");
+        if (isPnpmNodeEntrypoint(npmLayout)) {
+          return npmLayout;
+        }
+        const fromWrapper = readPnpmEntrypointFromCmdWrapper(line);
+        if (fromWrapper) {
+          return fromWrapper;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Standalone / PATH `pnpm.exe` can run with UNC cwd without `cmd.exe`.
+ * @returns {string | null}
+ */
+function resolvePnpmExeFromPath() {
+  const cwd = whereCommandCwd();
+  const whereResult = spawnSync("where", ["pnpm.exe"], {
+    cwd,
+    stdio: ["ignore", "pipe", "ignore"],
+    encoding: "utf8",
+  });
+  if (whereResult.error || whereResult.status !== 0) {
+    return null;
+  }
+  const line = whereResult.stdout
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!line || !line.toLowerCase().endsWith(".exe") || !existsSync(line)) {
+    return null;
+  }
+  return line;
+}
+
+function resolveExecutableCandidate(executable) {
+  if (process.platform !== "win32" || !executable.toLowerCase().endsWith(".cmd")) {
+    return executable;
+  }
+
+  if (path.isAbsolute(executable)) {
+    return existsSync(executable) ? executable : null;
+  }
+
+  const whereResult = spawnSync("where", [executable], {
+    cwd: rootDir,
+    stdio: ["ignore", "pipe", "ignore"],
+    encoding: "utf8",
+  });
+  if (whereResult.error || whereResult.status !== 0) {
+    return null;
+  }
+
+  const resolved = whereResult.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return resolved ?? null;
+}
+
+function createCommandError(code, command, args, details) {
+  const error = new Error(details.message);
+  error.code = code;
+  error.command = command;
+  error.args = args;
+  error.details = details;
+  return error;
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {{ spawnCwd?: string }} [options] When set, used as `cwd` instead of UNC `.cmd` workaround
+ *   (`pnpm exec` must run with the repo root so local bins resolve).
+ */
+function runCommand(command, args, options) {
+  const executables = resolveExecutables(command);
+  let lastNonZero = null;
+  for (const executable of executables) {
+    const candidate = resolveExecutableCandidate(executable);
+    if (!candidate) {
+      continue;
+    }
+    const useShell = process.platform === "win32" && candidate.toLowerCase().endsWith(".cmd");
+    const cwd = options?.spawnCwd !== undefined ? options.spawnCwd : resolveCommandCwd(useShell);
+
+    if (command === "pnpm" && process.platform === "win32" && isWindowsUncPath(cwd)) {
+      const pnpmEntrypoint = resolvePnpmEntrypoint();
+      const pnpmExe = pnpmEntrypoint ? null : resolvePnpmExeFromPath();
+      if (!pnpmEntrypoint && !pnpmExe) {
+        throw createCommandError("OPENCLAW_COMMAND_NOT_FOUND", command, args, {
+          message: `Cannot run pnpm with UNC working directory (${cwd}). cmd.exe cannot keep a UNC cwd; ensure pnpm is on PATH (pnpm.cmd / pnpm.exe), install deps for a local pnpm.cjs, or use a mapped drive letter.`,
+        });
+      }
+      const uncResult = pnpmEntrypoint
+        ? spawnSync(process.execPath, [pnpmEntrypoint, ...args], {
+            cwd,
+            stdio: "inherit",
+            shell: false,
+          })
+        : spawnSync(pnpmExe, args, {
+            cwd,
+            stdio: "inherit",
+            shell: false,
+          });
+      const candidateLabel = pnpmEntrypoint ?? pnpmExe;
+      if (uncResult.error) {
+        throw uncResult.error;
+      }
+      if (uncResult.status !== 0) {
+        throw createCommandError("OPENCLAW_COMMAND_FAILED", command, args, {
+          candidate: candidateLabel,
+          status: uncResult.status ?? "unknown",
+          message: `Command failed: ${[command, ...args].join(" ")} (pnpm: ${candidateLabel}, exit: ${uncResult.status ?? "unknown"})`,
+        });
+      }
+      return;
+    }
+
+    const result = spawnSync(candidate, args, {
+      cwd,
+      stdio: "inherit",
+      shell: useShell,
+    });
+    if (!result.error) {
+      if (result.status !== 0) {
+        lastNonZero = {
+          candidate,
+          status: result.status ?? "unknown",
+        };
+        continue;
+      }
+      return;
+    }
+    if (result.error.code !== "ENOENT" && result.error.code !== "EINVAL") {
+      throw result.error;
+    }
+  }
+  if (lastNonZero) {
+    const printable = [command, ...args].join(" ");
+    throw createCommandError("OPENCLAW_COMMAND_FAILED", command, args, {
+      ...lastNonZero,
+      message: `Command failed after trying executable fallbacks: ${printable} (last candidate: ${lastNonZero.candidate}, exit: ${lastNonZero.status})`,
+    });
+  }
+  throw createCommandError("OPENCLAW_COMMAND_NOT_FOUND", command, args, {
+    message: `Command not found: ${command}`,
+  });
+}
+
+function hasRolldown() {
+  if (existsSync(resolveLocalBin("rolldown")) || resolvePnpmStoreRolldownBin()) {
+    return true;
+  }
+  const executables = resolveExecutables("rolldown");
+  for (const executable of executables) {
+    const candidate = resolveExecutableCandidate(executable);
+    if (!candidate) {
+      continue;
+    }
+    const useShell = process.platform === "win32" && candidate.toLowerCase().endsWith(".cmd");
+    const result = spawnSync(candidate, ["--version"], {
+      cwd: resolveCommandCwd(useShell),
+      stdio: "ignore",
+      shell: useShell,
+    });
+    if (!result.error) {
+      if (result.status === 0) {
+        return true;
+      }
+      continue;
+    }
+    if (result.error.code !== "ENOENT" && result.error.code !== "EINVAL") {
+      continue;
+    }
+  }
+  return false;
+}
+
+function canRunCommand(command, args) {
+  try {
+    runCommand(command, args);
+    return true;
+  } catch (error) {
+    if (error?.code === "OPENCLAW_COMMAND_NOT_FOUND" || error?.code === "OPENCLAW_COMMAND_FAILED") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {{ continueOnCommandFailure?: boolean }} [options]
+ * @returns {boolean}
+ */
+function tryRunCommand(command, args, options) {
+  const continueOnCommandFailure = options?.continueOnCommandFailure ?? false;
+  try {
+    runCommand(command, args);
+    return true;
+  } catch (error) {
+    if (error?.code === "OPENCLAW_COMMAND_NOT_FOUND") {
+      return false;
+    }
+    // Local `.bin` wrappers and `.cmd` shims can exit non-zero on partial/stale installs.
+    // Only fall through when the wrapper also fails a lightweight `--version` probe; if the
+    // probe succeeds, a non-zero bundle run is a real rolldown/config failure and should surface.
+    if (continueOnCommandFailure && error?.code === "OPENCLAW_COMMAND_FAILED") {
+      if (canRunCommand(command, ["--version"])) {
+        throw error;
+      }
+      return false;
+    }
+    throw error;
+  }
+}
+
+function runStep(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    stdio: "inherit",
+    env: process.env,
+    ...options,
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+/** Prefer `resolvePnpmRunner` on normal Windows cwd; use UNC-safe `runCommand` on `\\\\` roots. */
+function runPnpm(pnpmArgs) {
+  if (process.platform === "win32" && isWindowsUncPath(rootDir)) {
+    runCommand("pnpm", pnpmArgs, { spawnCwd: rootDir });
+    return;
+  }
+  const runner = resolvePnpmRunner({
+    pnpmArgs,
+    nodeExecPath: process.execPath,
+    npmExecPath: process.env.npm_execpath,
+    comSpec: process.env.ComSpec,
+    platform: process.platform,
+  });
+  runStep(runner.command, runner.args, {
+    shell: runner.shell,
+    windowsVerbatimArguments: runner.windowsVerbatimArguments,
+  });
 }
 
 async function walkFiles(entryPath, files) {
@@ -68,32 +502,6 @@ async function computeHash() {
   return hash.digest("hex");
 }
 
-function runStep(command, args, options = {}) {
-  const result = spawnSync(command, args, {
-    cwd: rootDir,
-    stdio: "inherit",
-    env: process.env,
-    ...options,
-  });
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
-}
-
-function runPnpm(pnpmArgs) {
-  const runner = resolvePnpmRunner({
-    pnpmArgs,
-    nodeExecPath: process.execPath,
-    npmExecPath: process.env.npm_execpath,
-    comSpec: process.env.ComSpec,
-    platform: process.platform,
-  });
-  runStep(runner.command, runner.args, {
-    shell: runner.shell,
-    windowsVerbatimArguments: runner.windowsVerbatimArguments,
-  });
-}
-
 async function main() {
   const hasRendererDir = await pathExists(a2uiRendererDir);
   const hasAppDir = await pathExists(a2uiAppDir);
@@ -121,39 +529,51 @@ async function main() {
     }
   }
 
-  runPnpm(["-s", "exec", "tsc", "-p", path.join(a2uiRendererDir, "tsconfig.json")]);
-
-  const localRolldownCliCandidates = [
-    path.join(rootDir, "node_modules", ".pnpm", "node_modules", "rolldown", "bin", "cli.mjs"),
-    path.join(
-      rootDir,
-      "node_modules",
-      ".pnpm",
-      "rolldown@1.0.0-rc.9",
-      "node_modules",
-      "rolldown",
-      "bin",
-      "cli.mjs",
-    ),
-  ];
-  const localRolldownCli = (
-    await Promise.all(
-      localRolldownCliCandidates.map(async (candidate) =>
-        (await pathExists(candidate)) ? candidate : null,
-      ),
-    )
-  ).find(Boolean);
-
-  if (localRolldownCli) {
-    runStep(process.execPath, [
-      localRolldownCli,
-      "-c",
-      path.join(a2uiAppDir, "rolldown.config.mjs"),
-    ]);
+  const tscConfig = path.join(a2uiRendererDir, "tsconfig.json");
+  const tscCommand = resolveLocalTscCommand();
+  if (!tscCommand) {
+    fail(
+      `Local TypeScript binary missing under ${path.join(rootDir, "node_modules", ".bin")} (expected tsc or tsc.cmd on Windows)`,
+    );
+  }
+  if (tscCommand.kind === "path") {
+    const tscExe = tscCommand.executable;
+    const isWindowsTscCmd =
+      process.platform === "win32" && tscExe.toLowerCase().endsWith("tsc.cmd");
+    try {
+      runCommand(tscExe, ["-p", tscConfig]);
+    } catch (error) {
+      // Stale or broken `tsc.cmd` shims can fail even when `pnpm exec tsc` works.
+      if (isWindowsTscCmd && error && typeof error === "object" && error.code === "OPENCLAW_COMMAND_FAILED") {
+        runPnpm(["-s", "exec", "tsc", "-p", tscConfig]);
+      } else {
+        throw error;
+      }
+    }
   } else {
-    runPnpm(["-s", "dlx", "rolldown", "-c", path.join(a2uiAppDir, "rolldown.config.mjs")]);
+    runPnpm(["-s", "exec", "tsc", "-p", tscConfig]);
   }
 
+  const rolldownConfig = path.join(a2uiAppDir, "rolldown.config.mjs");
+  const localRolldown = resolveLocalBin("rolldown");
+  const pnpmStoreRolldown = resolvePnpmStoreRolldownBin();
+  if (
+    (pnpmStoreRolldown &&
+      tryRunCommand(process.execPath, [pnpmStoreRolldown, "-c", rolldownConfig])) ||
+    (existsSync(localRolldown) &&
+      tryRunCommand(localRolldown, ["-c", rolldownConfig], {
+        continueOnCommandFailure: true,
+      })) ||
+    (hasRolldown() &&
+      tryRunCommand("rolldown", ["-c", rolldownConfig], {
+        continueOnCommandFailure: true,
+      }))
+  ) {
+    await fs.writeFile(hashFile, `${currentHash}\n`, "utf8");
+    return;
+  }
+
+  runPnpm(["-s", "dlx", "rolldown", "-c", rolldownConfig]);
   await fs.writeFile(hashFile, `${currentHash}\n`, "utf8");
 }
 

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -1,4 +1,55 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-exec node "$ROOT_DIR/scripts/bundle-a2ui.mjs" "$@"
+SCRIPT_PATH="$ROOT_DIR/scripts/bundle-a2ui.mjs"
+
+# True when the shell is running inside WSL (not native Git Bash / MSYS).
+is_wsl() {
+  if [[ -n "${WSL_DISTRO_NAME:-}" ]] || [[ -n "${WSL_INTEROP:-}" ]]; then
+    return 0
+  fi
+  if [[ -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then
+    return 0
+  fi
+  if [[ -r /proc/version ]] && grep -qi microsoft /proc/version 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+run_windows_node() {
+  local node_bin="$1"
+  if command -v wslpath >/dev/null 2>&1; then
+    local script_windows_path windows_path
+    script_windows_path="$(wslpath -w "$SCRIPT_PATH")"
+    if command -v cmd.exe >/dev/null 2>&1; then
+      windows_path="$(cmd.exe /c echo %PATH% | tr -d '\r')"
+      if [[ -n "$windows_path" ]]; then
+        export PATH="$windows_path"
+      fi
+    fi
+    exec "$node_bin" "$script_windows_path"
+  fi
+  if is_wsl; then
+    echo "wslpath is required to run Windows Node.js from WSL (convert script path for node.exe)." >&2
+    exit 1
+  fi
+  # Git Bash / MSYS: node.exe accepts Unix-style paths from the shell; no wslpath there.
+  exec "$node_bin" "$SCRIPT_PATH"
+}
+
+if command -v node >/dev/null 2>&1; then
+  node_path="$(command -v node)"
+  if [[ "$node_path" == *.exe ]]; then
+    run_windows_node "$node_path"
+  fi
+  exec "$node_path" "$SCRIPT_PATH"
+fi
+
+if command -v node.exe >/dev/null 2>&1; then
+  run_windows_node "$(command -v node.exe)"
+fi
+
+echo "Node.js not found in PATH. Install Node 22+ to run A2UI bundling." >&2
+exit 1


### PR DESCRIPTION
## Summary

- Problem: `pnpm canvas:a2ui:bundle` was fragile in mixed Windows/WSL environments because bash, Windows `node.exe`, `.cmd` shims, and UNC working directories were handled inconsistently.
- Why it matters: `pnpm build` can fail on Windows setups even when Node/pnpm/rolldown are available, especially when WSL shell and Windows executables are mixed.
- What changed: moved the core A2UI bundling logic into `scripts/bundle-a2ui.mjs` and reduced `scripts/bundle-a2ui.sh` to a launcher that handles WSL-to-Windows Node execution explicitly. The new script adds Windows fallback handling for `pnpm`/`rolldown`, avoids UNC cwd issues for `.cmd` execution, and prefers real rolldown CLI paths over broken shim files.
- What did NOT change (scope boundary): this PR only changes the A2UI bundling scripts. It does not change the broader build pipeline, dependency graph, or unrelated CI failures currently present on `main`.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #31840
- [x] This PR fixes a bug or regression

This supersedes #31840 because that branch had drifted too far from current `main`. This PR re-applies only the still-relevant Windows/WSL A2UI bundling fix against the current codebase.

## Root Cause (if applicable)

- Root cause: the previous bash-based bundling flow assumed Linux-style execution and did not robustly handle Windows executable resolution, `.cmd` fallback behavior, or WSL path conversion when `node` resolved to `node.exe`.
- Missing detection / guardrail: the script treated missing or broken `.cmd` shims as hard failures too early and relied on hard-coded rolldown path assumptions.
- Contributing context (if known): mixed Windows + WSL setups can surface UNC cwd limitations and `node.exe` path conversion issues that do not appear on pure Linux/macOS environments.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: build-time coverage around `pnpm canvas:a2ui:bundle`
- Scenario the test should lock in: Windows/WSL mixed execution should still succeed when `node` resolves to `node.exe`, when `.cmd` candidates fail, and when local rolldown shims are stale.
- Why this is the smallest reliable guardrail: the failure depends on runtime process spawning and shell/path behavior, which is not well covered by pure unit tests.
- Existing test that already covers this (if any): None identified.
- If no new test is added, why not: this PR keeps scope to the build-script fix; reproducing these environment-specific shell behaviors in a stable automated test lane would likely require dedicated Windows/WSL seam coverage.

## User-visible / Behavior Changes

- Windows/WSL users should see `pnpm canvas:a2ui:bundle` and the A2UI part of `pnpm build` fail less often in mixed shell environments.
- No user-facing CLI/config changes.

## Diagram (if applicable)

```text
Before:
bash script -> directly runs node/pnpm/rolldown -> mixed Windows/WSL path/shim failure

After:
bash launcher -> normalize Windows node execution -> node bundling script -> fallback across executable candidates -> bundle succeeds
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - This changes local build-tool invocation only. Risk is limited to process spawning behavior during bundling. Mitigated by keeping arguments explicit, constraining logic to A2UI bundling, and preserving existing command intent.

## Repro + Verification

### Environment

- OS: Windows + WSL
- Runtime/container: local dev environment
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): mixed WSL bash + Windows Node/pnpm setup

### Steps

1. Run `pnpm canvas:a2ui:bundle` in a Windows/WSL mixed environment.
2. Ensure `node`/`pnpm`/`rolldown` resolution involves Windows executables or stale `.cmd` shims.
3. Compare behavior before and after this patch.

### Expected

- A2UI bundling succeeds or falls back cleanly across executable candidates.

### Actual

- Before this change, bundling could fail early on Windows/WSL due to path conversion, UNC cwd, or broken `.cmd` shim handling.
- After this change, `pnpm canvas:a2ui:bundle` succeeds locally in the reproduced environment.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm canvas:a2ui:bundle` passes locally after the change
  - `node scripts/bundle-a2ui.mjs` passes locally after the change
  - stale local `rolldown.cmd` shim no longer blocks successful fallback
- Edge cases checked:
  - `node` resolving to `node.exe`
  - `.cmd` fallback continuation after non-zero exit
  - UNC cwd handling for Windows shell execution
- What you did **not** verify:
  - full green `pnpm build && pnpm check && pnpm test` against a completely green `main`
  - CI is still affected by unrelated upstream/main instability at times

## AI-assisted

- AI-assisted: Codex
- Testing: lightly tested locally (`pnpm canvas:a2ui:bundle`, direct script execution)
- Understanding: this PR changes only the A2UI bundling path so Windows/WSL mixed environments can resolve and execute Node/pnpm/rolldown more reliably.
- Key prompts/review points addressed:
  - continue fallback candidates after non-zero shell exits from `.cmd`
  - continue rolldown candidate fallback after failed probe
  - avoid `.cmd` execution with UNC working directory
  - route Windows Node through WSL path conversion when `node` resolves to `node.exe`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: build-script behavior differs from the old bash-only path
  - Mitigation: scope is limited to A2UI bundling and validated against the reproduced Windows/WSL failure mode
- Risk: environment-specific behavior may still vary across Windows setups
  - Mitigation: executable resolution keeps multiple fallback paths instead of assuming a single shim layout
