### PR TITLE
fix(memory-core): isolate dreaming narrative sessions per workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Dreaming/diary: use the host local timezone for diary timestamps when `dreaming.timezone` is unset, so `DREAMS.md` and the UI stop defaulting to UTC. (#65034) Thanks @neo1027144-creator and @vincentkoc.
 - Dreaming/diary: include the timezone abbreviation in diary timestamps so `DREAMS.md` and the UI make UTC or local host time explicit. (#65057) Thanks @Yanhu007 and @vincentkoc.
 - Dreaming/narrative: harden transient narrative cleanup by retrying timed-out deletes and scrubbing stale dreaming session artifacts through the lock-aware session-store path. (#65320) Thanks @serkonyc and @vincentkoc.
+- Dreaming/narrative: isolate transient narrative session keys per workspace so simultaneous dreaming phases cannot cross-read or delete each other's session state. (#61674) Thanks @GaosCode and @vincentkoc.
 - Plugins/memory: restore cached memory capability public artifacts on plugin-registry cache hits so memory-backed artifact surfaces stay visible after warm loads. Thanks @sercada and @vincentkoc.
 - Gateway/cron: preserve requested isolated-agent config across runtime reloads so subagent jobs and heartbeat overrides keep the right workspace and heartbeat settings when the hot-loaded snapshot is stale. Thanks @l0cka and @vincentkoc.
 - Gateway/plugins: always send a non-empty `idempotencyKey` for plugin subagent runs, so dreaming narrative jobs stop failing gateway schema validation. (#65354) Thanks @CodeForgeNet and @vincentkoc.

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import * as configRuntimeModule from "openclaw/plugin-sdk/config-runtime";
@@ -583,7 +584,8 @@ describe("generateAndAppendDreamNarrative", () => {
     const subagent = createMockSubagent("The repository whispered of forgotten endpoints.");
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
-    const expectedSessionKey = `dreaming-narrative-light-${nowMs}`;
+    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
+    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
 
     await generateAndAppendDreamNarrative({
       subagent,
@@ -847,5 +849,38 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(sessionFiles.some((name) => name.startsWith("orphan.jsonl.deleted."))).toBe(true);
     expect(sessionFiles).toContain("still-live.jsonl");
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("dreaming cleanup scrubbed"));
+  });
+
+  it("isolates narrative sessions across workspaces even at the same timestamp", async () => {
+    const firstWorkspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const secondWorkspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("A quiet memory took shape.");
+    const logger = createMockLogger();
+    const nowMs = Date.parse("2026-04-05T03:00:00Z");
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir: firstWorkspaceDir,
+      data: { phase: "light", snippets: ["first workspace fragment"] },
+      nowMs,
+      logger,
+    });
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir: secondWorkspaceDir,
+      data: { phase: "light", snippets: ["second workspace fragment"] },
+      nowMs,
+      logger,
+    });
+
+    const firstSessionKey = subagent.run.mock.calls[0]?.[0]?.sessionKey;
+    const secondSessionKey = subagent.run.mock.calls[1]?.[0]?.sessionKey;
+    expect(firstSessionKey).toBeTypeOf("string");
+    expect(secondSessionKey).toBeTypeOf("string");
+    expect(firstSessionKey).not.toBe(secondSessionKey);
+    expect(firstSessionKey).toContain("dreaming-narrative-light-");
+    expect(secondSessionKey).toContain("dreaming-narrative-light-");
+    expect(subagent.deleteSession.mock.calls[0]?.[0]?.sessionKey).toBe(firstSessionKey);
+    expect(subagent.deleteSession.mock.calls[1]?.[0]?.sessionKey).toBe(secondSessionKey);
   });
 });

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -1,4 +1,5 @@
 import type { Dirent } from "node:fs";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -174,6 +175,15 @@ async function startNarrativeRunOrFallback(params: {
     }
     return null;
   }
+}
+
+function buildNarrativeSessionKey(params: {
+  workspaceDir: string;
+  phase: NarrativePhaseData["phase"];
+  nowMs: number;
+}): string {
+  const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
+  return `dreaming-narrative-${params.phase}-${workspaceHash}-${params.nowMs}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -835,7 +845,11 @@ export async function generateAndAppendDreamNarrative(params: {
     return;
   }
 
-  const sessionKey = `dreaming-narrative-${params.data.phase}-${nowMs}`;
+  const sessionKey = buildNarrativeSessionKey({
+    workspaceDir: params.workspaceDir,
+    phase: params.data.phase,
+    nowMs,
+  });
   const message = buildNarrativePrompt(params.data);
   let runId: string | null = null;
   let waitStatus: string | null = null;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: dreaming narrative generation derived its transient subagent `sessionKey` from only the phase and timestamp.
- Why it matters: in multi-workspace setups, two workspaces hitting the same phase in the same millisecond could reuse the same subagent session and race on message reads or cleanup.
- What changed: make the dreaming narrative session key workspace-aware by including a stable hash of `workspaceDir`, and add regression coverage for same-phase same-timestamp multi-workspace runs.
- What did NOT change (scope boundary): this does not change dreaming ranking, promotion thresholds, diary file format, or `DREAMS.md` write behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the temporary dreaming narrative subagent session key was not scoped by workspace, even though dreaming state and outputs are workspace-local.
- Missing detection / guardrail: there was no test covering multiple workspaces entering the same dreaming phase at the same timestamp.
- Contributing context (if known): dreaming now runs per workspace inside a shared sweep path, which makes key collisions possible when the session key omits workspace identity.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming-narrative.test.ts`
- Scenario the test should lock in: two different workspaces running the same phase at the same timestamp must use different subagent session keys and clean up their own sessions.
- Why this is the smallest reliable guardrail: the bug is local to narrative session-key construction and does not require a full dreaming sweep to reproduce.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[workspace A light phase @ t]
[workspace B light phase @ t]
        -> same sessionKey
        -> shared subagent session / cleanup race

After:
[workspace A light phase @ t] -> sessionKey(workspace A)
[workspace B light phase @ t] -> sessionKey(workspace B)
        -> isolated transient sessions
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `generateAndAppendDreamNarrative()` twice with the same phase and timestamp.
2. Pass different `workspaceDir` values to each call.
3. Inspect the `sessionKey` used for `subagent.run()` and `subagent.deleteSession()`.

### Expected

- Each workspace gets its own transient narrative session key.

### Actual

- Before this change, both calls could derive the same session key when phase and timestamp matched.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test extensions/memory-core/src/dreaming-narrative.test.ts` and confirmed the new same-phase same-timestamp multi-workspace test passes.
- Edge cases checked: same phase, same timestamp, different workspaces; cleanup still uses the matching per-workspace session key.
- What you did **not** verify: I did not run a full end-to-end dreaming sweep across multiple real workspaces.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: session keys now include a workspace-derived hash, so any debugging flow that expected the old exact key format would see different transient names.
  - Mitigation: the session is internal and short-lived; the new format remains deterministic, phase-scoped, and easy to recognize in logs.
