### PR TITLE
fix(delivery): treat HTTP 4xx client errors as permanent in recovery

### DIFF
--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -58,6 +58,11 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /outbound not configured for channel/i,
   /ambiguous .* recipient/i,
   /User .* not in room/i,
+  // HTTP 4xx client errors — these will not succeed on retry.
+  /failed!\s*\(4\d{2}:/i, // Grammy-style: "Call to sendMessage failed! (400: ...)"
+  /\b4\d{2}\b.*\bbad request\b/i, // Generic "400 Bad Request" variants
+  /message.*(is\s+)?too\s+long/i, // Message-too-long across channels
+  /request entity too large|payload too large/i, // 413-style body errors
 ];
 
 const drainInProgress = new Map<string, boolean>();

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -59,7 +59,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /ambiguous .* recipient/i,
   /User .* not in room/i,
   // HTTP 4xx client errors — these will not succeed on retry.
-  /failed!\s*\(4\d{2}:/i, // Grammy-style: "Call to sendMessage failed! (400: ...)"
+  /failed!\s*\(4(?!08|29)\d{2}:/i, // Grammy-style: "Call to sendMessage failed! (400: ...)" — excludes 408/429 (transient)
   /\b4\d{2}\b.*\bbad request\b/i, // Generic "400 Bad Request" variants
   /message.*(is\s+)?too\s+long/i, // Message-too-long across channels
   /request entity too large|payload too large/i, // 413-style body errors

--- a/src/infra/outbound/delivery-queue.policy.test.ts
+++ b/src/infra/outbound/delivery-queue.policy.test.ts
@@ -17,6 +17,12 @@ describe("delivery-queue policy", () => {
       "chat_id is empty",
       "Outbound not configured for channel: demo-channel",
       "MatrixError: [403] User @bot:matrix.example.com not in room !mixedCase:matrix.example.com",
+      "Call to sendMessage failed! (400: Bad Request: message is too long)",
+      "Call to sendPhoto failed! (413: Request Entity Too Large)",
+      "400 Bad Request: message is too long",
+      "message is too long",
+      "payload too large",
+      "request entity too large",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });
@@ -27,6 +33,8 @@ describe("delivery-queue policy", () => {
       "socket hang up",
       "rate limited",
       "500 Internal Server Error",
+      "Call to sendMessage failed! (502: Bad Gateway)",
+      "Call to sendMessage failed! (500: Internal Server Error)",
     ])("returns false for transient error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(false);
     });

--- a/src/infra/outbound/delivery-queue.policy.test.ts
+++ b/src/infra/outbound/delivery-queue.policy.test.ts
@@ -35,6 +35,8 @@ describe("delivery-queue policy", () => {
       "500 Internal Server Error",
       "Call to sendMessage failed! (502: Bad Gateway)",
       "Call to sendMessage failed! (500: Internal Server Error)",
+      "Call to sendMessage failed! (429: Too Many Requests)",
+      "Call to sendMessage failed! (408: Request Timeout)",
     ])("returns false for transient error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(false);
     });

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -138,6 +138,63 @@ describe("delivery-queue recovery", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
   });
 
+  it("treats Telegram 400 message-too-long as a permanent error", async () => {
+    const id = await enqueueDelivery(
+      { channel: "telegram", to: "chat:123", payloads: [{ text: "x".repeat(50_000) }] },
+      tmpDir(),
+    );
+    const deliver = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("Call to sendMessage failed! (400: Bad Request: message is too long)"),
+      );
+    const log = createRecoveryLog();
+    const { result } = await runRecovery({ deliver, log });
+
+    expect(result.failed).toBe(1);
+    expect(result.recovered).toBe(0);
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(fs.existsSync(path.join(tmpDir(), "delivery-queue", "failed", `${id}.json`))).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
+  });
+
+  it("treats Telegram 413 entity-too-large as a permanent error", async () => {
+    const id = await enqueueDelivery(
+      { channel: "telegram", to: "chat:456", payloads: [{ text: "huge" }] },
+      tmpDir(),
+    );
+    const deliver = vi
+      .fn()
+      .mockRejectedValue(new Error("Call to sendPhoto failed! (413: Request Entity Too Large)"));
+    const log = createRecoveryLog();
+    const { result } = await runRecovery({ deliver, log });
+
+    expect(result.failed).toBe(1);
+    expect(result.recovered).toBe(0);
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(fs.existsSync(path.join(tmpDir(), "delivery-queue", "failed", `${id}.json`))).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permanent error"));
+  });
+
+  it("still retries 5xx server errors (not permanent)", async () => {
+    await enqueueDelivery(
+      { channel: "telegram", to: "chat:789", payloads: [{ text: "retry me" }] },
+      tmpDir(),
+    );
+    const deliver = vi
+      .fn()
+      .mockRejectedValue(new Error("Call to sendMessage failed! (502: Bad Gateway)"));
+    const log = createRecoveryLog();
+    const { result } = await runRecovery({ deliver, log });
+
+    expect(result.failed).toBe(1);
+    expect(result.recovered).toBe(0);
+    // Entry stays in pending (not moved to failed/) — eligible for future retry
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.retryCount).toBe(1);
+  });
+
   it("passes skipQueue: true to prevent re-enqueueing during recovery", async () => {
     await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },


### PR DESCRIPTION
## Problem

On every gateway restart, delivery recovery picks up entries from the delivery queue and retries them — even when the error is permanent (e.g., Telegram's `400: Bad Request: message is too long`). This causes the same failed message to be re-sent to the user on every restart, indefinitely.

## Fix

Added four new patterns to `PERMANENT_ERROR_PATTERNS` in `delivery-queue-recovery.ts`:

- **Grammy-style 4xx errors**: `/failed!\s*\(4\d{2}:/i` — catches `Call to sendMessage failed! (400: ...)`
- **Generic 400 Bad Request**: `/\b4\d{2}\b.*\bbad request\b/i`
- **Message too long**: `/message.*(is\s+)?too\s+long/i` — channel-agnostic
- **Entity too large**: `/request entity too large|payload too large/i` — 413-style errors

5xx and network errors continue to be retried with backoff as before.

## Tests

- Added recovery integration tests for Telegram 400 (message too long), 413 (entity too large), and verified 5xx errors still retry
- Added unit tests for `isPermanentDeliveryError()` covering new patterns and confirming 5xx is not matched

All 45 tests pass.

Closes #61680