### PR TITLE
feat(github-copilot): add embedding provider for memory search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/Overview: add a Model Auth status card showing OAuth token health and provider rate-limit pressure at a glance, with attention callouts when OAuth tokens are expiring or expired. Backed by a new `models.authStatus` gateway method that strips credentials and caches for 60s. (#66211) Thanks @omarshahine.
 - docs-i18n: add behavior baseline fixtures (#64073). Thanks @hxy91819
 - docs-i18n: harden behavior fixture path reads (#67046). Thanks @hxy91819
+- GitHub Copilot/memory search: add a GitHub Copilot embedding provider for memory search, and expose a dedicated Copilot embedding host helper so plugins can reuse the transport while honoring remote overrides, token refresh, and safer payload validation. (#61718) Thanks @feiskyer and @vincentkoc.
 
 ### Fixes
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -15,8 +15,9 @@ chunks and searching them using embeddings, keywords, or both.
 
 ## Quick start
 
-If you have an OpenAI, Gemini, Voyage, or Mistral API key configured, memory
-search works automatically. To set a provider explicitly:
+If you have a GitHub Copilot subscription, OpenAI, Gemini, Voyage, or Mistral
+API key configured, memory search works automatically. To set a provider
+explicitly:
 
 ```json5
 {
@@ -35,15 +36,16 @@ node-llama-cpp).
 
 ## Supported providers
 
-| Provider | ID        | Needs API key | Notes                                                |
-| -------- | --------- | ------------- | ---------------------------------------------------- |
-| OpenAI   | `openai`  | Yes           | Auto-detected, fast                                  |
-| Gemini   | `gemini`  | Yes           | Supports image/audio indexing                        |
-| Voyage   | `voyage`  | Yes           | Auto-detected                                        |
-| Mistral  | `mistral` | Yes           | Auto-detected                                        |
-| Bedrock  | `bedrock` | No            | Auto-detected when the AWS credential chain resolves |
-| Ollama   | `ollama`  | No            | Local, must set explicitly                           |
-| Local    | `local`   | No            | GGUF model, ~0.6 GB download                         |
+| Provider       | ID               | Needs API key | Notes                                                |
+| -------------- | ---------------- | ------------- | ---------------------------------------------------- |
+| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription             |
+| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                  |
+| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                        |
+| Voyage         | `voyage`         | Yes           | Auto-detected                                        |
+| Mistral        | `mistral`        | Yes           | Auto-detected                                        |
+| Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves |
+| Ollama         | `ollama`         | No            | Local, must set explicitly                           |
+| Local          | `local`          | No            | GGUF model, ~0.6 GB download                         |
 
 ## How search works
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -38,14 +38,14 @@ node-llama-cpp).
 
 | Provider       | ID               | Needs API key | Notes                                                |
 | -------------- | ---------------- | ------------- | ---------------------------------------------------- |
-| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription             |
-| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                  |
-| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                        |
-| Voyage         | `voyage`         | Yes           | Auto-detected                                        |
-| Mistral        | `mistral`        | Yes           | Auto-detected                                        |
 | Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves |
-| Ollama         | `ollama`         | No            | Local, must set explicitly                           |
+| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                        |
+| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription             |
 | Local          | `local`          | No            | GGUF model, ~0.6 GB download                         |
+| Mistral        | `mistral`        | Yes           | Auto-detected                                        |
+| Ollama         | `ollama`         | No            | Local, must set explicitly                           |
+| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                  |
+| Voyage         | `voyage`         | Yes           | Auto-detected                                        |
 
 ## How search works
 

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -119,6 +119,46 @@ Requires an interactive TTY. Run the login command directly in a terminal, not
 inside a headless script or CI job.
 </Warning>
 
+## Memory search embeddings
+
+GitHub Copilot can also serve as an embedding provider for
+[memory search](/concepts/memory-search). If you have a Copilot subscription and
+have logged in, OpenClaw can use it for embeddings without a separate API key.
+
+### Auto-detection
+
+When `memorySearch.provider` is `"auto"` (the default), GitHub Copilot is tried
+at priority 15 -- after local embeddings but before OpenAI and other paid
+providers. If a GitHub token is available, OpenClaw discovers available
+embedding models from the Copilot API and picks the best one automatically.
+
+### Explicit config
+
+```json5
+{
+  agents: {
+    defaults: {
+      memorySearch: {
+        provider: "github-copilot",
+        // Optional: override the auto-discovered model
+        model: "text-embedding-3-small",
+      },
+    },
+  },
+}
+```
+
+### How it works
+
+1. OpenClaw resolves your GitHub token (from env vars or auth profile).
+2. Exchanges it for a short-lived Copilot API token.
+3. Queries the Copilot `/models` endpoint to discover available embedding models.
+4. Picks the best model (prefers `text-embedding-3-small`).
+5. Sends embedding requests to the Copilot `/embeddings` endpoint.
+
+Model availability depends on your GitHub plan. If no embedding models are
+available, OpenClaw skips Copilot and tries the next provider.
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -39,7 +39,7 @@ plugin-owned config, transcript persistence, and safe rollout pattern.
 
 | Key        | Type      | Default          | Description                                                                                                   |
 | ---------- | --------- | ---------------- | ------------------------------------------------------------------------------------------------------------- |
-| `provider` | `string`  | auto-detected    | Embedding adapter ID: `github-copilot`, `openai`, `gemini`, `voyage`, `mistral`, `bedrock`, `ollama`, `local` |
+| `provider` | `string`  | auto-detected    | Embedding adapter ID: `bedrock`, `gemini`, `github-copilot`, `local`, `mistral`, `ollama`, `openai`, `voyage` |
 | `model`    | `string`  | provider default | Embedding model name                                                                                          |
 | `fallback` | `string`  | `"none"`         | Fallback adapter ID when the primary fails                                                                    |
 | `enabled`  | `boolean` | `true`           | Enable or disable memory search                                                                               |
@@ -65,13 +65,13 @@ credential chain instead (instance roles, SSO, access keys).
 
 | Provider       | Env var                                            | Config key                        |
 | -------------- | -------------------------------------------------- | --------------------------------- |
-| GitHub Copilot | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | Auth profile via device login     |
-| OpenAI         | `OPENAI_API_KEY`                                   | `models.providers.openai.apiKey`  |
-| Gemini         | `GEMINI_API_KEY`                                   | `models.providers.google.apiKey`  |
-| Voyage         | `VOYAGE_API_KEY`                                   | `models.providers.voyage.apiKey`  |
-| Mistral        | `MISTRAL_API_KEY`                                  | `models.providers.mistral.apiKey` |
 | Bedrock        | AWS credential chain                               | No API key needed                 |
+| Gemini         | `GEMINI_API_KEY`                                   | `models.providers.google.apiKey`  |
+| GitHub Copilot | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | Auth profile via device login     |
+| Mistral        | `MISTRAL_API_KEY`                                  | `models.providers.mistral.apiKey` |
 | Ollama         | `OLLAMA_API_KEY` (placeholder)                     | --                                |
+| OpenAI         | `OPENAI_API_KEY`                                   | `models.providers.openai.apiKey`  |
+| Voyage         | `VOYAGE_API_KEY`                                   | `models.providers.voyage.apiKey`  |
 
 Codex OAuth covers chat/completions only and does not satisfy embedding
 requests.

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -37,23 +37,24 @@ plugin-owned config, transcript persistence, and safe rollout pattern.
 
 ## Provider selection
 
-| Key        | Type      | Default          | Description                                                                                 |
-| ---------- | --------- | ---------------- | ------------------------------------------------------------------------------------------- |
-| `provider` | `string`  | auto-detected    | Embedding adapter ID: `openai`, `gemini`, `voyage`, `mistral`, `bedrock`, `ollama`, `local` |
-| `model`    | `string`  | provider default | Embedding model name                                                                        |
-| `fallback` | `string`  | `"none"`         | Fallback adapter ID when the primary fails                                                  |
-| `enabled`  | `boolean` | `true`           | Enable or disable memory search                                                             |
+| Key        | Type      | Default          | Description                                                                                                   |
+| ---------- | --------- | ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| `provider` | `string`  | auto-detected    | Embedding adapter ID: `github-copilot`, `openai`, `gemini`, `voyage`, `mistral`, `bedrock`, `ollama`, `local` |
+| `model`    | `string`  | provider default | Embedding model name                                                                                          |
+| `fallback` | `string`  | `"none"`         | Fallback adapter ID when the primary fails                                                                    |
+| `enabled`  | `boolean` | `true`           | Enable or disable memory search                                                                               |
 
 ### Auto-detection order
 
 When `provider` is not set, OpenClaw selects the first available:
 
 1. `local` -- if `memorySearch.local.modelPath` is configured and the file exists.
-2. `openai` -- if an OpenAI key can be resolved.
-3. `gemini` -- if a Gemini key can be resolved.
-4. `voyage` -- if a Voyage key can be resolved.
-5. `mistral` -- if a Mistral key can be resolved.
-6. `bedrock` -- if the AWS SDK credential chain resolves (instance role, access keys, profile, SSO, web identity, or shared config).
+2. `github-copilot` -- if a GitHub Copilot token can be resolved (env var or auth profile).
+3. `openai` -- if an OpenAI key can be resolved.
+4. `gemini` -- if a Gemini key can be resolved.
+5. `voyage` -- if a Voyage key can be resolved.
+6. `mistral` -- if a Mistral key can be resolved.
+7. `bedrock` -- if the AWS SDK credential chain resolves (instance role, access keys, profile, SSO, web identity, or shared config).
 
 `ollama` is supported but not auto-detected (set it explicitly).
 
@@ -62,14 +63,15 @@ When `provider` is not set, OpenClaw selects the first available:
 Remote embeddings require an API key. Bedrock uses the AWS SDK default
 credential chain instead (instance roles, SSO, access keys).
 
-| Provider | Env var                        | Config key                        |
-| -------- | ------------------------------ | --------------------------------- |
-| OpenAI   | `OPENAI_API_KEY`               | `models.providers.openai.apiKey`  |
-| Gemini   | `GEMINI_API_KEY`               | `models.providers.google.apiKey`  |
-| Voyage   | `VOYAGE_API_KEY`               | `models.providers.voyage.apiKey`  |
-| Mistral  | `MISTRAL_API_KEY`              | `models.providers.mistral.apiKey` |
-| Bedrock  | AWS credential chain           | No API key needed                 |
-| Ollama   | `OLLAMA_API_KEY` (placeholder) | --                                |
+| Provider       | Env var                                            | Config key                        |
+| -------------- | -------------------------------------------------- | --------------------------------- |
+| GitHub Copilot | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` | Auth profile via device login     |
+| OpenAI         | `OPENAI_API_KEY`                                   | `models.providers.openai.apiKey`  |
+| Gemini         | `GEMINI_API_KEY`                                   | `models.providers.google.apiKey`  |
+| Voyage         | `VOYAGE_API_KEY`                                   | `models.providers.voyage.apiKey`  |
+| Mistral        | `MISTRAL_API_KEY`                                  | `models.providers.mistral.apiKey` |
+| Bedrock        | AWS credential chain                               | No API key needed                 |
+| Ollama         | `OLLAMA_API_KEY` (placeholder)                     | --                                |
 
 Codex OAuth covers chat/completions only and does not satisfy embedding
 requests.

--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ensureAuthProfileStoreMock = vi.hoisted(() => vi.fn());
+const listProfilesForProviderMock = vi.hoisted(() => vi.fn());
+const coerceSecretRefMock = vi.hoisted(() => vi.fn());
+const resolveRequiredConfiguredSecretRefInputStringMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  coerceSecretRef: coerceSecretRefMock,
+  ensureAuthProfileStore: ensureAuthProfileStoreMock,
+  listProfilesForProvider: listProfilesForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
+  resolveRequiredConfiguredSecretRefInputString: resolveRequiredConfiguredSecretRefInputStringMock,
+}));
+
+import { resolveFirstGithubToken } from "./auth.js";
+
+describe("resolveFirstGithubToken", () => {
+  beforeEach(() => {
+    ensureAuthProfileStoreMock.mockReturnValue({
+      profiles: {
+        "github-copilot:github": {
+          type: "token",
+          tokenRef: { source: "file", provider: "default", id: "/providers/github-copilot/token" },
+        },
+      },
+    });
+    listProfilesForProviderMock.mockReturnValue(["github-copilot:github"]);
+    coerceSecretRefMock.mockReturnValue({
+      source: "file",
+      provider: "default",
+      id: "/providers/github-copilot/token",
+    });
+    resolveRequiredConfiguredSecretRefInputStringMock.mockResolvedValue("resolved-profile-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    ensureAuthProfileStoreMock.mockReset();
+    listProfilesForProviderMock.mockReset();
+    coerceSecretRefMock.mockReset();
+    resolveRequiredConfiguredSecretRefInputStringMock.mockReset();
+  });
+
+  it("prefers env tokens when available", async () => {
+    const result = await resolveFirstGithubToken({
+      env: { GH_TOKEN: "env-token" } as NodeJS.ProcessEnv,
+    });
+
+    expect(result).toEqual({
+      githubToken: "env-token",
+      hasProfile: true,
+    });
+    expect(resolveRequiredConfiguredSecretRefInputStringMock).not.toHaveBeenCalled();
+  });
+
+  it("returns direct profile tokens before resolving SecretRefs", async () => {
+    ensureAuthProfileStoreMock.mockReturnValue({
+      profiles: {
+        "github-copilot:github": {
+          type: "token",
+          token: "profile-token",
+        },
+      },
+    });
+    coerceSecretRefMock.mockReturnValue(null);
+
+    const result = await resolveFirstGithubToken({
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(result).toEqual({
+      githubToken: "profile-token",
+      hasProfile: true,
+    });
+  });
+
+  it("resolves non-env SecretRefs when config is available", async () => {
+    const result = await resolveFirstGithubToken({
+      config: { secrets: { defaults: { provider: "default" } } } as never,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(result).toEqual({
+      githubToken: "resolved-profile-token",
+      hasProfile: true,
+    });
+    expect(resolveRequiredConfiguredSecretRefInputStringMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "providers.github-copilot.authProfiles.github-copilot:github.tokenRef",
+      }),
+    );
+  });
+});

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -1,0 +1,40 @@
+import {
+  coerceSecretRef,
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+} from "openclaw/plugin-sdk/provider-auth";
+import { PROVIDER_ID } from "./models.js";
+
+export function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.ProcessEnv }): {
+  githubToken: string;
+  hasProfile: boolean;
+} {
+  const authStore = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const hasProfile = listProfilesForProvider(authStore, PROVIDER_ID).length > 0;
+  const envToken =
+    params.env.COPILOT_GITHUB_TOKEN ?? params.env.GH_TOKEN ?? params.env.GITHUB_TOKEN ?? "";
+  const githubToken = envToken.trim();
+  if (githubToken || !hasProfile) {
+    return { githubToken, hasProfile };
+  }
+
+  const profileId = listProfilesForProvider(authStore, PROVIDER_ID)[0];
+  const profile = profileId ? authStore.profiles[profileId] : undefined;
+  if (profile?.type !== "token") {
+    return { githubToken: "", hasProfile };
+  }
+  const directToken = profile.token?.trim() ?? "";
+  if (directToken) {
+    return { githubToken: directToken, hasProfile };
+  }
+  const tokenRef = coerceSecretRef(profile.tokenRef);
+  if (tokenRef?.source === "env" && tokenRef.id.trim()) {
+    return {
+      githubToken: (params.env[tokenRef.id] ?? process.env[tokenRef.id] ?? "").trim(),
+      hasProfile,
+    };
+  }
+  return { githubToken: "", hasProfile };
+}

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -1,3 +1,5 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { resolveRequiredConfiguredSecretRefInputString } from "openclaw/plugin-sdk/config-runtime";
 import {
   coerceSecretRef,
   ensureAuthProfileStore,
@@ -5,14 +7,19 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { PROVIDER_ID } from "./models.js";
 
-export function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.ProcessEnv }): {
+export async function resolveFirstGithubToken(params: {
+  agentDir?: string;
+  config?: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<{
   githubToken: string;
   hasProfile: boolean;
-} {
+}> {
   const authStore = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
   });
-  const hasProfile = listProfilesForProvider(authStore, PROVIDER_ID).length > 0;
+  const profileIds = listProfilesForProvider(authStore, PROVIDER_ID);
+  const hasProfile = profileIds.length > 0;
   const envToken =
     params.env.COPILOT_GITHUB_TOKEN ?? params.env.GH_TOKEN ?? params.env.GITHUB_TOKEN ?? "";
   const githubToken = envToken.trim();
@@ -20,7 +27,7 @@ export function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS
     return { githubToken, hasProfile };
   }
 
-  const profileId = listProfilesForProvider(authStore, PROVIDER_ID)[0];
+  const profileId = profileIds[0];
   const profile = profileId ? authStore.profiles[profileId] : undefined;
   if (profile?.type !== "token") {
     return { githubToken: "", hasProfile };
@@ -36,5 +43,23 @@ export function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS
       hasProfile,
     };
   }
+
+  if (tokenRef && params.config) {
+    try {
+      const resolved = await resolveRequiredConfiguredSecretRefInputString({
+        config: params.config,
+        env: params.env,
+        value: profile.tokenRef,
+        path: `providers.github-copilot.authProfiles.${profileId ?? "default"}.tokenRef`,
+      });
+      return {
+        githubToken: resolved?.trim() ?? "",
+        hasProfile,
+      };
+    } catch {
+      return { githubToken: "", hasProfile };
+    }
+  }
+
   return { githubToken: "", hasProfile };
 }

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -1,0 +1,519 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveFirstGithubTokenMock = vi.hoisted(() => vi.fn());
+const resolveCopilotApiTokenMock = vi.hoisted(() => vi.fn());
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./auth.js", () => ({
+  resolveFirstGithubToken: resolveFirstGithubTokenMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/github-copilot-token", () => ({
+  DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",
+  resolveCopilotApiToken: resolveCopilotApiTokenMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  coerceSecretRef: vi.fn(),
+  ensureAuthProfileStore: vi.fn(() => ({ profiles: {} })),
+  listProfilesForProvider: vi.fn(() => []),
+}));
+
+import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
+
+const TEST_COPILOT_TOKEN = "copilot_test_token_abc";
+const TEST_BASE_URL = "https://api.githubcopilot.test";
+
+function buildModelsResponse(models: Array<{ id: string; supported_endpoints?: string[] }>) {
+  return { data: models };
+}
+
+function buildEmbeddingResponse(embeddings: Array<{ embedding: number[]; index: number }>) {
+  return { data: embeddings };
+}
+
+function mockFetchSequence(
+  responses: Array<{ ok: boolean; status?: number; json?: unknown; text?: string }>,
+) {
+  let callIndex = 0;
+  fetchWithSsrFGuardMock.mockImplementation(async () => {
+    const spec = responses[callIndex++];
+    if (!spec) {
+      throw new Error(`Unexpected fetchWithSsrFGuard call #${callIndex}`);
+    }
+    return {
+      response: {
+        ok: spec.ok,
+        status: spec.status ?? (spec.ok ? 200 : 500),
+        json: async () => spec.json,
+        text: async () => spec.text ?? "",
+      },
+      release: vi.fn(async () => {}),
+    };
+  });
+}
+
+function defaultCreateOptions() {
+  return {
+    config: {} as Record<string, unknown>,
+    agentDir: "/tmp/test-agent",
+    model: "",
+  };
+}
+
+describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
+  beforeEach(() => {
+    resolveFirstGithubTokenMock.mockReturnValue({
+      githubToken: "gh_test_token_123",
+      hasProfile: false,
+    });
+    resolveCopilotApiTokenMock.mockResolvedValue({
+      token: TEST_COPILOT_TOKEN,
+      expiresAt: Date.now() + 3_600_000,
+      source: "test",
+      baseUrl: TEST_BASE_URL,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resolveFirstGithubTokenMock.mockReset();
+    resolveCopilotApiTokenMock.mockReset();
+    fetchWithSsrFGuardMock.mockReset();
+  });
+
+  describe("adapter properties", () => {
+    it("has correct id", () => {
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.id).toBe("github-copilot");
+    });
+
+    it("has transport set to remote", () => {
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.transport).toBe("remote");
+    });
+
+    it("has autoSelectPriority of 15", () => {
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.autoSelectPriority).toBe(15);
+    });
+
+    it("allows explicit override when configured auto", () => {
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.allowExplicitWhenConfiguredAuto).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("model discovery", () => {
+    it("picks text-embedding-3-small when available", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-large", supported_endpoints: ["/v1/embeddings"] },
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+            { id: "text-embedding-ada-002", supported_endpoints: ["/v1/embeddings"] },
+            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      expect(result.provider?.model).toBe("text-embedding-3-small");
+    });
+
+    it("falls back to text-embedding-3-large when small is unavailable", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-large", supported_endpoints: ["/v1/embeddings"] },
+            { id: "text-embedding-ada-002", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      expect(result.provider?.model).toBe("text-embedding-3-large");
+    });
+
+    it("filters models by embedding endpoint support", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      expect(result.provider?.model).toBe("text-embedding-3-small");
+    });
+
+    it("discovers models by ID when supported_endpoints is empty", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
+            { id: "text-embedding-3-small", supported_endpoints: [] },
+            { id: "text-embedding-ada-002" },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      expect(result.provider?.model).toBe("text-embedding-3-small");
+    });
+
+    it("picks first available model when no preferred model is available", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "custom-embedding-v1", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      expect(result.provider?.model).toBe("custom-embedding-v1");
+    });
+  });
+
+  describe("user-configured model", () => {
+    it("uses user-configured model override", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+            { id: "custom-model", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      const result = await githubCopilotMemoryEmbeddingProviderAdapter.create({
+        ...defaultCreateOptions(),
+        model: "custom-model",
+      } as never);
+
+      expect(result.provider?.model).toBe("custom-model");
+    });
+
+    it("strips github-copilot/ prefix from user model", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      const result = await githubCopilotMemoryEmbeddingProviderAdapter.create({
+        ...defaultCreateOptions(),
+        model: "github-copilot/text-embedding-3-small",
+      } as never);
+
+      expect(result.provider?.model).toBe("text-embedding-3-small");
+    });
+
+    it("throws when user model is not in discovered list", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      await expect(
+        githubCopilotMemoryEmbeddingProviderAdapter.create({
+          ...defaultCreateOptions(),
+          model: "gpt-4o",
+        } as never),
+      ).rejects.toThrow('GitHub Copilot embedding model "gpt-4o" is not available');
+    });
+
+    it("throws when user model is set but no embedding models are discovered", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
+          ]),
+        },
+      ]);
+
+      await expect(
+        githubCopilotMemoryEmbeddingProviderAdapter.create({
+          ...defaultCreateOptions(),
+          model: "text-embedding-3-small",
+        } as never),
+      ).rejects.toThrow("No embedding models available from GitHub Copilot");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when no embedding models are available", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
+          ]),
+        },
+      ]);
+
+      await expect(
+        githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
+      ).rejects.toThrow("No embedding models available from GitHub Copilot");
+    });
+
+    it("throws when model discovery returns HTTP error", async () => {
+      mockFetchSequence([
+        {
+          ok: false,
+          status: 401,
+          text: "Unauthorized",
+        },
+      ]);
+
+      await expect(
+        githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
+      ).rejects.toThrow("GitHub Copilot model discovery HTTP 401");
+    });
+
+    it("throws when no GitHub token is available", async () => {
+      resolveFirstGithubTokenMock.mockReturnValue({
+        githubToken: "",
+        hasProfile: false,
+      });
+
+      await expect(
+        githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
+      ).rejects.toThrow("No GitHub token available");
+    });
+
+    it("throws when embeddings endpoint returns HTTP error", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+        { ok: false, status: 429, text: "Rate limit exceeded" },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+      await expect(result.provider!.embedQuery("hello")).rejects.toThrow(
+        "GitHub Copilot embeddings HTTP 429",
+      );
+    });
+
+    it("throws when embeddings response is malformed", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+        { ok: true, json: { model: "text-embedding-3-small" } },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+      await expect(result.provider!.embedQuery("hello")).rejects.toThrow(
+        "GitHub Copilot embeddings response missing data[]",
+      );
+    });
+  });
+
+  describe("shouldContinueAutoSelection", () => {
+    it("returns true for missing GitHub token errors", () => {
+      const err = new Error("No GitHub token available for Copilot embedding provider");
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
+        true,
+      );
+    });
+
+    it("returns true for token exchange failures", () => {
+      const err = new Error("Copilot token exchange failed: HTTP 401");
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
+        true,
+      );
+    });
+
+    it("returns true for no embedding models available", () => {
+      const err = new Error("No embedding models available from GitHub Copilot");
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
+        true,
+      );
+    });
+
+    it("returns true for model discovery failures", () => {
+      const err = new Error("GitHub Copilot model discovery HTTP 403: Forbidden");
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
+        true,
+      );
+    });
+
+    it("returns true for user model not available", () => {
+      const err = new Error(
+        'GitHub Copilot embedding model "gpt-4o" is not available. Available: text-embedding-3-small',
+      );
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
+        true,
+      );
+    });
+
+    it("returns false for non-Copilot errors", () => {
+      const err = new Error("Network timeout");
+      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
+        false,
+      );
+    });
+
+    it("returns false for non-Error values", () => {
+      expect(
+        githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!("some string"),
+      ).toBe(false);
+    });
+  });
+
+  describe("embedQuery", () => {
+    it("calls the endpoint and returns a vector", async () => {
+      const embedding = [0.1, 0.2, 0.3];
+      const magnitude = Math.sqrt(embedding.reduce((sum, v) => sum + v * v, 0));
+      const normalized = embedding.map((v) => v / magnitude);
+
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+        {
+          ok: true,
+          json: buildEmbeddingResponse([{ embedding, index: 0 }]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+      const vector = await result.provider!.embedQuery("hello world");
+
+      expect(vector).toEqual(normalized);
+
+      // Verify the embeddings call used POST with correct body (second fetch call)
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+      const embeddingsCall = fetchWithSsrFGuardMock.mock.calls[1][0] as {
+        url: string;
+        init: { method: string; body: string };
+      };
+      expect(embeddingsCall.url).toBe(`${TEST_BASE_URL}/embeddings`);
+      expect(embeddingsCall.init.method).toBe("POST");
+      const body = JSON.parse(embeddingsCall.init.body) as { model: string; input: string[] };
+      expect(body.model).toBe("text-embedding-3-small");
+      expect(body.input).toEqual(["hello world"]);
+    });
+  });
+
+  describe("embedBatch", () => {
+    it("returns multiple vectors sorted by index", async () => {
+      const emb0 = [0.1, 0.2, 0.3];
+      const emb1 = [0.4, 0.5, 0.6];
+
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+        {
+          ok: true,
+          // Return in reverse index order to verify sorting
+          json: buildEmbeddingResponse([
+            { embedding: emb1, index: 1 },
+            { embedding: emb0, index: 0 },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+      const vectors = await result.provider!.embedBatch(["first", "second"]);
+
+      expect(vectors).toHaveLength(2);
+      // Verify order matches input order (index 0 first, index 1 second)
+      const mag0 = Math.sqrt(emb0.reduce((sum, v) => sum + v * v, 0));
+      const mag1 = Math.sqrt(emb1.reduce((sum, v) => sum + v * v, 0));
+      expect(vectors[0]).toEqual(emb0.map((v) => v / mag0));
+      expect(vectors[1]).toEqual(emb1.map((v) => v / mag1));
+    });
+
+    it("returns empty array for empty input", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+      const vectors = await result.provider!.embedBatch([]);
+
+      expect(vectors).toEqual([]);
+      // No extra fetch call for empty input
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("runtime", () => {
+    it("includes cache key data with provider, baseUrl, and model", async () => {
+      mockFetchSequence([
+        {
+          ok: true,
+          json: buildModelsResponse([
+            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+          ]),
+        },
+      ]);
+
+      const result =
+        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+      expect(result.runtime).toBeDefined();
+      expect(result.runtime!.id).toBe("github-copilot");
+      expect(result.runtime!.cacheKeyData).toEqual({
+        provider: "github-copilot",
+        baseUrl: TEST_BASE_URL,
+        model: "text-embedding-3-small",
+      });
+    });
+  });
+});

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -2,10 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveFirstGithubTokenMock = vi.hoisted(() => vi.fn());
 const resolveCopilotApiTokenMock = vi.hoisted(() => vi.fn());
+const resolveConfiguredSecretInputStringMock = vi.hoisted(() => vi.fn());
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const createGitHubCopilotEmbeddingProviderMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./auth.js", () => ({
   resolveFirstGithubToken: resolveFirstGithubTokenMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
+  resolveConfiguredSecretInputString: resolveConfiguredSecretInputStringMock,
 }));
 
 vi.mock("openclaw/plugin-sdk/github-copilot-token", () => ({
@@ -13,48 +19,37 @@ vi.mock("openclaw/plugin-sdk/github-copilot-token", () => ({
   resolveCopilotApiToken: resolveCopilotApiTokenMock,
 }));
 
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
+  createGitHubCopilotEmbeddingProvider: createGitHubCopilotEmbeddingProviderMock,
+}));
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
-  coerceSecretRef: vi.fn(),
-  ensureAuthProfileStore: vi.fn(() => ({ profiles: {} })),
-  listProfilesForProvider: vi.fn(() => []),
-}));
-
 import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
 
-const TEST_COPILOT_TOKEN = "copilot_test_token_abc";
 const TEST_BASE_URL = "https://api.githubcopilot.test";
 
-function buildModelsResponse(models: Array<{ id: string; supported_endpoints?: string[] }>) {
+function buildModelsResponse(models: Array<{ id: string; supported_endpoints?: unknown }>) {
   return { data: models };
 }
 
-function buildEmbeddingResponse(embeddings: Array<{ embedding: number[]; index: number }>) {
-  return { data: embeddings };
-}
-
-function mockFetchSequence(
-  responses: Array<{ ok: boolean; status?: number; json?: unknown; text?: string }>,
-) {
-  let callIndex = 0;
-  fetchWithSsrFGuardMock.mockImplementation(async () => {
-    const spec = responses[callIndex++];
-    if (!spec) {
-      throw new Error(`Unexpected fetchWithSsrFGuard call #${callIndex}`);
-    }
-    return {
-      response: {
-        ok: spec.ok,
-        status: spec.status ?? (spec.ok ? 200 : 500),
-        json: async () => spec.json,
-        text: async () => spec.text ?? "",
-      },
-      release: vi.fn(async () => {}),
-    };
-  });
+function mockDiscoveryResponse(spec: {
+  ok: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+}) {
+  fetchWithSsrFGuardMock.mockImplementationOnce(async () => ({
+    response: {
+      ok: spec.ok,
+      status: spec.status ?? (spec.ok ? 200 : 500),
+      json: async () => spec.json,
+      text: async () => spec.text ?? "",
+    },
+    release: vi.fn(async () => {}),
+  }));
 }
 
 function defaultCreateOptions() {
@@ -67,453 +62,218 @@ function defaultCreateOptions() {
 
 describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
   beforeEach(() => {
-    resolveFirstGithubTokenMock.mockReturnValue({
+    resolveConfiguredSecretInputStringMock.mockResolvedValue({});
+    resolveFirstGithubTokenMock.mockResolvedValue({
       githubToken: "gh_test_token_123",
       hasProfile: false,
     });
     resolveCopilotApiTokenMock.mockResolvedValue({
-      token: TEST_COPILOT_TOKEN,
+      token: "copilot_test_token_abc",
       expiresAt: Date.now() + 3_600_000,
       source: "test",
       baseUrl: TEST_BASE_URL,
     });
+    createGitHubCopilotEmbeddingProviderMock.mockImplementation(async (client) => ({
+      provider: {
+        id: "github-copilot",
+        model: client.model,
+        embedQuery: async () => [0.1, 0.2, 0.3],
+        embedBatch: async (texts: string[]) => texts.map(() => [0.1, 0.2, 0.3]),
+      },
+      client,
+    }));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    resolveConfiguredSecretInputStringMock.mockReset();
     resolveFirstGithubTokenMock.mockReset();
     resolveCopilotApiTokenMock.mockReset();
+    createGitHubCopilotEmbeddingProviderMock.mockReset();
     fetchWithSsrFGuardMock.mockReset();
   });
 
-  describe("adapter properties", () => {
-    it("has correct id", () => {
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.id).toBe("github-copilot");
-    });
-
-    it("has transport set to remote", () => {
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.transport).toBe("remote");
-    });
-
-    it("has autoSelectPriority of 15", () => {
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.autoSelectPriority).toBe(15);
-    });
-
-    it("allows explicit override when configured auto", () => {
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.allowExplicitWhenConfiguredAuto).toBe(
-        true,
-      );
-    });
+  it("registers the expected adapter metadata", () => {
+    expect(githubCopilotMemoryEmbeddingProviderAdapter.id).toBe("github-copilot");
+    expect(githubCopilotMemoryEmbeddingProviderAdapter.transport).toBe("remote");
+    expect(githubCopilotMemoryEmbeddingProviderAdapter.autoSelectPriority).toBe(15);
+    expect(githubCopilotMemoryEmbeddingProviderAdapter.allowExplicitWhenConfiguredAuto).toBe(true);
   });
 
-  describe("model discovery", () => {
-    it("picks text-embedding-3-small when available", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-large", supported_endpoints: ["/v1/embeddings"] },
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-            { id: "text-embedding-ada-002", supported_endpoints: ["/v1/embeddings"] },
-            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
-          ]),
-        },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-
-      expect(result.provider?.model).toBe("text-embedding-3-small");
+  it("picks text-embedding-3-small when available", async () => {
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([
+        { id: "text-embedding-3-large", supported_endpoints: ["/v1/embeddings"] },
+        { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+        { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
+      ]),
     });
 
-    it("falls back to text-embedding-3-large when small is unavailable", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-large", supported_endpoints: ["/v1/embeddings"] },
-            { id: "text-embedding-ada-002", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
+    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
 
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-
-      expect(result.provider?.model).toBe("text-embedding-3-large");
-    });
-
-    it("filters models by embedding endpoint support", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-
-      expect(result.provider?.model).toBe("text-embedding-3-small");
-    });
-
-    it("discovers models by ID when supported_endpoints is empty", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
-            { id: "text-embedding-3-small", supported_endpoints: [] },
-            { id: "text-embedding-ada-002" },
-          ]),
-        },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-
-      expect(result.provider?.model).toBe("text-embedding-3-small");
-    });
-
-    it("picks first available model when no preferred model is available", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "custom-embedding-v1", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-
-      expect(result.provider?.model).toBe("custom-embedding-v1");
-    });
+    expect(result.provider?.model).toBe("text-embedding-3-small");
+    expect(createGitHubCopilotEmbeddingProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: TEST_BASE_URL,
+        githubToken: "gh_test_token_123",
+        model: "text-embedding-3-small",
+      }),
+    );
   });
 
-  describe("user-configured model", () => {
-    it("uses user-configured model override", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-            { id: "custom-model", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
+  it("matches embedding-capable models when supported_endpoints is missing or malformed", async () => {
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([
+        { id: "gpt-4o", supported_endpoints: { broken: true } },
+        { id: "text-embedding-3-small", supported_endpoints: [] },
+        { id: "text-embedding-ada-002" },
+      ]),
+    });
 
-      const result = await githubCopilotMemoryEmbeddingProviderAdapter.create({
+    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+    expect(result.provider?.model).toBe("text-embedding-3-small");
+  });
+
+  it("strips the provider prefix from a user-selected model", async () => {
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([
+        { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+      ]),
+    });
+
+    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      model: "github-copilot/text-embedding-3-small",
+    } as never);
+
+    expect(result.provider?.model).toBe("text-embedding-3-small");
+  });
+
+  it("throws when the user-selected model is unavailable", async () => {
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([
+        { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+      ]),
+    });
+
+    await expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.create({
         ...defaultCreateOptions(),
-        model: "custom-model",
-      } as never);
-
-      expect(result.provider?.model).toBe("custom-model");
-    });
-
-    it("strips github-copilot/ prefix from user model", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
-
-      const result = await githubCopilotMemoryEmbeddingProviderAdapter.create({
-        ...defaultCreateOptions(),
-        model: "github-copilot/text-embedding-3-small",
-      } as never);
-
-      expect(result.provider?.model).toBe("text-embedding-3-small");
-    });
-
-    it("throws when user model is not in discovered list", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
-
-      await expect(
-        githubCopilotMemoryEmbeddingProviderAdapter.create({
-          ...defaultCreateOptions(),
-          model: "gpt-4o",
-        } as never),
-      ).rejects.toThrow('GitHub Copilot embedding model "gpt-4o" is not available');
-    });
-
-    it("throws when user model is set but no embedding models are discovered", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
-          ]),
-        },
-      ]);
-
-      await expect(
-        githubCopilotMemoryEmbeddingProviderAdapter.create({
-          ...defaultCreateOptions(),
-          model: "text-embedding-3-small",
-        } as never),
-      ).rejects.toThrow("No embedding models available from GitHub Copilot");
-    });
+        model: "gpt-4o",
+      } as never),
+    ).rejects.toThrow('GitHub Copilot embedding model "gpt-4o" is not available');
   });
 
-  describe("error handling", () => {
-    it("throws when no embedding models are available", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] },
-          ]),
-        },
-      ]);
-
-      await expect(
-        githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
-      ).rejects.toThrow("No embedding models available from GitHub Copilot");
+  it("throws when discovery finds no embedding models", async () => {
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([{ id: "gpt-4o", supported_endpoints: ["/v1/chat/completions"] }]),
     });
 
-    it("throws when model discovery returns HTTP error", async () => {
-      mockFetchSequence([
-        {
-          ok: false,
-          status: 401,
-          text: "Unauthorized",
-        },
-      ]);
-
-      await expect(
-        githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
-      ).rejects.toThrow("GitHub Copilot model discovery HTTP 401");
-    });
-
-    it("throws when no GitHub token is available", async () => {
-      resolveFirstGithubTokenMock.mockReturnValue({
-        githubToken: "",
-        hasProfile: false,
-      });
-
-      await expect(
-        githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
-      ).rejects.toThrow("No GitHub token available");
-    });
-
-    it("throws when embeddings endpoint returns HTTP error", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-        { ok: false, status: 429, text: "Rate limit exceeded" },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-      await expect(result.provider!.embedQuery("hello")).rejects.toThrow(
-        "GitHub Copilot embeddings HTTP 429",
-      );
-    });
-
-    it("throws when embeddings response is malformed", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-        { ok: true, json: { model: "text-embedding-3-small" } },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-      await expect(result.provider!.embedQuery("hello")).rejects.toThrow(
-        "GitHub Copilot embeddings response missing data[]",
-      );
-    });
+    await expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
+    ).rejects.toThrow("No embedding models available from GitHub Copilot");
   });
 
-  describe("shouldContinueAutoSelection", () => {
-    it("returns true for missing GitHub token errors", () => {
-      const err = new Error("No GitHub token available for Copilot embedding provider");
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
-        true,
-      );
-    });
+  it("wraps invalid discovery JSON as a setup error", async () => {
+    fetchWithSsrFGuardMock.mockImplementationOnce(async () => ({
+      response: {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("bad json");
+        },
+        text: async () => "",
+      },
+      release: vi.fn(async () => {}),
+    }));
 
-    it("returns true for token exchange failures", () => {
-      const err = new Error("Copilot token exchange failed: HTTP 401");
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
-        true,
-      );
-    });
-
-    it("returns true for no embedding models available", () => {
-      const err = new Error("No embedding models available from GitHub Copilot");
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
-        true,
-      );
-    });
-
-    it("returns true for model discovery failures", () => {
-      const err = new Error("GitHub Copilot model discovery HTTP 403: Forbidden");
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
-        true,
-      );
-    });
-
-    it("returns true for user model not available", () => {
-      const err = new Error(
-        'GitHub Copilot embedding model "gpt-4o" is not available. Available: text-embedding-3-small',
-      );
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
-        true,
-      );
-    });
-
-    it("returns false for non-Copilot errors", () => {
-      const err = new Error("Network timeout");
-      expect(githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(err)).toBe(
-        false,
-      );
-    });
-
-    it("returns false for non-Error values", () => {
-      expect(
-        githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!("some string"),
-      ).toBe(false);
-    });
+    await expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
+    ).rejects.toThrow("GitHub Copilot model discovery returned invalid JSON");
   });
 
-  describe("embedQuery", () => {
-    it("calls the endpoint and returns a vector", async () => {
-      const embedding = [0.1, 0.2, 0.3];
-      const magnitude = Math.sqrt(embedding.reduce((sum, v) => sum + v * v, 0));
-      const normalized = embedding.map((v) => v / magnitude);
-
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-        {
-          ok: true,
-          json: buildEmbeddingResponse([{ embedding, index: 0 }]),
-        },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-      const vector = await result.provider!.embedQuery("hello world");
-
-      expect(vector).toEqual(normalized);
-
-      // Verify the embeddings call used POST with correct body (second fetch call)
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
-      const embeddingsCall = fetchWithSsrFGuardMock.mock.calls[1][0] as {
-        url: string;
-        init: { method: string; body: string };
-      };
-      expect(embeddingsCall.url).toBe(`${TEST_BASE_URL}/embeddings`);
-      expect(embeddingsCall.init.method).toBe("POST");
-      const body = JSON.parse(embeddingsCall.init.body) as { model: string; input: string[] };
-      expect(body.model).toBe("text-embedding-3-small");
-      expect(body.input).toEqual(["hello world"]);
+  it("honors remote overrides when creating the provider", async () => {
+    resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "gh_remote_token" });
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([
+        { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+      ]),
     });
+
+    await githubCopilotMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      remote: {
+        apiKey: "ignored-at-runtime",
+        baseUrl: "https://proxy.example/v1",
+        headers: { "X-Proxy-Token": "proxy" },
+      },
+    } as never);
+
+    expect(resolveFirstGithubTokenMock).toHaveBeenCalled();
+    expect(createGitHubCopilotEmbeddingProviderMock).toHaveBeenCalledWith({
+      baseUrl: "https://proxy.example/v1",
+      env: process.env,
+      fetchImpl: fetch,
+      githubToken: "gh_remote_token",
+      headers: { "X-Proxy-Token": "proxy" },
+      model: "text-embedding-3-small",
+    });
+
+    const discoveryCall = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+      init: { headers: Record<string, string> };
+      url: string;
+    };
+    expect(discoveryCall.url).toBe("https://proxy.example/v1/models");
+    expect(discoveryCall.init.headers["X-Proxy-Token"]).toBe("proxy");
   });
 
-  describe("embedBatch", () => {
-    it("returns multiple vectors sorted by index", async () => {
-      const emb0 = [0.1, 0.2, 0.3];
-      const emb1 = [0.4, 0.5, 0.6];
-
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-        {
-          ok: true,
-          // Return in reverse index order to verify sorting
-          json: buildEmbeddingResponse([
-            { embedding: emb1, index: 1 },
-            { embedding: emb0, index: 0 },
-          ]),
-        },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-      const vectors = await result.provider!.embedBatch(["first", "second"]);
-
-      expect(vectors).toHaveLength(2);
-      // Verify order matches input order (index 0 first, index 1 second)
-      const mag0 = Math.sqrt(emb0.reduce((sum, v) => sum + v * v, 0));
-      const mag1 = Math.sqrt(emb1.reduce((sum, v) => sum + v * v, 0));
-      expect(vectors[0]).toEqual(emb0.map((v) => v / mag0));
-      expect(vectors[1]).toEqual(emb1.map((v) => v / mag1));
+  it("includes provider, baseUrl, and model in runtime cache data", async () => {
+    mockDiscoveryResponse({
+      ok: true,
+      json: buildModelsResponse([
+        { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
+      ]),
     });
 
-    it("returns empty array for empty input", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
+    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
 
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-      const vectors = await result.provider!.embedBatch([]);
-
-      expect(vectors).toEqual([]);
-      // No extra fetch call for empty input
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("runtime", () => {
-    it("includes cache key data with provider, baseUrl, and model", async () => {
-      mockFetchSequence([
-        {
-          ok: true,
-          json: buildModelsResponse([
-            { id: "text-embedding-3-small", supported_endpoints: ["/v1/embeddings"] },
-          ]),
-        },
-      ]);
-
-      const result =
-        await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-
-      expect(result.runtime).toBeDefined();
-      expect(result.runtime!.id).toBe("github-copilot");
-      expect(result.runtime!.cacheKeyData).toEqual({
+    expect(result.runtime).toEqual({
+      id: "github-copilot",
+      cacheKeyData: {
         provider: "github-copilot",
         baseUrl: TEST_BASE_URL,
         model: "text-embedding-3-small",
-      });
+      },
     });
+  });
+
+  it("treats token parsing and discovery failures as auto-fallback errors", () => {
+    expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(
+        new Error("Copilot token response missing token"),
+      ),
+    ).toBe(true);
+    expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(
+        new Error("Unexpected response from GitHub Copilot token endpoint"),
+      ),
+    ).toBe(true);
+    expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(
+        new Error("GitHub Copilot model discovery returned invalid JSON"),
+      ),
+    ).toBe(true);
+    expect(
+      githubCopilotMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection!(
+        new Error("Network timeout"),
+      ),
+    ).toBe(false);
   });
 });

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -1,10 +1,11 @@
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/config-runtime";
 import {
   DEFAULT_COPILOT_API_BASE_URL,
   resolveCopilotApiToken,
 } from "openclaw/plugin-sdk/github-copilot-token";
-import type {
-  MemoryEmbeddingProvider,
-  MemoryEmbeddingProviderAdapter,
+import {
+  createGitHubCopilotEmbeddingProvider,
+  type MemoryEmbeddingProviderAdapter,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveFirstGithubToken } from "./auth.js";
@@ -39,22 +40,8 @@ function buildSsrfPolicy(baseUrl: string): SsrFPolicy | undefined {
 }
 
 type CopilotModelEntry = {
-  id: string;
-  supported_endpoints?: string[];
-};
-
-type CopilotModelsResponse = {
-  data?: CopilotModelEntry[];
-};
-
-type CopilotEmbeddingDataEntry = {
-  embedding: number[];
-  index: number;
-};
-
-type CopilotEmbeddingResponse = {
-  data?: CopilotEmbeddingDataEntry[];
-  model?: string;
+  id?: unknown;
+  supported_endpoints?: unknown;
 };
 
 function isCopilotSetupError(err: unknown): boolean {
@@ -68,15 +55,18 @@ function isCopilotSetupError(err: unknown): boolean {
   return (
     err.message.includes("No GitHub token available") ||
     err.message.includes("Copilot token exchange failed") ||
+    err.message.includes("Copilot token response") ||
     err.message.includes("No embedding models available") ||
     err.message.includes("GitHub Copilot model discovery") ||
-    err.message.includes("GitHub Copilot embedding model")
+    err.message.includes("GitHub Copilot embedding model") ||
+    err.message.includes("Unexpected response from GitHub Copilot token endpoint")
   );
 }
 
 async function discoverEmbeddingModels(params: {
   baseUrl: string;
   copilotToken: string;
+  headers?: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
 }): Promise<string[]> {
   const url = `${params.baseUrl.replace(/\/$/, "")}/models`;
@@ -86,6 +76,7 @@ async function discoverEmbeddingModels(params: {
       method: "GET",
       headers: {
         ...COPILOT_HEADERS_STATIC,
+        ...params.headers,
         Authorization: `Bearer ${params.copilotToken}`,
       },
     },
@@ -98,17 +89,31 @@ async function discoverEmbeddingModels(params: {
         `GitHub Copilot model discovery HTTP ${response.status}: ${await response.text()}`,
       );
     }
-    const body = (await response.json()) as CopilotModelsResponse;
-    const allModels = Array.isArray(body.data) ? body.data : [];
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new Error("GitHub Copilot model discovery returned invalid JSON");
+    }
+    const allModels = Array.isArray((payload as { data?: unknown })?.data)
+      ? ((payload as { data: CopilotModelEntry[] }).data ?? [])
+      : [];
     // Filter for embedding models. The Copilot API may list embedding models
     // with an explicit /v1/embeddings endpoint, or with an empty
     // supported_endpoints array. Match both: endpoint-declared embedding
     // models and models whose ID indicates embedding capability.
-    const models = allModels.filter(
-      (m) =>
-        m.supported_endpoints?.some((ep) => ep.includes("embeddings")) || /\bembedding/i.test(m.id),
-    );
-    return models.map((m) => m.id);
+    return allModels.flatMap((entry) => {
+      const id = typeof entry.id === "string" ? entry.id.trim() : "";
+      if (!id) {
+        return [];
+      }
+      const endpoints = Array.isArray(entry.supported_endpoints)
+        ? entry.supported_endpoints.filter((value): value is string => typeof value === "string")
+        : [];
+      return endpoints.some((ep) => ep.includes("embeddings")) || /\bembedding/i.test(id)
+        ? [id]
+        : [];
+    });
   } finally {
     await release();
   }
@@ -142,77 +147,6 @@ function pickBestModel(available: string[], userModel?: string): string {
   throw new Error("No embedding models available from GitHub Copilot");
 }
 
-function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
-  const sanitized = vec.map((value) => (Number.isFinite(value) ? value : 0));
-  const magnitude = Math.sqrt(sanitized.reduce((sum, value) => sum + value * value, 0));
-  if (magnitude < 1e-10) {
-    return sanitized;
-  }
-  return sanitized.map((value) => value / magnitude);
-}
-
-// Note: the Copilot token is captured at creation time. Copilot tokens are
-// short-lived (~30 min) so long-lived sessions may hit 401s. This matches
-// how other embedding providers capture API keys at creation. A token
-// refresh mechanism can be added if this becomes a practical issue.
-async function createCopilotEmbeddingProvider(params: {
-  baseUrl: string;
-  copilotToken: string;
-  model: string;
-  ssrfPolicy?: SsrFPolicy;
-}): Promise<MemoryEmbeddingProvider> {
-  const embeddingsUrl = `${params.baseUrl.replace(/\/$/, "")}/embeddings`;
-  const headers: Record<string, string> = {
-    ...COPILOT_HEADERS_STATIC,
-    Authorization: `Bearer ${params.copilotToken}`,
-  };
-
-  const embedBatch = async (texts: string[]): Promise<number[][]> => {
-    if (texts.length === 0) {
-      return [];
-    }
-    const { response, release } = await fetchWithSsrFGuard({
-      url: embeddingsUrl,
-      init: {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ model: params.model, input: texts }),
-      },
-      policy: params.ssrfPolicy,
-      auditContext: "memory-remote",
-    });
-    try {
-      if (!response.ok) {
-        throw new Error(
-          `GitHub Copilot embeddings HTTP ${response.status}: ${await response.text()}`,
-        );
-      }
-      const body = (await response.json()) as CopilotEmbeddingResponse;
-      if (!Array.isArray(body.data)) {
-        throw new Error("GitHub Copilot embeddings response missing data[]");
-      }
-      return body.data
-        .toSorted((a, b) => a.index - b.index)
-        .map((entry) => sanitizeAndNormalizeEmbedding(entry.embedding));
-    } finally {
-      await release();
-    }
-  };
-
-  return {
-    id: COPILOT_EMBEDDING_PROVIDER_ID,
-    model: params.model,
-    embedQuery: async (text: string) => {
-      const [result] = await embedBatch([text]);
-      if (!result) {
-        throw new Error("GitHub Copilot embeddings returned no vectors for query");
-      }
-      return result;
-    },
-    embedBatch,
-  };
-}
-
 export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
   id: COPILOT_EMBEDDING_PROVIDER_ID,
   transport: "remote",
@@ -220,18 +154,28 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
   allowExplicitWhenConfiguredAuto: true,
   shouldContinueAutoSelection: (err: unknown) => isCopilotSetupError(err),
   create: async (options) => {
-    const { githubToken } = resolveFirstGithubToken({
+    const remoteGithubToken = await resolveConfiguredSecretInputString({
+      config: options.config,
+      env: process.env,
+      value: options.remote?.apiKey,
+      path: "agents.*.memorySearch.remote.apiKey",
+    });
+    const { githubToken: profileGithubToken } = await resolveFirstGithubToken({
       agentDir: options.agentDir,
+      config: options.config,
       env: process.env,
     });
+    const githubToken = remoteGithubToken.value || profileGithubToken;
     if (!githubToken) {
       throw new Error("No GitHub token available for Copilot embedding provider");
     }
 
     const { token: copilotToken, baseUrl: resolvedBaseUrl } = await resolveCopilotApiToken({
       githubToken,
+      env: process.env,
     });
-    const baseUrl = resolvedBaseUrl || DEFAULT_COPILOT_API_BASE_URL;
+    const baseUrl =
+      options.remote?.baseUrl?.trim() || resolvedBaseUrl || DEFAULT_COPILOT_API_BASE_URL;
     const ssrfPolicy = buildSsrfPolicy(baseUrl);
 
     // Always discover models even when the user pins one: this validates
@@ -240,17 +184,20 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
     const availableModels = await discoverEmbeddingModels({
       baseUrl,
       copilotToken,
+      headers: options.remote?.headers,
       ssrfPolicy,
     });
 
     const userModel = options.model?.trim() || undefined;
     const model = pickBestModel(availableModels, userModel);
 
-    const provider = await createCopilotEmbeddingProvider({
+    const { provider } = await createGitHubCopilotEmbeddingProvider({
       baseUrl,
-      copilotToken,
+      env: process.env,
+      fetchImpl: fetch,
+      githubToken,
+      headers: options.remote?.headers,
       model,
-      ssrfPolicy,
     });
 
     return {

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -1,0 +1,268 @@
+import {
+  DEFAULT_COPILOT_API_BASE_URL,
+  resolveCopilotApiToken,
+} from "openclaw/plugin-sdk/github-copilot-token";
+import type {
+  MemoryEmbeddingProvider,
+  MemoryEmbeddingProviderAdapter,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { resolveFirstGithubToken } from "./auth.js";
+
+const COPILOT_EMBEDDING_PROVIDER_ID = "github-copilot";
+
+/**
+ * Preferred embedding models in order. The first available model wins.
+ */
+const PREFERRED_MODELS = [
+  "text-embedding-3-small",
+  "text-embedding-3-large",
+  "text-embedding-ada-002",
+] as const;
+
+const COPILOT_HEADERS_STATIC: Record<string, string> = {
+  "Content-Type": "application/json",
+  "Editor-Version": "vscode/1.96.2",
+  "User-Agent": "GitHubCopilotChat/0.26.7",
+};
+
+function buildSsrfPolicy(baseUrl: string): SsrFPolicy | undefined {
+  try {
+    const parsed = new URL(baseUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    return { allowedHostnames: [parsed.hostname] };
+  } catch {
+    return undefined;
+  }
+}
+
+type CopilotModelEntry = {
+  id: string;
+  supported_endpoints?: string[];
+};
+
+type CopilotModelsResponse = {
+  data?: CopilotModelEntry[];
+};
+
+type CopilotEmbeddingDataEntry = {
+  embedding: number[];
+  index: number;
+};
+
+type CopilotEmbeddingResponse = {
+  data?: CopilotEmbeddingDataEntry[];
+  model?: string;
+};
+
+function isCopilotSetupError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  // All Copilot-specific setup failures should allow auto-selection to
+  // fall through to the next provider (e.g. OpenAI). This covers: missing
+  // GitHub token, token exchange failures, no embedding models on the plan,
+  // model discovery errors, and user-pinned model not available on Copilot.
+  return (
+    err.message.includes("No GitHub token available") ||
+    err.message.includes("Copilot token exchange failed") ||
+    err.message.includes("No embedding models available") ||
+    err.message.includes("GitHub Copilot model discovery") ||
+    err.message.includes("GitHub Copilot embedding model")
+  );
+}
+
+async function discoverEmbeddingModels(params: {
+  baseUrl: string;
+  copilotToken: string;
+  ssrfPolicy?: SsrFPolicy;
+}): Promise<string[]> {
+  const url = `${params.baseUrl.replace(/\/$/, "")}/models`;
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      method: "GET",
+      headers: {
+        ...COPILOT_HEADERS_STATIC,
+        Authorization: `Bearer ${params.copilotToken}`,
+      },
+    },
+    policy: params.ssrfPolicy,
+    auditContext: "memory-remote",
+  });
+  try {
+    if (!response.ok) {
+      throw new Error(
+        `GitHub Copilot model discovery HTTP ${response.status}: ${await response.text()}`,
+      );
+    }
+    const body = (await response.json()) as CopilotModelsResponse;
+    const allModels = Array.isArray(body.data) ? body.data : [];
+    // Filter for embedding models. The Copilot API may list embedding models
+    // with an explicit /v1/embeddings endpoint, or with an empty
+    // supported_endpoints array. Match both: endpoint-declared embedding
+    // models and models whose ID indicates embedding capability.
+    const models = allModels.filter(
+      (m) =>
+        m.supported_endpoints?.some((ep) => ep.includes("embeddings")) || /\bembedding/i.test(m.id),
+    );
+    return models.map((m) => m.id);
+  } finally {
+    await release();
+  }
+}
+
+function pickBestModel(available: string[], userModel?: string): string {
+  if (userModel) {
+    const normalized = userModel.trim();
+    // Strip the provider prefix if users set "github-copilot/model-name".
+    const stripped = normalized.startsWith(`${COPILOT_EMBEDDING_PROVIDER_ID}/`)
+      ? normalized.slice(`${COPILOT_EMBEDDING_PROVIDER_ID}/`.length)
+      : normalized;
+    if (available.length === 0) {
+      throw new Error("No embedding models available from GitHub Copilot");
+    }
+    if (!available.includes(stripped)) {
+      throw new Error(
+        `GitHub Copilot embedding model "${stripped}" is not available. Available: ${available.join(", ")}`,
+      );
+    }
+    return stripped;
+  }
+  for (const preferred of PREFERRED_MODELS) {
+    if (available.includes(preferred)) {
+      return preferred;
+    }
+  }
+  if (available.length > 0) {
+    return available[0];
+  }
+  throw new Error("No embedding models available from GitHub Copilot");
+}
+
+function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
+  const sanitized = vec.map((value) => (Number.isFinite(value) ? value : 0));
+  const magnitude = Math.sqrt(sanitized.reduce((sum, value) => sum + value * value, 0));
+  if (magnitude < 1e-10) {
+    return sanitized;
+  }
+  return sanitized.map((value) => value / magnitude);
+}
+
+// Note: the Copilot token is captured at creation time. Copilot tokens are
+// short-lived (~30 min) so long-lived sessions may hit 401s. This matches
+// how other embedding providers capture API keys at creation. A token
+// refresh mechanism can be added if this becomes a practical issue.
+async function createCopilotEmbeddingProvider(params: {
+  baseUrl: string;
+  copilotToken: string;
+  model: string;
+  ssrfPolicy?: SsrFPolicy;
+}): Promise<MemoryEmbeddingProvider> {
+  const embeddingsUrl = `${params.baseUrl.replace(/\/$/, "")}/embeddings`;
+  const headers: Record<string, string> = {
+    ...COPILOT_HEADERS_STATIC,
+    Authorization: `Bearer ${params.copilotToken}`,
+  };
+
+  const embedBatch = async (texts: string[]): Promise<number[][]> => {
+    if (texts.length === 0) {
+      return [];
+    }
+    const { response, release } = await fetchWithSsrFGuard({
+      url: embeddingsUrl,
+      init: {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: params.model, input: texts }),
+      },
+      policy: params.ssrfPolicy,
+      auditContext: "memory-remote",
+    });
+    try {
+      if (!response.ok) {
+        throw new Error(
+          `GitHub Copilot embeddings HTTP ${response.status}: ${await response.text()}`,
+        );
+      }
+      const body = (await response.json()) as CopilotEmbeddingResponse;
+      if (!Array.isArray(body.data)) {
+        throw new Error("GitHub Copilot embeddings response missing data[]");
+      }
+      return body.data
+        .toSorted((a, b) => a.index - b.index)
+        .map((entry) => sanitizeAndNormalizeEmbedding(entry.embedding));
+    } finally {
+      await release();
+    }
+  };
+
+  return {
+    id: COPILOT_EMBEDDING_PROVIDER_ID,
+    model: params.model,
+    embedQuery: async (text: string) => {
+      const [result] = await embedBatch([text]);
+      if (!result) {
+        throw new Error("GitHub Copilot embeddings returned no vectors for query");
+      }
+      return result;
+    },
+    embedBatch,
+  };
+}
+
+export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
+  id: COPILOT_EMBEDDING_PROVIDER_ID,
+  transport: "remote",
+  autoSelectPriority: 15,
+  allowExplicitWhenConfiguredAuto: true,
+  shouldContinueAutoSelection: (err: unknown) => isCopilotSetupError(err),
+  create: async (options) => {
+    const { githubToken } = resolveFirstGithubToken({
+      agentDir: options.agentDir,
+      env: process.env,
+    });
+    if (!githubToken) {
+      throw new Error("No GitHub token available for Copilot embedding provider");
+    }
+
+    const { token: copilotToken, baseUrl: resolvedBaseUrl } = await resolveCopilotApiToken({
+      githubToken,
+    });
+    const baseUrl = resolvedBaseUrl || DEFAULT_COPILOT_API_BASE_URL;
+    const ssrfPolicy = buildSsrfPolicy(baseUrl);
+
+    // Always discover models even when the user pins one: this validates
+    // the Copilot token and confirms the plan supports embeddings before
+    // we attempt any embedding requests.
+    const availableModels = await discoverEmbeddingModels({
+      baseUrl,
+      copilotToken,
+      ssrfPolicy,
+    });
+
+    const userModel = options.model?.trim() || undefined;
+    const model = pickBestModel(availableModels, userModel);
+
+    const provider = await createCopilotEmbeddingProvider({
+      baseUrl,
+      copilotToken,
+      model,
+      ssrfPolicy,
+    });
+
+    return {
+      provider,
+      runtime: {
+        id: COPILOT_EMBEDDING_PROVIDER_ID,
+        cacheKeyData: {
+          provider: COPILOT_EMBEDDING_PROVIDER_ID,
+          baseUrl,
+          model,
+        },
+      },
+    };
+  },
+};

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -36,6 +36,28 @@ function registerProviderWithPluginConfig(pluginConfig: Record<string, unknown>)
 }
 
 describe("github-copilot plugin", () => {
+  it("registers embedding provider", () => {
+    const registerMemoryEmbeddingProviderMock = vi.fn();
+
+    plugin.register(
+      createTestPluginApi({
+        id: "github-copilot",
+        name: "GitHub Copilot",
+        source: "test",
+        config: {},
+        pluginConfig: {},
+        runtime: {} as never,
+        registerProvider: vi.fn(),
+        registerMemoryEmbeddingProvider: registerMemoryEmbeddingProviderMock,
+      }),
+    );
+
+    expect(registerMemoryEmbeddingProviderMock).toHaveBeenCalledTimes(1);
+    const adapter = registerMemoryEmbeddingProviderMock.mock.calls[0]?.[0];
+    expect(adapter.id).toBe("github-copilot");
+  });
+
+
   it("skips catalog discovery when plugin discovery is disabled", async () => {
     const provider = registerProviderWithPluginConfig({ discovery: { enabled: false } });
 

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -57,7 +57,6 @@ describe("github-copilot plugin", () => {
     expect(adapter.id).toBe("github-copilot");
   });
 
-
   it("skips catalog discovery when plugin discovery is disabled", async () => {
     const provider = registerProviderWithPluginConfig({ discovery: { enabled: false } });
 

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -1,11 +1,9 @@
 import { definePluginEntry, type ProviderAuthContext } from "openclaw/plugin-sdk/plugin-entry";
-import {
-  coerceSecretRef,
-  ensureAuthProfileStore,
-  listProfilesForProvider,
-} from "openclaw/plugin-sdk/provider-auth";
+import { ensureAuthProfileStore } from "openclaw/plugin-sdk/provider-auth";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
+import { resolveFirstGithubToken } from "./auth.js";
 import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
+import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
 import { buildGithubCopilotReplayPolicy } from "./replay-policy.js";
 import { wrapCopilotProviderStream } from "./stream.js";
 
@@ -27,39 +25,6 @@ export default definePluginEntry({
   description: "Bundled GitHub Copilot provider plugin",
   register(api) {
     const pluginConfig = (api.pluginConfig ?? {}) as GithubCopilotPluginConfig;
-    function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.ProcessEnv }): {
-      githubToken: string;
-      hasProfile: boolean;
-    } {
-      const authStore = ensureAuthProfileStore(params.agentDir, {
-        allowKeychainPrompt: false,
-      });
-      const hasProfile = listProfilesForProvider(authStore, PROVIDER_ID).length > 0;
-      const envToken =
-        params.env.COPILOT_GITHUB_TOKEN ?? params.env.GH_TOKEN ?? params.env.GITHUB_TOKEN ?? "";
-      const githubToken = envToken.trim();
-      if (githubToken || !hasProfile) {
-        return { githubToken, hasProfile };
-      }
-
-      const profileId = listProfilesForProvider(authStore, PROVIDER_ID)[0];
-      const profile = profileId ? authStore.profiles[profileId] : undefined;
-      if (profile?.type !== "token") {
-        return { githubToken: "", hasProfile };
-      }
-      const directToken = profile.token?.trim() ?? "";
-      if (directToken) {
-        return { githubToken: directToken, hasProfile };
-      }
-      const tokenRef = coerceSecretRef(profile.tokenRef);
-      if (tokenRef?.source === "env" && tokenRef.id.trim()) {
-        return {
-          githubToken: (params.env[tokenRef.id] ?? process.env[tokenRef.id] ?? "").trim(),
-          hasProfile,
-        };
-      }
-      return { githubToken: "", hasProfile };
-    }
 
     async function runGitHubCopilotAuth(ctx: ProviderAuthContext) {
       const { githubCopilotLoginCommand } = await loadGithubCopilotRuntime();
@@ -107,6 +72,8 @@ export default definePluginEntry({
         defaultModel: "github-copilot/gpt-4o",
       };
     }
+
+    api.registerMemoryEmbeddingProvider(githubCopilotMemoryEmbeddingProviderAdapter);
 
     api.registerProvider({
       id: PROVIDER_ID,

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -2,8 +2,8 @@ import { definePluginEntry, type ProviderAuthContext } from "openclaw/plugin-sdk
 import { ensureAuthProfileStore } from "openclaw/plugin-sdk/provider-auth";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
 import { resolveFirstGithubToken } from "./auth.js";
-import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
+import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { buildGithubCopilotReplayPolicy } from "./replay-policy.js";
 import { wrapCopilotProviderStream } from "./stream.js";
 
@@ -107,8 +107,9 @@ export default definePluginEntry({
           }
           const { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } =
             await loadGithubCopilotRuntime();
-          const { githubToken, hasProfile } = resolveFirstGithubToken({
+          const { githubToken, hasProfile } = await resolveFirstGithubToken({
             agentDir: ctx.agentDir,
+            config: ctx.config,
             env: ctx.env,
           });
           if (!hasProfile && !githubToken) {

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -2,6 +2,9 @@
   "id": "github-copilot",
   "enabledByDefault": true,
   "providers": ["github-copilot"],
+  "contracts": {
+    "memoryEmbeddingProviders": ["github-copilot"]
+  },
   "providerAuthEnvVars": {
     "github-copilot": ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
   },

--- a/src/memory-host-sdk/engine-embeddings.ts
+++ b/src/memory-host-sdk/engine-embeddings.ts
@@ -31,6 +31,10 @@ export {
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
 } from "./host/embeddings-mistral.js";
 export {
+  createGitHubCopilotEmbeddingProvider,
+  type GitHubCopilotEmbeddingClient,
+} from "./host/embeddings-github-copilot.js";
+export {
   createOllamaEmbeddingProvider,
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
 } from "./host/embeddings-ollama.js";

--- a/src/memory-host-sdk/host/embeddings-github-copilot.test.ts
+++ b/src/memory-host-sdk/host/embeddings-github-copilot.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveCopilotApiTokenMock = vi.hoisted(() => vi.fn());
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/github-copilot-token.js", () => ({
+  DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",
+  resolveCopilotApiToken: resolveCopilotApiTokenMock,
+}));
+
+vi.mock("../../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import { createGitHubCopilotEmbeddingProvider } from "./embeddings-github-copilot.js";
+
+function mockFetchResponse(spec: { ok: boolean; status?: number; json?: unknown; text?: string }) {
+  fetchWithSsrFGuardMock.mockImplementationOnce(async () => ({
+    response: {
+      ok: spec.ok,
+      status: spec.status ?? (spec.ok ? 200 : 500),
+      json: async () => spec.json,
+      text: async () => spec.text ?? "",
+    },
+    release: vi.fn(async () => {}),
+  }));
+}
+
+describe("createGitHubCopilotEmbeddingProvider", () => {
+  beforeEach(() => {
+    resolveCopilotApiTokenMock.mockResolvedValue({
+      token: "copilot-token-a",
+      expiresAt: Date.now() + 3_600_000,
+      source: "test",
+      baseUrl: "https://api.githubcopilot.test",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resolveCopilotApiTokenMock.mockReset();
+    fetchWithSsrFGuardMock.mockReset();
+  });
+
+  it("normalizes embeddings returned for queries", async () => {
+    mockFetchResponse({
+      ok: true,
+      json: {
+        data: [{ index: 0, embedding: [3, 4] }],
+      },
+    });
+
+    const { provider } = await createGitHubCopilotEmbeddingProvider({
+      githubToken: "gh_test",
+      model: "text-embedding-3-small",
+    });
+
+    await expect(provider.embedQuery("hello")).resolves.toEqual([0.6, 0.8]);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.githubcopilot.test/embeddings",
+      }),
+    );
+  });
+
+  it("preserves input order by explicit response index", async () => {
+    mockFetchResponse({
+      ok: true,
+      json: {
+        data: [
+          { index: 1, embedding: [0, 2] },
+          { index: 0, embedding: [1, 0] },
+        ],
+      },
+    });
+
+    const { provider } = await createGitHubCopilotEmbeddingProvider({
+      githubToken: "gh_test",
+      model: "text-embedding-3-small",
+    });
+
+    await expect(provider.embedBatch(["first", "second"])).resolves.toEqual([
+      [1, 0],
+      [0, 1],
+    ]);
+  });
+
+  it("uses a fresh Copilot token for later requests", async () => {
+    resolveCopilotApiTokenMock
+      .mockResolvedValueOnce({
+        token: "copilot-token-create",
+        expiresAt: Date.now() + 3_600_000,
+        source: "test",
+        baseUrl: "https://api.githubcopilot.test",
+      })
+      .mockResolvedValueOnce({
+        token: "copilot-token-first",
+        expiresAt: Date.now() + 3_600_000,
+        source: "test",
+        baseUrl: "https://api.githubcopilot.test",
+      })
+      .mockResolvedValueOnce({
+        token: "copilot-token-second",
+        expiresAt: Date.now() + 3_600_000,
+        source: "test",
+        baseUrl: "https://api.githubcopilot.test",
+      });
+    mockFetchResponse({
+      ok: true,
+      json: { data: [{ index: 0, embedding: [1, 0] }] },
+    });
+    mockFetchResponse({
+      ok: true,
+      json: { data: [{ index: 0, embedding: [0, 1] }] },
+    });
+
+    const { provider } = await createGitHubCopilotEmbeddingProvider({
+      githubToken: "gh_test",
+      model: "text-embedding-3-small",
+    });
+
+    await provider.embedQuery("first");
+    await provider.embedQuery("second");
+
+    const firstHeaders = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.init?.headers as Record<
+      string,
+      string
+    >;
+    const secondHeaders = fetchWithSsrFGuardMock.mock.calls[1]?.[0]?.init?.headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders.Authorization).toBe("Bearer copilot-token-first");
+    expect(secondHeaders.Authorization).toBe("Bearer copilot-token-second");
+  });
+
+  it("honors custom baseUrl and header overrides", async () => {
+    mockFetchResponse({
+      ok: true,
+      json: { data: [{ index: 0, embedding: [1, 0] }] },
+    });
+
+    const { provider } = await createGitHubCopilotEmbeddingProvider({
+      githubToken: "gh_test",
+      model: "text-embedding-3-small",
+      baseUrl: "https://proxy.example/v1",
+      headers: { "X-Proxy-Token": "proxy" },
+    });
+
+    await provider.embedQuery("hello");
+
+    const call = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+      init: { headers: Record<string, string> };
+      url: string;
+    };
+    expect(call.url).toBe("https://proxy.example/v1/embeddings");
+    expect(call.init.headers["X-Proxy-Token"]).toBe("proxy");
+    expect(call.init.headers.Authorization).toBe("Bearer copilot-token-a");
+  });
+
+  it("fails fast on sparse or malformed embedding payloads", async () => {
+    mockFetchResponse({
+      ok: true,
+      json: {
+        data: [{ index: 1, embedding: [1, 0] }],
+      },
+    });
+
+    const { provider } = await createGitHubCopilotEmbeddingProvider({
+      githubToken: "gh_test",
+      model: "text-embedding-3-small",
+    });
+
+    await expect(provider.embedBatch(["first", "second"])).rejects.toThrow(
+      "GitHub Copilot embeddings response missing vectors for some inputs",
+    );
+  });
+});

--- a/src/memory-host-sdk/host/embeddings-github-copilot.ts
+++ b/src/memory-host-sdk/host/embeddings-github-copilot.ts
@@ -1,0 +1,151 @@
+import {
+  DEFAULT_COPILOT_API_BASE_URL,
+  resolveCopilotApiToken,
+} from "../../agents/github-copilot-token.js";
+import { sanitizeAndNormalizeEmbedding } from "./embedding-vectors.js";
+import type { EmbeddingProvider } from "./embeddings.types.js";
+import { buildRemoteBaseUrlPolicy, withRemoteHttpResponse } from "./remote-http.js";
+
+export type GitHubCopilotEmbeddingClient = {
+  githubToken: string;
+  model: string;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+};
+
+const COPILOT_EMBEDDING_PROVIDER_ID = "github-copilot";
+
+const COPILOT_HEADERS_STATIC: Record<string, string> = {
+  "Content-Type": "application/json",
+  "Editor-Version": "vscode/1.96.2",
+  "User-Agent": "GitHubCopilotChat/0.26.7",
+};
+
+function resolveConfiguredBaseUrl(
+  configuredBaseUrl: string | undefined,
+  tokenBaseUrl: string | undefined,
+): string {
+  const trimmed = configuredBaseUrl?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  return tokenBaseUrl || DEFAULT_COPILOT_API_BASE_URL;
+}
+
+async function resolveGitHubCopilotEmbeddingSession(client: GitHubCopilotEmbeddingClient): Promise<{
+  baseUrl: string;
+  headers: Record<string, string>;
+}> {
+  const token = await resolveCopilotApiToken({
+    githubToken: client.githubToken,
+    env: client.env,
+    fetchImpl: client.fetchImpl,
+  });
+  const baseUrl = resolveConfiguredBaseUrl(client.baseUrl, token.baseUrl);
+  return {
+    baseUrl,
+    headers: {
+      ...COPILOT_HEADERS_STATIC,
+      ...client.headers,
+      Authorization: `Bearer ${token.token}`,
+    },
+  };
+}
+
+function parseGitHubCopilotEmbeddingPayload(payload: unknown, expectedCount: number): number[][] {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("GitHub Copilot embeddings response missing data[]");
+  }
+  const data = (payload as { data?: unknown }).data;
+  if (!Array.isArray(data)) {
+    throw new Error("GitHub Copilot embeddings response missing data[]");
+  }
+
+  const vectors = Array.from<number[] | undefined>({ length: expectedCount });
+  for (const entry of data) {
+    if (!entry || typeof entry !== "object") {
+      throw new Error("GitHub Copilot embeddings response contains an invalid entry");
+    }
+    const indexValue = (entry as { index?: unknown }).index;
+    const embedding = (entry as { embedding?: unknown }).embedding;
+    const index = typeof indexValue === "number" ? indexValue : Number.NaN;
+    if (!Number.isInteger(index)) {
+      throw new Error("GitHub Copilot embeddings response contains an invalid index");
+    }
+    if (index < 0 || index >= expectedCount) {
+      throw new Error("GitHub Copilot embeddings response contains an out-of-range index");
+    }
+    if (vectors[index] !== undefined) {
+      throw new Error("GitHub Copilot embeddings response contains duplicate indexes");
+    }
+    if (!Array.isArray(embedding) || !embedding.every((value) => typeof value === "number")) {
+      throw new Error("GitHub Copilot embeddings response contains an invalid embedding");
+    }
+    vectors[index] = sanitizeAndNormalizeEmbedding(embedding);
+  }
+
+  for (let index = 0; index < expectedCount; index += 1) {
+    if (vectors[index] === undefined) {
+      throw new Error("GitHub Copilot embeddings response missing vectors for some inputs");
+    }
+  }
+  return vectors as number[][];
+}
+
+export async function createGitHubCopilotEmbeddingProvider(
+  client: GitHubCopilotEmbeddingClient,
+): Promise<{ provider: EmbeddingProvider; client: GitHubCopilotEmbeddingClient }> {
+  const initialSession = await resolveGitHubCopilotEmbeddingSession(client);
+
+  const embed = async (input: string[]): Promise<number[][]> => {
+    if (input.length === 0) {
+      return [];
+    }
+
+    const session = await resolveGitHubCopilotEmbeddingSession(client);
+    const url = `${session.baseUrl.replace(/\/$/, "")}/embeddings`;
+    return await withRemoteHttpResponse({
+      url,
+      fetchImpl: client.fetchImpl,
+      ssrfPolicy: buildRemoteBaseUrlPolicy(session.baseUrl),
+      init: {
+        method: "POST",
+        headers: session.headers,
+        body: JSON.stringify({ model: client.model, input }),
+      },
+      onResponse: async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `GitHub Copilot embeddings HTTP ${response.status}: ${await response.text()}`,
+          );
+        }
+
+        let payload: unknown;
+        try {
+          payload = await response.json();
+        } catch {
+          throw new Error("GitHub Copilot embeddings returned invalid JSON");
+        }
+        return parseGitHubCopilotEmbeddingPayload(payload, input.length);
+      },
+    });
+  };
+
+  return {
+    provider: {
+      id: COPILOT_EMBEDDING_PROVIDER_ID,
+      model: client.model,
+      embedQuery: async (text) => {
+        const [vector] = await embed([text]);
+        return vector ?? [];
+      },
+      embedBatch: embed,
+    },
+    client: {
+      ...client,
+      baseUrl: initialSession.baseUrl,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Problem: Users with GitHub Copilot subscriptions must configure a separate API key (OpenAI, Gemini, etc.) to use memory search embeddings.
- Why it matters: Many developers already have Copilot through their GitHub plan but lack separate embedding API keys, leaving memory search unavailable.
- What changed: Added a `MemoryEmbeddingProviderAdapter` to the `github-copilot` plugin that discovers embedding models via the Copilot API and registers at auto-selection priority 15.
- What did NOT change (scope boundary): No changes to core embedding infrastructure, token management, or other providers. The existing `createRemoteEmbeddingProvider` pattern is not reused because it is not exported through the plugin SDK; the adapter builds its own HTTP client following the Ollama extension pattern.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61717
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — new feature.

## Regression Test Plan (if applicable)

N/A — new feature, but comprehensive test coverage added.

- Coverage level:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/github-copilot/embeddings.test.ts` (22 tests)
- Scenario the test should lock in: Model discovery, provider creation, embedQuery/embedBatch, error handling, auto-selection behavior, ID-based model matching
- Existing test that already covers this: `extensions/github-copilot/index.test.ts` updated with registration test

## User-visible / Behavior Changes

- New embedding provider `github-copilot` available for `agents.defaults.memorySearch.provider`
- When `provider: "auto"`, GitHub Copilot is tried at priority 15 (after local, before OpenAI) if a GitHub token is available
- Embedding models are auto-discovered from the Copilot `/models` endpoint (prefers `text-embedding-3-small`)
- No new config keys required — reuses existing Copilot auth (env vars or `openclaw models auth login-github-copilot`)

## Diagram (if applicable)

```text
User config (provider: "github-copilot" or "auto")
  → resolveFirstGithubToken (env vars / auth profile)
  → resolveCopilotApiToken (GitHub token → Copilot API token)
  → GET {baseUrl}/models (discover embedding models)
  → pickBestModel (text-embedding-3-small preferred)
  → POST {baseUrl}/embeddings (OpenAI-compatible)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — reuses existing Copilot token infrastructure
- New/changed network calls? Yes — embedding requests to Copilot `/embeddings` and `/models` endpoints
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: New network calls use `fetchWithSsrFGuard` with SSRF policy scoped to the resolved Copilot API hostname. Tokens are sent only via `Authorization` header and never logged.

## Repro + Verification

### Environment

- OS: Linux (Docker)
- Runtime/container: Docker with `openclaw-e2e-copilot-embed` image
- Model/provider: GitHub Copilot (Enterprise plan)
- Relevant config: `agents.defaults.memorySearch.provider: "github-copilot"`

### Steps

1. Configure GitHub Copilot auth (`openclaw models auth login-github-copilot` or set `GH_TOKEN`)
2. Set `agents.defaults.memorySearch.provider: "github-copilot"` in `openclaw.json`
3. Write memory notes and run `openclaw memory index --force`
4. Run `openclaw memory search "query"`

### Expected

- Memory status shows `Provider: github-copilot`, `Model: text-embedding-3-small`, `Vector: ready`
- Memory search returns ranked results using Copilot embeddings

### Actual

- Confirmed working: provider detected, model auto-discovered, 2 files indexed, vector search returns matches (score 0.323 for "capital of France", 0.362 for "Copilot embedding")

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Unit tests: 22 passing in `embeddings.test.ts`, 46 total across `extensions/github-copilot/`

Docker E2E output:
```
Provider: github-copilot (requested: github-copilot)
Model: text-embedding-3-small
Indexed: 2/2 files · 2 chunks
Vector: ready
Vector dims: 1536
Embeddings: ready
Embedding cache: enabled (3 entries)

Search "capital of France":
0.323 memory/test-copilot-embedding.md:1-5

Search "Copilot embedding":
0.362 memory/project-notes.md:1-6
```

## Human Verification (required)

- Verified scenarios: Docker E2E with real GitHub Copilot Enterprise subscription — token exchange, model discovery, indexing, and vector search all working
- Edge cases checked: empty `supported_endpoints` (Copilot API quirk — models matched by ID pattern), missing GitHub token (graceful fallthrough), model discovery HTTP error, malformed response
- What you did **not** verify: `openclaw message send` in Docker (pre-existing Node 24 ESM bug on v2026.4.5 tag, unrelated to this PR)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — new optional provider value, existing configs unaffected
- Migration needed? No
- New plugin SDK exports: None

## Risks and Mitigations

- Risk: Copilot token is captured at creation time and may expire during long sessions (~30 min TTL)
  - Mitigation: Matches existing pattern across all other embedding providers. Documented in code comment. Token refresh can be added as a follow-up if needed.
- Risk: Copilot API model availability varies by plan
  - Mitigation: Dynamic discovery with graceful fallthrough; auto-selection skips to next provider when no embedding models are available.