### PR TITLE
fix: repair corrupted command queue singleton state

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -413,4 +413,39 @@ describe("command queue", () => {
       commandQueueA.resetAllLanes();
     }
   });
+
+  it("repairs corrupted global queue waiters before draining active tasks", async () => {
+    const queueStateKey = Symbol.for("openclaw.commandQueueState");
+    (
+      globalThis as typeof globalThis & {
+        [queueStateKey]?: unknown;
+      }
+    )[queueStateKey] = {
+      gatewayDraining: false,
+      lanes: new Map(),
+      activeTaskWaiters: undefined,
+      nextTaskId: 1,
+    };
+
+    const freshQueue = await importFreshModule<typeof import("./command-queue.js")>(
+      import.meta.url,
+      "./command-queue.js?scope=corrupted-waiters",
+    );
+
+    let release!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const task = freshQueue.enqueueCommand(async () => {
+      await blocker;
+      return "done";
+    });
+
+    const drainPromise = freshQueue.waitForActiveTasks(1000);
+    release();
+
+    await expect(drainPromise).resolves.toEqual({ drained: true });
+    await expect(task).resolves.toBe("done");
+  });
 });

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -53,6 +53,13 @@ type ActiveTaskWaiter = {
   timeout?: ReturnType<typeof setTimeout>;
 };
 
+type QueueState = {
+  gatewayDraining: boolean;
+  lanes: Map<string, LaneState>;
+  activeTaskWaiters: Set<ActiveTaskWaiter>;
+  nextTaskId: number;
+};
+
 function isExpectedNonErrorLaneFailure(err: unknown): boolean {
   return err instanceof Error && err.name === "LiveSessionModelSwitchError";
 }
@@ -63,13 +70,38 @@ function isExpectedNonErrorLaneFailure(err: unknown): boolean {
  */
 const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
 
-function getQueueState() {
-  return resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
+function createQueueState(): QueueState {
+  return {
     gatewayDraining: false,
     lanes: new Map<string, LaneState>(),
     activeTaskWaiters: new Set<ActiveTaskWaiter>(),
     nextTaskId: 1,
-  }));
+  };
+}
+
+function getQueueState(): QueueState {
+  const state = resolveGlobalSingleton(
+    COMMAND_QUEUE_STATE_KEY,
+    createQueueState,
+  ) as Partial<QueueState>;
+
+  // The command queue singleton is shared across bundled entrypoints on globalThis.
+  // If a restart or mixed-runtime edge case leaves this object partially corrupted,
+  // repair the top-level containers in place instead of crashing the gateway.
+  if (!(state.lanes instanceof Map)) {
+    state.lanes = new Map<string, LaneState>();
+  }
+  if (!(state.activeTaskWaiters instanceof Set)) {
+    state.activeTaskWaiters = new Set<ActiveTaskWaiter>();
+  }
+  if (typeof state.gatewayDraining !== "boolean") {
+    state.gatewayDraining = false;
+  }
+  if (!Number.isSafeInteger(state.nextTaskId) || (state.nextTaskId ?? 0) < 1) {
+    state.nextTaskId = 1;
+  }
+
+  return state as QueueState;
 }
 
 function normalizeLane(lane: string): string {


### PR DESCRIPTION
## Summary
- repair the shared command queue singleton when top-level fields are corrupted instead of crashing the gateway
- rebuild invalid `activeTaskWaiters` / `lanes` containers and normalize primitive state in `getQueueState()`
- add a regression test covering a corrupted global singleton before `waitForActiveTasks()` drains active work

## Testing
- pnpm vitest run src/process/command-queue.test.ts
- pnpm exec oxlint src/process/command-queue.ts src/process/command-queue.test.ts

Closes #61730