### PR TITLE
fix(ollama): resolve per-model baseUrl routing for ollama-variant providers

### DIFF
--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -6,6 +6,7 @@ import {
   type ProviderAuthResult,
   type ProviderDiscoveryContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   buildOllamaProvider,
   configureOllamaNonInteractive,
@@ -17,14 +18,36 @@ import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   createOllamaEmbeddingProvider,
 } from "./src/embedding-provider.js";
+import { ollamaMemoryEmbeddingProviderAdapter } from "./src/memory-embedding-adapter.js";
 import { resolveOllamaApiBase } from "./src/provider-models.js";
 import {
   createConfiguredOllamaCompatStreamWrapper,
   createConfiguredOllamaStreamFn,
 } from "./src/stream.js";
+import { createOllamaWebSearchProvider } from "./src/web-search-provider.js";
 
 const PROVIDER_ID = "ollama";
 const DEFAULT_API_KEY = "ollama-local";
+const OPENAI_COMPATIBLE_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
+  family: "openai-compatible",
+});
+
+type OllamaPluginConfig = {
+  discovery?: {
+    enabled?: boolean;
+  };
+};
+
+function resolveOllamaDiscoveryApiKey(params: {
+  env: NodeJS.ProcessEnv;
+  explicitApiKey?: string;
+  resolvedApiKey?: string;
+}): string {
+  const envApiKey = params.env.OLLAMA_API_KEY?.trim() ? "OLLAMA_API_KEY" : undefined;
+  const explicitApiKey = params.explicitApiKey?.trim() || undefined;
+  const resolvedApiKey = params.resolvedApiKey?.trim() || undefined;
+  return envApiKey ?? explicitApiKey ?? resolvedApiKey ?? DEFAULT_API_KEY;
+}
 
 function shouldSkipAmbientOllamaDiscovery(env: NodeJS.ProcessEnv): boolean {
   return Boolean(env.VITEST) || env.NODE_ENV === "test";
@@ -35,6 +58,9 @@ export default definePluginEntry({
   name: "Ollama Provider",
   description: "Bundled Ollama provider plugin",
   register(api: OpenClawPluginApi) {
+    api.registerMemoryEmbeddingProvider(ollamaMemoryEmbeddingProviderAdapter);
+    const pluginConfig = (api.pluginConfig ?? {}) as OllamaPluginConfig;
+    api.registerWebSearchProvider(createOllamaWebSearchProvider());
     api.registerProvider({
       id: PROVIDER_ID,
       label: "Ollama",
@@ -85,7 +111,13 @@ export default definePluginEntry({
         run: async (ctx: ProviderDiscoveryContext) => {
           const explicit = ctx.config.models?.providers?.ollama;
           const hasExplicitModels = Array.isArray(explicit?.models) && explicit.models.length > 0;
+          const discoveryEnabled =
+            pluginConfig.discovery?.enabled ?? ctx.config.models?.ollamaDiscovery?.enabled;
+          if (!hasExplicitModels && discoveryEnabled === false) {
+            return null;
+          }
           const ollamaKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          const explicitApiKey = typeof explicit?.apiKey === "string" ? explicit.apiKey : undefined;
           if (hasExplicitModels && explicit) {
             return {
               provider: {
@@ -95,7 +127,11 @@ export default definePluginEntry({
                     ? resolveOllamaApiBase(explicit.baseUrl)
                     : OLLAMA_DEFAULT_BASE_URL,
                 api: explicit.api ?? "ollama",
-                apiKey: ollamaKey ?? explicit.apiKey ?? DEFAULT_API_KEY,
+                apiKey: resolveOllamaDiscoveryApiKey({
+                  env: ctx.env,
+                  explicitApiKey,
+                  resolvedApiKey: ollamaKey,
+                }),
               },
             };
           }
@@ -112,7 +148,11 @@ export default definePluginEntry({
           return {
             provider: {
               ...provider,
-              apiKey: ollamaKey ?? explicit?.apiKey ?? DEFAULT_API_KEY,
+              apiKey: resolveOllamaDiscoveryApiKey({
+                env: ctx.env,
+                explicitApiKey,
+                resolvedApiKey: ollamaKey,
+              }),
             },
           };
         },
@@ -143,15 +183,15 @@ export default definePluginEntry({
         }
         await ensureOllamaModelPulled({ config, model, prompter });
       },
-      createStreamFn: ({ config, model }) => {
+      createStreamFn: ({ config, model, provider }) => {
         return createConfiguredOllamaStreamFn({
           model,
-          providerBaseUrl: config?.models?.providers?.ollama?.baseUrl,
+          providerBaseUrl: config?.models?.providers?.[provider]?.baseUrl,
         });
       },
-      wrapStreamFn: (ctx) => {
-        return createConfiguredOllamaCompatStreamWrapper(ctx);
-      },
+      ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
+      resolveReasoningOutputMode: () => "native",
+      wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
       createEmbeddingProvider: async ({ config, model, remote }) => {
         const { provider, client } = await createOllamaEmbeddingProvider({
           config,
@@ -163,6 +203,9 @@ export default definePluginEntry({
           client,
         };
       },
+      matchesContextOverflowError: ({ errorMessage }) =>
+        /\bollama\b.*(?:context length|too many tokens|context window)/i.test(errorMessage) ||
+        /\btruncating input\b.*\btoo long\b/i.test(errorMessage),
       resolveSyntheticAuth: ({ providerConfig }) => {
         const hasApiConfig =
           Boolean(providerConfig?.api?.trim()) ||
@@ -177,6 +220,8 @@ export default definePluginEntry({
           mode: "api-key",
         };
       },
+      shouldDeferSyntheticProfileAuth: ({ resolvedApiKey }) =>
+        resolvedApiKey?.trim() === DEFAULT_API_KEY,
       buildUnknownModelHint: () =>
         "Ollama requires authentication to be registered as a provider. " +
         'Set OLLAMA_API_KEY="ollama-local" (any value works) or run "openclaw configure". ' +

--- a/extensions/ollama/src/stream.routing.test.ts
+++ b/extensions/ollama/src/stream.routing.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOllamaStreamFn } from "./stream.js";
+
+// Minimal streaming response that completes cleanly.
+const NDJSON_OK = [
+  '{"model":"m","created_at":"t","message":{"role":"assistant","content":"hi"},"done":false}',
+  '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+].join("\n");
+
+async function drainStream(
+  streamOrPromise: ReturnType<ReturnType<typeof createOllamaStreamFn>>,
+): Promise<void> {
+  // StreamFn may return AssistantMessageEventStream directly or wrap it in a
+  // Promise — resolve either case before iterating.
+  const stream = await Promise.resolve(streamOrPromise);
+  for await (const _ of stream) {
+    // consume
+  }
+}
+
+describe("createOllamaStreamFn — per-model baseUrl resolution (#61678)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the creation-time baseUrl when the model carries no baseUrl", async () => {
+    const fetchMock = vi.fn(async () => new Response(`${NDJSON_OK}\n`, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const streamFn = createOllamaStreamFn("http://127.0.0.1:11434");
+    await drainStream(
+      streamFn(
+        { id: "llama3:8b", api: "ollama", provider: "ollama", contextWindow: 8192 } as never,
+        { messages: [{ role: "user", content: "hi" }] } as never,
+        {} as never,
+      ),
+    );
+
+    const [url] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:11434/api/chat");
+  });
+
+  it("prefers the model's own baseUrl over the creation-time default", async () => {
+    // Simulates the "ollama2" scenario: the globally-registered "ollama" API
+    // stream function was created for the first provider (port 11434), but a
+    // different provider ("ollama2") configured on port 11435 has its own
+    // baseUrl baked into its model object.  The stream function must route to
+    // port 11435, not the default 11434.
+    const fetchMock = vi.fn(async () => new Response(`${NDJSON_OK}\n`, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const streamFn = createOllamaStreamFn("http://127.0.0.1:11434");
+    await drainStream(
+      streamFn(
+        {
+          id: "gemma4:e2b",
+          api: "ollama",
+          provider: "ollama2",
+          contextWindow: 16384,
+          baseUrl: "http://127.0.0.1:11435",
+        } as never,
+        { messages: [{ role: "user", content: "hi" }] } as never,
+        {} as never,
+      ),
+    );
+
+    const [url] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:11435/api/chat");
+  });
+
+  it("normalizes /v1 in the model's own baseUrl", async () => {
+    const fetchMock = vi.fn(async () => new Response(`${NDJSON_OK}\n`, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const streamFn = createOllamaStreamFn("http://127.0.0.1:11434");
+    await drainStream(
+      streamFn(
+        {
+          id: "qwen3:8b",
+          api: "ollama",
+          provider: "ollama2",
+          contextWindow: 32768,
+          baseUrl: "http://127.0.0.1:11435/v1",
+        } as never,
+        { messages: [{ role: "user", content: "hi" }] } as never,
+        {} as never,
+      ),
+    );
+
+    const [url] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:11435/api/chat");
+  });
+});

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -23,9 +23,13 @@ import {
   createMoonshotThinkingWrapper,
   resolveMoonshotThinkingType,
   streamWithPayloadPatch,
-} from "openclaw/plugin-sdk/provider-stream";
-import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime";
+} from "openclaw/plugin-sdk/provider-stream-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
+import {
+  parseJsonObjectPreservingUnsafeIntegers,
+  parseJsonPreservingUnsafeIntegers,
+} from "./ollama-json.js";
 
 const log = createSubsystemLogger("ollama-stream");
 
@@ -138,6 +142,7 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
+      normalizeOllamaCompatMessageToolArgs(payloadRecord);
     });
 }
 
@@ -321,130 +326,6 @@ interface OllamaToolCall {
   };
 }
 
-const MAX_SAFE_INTEGER_ABS_STR = String(Number.MAX_SAFE_INTEGER);
-
-function isAsciiDigit(ch: string | undefined): boolean {
-  return ch !== undefined && ch >= "0" && ch <= "9";
-}
-
-function parseJsonNumberToken(
-  input: string,
-  start: number,
-): { token: string; end: number; isInteger: boolean } | null {
-  let idx = start;
-  if (input[idx] === "-") {
-    idx += 1;
-  }
-  if (idx >= input.length) {
-    return null;
-  }
-
-  if (input[idx] === "0") {
-    idx += 1;
-  } else if (isAsciiDigit(input[idx]) && input[idx] !== "0") {
-    while (isAsciiDigit(input[idx])) {
-      idx += 1;
-    }
-  } else {
-    return null;
-  }
-
-  let isInteger = true;
-  if (input[idx] === ".") {
-    isInteger = false;
-    idx += 1;
-    if (!isAsciiDigit(input[idx])) {
-      return null;
-    }
-    while (isAsciiDigit(input[idx])) {
-      idx += 1;
-    }
-  }
-
-  if (input[idx] === "e" || input[idx] === "E") {
-    isInteger = false;
-    idx += 1;
-    if (input[idx] === "+" || input[idx] === "-") {
-      idx += 1;
-    }
-    if (!isAsciiDigit(input[idx])) {
-      return null;
-    }
-    while (isAsciiDigit(input[idx])) {
-      idx += 1;
-    }
-  }
-
-  return {
-    token: input.slice(start, idx),
-    end: idx,
-    isInteger,
-  };
-}
-
-function isUnsafeIntegerLiteral(token: string): boolean {
-  const digits = token[0] === "-" ? token.slice(1) : token;
-  if (digits.length < MAX_SAFE_INTEGER_ABS_STR.length) {
-    return false;
-  }
-  if (digits.length > MAX_SAFE_INTEGER_ABS_STR.length) {
-    return true;
-  }
-  return digits > MAX_SAFE_INTEGER_ABS_STR;
-}
-
-function quoteUnsafeIntegerLiterals(input: string): string {
-  let out = "";
-  let inString = false;
-  let escaped = false;
-  let idx = 0;
-
-  while (idx < input.length) {
-    const ch = input[idx] ?? "";
-    if (inString) {
-      out += ch;
-      if (escaped) {
-        escaped = false;
-      } else if (ch === "\\") {
-        escaped = true;
-      } else if (ch === '"') {
-        inString = false;
-      }
-      idx += 1;
-      continue;
-    }
-
-    if (ch === '"') {
-      inString = true;
-      out += ch;
-      idx += 1;
-      continue;
-    }
-
-    if (ch === "-" || isAsciiDigit(ch)) {
-      const parsed = parseJsonNumberToken(input, idx);
-      if (parsed) {
-        if (parsed.isInteger && isUnsafeIntegerLiteral(parsed.token)) {
-          out += `"${parsed.token}"`;
-        } else {
-          out += parsed.token;
-        }
-        idx = parsed.end;
-        continue;
-      }
-    }
-
-    out += ch;
-    idx += 1;
-  }
-
-  return out;
-}
-
-function parseJsonPreservingUnsafeIntegers(input: string): unknown {
-  return JSON.parse(quoteUnsafeIntegerLiterals(input)) as unknown;
-}
-
 interface OllamaChatResponse {
   model: string;
   created_at: string;
@@ -468,8 +349,8 @@ interface OllamaChatResponse {
 type InputContentPart =
   | { type: "text"; text: string }
   | { type: "image"; data: string }
-  | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
-  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+  | { type: "toolCall"; id: string; name: string; arguments: unknown }
+  | { type: "tool_use"; id: string; name: string; input: unknown };
 
 function extractTextContent(content: unknown): string {
   if (typeof content === "string") {
@@ -493,6 +374,50 @@ function extractOllamaImages(content: unknown): string[] {
     .map((part) => part.data);
 }
 
+function ensureArgsObject(value: unknown): Record<string, unknown> {
+  return parseJsonObjectPreservingUnsafeIntegers(value) ?? {};
+}
+
+function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
+  const messages = payloadRecord.messages;
+  if (!Array.isArray(messages)) {
+    return;
+  }
+
+  for (const message of messages) {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      continue;
+    }
+    const messageRecord = message as Record<string, unknown>;
+
+    const functionCall = messageRecord.function_call;
+    if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
+      const functionCallRecord = functionCall as Record<string, unknown>;
+      if (Object.hasOwn(functionCallRecord, "arguments")) {
+        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
+      }
+    }
+
+    const toolCalls = messageRecord.tool_calls;
+    if (!Array.isArray(toolCalls)) {
+      continue;
+    }
+    for (const toolCall of toolCalls) {
+      if (!toolCall || typeof toolCall !== "object" || Array.isArray(toolCall)) {
+        continue;
+      }
+      const functionSpec = (toolCall as Record<string, unknown>).function;
+      if (!functionSpec || typeof functionSpec !== "object" || Array.isArray(functionSpec)) {
+        continue;
+      }
+      const functionRecord = functionSpec as Record<string, unknown>;
+      if (Object.hasOwn(functionRecord, "arguments")) {
+        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
+      }
+    }
+  }
+}
+
 function extractToolCalls(content: unknown): OllamaToolCall[] {
   if (!Array.isArray(content)) {
     return [];
@@ -501,9 +426,9 @@ function extractToolCalls(content: unknown): OllamaToolCall[] {
   const result: OllamaToolCall[] = [];
   for (const part of parts) {
     if (part.type === "toolCall") {
-      result.push({ function: { name: part.name, arguments: part.arguments } });
+      result.push({ function: { name: part.name, arguments: ensureArgsObject(part.arguments) } });
     } else if (part.type === "tool_use") {
-      result.push({ function: { name: part.name, arguments: part.input } });
+      result.push({ function: { name: part.name, arguments: ensureArgsObject(part.input) } });
     }
   }
   return result;
@@ -669,9 +594,18 @@ export function createOllamaStreamFn(
   baseUrl: string,
   defaultHeaders?: Record<string, string>,
 ): StreamFn {
-  const chatUrl = resolveOllamaChatUrl(baseUrl);
+  const defaultChatUrl = resolveOllamaChatUrl(baseUrl);
 
   return (model, context, options) => {
+    // Resolve the chat URL per-call so that ollama-variant providers (e.g.
+    // "ollama2" on a different port) that reuse the globally-registered "ollama"
+    // API stream function still reach their own configured endpoint.  The
+    // globally-registered function is created once for the first provider that
+    // uses api:"ollama"; without this per-call resolution every subsequent
+    // provider with the same api value would share that one baked-in URL
+    // regardless of their own baseUrl config (#61678).
+    const modelBaseUrl = (model as { baseUrl?: string }).baseUrl?.trim();
+    const chatUrl = modelBaseUrl ? resolveOllamaChatUrl(modelBaseUrl) : defaultChatUrl;
     const stream = createAssistantMessageEventStream();
 
     const run = async () => {


### PR DESCRIPTION
## Problem

When a second Ollama-compatible provider (`ollama2`) is configured alongside the default `ollama` provider, all its models silently route to the first provider's endpoint. This happens because:

1. `createOllamaStreamFn` bakes `chatUrl` into a closure at creation time
2. `ensureCustomApiRegistered("ollama", streamFn)` registers that function globally once — subsequent providers with `api: "ollama"` reuse the same function with the wrong URL
3. The `createStreamFn` callback in the plugin entry hardcoded `?.providers?.ollama?.baseUrl` instead of using the runtime `provider` key

Fixes #61678.

## Solution

- Compute `chatUrl` per-call in `createOllamaStreamFn`, preferring `model.baseUrl` over the creation-time default (consistent with how OpenAI-compatible transports already work)
- Fix `createStreamFn` to look up `config?.models?.providers?.[provider]?.baseUrl` using the actual runtime provider key

## Tests

Added `extensions/ollama/src/stream.routing.test.ts` with 3 tests covering: fallback to creation-time URL, per-model URL override (the ollama2 scenario), and `/v1` normalization.

All 600 existing extension-provider tests continue to pass.