### PR TITLE
fix(msteams): include tenantId and bot aadObjectId on connector sends (#58774)

### DIFF
--- a/extensions/msteams/src/monitor-handler.feedback-authz.test.ts
+++ b/extensions/msteams/src/monitor-handler.feedback-authz.test.ts
@@ -76,6 +76,7 @@ function createFeedbackInvokeContext(params: {
   conversationType: string;
   senderId: string;
   senderName?: string;
+  recipientAadObjectId?: string;
   teamId?: string;
   channelName?: string;
   comment?: string;
@@ -95,6 +96,7 @@ function createFeedbackInvokeContext(params: {
       recipient: {
         id: "bot-id",
         name: "Bot",
+        aadObjectId: params.recipientAadObjectId,
       },
       conversation: {
         id: params.conversationId,
@@ -298,6 +300,58 @@ describe("msteams feedback invoke authz", () => {
 
       await expectFileMissing(path.join(tmpDir, "msteams_group_19_group_thread_tacv2.jsonl"));
       expect(feedbackReflectionMockState.runFeedbackReflection).not.toHaveBeenCalled();
+      expect(originalRun).not.toHaveBeenCalled();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes bot aadObjectId through feedback reflection proactive refs", async () => {
+    const tmpDir = await mkdtemp(path.join(tmpdir(), "openclaw-msteams-feedback-"));
+    try {
+      const originalRun = vi.fn(async () => undefined);
+      const handler = registerMSTeamsHandlers(
+        createActivityHandler(originalRun),
+        createDeps({
+          cfg: {
+            session: { store: tmpDir },
+            channels: {
+              msteams: {
+                dmPolicy: "allowlist",
+                allowFrom: ["owner-aad"],
+                feedbackReflection: true,
+              },
+            },
+          } as OpenClawConfig,
+        }),
+      ) as MSTeamsActivityHandler & {
+        run: NonNullable<MSTeamsActivityHandler["run"]>;
+      };
+
+      await handler.run(
+        createFeedbackInvokeContext({
+          reaction: "dislike",
+          conversationId: "a:personal-chat;messageid=bot-msg-1",
+          conversationType: "personal",
+          senderId: "owner-aad",
+          senderName: "Owner",
+          recipientAadObjectId: "bot-aad-object-id",
+          comment: "needs follow-up",
+        }),
+      );
+
+      expect(feedbackReflectionMockState.runFeedbackReflection).toHaveBeenCalledTimes(1);
+      expect(feedbackReflectionMockState.runFeedbackReflection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationRef: expect.objectContaining({
+            agent: expect.objectContaining({
+              id: "bot-id",
+              name: "Bot",
+              aadObjectId: "bot-aad-object-id",
+            }),
+          }),
+        }),
+      );
       expect(originalRun).not.toHaveBeenCalled();
     } finally {
       await rm(tmpDir, { recursive: true, force: true });

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -327,7 +327,11 @@ async function handleFeedbackInvoke(
       aadObjectId: activity.from?.aadObjectId,
     },
     agent: activity.recipient
-      ? { id: activity.recipient.id, name: activity.recipient.name }
+      ? {
+          id: activity.recipient.id,
+          name: activity.recipient.name,
+          aadObjectId: activity.recipient.aadObjectId,
+        }
       : undefined,
     bot: activity.recipient
       ? { id: activity.recipient.id, name: activity.recipient.name }

--- a/extensions/msteams/src/sdk-types.ts
+++ b/extensions/msteams/src/sdk-types.ts
@@ -21,7 +21,7 @@ export type MSTeamsActivity = {
     name?: string;
     isGroup?: boolean;
   };
-  recipient?: { id?: string; name?: string };
+  recipient?: { id?: string; name?: string; aadObjectId?: string };
   text?: string;
   textFormat?: string;
   locale?: string;

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -9,6 +9,7 @@ import type { MSTeamsCredentials } from "./token.js";
 
 const clientConstructorState = vi.hoisted(() => ({
   calls: [] as Array<{ serviceUrl: string; options: unknown }>,
+  outboundCreatePayloads: [] as unknown[],
 }));
 
 // Track jwt.verify calls to assert audience/issuer/algorithm config.
@@ -53,6 +54,7 @@ const originalFetch = globalThis.fetch;
 afterEach(() => {
   globalThis.fetch = originalFetch;
   clientConstructorState.calls.length = 0;
+  clientConstructorState.outboundCreatePayloads.length = 0;
   jwtState.verifyCalls.length = 0;
   jwtState.verifyBehavior = "success";
   jwtState.decodedHeader = { kid: "key-1" };
@@ -78,7 +80,10 @@ function createSdkStub(): MSTeamsTeamsSdk {
 
     conversations = {
       activities: (_conversationId: string) => ({
-        create: async (_activity: unknown) => ({ id: "created" }),
+        create: async (activity: unknown) => {
+          clientConstructorState.outboundCreatePayloads.push(activity);
+          return { id: "created" };
+        },
       }),
     };
   }
@@ -185,6 +190,59 @@ describe("createMSTeamsAdapter", () => {
         headers: {
           "User-Agent": expect.stringMatching(/^teams\.ts\[apps\]\/.+ OpenClaw\/.+$/),
         },
+      },
+    });
+  });
+
+  it("includes conversation.tenantId and bot aadObjectId on connector activity create (matches ActivitySender)", async () => {
+    const creds = {
+      appId: "app-id",
+      appPassword: "secret",
+      tenantId: "tenant-id",
+    } satisfies MSTeamsCredentials;
+    const sdk = createSdkStub();
+    const app = new sdk.App({
+      clientId: creds.appId,
+      clientSecret: creds.appPassword,
+      tenantId: creds.tenantId,
+    });
+    const adapter = createMSTeamsAdapter(app, sdk);
+
+    await adapter.continueConversation(
+      creds.appId,
+      {
+        serviceUrl: "https://service.example.com/",
+        conversation: {
+          id: "19:conversation@thread.tacv2",
+          conversationType: "channel",
+          tenantId: "6d8e5c5b-4f2f-4e4a-9b2b-0b4e5f6a7c8d",
+        },
+        channelId: "msteams",
+        agent: {
+          id: "28:bot-id",
+          name: "TestBot",
+          aadObjectId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        },
+      },
+      async (ctx) => {
+        await ctx.sendActivity("hello");
+      },
+    );
+
+    expect(clientConstructorState.outboundCreatePayloads).toHaveLength(1);
+    expect(clientConstructorState.outboundCreatePayloads[0]).toMatchObject({
+      type: "message",
+      text: "hello",
+      from: {
+        id: "28:bot-id",
+        name: "TestBot",
+        aadObjectId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        role: "bot",
+      },
+      conversation: {
+        id: "19:conversation@thread.tacv2",
+        conversationType: "channel",
+        tenantId: "6d8e5c5b-4f2f-4e4a-9b2b-0b4e5f6a7c8d",
       },
     });
   });

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -31,6 +31,8 @@ export type MSTeamsTokenProvider = {
 type MSTeamsBotIdentity = {
   id?: string;
   name?: string;
+  /** Present on inbound activities as `recipient.aadObjectId`; include on outbound for Connector validation. */
+  aadObjectId?: string;
 };
 
 type MSTeamsSendContext = {
@@ -146,6 +148,8 @@ function createSendContext(params: {
   serviceUrl?: string;
   conversationId?: string;
   conversationType?: string;
+  /** Teams tenant for this conversation (`activity.conversation.tenantId`); required by Connector for many outbound sends. */
+  conversationTenantId?: string;
   bot?: MSTeamsBotIdentity;
   replyToActivityId?: string;
   getToken: () => Promise<string | undefined>;
@@ -166,16 +170,29 @@ function createSendContext(params: {
         return { id: "unknown" };
       }
 
+      const conversationPayload: Record<string, unknown> = {
+        id: params.conversationId,
+        conversationType: params.conversationType ?? "personal",
+      };
+      if (params.conversationTenantId) {
+        conversationPayload.tenantId = params.conversationTenantId;
+      }
+
+      const fromPayload =
+        params.bot?.id != null && params.bot.id !== ""
+          ? {
+              id: params.bot.id,
+              name: params.bot.name ?? "",
+              ...(params.bot.aadObjectId ? { aadObjectId: params.bot.aadObjectId } : {}),
+              role: "bot",
+            }
+          : undefined;
+
       return await apiClient.conversations.activities(params.conversationId).create({
         type: "message",
         ...msg,
-        from: params.bot?.id
-          ? { id: params.bot.id, name: params.bot.name ?? "", role: "bot" }
-          : undefined,
-        conversation: {
-          id: params.conversationId,
-          conversationType: params.conversationType ?? "personal",
-        },
+        from: fromPayload,
+        conversation: conversationPayload,
         ...(params.replyToActivityId && !msg.replyToId
           ? { replyToId: params.replyToActivityId }
           : {}),
@@ -234,12 +251,17 @@ function createProcessContext(params: {
     | undefined;
   const conversationType = (params.activity?.conversation as Record<string, unknown>)
     ?.conversationType as string | undefined;
+  const conversationTenantId = (params.activity?.conversation as Record<string, unknown>)
+    ?.tenantId as string | undefined;
   const replyToActivityId = params.activity?.id as string | undefined;
   const bot: MSTeamsBotIdentity | undefined =
     params.activity?.recipient && typeof params.activity.recipient === "object"
       ? {
           id: (params.activity.recipient as Record<string, unknown>).id as string | undefined,
           name: (params.activity.recipient as Record<string, unknown>).name as string | undefined,
+          aadObjectId: (params.activity.recipient as Record<string, unknown>).aadObjectId as
+            | string
+            | undefined,
         }
       : undefined;
   const sendContext = createSendContext({
@@ -247,6 +269,7 @@ function createProcessContext(params: {
     serviceUrl,
     conversationId,
     conversationType,
+    conversationTenantId,
     bot,
     replyToActivityId,
     getToken: params.getToken,
@@ -369,6 +392,7 @@ export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MST
         serviceUrl,
         conversationId,
         conversationType: reference.conversation?.conversationType,
+        conversationTenantId: reference.conversation?.tenantId,
         bot: reference.agent ?? undefined,
         getToken: createBotTokenGetter(app),
       });


### PR DESCRIPTION
## Summary

- Problem: After the Teams SDK adapter migration, outbound activities sent through `@microsoft/teams.api` omitted `conversation.tenantId` and bot `aadObjectId` on the JSON payload. Microsoft’s own `ActivitySender` merges the full `ref.conversation` and `ref.bot`; without those fields, some tenants return HTTP **403** on proactive / Connector posts (see #58774).
- Why it matters: Breaks cron, `message send`, and other proactive paths while inbound webhooks can still look “fine”; users reported rollback to an older release restores behavior.
- What changed: `createSendContext` now passes `conversation.tenantId` (from inbound activity or stored conversation ref) and includes `aadObjectId` on `from` when present. `createProcessContext` and `continueConversation` thread these through. Added a unit test that locks the payload shape to match `ActivitySender`.
- What did NOT change (scope boundary): No RSC install/consent flow, no token acquisition refactor, no changes to Graph or non-Connector paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58774
- Related #58774
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: OpenClaw’s custom `createSendContext` did not mirror the Teams SDK `ActivitySender` merge of `conversation` (including `tenantId`) and `from` (including `aadObjectId`) before POSTing to `/v3/conversations/.../activities`. Stricter Connector validation can reject the leaner payload with HTTP 403.
- Missing detection / guardrail: No unit test asserted parity with the SDK merge shape for proactive sends.
- Contributing context (if known): Regression surfaced after moving off hosting/`CloudAdapter` toward `@microsoft/teams.api` `Client` for outbound messages.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/sdk.test.ts`
- Scenario the test should lock in: Proactive `continueConversation` → `sendActivity` issues a `create` payload containing `conversation.tenantId` and `from.aadObjectId` when the reference provides them.
- Why this is the smallest reliable guardrail: Asserts the outbound contract without needing live Teams.
- Existing test that already covers this (if any): None for this shape before this PR.
- If no new test is added, why not: N/A (test added).

## User-visible / Behavior Changes

Microsoft Teams: proactive and Connector-based outbound messages should succeed again for tenants that require full conversation/bot identity on the activity; no config changes.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Any (plugin change)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Microsoft Teams
- Relevant config (redacted): Standard `channels.msteams` app registration credentials

### Steps

1. Upgrade to a build including this patch; ensure conversation store has refs from recent inbound messages (so `tenantId` is present on stored refs).
2. Trigger a proactive send (e.g. cron, `openclaw message send` to a known Teams target).
3. Confirm delivery succeeds (no HTTP 403 from Connector).

### Expected

Message is accepted by the Bot Framework Connector and appears in Teams.

### Actual

(Pending maintainer / reporter confirmation against staging or next release; locally: `pnpm test extensions/msteams/src/sdk.test.ts` passes.)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New unit test documents expected payload; full Teams/Copilot repro was not executed in this environment.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test extensions/msteams/src/sdk.test.ts` (pass).
- Edge cases checked: Refs without `tenantId` still omit the field (same as prior behavior).
- What you did **not** verify: Live Teams tenant round-trip after patch (needs reporter or staging).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Stored conversation refs missing `tenantId` (very old cache) behave as before until the next inbound message refreshes the ref.
  - Mitigation: Same as pre-fix; users can ping the bot once to refresh.
