### PR TITLE
fix(browser): guard concurrent lazy-start to prevent PortInUseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Docs: https://docs.openclaw.ai
 - Browser/security: require `operator.admin` for the `browser.request` gateway method, matching the host/browser-node control authority exposed by that route. Thanks @RichardCao.
 - Browser/profiles: allow local managed profiles to override `browser.executablePath`, so different profiles can launch different Chromium-based browsers. Thanks @nobrainer-tech.
 - Agents/replay: repair displaced or missing tool results before strict provider replay, use Codex-compatible `aborted` outputs for OpenAI Responses history, and drop partial aborted/error transport turns before retries.
+- Browser/startup: deduplicate concurrent lazy-start calls per profile so simultaneous browser tool requests no longer race into duplicate Chrome launches and `PortInUseError`. (#61772) Thanks @sukhdeepjohar.
 - Browser/profiles: recover from stale Chromium `Singleton*` profile locks after crashes or host moves by clearing dead/foreign locks and retrying launch once. Thanks @seanc-dev.
 - Reply media: allow sandboxed replies to deliver OpenClaw-managed `media/outbound` and `media/tool-*` attachments without treating them as sandbox escapes, while keeping alias-escape checks on the managed media root. Fixes #71138. Thanks @mayor686, @truffle-dev, and @neeravmakwana.
 - CLI/agent: keep `openclaw agent --json` stdout reserved for the JSON response by routing gateway, plugin, and embedded-fallback diagnostics to stderr before execution starts. Fixes #71319.

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -200,7 +200,9 @@ export function createProfileAvailability({
     throw new BrowserProfileUnavailableError(formatChromeMcpAttachFailure(lastError));
   };
 
-  const ensureBrowserAvailable = async (): Promise<void> => {
+  let inflightEnsureBrowserAvailable: Promise<void> | null = null;
+
+  const ensureBrowserAvailableOnce = async (): Promise<void> => {
     await reconcileProfileRuntime();
     if (capabilities.usesChromeMcp) {
       if (profile.userDataDir && !fs.existsSync(profile.userDataDir)) {
@@ -303,6 +305,16 @@ export function createProfileAvailability({
         )}`,
       );
     }
+  };
+
+  const ensureBrowserAvailable = async (): Promise<void> => {
+    if (inflightEnsureBrowserAvailable) {
+      return inflightEnsureBrowserAvailable;
+    }
+    inflightEnsureBrowserAvailable = ensureBrowserAvailableOnce().finally(() => {
+      inflightEnsureBrowserAvailable = null;
+    });
+    return inflightEnsureBrowserAvailable;
   };
 
   const stopRunningBrowser = async (): Promise<{ stopped: boolean }> => {

--- a/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -88,6 +88,42 @@ describe("browser server-context ensureBrowserAvailable", () => {
     expect(stopOpenClawChrome).toHaveBeenCalledTimes(1);
   });
 
+  it("deduplicates concurrent lazy-start calls to prevent PortInUseError", async () => {
+    const { launchOpenClawChrome, stopOpenClawChrome, isChromeCdpReady, profile } =
+      setupEnsureBrowserAvailableHarness();
+    isChromeCdpReady.mockResolvedValue(true);
+    mockLaunchedChrome(launchOpenClawChrome, 456);
+
+    const first = profile.ensureBrowserAvailable();
+    const second = profile.ensureBrowserAvailable();
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+
+    expect(launchOpenClawChrome).toHaveBeenCalledTimes(1);
+    expect(stopOpenClawChrome).not.toHaveBeenCalled();
+  });
+
+  it("clears the concurrent lazy-start guard after launch failure", async () => {
+    const { launchOpenClawChrome, stopOpenClawChrome, isChromeCdpReady, profile } =
+      setupEnsureBrowserAvailableHarness();
+    isChromeCdpReady.mockResolvedValue(true);
+    launchOpenClawChrome.mockRejectedValueOnce(
+      new Error("PortInUseError: listen EADDRINUSE 127.0.0.1:18800"),
+    );
+
+    const first = profile.ensureBrowserAvailable();
+    const second = profile.ensureBrowserAvailable();
+    await expect(Promise.all([first, second])).rejects.toThrow("PortInUseError");
+
+    mockLaunchedChrome(launchOpenClawChrome, 789);
+    const retry = profile.ensureBrowserAvailable();
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(retry).resolves.toBeUndefined();
+
+    expect(launchOpenClawChrome).toHaveBeenCalledTimes(2);
+    expect(stopOpenClawChrome).not.toHaveBeenCalled();
+  });
+
   it("reuses a pre-existing loopback browser after an initial short probe miss", async () => {
     const { launchOpenClawChrome, stopOpenClawChrome, isChromeCdpReady, profile, state } =
       setupEnsureBrowserAvailableHarness();


### PR DESCRIPTION
## Summary

- Problem: When two tasks trigger the browser tool simultaneously on first use, both calls pass the `isHttpReachable()` check before either launches Chrome, causing a double `launchOpenClawChrome()` and a `PortInUseError` on the second spawn.
- Why it matters: Multi-task agent workloads that use the browser tool hit this race on cold start, crashing the second task.
- What changed: Added a singleton promise guard (`inflightLaunch`) around `ensureBrowserAvailable` so concurrent callers share the same in-flight launch attempt instead of each racing through the launch path independently.
- What did NOT change (scope boundary): The lazy-load behavior, CDP readiness polling, and all other availability/reachability logic remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #21149 (sequential variant of the same PortInUseError, fixed in v2026.2.28 — this PR fixes the concurrent variant that the original fix did not cover)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `ensureBrowserAvailable()` has no concurrency guard. Two concurrent calls both see `isHttpReachable() → false` and `!profileState.running`, then both call `launchOpenClawChrome()`. The second spawn fails because the first already bound the CDP port.
- Missing detection / guardrail: No mutex or inflight-promise deduplication on the launch path. The existing `waitForCdpReadyAfterLaunch` (#21149) prevents sequential races but not concurrent ones.
- Contributing context (if known): The race window is between `isHttpReachable()` (line 191) and `attachRunning(launched)` (line 219) in `server-context.availability.ts`. Any concurrent call entering this window before the first call sets `profileState.running` will attempt its own launch.

## Regression Test Plan (if applicable)

- Coverage level that should catch this:
  - [x] Unit test
- Target test or file: `extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts`
- Scenario the test should lock in: Two simultaneous `ensureBrowserAvailable()` calls result in exactly one `launchOpenClawChrome()` invocation.
- Why this is the smallest reliable guardrail: The test directly exercises the deduplication guard at the function boundary where the race occurs.
- Existing test that already covers this (if any): Existing tests cover sequential CDP readiness and timeout cleanup, but not concurrent entry.

## User-visible / Behavior Changes

None — browser lazy-start works the same, concurrent callers now wait for the in-flight launch instead of crashing.

## Diagram (if applicable)

```text
Before:
[task A] -> isHttpReachable()=false -> launchChrome() -> OK
[task B] -> isHttpReachable()=false -> launchChrome() -> PortInUseError!

After:
[task A] -> isHttpReachable()=false -> launchChrome() -> OK
[task B] -> joins inflightLaunch promise --------------------^
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0, arm64) + Linux amd64 (Docker E2E)
- Runtime/container: Node 22+
- Model/provider: N/A (browser tool infrastructure)
- Integration/channel (if any): Browser plugin
- Relevant config (redacted): Default browser profile on loopback CDP port

### Steps

1. Configure browser tool with a local Chrome profile
2. Trigger two browser tool calls simultaneously (e.g., two concurrent agent tasks on first use)
3. Second call fails with PortInUseError on the CDP port

### Expected

- Both calls succeed; second call waits for the first launch to complete.

### Actual

- Second call crashes with PortInUseError.

## Evidence

- [x] Failing test/log before + passing after
  - New unit test: "deduplicates concurrent lazy-start calls to prevent PortInUseError" — verifies two simultaneous calls produce exactly one `launchOpenClawChrome` invocation
  - Docker E2E (linux/amd64): old image — both concurrent browser open calls fail instantly with Chromium profile lock error. Fix image — both calls run concurrently without conflict.
- [x] Trace/log snippets
  - Race window identified by code review: `server-context.availability.ts:186-219`

## Human Verification (required)

- Verified scenarios:
  - `pnpm check` — 0 warnings, 0 errors (lint + typecheck)
  - `pnpm build` — passed
  - `pnpm test:extension browser` — 547/547 tests passed
  - `pnpm test` (full suite) — passed (exit 0); 15 pre-existing failures in unrelated `src/agents/` files (minimax, stepfun, openrouter, sandbox-policy, bash-tools, tool-images)
  - `pnpm format` — no formatting changes in touched files
  - Docker E2E on linux/amd64 VPS — confirmed fix resolves concurrent browser launch conflict
- Edge cases checked:
  - Launch failure cleanup: `inflightLaunch` clears via `.finally()`, so subsequent calls retry fresh
  - Per-profile scoping: guard is inside `createProfileAvailability`, so different profiles can still launch in parallel
  - Non-concurrent calls: existing fast path (`isHttpReachable() → true`) is unchanged
- What you did **not** verify:
  - Sustained load testing beyond two concurrent calls

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: If the first launch fails, all concurrent waiters receive the same rejection.
  - Mitigation: `inflightLaunch` clears in `.finally()`, so the next call retries a fresh launch. Same failure semantics as before, just without the duplicate spawn.

## AI Disclosure

- [x] This PR was AI-assisted (Claude Code / Claude Opus 4.6)
- [x] Degree of testing: Fully tested — `pnpm build`, `pnpm check`, `pnpm test:extension browser` (547/547), `pnpm test` (full suite passed), Docker E2E on linux/amd64
- [x] I understand what the code does: singleton promise guard ensures concurrent `ensureBrowserAvailable()` calls share one in-flight launch instead of racing independently