### PR TITLE
fix(queue): heal missing active task waiters state

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -243,6 +243,30 @@ describe("command queue", () => {
     }
   });
 
+  it("heals missing activeTaskWaiters in preserved global queue state", async () => {
+    const queueStateKey = Symbol.for("openclaw.commandQueueState");
+    const queueState = (globalThis as Record<PropertyKey, unknown>)[queueStateKey] as
+      | { activeTaskWaiters?: unknown }
+      | undefined;
+    delete queueState?.activeTaskWaiters;
+
+    const { task, release } = enqueueBlockedMainTask();
+
+    vi.useFakeTimers();
+    try {
+      const drainPromise = waitForActiveTasks(5000);
+
+      await vi.advanceTimersByTimeAsync(50);
+      release();
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expect(drainPromise).resolves.toEqual({ drained: true });
+      await expect(task).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("resetAllLanes drains queued work immediately after reset", async () => {
     const lane = `reset-test-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     setCommandLaneConcurrency(lane, 1);

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -53,6 +53,13 @@ type ActiveTaskWaiter = {
   timeout?: ReturnType<typeof setTimeout>;
 };
 
+type QueueState = {
+  gatewayDraining: boolean;
+  lanes: Map<string, LaneState>;
+  activeTaskWaiters: Set<ActiveTaskWaiter>;
+  nextTaskId: number;
+};
+
 function isExpectedNonErrorLaneFailure(err: unknown): boolean {
   return err instanceof Error && err.name === "LiveSessionModelSwitchError";
 }
@@ -64,12 +71,16 @@ function isExpectedNonErrorLaneFailure(err: unknown): boolean {
 const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
 
 function getQueueState() {
-  return resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
+  const state = resolveGlobalSingleton<QueueState>(COMMAND_QUEUE_STATE_KEY, () => ({
     gatewayDraining: false,
     lanes: new Map<string, LaneState>(),
     activeTaskWaiters: new Set<ActiveTaskWaiter>(),
     nextTaskId: 1,
   }));
+  if (!(state.activeTaskWaiters instanceof Set)) {
+    state.activeTaskWaiters = new Set<ActiveTaskWaiter>();
+  }
+  return state;
 }
 
 function normalizeLane(lane: string): string {


### PR DESCRIPTION
## Summary

- Problem: `src/process/command-queue.ts` stores `activeTaskWaiters` in a global singleton, but `getQueueState()` trusted any pre-existing singleton shape.
- Why it matters: when a preserved/shared queue state is missing `activeTaskWaiters`, `waitForActiveTasks()` and `notifyActiveTaskWaiters()` can crash with `TypeError: undefined is not iterable`, which breaks restart drain handling and can leave channels with generated replies that never flush out.
- What changed: `getQueueState()` now heals a missing `activeTaskWaiters` set before queue drain logic uses it, and `src/process/command-queue.test.ts` adds a regression test for that exact corrupted-state scenario.
- What did NOT change (scope boundary): no queue algorithm rewrite, no restart flow changes, no channel/plugin changes, no unrelated cleanup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: queue runtime state lives on `globalThis`, but `getQueueState()` only initialized the singleton on first creation and did not repair a reused singleton whose `activeTaskWaiters` field was missing.
- Missing detection / guardrail: there was no regression test covering a preserved global queue state with a missing waiter set.
- Contributing context (if known): this surfaced during live gateway restarts/drain handling, where the active-task waiter path is exercised after shared runtime state has already been established.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/process/command-queue.test.ts`
- Scenario the test should lock in: a preserved `openclaw.commandQueueState` singleton that has lost `activeTaskWaiters` should still let `waitForActiveTasks()` resolve normally.
- Why this is the smallest reliable guardrail: the failure happens inside queue-state hydration before any channel-specific behavior, so a focused queue unit test catches it without dragging restart/channel stacks into the PR.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Gateway restart/drain no longer crashes on a missing `activeTaskWaiters` set in preserved queue state, which prevents the observed “message generated but never delivered” symptom from this queue crash path.

## Diagram (if applicable)

```text
Before:
[preserved queue singleton missing activeTaskWaiters]
  -> waitForActiveTasks()/notifyActiveTaskWaiters()
  -> TypeError
  -> drain/reply flow aborts

After:
[preserved queue singleton missing activeTaskWaiters]
  -> getQueueState() heals missing Set
  -> waiter/drain flow continues
  -> reply flush can complete
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.1
- Runtime/container: local gateway, Node.js 25.7.0
- Model/provider: not provider-specific
- Integration/channel (if any): reproduced via Telegram and Feishu delivery flows hitting restart/drain queue handling
- Relevant config (redacted): gateway with restart/drain path active; preserved global queue singleton missing `activeTaskWaiters`

### Steps

1. Start from a process-global `openclaw.commandQueueState` object that is missing `activeTaskWaiters`.
2. Enqueue a task and call `waitForActiveTasks()`.
3. Let the task finish.

### Expected

- Queue drain logic heals the missing waiter set and resolves `{ drained: true }`.

### Actual

- Before this patch, the waiter path could throw `TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator)))` from `notifyActiveTaskWaiters()` / `waitForActiveTasks()`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local log snippet before patch:

```text
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Array.from (<anonymous>)
    at notifyActiveTaskWaiters (.../command-queue-*.js)
```

Passing verification after patch:

```text
pnpm exec node scripts/run-vitest.mjs run --config vitest.process.config.ts src/process/command-queue.test.ts
Test Files  1 passed (1)
Tests       19 passed (19)
```

## Human Verification (required)

- Verified scenarios: targeted queue regression test; reviewed the live failure stack against the repaired code path.
- Edge cases checked: missing waiter set with active task present; drain still resolves after task completion.
- What you did **not** verify: full repo `pnpm check`; commit hook `oxlint` is unavailable in this local environment, so I used targeted test coverage instead of repo-wide hook validation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: this intentionally heals only the missing `activeTaskWaiters` field, not arbitrary queue-state corruption.
  - Mitigation: keeps the PR extremely small and directly targeted to the observed crash; broader queue-state hardening can be discussed separately if maintainers want it.
