### PR TITLE
fix(bluebubbles): prefer iMessage over SMS when both chats exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Cron/isolated-agent: keep `delivery.mode: "none"` account-only or thread-only configs from inheriting a stale implicit recipient, so isolated runs only resolve message routing when the job authored an explicit `to` target. (#69163) Thanks @obviyus.
 - Gateway/TUI: retry session history while the local gateway is still finishing startup, so `openclaw tui` reconnects no longer fail on transient `chat.history unavailable during gateway startup` errors. (#69164) Thanks @shakkernerd.
 - BlueBubbles/reactions: fall back to `love` when an agent reacts with an emoji outside the iMessage tapback set (`love`/`like`/`dislike`/`laugh`/`emphasize`/`question`), so wider-vocabulary model reactions like `👀` still produce a visible tapback instead of failing the whole reaction request. Configured ack reactions still validate strictly via the new `normalizeBlueBubblesReactionInputStrict` path. (#64693) Thanks @zqchris.
+- BlueBubbles: prefer iMessage over SMS when both chats exist for the same handle, honor explicit `sms:` targets, and never silently downgrade iMessage-available recipients. (#61781) Thanks @rmartin.
 
 ## 2026.4.19-beta.2
 

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -220,6 +220,90 @@ describe("send", () => {
       expect(result).toBe("iMessage;-;+15551234567");
     });
 
+    it("prefers iMessage over SMS when both chats exist for the same handle", async () => {
+      // Both chats exist; we should never silently downgrade to SMS.
+      const result = await resolveHandleTargetGuid([
+        {
+          guid: "SMS;-;+15551234567",
+          participants: [{ address: "+15551234567" }],
+        },
+        {
+          guid: "iMessage;-;+15551234567",
+          participants: [{ address: "+15551234567" }],
+        },
+      ]);
+
+      expect(result).toBe("iMessage;-;+15551234567");
+    });
+
+    it("prefers iMessage over SMS even when SMS appears first", async () => {
+      const result = await resolveHandleTargetGuid([
+        {
+          guid: "SMS;-;+15551234567",
+          participants: [{ address: "+15551234567" }],
+        },
+        {
+          guid: "iMessage;-;+15559999999",
+          participants: [{ address: "+15559999999" }],
+        },
+        {
+          guid: "iMessage;-;+15551234567",
+          participants: [{ address: "+15551234567" }],
+        },
+      ]);
+
+      expect(result).toBe("iMessage;-;+15551234567");
+    });
+
+    it("falls back to SMS when no iMessage chat exists for the handle", async () => {
+      // First page: SMS-only DM. Second page: empty (stops pagination).
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "SMS;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "imessage",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("SMS;-;+15551234567");
+    });
+
+    it("prefers iMessage over SMS via participant match", async () => {
+      const result = await resolveHandleTargetGuid([
+        {
+          guid: "SMS;-;alt-handle",
+          participants: [{ address: "+15551234567" }],
+        },
+        {
+          guid: "iMessage;-;alt-handle",
+          participants: [{ address: "+15551234567" }],
+        },
+      ]);
+
+      expect(result).toBe("iMessage;-;alt-handle");
+    });
+
     it("returns null when handle only exists in group chat (not DM)", async () => {
       // This is the critical fix: if a phone number only exists as a participant in a group chat
       // (no direct DM chat), we should NOT send to that group. Return null instead.

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -77,16 +77,29 @@ function installSsrFPolicyCapture(policies: unknown[]) {
 
 describe("send", () => {
   describe("resolveChatGuidForTarget", () => {
-    const resolveHandleTargetGuid = async (data: Array<Record<string, unknown>>) => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data }),
-      });
+    const resolveHandleTargetGuid = async (
+      data: Array<Record<string, unknown>>,
+      service: "imessage" | "sms" | "auto" = "imessage",
+    ) => {
+      // First page returns the provided chats; second page is empty so the
+      // pagination loop exits cleanly. We can't break early on participant or
+      // non-preferred direct matches — a stronger preferred-service direct
+      // match could still appear on a later page — so we always need to mock
+      // at least one trailing empty page.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
 
       const target: BlueBubblesSendTarget = {
         kind: "handle",
         address: "+15551234567",
-        service: "imessage",
+        service,
       };
       return await resolveChatGuidForTarget({
         baseUrl: "http://localhost:1234",
@@ -287,6 +300,125 @@ describe("send", () => {
       });
 
       expect(result).toBe("SMS;-;+15551234567");
+    });
+
+    it("respects explicit service: 'sms' and prefers SMS direct match over iMessage", async () => {
+      // Regression: when caller passes `sms:+15551234567` (target.service ===
+      // 'sms'), explicit SMS intent must beat the default iMessage preference.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "iMessage;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+                {
+                  guid: "SMS;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "sms",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("SMS;-;+15551234567");
+    });
+
+    it("falls back to iMessage when service: 'sms' is requested but no SMS chat exists", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "iMessage;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "sms",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("iMessage;-;+15551234567");
+    });
+
+    it("prefers a later-page direct iMessage match over an earlier participant iMessage match", async () => {
+      // Regression: a participant-based iMessage match must NOT short-circuit
+      // pagination and beat a direct `iMessage;-;<handle>` match on a later page.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "iMessage;-;alt-handle",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "iMessage;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "imessage",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("iMessage;-;+15551234567");
     });
 
     it("prefers a later-page iMessage participant match over an earlier unknown-service direct match", async () => {

--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -289,6 +289,53 @@ describe("send", () => {
       expect(result).toBe("SMS;-;+15551234567");
     });
 
+    it("prefers a later-page iMessage participant match over an earlier unknown-service direct match", async () => {
+      // Regression: an unknown-service direct match on page 1 must NOT short-circuit
+      // pagination and beat a real iMessage participant match on page 2.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "WeirdService;-;+15551234567",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [
+                {
+                  guid: "iMessage;-;alt-handle",
+                  participants: [{ address: "+15551234567" }],
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "imessage",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("iMessage;-;alt-handle");
+    });
+
     it("prefers iMessage over SMS via participant match", async () => {
       const result = await resolveHandleTargetGuid([
         {

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -248,16 +248,27 @@ export async function resolveChatGuidForTarget(params: {
     params.target.kind === "chat_identifier" ? params.target.chatIdentifier : null;
 
   const limit = 500;
-  // When matching by handle, prefer iMessage over SMS. A user may have both
-  // an `iMessage;-;<handle>` and `SMS;-;<handle>` chat; we should never silently
-  // downgrade to SMS when an iMessage chat exists for the same handle.
+  // When matching by handle, prefer the caller's requested service. A user may
+  // have both an `iMessage;-;<handle>` and `SMS;-;<handle>` chat:
+  //   - default / `service: "imessage"` / `service: "auto"` -> prefer iMessage
+  //     so we never silently downgrade to SMS when iMessage is available.
+  //   - explicit `service: "sms"` (e.g. caller passed `sms:+15551234567`) ->
+  //     prefer SMS so explicit SMS intent is respected.
   //
-  // Note: real `iMessage;-;<handle>` direct matches `return` immediately below,
-  // so we only need to remember SMS and unknown-service direct fallbacks here.
-  let directHandleSmsMatch: string | null = null;
+  // A direct `<preferred>;-;<handle>` match is the strongest signal and
+  // returns immediately. Everything else is recorded as a ranked fallback.
+  const preferredService: "iMessage" | "SMS" =
+    params.target.kind === "handle" && params.target.service === "sms" ? "SMS" : "iMessage";
+  const preferredPrefix = `${preferredService};-;`;
+  const otherPrefix = preferredService === "iMessage" ? "SMS;-;" : "iMessage;-;";
+
+  // Note: a direct `preferredPrefix` match `return`s immediately below, so we
+  // only need to remember the other-service and unknown-service direct fallbacks.
+  let directHandleOtherServiceMatch: string | null = null;
   let directHandleUnknownServiceMatch: string | null = null;
-  let participantIMessageMatch: string | null = null;
-  let participantSmsMatch: string | null = null;
+  let participantPreferredMatch: string | null = null;
+  let participantOtherServiceMatch: string | null = null;
+  let participantUnknownServiceMatch: string | null = null;
   for (let offset = 0; offset < 5000; offset += limit) {
     const chats = await queryChats({
       baseUrl: params.baseUrl,
@@ -309,22 +320,22 @@ export async function resolveChatGuidForTarget(params: {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
         if (directHandle && directHandle === normalizedHandle && guid) {
-          // Prefer iMessage over SMS. If this chat is iMessage we can return
-          // immediately; if it is SMS we remember it as a fallback and keep
-          // scanning in case an iMessage chat for the same handle exists.
-          if (guid.startsWith("iMessage;-;")) {
+          // A direct `<preferredPrefix><handle>` is the strongest signal and we
+          // can return immediately. Other services are remembered as fallbacks
+          // and we keep scanning in case a preferred-service chat exists later.
+          if (guid.startsWith(preferredPrefix)) {
             return guid;
           }
-          if (guid.startsWith("SMS;-;")) {
-            if (!directHandleSmsMatch) {
-              directHandleSmsMatch = guid;
+          if (guid.startsWith(otherPrefix)) {
+            if (!directHandleOtherServiceMatch) {
+              directHandleOtherServiceMatch = guid;
             }
           } else if (!directHandleUnknownServiceMatch) {
             // Unknown service; treat as a last-resort direct match.
             directHandleUnknownServiceMatch = guid;
           }
         }
-        if (guid && !participantIMessageMatch) {
+        if (guid) {
           // Only consider DM chats (`;-;` separator) as participant matches.
           // Group chats (`;+;` separator) should never match when searching by handle/phone.
           // This prevents routing "send to +1234567890" to a group chat that contains that number.
@@ -334,31 +345,32 @@ export async function resolveChatGuidForTarget(params: {
               normalizeBlueBubblesHandle(entry),
             );
             if (participants.includes(normalizedHandle)) {
-              if (guid.startsWith("iMessage;-;")) {
-                participantIMessageMatch = guid;
-              } else if (guid.startsWith("SMS;-;") && !participantSmsMatch) {
-                participantSmsMatch = guid;
-              } else if (!participantSmsMatch) {
-                participantSmsMatch = guid;
+              if (guid.startsWith(preferredPrefix)) {
+                if (!participantPreferredMatch) {
+                  participantPreferredMatch = guid;
+                }
+              } else if (guid.startsWith(otherPrefix)) {
+                if (!participantOtherServiceMatch) {
+                  participantOtherServiceMatch = guid;
+                }
+              } else if (!participantUnknownServiceMatch) {
+                participantUnknownServiceMatch = guid;
               }
             }
           }
         }
       }
     }
-    // If we already found an iMessage participant match we can stop scanning
-    // further pages; any later SMS chat would still lose out. We deliberately
-    // do NOT break on an unknown-service direct match — a real iMessage
-    // participant match on a later page should still win.
-    if (participantIMessageMatch) {
-      break;
-    }
+    // We deliberately do NOT break early on participant or non-preferred direct
+    // matches: a higher-priority direct `<preferredPrefix><handle>` chat may
+    // still exist on a later page, and only that branch can short-circuit.
   }
   return (
-    participantIMessageMatch ??
-    directHandleSmsMatch ??
+    participantPreferredMatch ??
+    directHandleOtherServiceMatch ??
+    participantOtherServiceMatch ??
     directHandleUnknownServiceMatch ??
-    participantSmsMatch
+    participantUnknownServiceMatch
   );
 }
 

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -248,7 +248,13 @@ export async function resolveChatGuidForTarget(params: {
     params.target.kind === "chat_identifier" ? params.target.chatIdentifier : null;
 
   const limit = 500;
-  let participantMatch: string | null = null;
+  // When matching by handle, prefer iMessage over SMS. A user may have both
+  // an `iMessage;-;<handle>` and `SMS;-;<handle>` chat; we should never silently
+  // downgrade to SMS when an iMessage chat exists for the same handle.
+  let directHandleIMessageMatch: string | null = null;
+  let directHandleSmsMatch: string | null = null;
+  let participantIMessageMatch: string | null = null;
+  let participantSmsMatch: string | null = null;
   for (let offset = 0; offset < 5000; offset += limit) {
     const chats = await queryChats({
       baseUrl: params.baseUrl,
@@ -299,10 +305,21 @@ export async function resolveChatGuidForTarget(params: {
       if (normalizedHandle) {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
-        if (directHandle && directHandle === normalizedHandle) {
-          return guid;
+        if (directHandle && directHandle === normalizedHandle && guid) {
+          // Prefer iMessage over SMS. If this chat is iMessage we can return
+          // immediately; if it is SMS we remember it as a fallback and keep
+          // scanning in case an iMessage chat for the same handle exists.
+          if (guid.startsWith("iMessage;-;")) {
+            return guid;
+          }
+          if (guid.startsWith("SMS;-;") && !directHandleSmsMatch) {
+            directHandleSmsMatch = guid;
+          } else if (!directHandleIMessageMatch && !directHandleSmsMatch) {
+            // Unknown service; treat as a last-resort direct match.
+            directHandleIMessageMatch = guid;
+          }
         }
-        if (!participantMatch && guid) {
+        if (guid && !participantIMessageMatch) {
           // Only consider DM chats (`;-;` separator) as participant matches.
           // Group chats (`;+;` separator) should never match when searching by handle/phone.
           // This prevents routing "send to +1234567890" to a group chat that contains that number.
@@ -312,14 +329,30 @@ export async function resolveChatGuidForTarget(params: {
               normalizeBlueBubblesHandle(entry),
             );
             if (participants.includes(normalizedHandle)) {
-              participantMatch = guid;
+              if (guid.startsWith("iMessage;-;")) {
+                participantIMessageMatch = guid;
+              } else if (guid.startsWith("SMS;-;") && !participantSmsMatch) {
+                participantSmsMatch = guid;
+              } else if (!participantSmsMatch) {
+                participantSmsMatch = guid;
+              }
             }
           }
         }
       }
     }
+    // If we already found an iMessage direct or participant match we can stop
+    // scanning further pages; any later SMS chat would still lose out.
+    if (directHandleIMessageMatch || participantIMessageMatch) {
+      break;
+    }
   }
-  return participantMatch;
+  return (
+    directHandleIMessageMatch ??
+    participantIMessageMatch ??
+    directHandleSmsMatch ??
+    participantSmsMatch
+  );
 }
 
 /**

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -251,8 +251,11 @@ export async function resolveChatGuidForTarget(params: {
   // When matching by handle, prefer iMessage over SMS. A user may have both
   // an `iMessage;-;<handle>` and `SMS;-;<handle>` chat; we should never silently
   // downgrade to SMS when an iMessage chat exists for the same handle.
-  let directHandleIMessageMatch: string | null = null;
+  //
+  // Note: real `iMessage;-;<handle>` direct matches `return` immediately below,
+  // so we only need to remember SMS and unknown-service direct fallbacks here.
   let directHandleSmsMatch: string | null = null;
+  let directHandleUnknownServiceMatch: string | null = null;
   let participantIMessageMatch: string | null = null;
   let participantSmsMatch: string | null = null;
   for (let offset = 0; offset < 5000; offset += limit) {
@@ -312,11 +315,13 @@ export async function resolveChatGuidForTarget(params: {
           if (guid.startsWith("iMessage;-;")) {
             return guid;
           }
-          if (guid.startsWith("SMS;-;") && !directHandleSmsMatch) {
-            directHandleSmsMatch = guid;
-          } else if (!directHandleIMessageMatch && !directHandleSmsMatch) {
+          if (guid.startsWith("SMS;-;")) {
+            if (!directHandleSmsMatch) {
+              directHandleSmsMatch = guid;
+            }
+          } else if (!directHandleUnknownServiceMatch) {
             // Unknown service; treat as a last-resort direct match.
-            directHandleIMessageMatch = guid;
+            directHandleUnknownServiceMatch = guid;
           }
         }
         if (guid && !participantIMessageMatch) {
@@ -341,16 +346,18 @@ export async function resolveChatGuidForTarget(params: {
         }
       }
     }
-    // If we already found an iMessage direct or participant match we can stop
-    // scanning further pages; any later SMS chat would still lose out.
-    if (directHandleIMessageMatch || participantIMessageMatch) {
+    // If we already found an iMessage participant match we can stop scanning
+    // further pages; any later SMS chat would still lose out. We deliberately
+    // do NOT break on an unknown-service direct match — a real iMessage
+    // participant match on a later page should still win.
+    if (participantIMessageMatch) {
       break;
     }
   }
   return (
-    directHandleIMessageMatch ??
     participantIMessageMatch ??
     directHandleSmsMatch ??
+    directHandleUnknownServiceMatch ??
     participantSmsMatch
   );
 }


### PR DESCRIPTION
## Problem

When sending a BlueBubbles message to a handle (phone number) that has **both** an iMessage chat and an SMS chat, `resolveChatGuidForTarget` returns whichever chat it encounters first while iterating results. This causes messages to silently downgrade from iMessage to SMS for recipients who actively use iMessage.

## Reproduction

A user may have two chats with the same recipient:
- `iMessage;-;+15551234567` (active, most messages here)
- `SMS;-;+15551234567` (a few old SMS messages from when their iPhone was offline)

Sending via:

```js
message({ action: 'send', channel: 'bluebubbles', target: '+15551234567', message: '...' })
```

…would hit the SMS chat instead of iMessage. On macOS, BlueBubbles then tries to AppleScript into the SMS chat id and may fail entirely (`Messages got an error: Can't get chat id SMS;-;+15551234567`), or send as SMS and produce an empty or unexpected message.

## Fix

`resolveChatGuidForTarget` now tracks iMessage and SMS matches separately and always prefers iMessage when both exist. Specifically:

- **Direct handle match** (chat guid `service;-;<handle>`): iMessage matches return immediately; SMS matches are remembered as a fallback and we keep scanning for an iMessage chat.
- **Participant match** (handle appears in chat's participants list): same iMessage-first preference.
- SMS is only returned when no iMessage chat exists for the handle anywhere in the result set.
- Once an iMessage match is found, we short-circuit further pagination — any later SMS chat would still lose out.

Behavior when the recipient only has an SMS chat is unchanged.

## Tests

Added 5 new unit tests in `extensions/bluebubbles/src/send.test.ts`:

1. `prefers iMessage over SMS when both chats exist for the same handle`
2. `prefers iMessage over SMS even when SMS appears first`
3. `falls back to SMS when no iMessage chat exists for the handle`
4. `prefers iMessage over SMS via participant match`

All 51 tests in `send.test.ts` pass:

```
Test Files  1 passed (1)
     Tests  51 passed (51)
```

## Real-world impact

Confirmed this fix on a real account where an OpenClaw-driven `bluebubbles` send to a phone number was consistently landing in the SMS chat instead of the active iMessage chat. With the fix, sends go to iMessage as expected.