### PR TITLE
fix(failover): classify finish_reason: network_error as timeout (#61281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: cap the compaction reserve-token floor to the model context window so small-context local models (e.g. Ollama with 16K tokens) no longer trigger context-overflow errors or infinite compaction loops on every prompt. (#65671) Thanks @openperf.
 - Agents/OpenAI Responses: classify the exact `Unknown error (no error details in response)` transport failure as failover reason `unknown` so assistant/model fallback still runs for that no-details failure path. (#65254) Thanks @OpenCodeEngineer.
 - Models/probe: surface invalid-model probe failures as `format` instead of `unknown` in `models list --probe`, and lock the invalid-model fallback path in with regression coverage. (#50028) Thanks @xiwuqi.
+- Agents/failover: classify OpenAI-compatible `finish_reason: network_error` stream failures as timeout so model fallback retries continue instead of stopping with an unknown failover reason. (#61784) thanks @lawrence3699.
 
 ## 2026.4.14
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -779,6 +779,17 @@ describe("isFailoverErrorMessage", () => {
     ]);
   });
 
+  it("matches Provider finish_reason: network_error as timeout (#61281)", () => {
+    // OpenAI-compatible providers like Z.AI emit this exact format.
+    // `\breason:` does not match `finish_reason:` because `_` is a word
+    // character and there is no word boundary before `reason`.
+    expectTimeoutFailoverSamples([
+      "Provider finish_reason: network_error",
+      "Provider finish_reason: abort",
+      "Provider finish_reason: malformed_response",
+    ]);
+  });
+
   it("does not classify MALFORMED_FUNCTION_CALL as timeout", () => {
     const sample = "Unhandled stop reason: MALFORMED_FUNCTION_CALL";
     expect(isTimeoutErrorMessage(sample)).toBe(false);

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -780,9 +780,6 @@ describe("isFailoverErrorMessage", () => {
   });
 
   it("matches Provider finish_reason: network_error as timeout (#61281)", () => {
-    // OpenAI-compatible providers like Z.AI emit this exact format.
-    // `\breason:` does not match `finish_reason:` because `_` is a word
-    // character and there is no word boundary before `reason`.
     expectTimeoutFailoverSamples([
       "Provider finish_reason: network_error",
       "Provider finish_reason: abort",

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -114,6 +114,11 @@ const ERROR_PATTERNS = {
     /\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
+    // OpenAI-compatible providers (e.g. Z.AI) surface transport-level errors as
+    // `finish_reason: network_error` in the stream body. The `\breason:` pattern
+    // above does NOT match `finish_reason:` because `_` is a word character so
+    // there is no word boundary before `reason` in `finish_reason` (#61281).
+    /\bfinish_reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     // AbortError messages from fetch/stream aborts (Ollama NDJSON stream
     // timeouts, signal aborts, etc.) — without these the flattened message
     // falls through to reason=unknown (#58315).

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -114,10 +114,7 @@ const ERROR_PATTERNS = {
     /\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
-    // OpenAI-compatible providers (e.g. Z.AI) surface transport-level errors as
-    // `finish_reason: network_error` in the stream body. The `\breason:` pattern
-    // above does NOT match `finish_reason:` because `_` is a word character so
-    // there is no word boundary before `reason` in `finish_reason` (#61281).
+    // `\breason:` does not match provider payloads like `finish_reason: network_error` (#61281).
     /\bfinish_reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     // AbortError messages from fetch/stream aborts (Ollama NDJSON stream
     // timeouts, signal aborts, etc.) — without these the flattened message


### PR DESCRIPTION
## Problem

OpenAI-compatible providers (e.g. Z.AI) surface transport-level errors as `finish_reason: network_error` in the stream body. The existing `\breason:` pattern in `failover-matches.ts` does not match `finish_reason:` because `_` is a word character — there is no word boundary before `reason` in `finish_reason`. As a result, these errors fall through unclassified and the timeout-failover path (retry with the next configured model) is never triggered.

Reported in #61281 with exact logs:
```
error=Provider finish_reason: network_error
```

## Fix

Add an explicit `\bfinish_reason:` pattern that covers the same set of terminal reasons (`abort`, `error`, `malformed_response`, `network_error`) already handled by the `\breason:` pattern.

## Tests

Added 3 new test cases to `pi-embedded-helpers.isbillingerrormessage.test.ts` covering the exact format reported in the issue. All 94 tests pass.