### PR TITLE
fix(plugins): reuse gateway-bindable active registry for default runtime requests

### DIFF
--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -54,12 +54,31 @@ describe("getCompatibleActivePluginRegistry", () => {
         onlyPluginIds: ["demo"],
       }),
     ).toBeUndefined();
+  });
+
+  it("treats an active gateway-bindable registry as compatible with default runtime requests", () => {
+    const registry = createEmptyPluginRegistry();
+    const gatewayBindableLoadOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          load: { paths: ["/tmp/demo.js"] },
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    };
+    const { cacheKey } = __testing.resolvePluginLoadCacheContext(gatewayBindableLoadOptions);
+    setActivePluginRegistry(registry, cacheKey, "gateway-bindable");
+
     expect(
       __testing.getCompatibleActivePluginRegistry({
-        ...loadOptions,
-        runtimeOptions: undefined,
+        config: gatewayBindableLoadOptions.config,
+        workspaceDir: gatewayBindableLoadOptions.workspaceDir,
       }),
-    ).toBeUndefined();
+    ).toBe(registry);
   });
 
   it("does not embed activation secrets in the loader cache key", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -457,7 +457,7 @@ function getCompatibleActivePluginRegistry(
     const gatewayBindableContext = resolvePluginLoadCacheContext({
       ...options,
       runtimeOptions: {
-        ...(options.runtimeOptions ?? {}),
+        ...options.runtimeOptions,
         allowGatewaySubagentBinding: true,
       },
     });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -49,6 +49,7 @@ import { resolvePluginCacheInputs } from "./roots.js";
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
+  getActivePluginRuntimeSubagentMode,
   recordImportedPluginId,
   setActivePluginRegistry,
 } from "./runtime.js";
@@ -442,9 +443,29 @@ function getCompatibleActivePluginRegistry(
   if (!activeCacheKey) {
     return undefined;
   }
-  return resolvePluginLoadCacheContext(options).cacheKey === activeCacheKey
-    ? activeRegistry
-    : undefined;
+  const requestedContext = resolvePluginLoadCacheContext(options);
+  if (requestedContext.cacheKey === activeCacheKey) {
+    return activeRegistry;
+  }
+  // A gateway-bindable runtime is a strict superset of the default runtime for
+  // plugin loading purposes, so default callers should still reuse that active
+  // registry instead of forcing a redundant reload and another register() pass.
+  if (
+    getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
+    requestedContext.runtimeSubagentMode === "default"
+  ) {
+    const gatewayBindableContext = resolvePluginLoadCacheContext({
+      ...options,
+      runtimeOptions: {
+        ...(options.runtimeOptions ?? {}),
+        allowGatewaySubagentBinding: true,
+      },
+    });
+    if (gatewayBindableContext.cacheKey === activeCacheKey) {
+      return activeRegistry;
+    }
+  }
+  return undefined;
 }
 
 export function resolveRuntimePluginRegistry(


### PR DESCRIPTION
## Summary

- Problem: plugin loads started from a gateway-bindable runtime were not reused by later default runtime requests, so OpenClaw could trigger redundant plugin `register()` passes.
- Why it matters: this matches `openclaw/openclaw#61756`, where repeated cache misses caused many extra plugin reloads during normal gateway message handling.
- What changed: `getCompatibleActivePluginRegistry()` now treats an active `gateway-bindable` registry as compatible with a default runtime request when the rest of the cache context still matches, and `src/plugins/loader.runtime-registry.test.ts` adds regression coverage for that path.
- What did NOT change (scope boundary): this does not change cache-key construction, runtime mode semantics outside this compatibility check, or any plugin activation behavior unrelated to default-versus-gateway-bindable registry reuse.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61756
- Related #61756
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the active registry cache key encoded `runtimeSubagentMode`, so a registry created with `allowGatewaySubagentBinding=true` could not be reused by later default-runtime lookups even when all other compatibility inputs matched.
- Missing detection / guardrail: there was no regression test for the gateway-bindable active registry default runtime lookup path.
- Contributing context (if known): message-processing call sites can mix gateway-bindable startup loads with later default runtime requests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.runtime-registry.test.ts`
- Scenario the test should lock in: an active registry created with `allowGatewaySubagentBinding: true` should still be reused when a later request only asks for the default runtime and the remaining cache context matches.
- Why this is the smallest reliable guardrail: the bug is in loader compatibility resolution, so this test hits the exact decision point without needing a full gateway repro.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Plugin registries created during gateway-bindable startup should now be reused by later default runtime requests instead of forcing redundant plugin reloads.

## Diagram (if applicable)

```text
Before:
[gateway-bindable startup load] -> [active registry cached under gateway-bindable mode]
[default runtime request] -> [cache miss] -> [reload + register() again]

After:
[gateway-bindable startup load] -> [active registry cached under gateway-bindable mode]
[default runtime request] -> [compatibility fallback hit] -> [reuse active registry]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 for the reported issue; local verification ran in the ROOM shell environment.
- Runtime/container: Node 20.20.2
- Model/provider: N/A
- Integration/channel (if any): plugin loader / gateway runtime path
- Relevant config (redacted): plugin allowlist with `allowGatewaySubagentBinding: true`

### Steps

1. Create an active plugin registry using a load context with `allowGatewaySubagentBinding: true`.
2. Resolve the compatible active registry with the same plugin/workspace context but without explicit runtime options.
3. Verify that the active registry is reused instead of returning `undefined` and forcing a reload.

### Expected

- The default runtime request reuses the existing active registry.

### Actual

- Before this patch, the default runtime request missed the active registry because the cache key only matched the gateway-bindable variant.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `node scripts/run-vitest.mjs run --config vitest.plugins.config.ts src/plugins/loader.runtime-registry.test.ts` and `node scripts/run-vitest.mjs run --config vitest.plugins.config.ts src/plugins/tools.optional.test.ts -t gateway-bindable` both exited `0`; `git diff --check` also passed locally.
- Edge cases checked: the existing cache-key mismatch cases for different workspace and `onlyPluginIds` inputs still remain covered in the same test file.
- What you did **not** verify: a full gateway/channel repro with live Telegram traffic, and full-repo green beyond the targeted checks above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: treating `gateway-bindable` as a superset could accidentally reuse an incompatible registry if another compatibility input differs.
  - Mitigation: the fallback only returns the active registry when recomputing the same cache context with `allowGatewaySubagentBinding: true` matches the active cache key exactly.
