### PR TITLE
🤖 Fix WebChat image-only messages rejected as empty (opts.images not checked in hasMediaAttachment)

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -330,11 +330,8 @@ describe("runPreparedReply media-only handling", () => {
           images: [
             {
               type: "image",
-              source: {
-                type: "base64",
-                mediaType: "image/png",
-                data: "iVBORw0KGgoAAAANSUhEUg==",
-              },
+              data: "iVBORw0KGgoAAAANSUhEUg==",
+              mimeType: "image/png",
             },
           ],
         },

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -306,6 +306,73 @@ describe("runPreparedReply media-only handling", () => {
     expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
   });
 
+  it("accepts image-only WebChat messages via opts.images (empty body + non-empty images)", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          OriginatingChannel: "webchat",
+          OriginatingTo: "session:abc",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+          ChatType: "direct",
+          OriginatingChannel: "webchat",
+          OriginatingTo: "session:abc",
+          // No MediaPath or MediaPaths — images come through opts only
+        },
+        opts: {
+          images: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                mediaType: "image/png",
+                data: "iVBORw0KGgoAAAANSUhEUg==",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Should proceed to agent run, not return empty-body rejection
+    expect(result).toEqual({ text: "ok" });
+    expect(vi.mocked(runReplyAgent)).toHaveBeenCalledOnce();
+
+    // Verify placeholder caption is used since body is empty
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
+  });
+
+  it("still rejects empty body when both sessionCtx media and opts.images are absent", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: { Body: "", RawBody: "", CommandBody: "" },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+          ChatType: "direct",
+        },
+        opts: {
+          images: [],
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "I didn't receive any text in your message. Please resend or add a caption.",
+    });
+    expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
+  });
+
   it("does not send a standalone reset notice for reply-producing /new turns", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -262,7 +262,9 @@ export async function runPreparedReply(
     : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
   const baseBodyTrimmed = baseBodyForPrompt.trim();
   const hasMediaAttachment = Boolean(
-    sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
+    sessionCtx.MediaPath ||
+    (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0) ||
+    (opts?.images && opts.images.length > 0),
   );
   if (!baseBodyTrimmed && !hasMediaAttachment) {
     await typing.onReplyStart();


### PR DESCRIPTION
## 🤖 AI-Assisted PR

Built with Claude Code (AI coding agent).
- **Testing degree:** Lightly tested — change follows existing patterns
- **I confirm I understand the code:** Yes — single-condition addition to `hasMediaAttachment` guard

---

Fixes #24662
Fixes #43590
Fixes #45487
Fixes #45917
Fixes #46534
Fixes #52673
Fixes #53271
Fixes #56561
Fixes #57064
Related #41801
Related #44446
Related #53687

## Summary

- **Problem:** WebChat image-only messages are incorrectly rejected as empty with *"I didn't receive any text in your message"* because `hasMediaAttachment` does not check `opts.images`
- **Why it matters:** Blocks all multimodal workflows via WebChat — users cannot send images through the Control UI for agent analysis
- **What changed:** Added `opts?.images && opts.images.length > 0` check to the `hasMediaAttachment` condition in `get-reply-run.ts`

## Root Cause

The `hasMediaAttachment` guard only checked `sessionCtx.MediaPath` and `sessionCtx.MediaPaths`, but not `opts.images`. When WebChat sends images via `chat.send` with the `attachments` parameter, they arrive as `opts.images` — completely bypassing the media check.

Other channels (Telegram, Discord, QQ, 飞书, etc.) use `sessionCtx.MediaPath` / `sessionCtx.MediaPaths`, so they are unaffected. This is a **WebChat-specific** bug.

```diff
  const hasMediaAttachment = Boolean(
-   sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
+   sessionCtx.MediaPath ||
+   (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0) ||
+   (opts?.images && opts.images.length > 0),
  );
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- Command/tool execution surface changed? **No**

## Compatibility

- Backward compatible? **Yes**
- Config/env changes? **No**
- Revert plan: Single-line revert
