### PR TITLE
fix: catch up missed cron-expression job runs on gateway restart

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -425,6 +425,15 @@ function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob
       params.job.state.scheduleErrorCount = undefined;
       changed = true;
     }
+    // Catch-up: if a cron job missed a scheduled run between lastRunAtMs and now,
+    // fire it immediately to prevent silent skips on gateway restart (see #33092, #12744).
+    if (params.job.schedule.kind === "cron" && typeof params.job.state.lastRunAtMs === "number") {
+      const missedAt = computeNextRunAtMs(params.job.schedule, params.job.state.lastRunAtMs);
+      if (isFiniteTimestamp(missedAt) && missedAt <= params.nowMs) {
+        params.job.state.nextRunAtMs = params.nowMs;
+        changed = true;
+      }
+    }
   } catch (err) {
     if (recordScheduleComputeError({ state: params.state, job: params.job, err })) {
       changed = true;


### PR DESCRIPTION
## Summary

Crontab jobs (e.g. `0 6 * * *`) silently skip when the gateway restarts after the scheduled time. After restart, `computeJobNextRunAtMs` returns the next future occurrence from now, skipping any run that fell in the downtime window.

## Fix

Adds catch-up detection in `recomputeJobNextRuns`: after computing `newNext`, check if a cron job missed a scheduled run between `lastRunAtMs` and `now`. If so, set `nextRunAtMs = now` to fire immediately.

```typescript
// Catch-up: if a cron job missed a scheduled run between lastRunAtMs and now,
// fire it immediately to prevent silent skips on gateway restart (see #33092, #12744).
if (params.job.schedule.kind === "cron" && typeof params.job.state.lastRunAtMs === "number") {
  const missedAt = computeNextRunAtMs(params.job.schedule, params.job.state.lastRunAtMs);
  if (isFiniteTimestamp(missedAt) && missedAt <= params.nowMs) {
    params.job.state.nextRunAtMs = params.nowMs;
    changed = true;
  }
}
```

## Impact

- Daily/weekly cron jobs will no longer be silently skipped on gateway restart
- `every`-interval jobs are unaffected (already recalculate correctly)
- Backward compatible: only affects cron-expression schedules

Fixes #33092
Fixes #12744 (previous PR was never merged)