### PR TITLE
fix: read logger settings from openclaw.json

### DIFF
--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,10 +1,8 @@
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
+import { loadConfig } from "../config/config.js";
 
 type LoggingConfig = OpenClawConfig["logging"];
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
@@ -16,12 +14,7 @@ export function readLoggingConfig(): LoggingConfig | undefined {
     return undefined;
   }
   try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    const parsed = loaded?.loadConfig?.();
+    const parsed = loadConfig();
     const logging = parsed?.logging;
     if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
       return undefined;

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -1,4 +1,5 @@
 import util from "node:util";
+import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { isVerbose } from "../global-state.js";
 import { stripAnsi } from "../terminal/ansi.js";
@@ -6,7 +7,6 @@ import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
 import { getLogger, type LoggerSettings } from "./logger.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 import { formatLocalIsoWithOffset, formatTimestamp } from "./timestamps.js";
 
@@ -17,16 +17,10 @@ type ConsoleSettings = {
 };
 export type ConsoleLoggerSettings = ConsoleSettings;
 
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 type ConsoleConfigLoader = () => OpenClawConfig["logging"] | undefined;
 const loadConfigFallbackDefault: ConsoleConfigLoader = () => {
   try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    return loaded?.loadConfig?.().logging;
+    return loadConfig().logging;
   } catch {
     return undefined;
   }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
+import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.js";
 import {
   POSIX_OPENCLAW_TMP_DIR,
@@ -10,7 +11,6 @@ import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config
 import type { ConsoleStyle } from "./console.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
 
@@ -47,8 +47,6 @@ const LOG_PREFIX = "openclaw";
 const LOG_SUFFIX = ".log";
 const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFAULT_MAX_LOG_FILE_BYTES = 500 * 1024 * 1024; // 500 MB
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export type LoggerSettings = {
   level?: LogLevel;
@@ -117,12 +115,7 @@ function resolveSettings(): ResolvedSettings {
     (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
   if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
     try {
-      const loaded = requireConfig?.("../config/config.js") as
-        | {
-            loadConfig?: () => OpenClawConfig;
-          }
-        | undefined;
-      cfg = loaded?.loadConfig?.().logging;
+      cfg = loadConfig().logging;
     } catch {
       cfg = undefined;
     }

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1,9 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
 import { compileConfigRegex } from "../security/config-regex.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { replacePatternBounded } from "./redact-bounded.js";
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export type RedactSensitiveMode = "off" | "tools";
 
@@ -108,12 +106,7 @@ function redactText(text: string, patterns: RegExp[]): string {
 function resolveConfigRedaction(): RedactOptions {
   let cfg: OpenClawConfig["logging"] | undefined;
   try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    cfg = loaded?.loadConfig?.().logging;
+    cfg = loadConfig().logging;
   } catch {
     cfg = undefined;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The logger was no longer respecting defaults defined under `"logging"` in `openclaw.json`
- Why it matters: Defaults defined under `"logging"` in `openclaw.json` should be respected
- What changed: Defaults defined under `"logging"` in `openclaw.json` are now applied

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [X] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61295
- [X] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `requireConfig?.("../config/config.js")` does not actually resolve to the compiled version of `/openclaw/src/config/config.ts`.
- Missing detection / guardrail: Unknown
- Contributing context (if known): The root cause of this regression was that a custom function was introduced to attempt to import the compiled version `/openclaw/src/config/config.ts` into various logger-related files. This function is `resolveNodeRequireFromMeta`.  It's ultimate usage follows this type of pattern:

```typescript
// Custom Import

import { resolveNodeRequireFromMeta } from "./node-require.js";

const requireConfig = resolveNodeRequireFromMeta(import.meta.url);

const loaded = requireConfig?.("../config/config.js") as
  | {
      loadConfig?: () => OpenClawConfig;
    }
  | undefined;
```

This appears to be in lieu of doing the following.

```typescript
// Direct Import

import { loadConfig } from "../config/config.js";

const cfg = loadConfig();
```

It should be noted that **Direct Import** statements are used extensively in other places in the codebase. I would like to better understand why the **Custom Import** approach was defined within the logging code.  

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [X] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config): Users will see that their logging preferences defined in openclaw.json are applied

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Mac
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Define a logging section in `openclaw.json` similar to the following:

```
{
  ...,
  "logging": {
    "file": "/tmp/openclaw/CUSTOMLOGFILENAMEopenclaw-YYYY-MM-DD.log"
  }
}
```

3. Run `pnpm gateway:watch` and observe which file receives logs

### Expected

```
06:23:38-04:00 [gateway] log file: /tmp/openclaw/CUSTOMFILENAMEopenclaw-2026-04-06.log
```

### Actual

```
06:23:38-04:00 [gateway] log file: /tmp/openclaw/openclaw-2026-04-06.log
```

## Evidence

Attach at least one:

- [X] Failing test/log before + passing after
- [X] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before fix:

<img width="596" height="36" alt="image" src="https://github.com/user-attachments/assets/ddf9495b-056f-4ac3-ab58-177cfa0dcad7" />

After fix:

<img width="725" height="38" alt="image" src="https://github.com/user-attachments/assets/de8a1325-7ede-4f46-9fdc-78dcfb4c6599" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: That logs are written to the file specified in `openclaw.json`
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`Yes`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A
