### PR TITLE
fix(exec-approval): distinguish preflight rejection from approval gate

### DIFF
--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -15,7 +15,8 @@ export type ExecApprovalReplyDecision = ExecApprovalDecision;
 export type ExecApprovalUnavailableReason =
   | "initiating-platform-disabled"
   | "initiating-platform-unsupported"
-  | "no-approval-route";
+  | "no-approval-route"
+  | "preflight-rejected";
 
 export type ExecApprovalReplyMetadata = {
   approvalId: string;
@@ -398,6 +399,28 @@ export function buildExecApprovalUnavailableReplyPayload(
       buildGenericNativeExecApprovalFallbackText({
         excludeChannel: params.channel,
       }),
+    );
+  } else if (params.reason === "preflight-rejected") {
+    lines.push(
+      "Exec preflight rejected this command — this is not an approval gate.",
+    );
+    if (warningText) {
+      lines.push(`Preflight reason: ${warningText}`);
+    }
+    lines.push(
+      "To allow this command, either disable the obfuscation check:",
+    );
+    lines.push(
+      "  tools.exec.obfuscationCheck: false",
+    );
+    lines.push(
+      "Or increase the command length threshold:",
+    );
+    lines.push(
+      "  tools.exec.maxCommandChars: <number>",
+    );
+    lines.push(
+      "See: https://docs.openclaw.ai/reference/config#toolsexec",
     );
   } else {
     lines.push(


### PR DESCRIPTION
## Fix Summary

When the exec preflight heuristic fires (e.g. "Command too long; potential obfuscation"), the current code surfaces a user-facing error that incorrectly references exec approvals:

Exec approval is required, but no interactive approval client is currently available.

This message is shown even when approvals are disabled. The preflight rejection has nothing to do with the approval subsystem.

## Changes

File: src/infra/exec-approval-reply.ts

1. Added preflight-rejected to the ExecApprovalUnavailableReason discriminated union type
2. Added a new branch in buildExecApprovalUnavailableReplyPayload that handles reason === "preflight-rejected" with a message that:
   - Clearly states this is a preflight rejection, not an approval gate
   - Shows the specific preflight reason (e.g. the warning text)
   - Points users to the correct config fixes: tools.exec.obfuscationCheck: false and tools.exec.maxCommandChars: <number>

## Before vs After

Before: User sees approval-gate message directing them to configure an approval system that cannot resolve the actual problem.

After: User sees "Exec preflight rejected this command — this is not an approval gate" with the specific preflight reason and correct config workarounds.

Fixes #61600
