### PR TITLE
fix(context): make session context-window lookup provider-aware

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -328,6 +328,9 @@ export async function runPreflightCompactionIfNeeded(params: {
   }
 
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
+    model: params.followupRun.run.model ?? params.defaultModel,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
@@ -492,6 +495,9 @@ export async function runMemoryFlushIfNeeded(params: {
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
+    model: params.followupRun.run.model ?? params.defaultModel,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -331,7 +331,6 @@ export async function runPreflightCompactionIfNeeded(params: {
     cfg: params.cfg,
     provider: params.followupRun.run.provider,
     model: params.followupRun.run.model ?? params.defaultModel,
-    modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
   const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
@@ -498,7 +497,6 @@ export async function runMemoryFlushIfNeeded(params: {
     cfg: params.cfg,
     provider: params.followupRun.run.provider,
     model: params.followupRun.run.model ?? params.defaultModel,
-    modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
@@ -559,7 +559,12 @@ export async function runReplyAgent(params: {
     }
     const contextTokensUsed =
       agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
+      resolveContextTokensForModel({
+        cfg,
+        provider: providerUsed,
+        model: modelUsed,
+        allowAsyncLoad: false,
+      }) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;
 

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -25,6 +25,7 @@ const queueMocks = vi.hoisted(() => ({
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: vi.fn(() => ({})),
   resolveAgentDir: vi.fn(() => "/tmp/agent"),
+  resolveDefaultAgentId: vi.fn(() => "main"),
   resolveSessionAgentId: vi.fn(() => "main"),
 }));
 
@@ -271,6 +272,39 @@ describe("/model chat UX", () => {
       model: "claude-opus-4-6",
       isDefault: true,
     });
+  });
+
+  it("persists provider-qualified context windows for same-named models", async () => {
+    const persisted = await persistInlineDirectives({
+      directives: parseInlineDirectives("hello"),
+      cfg: {
+        commands: { text: true },
+        agents: { defaults: {} },
+        models: {
+          providers: {
+            litellm: {
+              models: [{ id: "gpt-5.4", contextWindow: 128_000 }],
+            },
+            "openai-codex": {
+              models: [{ id: "gpt-5.4", contextWindow: 919_948 }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      elevatedEnabled: true,
+      elevatedAllowed: true,
+      defaultProvider: "litellm",
+      defaultModel: "gpt-5.4",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys: new Set(["litellm/gpt-5.4", "openai-codex/gpt-5.4"]),
+      provider: "litellm",
+      model: "gpt-5.4",
+      initialModelLabel: "litellm/gpt-5.4",
+      formatModelSwitchEvent: (label) => label,
+      agentCfg: undefined,
+    });
+
+    expect(persisted.contextTokens).toBe(128_000);
   });
 
   it("keeps openrouter provider/model split for exact selections", () => {

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,7 +3,7 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupCachedContextTokens } from "../../agents/context-cache.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -221,6 +221,13 @@ export async function persistInlineDirectives(params: {
     provider,
     model,
     contextTokens:
-      agentCfg?.contextTokens ?? lookupCachedContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+      agentCfg?.contextTokens ??
+      resolveContextTokensForModel({
+        cfg,
+        provider,
+        model,
+        allowAsyncLoad: false,
+      }) ??
+      DEFAULT_CONTEXT_TOKENS,
   };
 }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -285,10 +285,17 @@ export function createFollowupRunner(params: {
 
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
+      const providerUsed =
+        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const contextTokensUsed =
         agentCfgContextTokens ??
-        lookupContextTokens(modelUsed) ??
+        resolveContextTokensForModel({
+          cfg: queued.run.config,
+          provider: providerUsed,
+          model: modelUsed,
+          allowAsyncLoad: false,
+        }) ??
         sessionEntry?.contextTokens ??
         DEFAULT_CONTEXT_TOKENS;
 
@@ -301,7 +308,7 @@ export function createFollowupRunner(params: {
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           promptTokens,
           modelUsed,
-          providerUsed: fallbackProvider,
+          providerUsed,
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
           usageIsContextSnapshot: false,

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,14 +1,23 @@
 import crypto from "node:crypto";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 
 export function resolveMemoryFlushContextWindowTokens(params: {
+  cfg?: OpenClawConfig;
+  provider?: string;
+  model?: string;
   modelId?: string;
   agentCfgContextTokens?: number;
 }): number {
   return (
-    lookupContextTokens(params.modelId, { allowAsyncLoad: false }) ??
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model ?? params.modelId,
+      allowAsyncLoad: false,
+    }) ??
     params.agentCfgContextTokens ??
     DEFAULT_CONTEXT_TOKENS
   );

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -369,6 +369,29 @@ describe("resolveMemoryFlushContextWindowTokens", () => {
   it("falls back to agent config or default tokens", () => {
     expect(resolveMemoryFlushContextWindowTokens({ agentCfgContextTokens: 42_000 })).toBe(42_000);
   });
+
+  it("prefers provider-qualified context windows for same-named models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          litellm: {
+            models: [{ id: "gpt-5.4", contextWindow: 128_000 }],
+          },
+          "openai-codex": {
+            models: [{ id: "gpt-5.4", contextWindow: 919_948 }],
+          },
+        },
+      },
+    } as const;
+
+    expect(
+      resolveMemoryFlushContextWindowTokens({
+        cfg: cfg as never,
+        provider: "litellm",
+        model: "gpt-5.4",
+      }),
+    ).toBe(128_000);
+  });
 });
 
 describe("incrementCompactionCount", () => {


### PR DESCRIPTION
## What changed

This makes session context-window lookup provider-aware in the remaining runtime paths that still resolved by bare model id.

Changed paths:
- `src/auto-reply/reply/directive-handling.persist.ts`
- `src/auto-reply/reply/agent-runner.ts`
- `src/auto-reply/reply/followup-runner.ts`
- `src/auto-reply/reply/memory-flush.ts`
- `src/auto-reply/reply/agent-runner-memory.ts`

## Why

OpenClaw can be configured with the same model id under multiple providers, for example:
- `litellm/gpt-5.4`
- `openai-codex/gpt-5.4`

When some session/runtime paths look up context windows by the bare model id (`gpt-5.4`) instead of the provider-qualified identity, they can pick up the wrong provider's context window.

That can corrupt session state and compaction decisions. In our production repro, a `litellm/gpt-5.4` session could inherit the `openai-codex/gpt-5.4` context window.

## Root cause

`resolveContextTokensForModel(...)` already exists and is provider-aware, but a few reply/session paths were still using:
- `lookupCachedContextTokens(model)`
- `lookupContextTokens(modelUsed)`
- `lookupContextTokens(modelId)`

Those calls lose provider identity and can mis-handle same-named models across providers.

## Related issue

- #49355

## Validation

Passed targeted tests:
- `pnpm exec vitest run src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/reply-state.test.ts`

I also tried full-repo typecheck / pre-commit checks, but upstream `main` currently has unrelated existing type failures in other areas (`commands/status*`, `discord`, `security`, etc.), so this PR keeps validation focused on the touched invariant.

## Scope intentionally excluded

This PR does not include the later local follow-ups around:
- post-compaction snapshot persistence
- `/status` stale pre-compaction totals
- `/new` or `/reset` usage/cache cleanup

Those are separate issues and should be reviewed independently.
