### PR TITLE
docs: warn that npm global install may drop channel plugin dependencies (#61787)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Runtime: **Node ≥22**.
 > some channel plugin dependencies (Discord, Slack, Telegram, Feishu) may not resolve correctly
 > when installed via `npm install -g`. If you see errors like `Cannot find package '@slack/logger'`
 > or `Cannot find package '@buape/carbon'` after installing with npm, reinstall using pnpm.
+> Note: `openclaw doctor --fix` will also fail in this state — reinstalling with pnpm is the fix.
 > See [#61787](https://github.com/openclaw/openclaw/issues/61787) for details.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -51,9 +51,18 @@ Model note: while many providers/models are supported, for the best experience a
 
 Runtime: **Node ≥22**.
 
+> **⚠️ Important:** Use **pnpm** for global installation. OpenClaw uses a pnpm workspace and
+> some channel plugin dependencies (Discord, Slack, Telegram, Feishu) may not resolve correctly
+> when installed via `npm install -g`. If you see errors like `Cannot find package '@slack/logger'`
+> or `Cannot find package '@buape/carbon'` after installing with npm, reinstall using pnpm.
+> See [#61787](https://github.com/openclaw/openclaw/issues/61787) for details.
+
 ```bash
+# Recommended
+pnpm add -g openclaw@latest
+
+# npm also works for most setups, but pnpm is preferred
 npm install -g openclaw@latest
-# or: pnpm add -g openclaw@latest
 
 openclaw onboard --install-daemon
 ```


### PR DESCRIPTION
## Summary

Fixes #61787

When OpenClaw is installed globally with `npm install -g`, some channel plugin
dependencies (`@slack/logger`, `@buape/carbon`, `grammy`, `@larksuiteoapi/node-sdk`,
etc.) fail to resolve at runtime due to pnpm workspace structure incompatibility
with npm's flat hoisting strategy.

This is a user-facing documentation fix: add a visible warning block to the
README Install section recommending **pnpm** for global installation, and
noting that `openclaw doctor --fix` also fails in this broken state (so users
skip that dead-end recovery step).

## Changes

- Promote `pnpm add -g openclaw@latest` as the recommended install command
- Add a callout warning block explaining the npm limitation and known error patterns
- Note that `openclaw doctor --fix` does not recover from this state
- Keep npm as an option for users who prefer it (works in most setups)

## Testing

Docs-only change, no code path affected.