### PR TITLE
Improve WhatsApp channels add guidance and docs

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -11,10 +11,9 @@ Status: production-ready via WhatsApp Web (Baileys). Gateway owns linked session
 
 ## Install (on demand)
 
-- Onboarding (`openclaw onboard`) and `openclaw channels login --channel whatsapp`
-  prompt to install the WhatsApp plugin the first time you select it.
-- `openclaw channels login --channel whatsapp` also offers the install flow when
-  the plugin is not present yet.
+- Onboarding (`openclaw onboard`), `openclaw channels add --channel whatsapp`,
+  and `openclaw channels login --channel whatsapp` prompt to install the
+  WhatsApp plugin the first time you select it.
 - Dev channel + git checkout: defaults to the local plugin path.
 - Stable/Beta: defaults to the npm package `@openclaw/whatsapp`.
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -11,7 +11,7 @@ Status: production-ready via WhatsApp Web (Baileys). Gateway owns linked session
 
 ## Install (on demand)
 
-- Onboarding (`openclaw onboard`) and `openclaw channels add --channel whatsapp`
+- Onboarding (`openclaw onboard`) and `openclaw channels login --channel whatsapp`
   prompt to install the WhatsApp plugin the first time you select it.
 - `openclaw channels login --channel whatsapp` also offers the install flow when
   the plugin is not present yet.

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -48,6 +48,7 @@ openclaw channels remove --channel telegram --delete
 ```
 
 Tip: `openclaw channels add --help` shows per-channel flags (token, private key, app token, signal-cli paths, etc).
+For WhatsApp specifically, use `openclaw channels login --channel whatsapp` to link the account.
 
 Common non-interactive add surfaces include:
 

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -487,4 +487,34 @@ describe("channelsAddCommand", () => {
       'Channel signal post-setup warning for "ops": hook failed',
     );
   });
+
+  it("shows login guidance when a channel supports auth login but not add", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "whatsapp",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "whatsapp",
+              label: "WhatsApp",
+              docsPath: "/channels/whatsapp",
+            }),
+            auth: {
+              login: vi.fn(async () => {}),
+            },
+          } as ChannelPlugin,
+          source: "test",
+        },
+      ]),
+    );
+
+    await channelsAddCommand({ channel: "whatsapp" }, runtime, { hasFlags: true });
+
+    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Channel whatsapp does not support add. Use openclaw channels login --channel whatsapp to link it.",
+    );
+  });
 });

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -263,7 +263,13 @@ export async function channelsAddCommand(
 
   const plugin = await loadScopedPlugin(channel, catalogEntry?.pluginId);
   if (!plugin?.setup?.applyAccountConfig) {
-    runtime.error(`Channel ${channel} does not support add.`);
+    if (plugin?.auth?.login) {
+      runtime.error(
+        `Channel ${channel} does not support add. Use openclaw channels login --channel ${channel} to link it.`,
+      );
+    } else {
+      runtime.error(`Channel ${channel} does not support add.`);
+    }
     runtime.exit(1);
     return;
   }


### PR DESCRIPTION
## Summary
- improve `openclaw channels add` error guidance for auth-only channels by pointing users to `channels login`
- add a regression test covering channels that support login but not add
- align WhatsApp docs and CLI docs with the supported login-first linking flow

## Problem
Users attempting `openclaw channels add --channel whatsapp` can hit an opaque `does not support add` message depending on plugin/setup state, despite WhatsApp onboarding being login-based.

## Root cause
`channels add` returned a generic unsupported message when `setup.applyAccountConfig` is unavailable, even when the channel exposes `auth.login`.

## Fix
When a channel does not support `add` but does support `login`, emit:
`Channel <id> does not support add. Use openclaw channels login --channel <id> to link it.`

## Testing
- `pnpm exec vitest run src/commands/channels.add.test.ts -t "shows login guidance when a channel supports auth login but not add"`

## Linked issue
Closes #61923

## AI usage disclosure
I am Codex (OpenAI) and I prepared this patch and test update. The final content was reviewed before submission.
