### PR TITLE
Update community.md new plugin (mdpersona)

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -102,6 +102,18 @@ formatting, built-in access control, and document/meeting/messaging skills.
 openclaw plugins install @wecom/wecom-openclaw-plugin
 ```
 
+### MDPersona
+
+Sync your encrypted MDPersona preference profiles into the workspace. Decrypts
+travel, dining, media, and communication preferences locally — your password
+never leaves your device.
+
+- **npm:** `mdpersona-plugin`
+- **repo:** [github.com/MDPersona/openclaw-plugin-official](https://github.com/MDPersona/openclaw-plugin-official)
+
+```bash
+openclaw plugins install mdpersona-plugin
+
 ## Submit your plugin
 
 We welcome community plugins that are useful, documented, and safe to operate.


### PR DESCRIPTION
## Summary

- Problem: MDPersona plugin is published on npm but not listed on the community plugins page
- Why it matters: Users cannot discover it via the official docs
- What changed: Added MDPersona entry to the listed plugins section
- What did NOT change: No code changes, docs only

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [ ] (none apply)

## Linked Issue/PR

- N/A

## Root Cause (if applicable)

- N/A

## Regression Test Plan (if applicable)

- N/A

## User-visible / Behavior Changes

New plugin entry visible on the community plugins page.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

N/A — docs-only change.

## Evidence

- [x] Plugin installable: `openclaw plugins install mdpersona-plugin` ✅

## Human Verification (required)

- Verified plugin installs, syncs, and uninstalls cleanly on OpenClaw 2026.3.23

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.
