### PR TITLE
fix(whatsapp): add application-level health probe to inbound monitor

### DIFF
--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -24,6 +24,7 @@ type MockWebListener = {
   sendPoll: () => Promise<{ messageId: string }>;
   sendReaction: () => Promise<void>;
   sendComposingTo: () => Promise<void>;
+  getHealthProbeState: () => { lastProbeAt: number | null; ok: boolean; error?: string };
 };
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 type AsyncUnknownMock = Mock<(...args: unknown[]) => Promise<unknown>>;
@@ -197,6 +198,7 @@ export function createMockWebListener(): MockWebListener {
     sendPoll: vi.fn(async () => ({ messageId: "poll-1" })),
     sendReaction: vi.fn(async () => undefined),
     sendComposingTo: vi.fn(async () => undefined),
+    getHealthProbeState: vi.fn(() => ({ lastProbeAt: null, ok: true })),
   };
 }
 

--- a/extensions/whatsapp/src/inbound/monitor-health-probe.test.ts
+++ b/extensions/whatsapp/src/inbound/monitor-health-probe.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSock,
+  installWebMonitorInboxUnitTestHooks,
+  startInboxMonitor,
+} from "../monitor-inbox.test-harness.js";
+
+installWebMonitorInboxUnitTestHooks();
+
+describe("WA health probe", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exposes getHealthProbeState on the listener", async () => {
+    const onMessage = vi.fn();
+    const sock = getSock();
+    // fetchStatus must exist on the mock for the probe to work
+    (sock as any).fetchStatus = vi.fn().mockResolvedValue({ status: "Hey there!" });
+
+    const { listener } = await startInboxMonitor(onMessage);
+
+    expect(typeof listener.getHealthProbeState).toBe("function");
+    // Allow the initial probe to settle
+    await vi.advanceTimersByTimeAsync(50);
+
+    const state = listener.getHealthProbeState();
+    expect(state.ok).toBe(true);
+    expect(state.lastProbeAt).toBeTypeOf("number");
+
+    await listener.close();
+  });
+
+  it("marks probe as failed when fetchStatus rejects", async () => {
+    const onMessage = vi.fn();
+    const sock = getSock();
+    (sock as any).fetchStatus = vi.fn().mockRejectedValue(new Error("server down"));
+
+    const { listener } = await startInboxMonitor(onMessage);
+    await vi.advanceTimersByTimeAsync(50);
+
+    const state = listener.getHealthProbeState();
+    expect(state.ok).toBe(false);
+    expect(state.error).toContain("server down");
+
+    await listener.close();
+  });
+
+  it("marks probe as failed on timeout", async () => {
+    const onMessage = vi.fn();
+    const sock = getSock();
+    // Never resolves → triggers timeout
+    (sock as any).fetchStatus = vi.fn().mockReturnValue(new Promise(() => {}));
+
+    const { listener } = await startInboxMonitor(onMessage);
+    // Advance past the 10s timeout
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    const state = listener.getHealthProbeState();
+    expect(state.ok).toBe(false);
+    expect(state.error).toContain("probe timeout");
+
+    await listener.close();
+  });
+
+  it("runs probe periodically every 60s", async () => {
+    const onMessage = vi.fn();
+    const sock = getSock();
+    const fetchStatus = vi.fn().mockResolvedValue({ status: "ok" });
+    (sock as any).fetchStatus = fetchStatus;
+
+    const { listener } = await startInboxMonitor(onMessage);
+    // Initial probe fires immediately
+    await vi.advanceTimersByTimeAsync(50);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    // Advance 60s for second probe
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+
+    // Advance another 60s for third
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+
+    await listener.close();
+  });
+
+  it("clears interval on close", async () => {
+    const onMessage = vi.fn();
+    const sock = getSock();
+    const fetchStatus = vi.fn().mockResolvedValue({ status: "ok" });
+    (sock as any).fetchStatus = fetchStatus;
+
+    const { listener } = await startInboxMonitor(onMessage);
+    await vi.advanceTimersByTimeAsync(50);
+    const callsBefore = fetchStatus.mock.calls.length;
+
+    await listener.close();
+
+    // Advance time — no more probes should fire
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(callsBefore);
+  });
+});

--- a/extensions/whatsapp/src/inbound/monitor-health-probe.test.ts
+++ b/extensions/whatsapp/src/inbound/monitor-health-probe.test.ts
@@ -19,8 +19,7 @@ describe("WA health probe", () => {
   it("exposes getHealthProbeState on the listener", async () => {
     const onMessage = vi.fn();
     const sock = getSock();
-    // fetchStatus must exist on the mock for the probe to work
-    (sock as any).fetchStatus = vi.fn().mockResolvedValue({ status: "Hey there!" });
+    sock.fetchStatus = vi.fn().mockResolvedValue({ status: "Hey there!" });
 
     const { listener } = await startInboxMonitor(onMessage);
 
@@ -38,7 +37,7 @@ describe("WA health probe", () => {
   it("marks probe as failed when fetchStatus rejects", async () => {
     const onMessage = vi.fn();
     const sock = getSock();
-    (sock as any).fetchStatus = vi.fn().mockRejectedValue(new Error("server down"));
+    sock.fetchStatus = vi.fn().mockRejectedValue(new Error("server down"));
 
     const { listener } = await startInboxMonitor(onMessage);
     await vi.advanceTimersByTimeAsync(50);
@@ -54,7 +53,7 @@ describe("WA health probe", () => {
     const onMessage = vi.fn();
     const sock = getSock();
     // Never resolves → triggers timeout
-    (sock as any).fetchStatus = vi.fn().mockReturnValue(new Promise(() => {}));
+    sock.fetchStatus = vi.fn().mockReturnValue(new Promise(() => {}));
 
     const { listener } = await startInboxMonitor(onMessage);
     // Advance past the 10s timeout
@@ -71,7 +70,7 @@ describe("WA health probe", () => {
     const onMessage = vi.fn();
     const sock = getSock();
     const fetchStatus = vi.fn().mockResolvedValue({ status: "ok" });
-    (sock as any).fetchStatus = fetchStatus;
+    sock.fetchStatus = fetchStatus;
 
     const { listener } = await startInboxMonitor(onMessage);
     // Initial probe fires immediately
@@ -93,7 +92,7 @@ describe("WA health probe", () => {
     const onMessage = vi.fn();
     const sock = getSock();
     const fetchStatus = vi.fn().mockResolvedValue({ status: "ok" });
-    (sock as any).fetchStatus = fetchStatus;
+    sock.fetchStatus = fetchStatus;
 
     const { listener } = await startInboxMonitor(onMessage);
     await vi.advanceTimersByTimeAsync(50);

--- a/extensions/whatsapp/src/inbound/monitor-health-probe.test.ts
+++ b/extensions/whatsapp/src/inbound/monitor-health-probe.test.ts
@@ -88,6 +88,29 @@ describe("WA health probe", () => {
     await listener.close();
   });
 
+  it("does not accumulate probes when fetchStatus hangs", async () => {
+    const onMessage = vi.fn();
+    const sock = getSock();
+    // fetchStatus never resolves — simulates hung connection
+    const fetchStatus = vi.fn().mockReturnValue(new Promise(() => {}));
+    sock.fetchStatus = fetchStatus;
+
+    const { listener } = await startInboxMonitor(onMessage);
+    // Advance past timeout (10s) so first probe times out
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    // Advance 60s — interval fires but probeInFlight should block a new call
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    // Advance another 60s — still blocked
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
   it("clears interval on close", async () => {
     const onMessage = vi.fn();
     const sock = getSock();

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -634,8 +634,9 @@ export async function monitorWebInbox(options: {
       probeInFlight = true;
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       let timedOut = false;
-      const fetchPromise = sock.fetchStatus(selfJid);
+      let fetchPromise: Promise<unknown> | null = null;
       try {
+        fetchPromise = sock.fetchStatus(selfJid);
         const timeout = new Promise<never>((_, reject) => {
           timeoutHandle = setTimeout(() => {
             timedOut = true;
@@ -670,7 +671,7 @@ export async function monitorWebInbox(options: {
         healthProbeState.error = String(err);
         inboundLogger.warn({ error: String(err) }, "WA health probe failed");
       } finally {
-        if (timedOut) {
+        if (timedOut && fetchPromise) {
           // fetchStatus is still pending — keep probeInFlight true to prevent
           // accumulation of hung promises. Release only when it settles.
           void fetchPromise

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -622,14 +622,33 @@ export async function monitorWebInbox(options: {
   const healthProbeState: HealthProbeState = { lastProbeAt: null, ok: true };
   const selfJid = self.jid ?? sock.user?.id ?? null;
   let healthProbeInterval: ReturnType<typeof setInterval> | null = null;
+  let probeClosed = false;
+  let activeProbeTimeout: ReturnType<typeof setTimeout> | null = null;
+  let probeInFlight = false;
 
   if (selfJid) {
     const doProbe = async () => {
+      if (probeClosed || probeInFlight) {
+        return;
+      }
+      probeInFlight = true;
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       try {
-        const timeout = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("probe timeout")), HEALTH_PROBE_TIMEOUT_MS),
-        );
+        const timeout = new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error("probe timeout")),
+            HEALTH_PROBE_TIMEOUT_MS,
+          );
+          activeProbeTimeout = timeoutHandle;
+        });
         await Promise.race([sock.fetchStatus(selfJid), timeout]);
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+          activeProbeTimeout = null;
+        }
+        if (probeClosed) {
+          return;
+        }
         healthProbeState.lastProbeAt = Date.now();
         healthProbeState.ok = true;
         healthProbeState.error = undefined;
@@ -637,10 +656,19 @@ export async function monitorWebInbox(options: {
           logVerbose("WA health probe: ok");
         }
       } catch (err) {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+          activeProbeTimeout = null;
+        }
+        if (probeClosed) {
+          return;
+        }
         healthProbeState.lastProbeAt = Date.now();
         healthProbeState.ok = false;
         healthProbeState.error = String(err);
         inboundLogger.warn({ error: String(err) }, "WA health probe failed");
+      } finally {
+        probeInFlight = false;
       }
     };
     void doProbe();
@@ -681,6 +709,11 @@ export async function monitorWebInbox(options: {
         if (healthProbeInterval) {
           clearInterval(healthProbeInterval);
           healthProbeInterval = null;
+        }
+        probeClosed = true;
+        if (activeProbeTimeout) {
+          clearTimeout(activeProbeTimeout);
+          activeProbeTimeout = null;
         }
         detachMessagesUpsert();
         detachConnectionUpdate();

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -623,7 +623,7 @@ export async function monitorWebInbox(options: {
   const selfJid = self.jid ?? sock.user?.id ?? null;
   let healthProbeInterval: ReturnType<typeof setInterval> | null = null;
   let probeClosed = false;
-  let activeProbeTimeout: ReturnType<typeof setTimeout> | null = null;
+  let _activeProbeTimeout: ReturnType<typeof setTimeout> | null = null;
   let probeInFlight = false;
 
   if (selfJid && typeof sock.fetchStatus === "function") {
@@ -642,12 +642,12 @@ export async function monitorWebInbox(options: {
             timedOut = true;
             reject(new Error("probe timeout"));
           }, HEALTH_PROBE_TIMEOUT_MS);
-          activeProbeTimeout = timeoutHandle;
+          _activeProbeTimeout = timeoutHandle;
         });
         await Promise.race([fetchPromise, timeout]);
         if (timeoutHandle) {
           clearTimeout(timeoutHandle);
-          activeProbeTimeout = null;
+          _activeProbeTimeout = null;
         }
         if (probeClosed) {
           return;
@@ -661,7 +661,7 @@ export async function monitorWebInbox(options: {
       } catch (err) {
         if (timeoutHandle) {
           clearTimeout(timeoutHandle);
-          activeProbeTimeout = null;
+          _activeProbeTimeout = null;
         }
         if (probeClosed) {
           return;
@@ -724,10 +724,10 @@ export async function monitorWebInbox(options: {
           healthProbeInterval = null;
         }
         probeClosed = true;
-        if (activeProbeTimeout) {
-          clearTimeout(activeProbeTimeout);
-          activeProbeTimeout = null;
-        }
+        // Note: Don't clear _activeProbeTimeout here. If a probe is in-flight
+        // awaiting Promise.race([fetchStatus, timeout]) and fetchStatus is hung,
+        // clearing the timeout removes the only settle path for the race.
+        // Let the timeout fire normally; probeClosed guard prevents state mutations.
         detachMessagesUpsert();
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -28,6 +28,15 @@ import { DisconnectReason, isJidGroup, saveMediaBuffer } from "./runtime-api.js"
 import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
+export type HealthProbeState = {
+  lastProbeAt: number | null;
+  ok: boolean;
+  error?: string;
+};
+
+const HEALTH_PROBE_INTERVAL_MS = 60_000;
+const HEALTH_PROBE_TIMEOUT_MS = 10_000;
+
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 const RECONNECT_IN_PROGRESS_ERROR = "no active socket - reconnection in progress";
 
@@ -608,6 +617,36 @@ export async function monitorWebInbox(options: {
     handleConnectionUpdate as unknown as (...args: unknown[]) => void,
   );
 
+  // Application-level health probe: periodically call fetchStatus(selfJid)
+  // to verify the WA server is responding, not just that the socket is alive.
+  const healthProbeState: HealthProbeState = { lastProbeAt: null, ok: true };
+  const selfJid = self.jid ?? sock.user?.id ?? null;
+  let healthProbeInterval: ReturnType<typeof setInterval> | null = null;
+
+  if (selfJid) {
+    const doProbe = async () => {
+      try {
+        const timeout = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("probe timeout")), HEALTH_PROBE_TIMEOUT_MS),
+        );
+        await Promise.race([sock.fetchStatus(selfJid), timeout]);
+        healthProbeState.lastProbeAt = Date.now();
+        healthProbeState.ok = true;
+        healthProbeState.error = undefined;
+        if (shouldLogVerbose()) {
+          logVerbose("WA health probe: ok");
+        }
+      } catch (err) {
+        healthProbeState.lastProbeAt = Date.now();
+        healthProbeState.ok = false;
+        healthProbeState.error = String(err);
+        inboundLogger.warn({ error: String(err) }, "WA health probe failed");
+      }
+    };
+    void doProbe();
+    healthProbeInterval = setInterval(() => void doProbe(), HEALTH_PROBE_INTERVAL_MS);
+  }
+
   void (async () => {
     try {
       const groups = await sock.groupFetchAllParticipating();
@@ -639,6 +678,10 @@ export async function monitorWebInbox(options: {
   return {
     close: async () => {
       try {
+        if (healthProbeInterval) {
+          clearInterval(healthProbeInterval);
+          healthProbeInterval = null;
+        }
         detachMessagesUpsert();
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);
@@ -650,6 +693,7 @@ export async function monitorWebInbox(options: {
     signalClose: (reason?: WebListenerCloseReason) => {
       resolveClose(reason ?? { status: undefined, isLoggedOut: false, error: "closed" });
     },
+    getHealthProbeState: (): HealthProbeState => ({ ...healthProbeState }),
     // IPC surface (sendMessage/sendPoll/sendReaction/sendComposingTo)
     ...sendApi,
   } as const;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -633,15 +633,17 @@ export async function monitorWebInbox(options: {
       }
       probeInFlight = true;
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+      let timedOut = false;
+      const fetchPromise = sock.fetchStatus(selfJid);
       try {
         const timeout = new Promise<never>((_, reject) => {
-          timeoutHandle = setTimeout(
-            () => reject(new Error("probe timeout")),
-            HEALTH_PROBE_TIMEOUT_MS,
-          );
+          timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            reject(new Error("probe timeout"));
+          }, HEALTH_PROBE_TIMEOUT_MS);
           activeProbeTimeout = timeoutHandle;
         });
-        await Promise.race([sock.fetchStatus(selfJid), timeout]);
+        await Promise.race([fetchPromise, timeout]);
         if (timeoutHandle) {
           clearTimeout(timeoutHandle);
           activeProbeTimeout = null;
@@ -668,7 +670,17 @@ export async function monitorWebInbox(options: {
         healthProbeState.error = String(err);
         inboundLogger.warn({ error: String(err) }, "WA health probe failed");
       } finally {
-        probeInFlight = false;
+        if (timedOut) {
+          // fetchStatus is still pending — keep probeInFlight true to prevent
+          // accumulation of hung promises. Release only when it settles.
+          void fetchPromise
+            .catch(() => {})
+            .finally(() => {
+              probeInFlight = false;
+            });
+        } else {
+          probeInFlight = false;
+        }
       }
     };
     void doProbe();

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -626,7 +626,7 @@ export async function monitorWebInbox(options: {
   let activeProbeTimeout: ReturnType<typeof setTimeout> | null = null;
   let probeInFlight = false;
 
-  if (selfJid) {
+  if (selfJid && typeof sock.fetchStatus === "function") {
     const doProbe = async () => {
       if (probeClosed || probeInFlight) {
         return;

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -40,6 +40,7 @@ export type MockSock = {
   readMessages: AnyMockFn;
   groupFetchAllParticipating: AnyMockFn;
   updateMediaMessage: AnyMockFn;
+  fetchStatus?: AnyMockFn;
   logger: Record<string, unknown>;
   signalRepository: {
     lidMapping: {


### PR DESCRIPTION
## Summary

Baileys keepalive only checks TCP/WebSocket layer. If the socket is alive but WhatsApp stops responding at the application level, the connection appears healthy while messages silently fail to deliver.

### Changes

Add a periodic health probe inside `monitorWebInbox()` that calls `sock.fetchStatus(selfJid)` every 60 seconds with a 10-second timeout:

- **Success**: updates probe state to `{ ok: true, lastProbeAt }` and logs verbose
- **Failure/timeout**: updates probe state to `{ ok: false, error }` and logs a warning
- **Cleanup**: interval is cleared in the `close()` handler
- **API**: `getHealthProbeState()` exposed on the listener return object for external watchdog consumption

### Files Changed

- `extensions/whatsapp/src/inbound/monitor.ts` --- probe interval + cleanup + getter
- `extensions/whatsapp/src/inbound/monitor-health-probe.test.ts` --- 5 tests (happy path, reject, timeout, periodic execution, cleanup on close)
- `extensions/whatsapp/src/auto-reply.test-harness.ts` --- add `getHealthProbeState` to mock listener type

### Tests

All 5 tests pass:
- Exposes getHealthProbeState on the listener
- Marks probe as failed when fetchStatus rejects
- Marks probe as failed on timeout (10s)
- Runs probe periodically every 60s
- Clears interval on close