### PR TITLE
fix: propagate AWS SDK auth to pi's authStorage for Bedrock IMDS

### DIFF
--- a/src/agents/model-auth-runtime-shared.ts
+++ b/src/agents/model-auth-runtime-shared.ts
@@ -22,6 +22,12 @@ export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): s
   if (env[AWS_PROFILE_ENV]?.trim()) {
     return AWS_PROFILE_ENV;
   }
+  // EC2 instances with IAM roles use IMDS for credentials — no env vars needed.
+  // Return a sentinel so callers know AWS SDK auth is available via the default
+  // credential chain even when no explicit env vars are set.
+  if (env["AWS_EXECUTION_ENV"]?.trim() || env["ECS_CONTAINER_METADATA_URI"]?.trim()) {
+    return "AWS_EXECUTION_ENV";
+  }
   return undefined;
 }
 

--- a/src/agents/pi-embedded-runner/run/auth-controller.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.ts
@@ -333,6 +333,11 @@ export function createEmbeddedRunAuthController(params: {
           `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );
       }
+      // AWS SDK auth (Bedrock via IMDS/env/profile): no API key needed, but
+      // we must notify pi's authStorage so hasConfiguredAuth() passes.
+      // Use a sentinel value that signals 'use SDK signing'.
+      const runtimeModel = params.getRuntimeModel();
+      params.authStorage.setRuntimeApiKey(runtimeModel.provider, "__aws_sdk_auth__");
       params.setLastProfileId(resolvedProfileId);
       return;
     }


### PR DESCRIPTION
## Problem

When Bedrock auth resolves via AWS SDK (IMDS, env vars, or profiles), the auth controller in `pi-embedded-runner` does an early return without calling `setRuntimeApiKey()`. This means pi's `authStorage` never learns about Bedrock credentials, causing `"No API key found for amazon-bedrock"` errors even though AWS SDK auth was successfully resolved.

This is the **root cause** of Bedrock auth failures on EC2 instances using IAM instance profiles.

## Fix

- **`auth-controller.ts`**: When `aws-sdk` auth mode is detected and no API key is present, call `setRuntimeApiKey()` with a sentinel value (`__aws_sdk_auth__`) so pi's `hasConfiguredAuth()` recognizes the provider as authenticated.
- **`model-auth-runtime-shared.ts`**: Detect `AWS_EXECUTION_ENV` and `ECS_CONTAINER_METADATA_URI` as indicators that IMDS/container credentials are available, improving fallback detection for EC2/ECS environments where no explicit AWS env vars are set.

## Environment

- Amazon Linux 2023 on EC2 with IAM instance profile
- Auth: Bedrock via IMDS (no API keys, no env vars)
- Config: `models.providers.amazon-bedrock.auth: "aws-sdk"`
- Current workaround: patching pi's dist files at install time (overwritten on every update)

## Related

A companion PR has been submitted to [pi-mono](https://github.com/badlogic/pi-mono/pull/2879) with defensive checks in pi's `hasConfiguredAuth()` and `_getRequiredRequestAuth()`.