### PR TITLE
feat(prodia): add bundled Prodia image and video generation provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -317,6 +317,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/phone-control/**"
+"extensions: prodia":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/prodia/**"
 "extensions: qianfan":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1257,6 +1257,7 @@
                   "providers/opencode-go",
                   "providers/openrouter",
                   "providers/perplexity-provider",
+                  "providers/prodia",
                   "providers/qianfan",
                   "providers/qwen",
                   "providers/runway",

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -53,6 +53,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [OpenCode Go](/providers/opencode-go)
 - [OpenRouter](/providers/openrouter)
 - [Perplexity (web search)](/providers/perplexity-provider)
+- [Prodia](/providers/prodia)
 - [Qianfan](/providers/qianfan)
 - [Qwen Cloud](/providers/qwen)
 - [Runway](/providers/runway)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -40,6 +40,7 @@ model as `provider/model`.
 - [OpenAI (API + Codex)](/providers/openai)
 - [OpenCode (Zen + Go)](/providers/opencode)
 - [OpenRouter](/providers/openrouter)
+- [Prodia](/providers/prodia)
 - [Qianfan](/providers/qianfan)
 - [Qwen](/providers/qwen)
 - [Runway](/providers/runway)

--- a/docs/providers/prodia.md
+++ b/docs/providers/prodia.md
@@ -1,0 +1,86 @@
+---
+title: "Prodia"
+summary: "Prodia image and video generation setup in OpenClaw"
+read_when:
+  - You want to use Prodia image or video generation in OpenClaw
+  - You need the PRODIA_TOKEN auth flow
+  - You want Prodia defaults for image_generate or video_generate
+---
+
+# Prodia
+
+OpenClaw ships a bundled `prodia` provider for hosted image and video generation via the Prodia inference API.
+
+- Provider id: `prodia`
+- Auth: `PRODIA_TOKEN`
+- API: Prodia `/v2/job` synchronous inference endpoint (`https://inference.prodia.com`)
+
+## Quick start
+
+1. Set the API key:
+
+```bash
+openclaw onboard --auth-choice prodia-api-key
+```
+
+2. Set Prodia as the default video provider:
+
+```bash
+openclaw config set agents.defaults.videoGenerationModel.primary "prodia/veo-fast"
+```
+
+3. Ask the agent to generate a video or image. Prodia will be used automatically.
+
+## Image generation models
+
+| Short id                      | Prodia job type                                       | Mode          |
+| ----------------------------- | ----------------------------------------------------- | ------------- |
+| `flux-fast-schnell` (default) | `inference.flux-fast.schnell.txt2img.v2`              | Text-to-image |
+| `flux-dev`                    | `inference.flux-2.dev.txt2img.v1` / `img2img.v1`      | Text + edit   |
+| `flux-pro`                    | `inference.flux-2.pro.txt2img.v1` / `img2img.v1`      | Text + edit   |
+| `flux-max`                    | `inference.flux-2.max.txt2img.v1` / `img2img.v1`      | Text + edit   |
+| `flux-flex`                   | `inference.flux-2.flex.txt2img.v1` / `img2img.v1`     | Text + edit   |
+| `flux-klein`                  | `inference.flux-2.klein.txt2img.v1` / `img2img.v1`    | Text + edit   |
+| `flux-klein-4b`               | `inference.flux-2.klein.4b.txt2img.v1` / `img2img.v1` | Text + edit   |
+| `flux-klein-9b`               | `inference.flux-2.klein.9b.txt2img.v1` / `img2img.v1` | Text + edit   |
+| `flux-ghibli`                 | `inference.flux-control.dev.ghibli.img2img.v1`        | Edit only     |
+| `flux-kontext`                | `inference.flux-fast.dev-kontext.img2img.v1`          | Edit only     |
+| `recraft-v4`                  | `inference.recraft.v4.txt2vec.v1`                     | Text-to-SVG   |
+
+## Video generation models
+
+| Short id             | Prodia job type                         | Mode           |
+| -------------------- | --------------------------------------- | -------------- |
+| `veo-fast` (default) | `inference.veo.fast.txt2vid.v1`         | Text-to-video  |
+| `veo-fast`           | `inference.veo.fast.img2vid.v1`         | Image-to-video |
+| `wan2.2-lightning`   | `inference.wan2-2.lightning.txt2vid.v0` | Text-to-video  |
+| `seedance-lite`      | `inference.seedance.lite.img2vid.v1`    | Image-to-video |
+| `seedance-pro`       | `inference.seedance.pro.img2vid.v1`     | Image-to-video |
+
+- `veo-fast` supports both text-to-video and image-to-video.
+- `wan2.2-lightning` supports text-to-video with optional `resolution` (`480P`, `720P`, `1080P`).
+- `seedance-lite` and `seedance-pro` support image-to-video only.
+- Video-to-video is not supported by any Prodia model.
+
+## Configuration
+
+```json5
+{
+  agents: {
+    defaults: {
+      videoGenerationModel: {
+        primary: "prodia/veo-fast",
+      },
+      imageGenerationModel: {
+        primary: "prodia/flux-fast-schnell",
+      },
+    },
+  },
+}
+```
+
+## Related
+
+- [Video Generation](/tools/video-generation) -- shared tool parameters, provider selection, and async behavior
+- [Image Generation](/tools/image-generation) -- shared tool parameters and provider selection
+- [Configuration Reference](/gateway/configuration-reference#agent-defaults)

--- a/docs/providers/prodia.md
+++ b/docs/providers/prodia.md
@@ -54,11 +54,12 @@ openclaw config set agents.defaults.videoGenerationModel.primary "prodia/veo-fas
 | `veo-fast` (default) | `inference.veo.fast.txt2vid.v1`         | Text-to-video  |
 | `veo-fast`           | `inference.veo.fast.img2vid.v1`         | Image-to-video |
 | `wan2.2-lightning`   | `inference.wan2-2.lightning.txt2vid.v0` | Text-to-video  |
+| `wan2.2-lightning`   | `inference.wan2-2.lightning.img2vid.v0` | Image-to-video |
 | `seedance-lite`      | `inference.seedance.lite.img2vid.v1`    | Image-to-video |
 | `seedance-pro`       | `inference.seedance.pro.img2vid.v1`     | Image-to-video |
 
 - `veo-fast` supports both text-to-video and image-to-video.
-- `wan2.2-lightning` supports text-to-video with optional `resolution` (`480P`, `720P`, `1080P`).
+- `wan2.2-lightning` supports text-to-video and image-to-video with optional `resolution` (`480P`, `720P`, `1080P`).
 - `seedance-lite` and `seedance-pro` support image-to-video only.
 - Video-to-video is not supported by any Prodia model.
 

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -1,5 +1,5 @@
 ---
-summary: "Generate and edit images using configured providers (OpenAI, Google Gemini, fal, MiniMax, ComfyUI, Vydra)"
+summary: "Generate and edit images using configured providers (OpenAI, Google Gemini, fal, MiniMax, ComfyUI, Prodia, Vydra)"
 read_when:
   - Generating images via the agent
   - Configuring image generation providers and models
@@ -45,6 +45,7 @@ The agent calls `image_generate` automatically. No tool allow-listing needed —
 | fal      | `fal-ai/flux/dev`                | Yes                                | `FAL_KEY`                                             |
 | MiniMax  | `image-01`                       | Yes (subject reference)            | `MINIMAX_API_KEY` or MiniMax OAuth (`minimax-portal`) |
 | ComfyUI  | `workflow`                       | Yes (1 image, workflow-configured) | `COMFY_API_KEY` or `COMFY_CLOUD_API_KEY` for cloud    |
+| Prodia   | `flux-fast-schnell`              | Yes (1 image)                      | `PRODIA_TOKEN`                                        |
 | Vydra    | `grok-imagine`                   | No                                 | `VYDRA_API_KEY`                                       |
 
 Use `action: "list"` to inspect available providers and models at runtime:
@@ -109,13 +110,13 @@ Notes:
 
 ### Image editing
 
-OpenAI, Google, fal, MiniMax, and ComfyUI support editing reference images. Pass a reference image path or URL:
+OpenAI, Google, fal, MiniMax, ComfyUI, and Prodia support editing reference images. Pass a reference image path or URL:
 
 ```
 "Generate a watercolor version of this photo" + image: "/path/to/photo.jpg"
 ```
 
-OpenAI and Google support up to 5 reference images via the `images` parameter. fal, MiniMax, and ComfyUI support 1.
+OpenAI and Google support up to 5 reference images via the `images` parameter. fal, MiniMax, ComfyUI, and Prodia support 1.
 
 MiniMax image generation is available through both bundled MiniMax auth paths:
 
@@ -124,13 +125,13 @@ MiniMax image generation is available through both bundled MiniMax auth paths:
 
 ## Provider capabilities
 
-| Capability            | OpenAI               | Google               | fal                 | MiniMax                    | ComfyUI                            | Vydra   |
-| --------------------- | -------------------- | -------------------- | ------------------- | -------------------------- | ---------------------------------- | ------- |
-| Generate              | Yes (up to 4)        | Yes (up to 4)        | Yes (up to 4)       | Yes (up to 9)              | Yes (workflow-defined outputs)     | Yes (1) |
-| Edit/reference        | Yes (up to 5 images) | Yes (up to 5 images) | Yes (1 image)       | Yes (1 image, subject ref) | Yes (1 image, workflow-configured) | No      |
-| Size control          | Yes                  | Yes                  | Yes                 | No                         | No                                 | No      |
-| Aspect ratio          | No                   | Yes                  | Yes (generate only) | Yes                        | No                                 | No      |
-| Resolution (1K/2K/4K) | No                   | Yes                  | Yes                 | No                         | No                                 | No      |
+| Capability            | OpenAI               | Google               | fal                 | MiniMax                    | ComfyUI                            | Prodia        | Vydra   |
+| --------------------- | -------------------- | -------------------- | ------------------- | -------------------------- | ---------------------------------- | ------------- | ------- |
+| Generate              | Yes (up to 4)        | Yes (up to 4)        | Yes (up to 4)       | Yes (up to 9)              | Yes (workflow-defined outputs)     | Yes (1)       | Yes (1) |
+| Edit/reference        | Yes (up to 5 images) | Yes (up to 5 images) | Yes (1 image)       | Yes (1 image, subject ref) | Yes (1 image, workflow-configured) | Yes (1 image) | No      |
+| Size control          | Yes                  | Yes                  | Yes                 | No                         | No                                 | Yes           | No      |
+| Aspect ratio          | No                   | Yes                  | Yes (generate only) | Yes                        | No                                 | No            | No      |
+| Resolution (1K/2K/4K) | No                   | Yes                  | Yes                 | No                         | No                                 | No            | No      |
 
 ## Related
 
@@ -140,6 +141,7 @@ MiniMax image generation is available through both bundled MiniMax auth paths:
 - [Google (Gemini)](/providers/google) — Gemini image provider setup
 - [MiniMax](/providers/minimax) — MiniMax image provider setup
 - [OpenAI](/providers/openai) — OpenAI Images provider setup
+- [Prodia](/providers/prodia) — Prodia image and video provider setup
 - [Vydra](/providers/vydra) — Vydra image, video, and speech setup
 - [Configuration Reference](/gateway/configuration-reference#agent-defaults) — `imageGenerationModel` config
 - [Models](/concepts/models) — model configuration and failover

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -9,7 +9,7 @@ title: "Video Generation"
 
 # Video Generation
 
-OpenClaw agents can generate videos from text prompts, reference images, or existing videos. Twelve provider backends are supported, each with different model options, input modes, and feature sets. The agent picks the right provider automatically based on your configuration and available API keys.
+OpenClaw agents can generate videos from text prompts, reference images, or existing videos. Thirteen provider backends are supported, each with different model options, input modes, and feature sets. The agent picks the right provider automatically based on your configuration and available API keys.
 
 <Note>
 The `video_generate` tool only appears when at least one video-generation provider is available. If you do not see it in your agent tools, set a provider API key or configure `agents.defaults.videoGenerationModel`.
@@ -87,6 +87,7 @@ Duplicate prevention: if a video task is already `queued` or `running` for the c
 | Google   | `veo-3.1-fast-generate-preview` | Yes  | 1 image           | 1 video          | `GEMINI_API_KEY`                         |
 | MiniMax  | `MiniMax-Hailuo-2.3`            | Yes  | 1 image           | No               | `MINIMAX_API_KEY`                        |
 | OpenAI   | `sora-2`                        | Yes  | 1 image           | 1 video          | `OPENAI_API_KEY`                         |
+| Prodia   | `veo-fast`                      | Yes  | 1 image           | No               | `PRODIA_TOKEN`                           |
 | Qwen     | `wan2.6-t2v`                    | Yes  | Yes (remote URL)  | Yes (remote URL) | `QWEN_API_KEY`                           |
 | Runway   | `gen4.5`                        | Yes  | 1 image           | 1 video          | `RUNWAYML_API_SECRET`                    |
 | Together | `Wan-AI/Wan2.2-T2V-A14B`        | Yes  | 1 image           | No               | `TOGETHER_API_KEY`                       |
@@ -112,6 +113,7 @@ and the shared live sweep.
 | Google   | Yes        | Yes            | Yes            | `generate`, `imageToVideo`; shared `videoToVideo` skipped because the current buffer-backed Gemini/Veo sweep does not accept that input  |
 | MiniMax  | Yes        | Yes            | No             | `generate`, `imageToVideo`                                                                                                               |
 | OpenAI   | Yes        | Yes            | Yes            | `generate`, `imageToVideo`; shared `videoToVideo` skipped because this org/input path currently needs provider-side inpaint/remix access |
+| Prodia   | Yes        | Yes            | No             | `generate`, `imageToVideo`                                                                                                               |
 | Qwen     | Yes        | Yes            | Yes            | `generate`, `imageToVideo`; `videoToVideo` skipped because this provider needs remote `http(s)` video URLs                               |
 | Runway   | Yes        | Yes            | Yes            | `generate`, `imageToVideo`; `videoToVideo` runs only when the selected model is `runway/gen4_aleph`                                      |
 | Together | Yes        | Yes            | No             | `generate`, `imageToVideo`                                                                                                               |
@@ -206,6 +208,7 @@ If a provider fails, the next candidate is tried automatically. If all candidate
 | Google   | Uses Gemini/Veo. Supports one image or one video reference.                                                                                                 |
 | MiniMax  | Single image reference only.                                                                                                                                |
 | OpenAI   | Only `size` override is forwarded. Other style overrides (`aspectRatio`, `resolution`, `audio`, `watermark`) are ignored with a warning.                    |
+| Prodia   | Synchronous `/v2/job` API. Supports Veo (text + image) and Seedance (image-only). Single image reference only.                                              |
 | Qwen     | Same DashScope backend as Alibaba. Reference inputs must be remote `http(s)` URLs; local files are rejected upfront.                                        |
 | Runway   | Supports local files via data URIs. Video-to-video requires `runway/gen4_aleph`. Text-only runs expose `16:9` and `9:16` aspect ratios.                     |
 | Together | Single image reference only.                                                                                                                                |
@@ -307,6 +310,7 @@ openclaw config set agents.defaults.videoGenerationModel.primary "qwen/wan2.6-t2
 - [Google (Gemini)](/providers/google)
 - [MiniMax](/providers/minimax)
 - [OpenAI](/providers/openai)
+- [Prodia](/providers/prodia)
 - [Qwen](/providers/qwen)
 - [Runway](/providers/runway)
 - [Together AI](/providers/together)

--- a/extensions/prodia/image-generation-provider.test.ts
+++ b/extensions/prodia/image-generation-provider.test.ts
@@ -134,6 +134,47 @@ describe("prodia image generation provider", () => {
     expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
   });
 
+  it("parses multipart/form-data responses with job and output parts", async () => {
+    const boundary = "----ProdiaBoundary";
+    const jobJson = JSON.stringify({ id: "job-99", state: { current: "completed" } });
+    const imageBytes = Buffer.from("fake-multipart-png");
+    const body = [
+      `------ProdiaBoundary\r\n`,
+      `Content-Disposition: form-data; name="job"\r\n`,
+      `Content-Type: application/json\r\n\r\n`,
+      `${jobJson}\r\n`,
+      `------ProdiaBoundary\r\n`,
+      `Content-Disposition: form-data; name="output"\r\n`,
+      `Content-Type: image/png\r\n\r\n`,
+    ].join("");
+    const bodyBuffer = Buffer.concat([
+      Buffer.from(body),
+      imageBytes,
+      Buffer.from("\r\n------ProdiaBoundary--"),
+    ]);
+
+    fetchWithTimeoutMock.mockResolvedValue(
+      new Response(bodyBuffer, {
+        status: 200,
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      }),
+    );
+
+    const provider = buildProdiaImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "prodia",
+      model: "flux-fast-schnell",
+      prompt: "multipart test",
+      cfg: {},
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe("fake-multipart-png");
+    expect(result.metadata).toEqual(
+      expect.objectContaining({ jobId: "job-99", state: "completed" }),
+    );
+  });
+
   it("throws when API key is missing", async () => {
     resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: "" });
     const provider = buildProdiaImageGenerationProvider();

--- a/extensions/prodia/image-generation-provider.test.ts
+++ b/extensions/prodia/image-generation-provider.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildProdiaImageGenerationProvider } from "./image-generation-provider.js";
+
+const {
+  resolveApiKeyForProviderMock,
+  fetchWithTimeoutMock,
+  assertOkOrThrowHttpErrorMock,
+  resolveProviderHttpRequestConfigMock,
+} = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "prodia-key" })),
+  fetchWithTimeoutMock: vi.fn(),
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  resolveProviderHttpRequestConfigMock: vi.fn((params) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders),
+    dispatcherPolicy: undefined,
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+  fetchWithTimeout: fetchWithTimeoutMock,
+  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+}));
+
+function makeImagePngResponse(): Response {
+  const imageBytes = Buffer.from("fake-png-image-bytes");
+  return new Response(imageBytes, {
+    status: 200,
+    headers: { "content-type": "image/png" },
+  });
+}
+
+describe("prodia image generation provider", () => {
+  afterEach(() => {
+    resolveApiKeyForProviderMock.mockClear();
+    fetchWithTimeoutMock.mockReset();
+    assertOkOrThrowHttpErrorMock.mockClear();
+    resolveProviderHttpRequestConfigMock.mockClear();
+  });
+
+  it("submits a text-to-image job and returns the image", async () => {
+    fetchWithTimeoutMock.mockResolvedValue(makeImagePngResponse());
+
+    const provider = buildProdiaImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "prodia",
+      model: "flux-fast-schnell",
+      prompt: "a friendly lobster in a top hat",
+      cfg: {},
+    });
+
+    expect(fetchWithTimeoutMock).toHaveBeenCalledWith(
+      "https://inference.prodia.com/v2/job",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          type: "inference.flux-fast.schnell.txt2img.v2",
+          config: { prompt: "a friendly lobster in a top hat" },
+        }),
+      }),
+      120_000,
+      fetch,
+    );
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].mimeType).toBe("image/png");
+    expect(result.model).toBe("flux-fast-schnell");
+  });
+
+  it("sends size dimensions in config", async () => {
+    fetchWithTimeoutMock.mockResolvedValue(makeImagePngResponse());
+
+    const provider = buildProdiaImageGenerationProvider();
+    await provider.generateImage({
+      provider: "prodia",
+      model: "flux-dev",
+      prompt: "landscape painting",
+      cfg: {},
+      size: "1024x768",
+    });
+
+    const callArgs = fetchWithTimeoutMock.mock.calls[0];
+    const body = JSON.parse(callArgs[1].body as string) as { config: Record<string, unknown> };
+    expect(body.config.width).toBe(1024);
+    expect(body.config.height).toBe(768);
+  });
+
+  it("submits an image-to-image job with multipart form data", async () => {
+    fetchWithTimeoutMock.mockResolvedValue(makeImagePngResponse());
+
+    const provider = buildProdiaImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "prodia",
+      model: "flux-dev",
+      prompt: "add a sunset background",
+      cfg: {},
+      inputImages: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+    });
+
+    const callArgs = fetchWithTimeoutMock.mock.calls[0];
+    expect(callArgs[1].body).toBeInstanceOf(FormData);
+    expect(result.images).toHaveLength(1);
+  });
+
+  it("rejects unsupported text-to-image models", async () => {
+    const provider = buildProdiaImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "prodia",
+        model: "flux-ghibli",
+        prompt: "a lobster in ghibli style",
+        cfg: {},
+      }),
+    ).rejects.toThrow('Prodia text-to-image does not support model "flux-ghibli"');
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported image-to-image models", async () => {
+    const provider = buildProdiaImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "prodia",
+        model: "flux-fast-schnell",
+        prompt: "edit this",
+        cfg: {},
+        inputImages: [{ buffer: Buffer.from("png"), mimeType: "image/png" }],
+      }),
+    ).rejects.toThrow('Prodia image editing does not support model "flux-fast-schnell"');
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when API key is missing", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: "" });
+    const provider = buildProdiaImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "prodia",
+        model: "flux-fast-schnell",
+        prompt: "test",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Prodia API key missing");
+  });
+});

--- a/extensions/prodia/image-generation-provider.ts
+++ b/extensions/prodia/image-generation-provider.ts
@@ -141,7 +141,7 @@ async function parseProdiaImageResponse(
     if (idx === -1) {
       break;
     }
-    if (parts.length > 0) {
+    if (start > 0) {
       parts.push(raw.subarray(start, idx));
     }
     start = idx + boundaryBytes.length;

--- a/extensions/prodia/image-generation-provider.ts
+++ b/extensions/prodia/image-generation-provider.ts
@@ -1,0 +1,341 @@
+import type {
+  GeneratedImageAsset,
+  ImageGenerationProvider,
+  ImageGenerationRequest,
+  ImageGenerationResult,
+} from "openclaw/plugin-sdk/image-generation";
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  assertOkOrThrowHttpError,
+  fetchWithTimeout,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+
+const DEFAULT_PRODIA_BASE_URL = "https://inference.prodia.com";
+const DEFAULT_PRODIA_IMAGE_MODEL = "flux-fast-schnell";
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+// Prodia image model IDs mapped to /v2/job type strings.
+const TEXT_TO_IMAGE_TYPES: Record<string, string> = {
+  "flux-fast-schnell": "inference.flux-fast.schnell.txt2img.v2",
+  "flux-dev": "inference.flux-2.dev.txt2img.v1",
+  "flux-pro": "inference.flux-2.pro.txt2img.v1",
+  "flux-max": "inference.flux-2.max.txt2img.v1",
+  "flux-flex": "inference.flux-2.flex.txt2img.v1",
+  "flux-klein": "inference.flux-2.klein.txt2img.v1",
+  "flux-klein-4b": "inference.flux-2.klein.4b.txt2img.v1",
+  "flux-klein-9b": "inference.flux-2.klein.9b.txt2img.v1",
+  "recraft-v4": "inference.recraft.v4.txt2vec.v1",
+};
+
+const IMAGE_TO_IMAGE_TYPES: Record<string, string> = {
+  "flux-dev": "inference.flux-2.dev.img2img.v1",
+  "flux-pro": "inference.flux-2.pro.img2img.v1",
+  "flux-max": "inference.flux-2.max.img2img.v1",
+  "flux-flex": "inference.flux-2.flex.img2img.v1",
+  "flux-klein": "inference.flux-2.klein.img2img.v1",
+  "flux-klein-4b": "inference.flux-2.klein.4b.img2img.v1",
+  "flux-klein-9b": "inference.flux-2.klein.9b.img2img.v1",
+  "flux-ghibli": "inference.flux-control.dev.ghibli.img2img.v1",
+  "flux-kontext": "inference.flux-fast.dev-kontext.img2img.v1",
+};
+
+const ALL_MODELS = [
+  "flux-fast-schnell",
+  "flux-dev",
+  "flux-pro",
+  "flux-max",
+  "flux-flex",
+  "flux-klein",
+  "flux-klein-4b",
+  "flux-klein-9b",
+  "flux-ghibli",
+  "flux-kontext",
+  "recraft-v4",
+];
+
+type ProdiaJobPart = {
+  id?: string;
+  type?: string;
+  state?: { current?: string };
+  error?: string;
+  config?: Record<string, unknown>;
+};
+
+function resolveJobType(model: string, hasImage: boolean): string {
+  if (hasImage) {
+    const type = IMAGE_TO_IMAGE_TYPES[model];
+    if (!type) {
+      throw new Error(
+        `Prodia image editing does not support model "${model}". Use one of: ${Object.keys(IMAGE_TO_IMAGE_TYPES).join(", ")}.`,
+      );
+    }
+    return type;
+  }
+  const type = TEXT_TO_IMAGE_TYPES[model];
+  if (!type) {
+    throw new Error(
+      `Prodia text-to-image does not support model "${model}". Use one of: ${Object.keys(TEXT_TO_IMAGE_TYPES).join(", ")}.`,
+    );
+  }
+  return type;
+}
+
+function buildJobConfig(req: ImageGenerationRequest): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    prompt: req.prompt,
+  };
+  if (req.size?.trim()) {
+    const [w, h] = req.size.trim().split("x").map(Number);
+    if (w && h) {
+      config.width = w;
+      config.height = h;
+    }
+  }
+  return config;
+}
+
+function resolveBaseUrl(req: ImageGenerationRequest): string {
+  return req.cfg?.models?.providers?.prodia?.baseUrl?.trim() || DEFAULT_PRODIA_BASE_URL;
+}
+
+/**
+ * Prodia /v2/job returns either raw image bytes (when Accept specifies an image
+ * format) or a multipart/form-data response with "job" and "output" parts.
+ */
+async function parseProdiaImageResponse(
+  response: Response,
+): Promise<{ job: ProdiaJobPart; imageBuffers: Array<{ buffer: Buffer; mimeType: string }> }> {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  // Direct image response.
+  if (contentType.startsWith("image/")) {
+    const arrayBuffer = await response.arrayBuffer();
+    return {
+      job: { state: { current: "completed" } },
+      imageBuffers: [{ buffer: Buffer.from(arrayBuffer), mimeType: contentType.split(";")[0] }],
+    };
+  }
+
+  // Multipart response.
+  const boundary = contentType.match(/boundary=([^\s;]+)/)?.[1];
+  if (!boundary) {
+    const text = await response.text();
+    try {
+      const job = JSON.parse(text) as ProdiaJobPart;
+      return { job, imageBuffers: [] };
+    } catch {
+      throw new Error(`Prodia: unexpected response content-type "${contentType}"`);
+    }
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const raw = Buffer.from(arrayBuffer);
+  const boundaryBytes = Buffer.from(`--${boundary}`);
+  const parts: Buffer[] = [];
+  let start = 0;
+
+  while (true) {
+    const idx = raw.indexOf(boundaryBytes, start);
+    if (idx === -1) {
+      break;
+    }
+    if (parts.length > 0) {
+      parts.push(raw.subarray(start, idx));
+    }
+    start = idx + boundaryBytes.length;
+    if (raw[start] === 0x2d && raw[start + 1] === 0x2d) {
+      break;
+    }
+    if (raw[start] === 0x0d) {
+      start += 1;
+    }
+    if (raw[start] === 0x0a) {
+      start += 1;
+    }
+  }
+
+  let job: ProdiaJobPart = {};
+  const imageBuffers: Array<{ buffer: Buffer; mimeType: string }> = [];
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) {
+      continue;
+    }
+    const headerText = part.subarray(0, headerEnd).toString("utf-8");
+    const body = part.subarray(headerEnd + 4);
+    const trimmedBody =
+      body.length >= 2 && body[body.length - 2] === 0x0d && body[body.length - 1] === 0x0a
+        ? body.subarray(0, body.length - 2)
+        : body;
+
+    if (headerText.includes('name="job"') || headerText.includes("application/json")) {
+      try {
+        job = JSON.parse(trimmedBody.toString("utf-8")) as ProdiaJobPart;
+      } catch {
+        // Ignore parse failures.
+      }
+    } else if (
+      headerText.includes('name="output"') ||
+      headerText.includes("image/") ||
+      headerText.includes("application/octet-stream")
+    ) {
+      if (trimmedBody.length > 0) {
+        const partMime = headerText.match(/Content-Type:\s*([^\s;\r\n]+)/i)?.[1] || "image/png";
+        imageBuffers.push({ buffer: Buffer.from(trimmedBody), mimeType: partMime });
+      }
+    }
+  }
+
+  return { job, imageBuffers };
+}
+
+export function buildProdiaImageGenerationProvider(): ImageGenerationProvider {
+  return {
+    id: "prodia",
+    label: "Prodia",
+    defaultModel: DEFAULT_PRODIA_IMAGE_MODEL,
+    models: ALL_MODELS,
+    isConfigured: ({ agentDir }) =>
+      isProviderApiKeyConfigured({
+        provider: "prodia",
+        agentDir,
+      }),
+    capabilities: {
+      generate: {
+        maxCount: 1,
+        supportsSize: true,
+      },
+      edit: {
+        enabled: true,
+        maxInputImages: 1,
+        supportsSize: true,
+      },
+    },
+    async generateImage(req): Promise<ImageGenerationResult> {
+      const auth = await resolveApiKeyForProvider({
+        provider: "prodia",
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      if (!auth.apiKey) {
+        throw new Error("Prodia API key missing");
+      }
+
+      const hasImage = (req.inputImages?.length ?? 0) > 0;
+      if ((req.inputImages?.length ?? 0) > 1) {
+        throw new Error("Prodia image generation supports at most one input image.");
+      }
+
+      const model = req.model?.trim() || DEFAULT_PRODIA_IMAGE_MODEL;
+      const jobType = resolveJobType(model, hasImage);
+      const config = buildJobConfig(req);
+      const baseUrl = resolveBaseUrl(req);
+      const fetchFn = fetch;
+
+      if (hasImage) {
+        const image = req.inputImages![0];
+        if (!image.buffer) {
+          throw new Error("Prodia image editing requires a local image buffer.");
+        }
+
+        const jobPayload = JSON.stringify({ type: jobType, config });
+        const formData = new FormData();
+        formData.append("job", new Blob([jobPayload], { type: "application/json" }));
+        formData.append(
+          "input",
+          new Blob([new Uint8Array(image.buffer)], { type: image.mimeType?.trim() || "image/png" }),
+          image.fileName || "input.png",
+        );
+
+        const { baseUrl: resolvedBaseUrl, headers } = resolveProviderHttpRequestConfig({
+          baseUrl,
+          defaultBaseUrl: DEFAULT_PRODIA_BASE_URL,
+          defaultHeaders: {
+            Authorization: `Bearer ${auth.apiKey}`,
+            Accept: "multipart/form-data",
+          },
+          provider: "prodia",
+          capability: "image",
+          transport: "http",
+        });
+        headers.delete("Content-Type");
+
+        const response = await fetchWithTimeout(
+          `${resolvedBaseUrl}/v2/job`,
+          { method: "POST", headers, body: formData },
+          req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          fetchFn,
+        );
+        await assertOkOrThrowHttpError(response, "Prodia image generation failed");
+
+        const { job, imageBuffers } = await parseProdiaImageResponse(response);
+        if (job.state?.current === "failed" || job.error) {
+          throw new Error(job.error?.trim() || "Prodia image generation failed");
+        }
+        if (imageBuffers.length === 0) {
+          throw new Error("Prodia image generation completed without output");
+        }
+
+        return {
+          images: imageBuffers.map<GeneratedImageAsset>((img, i) => ({
+            buffer: img.buffer,
+            mimeType: img.mimeType,
+            fileName: `image-${i + 1}.${img.mimeType.includes("png") ? "png" : img.mimeType.includes("webp") ? "webp" : "jpg"}`,
+            metadata: { jobId: job.id },
+          })),
+          model,
+          metadata: { jobId: job.id, jobType, state: job.state?.current },
+        };
+      }
+
+      // Text-to-image: JSON request.
+      const { baseUrl: resolvedBaseUrl, headers } = resolveProviderHttpRequestConfig({
+        baseUrl,
+        defaultBaseUrl: DEFAULT_PRODIA_BASE_URL,
+        defaultHeaders: {
+          Authorization: `Bearer ${auth.apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "multipart/form-data",
+        },
+        provider: "prodia",
+        capability: "image",
+        transport: "http",
+      });
+
+      const response = await fetchWithTimeout(
+        `${resolvedBaseUrl}/v2/job`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ type: jobType, config }),
+        },
+        req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        fetchFn,
+      );
+      await assertOkOrThrowHttpError(response, "Prodia image generation failed");
+
+      const { job, imageBuffers } = await parseProdiaImageResponse(response);
+      if (job.state?.current === "failed" || job.error) {
+        throw new Error(job.error?.trim() || "Prodia image generation failed");
+      }
+      if (imageBuffers.length === 0) {
+        throw new Error("Prodia image generation completed without output");
+      }
+
+      return {
+        images: imageBuffers.map<GeneratedImageAsset>((img, i) => ({
+          buffer: img.buffer,
+          mimeType: img.mimeType,
+          fileName: `image-${i + 1}.${img.mimeType.includes("png") ? "png" : img.mimeType.includes("webp") ? "webp" : "jpg"}`,
+          metadata: { jobId: job.id },
+        })),
+        model,
+        metadata: { jobId: job.id, jobType, state: job.state?.current },
+      };
+    },
+  };
+}

--- a/extensions/prodia/index.ts
+++ b/extensions/prodia/index.ts
@@ -1,0 +1,13 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { buildProdiaImageGenerationProvider } from "./image-generation-provider.js";
+import { buildProdiaVideoGenerationProvider } from "./video-generation-provider.js";
+
+export default definePluginEntry({
+  id: "prodia",
+  name: "Prodia Provider",
+  description: "Bundled Prodia image and video provider plugin",
+  register(api) {
+    api.registerImageGenerationProvider(buildProdiaImageGenerationProvider());
+    api.registerVideoGenerationProvider(buildProdiaVideoGenerationProvider());
+  },
+});

--- a/extensions/prodia/openclaw.plugin.json
+++ b/extensions/prodia/openclaw.plugin.json
@@ -1,0 +1,31 @@
+{
+  "id": "prodia",
+  "enabledByDefault": true,
+  "providerAuthEnvVars": {
+    "prodia": ["PRODIA_TOKEN"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "prodia",
+      "method": "api-key",
+      "choiceId": "prodia-api-key",
+      "choiceLabel": "Prodia API key",
+      "groupId": "prodia",
+      "groupLabel": "Prodia",
+      "groupHint": "API key",
+      "optionKey": "prodiaApiKey",
+      "cliFlag": "--prodia-api-key",
+      "cliOption": "--prodia-api-key <key>",
+      "cliDescription": "Prodia API key"
+    }
+  ],
+  "contracts": {
+    "imageGenerationProviders": ["prodia"],
+    "videoGenerationProviders": ["prodia"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/prodia/package.json
+++ b/extensions/prodia/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/prodia-provider",
+  "version": "2026.4.5",
+  "private": true,
+  "description": "OpenClaw Prodia image and video provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/prodia/plugin-registration.contract.test.ts
+++ b/extensions/prodia/plugin-registration.contract.test.ts
@@ -1,0 +1,9 @@
+import { describePluginRegistrationContract } from "../../test/helpers/plugins/plugin-registration-contract.js";
+
+describePluginRegistrationContract({
+  pluginId: "prodia",
+  imageGenerationProviderIds: ["prodia"],
+  videoGenerationProviderIds: ["prodia"],
+  requireGenerateImage: true,
+  requireGenerateVideo: true,
+});

--- a/extensions/prodia/video-generation-provider.test.ts
+++ b/extensions/prodia/video-generation-provider.test.ts
@@ -124,6 +124,61 @@ describe("prodia video generation provider", () => {
     expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
   });
 
+  it("parses multipart/form-data responses with job and output parts", async () => {
+    const boundary = "----ProdiaBoundary";
+    const jobJson = JSON.stringify({ id: "job-42", state: { current: "completed" } });
+    const videoBytes = Buffer.from("fake-multipart-video");
+    const body = [
+      `------ProdiaBoundary\r\n`,
+      `Content-Disposition: form-data; name="job"\r\n`,
+      `Content-Type: application/json\r\n\r\n`,
+      `${jobJson}\r\n`,
+      `------ProdiaBoundary\r\n`,
+      `Content-Disposition: form-data; name="output"\r\n`,
+      `Content-Type: video/mp4\r\n\r\n`,
+    ].join("");
+    const bodyBuffer = Buffer.concat([
+      Buffer.from(body),
+      videoBytes,
+      Buffer.from("\r\n------ProdiaBoundary--"),
+    ]);
+
+    fetchWithTimeoutMock.mockResolvedValue(
+      new Response(bodyBuffer, {
+        status: 200,
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      }),
+    );
+
+    const provider = buildProdiaVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "prodia",
+      model: "veo-fast",
+      prompt: "multipart test",
+      cfg: {},
+    });
+
+    expect(result.videos).toHaveLength(1);
+    expect(result.videos[0].buffer.toString()).toBe("fake-multipart-video");
+    expect(result.metadata).toEqual(
+      expect.objectContaining({ jobId: "job-42", state: "completed" }),
+    );
+  });
+
+  it("rejects URL-only image input", async () => {
+    const provider = buildProdiaVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "prodia",
+        model: "veo-fast",
+        prompt: "animate this",
+        cfg: {},
+        inputImages: [{ url: "https://example.com/img.png" }],
+      }),
+    ).rejects.toThrow("Prodia image-to-video requires a local image buffer");
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
   it("throws when API key is missing", async () => {
     resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: "" });
     const provider = buildProdiaVideoGenerationProvider();

--- a/extensions/prodia/video-generation-provider.test.ts
+++ b/extensions/prodia/video-generation-provider.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildProdiaVideoGenerationProvider } from "./video-generation-provider.js";
+
+const {
+  resolveApiKeyForProviderMock,
+  fetchWithTimeoutMock,
+  assertOkOrThrowHttpErrorMock,
+  resolveProviderHttpRequestConfigMock,
+} = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "prodia-key" })),
+  fetchWithTimeoutMock: vi.fn(),
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  resolveProviderHttpRequestConfigMock: vi.fn((params) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders),
+    dispatcherPolicy: undefined,
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+  fetchWithTimeout: fetchWithTimeoutMock,
+  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+}));
+
+function makeVideoMp4Response(): Response {
+  const videoBytes = Buffer.from("fake-mp4-video-bytes");
+  return new Response(videoBytes, {
+    status: 200,
+    headers: { "content-type": "video/mp4" },
+  });
+}
+
+describe("prodia video generation provider", () => {
+  afterEach(() => {
+    resolveApiKeyForProviderMock.mockClear();
+    fetchWithTimeoutMock.mockReset();
+    assertOkOrThrowHttpErrorMock.mockClear();
+    resolveProviderHttpRequestConfigMock.mockClear();
+  });
+
+  it("submits a text-to-video job and returns the video", async () => {
+    fetchWithTimeoutMock.mockResolvedValue(makeVideoMp4Response());
+
+    const provider = buildProdiaVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "prodia",
+      model: "veo-fast",
+      prompt: "a lobster surfing at sunset",
+      cfg: {},
+    });
+
+    expect(fetchWithTimeoutMock).toHaveBeenCalledWith(
+      "https://inference.prodia.com/v2/job",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          type: "inference.veo.fast.txt2vid.v1",
+          config: { prompt: "a lobster surfing at sunset" },
+        }),
+      }),
+      300_000,
+      fetch,
+    );
+    expect(result.videos).toHaveLength(1);
+    expect(result.videos[0].mimeType).toBe("video/mp4");
+    expect(result.model).toBe("veo-fast");
+  });
+
+  it("submits an image-to-video job with multipart form data", async () => {
+    fetchWithTimeoutMock.mockResolvedValue(makeVideoMp4Response());
+
+    const provider = buildProdiaVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "prodia",
+      model: "seedance-lite",
+      prompt: "animate this frame",
+      cfg: {},
+      inputImages: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+    });
+
+    expect(fetchWithTimeoutMock).toHaveBeenCalledWith(
+      "https://inference.prodia.com/v2/job",
+      expect.objectContaining({ method: "POST" }),
+      300_000,
+      fetch,
+    );
+    // The body should be FormData for image-to-video.
+    const callArgs = fetchWithTimeoutMock.mock.calls[0];
+    expect(callArgs[1].body).toBeInstanceOf(FormData);
+    expect(result.videos).toHaveLength(1);
+    expect(result.model).toBe("seedance-lite");
+  });
+
+  it("rejects video reference inputs", async () => {
+    const provider = buildProdiaVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "prodia",
+        model: "veo-fast",
+        prompt: "restyle this clip",
+        cfg: {},
+        inputVideos: [{ url: "https://example.com/input.mp4" }],
+      }),
+    ).rejects.toThrow("Prodia video generation does not support video reference inputs.");
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported text-to-video models", async () => {
+    const provider = buildProdiaVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "prodia",
+        model: "seedance-lite",
+        prompt: "a lobster dancing",
+        cfg: {},
+      }),
+    ).rejects.toThrow('Prodia text-to-video does not support model "seedance-lite"');
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when API key is missing", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: "" });
+    const provider = buildProdiaVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "prodia",
+        model: "veo-fast",
+        prompt: "test",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Prodia API key missing");
+  });
+});

--- a/extensions/prodia/video-generation-provider.ts
+++ b/extensions/prodia/video-generation-provider.ts
@@ -135,7 +135,7 @@ async function parseMultipartJobResponse(
     if (idx === -1) {
       break;
     }
-    if (parts.length > 0) {
+    if (start > 0) {
       // Capture from previous boundary end to this boundary start.
       parts.push(raw.subarray(start, idx));
     }
@@ -244,25 +244,22 @@ export function buildProdiaVideoGenerationProvider(): VideoGenerationProvider {
       // For text-to-video, we use application/json.
       if (hasImage) {
         const image = req.inputImages![0];
-        const imageBuffer = image.buffer;
-        const imageUrl = image.url?.trim();
-
-        if (!imageBuffer && !imageUrl) {
-          throw new Error("Prodia image-to-video input is missing image data.");
+        if (!image.buffer) {
+          throw new Error(
+            "Prodia image-to-video requires a local image buffer; URL-only input is not supported.",
+          );
         }
 
         const jobPayload = JSON.stringify({ type: jobType, config });
         const formData = new FormData();
         formData.append("job", new Blob([jobPayload], { type: "application/json" }));
 
-        if (imageBuffer) {
-          const mimeType = image.mimeType?.trim() || "image/png";
-          formData.append(
-            "input",
-            new Blob([new Uint8Array(imageBuffer)], { type: mimeType }),
-            image.fileName || "input.png",
-          );
-        }
+        const mimeType = image.mimeType?.trim() || "image/png";
+        formData.append(
+          "input",
+          new Blob([new Uint8Array(image.buffer)], { type: mimeType }),
+          image.fileName || "input.png",
+        );
 
         const { baseUrl: resolvedBaseUrl, headers } = resolveProviderHttpRequestConfig({
           baseUrl,

--- a/extensions/prodia/video-generation-provider.ts
+++ b/extensions/prodia/video-generation-provider.ts
@@ -1,0 +1,369 @@
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  assertOkOrThrowHttpError,
+  fetchWithTimeout,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+import type {
+  VideoGenerationProvider,
+  VideoGenerationRequest,
+  VideoGenerationResult,
+} from "openclaw/plugin-sdk/video-generation";
+
+const DEFAULT_PRODIA_BASE_URL = "https://inference.prodia.com";
+const DEFAULT_PRODIA_VIDEO_MODEL = "veo-fast";
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+// Prodia video model IDs mapped to the /v2/job type strings.
+const TEXT_TO_VIDEO_TYPES: Record<string, string> = {
+  "veo-fast": "inference.veo.fast.txt2vid.v1",
+  "wan2.2-lightning": "inference.wan2-2.lightning.txt2vid.v0",
+};
+
+const IMAGE_TO_VIDEO_TYPES: Record<string, string> = {
+  "veo-fast": "inference.veo.fast.img2vid.v1",
+  "seedance-lite": "inference.seedance.lite.img2vid.v1",
+  "seedance-pro": "inference.seedance.pro.img2vid.v1",
+};
+
+const ALL_MODELS = ["veo-fast", "wan2.2-lightning", "seedance-lite", "seedance-pro"];
+
+type ProdiaJobPart = {
+  id?: string;
+  type?: string;
+  state?: { current?: string };
+  error?: string;
+  config?: Record<string, unknown>;
+  metrics?: Record<string, unknown>;
+};
+
+function resolveJobType(model: string, hasImage: boolean): string {
+  if (hasImage) {
+    const type = IMAGE_TO_VIDEO_TYPES[model];
+    if (!type) {
+      throw new Error(
+        `Prodia image-to-video does not support model "${model}". Use one of: ${Object.keys(IMAGE_TO_VIDEO_TYPES).join(", ")}.`,
+      );
+    }
+    return type;
+  }
+  const type = TEXT_TO_VIDEO_TYPES[model];
+  if (!type) {
+    throw new Error(
+      `Prodia text-to-video does not support model "${model}". Use one of: ${Object.keys(TEXT_TO_VIDEO_TYPES).join(", ")}.`,
+    );
+  }
+  return type;
+}
+
+function resolveResolution(req: VideoGenerationRequest): string | undefined {
+  if (req.resolution) {
+    switch (req.resolution) {
+      case "480P":
+        return "480p";
+      case "720P":
+        return "720p";
+      case "1080P":
+        return "1080p";
+      default:
+        return undefined;
+    }
+  }
+  return undefined;
+}
+
+function buildJobConfig(req: VideoGenerationRequest): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    prompt: req.prompt,
+  };
+  const resolution = resolveResolution(req);
+  if (resolution) {
+    config.resolution = resolution;
+  }
+  return config;
+}
+
+function resolveBaseUrl(req: VideoGenerationRequest): string {
+  return req.cfg?.models?.providers?.prodia?.baseUrl?.trim() || DEFAULT_PRODIA_BASE_URL;
+}
+
+/**
+ * Prodia /v2/job returns a multipart/form-data response containing:
+ * - A "job" part with JSON metadata
+ * - One or more "output" parts with the generated media
+ *
+ * When the Accept header requests a specific media type (e.g. video/mp4),
+ * the response is the raw media bytes directly.
+ */
+async function parseMultipartJobResponse(
+  response: Response,
+): Promise<{ job: ProdiaJobPart; videoBuffers: Buffer[] }> {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  // When we request video/mp4 via Accept, Prodia may return raw bytes.
+  if (contentType.startsWith("video/")) {
+    const arrayBuffer = await response.arrayBuffer();
+    return {
+      job: { state: { current: "completed" } },
+      videoBuffers: [Buffer.from(arrayBuffer)],
+    };
+  }
+
+  // multipart/form-data response: parse boundary parts.
+  const boundary = contentType.match(/boundary=([^\s;]+)/)?.[1];
+  if (!boundary) {
+    // Fallback: treat the entire body as JSON job metadata with no output.
+    const text = await response.text();
+    try {
+      const job = JSON.parse(text) as ProdiaJobPart;
+      return { job, videoBuffers: [] };
+    } catch {
+      throw new Error(`Prodia: unexpected response content-type "${contentType}"`);
+    }
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const raw = Buffer.from(arrayBuffer);
+  const boundaryBytes = Buffer.from(`--${boundary}`);
+  const parts: Buffer[] = [];
+  let start = 0;
+
+  while (true) {
+    const idx = raw.indexOf(boundaryBytes, start);
+    if (idx === -1) {
+      break;
+    }
+    if (parts.length > 0) {
+      // Capture from previous boundary end to this boundary start.
+      parts.push(raw.subarray(start, idx));
+    }
+    start = idx + boundaryBytes.length;
+    // Skip past CRLF or -- (end marker).
+    if (raw[start] === 0x2d && raw[start + 1] === 0x2d) {
+      break;
+    }
+    if (raw[start] === 0x0d) {
+      start += 1;
+    }
+    if (raw[start] === 0x0a) {
+      start += 1;
+    }
+  }
+
+  let job: ProdiaJobPart = {};
+  const videoBuffers: Buffer[] = [];
+
+  for (const part of parts) {
+    // Each part has headers separated from body by \r\n\r\n.
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) {
+      continue;
+    }
+    const headerText = part.subarray(0, headerEnd).toString("utf-8");
+    const body = part.subarray(headerEnd + 4);
+    // Trim trailing \r\n from body.
+    const trimmedBody =
+      body.length >= 2 && body[body.length - 2] === 0x0d && body[body.length - 1] === 0x0a
+        ? body.subarray(0, body.length - 2)
+        : body;
+
+    if (headerText.includes('name="job"') || headerText.includes("application/json")) {
+      try {
+        job = JSON.parse(trimmedBody.toString("utf-8")) as ProdiaJobPart;
+      } catch {
+        // Ignore parse failures for metadata.
+      }
+    } else if (
+      headerText.includes('name="output"') ||
+      headerText.includes("video/") ||
+      headerText.includes("application/octet-stream")
+    ) {
+      if (trimmedBody.length > 0) {
+        videoBuffers.push(Buffer.from(trimmedBody));
+      }
+    }
+  }
+
+  return { job, videoBuffers };
+}
+
+export function buildProdiaVideoGenerationProvider(): VideoGenerationProvider {
+  return {
+    id: "prodia",
+    label: "Prodia",
+    defaultModel: DEFAULT_PRODIA_VIDEO_MODEL,
+    models: ALL_MODELS,
+    isConfigured: ({ agentDir }) =>
+      isProviderApiKeyConfigured({
+        provider: "prodia",
+        agentDir,
+      }),
+    capabilities: {
+      generate: {
+        maxVideos: 1,
+        supportsResolution: true,
+      },
+      imageToVideo: {
+        enabled: true,
+        maxVideos: 1,
+        maxInputImages: 1,
+      },
+      videoToVideo: {
+        enabled: false,
+      },
+    },
+    async generateVideo(req): Promise<VideoGenerationResult> {
+      const auth = await resolveApiKeyForProvider({
+        provider: "prodia",
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      if (!auth.apiKey) {
+        throw new Error("Prodia API key missing");
+      }
+
+      const hasImage = (req.inputImages?.length ?? 0) > 0;
+      if ((req.inputVideos?.length ?? 0) > 0) {
+        throw new Error("Prodia video generation does not support video reference inputs.");
+      }
+      if ((req.inputImages?.length ?? 0) > 1) {
+        throw new Error("Prodia video generation supports at most one image reference.");
+      }
+
+      const model = req.model?.trim() || DEFAULT_PRODIA_VIDEO_MODEL;
+      const jobType = resolveJobType(model, hasImage);
+      const config = buildJobConfig(req);
+
+      const baseUrl = resolveBaseUrl(req);
+      const fetchFn = fetch;
+
+      // For image-to-video, we use multipart/form-data to upload the image.
+      // For text-to-video, we use application/json.
+      if (hasImage) {
+        const image = req.inputImages![0];
+        const imageBuffer = image.buffer;
+        const imageUrl = image.url?.trim();
+
+        if (!imageBuffer && !imageUrl) {
+          throw new Error("Prodia image-to-video input is missing image data.");
+        }
+
+        const jobPayload = JSON.stringify({ type: jobType, config });
+        const formData = new FormData();
+        formData.append("job", new Blob([jobPayload], { type: "application/json" }));
+
+        if (imageBuffer) {
+          const mimeType = image.mimeType?.trim() || "image/png";
+          formData.append(
+            "input",
+            new Blob([new Uint8Array(imageBuffer)], { type: mimeType }),
+            image.fileName || "input.png",
+          );
+        }
+
+        const { baseUrl: resolvedBaseUrl, headers } = resolveProviderHttpRequestConfig({
+          baseUrl,
+          defaultBaseUrl: DEFAULT_PRODIA_BASE_URL,
+          defaultHeaders: {
+            Authorization: `Bearer ${auth.apiKey}`,
+            Accept: "multipart/form-data",
+          },
+          provider: "prodia",
+          capability: "video",
+          transport: "http",
+        });
+
+        // FormData sets its own Content-Type with boundary; remove any preset.
+        headers.delete("Content-Type");
+
+        const response = await fetchWithTimeout(
+          `${resolvedBaseUrl}/v2/job`,
+          {
+            method: "POST",
+            headers,
+            body: formData,
+          },
+          req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          fetchFn,
+        );
+        await assertOkOrThrowHttpError(response, "Prodia video generation failed");
+
+        const { job, videoBuffers } = await parseMultipartJobResponse(response);
+
+        if (job.state?.current === "failed" || job.error) {
+          throw new Error(job.error?.trim() || "Prodia video generation failed");
+        }
+        if (videoBuffers.length === 0) {
+          throw new Error("Prodia video generation completed without output");
+        }
+
+        return {
+          videos: videoBuffers.map((buffer, i) => ({
+            buffer,
+            mimeType: "video/mp4",
+            fileName: `video-${i + 1}.mp4`,
+            metadata: { jobId: job.id },
+          })),
+          model,
+          metadata: {
+            jobId: job.id,
+            jobType,
+            state: job.state?.current,
+          },
+        };
+      }
+
+      // Text-to-video: JSON request.
+      const { baseUrl: resolvedBaseUrl, headers } = resolveProviderHttpRequestConfig({
+        baseUrl,
+        defaultBaseUrl: DEFAULT_PRODIA_BASE_URL,
+        defaultHeaders: {
+          Authorization: `Bearer ${auth.apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "multipart/form-data",
+        },
+        provider: "prodia",
+        capability: "video",
+        transport: "http",
+      });
+
+      const response = await fetchWithTimeout(
+        `${resolvedBaseUrl}/v2/job`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ type: jobType, config }),
+        },
+        req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        fetchFn,
+      );
+      await assertOkOrThrowHttpError(response, "Prodia video generation failed");
+
+      const { job, videoBuffers } = await parseMultipartJobResponse(response);
+
+      if (job.state?.current === "failed" || job.error) {
+        throw new Error(job.error?.trim() || "Prodia video generation failed");
+      }
+      if (videoBuffers.length === 0) {
+        throw new Error("Prodia video generation completed without output");
+      }
+
+      return {
+        videos: videoBuffers.map((buffer, i) => ({
+          buffer,
+          mimeType: "video/mp4",
+          fileName: `video-${i + 1}.mp4`,
+          metadata: { jobId: job.id },
+        })),
+        model,
+        metadata: {
+          jobId: job.id,
+          jobType,
+          state: job.state?.current,
+        },
+      };
+    },
+  };
+}

--- a/extensions/prodia/video-generation-provider.ts
+++ b/extensions/prodia/video-generation-provider.ts
@@ -23,6 +23,7 @@ const TEXT_TO_VIDEO_TYPES: Record<string, string> = {
 
 const IMAGE_TO_VIDEO_TYPES: Record<string, string> = {
   "veo-fast": "inference.veo.fast.img2vid.v1",
+  "wan2.2-lightning": "inference.wan2-2.lightning.img2vid.v0",
   "seedance-lite": "inference.seedance.lite.img2vid.v1",
   "seedance-pro": "inference.seedance.pro.img2vid.v1",
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,8 @@ importers:
 
   extensions/perplexity: {}
 
+  extensions/prodia: {}
+
   extensions/qa-channel:
     devDependencies:
       openclaw:


### PR DESCRIPTION
## Summary

- Adds a new bundled `prodia` provider plugin for image and video generation via the Prodia `/v2/job` inference API
- **Video models:** `veo-fast` (text + image-to-video), `wan2.2-lightning` (text-to-video with resolution), `seedance-lite` and `seedance-pro` (image-to-video)
- **Image models:** Flux family (`flux-fast-schnell`, `flux-dev`, `flux-pro`, `flux-max`, `flux-flex`, `flux-klein` variants, `flux-ghibli`, `flux-kontext`) and `recraft-v4` (SVG)
- Auth via `PRODIA_TOKEN` env var
- Synchronous API (no polling needed)

## Files

- `extensions/prodia/` — full plugin: provider implementations, manifest, package, tests (15 tests across 3 files)
- `docs/providers/prodia.md` — new provider page
- `docs/tools/video-generation.md` — Prodia added to all tables and notes
- `docs/tools/image-generation.md` — Prodia added to all tables and notes
- `docs/docs.json`, `docs/providers/index.md`, `docs/providers/models.md` — nav entries
- `.github/labeler.yml` — label rule

## Test plan

- [x] `pnpm test extensions/prodia/` — 15 tests pass (video provider, image provider, contract registration)
- [x] `pnpm check` — clean (tsgo, lint, format)
- [ ] Live test with `PRODIA_TOKEN` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)