### PR TITLE
fix(config): suggest .config nesting for misplaced plugin entry keys

### DIFF
--- a/src/config/validation.plugin-entry-hint.test.ts
+++ b/src/config/validation.plugin-entry-hint.test.ts
@@ -19,7 +19,7 @@ describe("plugin entry unrecognized key config hint", () => {
       const issue = result.issues.find((entry) => entry.path === "plugins.entries.openshell");
       expect(issue).toBeDefined();
       expect(issue?.message).toContain("did you mean plugins.entries.openshell.config.policy?");
-      expect(issue?.message).toContain('Plugin-specific settings belong under the "config" key');
+      expect(issue?.message).toContain("plugin-specific settings belong under the `config` key");
     }
   });
 

--- a/src/config/validation.plugin-entry-hint.test.ts
+++ b/src/config/validation.plugin-entry-hint.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectRaw } from "./validation.js";
+
+describe("plugin entry unrecognized key config hint", () => {
+  it("suggests .config nesting for a single misplaced plugin key", () => {
+    const result = validateConfigObjectRaw({
+      plugins: {
+        entries: {
+          openshell: {
+            enabled: true,
+            policy: "/home/user/.openclaw/sandbox-policy.yaml",
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find((entry) => entry.path === "plugins.entries.openshell");
+      expect(issue).toBeDefined();
+      expect(issue?.message).toContain("did you mean plugins.entries.openshell.config.policy?");
+      expect(issue?.message).toContain('Plugin-specific settings belong under the "config" key');
+    }
+  });
+
+  it("suggests .config nesting for multiple misplaced plugin keys", () => {
+    const result = validateConfigObjectRaw({
+      plugins: {
+        entries: {
+          openshell: {
+            enabled: true,
+            policy: "/path/to/policy.yaml",
+            mode: "strict",
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find((entry) => entry.path === "plugins.entries.openshell");
+      expect(issue).toBeDefined();
+      expect(issue?.message).toContain(
+        "plugin-specific settings belong under plugins.entries.openshell.config",
+      );
+    }
+  });
+
+  it("does not add hint for unrecognized keys outside plugin entries", () => {
+    const result = validateConfigObjectRaw({
+      agents: {
+        defaults: {
+          notAKey: true,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find(
+        (entry) => entry.path === "agents.defaults" && entry.message.includes("Unrecognized key"),
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.message).not.toContain("Plugin-specific settings");
+      expect(issue?.message).not.toContain("did you mean");
+    }
+  });
+});

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -444,11 +444,28 @@ export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigVal
   return collectUnsupportedMutableSecretRefIssues(raw);
 }
 
+const PLUGIN_ENTRY_PATH_RE = /^plugins\.entries\.[^.]+$/;
+
+function enhancePluginEntryUnrecognizedKeyMessage(issuePath: string, message: string): string {
+  if (!PLUGIN_ENTRY_PATH_RE.test(issuePath) || !/Unrecognized key/i.test(message)) {
+    return message;
+  }
+  const keys = [...message.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  if (keys.length === 0) {
+    return message;
+  }
+  const configPath = `${issuePath}.config`;
+  if (keys.length === 1) {
+    return `${message} (did you mean ${configPath}.${keys[0]}? Plugin-specific settings belong under the "config" key)`;
+  }
+  return `${message} (plugin-specific settings belong under ${configPath})`;
+}
+
 function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   const record = toIssueRecord(issue);
-  const path = formatConfigPath(toConfigPathSegments(record?.path));
-  const message = typeof record?.message === "string" ? record.message : "Invalid input";
-
+  const issuePath = formatConfigPath(toConfigPathSegments(record?.path));
+  const rawMessage = typeof record?.message === "string" ? record.message : "Invalid input";
+  const message = enhancePluginEntryUnrecognizedKeyMessage(issuePath, rawMessage);
   const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
 
   // Bindings use a plain union because legacy route bindings may omit `type`.
@@ -460,18 +477,18 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
     record.code === "invalid_union" &&
     !allowedValuesSummary
   ) {
-    const betterIssue = extractBindingsSpecificUnionIssue(record, path);
+    const betterIssue = extractBindingsSpecificUnionIssue(record, issuePath);
     if (betterIssue) {
       return betterIssue;
     }
   }
 
   if (!allowedValuesSummary) {
-    return { path, message };
+    return { path: issuePath, message };
   }
 
   return {
-    path,
+    path: issuePath,
     message: appendAllowedValuesHint(message, allowedValuesSummary),
     allowedValues: allowedValuesSummary.values,
     allowedValuesHiddenCount: allowedValuesSummary.hiddenCount,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -456,7 +456,7 @@ function enhancePluginEntryUnrecognizedKeyMessage(issuePath: string, message: st
   }
   const configPath = `${issuePath}.config`;
   if (keys.length === 1) {
-    return `${message} (did you mean ${configPath}.${keys[0]}? Plugin-specific settings belong under the "config" key)`;
+    return `${message} (did you mean ${configPath}.${keys[0]}? plugin-specific settings belong under the \`config\` key)`;
   }
   return `${message} (plugin-specific settings belong under ${configPath})`;
 }


### PR DESCRIPTION
Plugin-specific config keys placed directly on `plugins.entries.<id>` (e.g. `plugins.entries.openshell.policy`) are rejected with a bare "Unrecognized key" message that doesn't indicate the correct nesting under `.config`.

The validation error now suggests the right path:

```
Unrecognized key(s) in object: "policy"
  (did you mean plugins.entries.openshell.config.policy?
   Plugin-specific settings belong under the "config" key)
```

The hint is added in the existing Zod issue post-processing pipeline — no schema changes. If the path/message pattern doesn't match, the original message is returned unchanged.

Fixes #60963

## Testing

- 3 new tests in `validation.plugin-entry-hint.test.ts`: single key hint, multiple key hint, no hint on non-plugin paths
- Existing `validation.policy.test.ts` suite passes (5/5)

> Note: `tsgo` in the pre-commit hook fails on 4 pre-existing type errors on `main` — unrelated to this change. Filed as #62014.