### PR TITLE
fix(memory): downgrade qmd collection already-exists warning to info

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -859,7 +859,7 @@ describe("QmdMemoryManager", () => {
     expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("rebinding"));
   });
 
-  it("warns instead of silently succeeding when add conflict metadata is unavailable", async () => {
+  it("logs info instead of warn when collection already exists and metadata is unavailable", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -890,7 +890,7 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager({ mode: "full" });
     await manager.close();
 
-    expect(logWarnMock).toHaveBeenCalledWith(
+    expect(logInfoMock).toHaveBeenCalledWith(
       expect.stringContaining("qmd collection add skipped for workspace-main"),
     );
   });

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -452,7 +452,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             addErrorMessage: message,
           });
           if (!rebound) {
-            log.warn(`qmd collection add skipped for ${collection.name}: ${message}`);
+            log.info(`qmd collection add skipped for ${collection.name} (already registered)`);
           }
           continue;
         }


### PR DESCRIPTION
## Summary

- When `listCollectionsBestEffort()` returns incomplete data, `ensureCollections()` tries to re-add existing QMD collections
- The "already exists" response is benign (collection is usable), but was logged at `warn` level
- This creates noisy output on every gateway restart that confuses operators and masks real memory initialization errors
- Downgrade to `log.info` with a concise "(already registered)" message

Closes #61848

## Changes

| File | Change |
|------|--------|
| `extensions/memory-core/src/memory/qmd-manager.ts:455` | `log.warn` → `log.info`, simplified message |
| `extensions/memory-core/src/memory/qmd-manager.test.ts` | Updated test to assert `logInfoMock` instead of `logWarnMock` |

## Test plan

- [x] Updated existing test assertion from `logWarnMock` to `logInfoMock`
- [ ] CI: `pnpm test extensions/memory-core`