### PR TITLE
fix: qualify provider-scoped chat model values

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -81,6 +81,49 @@ describe("chat-model-ref helpers", () => {
     });
   });
 
+  it("qualifies provider-scoped model ids whose raw ids also contain slashes", () => {
+    expect(
+      resolvePreferredServerChatModel("anthropic/claude-sonnet-4-6", "openrouter", [
+        {
+          id: "anthropic/claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          provider: "openrouter",
+        },
+      ]),
+    ).toEqual({
+      value: "openrouter/anthropic/claude-sonnet-4-6",
+      source: "catalog",
+    });
+  });
+
+  it("uses a unique catalog match when the server provider is generic", () => {
+    expect(
+      resolvePreferredServerChatModel("gpt-5.4", "openai", [
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          provider: "openai-codex",
+        },
+      ]),
+    ).toEqual({
+      value: "openai-codex/gpt-5.4",
+      source: "catalog",
+    });
+  });
+
+  it("keeps already-qualified server values unchanged", () => {
+    expect(
+      resolvePreferredServerChatModel(
+        "openrouter/anthropic/claude-opus-4-6",
+        "openrouter",
+        catalog,
+      ),
+    ).toEqual({
+      value: "openrouter/anthropic/claude-opus-4-6",
+      source: "qualified",
+    });
+  });
+
   it("falls back to the server provider when the catalog misses or is ambiguous", () => {
     expect(resolvePreferredServerChatModel("gpt-5-mini", "openai", [])).toEqual({
       value: "openai/gpt-5-mini",

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -92,6 +92,55 @@ export function resolveServerChatModelValue(
   return buildQualifiedChatModelValue(model, provider);
 }
 
+function resolveCatalogValueById(
+  model: string,
+  provider: string | null | undefined,
+  catalog: ModelCatalogEntry[],
+): ChatModelResolution | null {
+  const trimmedModel = model.trim();
+  const trimmedProvider = provider?.trim();
+  if (!trimmedModel) {
+    return null;
+  }
+
+  let providerMatch = "";
+  let uniqueMatch = "";
+  let matchCount = 0;
+  for (const entry of catalog) {
+    const entryId = entry.id.trim();
+    if (entryId.toLowerCase() !== trimmedModel.toLowerCase()) {
+      continue;
+    }
+    matchCount += 1;
+    const candidate = buildQualifiedChatModelValue(entryId, entry.provider);
+    if (trimmedProvider && entry.provider?.trim().toLowerCase() === trimmedProvider.toLowerCase()) {
+      providerMatch = candidate;
+    }
+    if (!uniqueMatch) {
+      uniqueMatch = candidate;
+      continue;
+    }
+    if (uniqueMatch.toLowerCase() !== candidate.toLowerCase()) {
+      uniqueMatch = "";
+    }
+  }
+
+  if (providerMatch) {
+    if (matchCount > 1) {
+      return {
+        value: buildQualifiedChatModelValue(trimmedModel, trimmedProvider),
+        source: "server",
+        reason: "ambiguous",
+      };
+    }
+    return { value: providerMatch, source: "catalog" };
+  }
+  if (uniqueMatch) {
+    return { value: uniqueMatch, source: "catalog" };
+  }
+  return null;
+}
+
 export function resolvePreferredServerChatModel(
   model: string | null | undefined,
   provider: string | null | undefined,
@@ -103,6 +152,19 @@ export function resolvePreferredServerChatModel(
   const trimmedModel = model.trim();
   if (!trimmedModel) {
     return { value: "", source: "empty", reason: "empty" };
+  }
+
+  const trimmedProvider = provider?.trim();
+  if (
+    trimmedProvider &&
+    trimmedModel.toLowerCase().startsWith(`${trimmedProvider.toLowerCase()}/`)
+  ) {
+    return { value: trimmedModel, source: "qualified" };
+  }
+
+  const catalogResolution = resolveCatalogValueById(trimmedModel, trimmedProvider, catalog);
+  if (catalogResolution) {
+    return catalogResolution;
   }
 
   const overrideResolution = resolveChatModelOverride(


### PR DESCRIPTION
## Summary
- fix server model normalization for provider-scoped model ids whose raw ids already contain slashes
- prefer catalog-qualified values when the server sends a generic provider but the catalog has a unique allowed match
- add regression tests for OpenRouter Claude and Codex model resolution

## Testing
- pnpm --dir /Users/wu/Github/openclaw/ui test chat-model-ref.test.ts chat-model-select-state.test.ts