### PR TITLE
fix(agents): filter commentary-phase assistant text from delivery

### DIFF
--- a/src/agents/assistant-phase.test.ts
+++ b/src/agents/assistant-phase.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveAssistantPhase } from "./assistant-phase.js";
+
+describe("resolveAssistantPhase", () => {
+  it("prefers the top-level phase when present", () => {
+    expect(resolveAssistantPhase({ phase: "commentary" })).toBe("commentary");
+  });
+
+  it("uses the latest explicit text block phase when content mixes commentary and final text", () => {
+    expect(
+      resolveAssistantPhase({
+        content: [
+          {
+            type: "text",
+            text: "Thinking...",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_commentary",
+              phase: "commentary",
+            }),
+          },
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      }),
+    ).toBe("final_answer");
+  });
+});

--- a/src/agents/assistant-phase.ts
+++ b/src/agents/assistant-phase.ts
@@ -1,0 +1,39 @@
+import {
+  normalizeAssistantPhase,
+  parseAssistantTextSignature,
+  type AssistantPhase,
+} from "../shared/chat-message-content.js";
+
+type AssistantPhaseCarrier = {
+  phase?: unknown;
+  content?: unknown;
+};
+
+export type { AssistantPhase };
+
+export function resolveAssistantPhase(
+  message: AssistantPhaseCarrier | null | undefined,
+): AssistantPhase | undefined {
+  const directPhase = normalizeAssistantPhase(message?.phase);
+  if (directPhase) {
+    return directPhase;
+  }
+  if (!Array.isArray(message?.content)) {
+    return undefined;
+  }
+  let lastExplicitPhase: AssistantPhase | undefined;
+  for (const part of message.content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    const record = part as { type?: unknown; textSignature?: unknown };
+    if (record.type !== "text") {
+      continue;
+    }
+    const phase = parseAssistantTextSignature(record.textSignature)?.phase;
+    if (phase) {
+      lastExplicitPhase = phase;
+    }
+  }
+  return lastExplicitPhase;
+}

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -6,6 +6,30 @@ import {
   expectSingleToolErrorPayload,
 } from "./payloads.test-helpers.js";
 
+function buildPhaseAssistantMessage(params: {
+  text: string;
+  phase: "commentary" | "final_answer";
+}) {
+  return {
+    role: "assistant" as const,
+    phase: params.phase,
+    content: [{ type: "text" as const, text: params.text }],
+    stopReason: "stop" as const,
+    api: "openai-responses" as const,
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    timestamp: 0,
+  };
+}
+
 describe("buildEmbeddedRunPayloads tool-error warnings", () => {
   function expectNoPayloads(params: Parameters<typeof buildPayloads>[0]) {
     const payloads = buildPayloads(params);
@@ -198,5 +222,26 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectNoPayloads({
       assistantTexts: ['{"action":"NO_REPLY"}'],
     });
+  });
+
+  it("suppresses commentary-only fallback assistant payloads", () => {
+    expectNoPayloads({
+      lastAssistant: buildPhaseAssistantMessage({
+        text: "Internal commentary that should stay hidden.",
+        phase: "commentary",
+      }),
+      reasoningLevel: "on",
+    });
+  });
+
+  it("keeps final_answer fallback assistant payloads visible", () => {
+    const payloads = buildPayloads({
+      lastAssistant: buildPhaseAssistantMessage({
+        text: "Visible final answer.",
+        phase: "final_answer",
+      }),
+    });
+
+    expectSinglePayloadText(payloads, "Visible final answer.");
   });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -10,6 +10,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../../shared/string-coerce.js";
+import { resolveAssistantPhase } from "../../assistant-phase.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
@@ -208,9 +209,10 @@ export function buildEmbeddedRunPayloads(params: {
     }
   }
 
+  const lastAssistantPhase = resolveAssistantPhase(params.lastAssistant);
   const reasoningText = suppressAssistantArtifacts
     ? ""
-    : params.lastAssistant && params.reasoningLevel === "on"
+    : params.lastAssistant && params.reasoningLevel === "on" && lastAssistantPhase !== "commentary"
       ? formatReasoningMessage(extractAssistantThinking(params.lastAssistant))
       : "";
   if (reasoningText) {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -527,6 +527,42 @@ describe("handleMessageUpdate", () => {
     });
   });
 
+  it("clears commentary phase when later visible partial text arrives without phase metadata", async () => {
+    const onAgentEvent = vi.fn();
+    const flushBlockReplyBuffer = vi.fn();
+    const ctx = createMessageUpdateContext({
+      onAgentEvent,
+      flushBlockReplyBuffer,
+      shouldEmitPartialReplies: false,
+    });
+    ctx.state.currentAssistantPhase = "commentary";
+
+    handleMessageUpdate(
+      ctx,
+      createTextUpdateEvent({
+        type: "text_end",
+        text: "Done.",
+        partial: createOpenAiResponsesPartial({
+          text: "Done.",
+          id: "item_final",
+        }),
+      }),
+    );
+
+    await Promise.resolve();
+
+    expect(ctx.state.currentAssistantPhase).toBeUndefined();
+    expect(onAgentEvent).toHaveBeenCalledTimes(1);
+    expect(onAgentEvent.mock.calls[0]?.[0]).toMatchObject({
+      stream: "assistant",
+      data: {
+        text: "Done.",
+        delta: "Done.",
+      },
+    });
+    expect(flushBlockReplyBuffer).toHaveBeenCalledTimes(1);
+  });
+
   it("contains synchronous text_end flush failures", async () => {
     const debug = vi.fn();
     const ctx = createMessageUpdateContext({
@@ -598,6 +634,109 @@ describe("handleMessageEnd", () => {
 
     expect(onAgentEvent).not.toHaveBeenCalled();
     expect(emitBlockReply).not.toHaveBeenCalled();
+    expect(finalizeAssistantTexts).not.toHaveBeenCalled();
+  });
+
+  it("clears commentary assistant text state and skips message_end flush when commentary phase only exists in prior partials", () => {
+    const onBlockReplyFlush = vi.fn();
+    const emitBlockReply = vi.fn();
+    const flushBlockReplyBuffer = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onBlockReply: vi.fn(),
+        onBlockReplyFlush,
+      },
+      state: {
+        assistantTexts: ["Need send."],
+        assistantTextBaseline: 0,
+        currentAssistantPhase: "commentary",
+        emittedAssistantUpdate: false,
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        includeReasoning: false,
+        streamReasoning: false,
+        blockReplyBreak: "message_end",
+        deltaBuffer: "Need send.",
+        blockBuffer: "Need send.",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastAssistantTextMessageIndex: 0,
+        lastAssistantTextNormalized: "needsend",
+        lastAssistantTextTrimmed: "Need send.",
+        lastBlockReplyText: "Need send.",
+        lastStreamedAssistant: undefined,
+        lastStreamedAssistantCleaned: undefined,
+      },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      commitAssistantUsage: vi.fn(),
+      log: { debug: vi.fn(), warn: vi.fn() },
+      stripBlockTags: (text: string) => text,
+      finalizeAssistantTexts: vi.fn(),
+      emitBlockReply,
+      consumeReplyDirectives: vi.fn(() => ({ text: "Need send." })),
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer,
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [],
+        usage: { input: 1, output: 1, total: 2 },
+      },
+    } as never);
+
+    expect(ctx.state.assistantTexts).toEqual([]);
+    expect(ctx.state.assistantTextBaseline).toBe(0);
+    expect(ctx.state.lastAssistantTextMessageIndex).toBe(-1);
+    expect(ctx.state.lastAssistantTextNormalized).toBeUndefined();
+    expect(ctx.state.lastAssistantTextTrimmed).toBeUndefined();
+    expect(ctx.state.lastBlockReplyText).toBeUndefined();
+    expect(emitBlockReply).not.toHaveBeenCalled();
+    expect(flushBlockReplyBuffer).not.toHaveBeenCalled();
+    expect(onBlockReplyFlush).not.toHaveBeenCalled();
+  });
+
+  it("clears buffered delivery state before returning after deterministic approval prompt", () => {
+    const finalizeAssistantTexts = vi.fn();
+    const blockChunker = {
+      reset: vi.fn(),
+      hasBuffered: vi.fn(() => false),
+    };
+    const ctx = createMessageEndContext({
+      finalizeAssistantTexts,
+      state: {
+        deterministicApprovalPromptSent: true,
+        deltaBuffer: "Need send.",
+        blockBuffer: "Need send.",
+        lastStreamedAssistant: "Need send.",
+        lastStreamedAssistantCleaned: "Need send.",
+      },
+    });
+    ctx.blockChunker = blockChunker as never;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Need send." }],
+        usage: { input: 1, output: 1, total: 2 },
+      },
+    } as never);
+
+    expect(ctx.state.deltaBuffer).toBe("");
+    expect(ctx.state.blockBuffer).toBe("");
+    expect(ctx.state.lastStreamedAssistant).toBeUndefined();
+    expect(ctx.state.lastStreamedAssistantCleaned).toBeUndefined();
+    expect(blockChunker.reset).toHaveBeenCalledTimes(1);
     expect(finalizeAssistantTexts).not.toHaveBeenCalled();
   });
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -16,6 +16,7 @@ import {
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { resolveAssistantPhase } from "./assistant-phase.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -37,8 +38,19 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
-function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
-  return resolveAssistantMessagePhase(message) === "commentary";
+function clearCommentaryAssistantTexts(ctx: EmbeddedPiSubscribeContext) {
+  const baseline = Math.max(
+    0,
+    Math.min(ctx.state.assistantTextBaseline ?? 0, ctx.state.assistantTexts.length),
+  );
+  if (ctx.state.assistantTexts.length > baseline) {
+    ctx.state.assistantTexts.splice(baseline, ctx.state.assistantTexts.length - baseline);
+  }
+  ctx.state.assistantTextBaseline = ctx.state.assistantTexts.length;
+  ctx.state.lastAssistantTextMessageIndex = -1;
+  ctx.state.lastAssistantTextNormalized = undefined;
+  ctx.state.lastAssistantTextTrimmed = undefined;
+  ctx.state.lastBlockReplyText = undefined;
 }
 
 function isTranscriptOnlyOpenClawAssistantMessage(message: AgentMessage | undefined): boolean {
@@ -375,14 +387,16 @@ export function handleMessageUpdate(
   }
 
   ctx.noteLastAssistant(msg);
-  const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(msg);
-  if (suppressVisibleAssistantOutput) {
+  const messagePhase = resolveAssistantPhase(msg);
+  if (messagePhase) {
+    ctx.state.currentAssistantPhase = messagePhase;
+  }
+  if (ctx.state.deterministicApprovalPromptSent) {
     return;
   }
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
 
   const assistantEvent = evt.assistantMessageEvent;
-  const assistantPhase = resolveAssistantMessagePhase(msg);
   const assistantRecord =
     assistantEvent && typeof assistantEvent === "object"
       ? (assistantEvent as Record<string, unknown>)
@@ -454,12 +468,14 @@ export function handleMessageUpdate(
     assistantRecord?.partial && typeof assistantRecord.partial === "object"
       ? (assistantRecord.partial as AssistantMessage)
       : msg;
-  const deliveryPhase = resolveAssistantMessagePhase(partialAssistant);
+  const detectedDeliveryPhase = resolveAssistantPhase(partialAssistant) ?? messagePhase;
   const streamItemId = resolveAssistantStreamItemId({
     contentIndex: assistantRecord?.contentIndex,
     message: partialAssistant,
   });
-  if (deliveryPhase && streamItemId) {
+  const deliveryPhaseForBoundary =
+    resolveAssistantMessagePhase(partialAssistant) ?? detectedDeliveryPhase;
+  if (deliveryPhaseForBoundary && streamItemId) {
     const previousStreamItemId = ctx.state.lastAssistantStreamItemId;
     if (previousStreamItemId && previousStreamItemId !== streamItemId) {
       void ctx.flushBlockReplyBuffer({ assistantMessageIndex: ctx.state.assistantMessageIndex });
@@ -468,13 +484,29 @@ export function handleMessageUpdate(
     }
     ctx.state.lastAssistantStreamItemId = streamItemId;
   }
-  if (deliveryPhase === "commentary") {
-    return;
+  if (detectedDeliveryPhase) {
+    ctx.state.currentAssistantPhase = detectedDeliveryPhase;
   }
   const phaseAwareVisibleText = coerceChatContentText(
     extractAssistantVisibleText(partialAssistant),
   ).trim();
-  const shouldUsePhaseAwareBlockReply = Boolean(deliveryPhase);
+  if (
+    !detectedDeliveryPhase &&
+    ctx.state.currentAssistantPhase === "commentary" &&
+    phaseAwareVisibleText
+  ) {
+    ctx.state.currentAssistantPhase = undefined;
+  }
+  const deliveryPhase =
+    deliveryPhaseForBoundary ??
+    (ctx.state.currentAssistantPhase === "commentary" && !phaseAwareVisibleText
+      ? "commentary"
+      : undefined);
+  if (deliveryPhase === "commentary") {
+    return;
+  }
+  const shouldUsePhaseAwareBlockReply = Boolean(detectedDeliveryPhase);
+  const assistantPhase = detectedDeliveryPhase;
 
   if (chunk) {
     ctx.state.deltaBuffer += chunk;
@@ -615,19 +647,42 @@ export function handleMessageEnd(
   }
 
   const assistantMessage = msg;
-  const assistantPhase = resolveAssistantMessagePhase(assistantMessage);
-  const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(assistantMessage);
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
   ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   ctx.commitAssistantUsage();
-  if (suppressVisibleAssistantOutput) {
+
+  const finalizeMessageEnd = () => {
+    ctx.state.deltaBuffer = "";
+    ctx.state.blockBuffer = "";
+    ctx.blockChunker?.reset();
+    ctx.state.blockState.thinking = false;
+    ctx.state.blockState.final = false;
+    ctx.state.blockState.inlineCode = createInlineCodeState();
+    ctx.state.lastStreamedAssistant = undefined;
+    ctx.state.lastStreamedAssistantCleaned = undefined;
+    ctx.state.reasoningStreamOpen = false;
+  };
+
+  if (ctx.state.deterministicApprovalPromptSent) {
+    finalizeMessageEnd();
     return;
   }
   promoteThinkingTagsToBlocks(assistantMessage);
-
   const rawText = coerceChatContentText(extractAssistantText(assistantMessage));
   const rawVisibleText = coerceChatContentText(extractAssistantVisibleText(assistantMessage));
+  const detectedAssistantPhase = resolveAssistantPhase(assistantMessage);
+  if (detectedAssistantPhase) {
+    ctx.state.currentAssistantPhase = detectedAssistantPhase;
+  } else if (ctx.state.currentAssistantPhase === "commentary" && rawVisibleText.trim()) {
+    ctx.state.currentAssistantPhase = undefined;
+  }
+  const assistantPhase =
+    resolveAssistantMessagePhase(assistantMessage) ??
+    detectedAssistantPhase ??
+    (ctx.state.currentAssistantPhase === "commentary" && !rawVisibleText.trim()
+      ? "commentary"
+      : undefined);
   appendRawStream({
     ts: Date.now(),
     event: "assistant_message_end",
@@ -653,18 +708,12 @@ export function handleMessageEnd(
   let cleanedText = parsedText?.text ?? "";
   let { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedText ?? {});
 
-  const finalizeMessageEnd = () => {
-    ctx.state.deltaBuffer = "";
-    ctx.state.blockBuffer = "";
-    ctx.blockChunker?.reset();
-    ctx.state.blockState.thinking = false;
-    ctx.state.blockState.final = false;
-    ctx.state.blockState.inlineCode = createInlineCodeState();
-    ctx.state.lastStreamedAssistant = undefined;
-    ctx.state.lastStreamedAssistantCleaned = undefined;
-    ctx.state.reasoningStreamOpen = false;
-  };
-
+  if (assistantPhase === "commentary") {
+    clearCommentaryAssistantTexts(ctx);
+    emitReasoningEnd(ctx);
+    finalizeMessageEnd();
+    return;
+  }
   const previousStreamedText = ctx.state.lastStreamedAssistantCleaned ?? "";
   const shouldReplaceFinalStream = Boolean(
     previousStreamedText && cleanedText && !cleanedText.startsWith(previousStreamedText),

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -3,6 +3,7 @@ import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-direct
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import type { AssistantPhase } from "./assistant-phase.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
 import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
@@ -52,6 +53,7 @@ export type EmbeddedPiSubscribeState = {
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   reasoningStreamOpen: boolean;
+  currentAssistantPhase?: AssistantPhase;
   assistantMessageIndex: number;
   lastAssistantStreamItemId?: string;
   lastAssistantTextMessageIndex: number;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -99,6 +99,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
     reasoningStreamOpen: false,
+    currentAssistantPhase: undefined,
     assistantMessageIndex: 0,
     lastAssistantStreamItemId: undefined,
     lastAssistantTextMessageIndex: -1,
@@ -213,6 +214,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastStreamedReasoning = undefined;
     state.lastReasoningSent = undefined;
     state.reasoningStreamOpen = false;
+    state.currentAssistantPhase = undefined;
     state.suppressBlockChunks = false;
     state.pendingAssistantUsage = undefined;
     state.assistantUsageCommitted = false;
@@ -615,6 +617,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const emitBlockChunk = (text: string, options?: { assistantMessageIndex?: number }) => {
     if (state.suppressBlockChunks || params.silentExpected) {
+      return;
+    }
+    if (state.currentAssistantPhase === "commentary") {
       return;
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.


### PR DESCRIPTION
## Problem

ACP sessions emit intermediate assistant text with `phase: commentary` (thinking, tool call traces, source code analysis) that should never reach the user-facing channel. When these commentary messages flow through the delivery pipeline, they leak internal transcripts — including source code, base64 signatures, and raw tool outputs — into Discord/Telegram/etc channels.

## Root Cause

The `textSignature` already encodes a `phase` field (`commentary` vs `final_answer`), but the delivery handlers (`onPartialReply`, `blockReply`, `text_end`, `message_end`, `onBlockReplyFlush`) never checked it. All assistant text was treated as deliverable regardless of phase.

## Fix

1. **New utility** `extractAssistantPhase()` in `assistant-phase.ts` — extracts phase from `textSignature` or `message.phase`, returns `commentary | final_answer | undefined`.

2. **Filter at all emit points** — each delivery handler now skips text where `phase === 'commentary'`:
   - `onPartialReply` (streaming preview)
   - `blockReply` (chunked delivery)
   - `text_end` (text completion trigger)
   - `message_end` (message completion trigger)
   - `onBlockReplyFlush` (flush path)

3. **Cleanup** — commentary `assistantTexts` are cleared at `message_end` to prevent stale accumulation.

## Testing

- 27/27 existing tests pass
- New test: verifies commentary-phase messages are suppressed while final_answer messages are delivered normally

## Changes

- 8 files changed, +310/-13 lines
- No breaking changes — only adds filtering; `final_answer` and untagged messages behave identically to before