### PR TITLE
Fix: fall through to --user when sudo machine scope fails (Resolves #61959)

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -169,6 +169,27 @@ describe("systemd availability", () => {
 
     await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
   });
+
+  it("falls back to --user when sudo machine scope fails with permission denied", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        // Under sudo, first attempt is --machine which fails
+        expect(args).toEqual(["--machine", "ai@", "--user", "status"]);
+        const err = createExecFileError("Failed to connect to bus: Permission denied", {
+          stderr: "Failed to connect to bus: Permission denied",
+        });
+        cb(err, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        // Falls back to direct --user which succeeds
+        expect(args).toEqual(["--user", "status"]);
+        cb(null, "", "");
+      });
+
+    await expect(isSystemdUserServiceAvailable({ SUDO_USER: "ai", USER: "ai" })).resolves.toBe(
+      true,
+    );
+  });
 });
 
 describe("isSystemdServiceEnabled", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -361,10 +361,15 @@ async function execSystemctlUser(
   const sudoUser = env.SUDO_USER?.trim();
 
   // Under sudo, prefer the invoking non-root user's scope directly.
+  // If the machine-scope attempt fails (e.g. systemd-machined unavailable or
+  // permission denied), fall through to the normal --user → machine fallback.
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
-      return await execSystemctl([...machineScopeArgs, ...args]);
+      const machineResult = await execSystemctl([...machineScopeArgs, ...args]);
+      if (machineResult.code === 0) {
+        return machineResult;
+      }
     }
   }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -370,6 +370,14 @@ async function execSystemctlUser(
       if (machineResult.code === 0) {
         return machineResult;
       }
+      // Only fall through when the machine scope itself is unreachable
+      // (e.g. systemd-machined unavailable or permission denied). If the
+      // machine scope returned a real service-state result (inactive,
+      // not-found, etc.) return it directly so we don't mask it with --user.
+      const machineDetail = `${machineResult.stderr} ${machineResult.stdout}`.trim();
+      if (!shouldFallbackToMachineUserScope(machineDetail)) {
+        return machineResult;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #61959.

`execSystemctlUser()` under sudo tried `systemctl --machine <user>@ --user` and returned immediately even on failure. On systems where `systemd-machined` is unavailable or permissions are denied (e.g. Ubuntu 24.04 without machinectl access), this prevented the direct `systemctl --user` fallback from ever running.

Now the sudo path falls through to the normal `--user` → machine fallback chain when the initial `--machine` attempt fails.

Adds a test covering the sudo + permission-denied → `--user` fallback scenario.