### PR TITLE
Fix: use 16MB video limit for generated videos (Resolves #61880)

### DIFF
--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { MAX_VIDEO_BYTES } from "../../media/constants.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { resolveUserPath } from "../../utils.js";
@@ -485,7 +486,7 @@ async function executeVideoGenerationJob(params: {
         video.buffer,
         video.mimeType,
         "tool-video-generation",
-        undefined,
+        MAX_VIDEO_BYTES,
         params.filename || video.fileName,
       ),
     ),


### PR DESCRIPTION
Fixes #61880.

`saveMediaBuffer` in the video-generate tool was called with `undefined` for `maxBytes`, falling back to the generic 5MB `MEDIA_MAX_BYTES` default. Generated videos regularly exceed 5MB, causing silent delivery failures (`Media exceeds 5MB limit`).

Now passes `MAX_VIDEO_BYTES` (16MB) from `src/media/constants.ts`, matching the media pipeline's existing video limit used elsewhere.