### PR TITLE
fix: use dist/extensions for OPENCLAW_BUNDLED_PLUGINS_DIR to fix Node 24 crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,9 +159,16 @@ COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 COPY --from=runtime-assets --chown=node:node /app/qa ./qa
 
-# In npm-installed Docker images, prefer the copied source extension tree for
-# bundled discovery so package metadata that points at source entries stays valid.
-ENV OPENCLAW_BUNDLED_PLUGINS_DIR=/app/${OPENCLAW_BUNDLED_PLUGIN_DIR}
+# Use the compiled dist/ extension tree for bundled discovery.
+# Node 24 includes native TypeScript support (process.features.typescript = true)
+# which causes it to load .ts source files directly when the source extension tree
+# is used. However, Node 24's native TS loader does not remap .js→.ts for static
+# imports inside those .ts files, causing crashes like:
+#   Cannot find module '/app/extensions/matrix/src/account-selection.js'
+# Using dist/extensions (compiled JS) avoids this. The dist/ tree is already
+# present in the runtime image (see COPY --from=runtime-assets line above).
+# See: https://github.com/openclaw/openclaw/issues/62044
+ENV OPENCLAW_BUNDLED_PLUGINS_DIR=/app/dist/${OPENCLAW_BUNDLED_PLUGIN_DIR}
 
 # Keep pnpm available in the runtime image for container-local workflows.
 # Use a shared Corepack home so the non-root `node` user does not need a


### PR DESCRIPTION
## Problem

On Node 24, `process.features.typescript` is `true`, meaning Node has native TypeScript support enabled. When `OPENCLAW_BUNDLED_PLUGINS_DIR` points to `/app/extensions` (the TypeScript source tree), Node 24 intercepts `.ts` file loading natively — but its native TS loader does **not** remap `.js` imports to `.ts` for static imports *inside* those files.

This causes a crash loop on startup:

```
Cannot find module '/app/extensions/matrix/src/account-selection.js'
imported from /app/extensions/matrix/src/credentials-read.ts
```

The call chain: JITI loads `credentials-read.ts` → inside that file, `account-selection.js` is imported statically → Node 24 native TS loader resolves `credentials-read.ts` but then tries to find `account-selection.js` literally (no `.js→.ts` remapping) → module not found → crash.

Note: the issue is **not** with JITI itself. JITI handles `.js→.ts` remapping correctly in isolation. The problem is Node 24 intercepting before JITI in this code path.

## Fix

Point `OPENCLAW_BUNDLED_PLUGINS_DIR` to `/app/dist/${OPENCLAW_BUNDLED_PLUGIN_DIR}` (compiled JS) instead of `/app/${OPENCLAW_BUNDLED_PLUGIN_DIR}` (TypeScript source). The `dist/` tree is already present in the runtime image via `COPY --from=runtime-assets ... /app/dist ./dist` (line 153).

Using compiled JS avoids the Node 24 native TS loader entirely for bundled plugins.

## Testing

Verified on:
- Node 24 (Ubuntu 24.04, Docker)
- OpenClaw `2026.4.5`
- Matrix channel: no crash loop, `MatrixRTCSession` syncing correctly after fix

## Related

Closes #62044