### PR TITLE
fix(discord): preserve normalized prefix in explicit target parsing

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -479,3 +479,32 @@ describe("discordPlugin groups", () => {
     ).toEqual({ allow: ["message.channel"] });
   });
 });
+
+describe("discordPlugin messaging.parseExplicitTarget", () => {
+  function parseExplicitTarget(raw: string) {
+    const fn = discordPlugin.messaging?.parseExplicitTarget;
+    if (!fn) {
+      throw new Error("Expected discordPlugin.messaging.parseExplicitTarget to be defined");
+    }
+    return fn({ raw });
+  }
+
+  it("preserves user: prefix instead of returning bare numeric id", () => {
+    const result = parseExplicitTarget("user:148297000000000000");
+    expect(result).toEqual({ to: "user:148297000000000000", chatType: "direct" });
+  });
+
+  it("preserves channel: prefix for channel targets", () => {
+    const result = parseExplicitTarget("channel:555000000000000000");
+    expect(result).toEqual({ to: "channel:555000000000000000", chatType: "channel" });
+  });
+
+  it("defaults bare numeric id to channel", () => {
+    const result = parseExplicitTarget("123456789000000000");
+    expect(result).toEqual({ to: "channel:123456789000000000", chatType: "channel" });
+  });
+
+  it("returns null for invalid targets", () => {
+    expect(parseExplicitTarget("@bob")).toBeNull();
+  });
+});

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -429,7 +429,7 @@ function parseDiscordExplicitTarget(raw: string) {
       return null;
     }
     return {
-      to: target.id,
+      to: target.normalized,
       chatType: target.kind === "user" ? ("direct" as const) : ("channel" as const),
     };
   } catch {


### PR DESCRIPTION
`parseDiscordExplicitTarget` returned `target.id` (bare numeric like `"148297..."`) instead of `target.normalized` (prefixed like `"user:148297..."`). Downstream, `normalizeDiscordOutboundTarget` matches the bare digits against a numeric regex and wrongly prepends `channel:`, routing user DMs to a non-existent channel (Discord API error 10003).

One-field fix: `target.id` → `target.normalized`. This also corrects `inferTargetChatType` (line 495), which re-parses the `to` value — previously a bare ID with `defaultKind: "channel"` would misclassify user targets.

Fixes #62024

## Testing

4 new tests through the public `discordPlugin.messaging.parseExplicitTarget` interface:
- `user:<id>` → preserves prefix, chatType = direct
- `channel:<id>` → preserves prefix, chatType = channel
- bare numeric → defaults to channel (existing behavior)
- invalid input → null

All 17 tests pass (13 pre-existing + 4 new).