### PR TITLE
fix(discord): warn on empty native slash replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/native commands: return an explicit warning when slash command dispatch or direct plugin execution produces no visible reply instead of a success-style completion ack. (#62057) Thanks @jb510.
 - Gateway/sessions: move hot transcript reads and mirror appends onto async bounded IO with serialized parent-linked writes, keeping large session histories from stalling Gateway requests and channel replies. Fixes #75656. Thanks @DerFlash.
 - Cron/TTS: run cron announce payloads through the normal TTS directive transform before outbound delivery, so scheduled `[[tts]]` replies generate voice payloads instead of leaking raw tags. Fixes #52125. Thanks @kenchen3000.
 - Doctor/WhatsApp: warn when Linux crontabs still run the legacy `ensure-whatsapp.sh` health check, which can misreport `Gateway inactive` when cron lacks the systemd user-bus environment. Fixes #60204. Thanks @mySebbe.

--- a/extensions/discord/src/monitor/native-command-agent-reply.ts
+++ b/extensions/discord/src/monitor/native-command-agent-reply.ts
@@ -111,7 +111,7 @@ export async function dispatchDiscordNativeAgentReply(params: {
 
   await safeDiscordInteractionCall("interaction empty fallback", async () => {
     const payload = {
-      content: "✅ Done.",
+      content: "⚠️ Command produced no visible reply.",
       ephemeral: true,
     };
     if (params.preferFollowUp) {

--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -491,6 +491,31 @@ describe("Discord native plugin command dispatch", () => {
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 
+  it("returns an explicit warning instead of success when dispatch produces zero visible replies", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
+    runtimeModuleMocks.dispatchReplyWithDispatcher.mockResolvedValue({
+      counts: { final: 0, block: 0, tool: 0 },
+      queuedFinal: false,
+    } as never);
+    const command = await createNativeCommand(cfg, {
+      name: "new",
+      description: "Start a new session.",
+      acceptsArgs: true,
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "⚠️ Command produced no visible reply.",
+        ephemeral: true,
+      }),
+    );
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
   it("executes matched plugin commands directly without invoking the agent dispatcher", async () => {
     const cfg = createConfig();
     const commandSpec: NativeCommandSpec = {
@@ -525,6 +550,41 @@ describe("Discord native plugin command dispatch", () => {
     expect(dispatchSpy).not.toHaveBeenCalled();
     expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({ content: "direct plugin output" }),
+    );
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("returns an explicit warning when a direct plugin command has no visible reply", async () => {
+    const cfg = createConfig();
+    const commandSpec: NativeCommandSpec = {
+      name: "cron_jobs",
+      description: "List cron jobs",
+      acceptsArgs: false,
+    };
+    const interaction = createInteraction();
+    const pluginMatch = {
+      command: {
+        name: "cron_jobs",
+        description: "List cron jobs",
+        pluginId: "cron-jobs",
+        acceptsArgs: false,
+        handler: vi.fn().mockResolvedValue({ text: "" }),
+      },
+      args: undefined,
+    };
+
+    runtimeModuleMocks.matchPluginCommand.mockReturnValue(pluginMatch as never);
+    runtimeModuleMocks.executePluginCommand.mockResolvedValue({});
+    const dispatchSpy = runtimeModuleMocks.dispatchReplyWithDispatcher.mockResolvedValue(
+      {} as never,
+    );
+    const command = await createNativeCommand(cfg, commandSpec);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "⚠️ Command produced no visible reply." }),
     );
     expect(interaction.reply).not.toHaveBeenCalled();
   });

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -535,7 +535,7 @@ async function dispatchDiscordCommandInteraction(params: {
       threadParentId: pluginThreadParentId,
     });
     if (!hasRenderableReplyPayload(pluginReply)) {
-      await respond("Done.");
+      await respond("⚠️ Command produced no visible reply.");
       return { accepted: true, effectiveRoute };
     }
     await deliverDiscordInteractionReply({


### PR DESCRIPTION
## Summary
- replace Discord native slash zero-visible-output success acknowledgements with an explicit warning
- cover both current fallback paths: direct plugin execution and native agent dispatch
- add the required changelog entry for the user-visible Discord behavior change

Fixes #58986.

## Why
Discord native slash commands could appear to succeed with `Done.` / `✅ Done.` even when no visible reply was produced. This refresh keeps the fix narrow: it does not change Discord auth or ACP recovery behavior, and only changes the response text for empty visible-output paths.

## Testing
- `pnpm test extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts`
- `pnpm test extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts extensions/discord/src/monitor/native-command.status-direct.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/discord/src/monitor/native-command.ts extensions/discord/src/monitor/native-command-agent-reply.ts extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts CHANGELOG.md`

## AI assistance
This PR was prepared with AI assistance, with changes reviewed and validation results reported transparently.
