### PR TITLE
fix: include xhigh in listThinkingLevelLabels when provider supports it

### DIFF
--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -86,7 +86,7 @@ export function listThinkingLevelLabels(provider?: string | null, model?: string
   if (isBinaryThinkingProvider(provider, model)) {
     return ["off", "on"];
   }
-  return listThinkingLevelLabelsFallback(provider, model);
+  return listThinkingLevels(provider, model);
 }
 
 export function formatThinkingLevels(


### PR DESCRIPTION
## Problem

`listThinkingLevelLabels()` in `src/auto-reply/thinking.ts` calls `listThinkingLevelLabelsFallback()` (from `thinking.shared.ts`), which always returns the base thinking levels: `["off", "minimal", "low", "medium", "high", "adaptive"]`.

This means `xhigh` never appears in:
- `/think` command option lists and inline keyboards
- `formatThinkingLevels()` output (used in help text)

Even when the provider+model supports xhigh (e.g. `openai-codex/gpt-5.4`), users cannot select it from the UI.

## Root Cause

The local `listThinkingLevels()` correctly inserts `xhigh` before `adaptive` when `supportsXHighThinking()` returns true. However, `listThinkingLevelLabels()` bypasses this by calling the shared fallback directly instead of the local `listThinkingLevels()`.

## Fix

One-line change: `listThinkingLevelLabels()` now calls the local `listThinkingLevels()` instead of `listThinkingLevelLabelsFallback()`, so xhigh is included in the label list when the provider supports it.

## Before / After

**Before:** `/think` on `openai-codex/gpt-5.4` shows: `off, minimal, low, medium, high, adaptive`

**After:** `/think` on `openai-codex/gpt-5.4` shows: `off, minimal, low, medium, high, xhigh, adaptive`