### PR TITLE
Fix fresh session transcript rotation on reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -617,6 +617,7 @@ export async function initSessionState(params: {
     sessionsDir: path.dirname(storePath),
     fallbackSessionFile,
     activeSessionKey: sessionKey,
+    forceFreshSessionFile: resetTriggered,
   });
   sessionEntry = resolvedSessionFile.sessionEntry;
   if (isNewSession) {

--- a/src/config/sessions/session-file.ts
+++ b/src/config/sessions/session-file.ts
@@ -12,13 +12,16 @@ export async function resolveAndPersistSessionFile(params: {
   sessionsDir?: string;
   fallbackSessionFile?: string;
   activeSessionKey?: string;
+  forceFreshSessionFile?: boolean;
 }): Promise<{ sessionFile: string; sessionEntry: SessionEntry }> {
   const { sessionId, sessionKey, sessionStore, storePath } = params;
   const baseEntry = params.sessionEntry ??
     sessionStore[sessionKey] ?? { sessionId, updatedAt: Date.now() };
   const fallbackSessionFile = params.fallbackSessionFile?.trim();
-  const entryForResolve =
-    !baseEntry.sessionFile && fallbackSessionFile
+  const forceFreshSessionFile = params.forceFreshSessionFile === true;
+  const entryForResolve = forceFreshSessionFile
+    ? { ...baseEntry, sessionId, sessionFile: undefined }
+    : !baseEntry.sessionFile && fallbackSessionFile
       ? { ...baseEntry, sessionFile: fallbackSessionFile }
       : baseEntry;
   const sessionFile = resolveSessionFilePath(sessionId, entryForResolve, {


### PR DESCRIPTION
## Summary

Fix `/new` and `/reset` so they force a fresh backing session transcript file instead of reusing the prior `sessionFile` pointer for the same channel session entry.

This makes reset behavior match the expected mental model for long-lived chat surfaces like Discord guild channels and Telegram chats: same channel/session key, but truly fresh underlying transcript after reset.

## Problem

In practice, a channel reset could still carry forward the previous transcript file because `resolveSessionFilePath()` reused `entry.sessionFile` when present.

That meant a channel could appear fresh at the UX layer while still retaining old transcript baggage underneath.

In our case, this showed up as:
- a large Discord channel session hitting preemptive context overflow
- auto-compaction timing out
- the session restarting
- the channel continuing to point at a heavy backing transcript instead of getting a truly fresh one
- stale `running` session state and queued messages behind a dead turn

## Fix

Add an explicit `forceFreshSessionFile` path to `resolveAndPersistSessionFile()` and use it for reset-triggered sessions.

When `/new` or `/reset` triggers a fresh session:
- keep the new `sessionId`
- intentionally ignore the prior `sessionFile`
- resolve a brand new transcript path for that new session
- persist the new session entry against that fresh file

## Files changed

- `src/config/sessions/session-file.ts`
- `src/auto-reply/reply/session.ts`

## Validation

Focused tests passed for the touched area after installing repo deps locally.

Note: committing with the repo's default verification hooks was blocked by an unrelated TypeScript error in `extensions/elevenlabs/speech-provider.ts` (`Cannot find name 'asNumber'`), which is outside the scope of this patch.

## Expected behavior after this PR

For long-lived chat surfaces:
- channel identity stays stable
- `/new` and `/reset` produce a truly fresh transcript backing file
- continuity comes from memory / carried metadata, not hidden reuse of the old transcript file
