### PR TITLE
fix(bluebubbles): coerce bare integer allowFrom entries to +E.164 strings

### DIFF
--- a/extensions/bluebubbles/src/targets.test.ts
+++ b/extensions/bluebubbles/src/targets.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBlueBubblesHandle } from "./targets.js";
+
+describe("normalizeBlueBubblesHandle", () => {
+  it("prefixes all-digit input with +", () => {
+    expect(normalizeBlueBubblesHandle("19175551234")).toBe("+19175551234");
+  });
+
+  it("leaves already-prefixed E.164 number unchanged", () => {
+    expect(normalizeBlueBubblesHandle("+19175551234")).toBe("+19175551234");
+  });
+
+  it("leaves email handle unchanged (lowercased)", () => {
+    expect(normalizeBlueBubblesHandle("User@Example.com")).toBe("user@example.com");
+  });
+
+  it("strips service prefix before normalizing digits", () => {
+    expect(normalizeBlueBubblesHandle("iMessage:19175551234")).toBe("+19175551234");
+    expect(normalizeBlueBubblesHandle("sms:19175551234")).toBe("+19175551234");
+    expect(normalizeBlueBubblesHandle("auto:19175551234")).toBe("+19175551234");
+  });
+
+  it("strips spaces from all-digit number and prefixes with +", () => {
+    expect(normalizeBlueBubblesHandle("1 917 555 1234")).toBe("+19175551234");
+  });
+
+  it("returns empty string for blank input", () => {
+    expect(normalizeBlueBubblesHandle("")).toBe("");
+    expect(normalizeBlueBubblesHandle("  ")).toBe("");
+  });
+});

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -127,7 +127,9 @@ export function normalizeBlueBubblesHandle(raw: string): string {
   if (trimmed.includes("@")) {
     return trimmed.toLowerCase();
   }
-  return trimmed.replace(/\s+/g, "");
+  const noSpaces = trimmed.replace(/\s+/g, "");
+  if (/^\d+$/.test(noSpaces)) return `+${noSpaces}`;
+  return noSpaces;
 }
 
 /**

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -128,7 +128,9 @@ export function normalizeBlueBubblesHandle(raw: string): string {
     return trimmed.toLowerCase();
   }
   const noSpaces = trimmed.replace(/\s+/g, "");
-  if (/^\d+$/.test(noSpaces)) return `+${noSpaces}`;
+  if (/^\d+$/.test(noSpaces)) {
+    return `+${noSpaces}`;
+  }
   return noSpaces;
 }
 

--- a/src/channels/plugins/config-schema.test.ts
+++ b/src/channels/plugins/config-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { buildChannelConfigSchema, emptyChannelConfigSchema } from "./config-schema.js";
+import { AllowFromEntrySchema, buildChannelConfigSchema, emptyChannelConfigSchema } from "./config-schema.js";
 
 describe("buildChannelConfigSchema", () => {
   it("builds json schema when toJSONSchema is available", () => {
@@ -63,5 +63,15 @@ describe("emptyChannelConfigSchema", () => {
       success: false,
       issues: [{ path: [], message: "config must be empty" }],
     });
+  });
+});
+
+describe("AllowFromEntrySchema", () => {
+  it("passes string values through unchanged", () => {
+    expect(AllowFromEntrySchema.parse("+19175551234")).toBe("+19175551234");
+  });
+
+  it("transforms numeric entries to +-prefixed E.164 strings", () => {
+    expect(AllowFromEntrySchema.parse(19175551234)).toBe("+19175551234");
   });
 });

--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -15,7 +15,7 @@ type ExtendableZodObject = ZodTypeAny & {
   extend: (shape: Record<string, ZodTypeAny>) => ZodTypeAny;
 };
 
-export const AllowFromEntrySchema = z.union([z.string(), z.number()]);
+export const AllowFromEntrySchema = z.union([z.string(), z.number().transform(n => `+${n}`)]);
 export const AllowFromListSchema = z.array(AllowFromEntrySchema).optional();
 
 export function buildNestedDmConfigSchema<TExtraShape extends ZodRawShape = {}>(


### PR DESCRIPTION
## Problem

When phone numbers are saved via the dashboard under **BlueBubbles → dmPolicy allowlist**, they are written back to `openclaw.json` as bare integers (e.g. `19175551234`) instead of `+E.164` strings (e.g. `"+19175551234"`). With `dmPolicy: "allowlist"`, every incoming message from those numbers is silently dropped because the handle comparison never matches.

Closes #49790

## Root cause

Two places need to handle this:

1. **Schema parse time** (`AllowFromEntrySchema` in `config-schema.ts`) — the `z.number()` branch accepted integers but passed them through as numbers. When Zod parses the config, a bare integer makes it into the allowlist as a number, not a `+`-prefixed string.

2. **Runtime matching** (`normalizeBlueBubblesHandle` in `targets.ts`) — even if an integer somehow survived into the allowlist array, the normalizer would return it without a `+`, so it would never match an incoming `+19175551234` handle.

## Fix

- `AllowFromEntrySchema`: add `.transform(n => \`+\${n}\`)` to the `z.number()` branch — integers are coerced to `+strings` at schema parse time.
- `normalizeBlueBubblesHandle`: add a guard for all-digit strings that prepends `+` — fixes runtime matching for any numbers already stored as integers in existing configs.

## Testing

With `dmPolicy: "allowlist"` and an integer entry saved by the dashboard, incoming messages from that number now route correctly instead of being dropped.