### PR TITLE
Google provider: implement proper Vertex AI endpoint routing

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -63,6 +63,14 @@ describe("google generative ai helpers", () => {
     ).toBe(false);
   });
 
+  it("does not treat google-vertex as a google-generative-ai provider", () => {
+    expect(
+      shouldNormalizeGoogleGenerativeAiProviderConfig("google-vertex", {
+        models: [{ api: "openai-completions" }],
+      }),
+    ).toBe(false);
+  });
+
   it("normalizes transport baseUrls only for Google Generative AI", () => {
     expect(
       resolveGoogleGenerativeAiTransport({

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -79,8 +79,11 @@ export function shouldNormalizeGoogleGenerativeAiProviderConfig(
   providerKey: string,
   provider: GoogleProviderConfigLike,
 ): boolean {
-  if (providerKey === "google" || providerKey === "google-vertex") {
+  if (providerKey === "google") {
     return true;
+  }
+  if (providerKey === "google-vertex") {
+    return false;
   }
   if (isGoogleGenerativeAiApi(provider.api)) {
     return true;
@@ -94,6 +97,7 @@ export function shouldNormalizeGoogleProviderConfig(
 ): boolean {
   return (
     providerKey === "google-antigravity" ||
+    providerKey === "google-vertex" ||
     shouldNormalizeGoogleGenerativeAiProviderConfig(providerKey, provider)
   );
 }
@@ -133,6 +137,10 @@ export function normalizeGoogleProviderConfig(
       normalizedBaseUrl !== modelNormalized.baseUrl
         ? { ...modelNormalized, baseUrl: normalizedBaseUrl ?? modelNormalized.baseUrl }
         : modelNormalized;
+  }
+
+  if (providerKey === "google-vertex") {
+    nextProvider = normalizeProviderModels(nextProvider, normalizeGoogleModelId);
   }
 
   if (providerKey === "google-antigravity") {

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -20,6 +20,7 @@ import { isModernGoogleModel, resolveGoogleGeminiForwardCompatModel } from "./pr
 import { createGeminiWebSearchProvider } from "./src/gemini-web-search-provider.js";
 import {
   buildGoogleVertexBaseUrl,
+  isValidGoogleVertexRegion,
   resolveGoogleVertexProjectId,
   resolveGoogleVertexRegion,
 } from "./vertex-region.js";
@@ -210,7 +211,10 @@ export default definePluginEntry({
               initialValue: resolveGoogleVertexRegion(env),
               placeholder: "us-central1",
             });
-            const locationStr = String(location).trim() || resolveGoogleVertexRegion(env);
+            const raw = String(location).trim() || resolveGoogleVertexRegion(env);
+            const locationStr = isValidGoogleVertexRegion(raw)
+              ? raw
+              : resolveGoogleVertexRegion(env);
 
             const spin = ctx.prompter.progress("Starting Google OAuth for Vertex AI…");
             try {

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -1,6 +1,7 @@
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
 import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { ProviderAuthContext } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import { buildProviderStreamFamilyHooks } from "openclaw/plugin-sdk/provider-stream-family";
@@ -14,8 +15,14 @@ import {
 import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import { buildGoogleMusicGenerationProvider } from "./music-generation-provider.js";
+import { formatGoogleOauthApiKey } from "./oauth-token-shared.js";
 import { isModernGoogleModel, resolveGoogleGeminiForwardCompatModel } from "./provider-models.js";
 import { createGeminiWebSearchProvider } from "./src/gemini-web-search-provider.js";
+import {
+  buildGoogleVertexBaseUrl,
+  resolveGoogleVertexProjectId,
+  resolveGoogleVertexRegion,
+} from "./vertex-region.js";
 import { buildGoogleVideoGenerationProvider } from "./video-generation-provider.js";
 
 let googleImageGenerationProviderPromise: Promise<ImageGenerationProvider> | null = null;
@@ -34,6 +41,9 @@ const GOOGLE_GEMINI_PROVIDER_HOOKS = {
   }),
   ...buildProviderStreamFamilyHooks("google-thinking"),
 };
+
+const GOOGLE_VERTEX_PROVIDER_ID = "google-vertex";
+const GOOGLE_VERTEX_DEFAULT_MODEL = `${GOOGLE_VERTEX_PROVIDER_ID}/gemini-3.1-pro-preview`;
 
 async function loadGoogleImageGenerationProvider(): Promise<ImageGenerationProvider> {
   if (!googleImageGenerationProviderPromise) {
@@ -130,7 +140,7 @@ export default definePluginEntry({
       id: "google",
       label: "Google AI Studio",
       docsPath: "/providers/models",
-      hookAliases: ["google-antigravity", "google-vertex"],
+      hookAliases: ["google-antigravity"],
       envVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
       auth: [
         createProviderApiKeyAuthMethod({
@@ -164,6 +174,145 @@ export default definePluginEntry({
           providerId: ctx.provider,
           ctx,
         }),
+      ...GOOGLE_GEMINI_PROVIDER_HOOKS,
+      isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
+    });
+    api.registerProvider({
+      id: GOOGLE_VERTEX_PROVIDER_ID,
+      label: "Google Vertex AI",
+      docsPath: "/providers/models",
+      envVars: [
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_PROJECT_ID",
+        "GOOGLE_CLOUD_LOCATION",
+        "CLOUD_ML_REGION",
+      ],
+      auth: [
+        {
+          id: "oauth",
+          label: "Google Vertex AI OAuth",
+          hint: "Google OAuth for Vertex AI with project + location",
+          kind: "oauth" as const,
+          wizard: {
+            choiceId: "google-vertex-oauth",
+            choiceLabel: "Google Vertex AI (OAuth)",
+            choiceHint: "Google OAuth targeting Vertex AI endpoints",
+            groupId: "google",
+            groupLabel: "Google",
+            groupHint: "Gemini API key + OAuth + Vertex AI",
+          },
+          run: async (ctx: ProviderAuthContext) => {
+            const env = ctx.env ?? process.env;
+            const location = await ctx.prompter.text({
+              message: "Vertex AI location (region)",
+              initialValue: resolveGoogleVertexRegion(env),
+              placeholder: "us-central1",
+            });
+            const locationStr = String(location).trim() || resolveGoogleVertexRegion(env);
+
+            const spin = ctx.prompter.progress("Starting Google OAuth for Vertex AI…");
+            try {
+              const { loginGeminiCliOAuth } = await import("./oauth.runtime.js");
+              const result = await loginGeminiCliOAuth({
+                isRemote: ctx.isRemote,
+                openUrl: ctx.openUrl,
+                log: (msg) => ctx.runtime.log(msg),
+                note: ctx.prompter.note,
+                prompt: async (message) => String(await ctx.prompter.text({ message })),
+                progress: spin,
+              });
+
+              spin.stop("Google Vertex AI OAuth complete");
+
+              const projectId = result.projectId || resolveGoogleVertexProjectId(env);
+              if (!projectId) {
+                throw new Error(
+                  "Could not determine Google Cloud project ID. Set GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID.",
+                );
+              }
+
+              const baseUrl = buildGoogleVertexBaseUrl({
+                region: locationStr,
+                projectId,
+              });
+
+              const { buildOauthProviderAuthResult } =
+                await import("openclaw/plugin-sdk/provider-auth-result");
+              return buildOauthProviderAuthResult({
+                providerId: GOOGLE_VERTEX_PROVIDER_ID,
+                defaultModel: GOOGLE_VERTEX_DEFAULT_MODEL,
+                access: result.access,
+                refresh: result.refresh,
+                expires: result.expires,
+                email: result.email,
+                ...(result.projectId ? { credentialExtra: { projectId: result.projectId } } : {}),
+                configPatch: {
+                  models: {
+                    providers: {
+                      [GOOGLE_VERTEX_PROVIDER_ID]: {
+                        baseUrl,
+                        api: "google-generative-ai",
+                      },
+                    },
+                  },
+                } as never,
+                notes: [
+                  `Vertex AI endpoint: ${locationStr}`,
+                  "If requests fail, verify GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION.",
+                ],
+              });
+            } catch (err) {
+              spin.stop("Google Vertex AI OAuth failed");
+              throw err;
+            }
+          },
+        },
+      ],
+      catalog: {
+        order: "simple" as const,
+        run: async (ctx) => {
+          const env = ctx.env;
+          const existing = ctx.config.models?.providers?.[GOOGLE_VERTEX_PROVIDER_ID];
+
+          // If user already has an explicit baseUrl configured, respect it
+          if (existing?.baseUrl) {
+            return null;
+          }
+
+          const projectId = resolveGoogleVertexProjectId(env);
+          if (!projectId) {
+            return null;
+          }
+
+          const apiKey = ctx.resolveProviderApiKey(GOOGLE_VERTEX_PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+
+          const region = resolveGoogleVertexRegion(env);
+          const baseUrl = buildGoogleVertexBaseUrl({ region, projectId });
+
+          return {
+            provider: {
+              baseUrl,
+              api: "google-generative-ai",
+              apiKey,
+              models: existing?.models ?? [],
+            },
+          };
+        },
+      },
+      normalizeConfig: ({ provider, providerConfig }) =>
+        normalizeGoogleProviderConfig(provider, providerConfig),
+      normalizeModelId: ({ modelId }) => normalizeGoogleModelId(modelId),
+      resolveDynamicModel: (ctx) =>
+        resolveGoogleGeminiForwardCompatModel({
+          providerId: ctx.provider,
+          ctx,
+        }),
+      formatApiKey: (cred) => formatGoogleOauthApiKey(cred),
       ...GOOGLE_GEMINI_PROVIDER_HOOKS,
       isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
     });

--- a/extensions/google/setup-api.ts
+++ b/extensions/google/setup-api.ts
@@ -9,7 +9,7 @@ export default definePluginEntry({
     api.registerProvider({
       id: "google",
       label: "Google AI Studio",
-      hookAliases: ["google-antigravity", "google-vertex"],
+      hookAliases: ["google-antigravity"],
       auth: [],
       normalizeConfig: ({ provider, providerConfig }) =>
         normalizeGoogleProviderConfig(provider, providerConfig),

--- a/extensions/google/vertex-region.test.ts
+++ b/extensions/google/vertex-region.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildGoogleVertexBaseUrl,
+  isValidGoogleVertexRegion,
   resolveGoogleVertexProjectId,
   resolveGoogleVertexRegion,
   resolveGoogleVertexRegionFromBaseUrl,
@@ -136,6 +137,32 @@ describe("google vertex region helpers", () => {
       expect(buildGoogleVertexBaseUrl({ region: "europe-west4", projectId: "eu-proj" })).toBe(
         "https://europe-west4-aiplatform.googleapis.com/v1/projects/eu-proj/locations/europe-west4/publishers/google",
       );
+    });
+
+    it("rejects malformed region values", () => {
+      expect(() =>
+        buildGoogleVertexBaseUrl({ region: "us-central1.typo", projectId: "proj" }),
+      ).toThrow("Invalid Vertex AI region");
+    });
+
+    it("rejects region with slashes", () => {
+      expect(() => buildGoogleVertexBaseUrl({ region: "us/central1", projectId: "proj" })).toThrow(
+        "Invalid Vertex AI region",
+      );
+    });
+  });
+
+  describe("isValidGoogleVertexRegion", () => {
+    it("accepts well-formed region strings", () => {
+      expect(isValidGoogleVertexRegion("us-central1")).toBe(true);
+      expect(isValidGoogleVertexRegion("europe-west4")).toBe(true);
+      expect(isValidGoogleVertexRegion("global")).toBe(true);
+    });
+
+    it("rejects malformed region strings", () => {
+      expect(isValidGoogleVertexRegion("us-central1.attacker.example")).toBe(false);
+      expect(isValidGoogleVertexRegion("us/central1")).toBe(false);
+      expect(isValidGoogleVertexRegion("")).toBe(false);
     });
   });
 });

--- a/extensions/google/vertex-region.test.ts
+++ b/extensions/google/vertex-region.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGoogleVertexBaseUrl,
+  resolveGoogleVertexProjectId,
+  resolveGoogleVertexRegion,
+  resolveGoogleVertexRegionFromBaseUrl,
+} from "./vertex-region.js";
+
+describe("google vertex region helpers", () => {
+  describe("resolveGoogleVertexRegion", () => {
+    it("uses GOOGLE_CLOUD_LOCATION when set", () => {
+      expect(
+        resolveGoogleVertexRegion({
+          GOOGLE_CLOUD_LOCATION: "europe-west4",
+        } as NodeJS.ProcessEnv),
+      ).toBe("europe-west4");
+    });
+
+    it("falls back to CLOUD_ML_REGION", () => {
+      expect(
+        resolveGoogleVertexRegion({
+          CLOUD_ML_REGION: "asia-east1",
+        } as NodeJS.ProcessEnv),
+      ).toBe("asia-east1");
+    });
+
+    it("prefers GOOGLE_CLOUD_LOCATION over CLOUD_ML_REGION", () => {
+      expect(
+        resolveGoogleVertexRegion({
+          GOOGLE_CLOUD_LOCATION: "us-west1",
+          CLOUD_ML_REGION: "us-east1",
+        } as NodeJS.ProcessEnv),
+      ).toBe("us-west1");
+    });
+
+    it("defaults to us-central1 when no env is set", () => {
+      expect(resolveGoogleVertexRegion({} as NodeJS.ProcessEnv)).toBe("us-central1");
+    });
+
+    it("rejects malformed region values", () => {
+      expect(
+        resolveGoogleVertexRegion({
+          GOOGLE_CLOUD_LOCATION: "us-central1.attacker.example",
+        } as NodeJS.ProcessEnv),
+      ).toBe("us-central1");
+    });
+
+    it("rejects empty and whitespace-only values", () => {
+      expect(
+        resolveGoogleVertexRegion({
+          GOOGLE_CLOUD_LOCATION: "  ",
+        } as NodeJS.ProcessEnv),
+      ).toBe("us-central1");
+    });
+  });
+
+  describe("resolveGoogleVertexProjectId", () => {
+    it("resolves from GOOGLE_CLOUD_PROJECT", () => {
+      expect(
+        resolveGoogleVertexProjectId({
+          GOOGLE_CLOUD_PROJECT: "my-project",
+        } as NodeJS.ProcessEnv),
+      ).toBe("my-project");
+    });
+
+    it("falls back to GOOGLE_CLOUD_PROJECT_ID", () => {
+      expect(
+        resolveGoogleVertexProjectId({
+          GOOGLE_CLOUD_PROJECT_ID: "other-project",
+        } as NodeJS.ProcessEnv),
+      ).toBe("other-project");
+    });
+
+    it("prefers GOOGLE_CLOUD_PROJECT over GOOGLE_CLOUD_PROJECT_ID", () => {
+      expect(
+        resolveGoogleVertexProjectId({
+          GOOGLE_CLOUD_PROJECT: "primary",
+          GOOGLE_CLOUD_PROJECT_ID: "secondary",
+        } as NodeJS.ProcessEnv),
+      ).toBe("primary");
+    });
+
+    it("returns undefined when no project env is set", () => {
+      expect(resolveGoogleVertexProjectId({} as NodeJS.ProcessEnv)).toBeUndefined();
+    });
+  });
+
+  describe("resolveGoogleVertexRegionFromBaseUrl", () => {
+    it("extracts region from a regional Vertex endpoint", () => {
+      expect(
+        resolveGoogleVertexRegionFromBaseUrl("https://us-central1-aiplatform.googleapis.com"),
+      ).toBe("us-central1");
+    });
+
+    it("returns global for the global Vertex endpoint", () => {
+      expect(resolveGoogleVertexRegionFromBaseUrl("https://aiplatform.googleapis.com")).toBe(
+        "global",
+      );
+    });
+
+    it("returns undefined for non-Vertex endpoints", () => {
+      expect(
+        resolveGoogleVertexRegionFromBaseUrl("https://generativelanguage.googleapis.com/v1beta"),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for proxy hosts", () => {
+      expect(
+        resolveGoogleVertexRegionFromBaseUrl("https://proxy.example.com/aiplatform"),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("buildGoogleVertexBaseUrl", () => {
+    it("builds a regional Vertex AI base URL", () => {
+      expect(buildGoogleVertexBaseUrl({ region: "us-central1", projectId: "my-project" })).toBe(
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google",
+      );
+    });
+
+    it("builds a global Vertex AI base URL", () => {
+      expect(buildGoogleVertexBaseUrl({ region: "global", projectId: "my-project" })).toBe(
+        "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global/publishers/google",
+      );
+    });
+
+    it("encodes special characters in project ID", () => {
+      const url = buildGoogleVertexBaseUrl({
+        region: "us-central1",
+        projectId: "my project/id",
+      });
+      expect(url).toContain("my%20project%2Fid");
+    });
+
+    it("uses correct endpoint for europe-west4", () => {
+      expect(buildGoogleVertexBaseUrl({ region: "europe-west4", projectId: "eu-proj" })).toBe(
+        "https://europe-west4-aiplatform.googleapis.com/v1/projects/eu-proj/locations/europe-west4/publishers/google",
+      );
+    });
+  });
+});

--- a/extensions/google/vertex-region.ts
+++ b/extensions/google/vertex-region.ts
@@ -3,6 +3,10 @@ import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-http";
 const GOOGLE_VERTEX_DEFAULT_REGION = "us-central1";
 const GOOGLE_VERTEX_REGION_RE = /^[a-z0-9-]+$/;
 
+export function isValidGoogleVertexRegion(value: string): boolean {
+  return GOOGLE_VERTEX_REGION_RE.test(value);
+}
+
 function normalizeOptionalString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -42,6 +46,9 @@ export function resolveGoogleVertexRegionFromBaseUrl(baseUrl?: string): string |
  */
 export function buildGoogleVertexBaseUrl(params: { region: string; projectId: string }): string {
   const { region, projectId } = params;
+  if (!isValidGoogleVertexRegion(region)) {
+    throw new Error(`Invalid Vertex AI region: ${region}`);
+  }
   const host =
     region.toLowerCase() === "global"
       ? "https://aiplatform.googleapis.com"

--- a/extensions/google/vertex-region.ts
+++ b/extensions/google/vertex-region.ts
@@ -1,0 +1,50 @@
+import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-http";
+
+const GOOGLE_VERTEX_DEFAULT_REGION = "us-central1";
+const GOOGLE_VERTEX_REGION_RE = /^[a-z0-9-]+$/;
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function resolveGoogleVertexRegion(env: NodeJS.ProcessEnv = process.env): string {
+  const region =
+    normalizeOptionalString(env.GOOGLE_CLOUD_LOCATION) ||
+    normalizeOptionalString(env.CLOUD_ML_REGION);
+
+  return region && GOOGLE_VERTEX_REGION_RE.test(region) ? region : GOOGLE_VERTEX_DEFAULT_REGION;
+}
+
+export function resolveGoogleVertexProjectId(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return (
+    normalizeOptionalString(env.GOOGLE_CLOUD_PROJECT) ||
+    normalizeOptionalString(env.GOOGLE_CLOUD_PROJECT_ID)
+  );
+}
+
+export function resolveGoogleVertexRegionFromBaseUrl(baseUrl?: string): string | undefined {
+  const endpoint = resolveProviderEndpoint(baseUrl);
+  return endpoint.endpointClass === "google-vertex" ? endpoint.googleVertexRegion : undefined;
+}
+
+/**
+ * Build the full Vertex AI base URL for Google Gemini models.
+ *
+ * Format: https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google
+ *
+ * The transport layer appends `/models/{model}:streamGenerateContent?alt=sse`.
+ */
+export function buildGoogleVertexBaseUrl(params: { region: string; projectId: string }): string {
+  const { region, projectId } = params;
+  const host =
+    region.toLowerCase() === "global"
+      ? "https://aiplatform.googleapis.com"
+      : `https://${region}-aiplatform.googleapis.com`;
+  return `${host}/v1/projects/${encodeURIComponent(projectId)}/locations/${encodeURIComponent(region)}/publishers/google`;
+}


### PR DESCRIPTION
## Summary

- Problem: The `google-vertex` hook alias was a no-op that routed through the same Gemini API OAuth flow with no Vertex AI-specific behavior. No location/region field, no Vertex endpoint routing, no way to distinguish Gemini API mode from Vertex AI mode.
- Why it matters: Users with Vertex AI access cannot use Gemini models through Vertex AI endpoints, which have different pricing, availability, and compliance properties.
- What changed: Registered `google-vertex` as a standalone provider with Vertex AI endpoint construction, OAuth onboarding with location collection, and auto-discovery catalog from env vars.
- What did NOT change (scope boundary): No changes to the transport layer (`google-transport-stream.ts`), no changes to the existing `google` or `google-gemini-cli` providers, no changes to the plugin SDK.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60736
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A -- new feature.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/google/vertex-region.test.ts`, `extensions/google/api.test.ts`
- Scenario the test should lock in: Region resolution from env vars, Vertex base URL construction, region validation, config normalization for google-vertex key
- Why this is the smallest reliable guardrail: Unit tests for the new helpers cover all input validation paths and URL construction logic
- If no new test is added, why not: New tests were added (20 new test cases)

## User-visible / Behavior Changes

- New provider `google-vertex` appears in onboarding wizard under the Google group
- `openclaw models auth login` with google-vertex choice prompts for Vertex AI location (region)
- With `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION` env vars set, google-vertex auto-discovers and constructs Vertex AI endpoints
- Default region: `us-central1` (matches GCP conventions)

## Diagram (if applicable)

```text
Before:
google-vertex hookAlias -> same google provider -> generativelanguage.googleapis.com (no-op)

After:
google-vertex provider -> OAuth + location prompt -> {region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:streamGenerateContent
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No (reuses existing Google OAuth flow with same scopes)
- New/changed network calls? Yes -- requests route to `{region}-aiplatform.googleapis.com` instead of `generativelanguage.googleapis.com` when using google-vertex
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: The Vertex AI endpoint is a Google-operated API surface. The existing OAuth scopes already include `cloud-platform`. Region is validated against `^[a-z0-9-]+$` before being embedded in the hostname.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Model/provider: Google Vertex AI
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Set `GOOGLE_CLOUD_PROJECT=my-project` and `GOOGLE_CLOUD_LOCATION=us-central1`
2. Run `openclaw models auth login` and select Google Vertex AI (OAuth)
3. Complete OAuth flow

### Expected

- Vertex AI endpoint is configured: `https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google`

### Actual

- Before: google-vertex was a no-op alias that routed to generativelanguage.googleapis.com

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test results:
- `pnpm test:extension google`: 15 files, 118 tests passed
- `pnpm test:contracts:plugins`: 81 files, 345 tests passed
- `pnpm build`: zero errors from google extension (pre-existing failures in extensions/memory-core only)

## Human Verification (required)

- Verified scenarios: All extension tests, plugin contract tests, type checking, lint, format
- Edge cases checked: Malformed region input (validated and rejected), missing project ID (throws with helpful message), global region endpoint
- What you did **not** verify: Live Vertex AI API calls (no GCP project available in this environment)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes -- new env vars `GOOGLE_CLOUD_LOCATION` / `CLOUD_ML_REGION` for Vertex AI region (optional, defaults to us-central1)
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Removing `google-vertex` from hookAliases could break configs that reference `google-vertex` as a provider key without the new provider registered.
  - Mitigation: The new `google-vertex` standalone provider registration handles the same key, so existing configs continue to work. Config normalization still applies model ID normalization for `google-vertex`.

---

AI-assisted: This PR was written with Claude Code (Opus 4.6). Fully tested locally. All code is understood by the author.