### PR TITLE
feat(workspace): add skipOptionalBootstrapFiles config option

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -289,6 +289,7 @@ async function prepareAgentCommandExecution(
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap,
+    skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
   });
   const workspaceDir = workspace.dir;
   const runId = opts.runId?.trim() || sessionId;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -436,8 +436,12 @@ export async function ensureAgentWorkspace(params?: {
     // indicators exist, treat setup as complete and avoid recreating BOOTSTRAP for
     // already-configured workspaces.
     const [identityContent, userContent] = await Promise.all([
-      fs.readFile(identityPath, "utf-8"),
-      fs.readFile(userPath, "utf-8"),
+      skipSet.has(DEFAULT_IDENTITY_FILENAME)
+        ? Promise.resolve(identityTemplate)
+        : fs.readFile(identityPath, "utf-8"),
+      skipSet.has(DEFAULT_USER_FILENAME)
+        ? Promise.resolve(userTemplate)
+        : fs.readFile(userPath, "utf-8"),
     ]);
     const hasUserContent = await (async () => {
       const indicators = [

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -327,6 +327,12 @@ async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean) {
 export async function ensureAgentWorkspace(params?: {
   dir?: string;
   ensureBootstrapFiles?: boolean;
+  /**
+   * List of optional bootstrap filenames to skip writing.
+   * Applies only to SOUL.md, USER.md, HEARTBEAT.md, IDENTITY.md.
+   * Required files (AGENTS.md, MEMORY.md, TOOLS.md) cannot be skipped.
+   */
+  skipOptionalBootstrapFiles?: string[];
 }): Promise<{
   dir: string;
   agentsPath?: string;
@@ -381,12 +387,32 @@ export async function ensureAgentWorkspace(params?: {
   const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
   const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
-  await writeFileIfMissing(agentsPath, agentsTemplate);
-  await writeFileIfMissing(soulPath, soulTemplate);
-  await writeFileIfMissing(toolsPath, toolsTemplate);
-  await writeFileIfMissing(identityPath, identityTemplate);
-  await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  // Determine which optional files should be skipped.
+  // Required files (AGENTS.md, MEMORY.md, TOOLS.md) are always written.
+  const OPTIONAL_BOOTSTRAP_FILES = new Set([
+    DEFAULT_SOUL_FILENAME,
+    DEFAULT_IDENTITY_FILENAME,
+    DEFAULT_USER_FILENAME,
+    DEFAULT_HEARTBEAT_FILENAME,
+  ]);
+  const skipSet = new Set(params?.skipOptionalBootstrapFiles ?? []);
+  const shouldWrite = (filename: string): boolean =>
+    !OPTIONAL_BOOTSTRAP_FILES.has(filename) || !skipSet.has(filename);
+
+  await writeFileIfMissing(agentsPath, agentsTemplate); // required — always written
+  if (shouldWrite(DEFAULT_SOUL_FILENAME)) {
+    await writeFileIfMissing(soulPath, soulTemplate);
+  }
+  await writeFileIfMissing(toolsPath, toolsTemplate); // required — always written
+  if (shouldWrite(DEFAULT_IDENTITY_FILENAME)) {
+    await writeFileIfMissing(identityPath, identityTemplate);
+  }
+  if (shouldWrite(DEFAULT_USER_FILENAME)) {
+    await writeFileIfMissing(userPath, userTemplate);
+  }
+  if (shouldWrite(DEFAULT_HEARTBEAT_FILENAME)) {
+    await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  }
 
   let state = await readWorkspaceSetupState(statePath);
   let stateDirty = false;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -149,6 +149,13 @@ export type AgentDefaultsConfig = {
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
   skipBootstrap?: boolean;
   /**
+   * List of optional bootstrap filenames to skip writing to the workspace root.
+   * Applies to: SOUL.md, USER.md, HEARTBEAT.md, IDENTITY.md.
+   * Required files (AGENTS.md, MEMORY.md, TOOLS.md) cannot be skipped.
+   * Example: ["SOUL.md", "USER.md", "HEARTBEAT.md", "IDENTITY.md"]
+   */
+  skipOptionalBootstrapFiles?: string[];
+  /**
    * Controls when workspace bootstrap files (AGENTS.md, SOUL.md, etc.) are
    * injected into the system prompt:
    * - always: inject on every turn (default)

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -44,6 +44,7 @@ export const AgentDefaultsSchema = z
     skills: z.array(z.string()).optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
+    skipOptionalBootstrapFiles: z.array(z.string()).optional(),
     contextInjection: z.union([z.literal("always"), z.literal("continuation-skip")]).optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

Allow agents to suppress optional bootstrap file generation (SOUL.md, USER.md, HEARTBEAT.md, IDENTITY.md) while preserving required files (AGENTS.md, MEMORY.md, TOOLS.md).

## Config

```json
{
  "agents": {
    "defaults": {
      "skipOptionalBootstrapFiles": ["SOUL.md", "USER.md", "HEARTBEAT.md", "IDENTITY.md"]
    }
  }
}
```

## Changes (4 files only — clean diff)

- `src/agents/workspace.ts`: `skipOptionalBootstrapFiles` param + `OPTIONAL_BOOTSTRAP_FILES` Set with conditional writes
- `src/agents/agent-command.ts`: pass `skipOptionalBootstrapFiles` through to `ensureAgentWorkspace`
- `src/config/types.agent-defaults.ts`: type declaration + JSDoc
- `src/config/zod-schema.agent-defaults.ts`: zod schema entry

## Notes

- Required files (AGENTS.md, MEMORY.md, TOOLS.md) cannot be skipped — enforced by the `OPTIONAL_BOOTSTRAP_FILES` Set
- Clean resubmission of #62058 — prior diff was contaminated with unrelated changes; this PR contains only the `skipOptionalBootstrapFiles` change