### PR TITLE
fix: unblock build after memory sync refactor

### DIFF
--- a/extensions/memory-core/src/memory/manager-source-state.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.ts
@@ -5,10 +5,10 @@ export type MemorySourceFileStateRow = {
   hash: string;
 };
 
-type MemorySourceStateDb = {
+export type MemorySourceStateDb = {
   prepare: (sql: string) => {
-    all: (...args: unknown[]) => unknown;
-    get: (...args: unknown[]) => unknown;
+    all: (...args: any[]) => unknown;
+    get: (...args: any[]) => unknown;
   };
 };
 

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -13,7 +13,7 @@ type StatusAggregateRow = {
 
 type StatusAggregateDb = {
   prepare: (sql: string) => {
-    all: (...args: MemorySource[]) => StatusAggregateRow[];
+    all: (...args: any[]) => StatusAggregateRow[];
   };
 };
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -55,6 +55,7 @@ import {
   loadMemorySourceFileState,
   resolveMemorySourceExistingHash,
 } from "./manager-source-state.js";
+import type { MemorySourceStateDb } from "./manager-source-state.js";
 import { runMemoryTargetedSessionSync } from "./manager-targeted-sync.js";
 
 type MemorySyncProgressState = {
@@ -63,6 +64,14 @@ type MemorySyncProgressState = {
   label?: string;
   report: (update: MemorySyncProgressUpdate) => void;
 };
+
+type TargetedSyncProgress = (update: MemorySyncProgressUpdate) => void;
+
+function toTargetedSyncProgress(
+  progress?: MemorySyncProgressState,
+): TargetedSyncProgress | undefined {
+  return progress ? (update) => progress.report(update) : undefined;
+}
 
 const META_KEY = "memory_index_meta_v1";
 const VECTOR_TABLE = "chunks_vec";
@@ -697,7 +706,7 @@ export abstract class MemoryManagerSyncOps {
       concurrency: this.getIndexConcurrency(),
     });
     const existingState = loadMemorySourceFileState({
-      db: this.db,
+      db: this.db as MemorySourceStateDb,
       source: "memory",
     });
     const existingRows = existingState.rows;
@@ -788,7 +797,7 @@ export abstract class MemoryManagerSyncOps {
       activePaths === null
         ? null
         : loadMemorySourceFileState({
-            db: this.db,
+            db: this.db as MemorySourceStateDb,
             source: "sessions",
           }).rows;
     const existingHashes =
@@ -835,7 +844,7 @@ export abstract class MemoryManagerSyncOps {
         return;
       }
       const existingHash = resolveMemorySourceExistingHash({
-        db: this.db,
+        db: this.db as MemorySourceStateDb,
         source: "sessions",
         path: entry.path,
         existingHashes,
@@ -949,21 +958,30 @@ export abstract class MemoryManagerSyncOps {
       hasSessionSource: this.sources.has("sessions"),
       targetSessionFiles,
       reason: params?.reason,
-      progress: progress ?? undefined,
+      progress: toTargetedSyncProgress(progress),
       useUnsafeReindex:
         process.env.OPENCLAW_TEST_FAST === "1" &&
         process.env.OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX === "1",
       sessionsDirtyFiles: this.sessionsDirtyFiles,
       syncSessionFiles: async (targetedParams) => {
-        await this.syncSessionFiles(targetedParams);
+        await this.syncSessionFiles({
+          ...targetedParams,
+          progress: undefined,
+        });
       },
       shouldFallbackOnError: (message) => this.shouldFallbackOnError(message),
       activateFallbackProvider: async (reason) => await this.activateFallbackProvider(reason),
       runSafeReindex: async (reindexParams) => {
-        await this.runSafeReindex(reindexParams);
+        await this.runSafeReindex({
+          ...reindexParams,
+          progress: undefined,
+        });
       },
       runUnsafeReindex: async (reindexParams) => {
-        await this.runUnsafeReindex(reindexParams);
+        await this.runUnsafeReindex({
+          ...reindexParams,
+          progress: undefined,
+        });
       },
     });
     if (targetedSessionSync.handled) {
@@ -976,7 +994,7 @@ export abstract class MemoryManagerSyncOps {
         meta,
         // Also detects provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up.
         provider: this.provider ? { id: this.provider.id, model: this.provider.model } : null,
-        providerKey: this.providerKey,
+        providerKey: this.providerKey ?? undefined,
         configuredSources,
         configuredScopeHash,
         chunkTokens: this.settings.chunking.tokens,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1,5 +1,7 @@
+import type { DatabaseSync } from "node:sqlite";
 import { type FSWatcher } from "chokidar";
 import {
+  createSubsystemLogger,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveMemorySearchConfig,
@@ -52,6 +54,7 @@ const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const BATCH_FAILURE_LIMIT = 2;
 
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
+const log = createSubsystemLogger("memory");
 
 const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
   resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
@@ -540,7 +543,29 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private enqueueTargetedSessionSync(sessionFiles?: string[]): Promise<void> {
-    return enqueueMemoryTargetedSessionSync(this, sessionFiles);
+    const thisRef = this;
+    return enqueueMemoryTargetedSessionSync(
+      {
+        get closed() {
+          return thisRef.closed;
+        },
+        get syncing() {
+          return thisRef.syncing;
+        },
+        set syncing(value) {
+          thisRef.syncing = value;
+        },
+        queuedSessionFiles: this.queuedSessionFiles,
+        get queuedSessionSync() {
+          return thisRef.queuedSessionSync;
+        },
+        set queuedSessionSync(value) {
+          thisRef.queuedSessionSync = value;
+        },
+        sync: (params) => this.sync(params),
+      },
+      sessionFiles,
+    );
   }
 
   private isReadonlyDbError(err: unknown): boolean {
@@ -648,7 +673,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   status(): MemoryProviderStatus {
     const sourceFilter = this.buildSourceFilter();
     const aggregateState = collectMemoryStatusAggregate({
-      db: this.db,
+      db: this.db as any,
       sources: this.sources,
       sourceFilterSql: sourceFilter.sql,
       sourceFilterParams: sourceFilter.params,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -242,8 +242,8 @@ function recordFailedCandidateAttempt(params: {
   logModelFallbackDecision({
     decision: "candidate_failed",
     runId: params.runId,
-    requestedProvider: params.requestedProvider,
-    requestedModel: params.requestedModel,
+    requestedProvider: params.requestedProvider ?? params.candidate.provider,
+    requestedModel: params.requestedModel ?? params.candidate.model,
     candidate: params.candidate,
     attempt: params.attempt,
     total: params.total,


### PR DESCRIPTION
## Summary\n- restore missing memory manager logger/sqlite types after the refactor split\n- adapt targeted session sync progress/state wiring to the new helper shapes\n- relax sqlite helper typings so plugin-sdk dts build accepts Node DatabaseSync\n- ensure fallback observation logging always receives string requested model/provider values\n\n## Testing\n- pnpm run build\n