### PR TITLE
feat(compaction): add pointer compaction mode

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -319,7 +319,7 @@ export type AgentDefaultsConfig = {
   sandbox?: AgentSandboxConfig;
 };
 
-export type AgentCompactionMode = "default" | "safeguard";
+export type AgentCompactionMode = "default" | "safeguard" | "pointer";
 export type AgentCompactionPostIndexSyncMode = "off" | "async" | "await";
 export type AgentCompactionIdentifierPolicy = "strict" | "off" | "custom";
 export type AgentCompactionQualityGuardConfig = {
@@ -344,6 +344,11 @@ export type AgentCompactionConfig = {
   customInstructions?: string;
   /** Preserve this many most-recent user/assistant turns verbatim in compaction summary context. */
   recentTurnsPreserve?: number;
+  /**
+   * Number of most-recent user/assistant turn pairs to preserve verbatim in pointer compaction.
+   * Only applies when compaction.mode is "pointer". Default: 10.
+   */
+  hotTailTurns?: number;
   /** Identifier-preservation instruction policy for compaction summaries. */
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   /** Custom identifier-preservation instructions used when identifierPolicy is "custom". */

--- a/src/context-engine/init.ts
+++ b/src/context-engine/init.ts
@@ -1,4 +1,5 @@
 import { registerLegacyContextEngine } from "./legacy.js";
+import { registerPointerContextEngine } from "./pointer.js";
 
 /**
  * Ensures all built-in context engines are registered exactly once.
@@ -6,6 +7,9 @@ import { registerLegacyContextEngine } from "./legacy.js";
  * The legacy engine is always registered as a safe fallback so that
  * `resolveContextEngine()` can resolve the default "legacy" slot without
  * callers needing to remember manual registration.
+ *
+ * The pointer engine is always registered so it is available when
+ * compaction.mode is "pointer" or plugins.slots.contextEngine is "pointer".
  *
  * Additional engines are registered by their own plugins via
  * `api.registerContextEngine()` during plugin load.
@@ -20,4 +24,8 @@ export function ensureContextEnginesInitialized(): void {
 
   // Always available – safe fallback for the "legacy" slot default.
   registerLegacyContextEngine();
+
+  // Opt-in lossless compaction mode: selected via compaction.mode="pointer"
+  // or plugins.slots.contextEngine="pointer".
+  registerPointerContextEngine();
 }

--- a/src/context-engine/pointer.test.ts
+++ b/src/context-engine/pointer.test.ts
@@ -1,0 +1,220 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AssistantMessage, Message, UserMessage } from "@mariozechner/pi-ai";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PointerContextEngine } from "./pointer.js";
+
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function makeUserMsg(text: string, timestamp = Date.now()): UserMessage {
+  return { role: "user", content: text, timestamp };
+}
+
+function makeAssistantMsg(text: string, timestamp = Date.now()): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "messages",
+    provider: "anthropic",
+    model: "test-model",
+    stopReason: "stop",
+    timestamp,
+    usage: ZERO_USAGE,
+  };
+}
+
+function seedSession(sessionFile: string, turnCount: number): SessionManager {
+  fs.writeFileSync(sessionFile, "");
+  const sm = SessionManager.open(sessionFile);
+  for (let i = 0; i < turnCount; i++) {
+    sm.appendMessage(makeUserMsg(`User message ${i + 1}`));
+    sm.appendMessage(makeAssistantMsg(`Assistant response ${i + 1}`));
+  }
+  return sm;
+}
+
+describe("PointerContextEngine", () => {
+  let tmpDir: string;
+  let engine: PointerContextEngine;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pointer-test-"));
+    engine = new PointerContextEngine();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips compaction when under budget", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    seedSession(sessionFile, 5);
+
+    const result = await engine.compact({
+      sessionId: "test",
+      sessionFile,
+      tokenBudget: 1_000_000, // very large budget
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toContain("within budget");
+  });
+
+  it("compacts when forced even if under budget", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    seedSession(sessionFile, 15);
+
+    const result = await engine.compact({
+      sessionId: "test",
+      sessionFile,
+      tokenBudget: 1_000_000,
+      force: true,
+      runtimeContext: {
+        config: {
+          agents: { defaults: { compaction: { hotTailTurns: 5 } } },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.result?.summary).toContain("📌");
+    expect(result.result?.summary).toContain("compacted");
+    expect(result.result?.tokensAfter).toBeLessThan(result.result!.tokensBefore);
+  });
+
+  it("preserves hot tail turns", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    seedSession(sessionFile, 20);
+
+    const result = await engine.compact({
+      sessionId: "test",
+      sessionFile,
+      tokenBudget: 100,
+      force: true,
+      runtimeContext: {
+        config: {
+          agents: { defaults: { compaction: { hotTailTurns: 5 } } },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+
+    // After compaction, re-read the session and verify the last 5 turn pairs survive
+    const sm = SessionManager.open(sessionFile);
+    const branch = sm.getBranch() as Array<{
+      type: string;
+      message?: { role: string; content: unknown };
+    }>;
+    const msgs = branch.filter((e) => e.type === "message" && e.message);
+
+    // Last messages should still be the original hot tail content
+    const lastUserMsgs = msgs
+      .filter((e) => e.message?.role === "user")
+      .map((e) => e.message?.content);
+    expect(lastUserMsgs[lastUserMsgs.length - 1]).toBe("User message 20");
+  });
+
+  it("is idempotent when already compacted", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    seedSession(sessionFile, 15);
+
+    // First compaction
+    await engine.compact({
+      sessionId: "test",
+      sessionFile,
+      tokenBudget: 100,
+      force: true,
+      runtimeContext: {
+        config: {
+          agents: { defaults: { compaction: { hotTailTurns: 5 } } },
+        },
+      },
+    });
+
+    // Second compaction — should be a no-op (compaction markers block further eviction)
+    const result2 = await engine.compact({
+      sessionId: "test",
+      sessionFile,
+      tokenBudget: 1_000_000,
+    });
+
+    expect(result2.ok).toBe(true);
+    expect(result2.compacted).toBe(false);
+  });
+
+  it("handles empty sessions gracefully", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    fs.writeFileSync(sessionFile, "");
+    SessionManager.open(sessionFile);
+
+    const result = await engine.compact({
+      sessionId: "test",
+      sessionFile,
+      tokenBudget: 100,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toContain("empty");
+  });
+
+  it("includes topic hints in the marker", async () => {
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    fs.writeFileSync(sessionFile, "");
+    const sm = SessionManager.open(sessionFile);
+
+    // Add messages with tool calls for richer hints
+    for (let i = 0; i < 15; i++) {
+      sm.appendMessage(makeUserMsg(`Tell me about topic number ${i + 1} in great detail`));
+      sm.appendMessage(makeAssistantMsg(`Here is information about topic ${i + 1}`));
+    }
+
+    const result = await engine.compact({
+      sessionId: "test",
+      sessionFile,
+      tokenBudget: 100,
+      force: true,
+      runtimeContext: {
+        config: {
+          agents: { defaults: { compaction: { hotTailTurns: 3 } } },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    // Marker should contain topic hints derived from message content
+    expect(result.result?.summary).toContain("Topics:");
+  });
+
+  describe("info", () => {
+    it("identifies as pointer engine that owns compaction", () => {
+      expect(engine.info.id).toBe("pointer");
+      expect(engine.info.ownsCompaction).toBe(true);
+    });
+  });
+
+  describe("assemble", () => {
+    it("passes messages through unchanged", async () => {
+      const msgs = [makeUserMsg("hello"), makeAssistantMsg("hi")] as Message[];
+      const result = await engine.assemble({
+        sessionId: "test",
+        messages: msgs,
+      });
+      expect(result.messages).toBe(msgs);
+    });
+  });
+});

--- a/src/context-engine/pointer.ts
+++ b/src/context-engine/pointer.ts
@@ -1,0 +1,340 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { estimateTokens, SessionManager } from "@mariozechner/pi-coding-agent";
+import { registerContextEngineForOwner } from "./registry.js";
+import type {
+  AssembleResult,
+  CompactResult,
+  ContextEngine,
+  ContextEngineInfo,
+  ContextEngineRuntimeContext,
+  IngestResult,
+} from "./types.js";
+
+const HOT_TAIL_DEFAULT = 10;
+
+// Compact when usage reaches 85% of budget (unless forced)
+const COMPACT_THRESHOLD_RATIO = 0.85;
+
+type RuntimeCtxWithConfig = ContextEngineRuntimeContext & {
+  config?: {
+    agents?: {
+      defaults?: {
+        compaction?: {
+          hotTailTurns?: number;
+        };
+      };
+    };
+  };
+};
+
+/**
+ * Safely extract the content array or string from an AgentMessage.
+ * Returns undefined for message types that don't have content.
+ */
+function getMessageContent(msg: AgentMessage): string | readonly unknown[] | undefined {
+  if ("content" in msg) {
+    return msg.content as string | readonly unknown[];
+  }
+  return undefined;
+}
+
+/**
+ * Extract topic hints from a set of messages.
+ *
+ * Pulls tool names from tool_use blocks and the first meaningful text snippet
+ * from user messages, deduplicates, and caps the list for readability.
+ */
+function extractTopicHints(messages: AgentMessage[]): string[] {
+  const hints = new Set<string>();
+
+  for (const msg of messages) {
+    const content = getMessageContent(msg);
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (
+          block &&
+          typeof block === "object" &&
+          "type" in block &&
+          (block as Record<string, unknown>).type === "tool_use" &&
+          "name" in block &&
+          typeof (block as Record<string, unknown>).name === "string"
+        ) {
+          hints.add((block as Record<string, string>).name);
+        }
+      }
+    }
+    // First short text snippet from user messages as a topic hint
+    if (msg.role === "user" && hints.size < 8) {
+      const text =
+        typeof content === "string"
+          ? content
+          : Array.isArray(content)
+            ? content
+                .filter(
+                  (b): b is { type: "text"; text: string } =>
+                    b !== null &&
+                    typeof b === "object" &&
+                    "type" in b &&
+                    (b as Record<string, unknown>).type === "text" &&
+                    "text" in b &&
+                    typeof (b as Record<string, unknown>).text === "string",
+                )
+                .map((b) => b.text)
+                .join(" ")
+            : "";
+      const snippet = text.trim().slice(0, 40).replace(/\s+/g, " ");
+      if (snippet.length > 10) {
+        hints.add(snippet + (text.trim().length > 40 ? "…" : ""));
+      }
+    }
+  }
+
+  // Cap hints to avoid overly long markers
+  return [...hints].slice(0, 6);
+}
+
+/**
+ * Count discrete tool/event interactions in a message set.
+ */
+function countEvents(messages: AgentMessage[]): number {
+  let count = 0;
+  for (const msg of messages) {
+    const content = getMessageContent(msg);
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block !== null && typeof block === "object" && "type" in block) {
+          const type = (block as Record<string, unknown>).type;
+          if (type === "tool_use" || type === "tool_result") {
+            count++;
+          }
+        }
+      }
+    }
+  }
+  return count;
+}
+
+/**
+ * Format the structured pointer compaction marker inserted in place of
+ * compacted turns. This is a plain-text string stored in the compaction
+ * entry's `summary` field and shown to the model as a compactionSummary
+ * message, so it must be provider-agnostic.
+ */
+function formatPointerMarker(params: {
+  firstTurn: number;
+  lastTurn: number;
+  tokensFreed: number;
+  topicHints: string[];
+  eventCount: number;
+}): string {
+  const { firstTurn, lastTurn, tokensFreed, topicHints, eventCount } = params;
+  const range = firstTurn === lastTurn ? `Turn ${firstTurn}` : `Turns ${firstTurn}–${lastTurn}`;
+  const topicsText = topicHints.length > 0 ? topicHints.join(", ") : "general conversation";
+  const eventsText = eventCount > 0 ? ` ${eventCount} events.` : "";
+  return (
+    `[📌 ${range} compacted (~${tokensFreed} tokens). Topics: ${topicsText}.${eventsText}` +
+    ` Use memory/recall to retrieve full context.]`
+  );
+}
+
+type SessionEntry = {
+  type: string;
+  id: string;
+  parentId: string | null;
+  message?: AgentMessage;
+};
+
+/**
+ * PointerContextEngine implements lossless compaction by replacing old turns
+ * with a structured marker message instead of an LLM-generated narrative.
+ *
+ * Old turns remain in the session JSONL (accessible via recall) but are
+ * excluded from the active context window. No LLM call is required.
+ *
+ * Configured via compaction.mode: "pointer" and compaction.hotTailTurns.
+ */
+export class PointerContextEngine implements ContextEngine {
+  readonly info: ContextEngineInfo = {
+    id: "pointer",
+    name: "Pointer Context Engine",
+    version: "1.0.0",
+    // This engine owns its compaction algorithm — no LLM summary needed.
+    ownsCompaction: true,
+  };
+
+  async ingest(_params: {
+    sessionId: string;
+    sessionKey?: string;
+    message: AgentMessage;
+    isHeartbeat?: boolean;
+  }): Promise<IngestResult> {
+    // No-op: SessionManager handles message persistence in the pointer flow
+    return { ingested: false };
+  }
+
+  async assemble(params: {
+    sessionId: string;
+    sessionKey?: string;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+    model?: string;
+  }): Promise<AssembleResult> {
+    // Pass-through: the compacted session file already has the pointer marker
+    // in place of old turns, so the standard Pi session context assembly works
+    // without any additional processing here.
+    return {
+      messages: params.messages,
+      estimatedTokens: 0,
+    };
+  }
+
+  async compact(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    tokenBudget?: number;
+    force?: boolean;
+    currentTokenCount?: number;
+    compactionTarget?: "budget" | "threshold";
+    customInstructions?: string;
+    runtimeContext?: ContextEngineRuntimeContext;
+  }): Promise<CompactResult> {
+    const { sessionFile, tokenBudget, force } = params;
+
+    // Resolve hotTailTurns from runtimeContext.config (set by the caller)
+    const rtCtx = params.runtimeContext as RuntimeCtxWithConfig | undefined;
+    const hotTailTurns =
+      rtCtx?.config?.agents?.defaults?.compaction?.hotTailTurns ?? HOT_TAIL_DEFAULT;
+
+    let sm: SessionManager;
+    try {
+      sm = SessionManager.open(sessionFile);
+    } catch (err) {
+      return {
+        ok: false,
+        compacted: false,
+        reason: `Failed to open session file: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    // getBranch() returns entries from root to current leaf in linear order
+    const branch = sm.getBranch() as SessionEntry[];
+
+    // Work only with message-type entries
+    const messageEntries = branch.filter((e) => e.type === "message" && e.message !== undefined);
+
+    if (messageEntries.length === 0) {
+      return { ok: true, compacted: false, reason: "empty session" };
+    }
+
+    const messages = messageEntries.map((e) => e.message as AgentMessage);
+
+    // Use caller-supplied token count when available; fall back to estimation
+    const estimatedTotal = messages.reduce((sum, msg) => sum + estimateTokens(msg), 0);
+    const currentTokens = params.currentTokenCount ?? estimatedTotal;
+
+    // Skip compaction when under budget (unless forced)
+    if (
+      !force &&
+      tokenBudget &&
+      tokenBudget > 0 &&
+      currentTokens < tokenBudget * COMPACT_THRESHOLD_RATIO
+    ) {
+      return {
+        ok: true,
+        compacted: false,
+        reason: `within budget (${currentTokens}/${tokenBudget} tokens)`,
+      };
+    }
+
+    // Identify consecutive user→assistant turn pairs
+    const turnPairStartIndices: number[] = [];
+    for (let i = 0; i < messageEntries.length - 1; i++) {
+      const cur = messages[i];
+      const next = messages[i + 1];
+      if (cur.role === "user" && next.role === "assistant") {
+        turnPairStartIndices.push(i);
+        i++; // advance past the assistant message
+      }
+    }
+
+    // Hot tail: the last N complete turn pairs (user+assistant)
+    const hotTailPairStart = Math.max(0, turnPairStartIndices.length - hotTailTurns);
+    // Index into messageEntries of the first hot-tail user message
+    const hotTailFirstMsgIdx =
+      hotTailPairStart < turnPairStartIndices.length
+        ? turnPairStartIndices[hotTailPairStart]
+        : messageEntries.length;
+
+    // Find the compactable range: skip protected messages at the head
+    // (system messages and existing compactionSummary markers)
+    let compactFrom = 0;
+    while (compactFrom < hotTailFirstMsgIdx) {
+      const role = messages[compactFrom].role;
+      if (role === "compactionSummary" || role === "branchSummary") {
+        compactFrom++;
+      } else {
+        break;
+      }
+    }
+
+    if (compactFrom >= hotTailFirstMsgIdx) {
+      return {
+        ok: true,
+        compacted: false,
+        reason: "no compactable messages outside hot tail",
+      };
+    }
+
+    // Estimate tokens freed by compacting this range
+    const messagesToCompact = messages.slice(compactFrom, hotTailFirstMsgIdx);
+    const tokensFreed = messagesToCompact.reduce((sum, msg) => sum + estimateTokens(msg), 0);
+
+    if (tokensFreed === 0) {
+      return { ok: true, compacted: false, reason: "zero tokens to free" };
+    }
+
+    // Build the marker
+    const topicHints = extractTopicHints(messagesToCompact);
+    const eventCount = countEvents(messagesToCompact);
+    const firstTurn = compactFrom + 1;
+    const lastTurn = hotTailFirstMsgIdx;
+
+    const marker = formatPointerMarker({
+      firstTurn,
+      lastTurn,
+      tokensFreed,
+      topicHints,
+      eventCount,
+    });
+
+    // firstKeptEntryId: first message the model should still see verbatim
+    const firstKeptEntry = messageEntries[hotTailFirstMsgIdx];
+    const firstKeptEntryId = firstKeptEntry?.id ?? "";
+
+    // Append the compaction entry to the session file.
+    // appendCompaction() persists synchronously via appendFileSync.
+    sm.appendCompaction(marker, firstKeptEntryId, estimatedTotal);
+
+    return {
+      ok: true,
+      compacted: true,
+      result: {
+        summary: marker,
+        firstKeptEntryId: firstKeptEntryId ?? undefined,
+        tokensBefore: estimatedTotal,
+        tokensAfter: estimatedTotal - tokensFreed,
+      },
+    };
+  }
+
+  async dispose(): Promise<void> {
+    // Nothing to clean up
+  }
+}
+
+export function registerPointerContextEngine(): void {
+  registerContextEngineForOwner("pointer", () => new PointerContextEngine(), "core", {
+    allowSameOwnerRefresh: true,
+  });
+}

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -404,16 +404,20 @@ export function listContextEngineIds(): string[] {
  *
  * Resolution order:
  *   1. `config.plugins.slots.contextEngine` (explicit slot override)
- *   2. Default slot value ("legacy")
+ *   2. `config.agents.defaults.compaction.mode === "pointer"` → "pointer"
+ *   3. Default slot value ("legacy")
  *
  * Throws if the resolved engine id has no registered factory.
  */
 export async function resolveContextEngine(config?: OpenClawConfig): Promise<ContextEngine> {
   const slotValue = config?.plugins?.slots?.contextEngine;
+  const compactionMode = config?.agents?.defaults?.compaction?.mode;
   const engineId =
     typeof slotValue === "string" && slotValue.trim()
       ? slotValue.trim()
-      : defaultSlotIdForKey("contextEngine");
+      : compactionMode === "pointer"
+        ? "pointer"
+        : defaultSlotIdForKey("contextEngine");
 
   const entry = getContextEngineRegistryState().engines.get(engineId);
   if (!entry) {


### PR DESCRIPTION
## Summary

- **Problem:** Narrative compaction is lossy — once turns are summarized by an LLM, original conversation details are permanently lost. For agents with memory/recall capabilities, this destroys retrievable context unnecessarily.
- **Why it matters:** Compaction is listed in the current roadmap focus. Users with recall-capable agents lose information they could otherwise retrieve.
- **What changed:** Added `compaction.mode: "pointer"` — a new lossless compaction strategy that replaces old turns with structured marker messages instead of LLM-generated summaries. No LLM call required, instant, zero cost.
- **What did NOT change:** Default compaction behavior is unchanged. Existing `"default"` and `"safeguard"` modes are untouched. This is strictly opt-in.

> **AI-assisted** (Claude Opus 4). Fully tested, author understands the code and compaction subsystem. Happy to convert to a Discussion first if the team prefers to discuss the approach before reviewing code.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- No existing issue — new feature proposal
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — new feature.

## Regression Test Plan (if applicable)

- 8 unit tests in `src/context-engine/pointer.test.ts`:
  - Budget threshold skip
  - Forced compaction
  - Hot tail preservation
  - Idempotency
  - Empty session handling
  - Topic hint extraction
  - Engine info / assemble pass-through

---

## How It Works

When `compaction.mode` is `"pointer"`, the new `PointerContextEngine` replaces old turns with a structured marker:

```
[📌 Turns 1-15 compacted (~4200 tokens). Topics: docker setup, file reading.
 12 events. Use memory/recall to retrieve full context.]
```

**Key properties:**
- **Lossless:** Old turns remain in the session JSONL, accessible via recall tools
- **No LLM call:** Pure algorithmic — instant, zero cost
- **Hot tail:** Preserves last N turn pairs verbatim (`compaction.hotTailTurns`, default 10)
- **Safe:** Never evicts `compactionSummary` or `branchSummary` markers
- **Compatible:** Uses `SessionManager.appendCompaction()` and the `ContextEngine` interface

```yaml
agents:
  defaults:
    compaction:
      mode: pointer
      hotTailTurns: 10  # optional, default 10
```

## Files Changed

| File | Change |
|------|--------|
| `src/context-engine/pointer.ts` | New `PointerContextEngine` (333 LOC) |
| `src/context-engine/pointer.test.ts` | 8 unit tests |
| `src/config/types.agent-defaults.ts` | Add `"pointer"` to `AgentCompactionMode`, add `hotTailTurns` |
| `src/context-engine/init.ts` | Register pointer engine on startup |
| `src/context-engine/registry.ts` | Resolve pointer engine from compaction mode config |