### PR TITLE
fix(minimax): add TTS speech provider with integer coercion for voice_setting params

### DIFF
--- a/extensions/minimax/api.ts
+++ b/extensions/minimax/api.ts
@@ -25,3 +25,10 @@ export {
   applyMinimaxApiProviderConfig,
   applyMinimaxApiProviderConfigCn,
 } from "./onboard.js";
+export { buildMinimaxSpeechProvider } from "./speech-provider.js";
+export {
+  DEFAULT_MINIMAX_TTS_BASE_URL,
+  MINIMAX_TTS_MODELS,
+  MINIMAX_TTS_VOICES,
+  minimaxTTS,
+} from "./tts.js";

--- a/extensions/minimax/index.ts
+++ b/extensions/minimax/index.ts
@@ -24,6 +24,7 @@ import {
 import type { MiniMaxRegion } from "./oauth.js";
 import { applyMinimaxApiConfig, applyMinimaxApiConfigCn } from "./onboard.js";
 import { buildMinimaxPortalProvider, buildMinimaxProvider } from "./provider-catalog.js";
+import { buildMinimaxSpeechProvider } from "./speech-provider.js";
 
 const API_PROVIDER_ID = "minimax";
 const PORTAL_PROVIDER_ID = "minimax-portal";
@@ -282,5 +283,6 @@ export default definePluginEntry({
     });
     api.registerImageGenerationProvider(buildMinimaxImageGenerationProvider());
     api.registerImageGenerationProvider(buildMinimaxPortalImageGenerationProvider());
+    api.registerSpeechProvider(buildMinimaxSpeechProvider());
   },
 });

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -1,0 +1,275 @@
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import type {
+  SpeechDirectiveTokenParseContext,
+  SpeechProviderConfig,
+  SpeechProviderOverrides,
+  SpeechProviderPlugin,
+} from "openclaw/plugin-sdk/speech";
+import { requireInRange } from "openclaw/plugin-sdk/speech";
+import {
+  DEFAULT_MINIMAX_TTS_BASE_URL,
+  MINIMAX_TTS_EMOTIONS,
+  MINIMAX_TTS_MODELS,
+  MINIMAX_TTS_VOICES,
+  minimaxTTS,
+  normalizeMinimaxTtsBaseUrl,
+} from "./tts.js";
+
+type MinimaxTtsProviderConfig = {
+  apiKey?: string;
+  baseUrl: string;
+  model: string;
+  voiceId: string;
+  speed: number;
+  vol: number;
+  pitch: number;
+  emotion?: string;
+  languageBoost?: string;
+};
+
+type MinimaxTtsProviderOverrides = {
+  model?: string;
+  voiceId?: string;
+  speed?: number;
+  vol?: number;
+  pitch?: number;
+  emotion?: string;
+};
+
+function trimToUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function normalizeMinimaxProviderConfig(
+  rawConfig: Record<string, unknown>,
+): MinimaxTtsProviderConfig {
+  const providers = asObject(rawConfig.providers);
+  const raw = asObject(providers?.minimax) ?? asObject(rawConfig.minimax);
+  return {
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw?.apiKey,
+      path: "messages.tts.providers.minimax.apiKey",
+    }),
+    baseUrl: normalizeMinimaxTtsBaseUrl(trimToUndefined(raw?.baseUrl)),
+    model: trimToUndefined(raw?.model) ?? "speech-2.8-hd",
+    voiceId: trimToUndefined(raw?.voiceId) ?? "English_expressive_narrator",
+    speed: asNumber(raw?.speed) ?? 1,
+    vol: asNumber(raw?.vol) ?? 1,
+    pitch: asNumber(raw?.pitch) ?? 0,
+    emotion: trimToUndefined(raw?.emotion),
+    languageBoost: trimToUndefined(raw?.languageBoost),
+  };
+}
+
+function readMinimaxProviderConfig(config: SpeechProviderConfig): MinimaxTtsProviderConfig {
+  const defaults = normalizeMinimaxProviderConfig({});
+  return {
+    apiKey: trimToUndefined(config.apiKey) ?? defaults.apiKey,
+    baseUrl: normalizeMinimaxTtsBaseUrl(trimToUndefined(config.baseUrl) ?? defaults.baseUrl),
+    model: trimToUndefined(config.model) ?? defaults.model,
+    voiceId: trimToUndefined(config.voiceId) ?? defaults.voiceId,
+    speed: asNumber(config.speed) ?? defaults.speed,
+    vol: asNumber(config.vol) ?? defaults.vol,
+    pitch: asNumber(config.pitch) ?? defaults.pitch,
+    emotion: trimToUndefined(config.emotion) ?? defaults.emotion,
+    languageBoost: trimToUndefined(config.languageBoost) ?? defaults.languageBoost,
+  };
+}
+
+function readMinimaxOverrides(
+  overrides: SpeechProviderOverrides | undefined,
+): MinimaxTtsProviderOverrides {
+  if (!overrides) {
+    return {};
+  }
+  return {
+    model: trimToUndefined(overrides.model),
+    voiceId: trimToUndefined(overrides.voiceId),
+    speed: asNumber(overrides.speed),
+    vol: asNumber(overrides.vol),
+    pitch: asNumber(overrides.pitch),
+    emotion: trimToUndefined(overrides.emotion),
+  };
+}
+
+function isValidMinimaxEmotion(emotion: string): boolean {
+  return (MINIMAX_TTS_EMOTIONS as readonly string[]).includes(emotion);
+}
+
+function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
+  handled: boolean;
+  overrides?: SpeechProviderOverrides;
+  warnings?: string[];
+} {
+  try {
+    switch (ctx.key) {
+      case "voice":
+      case "voice_id":
+      case "voiceid":
+      case "minimax_voice":
+      case "minimaxvoice":
+        if (!ctx.policy.allowVoice) {
+          return { handled: true };
+        }
+        return { handled: true, overrides: { voiceId: ctx.value } };
+
+      case "model":
+      case "minimax_model":
+      case "minimaxmodel":
+        if (!ctx.policy.allowModelId) {
+          return { handled: true };
+        }
+        return { handled: true, overrides: { model: ctx.value } };
+
+      case "speed": {
+        if (!ctx.policy.allowVoiceSettings) {
+          return { handled: true };
+        }
+        const value = Number.parseFloat(ctx.value);
+        if (!Number.isFinite(value)) {
+          return { handled: true, warnings: ["invalid speed value"] };
+        }
+        requireInRange(value, 0.5, 2, "speed");
+        return { handled: true, overrides: { speed: value } };
+      }
+
+      case "vol":
+      case "volume": {
+        if (!ctx.policy.allowVoiceSettings) {
+          return { handled: true };
+        }
+        const value = Number.parseFloat(ctx.value);
+        if (!Number.isFinite(value)) {
+          return { handled: true, warnings: ["invalid vol value"] };
+        }
+        requireInRange(value, 0.1, 10, "vol");
+        return { handled: true, overrides: { vol: value } };
+      }
+
+      case "pitch": {
+        if (!ctx.policy.allowVoiceSettings) {
+          return { handled: true };
+        }
+        const value = Number.parseInt(ctx.value, 10);
+        if (!Number.isFinite(value)) {
+          return { handled: true, warnings: ["invalid pitch value"] };
+        }
+        requireInRange(value, -12, 12, "pitch");
+        return { handled: true, overrides: { pitch: value } };
+      }
+
+      case "emotion": {
+        if (!ctx.policy.allowVoiceSettings) {
+          return { handled: true };
+        }
+        if (!isValidMinimaxEmotion(ctx.value)) {
+          return { handled: true, warnings: [`invalid MiniMax emotion "${ctx.value}"`] };
+        }
+        return { handled: true, overrides: { emotion: ctx.value } };
+      }
+
+      default:
+        return { handled: false };
+    }
+  } catch (error) {
+    return {
+      handled: true,
+      warnings: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
+export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "minimax",
+    label: "MiniMax",
+    aliases: ["minimax-tts"],
+    autoSelectOrder: 30,
+    models: MINIMAX_TTS_MODELS,
+    voices: MINIMAX_TTS_VOICES,
+    resolveConfig: ({ rawConfig }) => normalizeMinimaxProviderConfig(rawConfig),
+    parseDirectiveToken,
+    resolveTalkConfig: ({ baseTtsConfig, talkProviderConfig }) => {
+      const base = normalizeMinimaxProviderConfig(baseTtsConfig);
+      return {
+        ...base,
+        ...(talkProviderConfig.apiKey === undefined
+          ? {}
+          : {
+              apiKey: normalizeResolvedSecretInputString({
+                value: talkProviderConfig.apiKey,
+                path: "talk.providers.minimax.apiKey",
+              }),
+            }),
+        ...(trimToUndefined(talkProviderConfig.baseUrl) == null
+          ? {}
+          : { baseUrl: normalizeMinimaxTtsBaseUrl(trimToUndefined(talkProviderConfig.baseUrl)) }),
+        ...(trimToUndefined(talkProviderConfig.modelId) == null
+          ? {}
+          : { model: trimToUndefined(talkProviderConfig.modelId) }),
+        ...(trimToUndefined(talkProviderConfig.voiceId) == null
+          ? {}
+          : { voiceId: trimToUndefined(talkProviderConfig.voiceId) }),
+        ...(asNumber(talkProviderConfig.speed) == null
+          ? {}
+          : { speed: asNumber(talkProviderConfig.speed) }),
+      };
+    },
+    resolveTalkOverrides: ({ params }) => ({
+      ...(trimToUndefined(params.voiceId) == null
+        ? {}
+        : { voiceId: trimToUndefined(params.voiceId) }),
+      ...(trimToUndefined(params.modelId) == null
+        ? {}
+        : { model: trimToUndefined(params.modelId) }),
+      ...(asNumber(params.speed) == null ? {} : { speed: asNumber(params.speed) }),
+    }),
+    listVoices: async () =>
+      MINIMAX_TTS_VOICES.map((voice) => ({ id: voice, name: voice.replace(/_/g, " ") })),
+    isConfigured: ({ providerConfig }) =>
+      Boolean(
+        readMinimaxProviderConfig(providerConfig).apiKey ||
+        process.env.MINIMAX_API_KEY ||
+        process.env.MINIMAX_CODE_PLAN_KEY,
+      ),
+    synthesize: async (req) => {
+      const config = readMinimaxProviderConfig(req.providerConfig);
+      const overrides = readMinimaxOverrides(req.providerOverrides);
+      const apiKey =
+        config.apiKey || process.env.MINIMAX_API_KEY || process.env.MINIMAX_CODE_PLAN_KEY;
+      if (!apiKey) {
+        throw new Error("MiniMax API key missing");
+      }
+      const audioBuffer = await minimaxTTS({
+        text: req.text,
+        apiKey,
+        baseUrl: config.baseUrl,
+        model: overrides.model ?? config.model,
+        voiceId: overrides.voiceId ?? config.voiceId,
+        speed: overrides.speed ?? config.speed,
+        vol: overrides.vol ?? config.vol,
+        pitch: overrides.pitch ?? config.pitch,
+        emotion: overrides.emotion ?? config.emotion,
+        languageBoost: config.languageBoost,
+        audioFormat: "mp3",
+        timeoutMs: req.timeoutMs,
+      });
+      return {
+        audioBuffer,
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
+        voiceCompatible: req.target === "voice-note",
+      };
+    },
+  };
+}

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -5,7 +5,7 @@ import type {
   SpeechProviderOverrides,
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech";
-import { requireInRange } from "openclaw/plugin-sdk/speech";
+import { asObject, requireInRange, trimToUndefined } from "openclaw/plugin-sdk/speech";
 import {
   DEFAULT_MINIMAX_TTS_BASE_URL,
   MINIMAX_TTS_EMOTIONS,
@@ -36,18 +36,8 @@ type MinimaxTtsProviderOverrides = {
   emotion?: string;
 };
 
-function trimToUndefined(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
 function asNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function asObject(value: unknown): Record<string, unknown> | undefined {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function normalizeMinimaxProviderConfig(
@@ -131,32 +121,37 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
         }
         return { handled: true, overrides: { model: ctx.value } };
 
-      case "speed": {
+      case "minimax_speed":
+      case "minimaxspeed": {
         if (!ctx.policy.allowVoiceSettings) {
           return { handled: true };
         }
-        const value = Number.parseFloat(ctx.value);
+        const value = Number.parseInt(ctx.value, 10);
         if (!Number.isFinite(value)) {
           return { handled: true, warnings: ["invalid speed value"] };
         }
-        requireInRange(value, 0.5, 2, "speed");
+        requireInRange(value, 1, 2, "speed");
         return { handled: true, overrides: { speed: value } };
       }
 
       case "vol":
-      case "volume": {
+      case "volume":
+      case "minimax_vol":
+      case "minimaxvol": {
         if (!ctx.policy.allowVoiceSettings) {
           return { handled: true };
         }
-        const value = Number.parseFloat(ctx.value);
+        const value = Number.parseInt(ctx.value, 10);
         if (!Number.isFinite(value)) {
           return { handled: true, warnings: ["invalid vol value"] };
         }
-        requireInRange(value, 0.1, 10, "vol");
+        requireInRange(value, 1, 10, "vol");
         return { handled: true, overrides: { vol: value } };
       }
 
-      case "pitch": {
+      case "pitch":
+      case "minimax_pitch":
+      case "minimaxpitch": {
         if (!ctx.policy.allowVoiceSettings) {
           return { handled: true };
         }
@@ -168,7 +163,9 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
         return { handled: true, overrides: { pitch: value } };
       }
 
-      case "emotion": {
+      case "emotion":
+      case "minimax_emotion":
+      case "minimaxemotion": {
         if (!ctx.policy.allowVoiceSettings) {
           return { handled: true };
         }

--- a/extensions/minimax/tts.test.ts
+++ b/extensions/minimax/tts.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MINIMAX_TTS_BASE_URL,
+  MINIMAX_TTS_MODELS,
+  MINIMAX_TTS_VOICES,
+  minimaxTTS,
+  normalizeMinimaxTtsBaseUrl,
+} from "./tts.js";
+
+describe("minimax tts", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("normalizeMinimaxTtsBaseUrl", () => {
+    it("returns the default URL when no input is provided", () => {
+      expect(normalizeMinimaxTtsBaseUrl()).toBe(DEFAULT_MINIMAX_TTS_BASE_URL);
+      expect(normalizeMinimaxTtsBaseUrl("")).toBe(DEFAULT_MINIMAX_TTS_BASE_URL);
+      expect(normalizeMinimaxTtsBaseUrl("   ")).toBe(DEFAULT_MINIMAX_TTS_BASE_URL);
+    });
+
+    it("strips trailing slashes", () => {
+      expect(normalizeMinimaxTtsBaseUrl("https://api.minimax.io/v1/")).toBe(
+        "https://api.minimax.io/v1",
+      );
+      expect(normalizeMinimaxTtsBaseUrl("https://api.minimax.io/v1///")).toBe(
+        "https://api.minimax.io/v1",
+      );
+    });
+  });
+
+  describe("model and voice lists", () => {
+    it("exposes the expected model set", () => {
+      expect(MINIMAX_TTS_MODELS).toContain("speech-2.8-hd");
+      expect(MINIMAX_TTS_MODELS).toContain("speech-2.8-turbo");
+      expect(MINIMAX_TTS_MODELS.length).toBeGreaterThanOrEqual(8);
+    });
+
+    it("exposes the expected voice set", () => {
+      expect(MINIMAX_TTS_VOICES).toContain("English_expressive_narrator");
+      expect(MINIMAX_TTS_VOICES.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("minimaxTTS sends integer values for speed/vol/pitch (#62144)", () => {
+    it("truncates float speed/vol/pitch to integers in the request body", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      const hexAudio = Buffer.from("test-audio").toString("hex");
+      const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({
+            data: { audio: hexAudio, status: 2 },
+            base_resp: { status_code: 0, status_msg: "success" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await minimaxTTS({
+        text: "Hello",
+        apiKey: "test-key",
+        baseUrl: "https://api.minimax.io/v1",
+        model: "speech-2.8-hd",
+        voiceId: "English_expressive_narrator",
+        speed: 1.0,
+        vol: 1.0,
+        pitch: 0.0,
+        timeoutMs: 5_000,
+      });
+
+      expect(capturedBody).toBeDefined();
+      const voiceSetting = capturedBody!.voice_setting as Record<string, unknown>;
+      expect(voiceSetting.speed).toBe(1);
+      expect(voiceSetting.vol).toBe(1);
+      expect(voiceSetting.pitch).toBe(0);
+      expect(Number.isInteger(voiceSetting.speed)).toBe(true);
+      expect(Number.isInteger(voiceSetting.vol)).toBe(true);
+      expect(Number.isInteger(voiceSetting.pitch)).toBe(true);
+    });
+
+    it("truncates fractional values rather than rounding", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      const hexAudio = Buffer.from("test-audio").toString("hex");
+      const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({
+            data: { audio: hexAudio, status: 2 },
+            base_resp: { status_code: 0, status_msg: "success" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await minimaxTTS({
+        text: "Hello",
+        apiKey: "test-key",
+        baseUrl: "https://api.minimax.io/v1",
+        model: "speech-2.8-hd",
+        voiceId: "English_expressive_narrator",
+        speed: 1.7,
+        vol: 2.9,
+        pitch: -3.5,
+        timeoutMs: 5_000,
+      });
+
+      expect(capturedBody).toBeDefined();
+      const voiceSetting = capturedBody!.voice_setting as Record<string, unknown>;
+      expect(voiceSetting.speed).toBe(1);
+      expect(voiceSetting.vol).toBe(2);
+      expect(voiceSetting.pitch).toBe(-3);
+    });
+  });
+
+  describe("minimaxTTS error handling", () => {
+    it("throws on HTTP-level errors with detail from base_resp", async () => {
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              base_resp: {
+                status_code: 2013,
+                status_msg: "invalid params, Mismatch type int64 with value null",
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        minimaxTTS({
+          text: "hello",
+          apiKey: "test-key",
+          baseUrl: "https://api.minimax.io/v1",
+          model: "speech-2.8-hd",
+          voiceId: "English_expressive_narrator",
+          speed: 1,
+          vol: 1,
+          pitch: 0,
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow("MiniMax TTS API error");
+    });
+
+    it("throws when no audio data is returned", async () => {
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: { audio: null, status: 2 },
+              base_resp: { status_code: 0, status_msg: "success" },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        minimaxTTS({
+          text: "hello",
+          apiKey: "test-key",
+          baseUrl: "https://api.minimax.io/v1",
+          model: "speech-2.8-hd",
+          voiceId: "English_expressive_narrator",
+          speed: 1,
+          vol: 1,
+          pitch: 0,
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow("MiniMax TTS API returned no audio data");
+    });
+
+    it("throws on non-OK HTTP status with error detail", async () => {
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              base_resp: { status_code: 1004, status_msg: "authentication failed" },
+            }),
+            { status: 401 },
+          ),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        minimaxTTS({
+          text: "hello",
+          apiKey: "bad-key",
+          baseUrl: "https://api.minimax.io/v1",
+          model: "speech-2.8-hd",
+          voiceId: "English_expressive_narrator",
+          speed: 1,
+          vol: 1,
+          pitch: 0,
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow("MiniMax TTS API error (401): authentication failed [status_code=1004]");
+    });
+  });
+
+  describe("minimaxTTS request format", () => {
+    it("sends the correct request structure to the t2a_v2 endpoint", async () => {
+      let capturedUrl: string | undefined;
+      let capturedBody: Record<string, unknown> | undefined;
+
+      const hexAudio = Buffer.from("test-audio").toString("hex");
+      const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+        capturedUrl = url;
+        capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({
+            data: { audio: hexAudio, status: 2 },
+            base_resp: { status_code: 0, status_msg: "success" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await minimaxTTS({
+        text: "Hello world",
+        apiKey: "test-key",
+        baseUrl: "https://api.minimax.io/v1",
+        model: "speech-2.8-hd",
+        voiceId: "English_expressive_narrator",
+        speed: 1,
+        vol: 1,
+        pitch: 0,
+        emotion: "happy",
+        languageBoost: "English",
+        audioFormat: "mp3",
+        timeoutMs: 10_000,
+      });
+
+      expect(capturedUrl).toBe("https://api.minimax.io/v1/t2a_v2");
+      expect(capturedBody).toMatchObject({
+        model: "speech-2.8-hd",
+        text: "Hello world",
+        stream: false,
+        output_format: "hex",
+        language_boost: "English",
+        voice_setting: {
+          voice_id: "English_expressive_narrator",
+          speed: 1,
+          vol: 1,
+          pitch: 0,
+          emotion: "happy",
+        },
+        audio_setting: {
+          format: "mp3",
+        },
+      });
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.toString()).toBe("test-audio");
+    });
+  });
+});

--- a/extensions/minimax/tts.ts
+++ b/extensions/minimax/tts.ts
@@ -1,0 +1,194 @@
+import {
+  asObject,
+  readResponseTextLimited,
+  trimToUndefined,
+  truncateErrorDetail,
+} from "openclaw/plugin-sdk/speech";
+
+export const DEFAULT_MINIMAX_TTS_BASE_URL = "https://api.minimax.io/v1";
+
+export const MINIMAX_TTS_MODELS = [
+  "speech-2.8-hd",
+  "speech-2.8-turbo",
+  "speech-2.6-hd",
+  "speech-2.6-turbo",
+  "speech-02-hd",
+  "speech-02-turbo",
+  "speech-01-hd",
+  "speech-01-turbo",
+] as const;
+
+export const MINIMAX_TTS_VOICES = [
+  "English_expressive_narrator",
+  "English_Graceful_Lady",
+  "English_Insightful_Speaker",
+  "English_radiant_girl",
+  "English_Persuasive_Man",
+  "English_Lucky_Robot",
+] as const;
+
+export const MINIMAX_TTS_EMOTIONS = [
+  "happy",
+  "sad",
+  "angry",
+  "fearful",
+  "disgusted",
+  "surprised",
+  "calm",
+  "fluent",
+  "whisper",
+] as const;
+
+export function normalizeMinimaxTtsBaseUrl(baseUrl?: string): string {
+  const trimmed = baseUrl?.trim();
+  return trimmed?.replace(/\/+$/, "") || DEFAULT_MINIMAX_TTS_BASE_URL;
+}
+
+function formatMinimaxErrorPayload(payload: unknown): string | undefined {
+  const root = asObject(payload);
+  const baseResp = asObject(root?.base_resp);
+  if (!baseResp) {
+    return undefined;
+  }
+  const statusCode = baseResp.status_code;
+  const statusMsg = trimToUndefined(baseResp.status_msg);
+  if (typeof statusCode === "number" && statusCode !== 0) {
+    return statusMsg
+      ? `${truncateErrorDetail(statusMsg)} [status_code=${statusCode}]`
+      : `[status_code=${statusCode}]`;
+  }
+  if (statusMsg) {
+    return truncateErrorDetail(statusMsg);
+  }
+  return undefined;
+}
+
+async function extractMinimaxErrorDetail(response: Response): Promise<string | undefined> {
+  const rawBody = trimToUndefined(await readResponseTextLimited(response));
+  if (!rawBody) {
+    return undefined;
+  }
+  try {
+    return formatMinimaxErrorPayload(JSON.parse(rawBody)) ?? truncateErrorDetail(rawBody);
+  } catch {
+    return truncateErrorDetail(rawBody);
+  }
+}
+
+type MinimaxTtsResponse = {
+  data?: {
+    audio?: string;
+    status?: number;
+  };
+  base_resp?: {
+    status_code?: number;
+    status_msg?: string;
+  };
+  extra_info?: {
+    audio_format?: string;
+    audio_sample_rate?: number;
+  };
+  trace_id?: string;
+};
+
+export async function minimaxTTS(params: {
+  text: string;
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  voiceId: string;
+  speed: number;
+  vol: number;
+  pitch: number;
+  emotion?: string;
+  languageBoost?: string;
+  sampleRate?: number;
+  bitrate?: number;
+  audioFormat?: "mp3" | "pcm" | "flac";
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const {
+    text,
+    apiKey,
+    baseUrl,
+    model,
+    voiceId,
+    speed,
+    vol,
+    pitch,
+    emotion,
+    languageBoost,
+    sampleRate,
+    bitrate,
+    audioFormat,
+    timeoutMs,
+  } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const body: Record<string, unknown> = {
+      model,
+      text,
+      stream: false,
+      output_format: "hex",
+      voice_setting: {
+        voice_id: voiceId,
+        speed: Math.trunc(speed),
+        vol: Math.trunc(vol),
+        pitch: Math.trunc(pitch),
+      },
+    };
+
+    if (languageBoost) {
+      body.language_boost = languageBoost;
+    }
+
+    if (emotion) {
+      (body.voice_setting as Record<string, unknown>).emotion = emotion;
+    }
+
+    if (sampleRate != null || bitrate != null || audioFormat != null) {
+      const audioSetting: Record<string, unknown> = {};
+      if (sampleRate != null) audioSetting.sample_rate = sampleRate;
+      if (bitrate != null) audioSetting.bitrate = bitrate;
+      if (audioFormat != null) audioSetting.format = audioFormat;
+      body.audio_setting = audioSetting;
+    }
+
+    const response = await fetch(`${baseUrl}/t2a_v2`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await extractMinimaxErrorDetail(response);
+      throw new Error(`MiniMax TTS API error (${response.status})` + (detail ? `: ${detail}` : ""));
+    }
+
+    const json = (await response.json()) as MinimaxTtsResponse;
+
+    if (json.base_resp?.status_code && json.base_resp.status_code !== 0) {
+      const detail = formatMinimaxErrorPayload(json);
+      throw new Error(
+        `MiniMax TTS API error` +
+          (detail ? `: ${detail}` : `: status_code=${json.base_resp.status_code}`),
+      );
+    }
+
+    const hexAudio = json.data?.audio;
+    if (!hexAudio) {
+      throw new Error("MiniMax TTS API returned no audio data");
+    }
+
+    return Buffer.from(hexAudio, "hex");
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #62144

- Adds a new MiniMax TTS speech provider plugin (`extensions/minimax/tts.ts` + `speech-provider.ts`) that calls the MiniMax `t2a_v2` endpoint.
- Coerces `speed`, `vol`, and `pitch` in `voice_setting` to integers via `Math.trunc()` before sending to the API, preventing the `2013` ("invalid params, Mismatch type int64 with value null") error.
- Registers the provider in `extensions/minimax/index.ts` so `messages.tts.provider: "minimax"` is now a valid configuration.

### Root cause

There was no MiniMax speech provider registered in the plugin system. Users configuring `messages.tts.provider: "minimax"` would get a "no provider registered" skip, resulting in no audio output. The MiniMax TTS API (`/v1/t2a_v2`) requires `pitch` as an integer and empirically rejects float representations of `speed` and `vol` (even though the OpenAPI spec types them as `float`).

### What changed

| File | Change |
|------|--------|
| `extensions/minimax/tts.ts` | New: MiniMax TTS API client with `Math.trunc()` integer coercion, hex-decoded audio response handling, and MiniMax-specific error parsing |
| `extensions/minimax/speech-provider.ts` | New: `SpeechProviderPlugin` implementation with config resolution, directive parsing, and synthesis |
| `extensions/minimax/tts.test.ts` | New: 10 tests covering integer coercion, truncation behavior, error handling, and request format |
| `extensions/minimax/index.ts` | Registers the speech provider via `api.registerSpeechProvider()` |
| `extensions/minimax/api.ts` | Exports the new speech provider and TTS helpers |

## Test plan

- [x] `npx vitest run extensions/minimax/tts.test.ts` — 10/10 passing
- [x] `npx vitest run src/plugins/contracts/tts.contract.test.ts` — 40/40 passing
- [x] `npx vitest run src/plugins/contracts/plugin-registration.contract.test.ts` — 54/54 passing
- [ ] Manual verification with MiniMax API key (requires active MiniMax account)

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)