### PR TITLE
perf(gateway): cache sessions.list results and short-circuit unchanged responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Release: add first-class alpha prerelease support across version parsing, release workflows, package specs, published-package validation, plugin publish planning, and release docs.
+- Gateway/sessions: cache `sessions.list` results with stable hashes and unchanged responses while preserving bounded async cache-miss loading, and avoid needless config patch restarts for source-equivalent no-op writes. Thanks @sasan1200.
 - Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
 - Plugins/ClawHub: make diagnostics, onboarding, doctor repair, and channel setup carry ClawPack metadata through install records while keeping explicit `clawhub:` installs on ClawHub and bare package installs on npm for the launch cutover. Thanks @vincentkoc.
 - Plugins/runtime: scope broad runtime preloads to the effective plugin ids derived from config, startup planning, configured channels, slots, and auto-enable rules instead of importing every discoverable plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,7 +315,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Release: add first-class alpha prerelease support across version parsing, release workflows, package specs, published-package validation, plugin publish planning, and release docs.
 - Gateway/sessions: cache `sessions.list` results with stable hashes and unchanged responses while preserving bounded async cache-miss loading, and avoid needless config patch restarts for source-equivalent no-op writes. Thanks @sasan1200.
 - Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
 - Plugins/ClawHub: make diagnostics, onboarding, doctor repair, and channel setup carry ClawPack metadata through install records while keeping explicit `clawhub:` installs on ClawHub and bare package installs on npm for the launch cutover. Thanks @vincentkoc.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1425,6 +1425,7 @@ public struct SessionsListParams: Codable, Sendable {
     public let spawnedby: String?
     public let agentid: String?
     public let search: String?
+    public let lasthash: String?
 
     public init(
         limit: Int?,
@@ -1436,7 +1437,8 @@ public struct SessionsListParams: Codable, Sendable {
         label: String?,
         spawnedby: String?,
         agentid: String?,
-        search: String?)
+        search: String?,
+        lasthash: String?)
     {
         self.limit = limit
         self.activeminutes = activeminutes
@@ -1448,6 +1450,7 @@ public struct SessionsListParams: Codable, Sendable {
         self.spawnedby = spawnedby
         self.agentid = agentid
         self.search = search
+        self.lasthash = lasthash
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1461,6 +1464,7 @@ public struct SessionsListParams: Codable, Sendable {
         case spawnedby = "spawnedBy"
         case agentid = "agentId"
         case search
+        case lasthash = "lastHash"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1425,6 +1425,7 @@ public struct SessionsListParams: Codable, Sendable {
     public let spawnedby: String?
     public let agentid: String?
     public let search: String?
+    public let lasthash: String?
 
     public init(
         limit: Int?,
@@ -1436,7 +1437,8 @@ public struct SessionsListParams: Codable, Sendable {
         label: String?,
         spawnedby: String?,
         agentid: String?,
-        search: String?)
+        search: String?,
+        lasthash: String?)
     {
         self.limit = limit
         self.activeminutes = activeminutes
@@ -1448,6 +1450,7 @@ public struct SessionsListParams: Codable, Sendable {
         self.spawnedby = spawnedby
         self.agentid = agentid
         self.search = search
+        self.lasthash = lasthash
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1461,6 +1464,7 @@ public struct SessionsListParams: Codable, Sendable {
         case spawnedby = "spawnedBy"
         case agentid = "agentId"
         case search
+        case lasthash = "lastHash"
     }
 }
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -398,7 +398,7 @@ enumeration of `src/gateway/server-methods/*.ts`.
   </Accordion>
 
   <Accordion title="Session control">
-    - `sessions.list` returns the current session index, including per-row `agentRuntime` metadata when an agent runtime backend is configured.
+    - `sessions.list` returns the current session index, including per-row `agentRuntime` metadata when an agent runtime backend is configured. Responses include a stable `hash`; clients may pass that value back as `lastHash`, and the Gateway may return `{ unchanged: true, hash, ts, count }` when the visible session rows are unchanged.
     - `sessions.subscribe` and `sessions.unsubscribe` toggle session change event subscriptions for the current WS client.
     - `sessions.messages.subscribe` and `sessions.messages.unsubscribe` toggle transcript/message event subscriptions for one session.
     - `sessions.preview` returns bounded transcript previews for specific session keys.

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -59,7 +59,7 @@ export function createSubagentRegistryLifecycleController(params: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
   subagentAnnounceTimeoutMs: number;
-  persist(): void;
+  persist(opts?: { bumpGeneration?: boolean }): void;
   clearPendingLifecycleError(runId: string): void;
   countPendingDescendantRuns(rootSessionKey: string): number;
   suppressAnnounceForSteerRestart(entry?: SubagentRunRecord): boolean;
@@ -291,7 +291,7 @@ export function createSubagentRegistryLifecycleController(params: {
       changed = true;
     }
     if (changed) {
-      params.persist();
+      params.persist({ bumpGeneration: true });
     }
     return changed;
   };
@@ -356,7 +356,7 @@ export function createSubagentRegistryLifecycleController(params: {
       return false;
     }
     entry.cleanupHandled = true;
-    params.persist();
+    params.persist({ bumpGeneration: false });
     return true;
   };
 
@@ -393,7 +393,7 @@ export function createSubagentRegistryLifecycleController(params: {
             return;
           }
           current.cleanupHandled = false;
-          params.persist();
+          params.persist({ bumpGeneration: true });
         });
         continue;
       }
@@ -431,7 +431,7 @@ export function createSubagentRegistryLifecycleController(params: {
         workspaceDir: cleanupParams.entry.workspaceDir,
       });
       params.runs.delete(cleanupParams.runId);
-      params.persist();
+      params.persist({ bumpGeneration: true });
       retryDeferredCompletedAnnounces(cleanupParams.runId);
       return;
     }
@@ -442,7 +442,7 @@ export function createSubagentRegistryLifecycleController(params: {
       workspaceDir: cleanupParams.entry.workspaceDir,
     });
     cleanupParams.entry.cleanupCompletedAt = cleanupParams.completedAt;
-    params.persist();
+    params.persist({ bumpGeneration: true });
     retryDeferredCompletedAnnounces(cleanupParams.runId);
   };
 
@@ -533,7 +533,7 @@ export function createSubagentRegistryLifecycleController(params: {
       entry.wakeOnDescendantSettle = true;
       entry.cleanupHandled = false;
       params.resumedRuns.delete(runId);
-      params.persist();
+      params.persist({ bumpGeneration: true });
       scheduleResumeSubagentRun(runId, entry, deferredDecision.delayMs);
       return;
     }
@@ -573,7 +573,7 @@ export function createSubagentRegistryLifecycleController(params: {
 
     entry.cleanupHandled = false;
     params.resumedRuns.delete(runId);
-    params.persist();
+    params.persist({ bumpGeneration: true });
     if (deferredDecision.resumeDelayMs == null) {
       return;
     }
@@ -644,7 +644,7 @@ export function createSubagentRegistryLifecycleController(params: {
           return;
         }
         current.cleanupHandled = false;
-        params.persist();
+        params.persist({ bumpGeneration: true });
       });
     };
 
@@ -712,6 +712,7 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     let mutated = false;
+    let listVisibleMutated = false;
     if (
       completeParams.reason === SUBAGENT_ENDED_REASON_COMPLETE &&
       entry.suppressAnnounceReason === "killed" &&
@@ -729,6 +730,7 @@ export function createSubagentRegistryLifecycleController(params: {
     if (entry.endedAt !== endedAt) {
       entry.endedAt = endedAt;
       mutated = true;
+      listVisibleMutated = true;
     }
     const outcome = withSubagentOutcomeTiming(completeParams.outcome, {
       startedAt: entry.startedAt,
@@ -737,10 +739,12 @@ export function createSubagentRegistryLifecycleController(params: {
     if (shouldUpdateRunOutcome(entry.outcome, outcome)) {
       entry.outcome = outcome;
       mutated = true;
+      listVisibleMutated = true;
     }
     if (entry.endedReason !== completeParams.reason) {
       entry.endedReason = completeParams.reason;
       mutated = true;
+      listVisibleMutated = true;
     }
     if (entry.pauseReason !== undefined) {
       entry.pauseReason = undefined;
@@ -752,7 +756,7 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     if (mutated) {
-      params.persist();
+      params.persist({ bumpGeneration: listVisibleMutated });
     }
     safeFinalizeSubagentTaskRun({
       entry,

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -105,7 +105,7 @@ export function createSubagentRunManager(params: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
   endedHookInFlightRunIds: Set<string>;
-  persist(): void;
+  persist(opts?: { bumpGeneration?: boolean }): void;
   callGateway: typeof callGateway;
   getRuntimeConfig: typeof getRuntimeConfig;
   ensureRuntimePluginsLoaded:
@@ -226,7 +226,7 @@ export function createSubagentRunManager(params: {
         mutated = true;
       }
       if (mutated) {
-        params.persist();
+        params.persist({ bumpGeneration: true });
       }
       await params.completeSubagentRun({
         runId,
@@ -363,7 +363,7 @@ export function createSubagentRunManager(params: {
 
     params.runs.set(nextRunId, next);
     params.ensureListener();
-    params.persist();
+    params.persist({ bumpGeneration: true });
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
     params.startSweeper();
     void waitForSubagentCompletion(nextRunId, waitTimeoutMs, next);
@@ -443,7 +443,7 @@ export function createSubagentRunManager(params: {
       });
     }
     params.ensureListener();
-    params.persist();
+    params.persist({ bumpGeneration: true });
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
     params.startSweeper();
     // Wait for subagent completion via gateway RPC (cross-process).
@@ -467,7 +467,7 @@ export function createSubagentRunManager(params: {
     }
     const didDelete = params.runs.delete(runId);
     if (didDelete) {
-      params.persist();
+      params.persist({ bumpGeneration: true });
     }
     if (params.runs.size === 0) {
       params.stopSweeper();
@@ -525,7 +525,7 @@ export function createSubagentRunManager(params: {
       updated += 1;
     }
     if (updated > 0) {
-      params.persist();
+      params.persist({ bumpGeneration: true });
       for (const entry of entriesByChildSessionKey.values()) {
         const emitEndedHook = () =>
           emitSubagentEndedHookOnce({

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -170,7 +170,7 @@ export function createSubagentRunManager(params: {
             endedAt: wait.endedAt,
           })
         ) {
-          params.persist();
+          params.persist({ bumpGeneration: true });
         }
         return;
       }

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -102,6 +102,7 @@ vi.mock("../config/sessions.js", () => ({
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => null),
+  initializeGlobalHookRunner: vi.fn(),
 }));
 
 vi.mock("../browser-lifecycle-cleanup.js", () => ({
@@ -377,6 +378,90 @@ describe("subagent registry lifecycle error grace", () => {
     await waitForAgentCallCount(1);
     expect(readFirstAnnounceOutcome()?.status).toBe("error");
     expect(readFirstAnnounceOutcome()?.error).toContain("fatal failure");
+  });
+
+  it("bumps registry generation when registering a live run", () => {
+    const beforeGen = mod.getSubagentRegistryGeneration();
+
+    registerCompletionRun("run-generation-register", "generation-register", "generation register");
+
+    const afterGen = mod.getSubagentRegistryGeneration();
+    expect(afterGen).toBeGreaterThan(beforeGen);
+  });
+
+  it("bumps registry generation when lifecycle end completion mutates run timing/status", async () => {
+    registerCompletionRun("run-generation-end", "generation-end", "generation end test");
+    setAssistantOutput("agent:main:subagent:generation-end", "done");
+    const beforeGen = mod.getSubagentRegistryGeneration();
+
+    emitLifecycleEvent("run-generation-end", { phase: "end", endedAt: Date.now() });
+    await flushAsync();
+
+    await waitForAgentCallCount(1);
+    const afterGen = mod.getSubagentRegistryGeneration();
+    expect(afterGen).toBeGreaterThan(beforeGen);
+  });
+
+  it("bumps registry generation when deferred lifecycle error completion mutates run status", async () => {
+    registerCompletionRun("run-generation-error", "generation-error", "generation error test");
+    setAssistantOutput("agent:main:subagent:generation-error", "fatal");
+    const beforeGen = mod.getSubagentRegistryGeneration();
+
+    emitLifecycleEvent("run-generation-error", {
+      phase: "error",
+      error: "terminal failure",
+      endedAt: 3_000,
+    });
+    await flushAsync();
+    expect(getAgentCalls()).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await flushAsync();
+
+    await waitForAgentCallCount(1);
+    const afterGen = mod.getSubagentRegistryGeneration();
+    expect(afterGen).toBeGreaterThan(beforeGen);
+  });
+
+  it("bumps registry generation when releaseSubagentRun deletes a live run", () => {
+    registerCompletionRun("run-generation-release", "generation-release", "generation release");
+    const beforeGen = mod.getSubagentRegistryGeneration();
+
+    mod.releaseSubagentRun("run-generation-release");
+
+    const afterGen = mod.getSubagentRegistryGeneration();
+    expect(afterGen).toBeGreaterThan(beforeGen);
+  });
+
+  it("bumps registry generation when markSubagentRunTerminated kills a live run", () => {
+    registerCompletionRun("run-generation-kill", "generation-kill", "generation kill test");
+    const beforeGen = mod.getSubagentRegistryGeneration();
+
+    const killed = mod.markSubagentRunTerminated({
+      runId: "run-generation-kill",
+      reason: "killed",
+    });
+
+    expect(killed).toBe(1);
+    const afterGen = mod.getSubagentRegistryGeneration();
+    expect(afterGen).toBeGreaterThan(beforeGen);
+  });
+
+  it("does not bump registry generation for steer-restart bookkeeping toggles", () => {
+    registerCompletionRun(
+      "run-generation-bookkeeping",
+      "generation-bookkeeping",
+      "generation bookkeeping test",
+    );
+    const beforeGen = mod.getSubagentRegistryGeneration();
+
+    const marked = mod.markSubagentRunForSteerRestart("run-generation-bookkeeping");
+    expect(marked).toBe(true);
+    expect(mod.getSubagentRegistryGeneration()).toBe(beforeGen);
+
+    const cleared = mod.clearSubagentRunSteerRestart("run-generation-bookkeeping");
+    expect(cleared).toBe(true);
+    expect(mod.getSubagentRegistryGeneration()).toBe(beforeGen);
   });
 
   it("freezes completion result at run termination across deferred announce retries", async () => {

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.js";
 import { __testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.js";
-import { __testing as subagentAnnounceTesting } from "./subagent-announce.js";
+import {
+  __testing as subagentAnnounceTesting,
+  runSubagentAnnounceFlow,
+} from "./subagent-announce.js";
 import * as mod from "./subagent-registry.js";
 
 const noop = () => {};
@@ -163,6 +166,11 @@ describe("subagent registry lifecycle error grace", () => {
       getRuntimeConfig: loadConfigMock as typeof import("../config/config.js").getRuntimeConfig,
       onAgentEvent:
         onAgentEventMock as unknown as typeof import("../infra/agent-events.js").onAgentEvent,
+      runSubagentAnnounceFlow: (params) =>
+        runSubagentAnnounceFlow({
+          ...params,
+          timeoutMs: Math.min(params.timeoutMs, 1_000),
+        }),
     });
     subagentAnnounceTesting.setDepsForTest({
       callGateway: callGatewayMock as typeof import("../gateway/call.js").callGateway,

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.js";
 import { __testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.js";
-import {
-  __testing as subagentAnnounceTesting,
-  runSubagentAnnounceFlow,
-} from "./subagent-announce.js";
+import { __testing as subagentAnnounceTesting } from "./subagent-announce.js";
 import * as mod from "./subagent-registry.js";
 
 const noop = () => {};
@@ -112,6 +109,10 @@ vi.mock("../browser-lifecycle-cleanup.js", () => ({
   cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
 }));
 
+vi.mock("./pi-bundle-mcp-tools.js", () => ({
+  retireSessionMcpRuntimeForSessionKey: vi.fn(async () => true),
+}));
+
 vi.mock("./subagent-depth.js", () => ({
   getSubagentDepthFromSessionStore: () => 0,
 }));
@@ -166,11 +167,25 @@ describe("subagent registry lifecycle error grace", () => {
       getRuntimeConfig: loadConfigMock as typeof import("../config/config.js").getRuntimeConfig,
       onAgentEvent:
         onAgentEventMock as unknown as typeof import("../infra/agent-events.js").onAgentEvent,
-      runSubagentAnnounceFlow: (params) =>
-        runSubagentAnnounceFlow({
-          ...params,
-          timeoutMs: Math.min(params.timeoutMs, 1_000),
-        }),
+      runSubagentAnnounceFlow: async (params) => {
+        await callGatewayMock({
+          method: "agent",
+          params: {
+            inputProvenance: {
+              sourceSessionKey: params.childSessionKey,
+            },
+            internalEvents: [
+              {
+                status: params.outcome?.status === "error" ? "error" : "ok",
+                statusLabel:
+                  params.outcome?.status === "error" ? (params.outcome.error ?? "") : undefined,
+                result: params.roundOneReply ?? params.fallbackReply ?? "",
+              },
+            ],
+          },
+        });
+        return true;
+      },
     });
     subagentAnnounceTesting.setDepsForTest({
       callGateway: callGatewayMock as typeof import("../gateway/call.js").callGateway,
@@ -212,6 +227,7 @@ describe("subagent registry lifecycle error grace", () => {
     subagentAnnounceTesting.setDepsForTest();
     mod.__testing.setDepsForTest();
     mod.resetSubagentRegistryForTests({ persist: false });
+    vi.clearAllTimers();
     vi.useRealTimers();
     if (previousFastTestEnv === undefined) {
       delete process.env.OPENCLAW_TEST_FAST;

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -13,6 +13,7 @@ type LifecycleData = {
   startedAt?: number;
   endedAt?: number;
   aborted?: boolean;
+  yielded?: boolean;
   error?: string;
 };
 type LifecycleEvent = {
@@ -469,6 +470,92 @@ describe("subagent registry lifecycle error grace", () => {
     expect(killed).toBe(1);
     const afterGen = mod.getSubagentRegistryGeneration();
     expect(afterGen).toBeGreaterThan(beforeGen);
+  });
+
+  it("bumps registry generation when agent.wait pauses a run after sessions_yield", async () => {
+    type YieldedWaitResult = {
+      status: "ok";
+      startedAt: number;
+      endedAt: number;
+      livenessState: "paused";
+      yielded: true;
+    };
+    let resolveWait: ((value: YieldedWaitResult) => void) | undefined;
+    const defaultCallGatewayImplementation = callGatewayMock.getMockImplementation();
+    callGatewayMock.mockImplementation(async (request: GatewayRequest) => {
+      if (request.method === "agent.wait") {
+        return await new Promise<YieldedWaitResult>((resolve) => {
+          resolveWait = resolve;
+        });
+      }
+      if (request.method === "chat.history") {
+        const sessionKey =
+          typeof request.params?.sessionKey === "string" ? request.params.sessionKey : "";
+        return {
+          messages: chatHistoryBySessionKey.get(sessionKey) ?? [],
+        };
+      }
+      return {};
+    });
+    try {
+      registerCompletionRun(
+        "run-generation-yield-wait",
+        "generation-yield-wait",
+        "generation yield wait",
+      );
+      await flushAsync();
+      expect(resolveWait).toBeDefined();
+      const beforeGen = mod.getSubagentRegistryGeneration();
+
+      resolveWait?.({
+        status: "ok",
+        startedAt: 4_000,
+        endedAt: 4_500,
+        livenessState: "paused",
+        yielded: true,
+      });
+      await flushAsync();
+
+      const afterGen = mod.getSubagentRegistryGeneration();
+      expect(afterGen).toBeGreaterThan(beforeGen);
+      expect(
+        mod
+          .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+          .find((candidate) => candidate.runId === "run-generation-yield-wait")?.pauseReason,
+      ).toBe("sessions_yield");
+      expect(getAgentCalls()).toHaveLength(0);
+    } finally {
+      if (defaultCallGatewayImplementation) {
+        callGatewayMock.mockImplementation(defaultCallGatewayImplementation);
+      }
+    }
+  });
+
+  it("bumps registry generation when lifecycle yield pauses a run", async () => {
+    registerCompletionRun(
+      "run-generation-yield-lifecycle",
+      "generation-yield-lifecycle",
+      "generation yield lifecycle",
+    );
+    await flushAsync();
+    const beforeGen = mod.getSubagentRegistryGeneration();
+
+    emitLifecycleEvent("run-generation-yield-lifecycle", {
+      phase: "end",
+      startedAt: 5_000,
+      endedAt: 5_500,
+      yielded: true,
+    });
+    await flushAsync();
+
+    const afterGen = mod.getSubagentRegistryGeneration();
+    expect(afterGen).toBeGreaterThan(beforeGen);
+    expect(
+      mod
+        .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+        .find((candidate) => candidate.runId === "run-generation-yield-lifecycle")?.pauseReason,
+    ).toBe("sessions_yield");
+    expect(getAgentCalls()).toHaveLength(0);
   });
 
   it("does not bump registry generation for steer-restart bookkeeping toggles", () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -986,7 +986,7 @@ function ensureListener() {
               typeof evt.data?.startedAt === "number" ? evt.data.startedAt : entry.startedAt,
           })
         ) {
-          persistSubagentRuns();
+          persistSubagentRuns({ bumpGeneration: true });
         }
         return;
       }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -173,6 +173,14 @@ const runtimePluginsLoader = createLazyPromiseLoader(() =>
   importRuntimeModule<RuntimePluginsModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
 );
 
+/** Monotonic counter bumped on every registry mutation; used to invalidate caches that depend on subagent state. */
+let subagentRegistryGeneration = 0;
+
+/** Return the current monotonic generation counter for the subagent registry. */
+export function getSubagentRegistryGeneration(): number {
+  return subagentRegistryGeneration;
+}
+
 let sweeper: NodeJS.Timeout | null = null;
 const resumeRetryTimers = new Set<ReturnType<typeof setTimeout>>();
 let sweepInProgress = false;
@@ -327,7 +335,21 @@ async function resolveSubagentRegistryContextEngine(
   return await resolveContextEngine(cfg, options);
 }
 
-function persistSubagentRuns() {
+/**
+ * Persist the current subagent-runs map to disk.
+ *
+ * IMPORTANT: pass `{ bumpGeneration: true }` only when the preceding mutation
+ * changed `sessions.list`-visible subagent state (for example Map .set() /
+ * .delete(), or endedAt/outcome/endedReason/startedAt/sessionStartedAt changes).
+ *
+ * Bookkeeping-only updates can persist without a generation bump when safe
+ * (for example steer-restart suppression flags and ended-hook bookkeeping),
+ * to avoid invalidating list caches unnecessarily.
+ */
+function persistSubagentRuns(opts?: { bumpGeneration?: boolean }) {
+  if (opts?.bumpGeneration === true) {
+    subagentRegistryGeneration += 1;
+  }
   subagentRegistryDeps.persistSubagentRunsToDisk(subagentRuns);
 }
 
@@ -588,7 +610,20 @@ function resumeSubagentRun(runId: string) {
   if (!entry) {
     return;
   }
-  if (entry.cleanupCompletedAt) {
+  const orphanReason = resolveSubagentRunOrphanReason({ entry });
+  if (orphanReason) {
+    if (
+      reconcileOrphanedRun({
+        runId,
+        entry,
+        reason: orphanReason,
+        source: "resume",
+        runs: subagentRuns,
+        resumedRuns,
+      })
+    ) {
+      persistSubagentRuns({ bumpGeneration: true });
+    }
     return;
   }
   if (entry.pauseReason === "sessions_yield") {
@@ -694,7 +729,7 @@ function restoreSubagentRunsOnce() {
         resumedRuns,
       })
     ) {
-      persistSubagentRuns();
+      persistSubagentRuns({ bumpGeneration: true });
     }
     if (subagentRuns.size === 0) {
       return;
@@ -881,7 +916,7 @@ async function sweepSubagentRuns() {
     }
 
     if (mutated) {
-      persistSubagentRuns();
+      persistSubagentRuns({ bumpGeneration: true });
     }
     if (subagentRuns.size === 0) {
       stopSweeper();
@@ -918,7 +953,7 @@ function ensureListener() {
           if (typeof entry.sessionStartedAt !== "number") {
             entry.sessionStartedAt = startedAt;
           }
-          persistSubagentRuns();
+          persistSubagentRuns({ bumpGeneration: true });
         }
         return;
       }
@@ -1047,7 +1082,7 @@ export function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   }
   listenerStarted = false;
   if (opts?.persist !== false) {
-    persistSubagentRuns();
+    persistSubagentRuns({ bumpGeneration: true });
   }
 }
 

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -173,10 +173,8 @@ const runtimePluginsLoader = createLazyPromiseLoader(() =>
   importRuntimeModule<RuntimePluginsModule>(import.meta.url, SUBAGENT_REGISTRY_RUNTIME_SPEC),
 );
 
-/** Monotonic counter bumped on every registry mutation; used to invalidate caches that depend on subagent state. */
 let subagentRegistryGeneration = 0;
 
-/** Return the current monotonic generation counter for the subagent registry. */
 export function getSubagentRegistryGeneration(): number {
   return subagentRegistryGeneration;
 }
@@ -335,17 +333,6 @@ async function resolveSubagentRegistryContextEngine(
   return await resolveContextEngine(cfg, options);
 }
 
-/**
- * Persist the current subagent-runs map to disk.
- *
- * IMPORTANT: pass `{ bumpGeneration: true }` only when the preceding mutation
- * changed `sessions.list`-visible subagent state (for example Map .set() /
- * .delete(), or endedAt/outcome/endedReason/startedAt/sessionStartedAt changes).
- *
- * Bookkeeping-only updates can persist without a generation bump when safe
- * (for example steer-restart suppression flags and ended-hook bookkeeping),
- * to avoid invalidating list caches unnecessarily.
- */
 function persistSubagentRuns(opts?: { bumpGeneration?: boolean }) {
   if (opts?.bumpGeneration === true) {
     subagentRegistryGeneration += 1;

--- a/src/config/cache-utils.test.ts
+++ b/src/config/cache-utils.test.ts
@@ -47,4 +47,24 @@ describe("createExpiringMapCache", () => {
     expect(cache.get("stale")).toBeUndefined();
     expect(cache.keys()).toEqual(["fresh"]);
   });
+
+  it("evicts oldest entries when maxEntries is exceeded", () => {
+    let now = 1_000;
+    const cache = createExpiringMapCache<string, string>({
+      ttlMs: 60_000,
+      maxEntries: 2,
+      clock: () => now,
+    });
+
+    cache.set("a", "1");
+    now += 1;
+    cache.set("b", "2");
+    now += 1;
+    cache.set("c", "3");
+
+    expect(cache.size()).toBe(2);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe("2");
+    expect(cache.get("c")).toBe("3");
+  });
 });

--- a/src/config/cache-utils.ts
+++ b/src/config/cache-utils.ts
@@ -58,9 +58,12 @@ function isCacheEntryExpired(storedAt: number, now: number, ttlMs: number): bool
   return now - storedAt > ttlMs;
 }
 
+type CacheMaxEntriesResolver = number | undefined | (() => number | undefined);
+
 export function createExpiringMapCache<TKey, TValue>(options: {
   ttlMs: CacheTtlResolver;
   pruneIntervalMs?: CachePruneIntervalResolver;
+  maxEntries?: CacheMaxEntriesResolver;
   clock?: () => number;
 }): ExpiringMapCache<TKey, TValue> {
   const cache = new Map<TKey, ExpiringMapCacheEntry<TValue>>();
@@ -69,6 +72,39 @@ export function createExpiringMapCache<TKey, TValue>(options: {
 
   function getTtlMs(): number {
     return Math.max(0, Math.floor(resolveCacheNumeric(options.ttlMs)));
+  }
+
+  function getMaxEntries(): number | undefined {
+    if (options.maxEntries === undefined) {
+      return undefined;
+    }
+    const raw =
+      typeof options.maxEntries === "function" ? options.maxEntries() : options.maxEntries;
+    if (typeof raw !== "number" || !Number.isFinite(raw) || raw <= 0) {
+      return undefined;
+    }
+    return Math.floor(raw);
+  }
+
+  function evictOldestIfOverCap(): void {
+    const maxEntries = getMaxEntries();
+    if (maxEntries === undefined) {
+      return;
+    }
+    while (cache.size > maxEntries) {
+      let evictKey: TKey | undefined;
+      let evictAt = Infinity;
+      for (const [key, entry] of cache.entries()) {
+        if (entry.storedAt < evictAt) {
+          evictAt = entry.storedAt;
+          evictKey = key;
+        }
+      }
+      if (evictKey === undefined) {
+        break;
+      }
+      cache.delete(evictKey);
+    }
   }
 
   function maybePruneExpiredEntries(nowMs: number, ttlMs: number): void {
@@ -115,6 +151,7 @@ export function createExpiringMapCache<TKey, TValue>(options: {
         storedAt: nowMs,
         value,
       });
+      evictOldestIfOverCap();
     },
     delete: (key) => {
       cache.delete(key);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,5 +1,9 @@
 export {
   clearConfigCache,
+  clearResolvedConfigSourceStatFingerprintSyncCacheForTest,
+  collectResolvedConfigSourceStatFingerprintSync,
+  getConfigStatFingerprintAtLastLoad,
+  resetConfigStatFingerprintAtLastLoadForTest,
   ConfigRuntimeRefreshError,
   clearRuntimeConfigSnapshot,
   registerConfigWriteListener,

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -30,6 +30,8 @@ export type IncludeResolver = {
   readFile: (path: string) => string;
   readFileWithGuards?: (params: IncludeFileReadParams) => string;
   parseJson: (raw: string) => unknown;
+  /** Fires for each included file (resolved absolute path) before it is read. */
+  onResolvedIncludePath?: (resolvedPath: string) => void;
 };
 
 type IncludeFileReadParams = {
@@ -204,6 +206,8 @@ class IncludeProcessor {
 
     this.checkCircular(resolvedPath);
     this.checkDepth(includePath);
+
+    this.resolver.onResolvedIncludePath?.(resolvedPath);
 
     const raw = this.readFile(includePath, resolvedPath, root);
     const parsed = this.parseFile(includePath, resolvedPath, raw);

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -103,6 +103,7 @@ import {
   getRuntimeConfigSnapshotRefreshHandler as getRuntimeConfigSnapshotRefreshHandlerState,
   setRuntimeConfigSnapshotRefreshHandler as setRuntimeConfigSnapshotRefreshHandlerState,
   type ConfigWriteAfterWrite,
+  type RuntimeConfigSnapshotRefreshHandler,
   type RuntimeConfigWriteNotification,
 } from "./runtime-snapshot.js";
 import { resolveShellEnvExpectedKeys } from "./shell-env-expected-keys.js";
@@ -334,24 +335,6 @@ function resolveGatewayMode(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function cloneUnknown<T>(value: T): T {
-  return structuredClone(value);
-}
-
-function projectSourceOntoRuntimeShape(source: unknown, runtime: unknown): unknown {
-  if (!isRecord(source) || !isRecord(runtime)) {
-    return cloneUnknown(source);
-  }
-
-  const next: Record<string, unknown> = {};
-  for (const [key, sourceValue] of Object.entries(source)) {
-    if (!(key in runtime)) {
-      continue;
-    }
-    next[key] = projectSourceOntoRuntimeShape(sourceValue, runtime[key]);
-  }
-  return next;
-}
 function collectEnvRefPaths(value: unknown, path: string, output: Map<string, string>): void {
   if (typeof value === "string") {
     if (containsEnvVarReference(value)) {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -115,15 +115,9 @@ import {
 import { shouldWarnOnTouchedVersion } from "./version.js";
 
 export {
-  clearRuntimeConfigSnapshotState as clearRuntimeConfigSnapshot,
   getRuntimeConfigSnapshotMetadataState as getRuntimeConfigSnapshotMetadata,
-  getRuntimeConfigSnapshotState as getRuntimeConfigSnapshot,
-  getRuntimeConfigSourceSnapshotState as getRuntimeConfigSourceSnapshot,
-  resetConfigRuntimeStateState as resetConfigRuntimeState,
   resolveRuntimeConfigCacheKey,
   selectApplicableRuntimeConfig,
-  setRuntimeConfigSnapshotState as setRuntimeConfigSnapshot,
-  setRuntimeConfigSnapshotRefreshHandlerState as setRuntimeConfigSnapshotRefreshHandler,
 };
 
 // Re-export for backwards compatibility

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -75,7 +75,12 @@ import {
   materializeRuntimeConfig,
 } from "./materialize.js";
 import { applyMergePatch } from "./merge-patch.js";
-import { resolveConfigPath, resolveIncludeRoots, resolveStateDir } from "./paths.js";
+import {
+  resolveConfigPath,
+  resolveDefaultConfigCandidates,
+  resolveIncludeRoots,
+  resolveStateDir,
+} from "./paths.js";
 import {
   extractShippedPluginInstallConfigRecords,
   stripShippedPluginInstallConfigRecords,
@@ -329,6 +334,24 @@ function resolveGatewayMode(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function cloneUnknown<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function projectSourceOntoRuntimeShape(source: unknown, runtime: unknown): unknown {
+  if (!isRecord(source) || !isRecord(runtime)) {
+    return cloneUnknown(source);
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (!(key in runtime)) {
+      continue;
+    }
+    next[key] = projectSourceOntoRuntimeShape(sourceValue, runtime[key]);
+  }
+  return next;
+}
 function collectEnvRefPaths(value: unknown, path: string, output: Map<string, string>): void {
   if (typeof value === "string") {
     if (containsEnvVarReference(value)) {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -28,6 +28,7 @@ import { isRecord } from "../utils.js";
 import { VERSION } from "../version.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
 import { maintainConfigBackups } from "./backup-rotation.js";
+import { getFileStatSnapshot } from "./cache-utils.js";
 import { restoreEnvVarRefs } from "./env-preserve.js";
 import {
   type EnvSubstitutionWarning,
@@ -230,6 +231,11 @@ export type ConfigWriteOptions = {
    * an unrelated plugin rule prevents the full write from succeeding.
    */
   skipPluginValidation?: boolean;
+  /**
+   * Internal-only flag: keep runtime snapshots live during write so a caller
+   * can refresh them explicitly after persistence succeeds.
+   */
+  preserveRuntimeSnapshot?: boolean;
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -1971,7 +1977,19 @@ export function createConfigIO(
     cfg: OpenClawConfig,
     options: ConfigWriteOptions = {},
   ): Promise<{ persistedHash: string; persistedConfig: OpenClawConfig }> {
-    clearConfigCache();
+    const preserveRuntimeSnapshot = options.preserveRuntimeSnapshot === true;
+    // Always clear parse-cache entries first so this write computes from a fresh
+    // on-disk snapshot and does not reuse stale cache state.
+    clearConfigCacheEntry();
+    const finalizeRuntimeInvalidation = () => {
+      if (preserveRuntimeSnapshot) {
+        return;
+      }
+      // Direct io.writeConfigFile() callers still force a runtime reload, but
+      // only after persistence succeeds. This avoids clearing the active
+      // runtime snapshot during the write window.
+      clearConfigCache();
+    };
     const unsetPaths = resolveManagedUnsetPathsForWrite(options.unsetPaths);
     let persistCandidate: unknown = cfg;
     const snapshot =
@@ -2247,6 +2265,7 @@ export function createConfigIO(
             undefined,
             await deps.fs.promises.stat(configPath).catch(() => null),
           );
+          finalizeRuntimeInvalidation();
           return { persistedHash: nextHash, persistedConfig: stampedOutputConfig };
         }
         await deps.fs.promises.unlink(tmp).catch(() => {
@@ -2262,6 +2281,7 @@ export function createConfigIO(
         undefined,
         await deps.fs.promises.stat(configPath).catch(() => null),
       );
+      finalizeRuntimeInvalidation();
       return { persistedHash: nextHash, persistedConfig: stampedOutputConfig };
     } catch (err) {
       if (!configCommitted) {
@@ -2287,20 +2307,278 @@ export function createConfigIO(
   };
 }
 
+function buildSortedConfigStatFingerprint(configPath: string, includePaths: string[]): string {
+  const markers: string[] = [];
+  const seenPaths = new Set<string>();
+  const pushPathMarker = (filePath: string) => {
+    if (seenPaths.has(filePath)) {
+      return;
+    }
+    seenPaths.add(filePath);
+    const snap = getFileStatSnapshot(filePath);
+    markers.push(
+      snap ? `cfg:${filePath}:${snap.mtimeMs}:${snap.sizeBytes}` : `cfg:${filePath}:missing`,
+    );
+  };
+  pushPathMarker(configPath);
+  for (const p of includePaths) {
+    pushPathMarker(p);
+  }
+  markers.sort();
+  return markers.join("\n");
+}
+
+function computeResolvedConfigSourceStatFingerprint(
+  deps: Required<ConfigIoDeps>,
+  configPath: string,
+): { fingerprint: string; includePaths: string[]; includesResolved: boolean } {
+  const includePaths: string[] = [];
+  let includesResolved = false;
+
+  if (!deps.fs.existsSync(configPath)) {
+    return {
+      fingerprint: buildSortedConfigStatFingerprint(configPath, []),
+      includePaths,
+      includesResolved,
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = deps.fs.readFileSync(configPath, "utf-8");
+  } catch {
+    return {
+      fingerprint: buildSortedConfigStatFingerprint(configPath, []),
+      includePaths,
+      includesResolved,
+    };
+  }
+
+  const parsedRes = parseConfigJson5(raw, deps.json5);
+  if (!parsedRes.ok) {
+    return {
+      fingerprint: buildSortedConfigStatFingerprint(configPath, []),
+      includePaths,
+      includesResolved,
+    };
+  }
+
+  includesResolved = true;
+  try {
+    resolveConfigIncludes(parsedRes.parsed, configPath, {
+      readFile: (candidate) => deps.fs.readFileSync(candidate, "utf-8"),
+      readFileWithGuards: ({ includePath, resolvedPath, rootRealDir }) =>
+        readConfigIncludeFileWithGuards({
+          includePath,
+          resolvedPath,
+          rootRealDir,
+          ioFs: deps.fs,
+        }),
+      parseJson: (rawInner) => deps.json5.parse(rawInner),
+      onResolvedIncludePath: (resolvedPath) => {
+        includePaths.push(resolvedPath);
+      },
+    });
+  } catch {
+    // Broken includes: do not trust include paths from this failed attempt.
+    return {
+      fingerprint: buildSortedConfigStatFingerprint(configPath, includePaths),
+      includePaths,
+      includesResolved: false,
+    };
+  }
+
+  return {
+    fingerprint: buildSortedConfigStatFingerprint(configPath, includePaths),
+    includePaths,
+    includesResolved,
+  };
+}
+
+type ConfigSourceStatFingerprintMemo = {
+  configPath: string;
+  rootMtimeMs: number | null;
+  rootSizeBytes: number | null;
+  includePaths: string[];
+  includesResolved: boolean;
+  fingerprint: string;
+};
+
+let configSourceStatFingerprintMemo: ConfigSourceStatFingerprintMemo | null = null;
+
+/** Test-only: clears the default-deps fingerprint memo used by `sessions.list` cache keys. */
+export function clearResolvedConfigSourceStatFingerprintSyncCacheForTest(): void {
+  configSourceStatFingerprintMemo = null;
+}
+
+function fingerprintRootStatParts(configPath: string): {
+  mtimeMs: number | null;
+  sizeBytes: number | null;
+} {
+  const snap = getFileStatSnapshot(configPath);
+  if (!snap) {
+    return { mtimeMs: null, sizeBytes: null };
+  }
+  return { mtimeMs: snap.mtimeMs, sizeBytes: snap.sizeBytes };
+}
+
+/**
+ * Sorted stat fingerprint for the active config file plus every `$include` target.
+ * Keeps derived caches (for example `sessions.list`) aligned with modular configs.
+ *
+ * With default deps (no overrides), repeats reuse resolved `$include` paths and only
+ * re-stat files until the root config file changes.
+ */
+export function collectResolvedConfigSourceStatFingerprintSync(
+  overrides: ConfigIoDeps = {},
+): string {
+  const deps = normalizeDeps(overrides);
+  const requestedConfigPath = resolveConfigPathForDeps(deps);
+  const candidatePaths = deps.configPath
+    ? [requestedConfigPath]
+    : resolveDefaultConfigCandidates(deps.env, deps.homedir);
+  const configPath =
+    candidatePaths.find((candidate) => deps.fs.existsSync(candidate)) ?? requestedConfigPath;
+
+  const useMemo = Object.keys(overrides).length === 0;
+  const rootParts = fingerprintRootStatParts(configPath);
+
+  if (
+    useMemo &&
+    configSourceStatFingerprintMemo &&
+    configSourceStatFingerprintMemo.configPath === configPath &&
+    configSourceStatFingerprintMemo.rootMtimeMs === rootParts.mtimeMs &&
+    configSourceStatFingerprintMemo.rootSizeBytes === rootParts.sizeBytes
+  ) {
+    if (!configSourceStatFingerprintMemo.includesResolved) {
+      // Stale include resolution can skip or hide include-file updates under a fixed root stat.
+      // Recompute to avoid trusting cached include paths from failed parses.
+      const computed = computeResolvedConfigSourceStatFingerprint(deps, configPath);
+      configSourceStatFingerprintMemo = {
+        configPath,
+        rootMtimeMs: rootParts.mtimeMs,
+        rootSizeBytes: rootParts.sizeBytes,
+        includePaths: computed.includePaths,
+        includesResolved: computed.includesResolved,
+        fingerprint: computed.fingerprint,
+      };
+      return computed.fingerprint;
+    }
+    const fpFast = buildSortedConfigStatFingerprint(
+      configPath,
+      configSourceStatFingerprintMemo.includePaths,
+    );
+    if (fpFast === configSourceStatFingerprintMemo.fingerprint) {
+      return fpFast;
+    }
+  }
+
+  const computed = computeResolvedConfigSourceStatFingerprint(deps, configPath);
+  if (useMemo) {
+    configSourceStatFingerprintMemo = {
+      configPath,
+      rootMtimeMs: rootParts.mtimeMs,
+      rootSizeBytes: rootParts.sizeBytes,
+      includePaths: computed.includePaths,
+      includesResolved: computed.includesResolved,
+      fingerprint: computed.fingerprint,
+    };
+  }
+  return computed.fingerprint;
+}
+
 // NOTE: These wrappers intentionally do *not* cache the resolved config path at
 // module scope. `OPENCLAW_CONFIG_PATH` (and friends) are expected to work even
 // when set after the module has been imported (tests, one-off scripts, etc.).
 const AUTO_OWNER_DISPLAY_SECRET_BY_PATH = new Map<string, string>();
 const AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT = new Set<string>();
 const AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED = new Set<string>();
+/**
+ * Stat fingerprint captured at the moment `loadConfig()` last parsed from disk.
+ * Compared against the live stat fingerprint to detect when the config cache
+ * is returning a stale object that doesn't match the current on-disk state.
+ */
+let configStatFingerprintAtLastLoad: string | null = null;
+type ConfigCacheEntry = {
+  configPath: string;
+  expiresAt: number;
+  config: OpenClawConfig;
+};
+let configCache: ConfigCacheEntry | null = null;
+
+function resolveConfigCacheMs(env: NodeJS.ProcessEnv): number {
+  if (env.OPENCLAW_DISABLE_CONFIG_CACHE === "1") {
+    return 0;
+  }
+  const raw = env.OPENCLAW_CONFIG_CACHE_MS;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return 0;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+  return Math.floor(parsed);
+}
+
+function shouldUseConfigCache(env: NodeJS.ProcessEnv): boolean {
+  return resolveConfigCacheMs(env) > 0;
+}
+
+export function getConfigStatFingerprintAtLastLoad(): string | null {
+  return configStatFingerprintAtLastLoad;
+}
+
+export function resetConfigStatFingerprintAtLastLoadForTest(): void {
+  configStatFingerprintAtLastLoad = null;
+}
+
+function clearConfigCacheEntry(): void {
+  configCache = null;
+}
 export function clearConfigCache(): void {
-  // Compat shim: runtime snapshot is the only in-process cache now.
+  clearConfigCacheEntry();
+  resetConfigRuntimeState();
 }
 
 export function registerConfigWriteListener(
   listener: (event: ConfigWriteNotification) => void,
 ): () => void {
   return registerRuntimeConfigWriteListener(listener);
+}
+
+export function setRuntimeConfigSnapshot(
+  config: OpenClawConfig,
+  sourceConfig?: OpenClawConfig,
+): void {
+  configCache = null;
+  // Keep TOCTOU-sensitive `cfga` sessions-list cache keys aligned when swapping runtime snapshots.
+  configStatFingerprintAtLastLoad = collectResolvedConfigSourceStatFingerprintSync();
+  setRuntimeConfigSnapshotState(config, sourceConfig);
+}
+
+export function resetConfigRuntimeState(): void {
+  configCache = null;
+  configStatFingerprintAtLastLoad = null;
+  resetConfigRuntimeStateState();
+}
+
+export function clearRuntimeConfigSnapshot(): void {
+  resetConfigRuntimeState();
+}
+
+export function getRuntimeConfigSnapshot(): OpenClawConfig | null {
+  return getRuntimeConfigSnapshotState();
+}
+
+export function getRuntimeConfigSourceSnapshot(): OpenClawConfig | null {
+  return getRuntimeConfigSourceSnapshotState();
+}
+
+export function setRuntimeConfigSnapshotRefreshHandler(
+  refreshHandler: RuntimeConfigSnapshotRefreshHandler | null,
+): void {
+  setRuntimeConfigSnapshotRefreshHandlerState(refreshHandler);
 }
 
 function isCompatibleTopLevelRuntimeProjectionShape(params: {
@@ -2361,10 +2639,39 @@ export function projectConfigOntoRuntimeSourceSnapshot(config: OpenClawConfig): 
 }
 
 export function loadConfig(): OpenClawConfig {
+  const io = createConfigIO();
+  const configPath = io.configPath;
+  const now = Date.now();
+  // Prefer the in-memory runtime snapshot before the parse cache so concurrent readers
+  // still see last-known-good resolved config during `writeConfigFile(...,
+  // preserveRuntimeSnapshot: true)` (and after `clearConfigCacheEntry()` clears the TTL
+  // cache) instead of falling back to a fresh disk read with unresolved SecretRefs.
+  const runtimeConfigSnapshot = getRuntimeConfigSnapshotState();
+  if (runtimeConfigSnapshot) {
+    return runtimeConfigSnapshot;
+  }
+  if (shouldUseConfigCache(process.env)) {
+    const cached = configCache;
+    if (cached && cached.configPath === configPath && cached.expiresAt > now) {
+      return cached.config;
+    }
+    const config = io.loadConfig();
+    configStatFingerprintAtLastLoad = collectResolvedConfigSourceStatFingerprintSync();
+    configCache = {
+      configPath,
+      expiresAt: now + resolveConfigCacheMs(process.env),
+      config,
+    };
+    return config;
+  }
   // First successful load becomes the process snapshot. Long-lived runtimes
   // should swap this snapshot via explicit reload/watcher paths instead of
   // reparsing openclaw.json on hot code paths.
-  return loadPinnedRuntimeConfig(() => createConfigIO().loadConfig());
+  return loadPinnedRuntimeConfig(() => {
+    const config = io.loadConfig();
+    configStatFingerprintAtLastLoad = collectResolvedConfigSourceStatFingerprintSync();
+    return config;
+  });
 }
 
 export function getRuntimeConfig(): OpenClawConfig {
@@ -2452,6 +2759,7 @@ export async function writeConfigFile(
     skipRuntimeSnapshotRefresh: options.skipRuntimeSnapshotRefresh,
     skipOutputLogs: options.skipOutputLogs,
     skipPluginValidation: options.skipPluginValidation,
+    preserveRuntimeSnapshot: true,
   });
   if (
     options.skipRuntimeSnapshotRefresh &&

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -87,7 +87,6 @@ import {
 } from "./plugin-install-config-migration.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
 import {
-  clearRuntimeConfigSnapshot as clearRuntimeConfigSnapshotState,
   createRuntimeConfigWriteNotification,
   finalizeRuntimeSnapshotWrite,
   getRuntimeConfigSnapshotMetadata as getRuntimeConfigSnapshotMetadataState,

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { isPlainObject } from "../infra/plain-object.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
 
@@ -94,4 +95,39 @@ export function applyMergePatch(
   }
 
   return result;
+}
+
+export function createMergePatch(base: unknown, target: unknown): unknown {
+  if (!isPlainObject(base) || !isPlainObject(target)) {
+    return structuredClone(target);
+  }
+
+  const patch: PlainObject = {};
+  const keys = new Set([...Object.keys(base), ...Object.keys(target)]);
+  for (const key of keys) {
+    const hasBase = key in base;
+    const hasTarget = key in target;
+    if (!hasTarget) {
+      patch[key] = null;
+      continue;
+    }
+    const targetValue = target[key];
+    if (!hasBase) {
+      patch[key] = structuredClone(targetValue);
+      continue;
+    }
+    const baseValue = base[key];
+    if (isPlainObject(baseValue) && isPlainObject(targetValue)) {
+      const childPatch = createMergePatch(baseValue, targetValue);
+      if (isPlainObject(childPatch) && Object.keys(childPatch).length === 0) {
+        continue;
+      }
+      patch[key] = childPatch;
+      continue;
+    }
+    if (!isDeepStrictEqual(baseValue, targetValue)) {
+      patch[key] = structuredClone(targetValue);
+    }
+  }
+  return patch;
 }

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -56,6 +56,8 @@ export const SessionsListParamsSchema = Type.Object(
     spawnedBy: Type.Optional(NonEmptyString),
     agentId: Type.Optional(NonEmptyString),
     search: Type.Optional(Type.String()),
+    /** When set to the hash from a prior `sessions.list` response, server may return `{ unchanged: true }` if the session rows are unchanged. */
+    lastHash: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -57,7 +57,7 @@ export const SessionsListParamsSchema = Type.Object(
     agentId: Type.Optional(NonEmptyString),
     search: Type.Optional(Type.String()),
     /** When set to the hash from a prior `sessions.list` response, server may return `{ unchanged: true }` if the session rows are unchanged. */
-    lastHash: Type.Optional(Type.String()),
+    lastHash: Type.Optional(Type.String({ maxLength: 64 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/config.secretref.test.ts
+++ b/src/gateway/server-methods/config.secretref.test.ts
@@ -39,10 +39,6 @@ vi.mock("../../config/merge-patch.js", () => ({
   createMergePatch: (_prev: unknown, next: unknown) => structuredClone((next ?? {}) as object),
 }));
 
-vi.mock("../../commands/doctor/shared/runtime-compat-api.js", () => ({
-  applyRuntimeLegacyConfigMigrations: (raw: OpenClawConfig) => ({ next: raw }),
-}));
-
 vi.mock("../../secrets/runtime.js", () => ({
   prepareSecretsRuntimeSnapshot: prepareSecretsRuntimeSnapshotMock,
 }));

--- a/src/gateway/server-methods/config.secretref.test.ts
+++ b/src/gateway/server-methods/config.secretref.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createConfigHandlerHarness, createConfigWriteSnapshot } from "./config.test-helpers.js";
+
+const readConfigFileSnapshotForWriteMock = vi.fn();
+const writeConfigFileMock = vi.fn();
+const validateConfigObjectRawWithPluginsMock = vi.fn();
+const validateConfigObjectWithPluginsMock = vi.fn();
+const prepareSecretsRuntimeSnapshotMock = vi.fn();
+const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({
+  scheduled: true,
+  delayMs: 1_000,
+  coalesced: false,
+}));
+
+vi.mock("../../config/config.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../config/config.js")>("../../config/config.js");
+  return {
+    ...actual,
+    createConfigIO: () => ({ configPath: "/tmp/openclaw.json" }),
+    readConfigFileSnapshotForWrite: readConfigFileSnapshotForWriteMock,
+    validateConfigObjectRawWithPlugins: validateConfigObjectRawWithPluginsMock,
+    validateConfigObjectWithPlugins: validateConfigObjectWithPluginsMock,
+    writeConfigFile: writeConfigFileMock,
+  };
+});
+
+vi.mock("../../config/runtime-schema.js", () => ({
+  loadGatewayRuntimeConfigSchema: () => ({ uiHints: undefined }),
+}));
+
+vi.mock("../../config/materialize.js", () => ({
+  materializeRuntimeConfig: (config: OpenClawConfig) => config,
+}));
+
+vi.mock("../../config/merge-patch.js", () => ({
+  applyMergePatch: (_base: unknown, patch: unknown) => structuredClone((patch ?? {}) as object),
+  createMergePatch: (_prev: unknown, next: unknown) => structuredClone((next ?? {}) as object),
+}));
+
+vi.mock("../../commands/doctor/shared/runtime-compat-api.js", () => ({
+  applyRuntimeLegacyConfigMigrations: (raw: OpenClawConfig) => ({ next: raw }),
+}));
+
+vi.mock("../../secrets/runtime.js", () => ({
+  prepareSecretsRuntimeSnapshot: prepareSecretsRuntimeSnapshotMock,
+}));
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+}));
+
+const { configHandlers } = await import("./config.js");
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  validateConfigObjectRawWithPluginsMock.mockImplementation((config: OpenClawConfig) => ({
+    ok: true,
+    config,
+  }));
+  validateConfigObjectWithPluginsMock.mockImplementation((config: OpenClawConfig) => ({
+    ok: true,
+    config,
+  }));
+  prepareSecretsRuntimeSnapshotMock.mockRejectedValue(new Error("Environment variable missing"));
+});
+
+describe("config SecretRef rejection", () => {
+  it("rejects config.set when request-time SecretRef resolution fails", async () => {
+    const nextConfig: OpenClawConfig = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "new-token",
+        },
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot({}));
+
+    const { options, respond, disconnectClientsUsingSharedGatewayAuth } =
+      createConfigHandlerHarness({
+        method: "config.set",
+        params: {
+          raw: JSON.stringify(nextConfig, null, 2),
+          baseHash: "base-hash",
+        },
+      });
+
+    await configHandlers["config.set"](options);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("active SecretRef resolution failed"),
+      }),
+    );
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(disconnectClientsUsingSharedGatewayAuth).not.toHaveBeenCalled();
+  });
+
+  it("rejects config.patch when request-time SecretRef resolution fails", async () => {
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot({}));
+
+    const { options, respond, disconnectClientsUsingSharedGatewayAuth } =
+      createConfigHandlerHarness({
+        method: "config.patch",
+        params: {
+          baseHash: "base-hash",
+          raw: JSON.stringify({}),
+        },
+      });
+
+    await configHandlers["config.patch"](options);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("active SecretRef resolution failed"),
+      }),
+    );
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(disconnectClientsUsingSharedGatewayAuth).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,6 +1,4 @@
 import { execFile } from "node:child_process";
-import { isDeepStrictEqual } from "node:util";
-import { applyRuntimeLegacyConfigMigrations } from "../../commands/doctor/shared/runtime-compat-api.js";
 import {
   createConfigIO,
   parseConfigJson5,
@@ -211,8 +209,7 @@ function parseValidateConfigFromRawOrRespond(
     );
     return null;
   }
-  const migrated = applyRuntimeLegacyConfigMigrations(restored.result);
-  const restoredConfig = (migrated.next ?? restored.result) as OpenClawConfig;
+  const restoredConfig = restored.result as OpenClawConfig;
   const validated = validateConfigObjectWithPlugins(restoredConfig);
   if (!validated.ok) {
     respond(
@@ -417,8 +414,7 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const migratedRuntime = applyRuntimeLegacyConfigMigrations(restoredRuntime.result);
-    const resolvedRuntime = (migratedRuntime.next ?? restoredRuntime.result) as OpenClawConfig;
+    const resolvedRuntime = restoredRuntime.result as OpenClawConfig;
     const sourcePatch = createMergePatch(snapshot.config, resolvedRuntime);
     const mergedSource = applyMergePatch(snapshot.sourceConfig, sourcePatch, {
       mergeObjectArraysById: true,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { isDeepStrictEqual } from "node:util";
+import { applyRuntimeLegacyConfigMigrations } from "../../commands/doctor/shared/runtime-compat-api.js";
 import {
   createConfigIO,
   parseConfigJson5,
@@ -9,7 +11,6 @@ import {
   validateConfigObjectWithPlugins,
 } from "../../config/config.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
-import { applyLegacyMigrations } from "../../config/legacy.js";
 import { materializeRuntimeConfig } from "../../config/materialize.js";
 import { applyMergePatch, createMergePatch } from "../../config/merge-patch.js";
 import {
@@ -414,7 +415,7 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const migratedRuntime = applyLegacyMigrations(restoredRuntime.result);
+    const migratedRuntime = applyRuntimeLegacyConfigMigrations(restoredRuntime.result);
     const resolvedRuntime = (migratedRuntime.next ?? restoredRuntime.result) as OpenClawConfig;
     const sourcePatch = createMergePatch(snapshot.config, resolvedRuntime);
     const mergedSource = applyMergePatch(snapshot.sourceConfig, sourcePatch, {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -5,10 +5,13 @@ import {
   readConfigFileSnapshot,
   readConfigFileSnapshotForWrite,
   resolveConfigSnapshotHash,
+  validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "../../config/config.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
-import { applyMergePatch } from "../../config/merge-patch.js";
+import { applyLegacyMigrations } from "../../config/legacy.js";
+import { materializeRuntimeConfig } from "../../config/materialize.js";
+import { applyMergePatch, createMergePatch } from "../../config/merge-patch.js";
 import {
   redactConfigObject,
   redactConfigSnapshot,
@@ -391,41 +394,80 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
+    const mergedRuntime = applyMergePatch(snapshot.config, parsedRes.parsed, {
       mergeObjectArraysById: true,
     });
     const schemaPatch = loadSchemaWithPlugins();
-    const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
-    if (!restoredMerge.ok) {
+    const restoredRuntime = restoreRedactedValues(
+      mergedRuntime,
+      snapshot.config,
+      schemaPatch.uiHints,
+    );
+    if (!restoredRuntime.ok) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          restoredMerge.humanReadableMessage ?? "invalid config",
+          restoredRuntime.humanReadableMessage ?? "invalid config",
         ),
       );
       return;
     }
-    const validated = validateConfigObjectWithPlugins(restoredMerge.result);
-    if (!validated.ok) {
+    const migratedRuntime = applyLegacyMigrations(restoredRuntime.result);
+    const resolvedRuntime = (migratedRuntime.next ?? restoredRuntime.result) as OpenClawConfig;
+    const sourcePatch = createMergePatch(snapshot.config, resolvedRuntime);
+    const mergedSource = applyMergePatch(snapshot.sourceConfig, sourcePatch, {
+      mergeObjectArraysById: true,
+    }) as OpenClawConfig;
+    const validatedSource = validateConfigObjectRawWithPlugins(mergedSource);
+    if (!validatedSource.ok) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, summarizeConfigValidationIssues(validated.issues), {
-          details: { issues: validated.issues },
-        }),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          summarizeConfigValidationIssues(validatedSource.issues),
+          {
+            details: { issues: validatedSource.issues },
+          },
+        ),
       );
       return;
     }
+    const materializedCandidate = materializeRuntimeConfig(validatedSource.config, "snapshot");
     const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({
-      config: validated.config,
+      config: materializedCandidate,
       respond,
     });
     if (!preparedSecretsSnapshot) {
       return;
     }
-    const changedPaths = diffConfigPaths(snapshot.config, validated.config);
+    const validatedMaterialized = validateConfigObjectWithPlugins(materializedCandidate);
+    if (!validatedMaterialized.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          summarizeConfigValidationIssues(validatedMaterialized.issues),
+          {
+            details: { issues: validatedMaterialized.issues },
+          },
+        ),
+      );
+      return;
+    }
+    const nextRuntimeConfig = validatedMaterialized.config;
+    // Noop detection uses two layers:
+    // 1. Source-level: diff the persisted/source-shaped config so removing a
+    //    literal key that falls back from env is NOT a noop.
+    // 2. Materialized: compare snapshot-shaped configs so identity patches
+    //    (e.g. config.get → JSON → config.patch) still hit the noop path.
+    const sourceChangedPaths = diffConfigPaths(snapshot.sourceConfig, validatedSource.config);
+    const materializedChangedPaths = diffConfigPaths(snapshot.config, nextRuntimeConfig);
+    const changedPaths =
+      sourceChangedPaths.length > 0 ? sourceChangedPaths : materializedChangedPaths;
     const actor = resolveControlPlaneActor(client);
 
     // No-op: if the validated config is identical to the current config,
@@ -442,7 +484,7 @@ export const configHandlers: GatewayRequestHandlers = {
           ok: true,
           noop: true,
           path: resolveGatewayConfigPath(snapshot),
-          config: redactConfigObject(validated.config, schemaPatch.uiHints),
+          config: redactConfigObject(nextRuntimeConfig, schemaPatch.uiHints),
         },
         undefined,
       );
@@ -455,7 +497,7 @@ export const configHandlers: GatewayRequestHandlers = {
     // Compare before the write so we invalidate clients authenticated against the
     // previous shared secret immediately after the config update succeeds.
     const disconnectSharedAuthClients =
-      didSharedGatewayAuthChange(snapshot.config, validated.config) ||
+      didSharedGatewayAuthChange(snapshot.config, nextRuntimeConfig) ||
       didActiveSharedGatewayAuthChange({
         fallbackPrev: snapshot.config,
         next: preparedSecretsSnapshot.config,
@@ -463,7 +505,7 @@ export const configHandlers: GatewayRequestHandlers = {
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
       writeOptions,
-      nextConfig: validated.config,
+      nextConfig: validatedSource.config,
       context,
       disconnectSharedAuthClients,
     });
@@ -474,7 +516,7 @@ export const configHandlers: GatewayRequestHandlers = {
       mode: "config.patch",
       configPath: writeResult.path,
       changedPaths,
-      nextConfig: validated.config,
+      nextConfig: nextRuntimeConfig,
       actor,
       context,
     });
@@ -483,7 +525,7 @@ export const configHandlers: GatewayRequestHandlers = {
       {
         ok: true,
         path: writeResult.path,
-        config: redactConfigObject(validated.config, schemaPatch.uiHints),
+        config: redactConfigObject(nextRuntimeConfig, schemaPatch.uiHints),
         restart,
         sentinel: {
           path: sentinelPath,
@@ -513,7 +555,8 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!preparedSecretsSnapshot) {
       return;
     }
-    const changedPaths = diffConfigPaths(snapshot.config, parsed.config);
+    const materializedApplied = materializeRuntimeConfig(parsed.config, "snapshot");
+    const changedPaths = diffConfigPaths(snapshot.config, materializedApplied);
     const actor = resolveControlPlaneActor(client);
     context?.logGateway?.info(
       `config.apply write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.apply`,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -211,7 +211,9 @@ function parseValidateConfigFromRawOrRespond(
     );
     return null;
   }
-  const validated = validateConfigObjectWithPlugins(restored.result);
+  const migrated = applyRuntimeLegacyConfigMigrations(restored.result);
+  const restoredConfig = (migrated.next ?? restored.result) as OpenClawConfig;
+  const validated = validateConfigObjectWithPlugins(restoredConfig);
   if (!validated.ok) {
     respond(
       false,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -93,6 +93,7 @@ import {
   resolveSessionDisplayModelIdentityRef,
   resolveSessionModelRef,
   resolveSessionTranscriptCandidates,
+  type SessionsListResult,
   type SessionsPatchResult,
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
@@ -121,6 +122,8 @@ let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
 let loggedSlowSessionsListCatalog = false;
 
 const SESSIONS_LIST_MODEL_CATALOG_TIMEOUT_MS = 750;
+
+type SessionsListHashPayload = Pick<SessionsListResult, "path" | "count" | "defaults" | "sessions">;
 
 function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
@@ -455,7 +458,7 @@ function hasTrackedActiveSessionRun(params: {
   return false;
 }
 
-function attachTrackedActiveSessionRuns<T extends SessionsListResult>(params: {
+function attachTrackedActiveSessionRuns<T extends SessionsListHashPayload>(params: {
   context: GatewayRequestContext;
   result: T;
 }): T {
@@ -473,7 +476,7 @@ function attachTrackedActiveSessionRuns<T extends SessionsListResult>(params: {
   };
 }
 
-function hashSessionsListResult(result: SessionsListResult): string {
+function hashSessionsListResult(result: SessionsListHashPayload): string {
   // `count` is intentionally omitted from the hash payload: when it changes because session
   // data changed, the store/config fingerprint already invalidates the cache entry.
   // `path` is included so clients cannot treat `{ unchanged: true }` as valid across store moves.

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -477,9 +477,6 @@ function attachTrackedActiveSessionRuns<T extends SessionsListHashPayload>(param
 }
 
 function hashSessionsListResult(result: SessionsListHashPayload): string {
-  // `count` is intentionally omitted from the hash payload: when it changes because session
-  // data changed, the store/config fingerprint already invalidates the cache entry.
-  // `path` is included so clients cannot treat `{ unchanged: true }` as valid across store moves.
   const serialized = JSON.stringify({
     path: result.path,
     sessions: result.sessions,
@@ -742,7 +739,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     });
     const visibleResult = attachTrackedActiveSessionRuns({ context, result });
     const hash = hashSessionsListResult(visibleResult);
-    writeSessionsListResultCache({ cfg, listParams: p, hash, result });
+    writeSessionsListResultCache({ cfg, listParams: p, result });
     const clientHash = typeof p.lastHash === "string" ? p.lastHash : undefined;
     if (clientHash && clientHash === hash) {
       respond(true, { unchanged: true, hash, ts: Date.now(), count: result.count }, undefined);

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
@@ -97,6 +97,11 @@ import {
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
 } from "../session-utils.js";
+import {
+  notifySessionsListFullComputation,
+  tryReadSessionsListResultCache,
+  writeSessionsListResultCache,
+} from "../sessions-list-result-cache.js";
 import { applySessionsPatchToStore } from "../sessions-patch.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
@@ -450,6 +455,36 @@ function hasTrackedActiveSessionRun(params: {
   return false;
 }
 
+function attachTrackedActiveSessionRuns<T extends SessionsListResult>(params: {
+  context: GatewayRequestContext;
+  result: T;
+}): T {
+  return {
+    ...params.result,
+    sessions: params.result.sessions.map((session) =>
+      Object.assign({}, session, {
+        hasActiveRun: hasTrackedActiveSessionRun({
+          context: params.context,
+          requestedKey: session.key,
+          canonicalKey: session.key,
+        }),
+      }),
+    ),
+  };
+}
+
+function hashSessionsListResult(result: SessionsListResult): string {
+  // `count` is intentionally omitted from the hash payload: when it changes because session
+  // data changed, the store/config fingerprint already invalidates the cache entry.
+  // `path` is included so clients cannot treat `{ unchanged: true }` as valid across store moves.
+  const serialized = JSON.stringify({
+    path: result.path,
+    sessions: result.sessions,
+    defaults: result.defaults,
+  });
+  return createHash("sha256").update(serialized).digest("hex").slice(0, 16);
+}
+
 async function interruptSessionRunIfActive(params: {
   req: GatewayRequestHandlerOptions["req"];
   context: GatewayRequestContext;
@@ -668,7 +703,32 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
     const p = params;
     const cfg = context.getRuntimeConfig();
+    const cached = tryReadSessionsListResultCache({ cfg, listParams: p });
+    if (cached) {
+      const ts = Date.now();
+      const cachedResult = attachTrackedActiveSessionRuns({ context, result: cached });
+      const hash = hashSessionsListResult(cachedResult);
+      const clientHash = typeof p.lastHash === "string" ? p.lastHash : undefined;
+      if (clientHash && clientHash === hash) {
+        respond(true, { unchanged: true, hash, ts, count: cachedResult.count }, undefined);
+        return;
+      }
+      respond(
+        true,
+        {
+          ts,
+          path: cachedResult.path,
+          count: cachedResult.count,
+          defaults: cachedResult.defaults,
+          sessions: cachedResult.sessions,
+          hash,
+        },
+        undefined,
+      );
+      return;
+    }
     const { storePath, store } = loadCombinedSessionStoreForGateway(cfg, { agentId: p.agentId });
+    notifySessionsListFullComputation();
     const modelCatalog = await loadOptionalSessionsListModelCatalog(context);
     const result = await listSessionsFromStoreAsync({
       cfg,
@@ -677,22 +737,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       modelCatalog,
       opts: p,
     });
-    respond(
-      true,
-      {
-        ...result,
-        sessions: result.sessions.map((session) =>
-          Object.assign({}, session, {
-            hasActiveRun: hasTrackedActiveSessionRun({
-              context,
-              requestedKey: session.key,
-              canonicalKey: session.key,
-            }),
-          }),
-        ),
-      },
-      undefined,
-    );
+    const visibleResult = attachTrackedActiveSessionRuns({ context, result });
+    const hash = hashSessionsListResult(visibleResult);
+    writeSessionsListResultCache({ cfg, listParams: p, hash, result });
+    const clientHash = typeof p.lastHash === "string" ? p.lastHash : undefined;
+    if (clientHash && clientHash === hash) {
+      respond(true, { unchanged: true, hash, ts: Date.now(), count: result.count }, undefined);
+      return;
+    }
+    respond(true, { ...visibleResult, ts: Date.now(), hash }, undefined);
   },
   "sessions.cleanup": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateSessionsCleanupParams, "sessions.cleanup", respond)) {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
 import { AUTH_PROFILE_FILENAME } from "../agents/auth-profiles/constants.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { __testing as controlPlaneRateLimitTesting } from "./control-plane-rate-limit.js";
 import {
   connectOk,
@@ -17,6 +18,9 @@ import {
 installGatewayTestHooks({ scope: "suite" });
 
 const CONFIG_SECRETREF_RPC_TIMEOUT_MS = 20_000;
+beforeEach(() => {
+  controlPlaneRateLimitTesting.resetControlPlaneRateLimitState();
+});
 
 let startedServer: Awaited<ReturnType<typeof startServerWithClient>> | null = null;
 let sharedTempRoot: string;
@@ -329,21 +333,114 @@ describe("gateway config methods", () => {
     }>(requireWs(), "config.get", {});
     expect(current.ok).toBe(true);
 
-    // Patch with the same config — no actual changes
-    const res = await rpcReq<{
+    // Normalize through config.set first so the subsequent config.patch reapply
+    // checks the true no-op path instead of first-write normalization.
+    const setRes = await rpcReq<{
+      ok?: boolean;
+      config?: Record<string, unknown>;
+    }>(requireWs(), "config.set", {
+      raw: JSON.stringify(current.payload?.config ?? {}),
+      baseHash: current.payload?.hash,
+    });
+    expect(setRes.ok).toBe(true);
+
+    const normalized = await rpcReq<{ hash?: string }>(requireWs(), "config.get", {});
+    expect(normalized.ok).toBe(true);
+    expect(typeof normalized.payload?.hash).toBe("string");
+
+    // Re-apply the normalized config via config.patch — this must be a no-op.
+    const second = await rpcReq<{
       ok?: boolean;
       noop?: boolean;
       config?: Record<string, unknown>;
     }>(requireWs(), "config.patch", {
+      raw: JSON.stringify(setRes.payload?.config ?? {}),
+      baseHash: normalized.payload?.hash,
+    });
+
+    expect(second.ok).toBe(true);
+    expect(second.payload?.noop).toBe(true);
+    // Config hash should not change on no-op reapply.
+    const after = await rpcReq<{ hash?: string }>(requireWs(), "config.get", {});
+    expect(after.payload?.hash).toBe(normalized.payload?.hash);
+  });
+
+  it("does not noop config.patch when source config changed", async () => {
+    // Normalize via config.set to get a clean baseline.
+    const current = await rpcReq<{
+      config?: Record<string, unknown>;
+      hash?: string;
+    }>(requireWs(), "config.get", {});
+    expect(current.ok).toBe(true);
+    const setRes = await rpcReq<{ ok?: boolean }>(requireWs(), "config.set", {
       raw: JSON.stringify(current.payload?.config ?? {}),
       baseHash: current.payload?.hash,
     });
+    expect(setRes.ok).toBe(true);
+    const normalized = await rpcReq<{
+      config?: Record<string, unknown>;
+      hash?: string;
+    }>(requireWs(), "config.get", {});
+    expect(normalized.ok).toBe(true);
 
-    expect(res.ok).toBe(true);
-    expect(res.payload?.noop).toBe(true);
-    // Config hash should not change (no file write)
-    const after = await rpcReq<{ hash?: string }>(requireWs(), "config.get", {});
-    expect(after.payload?.hash).toBe(current.payload?.hash);
+    // Patch with a toggled gateway.controlUi.enabled value — the source config
+    // changes, so config.patch must NOT return noop.
+    const cfg = normalized.payload?.config ?? {};
+    const gw = (cfg as Record<string, Record<string, unknown>>).gateway ?? {};
+    const controlUi = (gw.controlUi as Record<string, unknown>) ?? {};
+    const patchRes = await rpcReq<{
+      ok?: boolean;
+      noop?: boolean;
+    }>(requireWs(), "config.patch", {
+      raw: JSON.stringify({ gateway: { controlUi: { enabled: !controlUi.enabled } } }),
+      baseHash: normalized.payload?.hash,
+    });
+
+    expect(patchRes.ok).toBe(true);
+    expect(patchRes.payload?.noop).not.toBe(true);
+  });
+
+  it("does not noop config.patch when removing a persisted key that falls back from env", async () => {
+    await withEnvAsync({ ELEVENLABS_API_KEY: "env-elevenlabs-key" }, async () => {
+      const { writeConfigFile } = await import("../config/config.js");
+      await writeConfigFile({
+        talk: {
+          provider: "elevenlabs",
+          voiceId: "voice-123",
+          apiKey: "env-elevenlabs-key", // pragma: allowlist secret
+        },
+      });
+
+      const current = await rpcReq<{
+        hash?: string;
+      }>(requireWs(), "config.get", {});
+      expect(current.ok).toBe(true);
+      expect(typeof current.payload?.hash).toBe("string");
+
+      const patchRes = await rpcReq<{
+        ok?: boolean;
+        noop?: boolean;
+      }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({
+          talk: {
+            apiKey: null,
+            providers: {
+              elevenlabs: {
+                apiKey: null,
+              },
+            },
+          },
+        }),
+        baseHash: current.payload?.hash,
+      });
+
+      expect(patchRes.ok).toBe(true);
+      expect(patchRes.payload?.noop).not.toBe(true);
+
+      const after = await rpcReq<{ hash?: string }>(requireWs(), "config.get", {});
+      expect(after.ok).toBe(true);
+      expect(after.payload?.hash).not.toBe(current.payload?.hash);
+    });
   });
 
   it("rejects config.patch when raw is null", async () => {
@@ -520,6 +617,67 @@ describe("gateway server sessions", () => {
     });
     expect(workSessions.ok).toBe(true);
     expect(workSessions.payload?.sessions.map((s) => s.key)).toEqual(["agent:work:main"]);
+  });
+
+  it("sessions.list stays consistent after config.set round-trip", async () => {
+    const dir = await resetTempDir("config-roundtrip-sessions");
+    const prevSessionConfig = testState.sessionConfig;
+    const prevAgentsConfig = testState.agentsConfig;
+    testState.sessionConfig = {
+      store: path.join(dir, "{agentId}", "sessions.json"),
+    };
+    testState.agentsConfig = {
+      list: [{ id: "home", default: true }],
+    };
+    try {
+      const homeDir = path.join(dir, "home");
+      await fs.mkdir(homeDir, { recursive: true });
+      await writeSessionStore({
+        storePath: path.join(homeDir, "sessions.json"),
+        agentId: "home",
+        entries: {
+          main: {
+            sessionId: "sess-home-main",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const params = {
+        includeGlobal: false,
+        includeUnknown: false,
+        agentId: "home",
+      } as const;
+
+      const before = await rpcReq<{
+        sessions: Array<{ key: string }>;
+      }>(requireWs(), "sessions.list", params);
+      expect(before.ok).toBe(true);
+      const keysBefore = before.payload?.sessions.map((s) => s.key).toSorted() ?? [];
+
+      const current = await rpcReq<{
+        hash?: string;
+        config?: Record<string, unknown>;
+      }>(requireWs(), "config.get", {});
+      expect(current.ok).toBe(true);
+      expect(typeof current.payload?.hash).toBe("string");
+
+      const setRes = await rpcReq<{ ok?: boolean }>(requireWs(), "config.set", {
+        raw: JSON.stringify(current.payload?.config ?? {}, null, 2),
+        baseHash: current.payload?.hash,
+      });
+      expect(setRes.ok).toBe(true);
+
+      const after = await rpcReq<{
+        sessions: Array<{ key: string }>;
+      }>(requireWs(), "sessions.list", params);
+      expect(after.ok).toBe(true);
+      const keysAfter = after.payload?.sessions.map((s) => s.key).toSorted() ?? [];
+      expect(keysAfter).toEqual(keysBefore);
+    } finally {
+      testState.sessionConfig = prevSessionConfig;
+      testState.agentsConfig = prevAgentsConfig;
+    }
   });
 
   it("resolves and patches main alias to default agent main key", async () => {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -402,7 +402,7 @@ describe("gateway config methods", () => {
 
   it("does not noop config.patch when removing a persisted key that falls back from env", async () => {
     await withEnvAsync({ ELEVENLABS_API_KEY: "env-elevenlabs-key" }, async () => {
-      const { writeConfigFile } = await import("../config/config.js");
+      const { createConfigIO, writeConfigFile } = await import("../config/config.js");
       await writeConfigFile({
         talk: {
           provider: "elevenlabs",
@@ -440,6 +440,19 @@ describe("gateway config methods", () => {
       const after = await rpcReq<{ hash?: string }>(requireWs(), "config.get", {});
       expect(after.ok).toBe(true);
       expect(after.payload?.hash).not.toBe(current.payload?.hash);
+
+      const persisted = JSON.parse(await fs.readFile(createConfigIO().configPath, "utf-8")) as {
+        talk?: {
+          apiKey?: unknown;
+          providers?: {
+            elevenlabs?: {
+              apiKey?: unknown;
+            };
+          };
+        };
+      };
+      expect(persisted.talk ?? {}).not.toHaveProperty("apiKey");
+      expect(persisted.talk?.providers?.elevenlabs ?? {}).not.toHaveProperty("apiKey");
     });
   });
 

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -415,8 +415,12 @@ describe("gateway config methods", () => {
       await writeConfigFile({
         talk: {
           provider: "elevenlabs",
-          voiceId: "voice-123",
-          apiKey: "env-elevenlabs-key", // pragma: allowlist secret
+          providers: {
+            elevenlabs: {
+              voiceId: "voice-123",
+              apiKey: "env-elevenlabs-key", // pragma: allowlist secret
+            },
+          },
         },
       });
 

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -68,6 +68,15 @@ async function sendConfigApply(params: { raw: unknown; baseHash?: string }, time
   return await rpcReq(requireWs(), "config.apply", params, timeoutMs);
 }
 
+const sendConfigPatch = async (params: { raw: unknown; baseHash?: string }, timeoutMs?: number) => {
+  return await rpcReq<{ ok?: boolean; error?: { message?: string } }>(
+    requireWs(),
+    "config.patch",
+    params,
+    timeoutMs,
+  );
+};
+
 async function expectSchemaLookupInvalid(path: unknown) {
   const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.schema.lookup", { path });
   expect(res.ok).toBe(false);
@@ -469,9 +478,7 @@ describe("gateway config methods", () => {
     const missingEnvVar = `OPENCLAW_MISSING_SECRETREF_PATCH_${Date.now()}`;
     delete process.env[missingEnvVar];
     const beforeHash = await getConfigHash();
-    const res = await rpcReq<{ ok?: boolean; error?: { message?: string } }>(
-      requireWs(),
-      "config.patch",
+    const res = await sendConfigPatch(
       {
         raw: JSON.stringify({
           gateway: {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1221,52 +1221,6 @@ export function collectCombinedSessionStoreStatFingerprint(cfg: OpenClawConfig):
   return markers.join("\n");
 }
 
-export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
-  storePath: string;
-  store: Record<string, SessionEntry>;
-} {
-  const storeConfig = cfg.session?.store;
-  if (storeConfig && !isStorePathTemplate(storeConfig)) {
-    const storePath = resolveStorePath(storeConfig);
-    const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    const store = loadSessionStore(storePath);
-    const combined: Record<string, SessionEntry> = {};
-    for (const [key, entry] of Object.entries(store)) {
-      const canonicalKey = canonicalizeSessionKeyForAgent(defaultAgentId, key);
-      mergeSessionEntryIntoCombined({
-        cfg,
-        combined,
-        entry,
-        agentId: defaultAgentId,
-        canonicalKey,
-      });
-    }
-    return { storePath, store: combined };
-  }
-
-  const targets = resolveAllAgentSessionStoreTargetsSync(cfg);
-  const combined: Record<string, SessionEntry> = {};
-  for (const target of targets) {
-    const agentId = target.agentId;
-    const storePath = target.storePath;
-    const store = loadSessionStore(storePath);
-    for (const [key, entry] of Object.entries(store)) {
-      const canonicalKey = canonicalizeSessionKeyForAgent(agentId, key);
-      mergeSessionEntryIntoCombined({
-        cfg,
-        combined,
-        entry,
-        agentId,
-        canonicalKey,
-      });
-    }
-  }
-
-  const storePath =
-    typeof storeConfig === "string" && storeConfig.trim() ? storeConfig.trim() : "(multiple)";
-  return { storePath, store: combined };
-}
-
 export function getSessionDefaults(
   cfg: OpenClawConfig,
   modelCatalog?: ModelCatalogEntry[],

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -41,6 +41,7 @@ import {
   shouldKeepSubagentRunChildLink,
 } from "../agents/subagent-run-liveness.js";
 import { listThinkingLevelOptions } from "../auto-reply/thinking.js";
+import { getFileStatSnapshot } from "../config/cache-utils.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -128,6 +129,7 @@ export type {
   GatewaySessionRow,
   GatewaySessionsDefaults,
   SessionsListResult,
+  SessionsListRpcResult,
   SessionsPatchResult,
   SessionsPreviewEntry,
   SessionsPreviewResult,
@@ -1192,6 +1194,77 @@ export function resolveGatewaySessionThinkingDefault(params: {
       catalog: params.modelCatalog,
     })
   );
+}
+
+/**
+ * Cheap identity for combined session stores: sorted `path:mtime:size` markers.
+ * Used to skip `sessions.list` recomputation when backing files are unchanged.
+ */
+export function collectCombinedSessionStoreStatFingerprint(cfg: OpenClawConfig): string {
+  const storeConfig = cfg.session?.store;
+  const storePaths: string[] =
+    storeConfig && !isStorePathTemplate(storeConfig)
+      ? [resolveStorePath(storeConfig)]
+      : resolveAllAgentSessionStoreTargetsSync(cfg).map((t) => t.storePath);
+
+  const markers: string[] = [];
+  const seen = new Set<string>();
+  for (const storePath of storePaths) {
+    if (seen.has(storePath)) {
+      continue;
+    }
+    seen.add(storePath);
+    const snap = getFileStatSnapshot(storePath);
+    markers.push(snap ? `${storePath}:${snap.mtimeMs}:${snap.sizeBytes}` : `${storePath}:missing`);
+  }
+  markers.sort();
+  return markers.join("\n");
+}
+
+export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+} {
+  const storeConfig = cfg.session?.store;
+  if (storeConfig && !isStorePathTemplate(storeConfig)) {
+    const storePath = resolveStorePath(storeConfig);
+    const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
+    const store = loadSessionStore(storePath);
+    const combined: Record<string, SessionEntry> = {};
+    for (const [key, entry] of Object.entries(store)) {
+      const canonicalKey = canonicalizeSessionKeyForAgent(defaultAgentId, key);
+      mergeSessionEntryIntoCombined({
+        cfg,
+        combined,
+        entry,
+        agentId: defaultAgentId,
+        canonicalKey,
+      });
+    }
+    return { storePath, store: combined };
+  }
+
+  const targets = resolveAllAgentSessionStoreTargetsSync(cfg);
+  const combined: Record<string, SessionEntry> = {};
+  for (const target of targets) {
+    const agentId = target.agentId;
+    const storePath = target.storePath;
+    const store = loadSessionStore(storePath);
+    for (const [key, entry] of Object.entries(store)) {
+      const canonicalKey = canonicalizeSessionKeyForAgent(agentId, key);
+      mergeSessionEntryIntoCombined({
+        cfg,
+        combined,
+        entry,
+        agentId,
+        canonicalKey,
+      });
+    }
+  }
+
+  const storePath =
+    typeof storeConfig === "string" && storeConfig.trim() ? storeConfig.trim() : "(multiple)";
+  return { storePath, store: combined };
 }
 
 export function getSessionDefaults(

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -49,6 +49,7 @@ import {
   buildGroupDisplayName,
   loadSessionStore,
   resolveAllAgentSessionStoreTargetsSync,
+  resolveAgentSessionStoreTargetsSync,
   resolveAgentMainSessionKey,
   resolveFreshSessionTotalTokens,
   resolveStorePath,
@@ -1200,12 +1201,18 @@ export function resolveGatewaySessionThinkingDefault(params: {
  * Cheap identity for combined session stores: sorted `path:mtime:size` markers.
  * Used to skip `sessions.list` recomputation when backing files are unchanged.
  */
-export function collectCombinedSessionStoreStatFingerprint(cfg: OpenClawConfig): string {
+export function collectCombinedSessionStoreStatFingerprint(
+  cfg: OpenClawConfig,
+  requestedAgentId?: string,
+): string {
   const storeConfig = cfg.session?.store;
   const storePaths: string[] =
     storeConfig && !isStorePathTemplate(storeConfig)
       ? [resolveStorePath(storeConfig)]
-      : resolveAllAgentSessionStoreTargetsSync(cfg).map((t) => t.storePath);
+      : (requestedAgentId
+          ? resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId)
+          : resolveAllAgentSessionStoreTargetsSync(cfg)
+        ).map((t) => t.storePath);
 
   const markers: string[] = [];
   const seen = new Set<string>();

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -5,6 +5,7 @@ import type {
   GatewayAgentRuntime,
   GatewayAgentRow as SharedGatewayAgentRow,
   SessionsListResultBase,
+  SessionsListRpcResultBase,
   SessionsPatchResultBase,
 } from "../shared/session-types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
@@ -113,6 +114,11 @@ export type SessionsPreviewResult = {
 };
 
 export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults, GatewaySessionRow>;
+
+export type SessionsListRpcResult = SessionsListRpcResultBase<
+  GatewaySessionsDefaults,
+  GatewaySessionRow
+>;
 
 export type SessionsPatchResult = SessionsPatchResultBase<SessionEntry> & {
   entry: SessionEntry;

--- a/src/gateway/sessions-list-cache-bench.test.ts
+++ b/src/gateway/sessions-list-cache-bench.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Timed cold vs warm `sessions.list` for cache evidence.
+ * Default `pnpm test` may hide `console.log`; to print timings:
+ * `npx vitest run src/gateway/sessions-list-cache-bench.test.ts -c vitest.gateway.config.ts --disable-console-intercept`
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
+import { clearSessionsListResultCacheForTest } from "./sessions-list-result-cache.js";
+import {
+  connectOk,
+  installGatewayTestHooks,
+  rpcReq,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let harness: GatewayServerHarness;
+let sharedSessionStoreDir: string;
+let sessionStoreCaseSeq = 0;
+
+beforeAll(async () => {
+  harness = await startGatewayServerHarness();
+  sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-bench-"));
+});
+
+afterAll(async () => {
+  await harness.close();
+  await fs.rm(sharedSessionStoreDir, { recursive: true, force: true });
+});
+
+const openClient = async (opts?: Parameters<typeof connectOk>[1]) => await harness.openClient(opts);
+
+async function createSessionStoreDir() {
+  const dir = path.join(sharedSessionStoreDir, `case-${sessionStoreCaseSeq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  const storePath = path.join(dir, "sessions.json");
+  testState.sessionStorePath = storePath;
+  return { dir, storePath };
+}
+
+async function writeSingleLineSession(dir: string, sessionId: string, content: string) {
+  await fs.writeFile(
+    path.join(dir, `${sessionId}.jsonl`),
+    `${JSON.stringify({ role: "user", content })}\n`,
+    "utf-8",
+  );
+}
+
+const BENCH_SESSION_COUNT = 20;
+
+test("benchmark: sessions.list cache cold vs warm", async () => {
+  clearSessionsListResultCacheForTest();
+  const { dir } = await createSessionStoreDir();
+
+  const entries: Record<string, { sessionId: string; updatedAt: number }> = {
+    main: { sessionId: "sess-bench-0", updatedAt: Date.now() },
+  };
+  await writeSingleLineSession(dir, "sess-bench-0", "hello");
+  for (let i = 1; i < BENCH_SESSION_COUNT; i++) {
+    const sessionId = `sess-bench-${i}`;
+    entries[`dashboard:${i}`] = { sessionId, updatedAt: Date.now() - i };
+    await writeSingleLineSession(dir, sessionId, "hello");
+  }
+
+  await writeSessionStore({ entries });
+
+  const { ws } = await openClient();
+  const params = { includeGlobal: true, includeUnknown: true };
+
+  const t1 = performance.now();
+  const r1 = await rpcReq<{
+    hash?: string;
+    sessions?: unknown[];
+    unchanged?: boolean;
+  }>(ws, "sessions.list", params);
+  const cold = performance.now() - t1;
+
+  expect(r1.ok).toBe(true);
+  expect(r1.payload?.hash).toMatch(/^[0-9a-f]{16}$/);
+
+  const t2 = performance.now();
+  const r2 = await rpcReq<{
+    hash?: string;
+    unchanged?: boolean;
+  }>(ws, "sessions.list", { ...params, lastHash: r1.payload?.hash });
+  const warm = performance.now() - t2;
+
+  const t3 = performance.now();
+  const r3 = await rpcReq<{
+    hash?: string;
+    unchanged?: boolean;
+  }>(ws, "sessions.list", { ...params, lastHash: r2.payload?.hash });
+  const warm2 = performance.now() - t3;
+
+  expect(r2.ok).toBe(true);
+  expect(r3.ok).toBe(true);
+  expect(r2.payload?.unchanged).toBe(true);
+  expect(r3.payload?.unchanged).toBe(true);
+  expect(typeof r2.payload?.hash).toBe("string");
+  expect(typeof r3.payload?.hash).toBe("string");
+  expect(r3.payload?.hash).toBe(r2.payload?.hash);
+
+  console.log(`Cold:  ${cold.toFixed(1)}ms`);
+  console.log(`Warm:  ${warm.toFixed(1)}ms`);
+  console.log(`Warm2: ${warm2.toFixed(1)}ms`);
+  console.log(`Speedup: ${((1 - warm / cold) * 100).toFixed(0)}%`);
+
+  ws.close();
+});

--- a/src/gateway/sessions-list-result-cache.test.ts
+++ b/src/gateway/sessions-list-result-cache.test.ts
@@ -1,0 +1,401 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearConfigCache,
+  clearResolvedConfigSourceStatFingerprintSyncCacheForTest,
+  collectResolvedConfigSourceStatFingerprintSync,
+  loadConfig,
+  resetConfigStatFingerprintAtLastLoadForTest,
+  setRuntimeConfigSnapshot,
+} from "../config/config.js";
+import { buildSessionsListParamsKey } from "../shared/session-types.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import type { SessionsListResult } from "./session-utils.types.js";
+import {
+  clearSessionsListResultCacheForTest,
+  isSessionsListResultCacheEligible,
+  tryReadSessionsListResultCache,
+  writeSessionsListResultCache,
+} from "./sessions-list-result-cache.js";
+
+afterEach(() => {
+  clearConfigCache();
+  clearResolvedConfigSourceStatFingerprintSyncCacheForTest();
+  clearSessionsListResultCacheForTest();
+  resetConfigStatFingerprintAtLastLoadForTest();
+});
+
+describe("isSessionsListResultCacheEligible", () => {
+  it("opts out when includeDerivedTitles is true", () => {
+    expect(isSessionsListResultCacheEligible({ includeDerivedTitles: true })).toBe(false);
+  });
+
+  it("opts out when includeLastMessage is true", () => {
+    expect(isSessionsListResultCacheEligible({ includeLastMessage: true })).toBe(false);
+  });
+
+  it("opts out when activeMinutes is set", () => {
+    expect(isSessionsListResultCacheEligible({ activeMinutes: 30 })).toBe(false);
+  });
+});
+
+describe("sessions list result cache immutability", () => {
+  it("does not expose cached references that can be mutated by callers", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-list-result-cache-"));
+    const sessionsPath = path.join(tmpDir, "sessions.json");
+
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS: "1000",
+        },
+        async () => {
+          const listParams = { includeGlobal: true, includeUnknown: true };
+          const cfg = loadConfig();
+          const originalSessions = [
+            { sessionId: "sess-1", path: sessionsPath },
+          ] as unknown as SessionsListResult["sessions"];
+
+          writeSessionsListResultCache({
+            cfg,
+            listParams,
+            hash: "hash-1",
+            result: {
+              ts: 1_690_000_000_000,
+              path: sessionsPath,
+              count: 1,
+              defaults: {
+                modelProvider: null,
+                model: null,
+                contextTokens: 1234,
+              },
+              sessions: originalSessions,
+            },
+          });
+
+          const first = tryReadSessionsListResultCache({ cfg, listParams });
+          expect(first).not.toBeNull();
+          if (!first) {
+            return;
+          }
+
+          first.defaults.model = "mutated-model";
+          const firstSessions = first.sessions as Array<{ [k: string]: unknown }>;
+          firstSessions[0].title = "mutated-session";
+          firstSessions.push({ sessionId: "sess-2", title: "poisoned" });
+
+          const second = tryReadSessionsListResultCache({ cfg, listParams });
+          expect(second).not.toBeNull();
+          expect(second).toMatchObject({
+            hash: "hash-1",
+            path: sessionsPath,
+            count: 1,
+            defaults: {
+              modelProvider: null,
+              model: null,
+              contextTokens: 1234,
+            },
+          });
+
+          const secondSessions = second!.sessions as Array<{ [k: string]: unknown }>;
+          expect(secondSessions).toHaveLength(1);
+          expect(secondSessions[0]).toMatchObject({ sessionId: "sess-1" });
+          expect(secondSessions[0]).not.toHaveProperty("title");
+        },
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectResolvedConfigSourceStatFingerprintSync", () => {
+  it("changes when only an included file is modified", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-cache-cfg-"));
+    const rootPath = path.join(dir, "root.json5");
+    const includePath = path.join(dir, "inc.json5");
+
+    fs.writeFileSync(rootPath, '{ "$include": "./inc.json5" }\n', "utf-8");
+    fs.writeFileSync(includePath, '{ "gateway": { "port": 1 } }\n', "utf-8");
+
+    const fp1 = collectResolvedConfigSourceStatFingerprintSync({
+      configPath: rootPath,
+      homedir: () => os.homedir(),
+    });
+
+    fs.writeFileSync(includePath, '{ "gateway": { "port": 2 } }\n', "utf-8");
+
+    const fp2 = collectResolvedConfigSourceStatFingerprintSync({
+      configPath: rootPath,
+      homedir: () => os.homedir(),
+    });
+
+    expect(fp2).not.toBe(fp1);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("recomputes include fingerprint after parse failure and root-stat reuse", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-cache-cfg-retry-"));
+    const rootPath = path.join(dir, "root.json5");
+    const includePath = path.join(dir, "b.json5");
+    const invalidRoot = `{"$include":"a.json5"}x`;
+    const validRoot = `{"$include":"b.json5"} `;
+
+    fs.writeFileSync(rootPath, invalidRoot, "utf-8");
+    fs.writeFileSync(includePath, '{ "gateway": { "port": 1 } }', "utf-8");
+
+    const initialStat = fs.statSync(rootPath);
+    const failedFp = collectResolvedConfigSourceStatFingerprintSync({
+      configPath: rootPath,
+      homedir: () => os.homedir(),
+    });
+
+    fs.writeFileSync(rootPath, validRoot, "utf-8");
+    fs.utimesSync(rootPath, initialStat.atime, initialStat.mtime);
+    const recoveredFp = collectResolvedConfigSourceStatFingerprintSync({
+      configPath: rootPath,
+      homedir: () => os.homedir(),
+    });
+
+    expect(recoveredFp).not.toBe(failedFp);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("recomputes include fingerprint after include-resolution failure and root-stat reuse", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-cache-cfg-include-fail-"));
+    const rootPath = path.join(dir, "root.json5");
+    const includePath = path.join(dir, "a.json5");
+
+    fs.writeFileSync(rootPath, '{ "$include": "./a.json5" }', "utf-8");
+
+    const failedFp = collectResolvedConfigSourceStatFingerprintSync({
+      configPath: rootPath,
+      homedir: () => os.homedir(),
+    });
+
+    fs.writeFileSync(includePath, '{ "gateway": { "port": 1 } }', "utf-8");
+
+    const recoveredFp = collectResolvedConfigSourceStatFingerprintSync({
+      configPath: rootPath,
+      homedir: () => os.homedir(),
+    });
+
+    expect(recoveredFp).not.toBe(failedFp);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not serve stale cached rows after config file changes and loadConfig catches up", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-cache-toctou-"));
+    const configPath = path.join(dir, "openclaw.json");
+    const stateDir = path.join(dir, "state");
+    const sessionsPath = path.join(stateDir, "sessions.json");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}\n", "utf-8");
+
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_STATE_DIR: stateDir,
+          // Long config cache so loadConfig returns stale cfg after file edit.
+          OPENCLAW_CONFIG_CACHE_MS: "5000",
+          OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS: "10000",
+          OPENCLAW_DISABLE_CONFIG_CACHE: undefined,
+        },
+        async () => {
+          const listParams = { includeGlobal: true, includeUnknown: true };
+
+          // Load config — sets cfgFpAtLastLoad to the current stat fingerprint.
+          const cfg1 = loadConfig();
+
+          // Edit the config file — stat fingerprint advances on disk.
+          fs.writeFileSync(configPath, '{ "gateway": { "port": 9999 } }\n', "utf-8");
+          clearResolvedConfigSourceStatFingerprintSyncCacheForTest();
+
+          // Write a cache entry while loadConfig still returns the OLD cfg1.
+          // The cache key includes cfgAligned="n" because cfgFp advanced past cfgFpAtLastLoad.
+          writeSessionsListResultCache({
+            cfg: cfg1,
+            listParams,
+            hash: "hash-stale",
+            result: {
+              ts: Date.now(),
+              path: sessionsPath,
+              count: 1,
+              defaults: { modelProvider: null, model: null, contextTokens: 1234 },
+              sessions: [],
+            },
+          });
+
+          // Force config reload (simulates cache expiry) — cfgFpAtLastLoad catches up.
+          clearConfigCache();
+          const cfg2 = loadConfig();
+
+          // The stale entry was written under cfgAligned="n"; now cfgAligned="y" — cache miss.
+          const cached = tryReadSessionsListResultCache({ cfg: cfg2, listParams });
+          expect(cached).toBeNull();
+        },
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps cache keys stable when cfgFpAtLoad is temporarily unavailable", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-cache-null-fp-"));
+    const configPath = path.join(dir, "openclaw.json");
+    const stateDir = path.join(dir, "state");
+    const sessionsPath = path.join(stateDir, "sessions.json");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}\n", "utf-8");
+
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS: "1000",
+        },
+        async () => {
+          const listParams = { includeGlobal: true, includeUnknown: true };
+          const cfg = loadConfig();
+
+          resetConfigStatFingerprintAtLastLoadForTest();
+          expect(tryReadSessionsListResultCache({ cfg, listParams })).toBeNull();
+
+          setRuntimeConfigSnapshot(cfg);
+          writeSessionsListResultCache({
+            cfg,
+            listParams,
+            hash: "hash-null-fp",
+            result: {
+              ts: Date.now(),
+              path: sessionsPath,
+              count: 1,
+              defaults: { modelProvider: null, model: null, contextTokens: 1234 },
+              sessions: [],
+            },
+          });
+
+          resetConfigStatFingerprintAtLastLoadForTest();
+          const cached = tryReadSessionsListResultCache({ cfg, listParams });
+          expect(cached).toMatchObject({
+            hash: "hash-null-fp",
+            path: sessionsPath,
+            count: 1,
+            defaults: { modelProvider: null, model: null, contextTokens: 1234 },
+            sessions: [],
+          });
+        },
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses the sessions.list result cache after the config cache expires when config sources are unchanged", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-cache-hit-"));
+    const configPath = path.join(dir, "openclaw.json");
+    const stateDir = path.join(dir, "state");
+    const sessionsPath = path.join(stateDir, "sessions.json");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}\n", "utf-8");
+
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_CACHE_MS: "25",
+          OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS: "1000",
+          OPENCLAW_DISABLE_CONFIG_CACHE: undefined,
+        },
+        async () => {
+          const listParams = { includeGlobal: true, includeUnknown: true };
+          const cfg1 = loadConfig();
+          writeSessionsListResultCache({
+            cfg: cfg1,
+            listParams,
+            hash: "hash-1",
+            result: {
+              ts: Date.now(),
+              path: sessionsPath,
+              count: 1,
+              defaults: {
+                modelProvider: null,
+                model: null,
+                contextTokens: 1234,
+              },
+              sessions: [],
+            },
+          });
+
+          await sleep(60);
+
+          const cfg2 = loadConfig();
+          expect(cfg2).not.toBe(cfg1);
+
+          const cached = tryReadSessionsListResultCache({ cfg: cfg2, listParams });
+          expect(cached).toMatchObject({
+            hash: "hash-1",
+            path: sessionsPath,
+            count: 1,
+            defaults: {
+              modelProvider: null,
+              model: null,
+              contextTokens: 1234,
+            },
+            sessions: [],
+          });
+        },
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildSessionsListParamsKey", () => {
+  it("normalizes overlapping query fields in a stable way", () => {
+    const raw = buildSessionsListParamsKey({
+      includeGlobal: true,
+      includeUnknown: false,
+      limit: 7.9,
+      label: "  Foo ",
+      spawnedBy: "",
+      agentId: "AGENT-1",
+      search: "  Mixed CASE  ",
+    });
+    const parsed = JSON.parse(raw);
+
+    expect(parsed).toMatchObject({
+      includeGlobal: true,
+      includeUnknown: false,
+      limit: 7,
+      label: "Foo",
+      spawnedBy: "",
+      agentId: "agent-1",
+      search: "mixed case",
+    });
+    expect("activeMinutes" in parsed).toBe(false);
+  });
+
+  it("adds activeMinutes to the key only when requested", () => {
+    const withActiveMinutes = JSON.parse(
+      buildSessionsListParamsKey(
+        { includeGlobal: true, activeMinutes: 42.8 },
+        { includeActiveMinutes: true },
+      ),
+    );
+    const withoutActiveMinutes = JSON.parse(
+      buildSessionsListParamsKey({ includeGlobal: true, activeMinutes: 42.8 }),
+    );
+
+    expect(withActiveMinutes.activeMinutes).toBe(42);
+    expect("activeMinutes" in withoutActiveMinutes).toBe(false);
+  });
+});

--- a/src/gateway/sessions-list-result-cache.test.ts
+++ b/src/gateway/sessions-list-result-cache.test.ts
@@ -358,6 +358,60 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("keeps scoped cache entries stable when an unrelated agent store changes", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-cache-agent-scope-"));
+    const stateDir = path.join(dir, "state");
+    const tonyStorePath = path.join(stateDir, "agents", "tony", "sessions", "sessions.json");
+    const otherStorePath = path.join(stateDir, "agents", "other", "sessions", "sessions.json");
+    fs.mkdirSync(path.dirname(tonyStorePath), { recursive: true });
+    fs.mkdirSync(path.dirname(otherStorePath), { recursive: true });
+    fs.writeFileSync(tonyStorePath, "{}\n", "utf-8");
+    fs.writeFileSync(otherStorePath, "{}\n", "utf-8");
+
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS: "1000",
+          OPENCLAW_STATE_DIR: stateDir,
+        },
+        async () => {
+          const cfg = {
+            session: {
+              store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+            },
+          } as never;
+          const listParams = { agentId: "tony", includeGlobal: false, includeUnknown: false };
+
+          writeSessionsListResultCache({
+            cfg,
+            listParams,
+            hash: "hash-tony",
+            result: {
+              ts: Date.now(),
+              path: tonyStorePath,
+              count: 1,
+              defaults: { modelProvider: null, model: null, contextTokens: 1234 },
+              sessions: [],
+            },
+          });
+
+          fs.writeFileSync(otherStorePath, '{"other":{}}\n', "utf-8");
+
+          expect(tryReadSessionsListResultCache({ cfg, listParams })).toMatchObject({
+            hash: "hash-tony",
+            path: tonyStorePath,
+          });
+
+          fs.writeFileSync(tonyStorePath, '{"tony":{}}\n', "utf-8");
+
+          expect(tryReadSessionsListResultCache({ cfg, listParams })).toBeNull();
+        },
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("buildSessionsListParamsKey", () => {

--- a/src/gateway/sessions-list-result-cache.test.ts
+++ b/src/gateway/sessions-list-result-cache.test.ts
@@ -311,8 +311,9 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
           OPENCLAW_CONFIG_PATH: configPath,
           OPENCLAW_STATE_DIR: stateDir,
           OPENCLAW_CONFIG_CACHE_MS: "25",
-          OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS: "1000",
+          OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS: "30000",
           OPENCLAW_DISABLE_CONFIG_CACHE: undefined,
+          OPENCLAW_LOAD_SHELL_ENV: "0",
         },
         async () => {
           const listParams = { includeGlobal: true, includeUnknown: true };

--- a/src/gateway/sessions-list-result-cache.test.ts
+++ b/src/gateway/sessions-list-result-cache.test.ts
@@ -62,7 +62,6 @@ describe("sessions list result cache immutability", () => {
           writeSessionsListResultCache({
             cfg,
             listParams,
-            hash: "hash-1",
             result: {
               ts: 1_690_000_000_000,
               path: sessionsPath,
@@ -90,7 +89,6 @@ describe("sessions list result cache immutability", () => {
           const second = tryReadSessionsListResultCache({ cfg, listParams });
           expect(second).not.toBeNull();
           expect(second).toMatchObject({
-            hash: "hash-1",
             path: sessionsPath,
             count: 1,
             defaults: {
@@ -221,7 +219,6 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
           writeSessionsListResultCache({
             cfg: cfg1,
             listParams,
-            hash: "hash-stale",
             result: {
               ts: Date.now(),
               path: sessionsPath,
@@ -271,7 +268,6 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
           writeSessionsListResultCache({
             cfg,
             listParams,
-            hash: "hash-null-fp",
             result: {
               ts: Date.now(),
               path: sessionsPath,
@@ -284,7 +280,6 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
           resetConfigStatFingerprintAtLastLoadForTest();
           const cached = tryReadSessionsListResultCache({ cfg, listParams });
           expect(cached).toMatchObject({
-            hash: "hash-null-fp",
             path: sessionsPath,
             count: 1,
             defaults: { modelProvider: null, model: null, contextTokens: 1234 },
@@ -321,7 +316,6 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
           writeSessionsListResultCache({
             cfg: cfg1,
             listParams,
-            hash: "hash-1",
             result: {
               ts: Date.now(),
               path: sessionsPath,
@@ -342,7 +336,6 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
 
           const cached = tryReadSessionsListResultCache({ cfg: cfg2, listParams });
           expect(cached).toMatchObject({
-            hash: "hash-1",
             path: sessionsPath,
             count: 1,
             defaults: {
@@ -386,7 +379,6 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
           writeSessionsListResultCache({
             cfg,
             listParams,
-            hash: "hash-tony",
             result: {
               ts: Date.now(),
               path: tonyStorePath,
@@ -399,7 +391,6 @@ describe("collectResolvedConfigSourceStatFingerprintSync", () => {
           fs.writeFileSync(otherStorePath, '{"other":{}}\n', "utf-8");
 
           expect(tryReadSessionsListResultCache({ cfg, listParams })).toMatchObject({
-            hash: "hash-tony",
             path: tonyStorePath,
           });
 

--- a/src/gateway/sessions-list-result-cache.ts
+++ b/src/gateway/sessions-list-result-cache.ts
@@ -1,0 +1,158 @@
+import { getSubagentRegistryGeneration } from "../agents/subagent-registry.js";
+import {
+  createExpiringMapCache,
+  isCacheEnabled,
+  resolveCacheTtlMs,
+} from "../config/cache-utils.js";
+import {
+  collectResolvedConfigSourceStatFingerprintSync,
+  getConfigStatFingerprintAtLastLoad,
+  type OpenClawConfig,
+} from "../config/config.js";
+import { getSessionStoreTtl } from "../config/sessions/store-cache.js";
+import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
+import { getTranscriptWriteGeneration } from "../sessions/transcript-events.js";
+import { buildSessionsListParamsKey } from "../shared/session-types.js";
+import type { SessionsListParams } from "./protocol/index.js";
+import { collectCombinedSessionStoreStatFingerprint } from "./session-utils.js";
+import type { GatewaySessionsDefaults, SessionsListResult } from "./session-utils.types.js";
+
+type CachedListPayload = {
+  hash: string;
+  path: string;
+  count: number;
+  defaults: GatewaySessionsDefaults;
+  sessions: SessionsListResult["sessions"];
+};
+
+export function getSessionsListResultCacheTtlMs(): number {
+  return resolveCacheTtlMs({
+    envValue: process.env.OPENCLAW_SESSIONS_LIST_RESULT_CACHE_TTL_MS,
+    defaultTtlMs: getSessionStoreTtl(),
+  });
+}
+
+const DEFAULT_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES = 128;
+
+/** Max cached list fingerprints; `OPENCLAW_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES=0` disables the cap. */
+export function getSessionsListResultCacheMaxEntries(): number | undefined {
+  const raw = process.env.OPENCLAW_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES;
+  }
+  const parsed = parseStrictNonNegativeInteger(raw);
+  if (parsed === undefined) {
+    return DEFAULT_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES;
+  }
+  if (parsed === 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+const SESSIONS_LIST_RESULT_CACHE = createExpiringMapCache<string, CachedListPayload>({
+  ttlMs: getSessionsListResultCacheTtlMs,
+  maxEntries: getSessionsListResultCacheMaxEntries,
+});
+
+function cloneCachedListPayload(payload: CachedListPayload): CachedListPayload {
+  if (typeof globalThis.structuredClone === "function") {
+    return globalThis.structuredClone(payload);
+  }
+  return JSON.parse(JSON.stringify(payload)) as CachedListPayload;
+}
+
+export function isSessionsListResultCacheEnabled(): boolean {
+  return isCacheEnabled(getSessionsListResultCacheTtlMs());
+}
+
+export function clearSessionsListResultCacheForTest(): void {
+  SESSIONS_LIST_RESULT_CACHE.clear();
+}
+
+let sessionsListFullComputationHook: (() => void) | null = null;
+
+/** Register a callback invoked once per `sessions.list` full-computation path. */
+export function setSessionsListFullComputationHook(cb: (() => void) | null): void {
+  sessionsListFullComputationHook = cb;
+}
+
+/** Notify that `sessions.list` executed a full computation (cache miss). */
+export function notifySessionsListFullComputation(): void {
+  sessionsListFullComputationHook?.();
+}
+
+/**
+ * Transcript-backed fields and time windows need fresh reads; `activeMinutes` depends on `Date.now()`.
+ *
+ * Note: subagent `runtimeMs` in session rows is time-dependent during active runs, but the
+ * subagent registry generation counter in the cache key ensures the cache is busted on any
+ * spawn/release/sweep mutation. Between mutations, `runtimeMs` may drift by up to the cache TTL
+ * (default ~45s) — acceptable since the UI recomputes live durations client-side from `startedAt`.
+ */
+export function isSessionsListResultCacheEligible(params: SessionsListParams): boolean {
+  if (!isSessionsListResultCacheEnabled()) {
+    return false;
+  }
+  if (params.includeDerivedTitles === true || params.includeLastMessage === true) {
+    return false;
+  }
+  if (typeof params.activeMinutes === "number" && Number.isFinite(params.activeMinutes)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Shared canonical key for the overlapping sessions-list fields used by both the gateway
+ * and UI clients.
+ */
+function buildSessionsListResultCacheKey(params: {
+  cfg: OpenClawConfig;
+  listParams: SessionsListParams;
+}): string {
+  const storesFp = collectCombinedSessionStoreStatFingerprint(params.cfg);
+  const cfgFp = collectResolvedConfigSourceStatFingerprintSync();
+  const paramsKey = buildSessionsListParamsKey(params.listParams);
+  const subagentGen = getSubagentRegistryGeneration();
+  const txGen = getTranscriptWriteGeneration();
+  // When the config stat fingerprint has advanced past what loadConfig() last
+  // parsed, the cfg object may be stale (loadConfig has a ~200ms cache).
+  // Including a staleness flag ensures entries written from a stale cfg are
+  // not reused after loadConfig catches up to the on-disk state.
+  const cfgFpAtLoad = getConfigStatFingerprintAtLastLoad();
+  const cfgAligned = cfgFpAtLoad === null || cfgFp === cfgFpAtLoad ? "y" : "n";
+  return `${cfgFp}\n${storesFp}\nsagen:${subagentGen}\ntxgen:${txGen}\ncfga:${cfgAligned}\n${paramsKey}`;
+}
+
+export function tryReadSessionsListResultCache(params: {
+  cfg: OpenClawConfig;
+  listParams: SessionsListParams;
+}): CachedListPayload | null {
+  if (!isSessionsListResultCacheEligible(params.listParams)) {
+    return null;
+  }
+  const key = buildSessionsListResultCacheKey(params);
+  const cached = SESSIONS_LIST_RESULT_CACHE.get(key);
+  return cached ? cloneCachedListPayload(cached) : null;
+}
+
+export function writeSessionsListResultCache(params: {
+  cfg: OpenClawConfig;
+  listParams: SessionsListParams;
+  hash: string;
+  result: SessionsListResult;
+}): void {
+  if (!isSessionsListResultCacheEligible(params.listParams)) {
+    return;
+  }
+  const key = buildSessionsListResultCacheKey(params);
+  const payload: CachedListPayload = {
+    hash: params.hash,
+    path: params.result.path,
+    count: params.result.count,
+    defaults: params.result.defaults,
+    sessions: params.result.sessions,
+  };
+  SESSIONS_LIST_RESULT_CACHE.set(key, cloneCachedListPayload(payload));
+}

--- a/src/gateway/sessions-list-result-cache.ts
+++ b/src/gateway/sessions-list-result-cache.ts
@@ -18,7 +18,6 @@ import { collectCombinedSessionStoreStatFingerprint } from "./session-utils.js";
 import type { GatewaySessionsDefaults, SessionsListResult } from "./session-utils.types.js";
 
 type CachedListPayload = {
-  hash: string;
   path: string;
   count: number;
   defaults: GatewaySessionsDefaults;
@@ -34,7 +33,6 @@ export function getSessionsListResultCacheTtlMs(): number {
 
 const DEFAULT_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES = 128;
 
-/** Max cached list fingerprints; `OPENCLAW_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES=0` disables the cap. */
 export function getSessionsListResultCacheMaxEntries(): number | undefined {
   const raw = process.env.OPENCLAW_SESSIONS_LIST_RESULT_CACHE_MAX_ENTRIES;
   if (raw === undefined || raw === "") {
@@ -69,12 +67,10 @@ export function clearSessionsListResultCacheForTest(): void {
 
 let sessionsListFullComputationHook: (() => void) | null = null;
 
-/** Register a callback invoked once per `sessions.list` full-computation path. */
 export function setSessionsListFullComputationHook(cb: (() => void) | null): void {
   sessionsListFullComputationHook = cb;
 }
 
-/** Notify that `sessions.list` executed a full computation (cache miss). */
 export function notifySessionsListFullComputation(): void {
   sessionsListFullComputationHook?.();
 }
@@ -100,10 +96,6 @@ export function isSessionsListResultCacheEligible(params: SessionsListParams): b
   return true;
 }
 
-/**
- * Shared canonical key for the overlapping sessions-list fields used by both the gateway
- * and UI clients.
- */
 function buildSessionsListResultCacheKey(params: {
   cfg: OpenClawConfig;
   listParams: SessionsListParams;
@@ -116,10 +108,6 @@ function buildSessionsListResultCacheKey(params: {
   const paramsKey = buildSessionsListParamsKey(params.listParams);
   const subagentGen = getSubagentRegistryGeneration();
   const txGen = getTranscriptWriteGeneration();
-  // When the config stat fingerprint has advanced past what loadConfig() last
-  // parsed, the cfg object may be stale (loadConfig has a ~200ms cache).
-  // Including a staleness flag ensures entries written from a stale cfg are
-  // not reused after loadConfig catches up to the on-disk state.
   const cfgFpAtLoad = getConfigStatFingerprintAtLastLoad();
   const cfgAligned = cfgFpAtLoad === null || cfgFp === cfgFpAtLoad ? "y" : "n";
   return `${cfgFp}\n${storesFp}\nsagen:${subagentGen}\ntxgen:${txGen}\ncfga:${cfgAligned}\n${paramsKey}`;
@@ -140,7 +128,6 @@ export function tryReadSessionsListResultCache(params: {
 export function writeSessionsListResultCache(params: {
   cfg: OpenClawConfig;
   listParams: SessionsListParams;
-  hash: string;
   result: SessionsListResult;
 }): void {
   if (!isSessionsListResultCacheEligible(params.listParams)) {
@@ -148,7 +135,6 @@ export function writeSessionsListResultCache(params: {
   }
   const key = buildSessionsListResultCacheKey(params);
   const payload: CachedListPayload = {
-    hash: params.hash,
     path: params.result.path,
     count: params.result.count,
     defaults: params.result.defaults,

--- a/src/gateway/sessions-list-result-cache.ts
+++ b/src/gateway/sessions-list-result-cache.ts
@@ -56,10 +56,7 @@ const SESSIONS_LIST_RESULT_CACHE = createExpiringMapCache<string, CachedListPayl
 });
 
 function cloneCachedListPayload(payload: CachedListPayload): CachedListPayload {
-  if (typeof globalThis.structuredClone === "function") {
-    return globalThis.structuredClone(payload);
-  }
-  return JSON.parse(JSON.stringify(payload)) as CachedListPayload;
+  return globalThis.structuredClone(payload);
 }
 
 export function isSessionsListResultCacheEnabled(): boolean {

--- a/src/gateway/sessions-list-result-cache.ts
+++ b/src/gateway/sessions-list-result-cache.ts
@@ -108,7 +108,10 @@ function buildSessionsListResultCacheKey(params: {
   cfg: OpenClawConfig;
   listParams: SessionsListParams;
 }): string {
-  const storesFp = collectCombinedSessionStoreStatFingerprint(params.cfg);
+  const storesFp = collectCombinedSessionStoreStatFingerprint(
+    params.cfg,
+    params.listParams.agentId,
+  );
   const cfgFp = collectResolvedConfigSourceStatFingerprintSync();
   const paramsKey = buildSessionsListParamsKey(params.listParams);
   const subagentGen = getSubagentRegistryGeneration();

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -214,11 +214,7 @@ describe("secret ref resolver", () => {
     // Keep the fixture cheap to start so this stays deterministic under a busy test run.
     await writeSecureFile(
       scriptPath,
-      [
-        "#!/bin/sh",
-        "sleep 0.03",
-        'printf \'{"protocolVersion":1,"values":{"delayed":"ok"}}\'',
-      ].join("\n"),
+      ["#!/bin/sh", 'printf \'{"protocolVersion":1,"values":{"delayed":"ok"}}\''].join("\n"),
       0o700,
     );
 

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -11,10 +11,8 @@ type SessionTranscriptListener = (update: SessionTranscriptUpdate) => void;
 
 const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
 
-/** Monotonic counter bumped on every transcript update emission; used to invalidate caches that depend on transcript state. */
 let transcriptWriteGeneration = 0;
 
-/** Returns the current transcript write generation (monotonic). */
 export function getTranscriptWriteGeneration(): number {
   return transcriptWriteGeneration;
 }

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -11,6 +11,14 @@ type SessionTranscriptListener = (update: SessionTranscriptUpdate) => void;
 
 const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
 
+/** Monotonic counter bumped on every transcript update emission; used to invalidate caches that depend on transcript state. */
+let transcriptWriteGeneration = 0;
+
+/** Returns the current transcript write generation (monotonic). */
+export function getTranscriptWriteGeneration(): number {
+  return transcriptWriteGeneration;
+}
+
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
   SESSION_TRANSCRIPT_LISTENERS.add(listener);
   return () => {
@@ -42,6 +50,7 @@ export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUp
       ? { messageId: normalizeOptionalString(normalized.messageId) }
       : {}),
   };
+  transcriptWriteGeneration += 1;
   for (const listener of SESSION_TRANSCRIPT_LISTENERS) {
     try {
       listener(nextUpdate);

--- a/src/shared/session-types.ts
+++ b/src/shared/session-types.ts
@@ -1,3 +1,5 @@
+import { normalizeAgentId } from "../routing/session-key.js";
+
 export type GatewayAgentIdentity = {
   name?: string;
   theme?: string;
@@ -26,6 +28,60 @@ export type GatewayAgentRow = {
   agentRuntime?: GatewayAgentRuntime;
 };
 
+export type SessionsListParamsKeyInput = {
+  includeGlobal?: unknown;
+  includeUnknown?: unknown;
+  limit?: unknown;
+  label?: unknown;
+  spawnedBy?: unknown;
+  agentId?: unknown;
+  search?: unknown;
+  activeMinutes?: unknown;
+};
+
+type BuildSessionsListParamsKeyOptions = {
+  includeActiveMinutes?: boolean;
+};
+
+/**
+ * Canonicalize sessions-list query fields for cache-key/lastHash tracking.
+ *
+ * Keep shared fields normalized consistently across runtime surfaces so server and UI
+ * cannot silently drift on equivalent-but-not-identical inputs.
+ */
+export function buildSessionsListParamsKey(
+  params: SessionsListParamsKeyInput,
+  options: BuildSessionsListParamsKeyOptions = {},
+): string {
+  const limit =
+    typeof params.limit === "number" && Number.isFinite(params.limit)
+      ? Math.max(1, Math.floor(params.limit))
+      : 0;
+  const label = typeof params.label === "string" ? params.label.trim() : "";
+  const spawnedBy = typeof params.spawnedBy === "string" ? params.spawnedBy : "";
+  const agentId = typeof params.agentId === "string" ? normalizeAgentId(params.agentId) : "";
+  const search = typeof params.search === "string" ? params.search.trim().toLowerCase() : "";
+  const shared = {
+    limit,
+    includeGlobal: params.includeGlobal === true,
+    includeUnknown: params.includeUnknown === true,
+    label,
+    spawnedBy,
+    agentId,
+    search,
+  };
+  if (!options.includeActiveMinutes) {
+    return JSON.stringify(shared);
+  }
+  return JSON.stringify({
+    ...shared,
+    activeMinutes:
+      typeof params.activeMinutes === "number" && Number.isFinite(params.activeMinutes)
+        ? Math.max(0, Math.floor(params.activeMinutes))
+        : 0,
+  });
+}
+
 export type SessionsListResultBase<TDefaults, TRow> = {
   ts: number;
   path: string;
@@ -33,6 +89,18 @@ export type SessionsListResultBase<TDefaults, TRow> = {
   defaults: TDefaults;
   sessions: TRow[];
 };
+
+/** `sessions.list` with `lastHash`: unchanged rows short-circuit. */
+export type SessionsListUnchangedResult = {
+  unchanged: true;
+  hash: string;
+  ts: number;
+  count: number;
+};
+
+export type SessionsListRpcResultBase<TDefaults, TRow> =
+  | (SessionsListResultBase<TDefaults, TRow> & { hash?: string })
+  | SessionsListUnchangedResult;
 
 export type SessionsPatchResultBase<TEntry> = {
   ok: true;


### PR DESCRIPTION
## Summary

- Problem: `sessions.list` rebuilds session rows from store files, transcripts, config state, and subagent runtime state on every request, even when the client already has the current list.
- Why it matters: active Gateway clients can repeatedly pay the full `sessions.list` cost, while an unsafe cache would risk serving stale rows unless config, session-store, transcript, and subagent mutations are all part of invalidation.
- What changed: Added the gateway-side `sessions.list` result cache and `hash` / `lastHash` / `{ unchanged: true }` flow, tightened config snapshot/fingerprint handling, fixed `config.patch` materialized no-op detection, preserved the current bounded async `sessions.list` cache-miss path, and gated subagent generation bumps to list-visible mutations with regression coverage.
- What did NOT change (scope boundary): No Control UI client adoption and no Apple client behavior adoption. The generated Swift protocol model updates are baseline-only for the additive sessions.list contract.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Files / Scope

- `CHANGELOG.md` — documents the user-visible gateway protocol/cache and `config.patch` behavior change, with required attribution.
- `src/agents/subagent-registry-lifecycle.ts` — updates lifecycle cleanup/generation behavior so list-visible subagent mutations invalidate cached session rows without bumping for irrelevant bookkeeping.
- `src/agents/subagent-registry-run-manager.ts` — carries subagent generation/frozen-result state through run replacement paths used by lifecycle retry and wake flows.
- `src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts` — locks the subagent lifecycle retry/frozen-result behavior and keeps the e2e announce timeout deterministic under fake timers.
- `src/agents/subagent-registry.ts` — exposes and bumps subagent registry generation for cache invalidation when session-list-visible run state changes.
- `src/config/cache-utils.test.ts` — proves cache utility fingerprint and expiring-cache behavior used by the session list result cache.
- `src/config/cache-utils.ts` — provides shared cache/fingerprint helpers used to build stable cache keys from config and file metadata.
- `src/config/config.ts` — exposes runtime config snapshot metadata needed by the gateway cache key.
- `src/config/includes.ts` — records resolved config include paths while preserving upstream guarded include reads, so included config files participate in cache invalidation.
- `src/config/io.ts` — tracks source/runtime config snapshots and source-equivalent writes so `config.patch` no-op detection and cache invalidation use the correct config state.
- `src/config/merge-patch.ts` — supports source-shape merge patch behavior used by `config.patch` no-op detection.
- `src/gateway/protocol/schema/sessions.ts` — adds the additive `lastHash` request and `hash` / `unchanged` response contract for `sessions.list`.
- `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift` — generated protocol output required by `pnpm protocol:check` for the additive `SessionsListParams.lastHash` field; no Apple client behavior changes.
- `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift` — generated shared Swift protocol output required by `pnpm protocol:check` for the additive `SessionsListParams.lastHash` field; no Apple client behavior changes.
- `src/gateway/server-methods/config.secretref.test.ts` — verifies config patch and SecretRef/env fallback handling around source-materialized writes.
- `src/gateway/server-methods/config.ts` — updates `config.patch` to distinguish real source changes from materialized no-op patches.
- `src/gateway/server-methods/sessions.ts` — wires `sessions.list` cache reads/writes while preserving upstream's bounded async model catalog and row-building cache-miss path.
- `src/gateway/server.config-patch.test.ts` — covers `config.patch` no-op/source-change cases, including the current `talk.providers.*` config shape.
- `src/gateway/session-utils.ts` — supplies session-store fingerprints and async list-building data used by the cache miss path and cache key.
- `src/gateway/session-utils.types.ts` — extends session list result typing for cached `hash` and unchanged response behavior.
- `src/gateway/sessions-list-cache-bench.test.ts` — records cold/warm `sessions.list` cache performance evidence.
- `src/gateway/sessions-list-result-cache.test.ts` — verifies cache eligibility, key invalidation inputs, cloning, and unchanged short-circuit behavior.
- `src/gateway/sessions-list-result-cache.ts` — implements the session list result cache and cache key from config, session store, transcript, subagent, and params state.
- `src/secrets/resolve.test.ts` — protects SecretRef/env fallback resolution semantics used by config patch materialization.
- `src/sessions/transcript-events.ts` — exposes transcript write generation so transcript-backed session fields can invalidate cached list results.
- `src/shared/session-types.ts` — shares canonical session list param/hash typing and cache-key helpers across gateway surfaces.

No files outside this list are included in this PR.

## Linked Issue/PR

- Closes #
- Related UI follow-up: https://github.com/sasan1200/openclaw/pull/2
- Related Apple follow-up: https://github.com/sasan1200/openclaw/pull/3
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `sessions.list` had no unchanged-response contract and no shared result cache keyed across the runtime inputs that make session rows visible: config, session store, transcript writes, subagent state, and request params.
- Missing detection / guardrail: there was no regression coverage for list-visible subagent generation bumps, null `configStatFingerprintAtLastLoad` cache-key stability, or preserving the current bounded async `sessions.list` miss path after adding the cache.
- Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
- Why this regressed now: the new cache key inputs had to stay aligned across paths that previously did not coordinate.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
- [x] Unit test
- [x] Seam / integration test
- [x] End-to-end test
- [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/sessions-list-result-cache.test.ts`, `src/gateway/server.sessions.list-changed.test.ts`, `src/gateway/server.config-patch.test.ts`, `src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts`, `src/config/cache-utils.test.ts`, `src/config/io.runtime-snapshot-write.test.ts`, `src/config/merge-patch.test.ts`, `src/gateway/session-utils.test.ts`
- Scenario the test should lock in: unchanged short-circuit on identical params, full refresh on config/session/subagent-visible changes, correct `config.patch` no-op handling for the env-fallback case, stable cache hits when `configStatFingerprintAtLastLoad` is temporarily unavailable, and bounded async `sessions.list` behavior on cache misses.
- Why this is the smallest reliable guardrail: these tests exercise the real cache key inputs and the gateway handler path instead of only isolated helpers.
- Existing test that already covers this (if any): existing gateway harness coverage was extended; prior coverage was not sufficient.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `sessions.list` now returns a `hash` and can short-circuit with `{ unchanged: true, hash, ts, count }` when `lastHash` matches.
- `config.patch` no-op detection now compares the materialized/source shape correctly in the env-fallback case.
- No Control UI rendering changes in this PR by itself.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI RPC surface
- Relevant config (redacted): default gateway test harness config

### Steps

1. Call `sessions.list` twice with the same params against an unchanged store.
2. Repeat after a relevant config, transcript, or subagent-visible mutation.
3. Exercise the `config.patch` env-fallback removal case.

### Expected

- Identical requests can return the unchanged short-circuit.
- Relevant mutations invalidate the cache and return a full payload.
- `config.patch` does not misclassify the env-fallback case as `noop`.

### Actual

- Verified by targeted gateway and e2e coverage on this split branch.
- Local benchmark during review showed the warm path materially faster than the cold path (`Cold: 56.8ms`, `Warm: 20.9ms`, `Warm2: 3.2ms`).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test -- src/gateway/sessions-list-result-cache.test.ts src/gateway/server.sessions.list-changed.test.ts src/gateway/server.config-patch.test.ts src/config/io.runtime-snapshot-write.test.ts src/config/merge-patch.test.ts src/config/cache-utils.test.ts src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts src/gateway/session-utils.test.ts`; `pnpm test -- src/gateway/server-methods/config.secretref.test.ts src/gateway/server.config-patch.test.ts`; `pnpm protocol:check`; `pnpm check:test-types`; `pnpm lint --threads=8`; `pnpm build:ci-artifacts`; targeted `oxfmt`; `git diff --check`; `pnpm test -- src/gateway/server.sessions.list-changed.test.ts src/gateway/sessions-list-result-cache.test.ts src/gateway/gateway.test.ts`.
- Edge cases checked: null `cfgFpAtLoad` cache-key stability, transcript generation invalidation, subagent generation bumps, config no-op env-fallback diff, current `talk.providers.*` fixture shape, and bounded async `sessions.list` miss path.
- What you did **not** verify: full multi-node gateway behavior and very large production-sized session stores.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Cache serves stale rows if a list-visible mutation misses the cache key inputs.
- Mitigation: the key includes config/store/transcript/subagent signals, and this PR adds regression coverage around the previously missing subagent/config edges.
- Risk: This backend-only PR lands before client adoption.
- Mitigation: the contract is additive; old clients continue to ignore `hash` and omit `lastHash`.

