### PR TITLE
fix(heartbeat): clear sessionFile on isolated/stale session rollover

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -226,6 +226,38 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.deliveryContext).toBeUndefined();
     });
 
+    it("clears sessionFile when forceNew is true so new sessionId drives a fresh transcript", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-sf",
+          updatedAt: NOW_MS - 1000,
+          sessionFile: "existing-session-id-sf.jsonl",
+          modelOverride: "sonnet-4",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+      // Per-session overrides must still be preserved
+      expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
+    });
+
+    it("clears sessionFile when session is stale", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "old-session-id",
+          updatedAt: NOW_MS - 86_400_000,
+          sessionFile: "old-session-id.jsonl",
+        },
+        fresh: false,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
     it("preserves delivery routing metadata when reusing fresh session", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -83,6 +83,11 @@ export function resolveCronSession(params: {
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      // Clear the cached transcript file path so the new sessionId drives a
+      // fresh .jsonl file.  Without this, `resolveSessionFilePath` sees the
+      // old `sessionFile` carried forward via `...entry` and keeps appending
+      // to the previous transcript — defeating isolatedSession / forceNew.
+      sessionFile: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary

- When `resolveCronSession` creates a new session (`forceNew` or stale expiry), the old entry's `sessionFile` was preserved via the `...entry` spread
- `resolveSessionFilePath` then reused that cached path instead of deriving a fresh one from the new `sessionId`, causing every isolated heartbeat run to append to the same transcript file — defeating `isolatedSession: true`
- Clear `sessionFile` alongside the other delivery routing fields when `isNewSession` is true so the new `sessionId` drives a fresh `.jsonl` transcript

Fixes #56941, #57577

## Root cause

`resolveSessionFilePath` prefers `entry.sessionFile` over recalculating from `sessionId`:

```ts
const candidate = entry?.sessionFile?.trim();
if (candidate) return resolvePathWithinSessionsDir(...); // prefers cached path
return resolveSessionTranscriptPathInDir(sessionId, sessionsDir); // only fallback
```

The `...entry` spread in `resolveCronSession` carried the old `sessionFile` into the new session entry, so despite generating a new UUID each heartbeat tick, every run kept appending to the original transcript. Users reported context growing from ~18K to 190K+ tokens over 24 hours.

## Test plan

- [x] Added test: `sessionFile` cleared when `forceNew` is true
- [x] Added test: `sessionFile` cleared when session is stale
- [x] Existing tests pass (per-session overrides still preserved, delivery routing still cleared)
- [x] `pnpm test src/cron/isolated-agent/session.test.ts` — 12 tests pass
- [x] `pnpm test src/infra/heartbeat-runner.model-override.test.ts` — 9 tests pass
- [x] `pnpm test src/infra/heartbeat-runner.ghost-reminder.test.ts` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)