### PR TITLE
fix(imessage): strip U+FFFD garbage chars from echo text key normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage/echo cache: strip only leading imsg corruption bytes from reflected text keys while preserving interior control characters, so duplicate-reply suppression does not collapse unrelated messages. (#62191) Thanks @maguilar631697.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -23,18 +23,19 @@ export type SentMessageCache = {
 const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
+// U+FFFD replacement characters and C0/C1 control characters that imsg injects when
+// extracting text from NSAttributedString (attributedBody column). Uses RegExp constructor
+// to keep Unicode escapes out of a regex literal (avoids no-control-regex). See: #61312, #61821
+const IMSG_GARBAGE_CHARS_RE = new RegExp(
+  "[\\ufffd\\ufffe\\uffff\\u0000-\\u0008\\u000b\\u000c\\u000e-\\u001f\\u007f-\\u009f]+",
+  "g",
+);
+
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {
     return null;
   }
-  // Strip U+FFFD replacement characters and C0/C1 control characters that imsg
-  // injects when extracting text from NSAttributedString (attributedBody column).
-  // Without this, the echo cache stores clean text but the reflected copy has
-  // garbage prefixes, defeating text-based deduplication. See: #61312, #61821
-  const normalized = text
-    .replace(/[\ufffd\ufffe\uffff\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]+/g, "")
-    .replace(/\r\n?/g, "\n")
-    .trim();
+  const normalized = text.replace(IMSG_GARBAGE_CHARS_RE, "").replace(/\r\n?/g, "\n").trim();
   return normalized ? normalized : null;
 }
 

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -24,12 +24,11 @@ const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
 // U+FFFD replacement characters and C0/C1 control characters that imsg injects when
-// extracting text from NSAttributedString (attributedBody column). Uses RegExp constructor
-// to keep Unicode escapes out of a regex literal (avoids no-control-regex). See: #61312, #61821
-const IMSG_GARBAGE_CHARS_RE = new RegExp(
-  "[\\ufffd\\ufffe\\uffff\\u0000-\\u0008\\u000b\\u000c\\u000e-\\u001f\\u007f-\\u009f]+",
-  "g",
-);
+// extracting text from NSAttributedString (attributedBody column). The pattern intentionally
+// matches control characters to strip garbage from echo cache keys. See: #61312, #61821
+// eslint-disable-next-line no-control-regex
+const IMSG_GARBAGE_CHARS_RE =
+  /[\ufffd\ufffe\uffff\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]+/g;
 
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -27,7 +27,14 @@ function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {
     return null;
   }
-  const normalized = text.replace(/\r\n?/g, "\n").trim();
+  // Strip U+FFFD replacement characters and C0/C1 control characters that imsg
+  // injects when extracting text from NSAttributedString (attributedBody column).
+  // Without this, the echo cache stores clean text but the reflected copy has
+  // garbage prefixes, defeating text-based deduplication. See: #61312, #61821
+  const normalized = text
+    .replace(/[\ufffd\ufffe\uffff\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]+/g, "")
+    .replace(/\r\n?/g, "\n")
+    .trim();
   return normalized ? normalized : null;
 }
 

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -23,18 +23,16 @@ export type SentMessageCache = {
 const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
-// U+FFFD replacement characters and C0/C1 control characters that imsg injects when
-// extracting text from NSAttributedString (attributedBody column). The pattern intentionally
-// matches control characters to strip garbage from echo cache keys. See: #61312, #61821
+// U+FFFD replacement characters and C0/C1 control characters that imsg can prepend when
+// extracting text from NSAttributedString (attributedBody column). Keep interior text intact.
 // eslint-disable-next-line no-control-regex
-const IMSG_GARBAGE_CHARS_RE =
-  /[\ufffd\ufffe\uffff\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]+/g;
+const LEADING_IMSG_GARBAGE_CHARS_RE = /^[\ufffd\ufffe\uffff\u0000-\u001f\u007f-\u009f]+/;
 
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {
     return null;
   }
-  const normalized = text.replace(IMSG_GARBAGE_CHARS_RE, "").replace(/\r\n?/g, "\n").trim();
+  const normalized = text.replace(LEADING_IMSG_GARBAGE_CHARS_RE, "").replace(/\r\n?/g, "\n").trim();
   return normalized ? normalized : null;
 }
 

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -17,6 +17,27 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has("acct:imessage:+1666", { text: "Reasoning:\n_step_" })).toBe(false);
   });
 
+  it("strips leading imsg corruption bytes from text keys", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { text: "\ufffd\u0000Reasoning:\n\t_step_" });
+
+    expect(cache.has("acct:imessage:+1555", { text: "Reasoning:\n\t_step_" })).toBe(true);
+  });
+
+  it("preserves interior control characters in text keys", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { text: "alpha\u0007beta\n\tgamma" });
+
+    expect(cache.has("acct:imessage:+1555", { text: "alpha\u0007beta\n\tgamma" })).toBe(true);
+    expect(cache.has("acct:imessage:+1555", { text: "alphabeta\n\tgamma" })).toBe(false);
+  });
+
   it("matches by outbound message id and ignores placeholder ids", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));


### PR DESCRIPTION
## Summary

U+FFFD replacement characters and C0/C1 control characters injected by `imsg` when extracting text from `NSAttributedString` (`attributedBody` column) break echo cache text-key matching, causing duplicate message delivery.

The echo cache stores clean outbound text, but the reflected inbound copy carries garbage character prefixes — `normalizeEchoTextKey()` only strips `\r\n`, so the keys never match and the echo slips through as a new inbound message.

**Fix**: Strip `[\ufffd\ufffe\uffff\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]+` before comparison in `normalizeEchoTextKey()`.

### Previously included fixes (now upstream)

The original PR included two additional fixes that have since been merged independently by the OpenClaw team (#61619, #63868, #63980, #63989, #64000):

- ~~**TTL 4s → 30s**~~ — shipped in 2026.4.10 (`SENT_MESSAGE_TEXT_TTL_MS = 30e3`)
- ~~**`destination_caller_id` self-chat detection**~~ — shipped in 2026.4.10 with `isSelfChat` + `isAmbiguousSelfThread`

This PR now contains only the remaining unmerged fix.

## Changes

- `extensions/imessage/src/monitor/echo-cache.ts`: Strip U+FFFD/control chars in `normalizeEchoTextKey`

## Related Issues

Fixes #61312, #61821

## Test Plan

- [x] Confirmed echo cache miss on messages with U+FFFD prefixes (unpatched)
- [x] Applied patch to compiled dist — garbage-prefixed echoes now correctly matched and suppressed
- [x] Clean text (no U+FFFD) still matches normally — no regression