### PR TITLE
fix(plugin-sdk): normalize bundled entry imports on Windows

### DIFF
--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { importFreshModule } from "../../test/helpers/import-fresh.ts";
 import { loadBundledEntryExportSync } from "./channel-entry-contract.js";
@@ -14,6 +14,7 @@ afterEach(() => {
   vi.doUnmock("jiti");
   vi.doUnmock("node:fs");
   vi.doUnmock("node:module");
+  vi.doUnmock("node:url");
   vi.doUnmock("../infra/boundary-file-read.js");
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -26,6 +27,8 @@ afterEach(() => {
 describe("loadBundledEntryExportSync", () => {
   it("converts Windows absolute paths to file URLs before handing them to jiti", async () => {
     const importerUrl = "file:///C:/openclaw/dist/extensions/signal/setup-entry.js";
+    const importerPath = fileURLToPath(importerUrl);
+    const resolvedAbsolutePath = path.resolve(path.dirname(importerPath), "./api.js");
     const modulePath = String.raw`C:\openclaw\dist\extensions\signal\api.js`;
     const safeImportPath = "file:///C:/openclaw/dist/extensions/signal/api.js";
 
@@ -43,11 +46,20 @@ describe("loadBundledEntryExportSync", () => {
         closeSync: vi.fn(),
       },
     }));
+    vi.doMock("node:url", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:url")>();
+      return {
+        ...actual,
+        pathToFileURL: vi.fn((value: string) =>
+          value === modulePath ? new URL(safeImportPath) : actual.pathToFileURL(value),
+        ),
+      };
+    });
     vi.doMock("../infra/boundary-file-read.js", () => ({
       openBoundaryFileSync: vi.fn(({ absolutePath }: { absolutePath: string }) => ({
         ok: true,
         fd: 1,
-        path: absolutePath === "./api.js" ? modulePath : absolutePath,
+        path: absolutePath === resolvedAbsolutePath ? modulePath : absolutePath,
       })),
     }));
 

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -9,6 +9,12 @@ import { loadBundledEntryExportSync } from "./channel-entry-contract.js";
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock("jiti");
+  vi.doUnmock("node:fs");
+  vi.doUnmock("node:module");
+  vi.doUnmock("../infra/boundary-file-read.js");
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -18,7 +24,53 @@ afterEach(() => {
 });
 
 describe("loadBundledEntryExportSync", () => {
-  it("includes importer and resolved path context when a bundled sidecar is missing", () => {
+  it("converts Windows absolute paths to file URLs before handing them to jiti", async () => {
+    const importerUrl = "file:///C:/openclaw/dist/extensions/signal/setup-entry.js";
+    const modulePath = String.raw`C:\openclaw\dist\extensions\signal\api.js`;
+    const safeImportPath = "file:///C:/openclaw/dist/extensions/signal/api.js";
+
+    const loader = vi.fn().mockReturnValue({ signalSetupPlugin: {} });
+    vi.doMock("jiti", () => ({
+      createJiti: vi.fn(() => loader),
+    }));
+    vi.doMock("node:module", () => ({
+      createRequire: vi.fn(() => () => {
+        throw new Error("force jiti fallback");
+      }),
+    }));
+    vi.doMock("node:fs", () => ({
+      default: {
+        closeSync: vi.fn(),
+      },
+    }));
+    vi.doMock("../infra/boundary-file-read.js", () => ({
+      openBoundaryFileSync: vi.fn(({ absolutePath }: { absolutePath: string }) => ({
+        ok: true,
+        fd: 1,
+        path: absolutePath === "./api.js" ? modulePath : absolutePath,
+      })),
+    }));
+
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    if (!platformDescriptor?.configurable) {
+      throw new Error("process.platform is not configurable in this test environment");
+    }
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      const { loadBundledEntryExportSync } = await import("./channel-entry-contract.js");
+      loadBundledEntryExportSync(importerUrl, {
+        specifier: "./api.js",
+        exportName: "signalSetupPlugin",
+      });
+      expect(loader).toHaveBeenCalledOnce();
+      expect(loader).toHaveBeenCalledWith(safeImportPath);
+    } finally {
+      Object.defineProperty(process, "platform", platformDescriptor);
+    }
+  });
+
+  it("includes importer and resolved path context when a bundled sidecar is missing", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
     tempDirs.push(tempRoot);
 
@@ -27,6 +79,8 @@ describe("loadBundledEntryExportSync", () => {
 
     const importerPath = path.join(pluginRoot, "index.js");
     fs.writeFileSync(importerPath, "export default {};\n", "utf8");
+
+    const { loadBundledEntryExportSync } = await import("./channel-entry-contract.js");
 
     let thrown: unknown;
     try {

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { importFreshModule } from "../../test/helpers/import-fresh.ts";
-import { loadBundledEntryExportSync } from "./channel-entry-contract.js";
 
 const tempDirs: string[] = [];
 
@@ -70,7 +69,9 @@ describe("loadBundledEntryExportSync", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
 
     try {
-      const { loadBundledEntryExportSync } = await import("./channel-entry-contract.js");
+      const { loadBundledEntryExportSync } = await importFreshModule<
+        typeof import("./channel-entry-contract.js")
+      >(import.meta.url, "./channel-entry-contract.js?scope=windows-safe-import-path");
       loadBundledEntryExportSync(importerUrl, {
         specifier: "./api.js",
         exportName: "signalSetupPlugin",
@@ -152,7 +153,7 @@ describe("loadBundledEntryExportSync", () => {
     }
   });
 
-  it("loads packaged telegram setup sidecars from dist-facing api modules", () => {
+  it("loads packaged telegram setup sidecars from dist-facing api modules", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
     tempDirs.push(tempRoot);
 
@@ -180,6 +181,8 @@ describe("loadBundledEntryExportSync", () => {
       "utf8",
     );
 
+    const { loadBundledEntryExportSync } = await import("./channel-entry-contract.js");
+
     expect(
       loadBundledEntryExportSync<{ id: string }>(pathToFileURL(importerPath).href, {
         specifier: "./setup-plugin-api.js",
@@ -199,7 +202,7 @@ describe("loadBundledEntryExportSync", () => {
     });
   });
 
-  it("can disable source-tree fallback for dist bundled entry checks", () => {
+  it("can disable source-tree fallback for dist bundled entry checks", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
     tempDirs.push(tempRoot);
 
@@ -216,6 +219,8 @@ describe("loadBundledEntryExportSync", () => {
       "export const sentinel = 42;\n",
       "utf8",
     );
+
+    const { loadBundledEntryExportSync } = await import("./channel-entry-contract.js");
 
     expect(
       loadBundledEntryExportSync<number>(pathToFileURL(importerPath).href, {

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createJiti } from "jiti";
 import { emptyChannelConfigSchema } from "../channels/plugins/config-schema.js";
 import type { ChannelConfigSchema, ChannelPlugin } from "../channels/plugins/types.plugin.js";
@@ -259,6 +259,19 @@ function resolveBundledEntryModulePath(importMetaUrl: string, specifier: string)
   );
 }
 
+function toSafeImportPath(specifier: string): string {
+  if (process.platform !== "win32") {
+    return specifier;
+  }
+  if (specifier.startsWith("file://")) {
+    return specifier;
+  }
+  if (path.win32.isAbsolute(specifier)) {
+    return pathToFileURL(specifier).href;
+  }
+  return specifier;
+}
+
 function getJiti(modulePath: string) {
   const { tryNative, aliasMap, cacheKey } = resolvePluginLoaderJitiConfig({
     modulePath,
@@ -280,6 +293,7 @@ function getJiti(modulePath: string) {
 
 function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): unknown {
   const modulePath = resolveBundledEntryModulePath(importMetaUrl, specifier);
+  const safeImportPath = toSafeImportPath(modulePath);
   const cached = loadedModuleExports.get(modulePath);
   if (cached !== undefined) {
     return cached;
@@ -293,10 +307,10 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
     try {
       loaded = nodeRequire(modulePath);
     } catch {
-      loaded = getJiti(modulePath)(modulePath);
+      loaded = getJiti(modulePath)(safeImportPath);
     }
   } else {
-    loaded = getJiti(modulePath)(modulePath);
+    loaded = getJiti(modulePath)(safeImportPath);
   }
   loadedModuleExports.set(modulePath, loaded);
   return loaded;


### PR DESCRIPTION
## Summary

- Problem: Bundled channel setup/runtime entry loading could hand raw Windows absolute paths like `C:\...` to Jiti, which triggers `ERR_UNSUPPORTED_ESM_URL_SCHEME` (`Received protocol 'c:'`) on Windows.
- Why it matters: This breaks channel-related setup/config flows on Windows, including the reported Signal/channel config path.
- What changed: Normalize bundled entry module paths to `file://` URLs before passing them to Jiti in `src/plugin-sdk/channel-entry-contract.ts`, and add a focused regression test for the Windows fallback path in `src/plugin-sdk/channel-entry-contract.test.ts`.
- What did NOT change (scope boundary): No broader plugin loader refactor, no behavior changes for non-Windows platforms, and no changes to channel/plugin manifests or runtime registration logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62083
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The bundled channel entry contract loader passed resolved Windows absolute paths directly into Jiti. On Windows ESM paths, drive-letter paths must be converted to `file://` URLs before import/loading.
- Missing detection / guardrail: The main plugin loader already normalized Windows import paths, but the bundled channel entry contract path did not have equivalent coverage.
- Contributing context (if known): The failure surfaced in a setup/config flow that loads bundled channel sidecar entries through `src/plugin-sdk/channel-entry-contract.ts`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/channel-entry-contract.test.ts`
- Scenario the test should lock in: When the bundled channel entry loader resolves a Windows absolute path and falls back to Jiti, it should pass a `file://` URL rather than a raw `C:\...` path.
- Why this is the smallest reliable guardrail: It exercises the actual bundled entry loading seam without requiring a full Windows E2E setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Windows channel setup/config flows that load bundled channel entry sidecars no longer fail with `ERR_UNSUPPORTED_ESM_URL_SCHEME` from raw drive-letter paths.

## Diagram (if applicable)

```text
Before:
[channel setup/config load] -> [resolved C:\...\api.js] -> [Jiti gets raw path] -> [ERR_UNSUPPORTED_ESM_URL_SCHEME]

After:
[channel setup/config load] -> [resolved C:\...\api.js] -> [convert to file:///C:/.../api.js] -> [Jiti load succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host for development; bug targets Windows path handling
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Signal / channel config flow
- Relevant config (redacted): N/A

### Steps

1. Resolve/load a bundled channel setup/runtime sidecar on Windows through `src/plugin-sdk/channel-entry-contract.ts`.
2. Hit the Jiti loading path with a Windows absolute path like `C:\openclaw\dist\extensions\signal\api.js`.
3. Verify the loader receives a `file://` URL instead of the raw absolute path.

### Expected

- Bundled entry loading succeeds without `ERR_UNSUPPORTED_ESM_URL_SCHEME`.

### Actual

- Before the fix, Jiti could receive a raw Windows path and fail with `Received protocol 'c:'`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Added and ran a focused regression test for the Windows bundled-entry Jiti fallback path.
  - Confirmed the exact focused test passes:
    - `corepack pnpm test src/plugin-sdk/channel-entry-contract.test.ts`
- Edge cases checked:
  - Non-Windows behavior is unchanged because normalization is gated on `process.platform === "win32"`.
  - Existing missing-sidecar error reporting test still passes.
- What you did **not** verify:
  - I did not run a full Windows end-to-end channel config flow locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Another Windows import surface outside this bundled entry contract path could still miss the same normalization.
  - Mitigation: This PR scopes the fix to the reported seam and adds regression coverage for that seam specifically.
