### PR TITLE
[codex] align tagged TTS docs with directive parser

### DIFF
--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -235,7 +235,8 @@ Then run:
 
 - `auto`: auto‑TTS mode (`off`, `always`, `inbound`, `tagged`).
   - `inbound` only sends audio after an inbound voice message.
-  - `tagged` only sends audio when the reply includes `[[tts]]` tags.
+  - `tagged` only sends audio when the reply includes `[[tts:text]]...[[/tts:text]]`
+    or `[[tts:...]]` directives.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
 - `provider`: speech provider id such as `"elevenlabs"`, `"microsoft"`, `"minimax"`, or `"openai"` (fallback is automatic).

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -397,7 +397,7 @@ export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefine
     autoMode === "inbound"
       ? "Only use TTS when the user's last message includes audio/voice."
       : autoMode === "tagged"
-        ? "Only use TTS when you include [[tts]] or [[tts:text]] tags."
+        ? "Only use TTS when you include [[tts:text]]...[[/tts:text]] or [[tts:...]] directives."
         : undefined;
   return [
     "Voice (TTS) is enabled.",


### PR DESCRIPTION
## What changed
- align the tagged TTS docs with the directive syntax the parser actually accepts
- update the speech-core system prompt hint to point models at `[[tts:text]]...[[/tts:text]]` blocks and `[[tts:...]]` directives instead of bare `[[tts]]`

## Why
The runtime parser in `src/tts/directives.ts` recognizes `[[tts:text]]...[[/tts:text]]` blocks and `[[tts:...]]` directives, but not a bare `[[tts]]` tag. The docs and the generated tagged-mode hint were still suggesting `[[tts]]`, which can leak raw markup into replies instead of triggering TTS.

## Impact
This is a focused docs/prompt-alignment fix only. It does not change parser behavior.

AI-assisted: yes. Tested locally and reviewed before opening.

## Validation
- `pnpm format:docs:check`
- `pnpm exec oxlint extensions/speech-core/src/tts.ts`
- `pnpm test:extension speech-core` (no tests found for this extension)
- `codex review --base origin/main` (no findings)
- `pnpm check` currently fails on unrelated type errors in untouched files:
  - `src/channels/plugins/acp-bindings.test.ts`
  - `src/cron/isolated-agent.model-formatting.test.ts`
