### PR TITLE
Fix: cast speed/vol/pitch to integers for MiniMax TTS API (Resolves #62144)

### DIFF
--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -135,10 +135,19 @@ describe("buildMinimaxSpeechProvider", () => {
       expect(result.overrides?.model).toBe("speech-01-240228");
     });
 
-    it("handles speed key with valid value", () => {
+    it("handles integer speed without warning", () => {
+      const result = provider.parseDirectiveToken!({ key: "speed", value: "1", policy });
+      expect(result.handled).toBe(true);
+      expect(result.overrides?.speed).toBe(1);
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it("handles non-integer speed with rounding warning", () => {
       const result = provider.parseDirectiveToken!({ key: "speed", value: "1.5", policy });
       expect(result.handled).toBe(true);
       expect(result.overrides?.speed).toBe(1.5);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings![0]).toContain("rounded to 2");
     });
 
     it("warns on invalid speed", () => {

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -271,7 +271,7 @@ describe("buildMinimaxSpeechProvider", () => {
       const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0][1]!.body as string);
       expect(body.model).toBe("speech-01-240228");
       expect(body.voice_setting.voice_id).toBe("custom_voice");
-      expect(body.voice_setting.speed).toBe(1.5);
+      expect(body.voice_setting.speed).toBe(2);
     });
 
     it("throws when API key is missing", async () => {

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -119,7 +119,13 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
       if (!Number.isFinite(speed) || speed < 0.5 || speed > 2.0) {
         return { handled: true, warnings: [`invalid MiniMax speed "${ctx.value}" (0.5-2.0)`] };
       }
-      return { handled: true, overrides: { speed } };
+      const warnings: string[] = [];
+      if (Math.round(speed) !== speed) {
+        warnings.push(
+          `MiniMax speed "${ctx.value}" rounded to ${Math.round(speed)} (API requires integers)`,
+        );
+      }
+      return { handled: true, overrides: { speed }, ...(warnings.length > 0 && { warnings }) };
     }
     case "vol":
     case "volume": {

--- a/extensions/minimax/tts.ts
+++ b/extensions/minimax/tts.ts
@@ -60,9 +60,9 @@ export async function minimaxTTS(params: {
         text,
         voice_setting: {
           voice_id: voiceId,
-          speed,
-          vol,
-          pitch,
+          speed: Math.round(speed),
+          vol: Math.round(vol),
+          pitch: Math.round(pitch),
         },
         audio_setting: {
           format,


### PR DESCRIPTION
Fixes #62144.

The MiniMax TTS API (`/v1/t2a_v2`) requires `speed`, `vol`, and `pitch` in
`voice_setting` to be integers. OpenClaw was sending float defaults (`1.0`,
`0.0`) which caused a 2013 "invalid params" error and no audio output.

Apply `Math.round()` to all three values in `minimaxTTS()` right before the
API call so user-configured floats are coerced to the integers the API expects.