### PR TITLE
[codex] fix inbound TTS detection for audio attachments

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -973,6 +973,32 @@ describe("dispatchReplyFromConfig", () => {
     expect(routed?.payload?.text).toBeUndefined();
   });
 
+  it("treats audio attachments with generic mime as inbound audio for TTS gating", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Body: "transcribed voice text",
+      BodyForAgent: "transcribed voice text",
+      BodyForCommands: "transcribed voice text",
+      RawBody: "transcribed voice text",
+      CommandBody: "transcribed voice text",
+      MediaPath: "/tmp/voice-note.ogg",
+      MediaType: "application/octet-stream",
+      MediaTypes: ["application/octet-stream"],
+    });
+
+    const replyResolver = async () => ({ text: "reply" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(ttsMocks.maybeApplyTtsToPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "final",
+        inboundAudio: true,
+      }),
+    );
+  });
+
   it("provides onToolResult in DM sessions", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -26,6 +26,7 @@ import {
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
+import { isAudioFileName } from "../../media/mime.js";
 import {
   buildPluginBindingDeclinedText,
   buildPluginBindingErrorText,
@@ -110,6 +111,16 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   ].filter(Boolean) as string[];
   const types = rawTypes.map((type) => normalizeMediaType(type));
   if (types.some((type) => type === "audio" || type.startsWith("audio/"))) {
+    return true;
+  }
+
+  const attachmentRefs = [
+    typeof ctx.MediaPath === "string" ? ctx.MediaPath : undefined,
+    ...(Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : []),
+    typeof ctx.MediaUrl === "string" ? ctx.MediaUrl : undefined,
+    ...(Array.isArray(ctx.MediaUrls) ? ctx.MediaUrls : []),
+  ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  if (attachmentRefs.some((value) => isAudioFileName(value.trim()))) {
     return true;
   }
 


### PR DESCRIPTION
## What changed
- add an attachment-path fallback when deciding whether a turn counts as inbound audio for TTS `auto: "inbound"`
- add a regression test for the case where the inbound voice note keeps a generic MIME type but still has an audio filename like `.ogg`

## Why
`isInboundAudioContext()` previously relied on `MediaType` / `MediaTypes` or audio placeholders in the body. That misses real voice-note turns after preprocessing when:
- the body has already been rewritten to plain transcript text, and
- the attachment MIME has fallen back to `application/octet-stream`

In that state, `messages.tts.auto: "inbound"` can incorrectly skip TTS even though the original inbound message was a voice note.

## Impact
This is a narrow bug fix in the reply-dispatch layer. It keeps the existing MIME and body checks, then falls back to known audio file extensions from attachment paths/URLs.

AI-assisted: yes. Reviewed locally before opening.

## Validation
- `pnpm exec oxlint src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts -t 'audio|tts|inbound'`
- `git commit` triggered `pnpm check`, which is currently blocked by unrelated type errors in untouched files:
  - `src/channels/plugins/acp-bindings.test.ts`
  - `src/cron/isolated-agent.model-formatting.test.ts`

