### PR TITLE
fix(exec-approval): add max-height and overflow to prevent button overflow on desktop

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2902,6 +2902,10 @@ td.data-table-key-col {
   border-radius: var(--radius-lg);
   padding: 20px;
   animation: scale-in 0.2s var(--ease-out);
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .exec-approval-header {
@@ -2941,6 +2945,8 @@ td.data-table-key-col {
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
+  max-height: 40vh;
+  overflow-y: auto;
 }
 
 .exec-approval-meta {


### PR DESCRIPTION
## Problem

When the exec approval dialog contains long command content (e.g. large heredocs from exec + python3), the action buttons (Allow once / Always allow / Deny) are pushed outside the viewport and cannot be clicked on desktop browsers.

## Root Cause

- `.exec-approval-card` had no max-height constraint on desktop (only on mobile via media query)
- `.exec-approval-command` had no max-height constraint, so long command text expanded the card indefinitely

## Fix

- `.exec-approval-card`: add `max-height: 90vh; overflow-y: auto; display: flex; flex-direction: column;`
- `.exec-approval-command`: add `max-height: 40vh; overflow-y: auto;`

This mirrors the existing mobile-responsive behavior, now applied to desktop as well.

---

**Before**: buttons unreachable when command content overflows viewport height

**After**: both the card and the command area scroll independently, buttons always visible

cc @steipete