### PR TITLE
fix(build): resolve @openclaw/plugin-sdk subpath imports in extensions/xai

### DIFF
--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -7,10 +7,7 @@
       "openclaw/plugin-sdk/*": ["../packages/plugin-sdk/dist/src/plugin-sdk/*.d.ts"],
       "openclaw/plugin-sdk/account-id": ["../src/plugin-sdk/account-id.ts"],
       "@openclaw/*": ["../packages/plugin-sdk/dist/extensions/*", "../extensions/*"],
-      "@openclaw/plugin-sdk/*": [
-        "../packages/plugin-sdk/dist/src/plugin-sdk/*.d.ts",
-        "../packages/plugin-sdk/src/*.ts"
-      ]
+      "@openclaw/plugin-sdk/*": ["../packages/plugin-sdk/dist/src/plugin-sdk/*.d.ts"]
     }
   }
 }

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -7,7 +7,10 @@
       "openclaw/plugin-sdk/*": ["../packages/plugin-sdk/dist/src/plugin-sdk/*.d.ts"],
       "openclaw/plugin-sdk/account-id": ["../src/plugin-sdk/account-id.ts"],
       "@openclaw/*": ["../packages/plugin-sdk/dist/extensions/*", "../extensions/*"],
-      "@openclaw/plugin-sdk/*": ["../packages/plugin-sdk/dist/src/plugin-sdk/*.d.ts"]
+      "@openclaw/plugin-sdk/*": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/*.d.ts",
+        "../packages/plugin-sdk/src/*.ts"
+      ]
     }
   }
 }

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -11,7 +11,10 @@
       ],
       "openclaw/plugin-sdk/account-id": ["../../src/plugin-sdk/account-id.ts"],
       "@openclaw/*": ["../*"],
-      "@openclaw/plugin-sdk/*": ["../../packages/plugin-sdk/dist/packages/plugin-sdk/src/*.d.ts"],
+      "@openclaw/plugin-sdk/*": [
+        "../../packages/plugin-sdk/dist/packages/plugin-sdk/src/*.d.ts",
+        "../../packages/plugin-sdk/src/*.ts"
+      ],
       "@openclaw/anthropic-vertex/api.js": ["./.boundary-stubs/anthropic-vertex-api.d.ts"],
       "@openclaw/ollama/api.js": ["./.boundary-stubs/ollama-api.d.ts"],
       "@openclaw/ollama/runtime-api.js": ["./.boundary-stubs/ollama-runtime-api.d.ts"],


### PR DESCRIPTION
## Summary
- `pnpm check` fails on a fresh clone because `@openclaw/plugin-sdk/*` path mapping in `extensions/tsconfig.package-boundary.paths.json` only resolves to `dist/*.d.ts` files
- The `dist/` directory doesn't exist until `pnpm build` runs, so TypeScript cannot resolve subpath imports like `@openclaw/plugin-sdk/testing`, `@openclaw/plugin-sdk/config-runtime`, and `@openclaw/plugin-sdk/provider-web-search` used by `extensions/xai`

## Changes
- Add a source `.ts` fallback path (`../packages/plugin-sdk/src/*.ts`) to the `@openclaw/plugin-sdk/*` mapping
- TypeScript will first try the dist `.d.ts` files (for post-build), then fall back to source `.ts` files (for pre-build/fresh clone)

## Test plan
- [ ] Fresh clone + `pnpm install --frozen-lockfile` + `pnpm check` should pass without needing `pnpm build` first
- [ ] Existing build workflows should be unaffected (dist path still takes priority)

Fixes #61893

🤖 Generated with [Claude Code](https://claude.com/claude-code)