### PR TITLE
fix(mcp): increase tool call timeout from 60s to 5 minutes

### DIFF
--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -269,10 +269,21 @@ export function createSessionMcpRuntime(params: {
       if (!session) {
         throw new Error(`bundle-mcp server "${serverName}" is not connected`);
       }
-      return (await session.client.callTool({
-        name: toolName,
-        arguments: isMcpConfigRecord(input) ? input : {},
-      })) as CallToolResult;
+      return (await session.client.callTool(
+        {
+          name: toolName,
+          arguments: isMcpConfigRecord(input) ? input : {},
+        },
+        undefined,
+        {
+          // MCP SDK defaults to 60s which is too short for long-running tools
+          // (code execution, web scraping, complex analysis). Use 5 minutes and
+          // reset the timer on progress notifications so tools that report
+          // progress can run indefinitely.
+          timeout: 300_000,
+          resetTimeoutOnProgress: true,
+        },
+      )) as CallToolResult;
     },
     async dispose() {
       if (disposed) {


### PR DESCRIPTION
## Summary

- MCP SDK defaults to 60-second request timeout for `callTool` which is too short for long-running tools (code execution, web scraping, complex analysis)
- Increase the default to 5 minutes (300,000ms) and enable `resetTimeoutOnProgress: true` so tools that send progress notifications can run indefinitely
- Single-file change in `src/agents/pi-bundle-mcp-runtime.ts`

## Test plan

- [ ] Existing MCP bundle tests pass
- [ ] MCP tools that take >60s complete successfully instead of timing out
- [ ] Tools that send progress notifications reset the timeout on each update

Fixes #61786

🤖 Generated with [Claude Code](https://claude.com/claude-code)