### PR TITLE
fix(github-copilot): return IDE identity headers from prepareRuntimeAuth

### DIFF
--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -4,6 +4,7 @@ import {
   ensureAuthProfileStore,
   listProfilesForProvider,
 } from "openclaw/plugin-sdk/provider-auth";
+import { buildCopilotIdeHeaders } from "openclaw/plugin-sdk/provider-stream-shared";
 import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { buildGithubCopilotReplayPolicy } from "./replay-policy.js";
 import { wrapCopilotProviderStream } from "./stream.js";
@@ -181,6 +182,7 @@ export default definePluginEntry({
           apiKey: token.token,
           baseUrl: token.baseUrl,
           expiresAt: token.expiresAt,
+          request: { headers: buildCopilotIdeHeaders() },
         };
       },
       resolveUsageAuth: async (ctx) => await ctx.resolveOAuthToken(),

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -22,6 +22,7 @@ export {
 } from "../agents/anthropic-payload-policy.js";
 export {
   buildCopilotDynamicHeaders,
+  buildCopilotIdeHeaders,
   hasCopilotVisionInput,
 } from "../agents/copilot-dynamic-headers.js";
 export { applyAnthropicEphemeralCacheControlMarkers } from "../agents/pi-embedded-runner/anthropic-cache-control-payload.js";


### PR DESCRIPTION
## Summary

Fixes #58056 — GitHub Copilot provider returns HTTP 400 `missing Editor-Version header for IDE auth` on all inference requests.

The prior fix in #60755 added IDE identity headers (`Editor-Version`, `User-Agent`) to openclaw's transport layer (`copilot-dynamic-headers.ts`) and the extension's `wrapStreamFn`. However, **these code paths are bypassed during normal inference** because:

1. **Boundary-aware transport is never activated.** `pi-coding-agent` wraps `streamSimple` in a custom auth-injecting function during `createAgentSession`. The identity check in `stream-resolution.ts:116` (`currentStreamFn === streamSimple`) fails because it's a different function reference, so openclaw's transport layer — which has the correct headers — is never used.

2. **The actual inference path falls through to `@mariozechner/pi-ai`'s internal providers** (`anthropic.js`, `openai-responses.js`, `openai-completions.js`), which call pi-ai's own `buildCopilotDynamicHeaders` from `dist/providers/github-copilot-headers.js`. This is a **separate copy** that was never updated with the IDE headers — it only returns `X-Initiator`, `Openai-Intent`, and `Copilot-Vision-Request`.

3. **The extension's `wrapStreamFn` only covers `anthropic-messages` API** (`stream.ts:16`), leaving GPT-through-Copilot models (`openai-responses` API) with no IDE header injection at all.

## Fix

Return the IDE headers from `prepareRuntimeAuth` via the existing `ProviderPreparedRuntimeAuth.request.headers` contract. This is a one-line addition:

```typescript
request: { headers: buildCopilotIdeHeaders() },
```

These headers flow through `applyPreparedRuntimeRequestOverrides` → `resolveProviderRequestConfig` → `model.headers`. Pi-ai's providers read `model.headers` early in their `mergeHeaders` chain, so the IDE headers reach the outgoing HTTP request **regardless of which stream function is active**.

This fixes:
- `anthropic-messages` API (Claude models through Copilot)
- `openai-responses` API (GPT models through Copilot)
- Both the main inference path and the compaction path

Also exports `buildCopilotIdeHeaders` from `openclaw/plugin-sdk/provider-stream-shared` so the extension can use it without violating boundary rules.

## Remaining issues (not addressed here)

- **`stream-resolution.ts:116` identity check**: The `=== streamSimple` check should be relaxed to also activate the boundary-aware transport for pi-coding-agent sessions. This would let openclaw's transport layer handle Copilot requests directly, bypassing pi-ai's providers entirely.
- **`@mariozechner/pi-ai` stale headers**: Pi-ai's `buildCopilotDynamicHeaders` should eventually be updated to include IDE headers for defense in depth.
- **Simple completion path**: Label generation and TTS use `streamSimple` without the `prepareRuntimeAuth` flow, so they remain affected. Lower severity since these are auxiliary tasks.

## Test plan

- [ ] Verify `openclaw gateway run` with `github-copilot/claude-sonnet-4.6` no longer returns HTTP 400
- [ ] Verify GPT models through Copilot (`github-copilot/gpt-4o`) also work
- [ ] Existing `extensions/github-copilot/stream.test.ts` continues to pass
- [ ] `auth-controller.test.ts` tests for `applyPreparedRuntimeRequestOverrides` pass with `request.headers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)