### PR TITLE
fix(exec): catch onUpdate errors when agent run ends while exec still produces output

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -580,26 +580,34 @@ export async function runExecProcess(opts: {
   };
   addSession(session);
 
+  let updateSuppressed = false;
   const emitUpdate = () => {
     if (!opts.onUpdate) {
       return;
     }
-    if (session.backgrounded || session.exited) {
+    if (session.backgrounded || session.exited || updateSuppressed) {
       return;
     }
     const tailText = session.tail || session.aggregated;
     const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
-    opts.onUpdate({
-      content: [{ type: "text", text: warningText + (tailText || "") }],
-      details: {
-        status: "running",
-        sessionId,
-        pid: session.pid ?? undefined,
-        startedAt,
-        cwd: session.cwd,
-        tail: session.tail,
-      },
-    });
+    try {
+      opts.onUpdate({
+        content: [{ type: "text", text: warningText + (tailText || "") }],
+        details: {
+          status: "running",
+          sessionId,
+          pid: session.pid ?? undefined,
+          startedAt,
+          cwd: session.cwd,
+          tail: session.tail,
+        },
+      });
+    } catch {
+      // The agent run may have ended while the exec process is still producing
+      // output (e.g. late stdout arriving after tool-call abort or turn timeout).
+      // Suppress further updates for this session to avoid repeated throws.
+      updateSuppressed = true;
+    }
   };
 
   const handleStdout = (data: string) => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -23,7 +23,7 @@ export {
   normalizeExecSecurity,
   normalizeExecTarget,
 } from "../infra/exec-approvals.js";
-import { logWarn } from "../logger.js";
+import { logDebug, logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit, TerminationReason } from "../process/supervisor/types.js";
@@ -602,11 +602,14 @@ export async function runExecProcess(opts: {
           tail: session.tail,
         },
       });
-    } catch {
+    } catch (err) {
       // The agent run may have ended while the exec process is still producing
       // output (e.g. late stdout arriving after tool-call abort or turn timeout).
       // Suppress further updates for this session to avoid repeated throws.
       updateSuppressed = true;
+      logDebug(
+        `[exec] onUpdate suppressed for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   };
 

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -733,3 +733,36 @@ describe("exec backgrounded onUpdate suppression", () => {
     isWin ? 15_000 : 5_000,
   );
 });
+
+describe("exec onUpdate error resilience", () => {
+  useCapturedEnv([...SHELL_ENV_KEYS], applyDefaultShellEnv);
+
+  it(
+    "does not crash when onUpdate throws (agent run ended while exec still producing output)",
+    async () => {
+      let callCount = 0;
+      const throwingOnUpdate = () => {
+        callCount++;
+        if (callCount > 1) {
+          // Simulate pi-agent-core throwing when the agent run has already ended
+          throw new Error("Agent listener invoked outside active run");
+        }
+      };
+      const tool = createTestExecTool();
+      // Run a command that produces multiple lines of output to trigger multiple onUpdate calls
+      const command = joinCommands([
+        shellEcho("line1"),
+        shortDelayCmd,
+        shellEcho("line2"),
+        shortDelayCmd,
+        shellEcho("line3"),
+      ]);
+      // Should not throw — the error from onUpdate should be caught internally
+      const result = await tool.execute(nextCallId(), { command }, undefined, throwingOnUpdate);
+      expect(readProcessStatus(result.details)).toBe(PROCESS_STATUS_COMPLETED);
+      // onUpdate was called at least once before the throw, and the throw was swallowed
+      expect(callCount).toBeGreaterThanOrEqual(2);
+    },
+    isWin ? 15_000 : 5_000,
+  );
+});


### PR DESCRIPTION
Fixes #62190
Fixes #62256

## Problem

When an exec process outlives its parent agent run (e.g. due to tool-call abort, turn timeout, or late stdout delivery after the lane task completes), the `onUpdate` callback throws `"Agent listener invoked outside active run"` from `pi-agent-core`. This becomes an unhandled promise rejection that **crashes the gateway**.

Multiple users report this on both macOS and Windows with 2026.4.5. The stack trace is always:

```
Agent.processEvents (pi-agent-core/src/agent.ts:533)
  ← Object.onUpdate (pi-agent-core/src/agent-loop.ts:539)
  ← emitUpdate (bash-tools.exec-runtime)
  ← handleStdout
  ← Object.onSupervisorStdout
  ← Socket.<anonymous>
```

## Root Cause

`emitUpdate()` guards on `session.backgrounded || session.exited`, which covers the common cases. However, there is a race where:

1. The agent run completes (lane task done)
2. The exec process is still running or its stdout pipe still has buffered data
3. Late stdout arrives → `handleStdout` → `emitUpdate` → `opts.onUpdate()`
4. `pi-agent-core` throws because the agent run is no longer active

The session is not yet marked as `exited` (process still running) and not `backgrounded` (foreground mode), so the guard passes.

## Fix

1. **try-catch on `onUpdate`:** Wrap `opts.onUpdate()` in a try-catch so late-arriving stdout from a finished agent run does not become an unhandled rejection
2. **`updateSuppressed` flag:** On first error, set a flag so subsequent stdout/stderr chunks skip `onUpdate` entirely instead of repeatedly throwing
3. **Debug logging:** Log a `[exec] onUpdate suppressed for session <id>` debug message on the first suppression, including the original error message — visible in `openclaw logs` for troubleshooting without being noisy at info/warn level

The exec process itself continues to run and its output is still captured in the session buffer. Only the streaming updates to the (now-dead) agent run are suppressed.

### Limitations and future work

- The catch is broad (catches all errors, not just the expected "Agent listener invoked outside active run"). This is intentional as a defensive measure — any `onUpdate` failure should not crash the gateway. If more granular handling is needed, error type discrimination can be added later.
- The root cause is a lifecycle mismatch between agent runs and exec processes. A cleaner long-term fix would be for `pi-agent-core` to expose a cancellation signal or detach hook so exec can proactively stop calling `onUpdate` when the run ends, rather than discovering it via a thrown error.

## Test Plan

- Added test: "does not crash when onUpdate throws (agent run ended while exec still producing output)"
- Verifies exec completes normally, `onUpdate` was called at least twice, and the thrown error was silently caught
- All existing bash-tools tests pass
- Boundary invariant test updated for upstream `setup-registry.runtime.ts` allowlist drift