### PR TITLE
fix(logging): refresh subsystem child loggers on rolling-log turnover

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -9,6 +9,7 @@ import {
   setLoggerOverride,
   stripRedundantSubsystemPrefixForConsole,
 } from "./logging.js";
+import { createSubsystemLogger } from "./logging/subsystem.js";
 import type { RuntimeEnv } from "./runtime.js";
 import { withTempDirSync } from "./test-helpers/temp-dir.js";
 
@@ -67,6 +68,28 @@ describe("logger helpers", () => {
       logWarn("warn-only");
       const content = fs.readFileSync(logPath, "utf-8");
       expect(content).toContain("warn-only");
+    });
+  });
+
+  it("re-targets long-lived subsystem loggers when the file path rolls over", () => {
+    withTempDirSync({ prefix: "openclaw-log-test-" }, (dir) => {
+      // Simulate a module-level subsystem logger captured before the rollover.
+      const oldPath = path.join(dir, "openclaw-2026-04-04.log");
+      setLoggerOverride({ level: "info", file: oldPath });
+      const log = createSubsystemLogger("rollover-test");
+      log.info("before-rollover");
+      expect(fs.readFileSync(oldPath, "utf-8")).toContain("before-rollover");
+
+      // Simulate the daily rolling-log path turning over.
+      const newPath = path.join(dir, "openclaw-2026-04-05.log");
+      setLoggerOverride({ level: "info", file: newPath });
+
+      log.info("after-rollover");
+
+      const newContent = fs.readFileSync(newPath, "utf-8");
+      expect(newContent).toContain("after-rollover");
+      // Old file must NOT receive post-rollover writes from the cached logger.
+      expect(fs.readFileSync(oldPath, "utf-8")).not.toContain("after-rollover");
     });
   });
 

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -9,6 +9,7 @@ import {
   setLoggerOverride,
   stripRedundantSubsystemPrefixForConsole,
 } from "./logging.js";
+import { loggingState } from "./logging/state.js";
 import { createSubsystemLogger } from "./logging/subsystem.js";
 import type { RuntimeEnv } from "./runtime.js";
 import { withTempDirSync } from "./test-helpers/temp-dir.js";
@@ -89,6 +90,31 @@ describe("logger helpers", () => {
       const newContent = fs.readFileSync(newPath, "utf-8");
       expect(newContent).toContain("after-rollover");
       // Old file must NOT receive post-rollover writes from the cached logger.
+      expect(fs.readFileSync(oldPath, "utf-8")).not.toContain("after-rollover");
+    });
+  });
+
+  it("detects file path rollover even without an external getLogger() call", () => {
+    // Regression for the natural midnight rollover case: long-lived subsystem
+    // loggers may keep emitting without anyone else calling getLogger(), so
+    // we must force a settings refresh inside the subsystem emit path itself
+    // rather than relying on the generation counter being bumped externally.
+    withTempDirSync({ prefix: "openclaw-log-test-" }, (dir) => {
+      const oldPath = path.join(dir, "openclaw-2026-04-04.log");
+      const newPath = path.join(dir, "openclaw-2026-04-05.log");
+      setLoggerOverride({ level: "info", file: oldPath });
+      const log = createSubsystemLogger("rollover-natural");
+      log.info("before-rollover");
+
+      // Mutate the override file in place to simulate
+      // `defaultRollingPathForToday()` returning a new value at midnight,
+      // without calling setLoggerOverride() (which would bump the generation
+      // counter on its own and mask the bug).
+      (loggingState.overrideSettings as { file: string }).file = newPath;
+
+      log.info("after-rollover");
+
+      expect(fs.readFileSync(newPath, "utf-8")).toContain("after-rollover");
       expect(fs.readFileSync(oldPath, "utf-8")).not.toContain("after-rollover");
     });
   });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -241,6 +241,9 @@ export function getLogger(): TsLogger<LogObj> {
   if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
     loggingState.cachedLogger = buildLogger(settings);
     loggingState.cachedSettings = settings;
+    // Invalidate subsystem-cached child loggers so they refetch and pick up
+    // the new file transport (for example after a daily rolling-log turnover).
+    loggingState.loggerGeneration += 1;
   }
   return loggingState.cachedLogger as TsLogger<LogObj>;
 }
@@ -303,6 +306,7 @@ export function setLoggerOverride(settings: LoggerSettings | null) {
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
+  loggingState.loggerGeneration += 1;
 }
 
 export function resetLogger() {
@@ -310,6 +314,7 @@ export function resetLogger() {
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
+  loggingState.loggerGeneration += 1;
 }
 
 export function registerLogTransport(transport: LogTransport): () => void {

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -1,6 +1,11 @@
 export const loggingState = {
   cachedLogger: null as unknown,
   cachedSettings: null as unknown,
+  // Bumped whenever the base file logger is rebuilt (settings change or daily
+  // rolling-log path turning over). Long-lived subsystem loggers compare their
+  // own captured generation against this to know when to refetch the child
+  // logger and pick up the new file transport.
+  loggerGeneration: 0,
   cachedConsoleSettings: null as unknown,
   overrideSettings: null as unknown,
   invalidEnvLogLevelValue: null as string | null,

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -11,7 +11,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { getChildLogger, getLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -315,9 +315,16 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   // Long-lived subsystem loggers (most callers do `const log =
   // createSubsystemLogger(...)` at module scope) cache their child file
   // logger. The base file logger can be rebuilt — for example when the daily
-  // rolling-log path turns over — so we re-fetch the child whenever the
-  // generation counter advances.
+  // rolling-log path turns over at midnight — so we re-fetch the child
+  // whenever the generation counter advances.
+  //
+  // Critically, we must call `getLogger()` first to force a settings refresh.
+  // The generation counter is only bumped when `getLogger()` rebuilds the
+  // base; if a long-lived subsystem logger keeps emitting without anyone else
+  // calling `getLogger()`, the counter would never advance and the cached
+  // child would keep writing to the previous day's file.
   const ensureFileLogger = (): TsLogger<LogObj> => {
+    getLogger();
     if (!fileLogger || fileLoggerGeneration !== loggingState.loggerGeneration) {
       fileLogger = getChildLogger({ subsystem });
       fileLoggerGeneration = loggingState.loggerGeneration;

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -310,6 +310,20 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerGeneration = -1;
+
+  // Long-lived subsystem loggers (most callers do `const log =
+  // createSubsystemLogger(...)` at module scope) cache their child file
+  // logger. The base file logger can be rebuilt — for example when the daily
+  // rolling-log path turns over — so we re-fetch the child whenever the
+  // generation counter advances.
+  const ensureFileLogger = (): TsLogger<LogObj> => {
+    if (!fileLogger || fileLoggerGeneration !== loggingState.loggerGeneration) {
+      fileLogger = getChildLogger({ subsystem });
+      fileLoggerGeneration = loggingState.loggerGeneration;
+    }
+    return fileLogger;
+  };
 
   const emitLog = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
     const consoleSettings = getConsoleSettings();
@@ -332,10 +346,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       fileMeta = Object.keys(rest).length > 0 ? rest : undefined;
     }
     if (fileEnabled) {
-      if (!fileLogger) {
-        fileLogger = getChildLogger({ subsystem });
-      }
-      logToFile(fileLogger, level, message, fileMeta);
+      logToFile(ensureFileLogger(), level, message, fileMeta);
     }
     if (!consoleEnabled) {
       return;
@@ -398,10 +409,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     },
     raw(message) {
       if (isFileLogLevelEnabled("info")) {
-        if (!fileLogger) {
-          fileLogger = getChildLogger({ subsystem });
-        }
-        logToFile(fileLogger, "info", message, { raw: true });
+        logToFile(ensureFileLogger(), "info", message, { raw: true });
       }
       if (
         shouldLogToConsole("info", { level: getConsoleSettings().level }) &&


### PR DESCRIPTION
## Summary

Long-lived subsystem loggers (most callers do `const log = createSubsystemLogger(...)` at module scope) cache their child file logger on first emit. The base file logger can be rebuilt — most commonly when the daily rolling-log path turns over at midnight — but the cached child still references the old base and keeps writing to the previous day's file.

Symptom: after a long-running process (gateway, bundled mac app) crosses midnight, most subsystem logs silently disappear from `openclaw-<today>.log`. They are still being written, but to the stale `openclaw-<yesterday>.log`. Only loggers created on demand land in today's file. Reproduced locally on multiple installs by inspecting `/tmp/openclaw/openclaw-*.log`: long-lived `gateway/channels/*` writes were going to a 3-day-old file at the current timestamp.

Fix: add a `loggerGeneration` counter in `loggingState`, bump it whenever `getLogger()` rebuilds the base (and on `setLoggerOverride` / `resetLogger`), and have `createSubsystemLogger` re-fetch its cached child whenever the captured generation goes stale.

## Test plan

- [x] New regression test in `src/logger.test.ts` simulates a rollover via `setLoggerOverride` and asserts a previously cached subsystem logger writes to the new file (and not the old one).
- [x] `pnpm test src/logger.test.ts` (13 passed).
- [ ] `pnpm check` was attempted; pre-existing tsgo failures in `src/gateway/gateway-cli-backend.live.test.ts` (introduced by an earlier unrelated commit on `main`) are not related to this change.