### PR TITLE
feat(plugins): add sessionKey to PluginHookMessageContext

### DIFF
--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -30,6 +30,7 @@ export type CanonicalInboundMessageHookContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  sessionKey?: string;
   messageId?: string;
   senderId?: string;
   senderName?: string;
@@ -118,6 +119,7 @@ export function deriveInboundMessageHookContext(
     channelId,
     accountId: ctx.AccountId,
     conversationId,
+    sessionKey: ctx.SessionKey,
     messageId:
       overrides?.messageId ??
       ctx.MessageSidFull ??
@@ -180,6 +182,7 @@ export function toPluginMessageContext(
     channelId: canonical.channelId,
     accountId: canonical.accountId,
     conversationId: canonical.conversationId,
+    sessionKey: "sessionKey" in canonical ? canonical.sessionKey : undefined,
   };
 }
 

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -238,6 +238,7 @@ export function toPluginInboundClaimContext(
     parentConversationId: conversation.parentConversationId,
     senderId: canonical.senderId,
     messageId: canonical.messageId,
+    sessionKey: canonical.sessionKey,
   };
 }
 

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -4,6 +4,7 @@ export type PluginHookMessageContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  sessionKey?: string;
 };
 
 export type PluginHookInboundClaimContext = PluginHookMessageContext & {


### PR DESCRIPTION
Exposes the resolved session key in message hook context so plugins can correlate inbound messages with the active agent session. Useful for multi-tenant plugins that need per-session routing, metering, or ACL decisions directly from message hooks without a separate lookup.

## Summary

- **Problem:** `PluginHookMessageContext` and `CanonicalInboundMessageHookContext` had no `sessionKey` field, so message hook handlers couldn't correlate an inbound message to the active agent session without an out-of-band lookup.
- **Why it matters:** Multi-tenant plugins (metering, ACL, model routing) need per-session identity at the earliest hook stage — before the agent loop — not just after a separate session resolution call.
- **What changed:** Added optional `sessionKey` to `PluginHookMessageContext`, `CanonicalInboundMessageHookContext`, both mapper functions (`toPluginMessageContext`, `toPluginInboundClaimContext`), and populated from `ctx.SessionKey` in `deriveInboundMessageHookContext`.
- **What did NOT change:** No changes to session resolution logic, hook dispatch order, or any other hook context shapes.

## Change Type

- [x] Feature

## Scope

- [x] API / contracts

## Linked Issue/PR

- Related: none

## Root Cause

N/A — additive feature.

## Regression Test Plan

N/A — new optional field with no existing callers. TypeScript strict mode enforces all mapper sites are correctly typed.

- If no new test is added, why not: the field is optional and additive; there is no prior behavior to regress against.

## User-visible / Behavior Changes

None. `sessionKey` is optional — all existing plugins and hook handlers are unaffected.

## Diagram

\`\`\`text
Before:
ctx.SessionKey -> deriveInboundMessageHookContext -> { channelId, accountId, ... }
                                                     (sessionKey missing)

After:
ctx.SessionKey -> deriveInboundMessageHookContext -> { channelId, accountId, ..., sessionKey }
                  -> toPluginMessageContext        -> { channelId, accountId, ..., sessionKey }
                  -> toPluginInboundClaimContext   -> { channelId, accountId, ..., sessionKey }
\`\`\`

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — sessionKey is an opaque correlation identifier, not a credential or secret.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Register a plugin hook on before_inbound_claim
2. Log context.sessionKey from the handler
3. Send a message when an agent session is active

### Expected

- sessionKey populated when a session is resolved for the inbound message
- sessionKey is undefined when no session is active (pre-session claim)

### Actual

- Verified field flows through all four mapper paths via code inspection
- pnpm check passes cleanly

## Human Verification

- Verified all four mapper paths forward sessionKey (derive + toPluginMessageContext + toPluginInboundClaimContext)
- Verified edge case: field absent/undefined when session not yet resolved
- What was NOT verified: live end-to-end test with a real multi-tenant plugin

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- None. sessionKey is a new optional field; all existing plugins and hook handlers that do not read it are unaffected.