### PR TITLE
fix(hooks): align session-memory filename with canonical YYYY-MM-DD.md convention

### DIFF
--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -24,29 +24,31 @@ When you run `/new` or `/reset` to start a fresh session:
 
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)
-3. **Generates descriptive slug** - Uses LLM to create a meaningful filename slug based on conversation content
-4. **Saves to memory** - Creates a new file at `<workspace>/memory/YYYY-MM-DD-slug.md`
+3. **Generates descriptive slug** - Uses LLM to create a meaningful session heading based on conversation content
+4. **Saves to memory** - Appends to the canonical daily file at `<workspace>/memory/YYYY-MM-DD.md`
 
 ## Output Format
 
 Memory files are created with the following format:
 
 ```markdown
-# Session: 2026-01-16 14:30:00 UTC
+## Session: 2026-01-16 14:30:00 UTC — vendor-pitch
 
 - **Session Key**: agent:main:main
 - **Session ID**: abc123def456
 - **Source**: telegram
+
+### Conversation Summary
+
+user: ...
+assistant: ...
 ```
 
-## Filename Examples
+Multiple `/reset` calls on the same day append to the same daily file, separated by `---`.
 
-The LLM generates descriptive slugs based on your conversation:
+## Filename Convention
 
-- `2026-01-16-vendor-pitch.md` - Discussion about vendor evaluation
-- `2026-01-16-api-design.md` - API architecture planning
-- `2026-01-16-bug-fix.md` - Debugging session
-- `2026-01-16-1430.md` - Fallback timestamp if slug generation fails
+All session memory files use the canonical daily filename `YYYY-MM-DD.md`, matching the rest of the memory system (flush plan, AGENTS templates, post-compaction context). The LLM-generated slug appears in the section heading for descriptive context. If slug generation fails, the heading uses an `HHMM` timestamp fallback.
 
 ## Requirements
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -32,7 +32,7 @@ When you run `/new` or `/reset` to start a fresh session:
 Memory files are created with the following format:
 
 ```markdown
-## Session: 2026-01-16 14:30:00 UTC — vendor-pitch
+## Session: 2026-01-16 14:30:00 — vendor-pitch
 
 - **Session Key**: agent:main:main
 - **Session ID**: abc123def456

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -247,6 +247,67 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Captured before reset");
   });
 
+  it("writes canonical YYYY-MM-DD.md filename without slug suffix", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Check filename convention" },
+      { role: "assistant", content: "Daily file should match YYYY-MM-DD.md" },
+    ]);
+    const { tempDir, files } = await runNewWithPreviousSession({ sessionContent });
+
+    expect(files.length).toBe(1);
+    // Filename must be pure YYYY-MM-DD.md — no slug suffix
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}\.md$/);
+
+    // Slug should appear inside the content as a section heading instead (HHMM fallback in test env)
+    const content = await fs.readFile(path.join(tempDir, "memory", files[0]), "utf-8");
+    expect(content).toMatch(/— \d{4}/); // HHMM timestamp slug in heading
+  });
+
+  it("appends to existing daily file on multiple resets", async () => {
+    const tempDir = await createCaseWorkspace("workspace");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // First reset
+    const sessionFile1 = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "session-1.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "First session topic" },
+        { role: "assistant", content: "First session reply" },
+      ]),
+    });
+    await runNewWithPreviousSessionEntry({
+      tempDir,
+      previousSessionEntry: { sessionId: "sess-1", sessionFile: sessionFile1 },
+    });
+
+    // Second reset
+    const sessionFile2 = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "session-2.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Second session topic" },
+        { role: "assistant", content: "Second session reply" },
+      ]),
+    });
+    await runNewWithPreviousSessionEntry({
+      tempDir,
+      previousSessionEntry: { sessionId: "sess-2", sessionFile: sessionFile2 },
+    });
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    // Both resets should land in a single daily file
+    expect(files.length).toBe(1);
+
+    const content = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    // Both sessions should be present, separated by ---
+    expect(content).toContain("user: First session topic");
+    expect(content).toContain("user: Second session topic");
+    expect(content).toContain("---");
+  });
+
   it("prefers workspaceDir from hook context when sessionKey points at main", async () => {
     const mainWorkspace = await createCaseWorkspace("workspace-main");
     const naviWorkspace = await createCaseWorkspace("workspace-navi");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -193,8 +193,14 @@ const saveSessionToMemory: HookHandler = async (event) => {
       path: memoryFilePath.replace(os.homedir(), "~"),
     });
 
-    // Format time as HH:MM:SS UTC
-    const timeStr = now.toISOString().split("T")[1].split(".")[0];
+    // Format time in the same user timezone as dateStr for consistency.
+    const timeStr = new Intl.DateTimeFormat("en-GB", {
+      timeZone: userTimezone,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).format(now);
 
     // Extract context details
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
@@ -202,7 +208,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Build Markdown entry (include slug in heading for descriptive context)
     const entryParts = [
-      `## Session: ${dateStr} ${timeStr} UTC — ${slug}`,
+      `## Session: ${dateStr} ${timeStr} — ${slug}`,
       "",
       `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -12,6 +12,7 @@ import {
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
 } from "../../../agents/agent-scope.js";
+import { resolveUserTimezone } from "../../../agents/date-time.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
@@ -27,6 +28,22 @@ import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
+
+function formatDateStampInTimezone(nowMs: number, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
 
 function resolveDisplaySessionKey(params: {
   cfg?: OpenClawConfig;
@@ -80,9 +97,11 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Get today's date for filename
+    // Get today's date for filename, respecting the user's configured timezone
+    // so the date stamp matches flush-plan and post-compaction context.
     const now = new Date(event.timestamp);
-    const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
+    const userTimezone = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+    const dateStr = formatDateStampInTimezone(now.getTime(), userTimezone);
 
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
@@ -165,8 +184,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
       log.debug("Using fallback timestamp slug", { slug });
     }
 
-    // Create filename with date and slug
-    const filename = `${dateStr}-${slug}.md`;
+    // Use canonical daily filename (YYYY-MM-DD.md) so post-compaction context
+    // and AGENTS templates can locate the file without slug awareness.
+    const filename = `${dateStr}.md`;
     const memoryFilePath = path.join(memoryDir, filename);
     log.debug("Memory file path resolved", {
       filename,
@@ -180,9 +200,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
     const source = (context.commandSource as string) || "unknown";
 
-    // Build Markdown entry
+    // Build Markdown entry (include slug in heading for descriptive context)
     const entryParts = [
-      `# Session: ${dateStr} ${timeStr} UTC`,
+      `## Session: ${dateStr} ${timeStr} UTC — ${slug}`,
       "",
       `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,
@@ -192,16 +212,27 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Include conversation content if available
     if (sessionContent) {
-      entryParts.push("## Conversation Summary", "", sessionContent, "");
+      entryParts.push("### Conversation Summary", "", sessionContent, "");
     }
 
     const entry = entryParts.join("\n");
+
+    // Append to existing daily file so multiple /reset calls in the same day
+    // accumulate in one canonical file instead of creating orphaned slug files.
+    const rawExisting = await fs.readFile(memoryFilePath, "utf-8").catch((err) => {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    });
+    const existingContent = rawExisting?.trim() || null;
+    const finalContent = existingContent ? `${existingContent}\n\n---\n\n${entry}` : entry;
 
     // Write under memory root with alias-safe file validation.
     await writeFileWithinRoot({
       rootDir: memoryDir,
       relativePath: filename,
-      data: entry,
+      data: finalContent,
       encoding: "utf-8",
     });
     log.debug("Memory file written successfully");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -225,6 +225,10 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Append to existing daily file so multiple /reset calls in the same day
     // accumulate in one canonical file instead of creating orphaned slug files.
+    // Read existing content with raw fs.readFile — the filename is constructed
+    // from Intl.DateTimeFormat output (pure YYYY-MM-DD), so there is no path
+    // traversal surface. The subsequent write goes through writeFileWithinRoot
+    // which enforces full symlink/boundary validation.
     const rawExisting = await fs.readFile(memoryFilePath, "utf-8").catch((err) => {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return null;


### PR DESCRIPTION
## Summary

Fixes #61384

The session-memory hook wrote files as `YYYY-MM-DD-slug.md` while flush-plan, AGENTS templates, and post-compaction context all expect `YYYY-MM-DD.md`. This mismatch caused ENOENT errors after `/reset` when the agent tried to read the canonical daily file.

- Use canonical `YYYY-MM-DD.md` filename (slug moved into `## Session:` heading for descriptive context)
- Respect user timezone via `Intl.DateTimeFormat` (matching flush-plan and post-compaction context)
- Append to existing daily file on multiple `/reset` calls in the same day (separated by `---`)
- Nest `### Conversation Summary` under `## Session:` heading for proper hierarchy
- Only catch `ENOENT` on existing-file read; re-throw real errors
- Update `HOOK.md` to reflect new filename convention and append behavior

## Test plan
- [x] Existing tests pass (19/19)
- [x] New test: verifies canonical `YYYY-MM-DD.md` filename without slug suffix
- [x] New test: verifies multiple resets append to the same daily file with `---` separator