### PR TITLE
fix(launchd): set ProcessType=Interactive to prevent macOS App Nap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -553,6 +553,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.
 - Gateway/startup: load provider plugins that own explicitly configured image, video, or music generation defaults so generation tools become live after gateway restart instead of remaining catalog-only. Fixes #77244. Thanks @buyuangtampan, @Nikoxx99, and @vincentkoc.

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -8,6 +8,7 @@ export const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS = 10;
 export const LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS = 20;
 // launchd stores plist integer values in decimal; 0o077 renders as 63 (owner-only files).
 export const LAUNCH_AGENT_UMASK_DECIMAL = 0o077;
+export const LAUNCH_AGENT_PROCESS_TYPE = "Interactive";
 
 const plistEscape = (value: string): string =>
   value
@@ -179,5 +180,5 @@ export function buildLaunchAgentPlist({
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ExitTimeOut</key>\n    <integer>${LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS}</integer>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>Umask</key>\n    <integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ExitTimeOut</key>\n    <integer>${LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS}</integer>\n    <key>ProcessType</key>\n    <string>${LAUNCH_AGENT_PROCESS_TYPE}</string>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>Umask</key>\n    <integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -2,6 +2,7 @@ import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS,
+  LAUNCH_AGENT_PROCESS_TYPE,
   LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS,
   LAUNCH_AGENT_UMASK_DECIMAL,
 } from "./launchd-plist.js";
@@ -578,6 +579,8 @@ describe("launchd install", () => {
     expect(plist).not.toContain("<key>SuccessfulExit</key>");
     expect(plist).toContain("<key>ExitTimeOut</key>");
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS}</integer>`);
+    expect(plist).toContain("<key>ProcessType</key>");
+    expect(plist).toContain(`<string>${LAUNCH_AGENT_PROCESS_TYPE}</string>`);
     expect(plist).toContain("<key>Umask</key>");
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>`);
     expect(plist).toContain("<key>ThrottleInterval</key>");


### PR DESCRIPTION
## Summary

- Add `ProcessType: Interactive` to the generated launchd plist so macOS does not App Nap the gateway process
- Prevents heartbeat timers from silently freezing during idle periods on macOS

## Problem

The gateway's heartbeat interval timer uses `setTimeout` inside the Node.js event loop. On macOS, when the gateway has no I/O activity, App Nap suspends the process, freezing all timers. Heartbeats stop silently and only resume when user activity wakes the process.

Setting `ProcessType` to `Interactive` in the launchd plist tells macOS to treat the gateway as a foreground-quality process that needs timely execution, opting it out of App Nap.

## Changes

- `src/daemon/launchd-plist.ts` - add `ProcessType: Interactive` to the plist template
- `src/daemon/launchd.test.ts` - add assertions for the new key

## Test plan

- [x] `pnpm test src/daemon/launchd.test.ts`
- [x] `pnpm exec oxfmt --check --threads=1 src/daemon/launchd-plist.ts src/daemon/launchd.test.ts`
- [ ] `pnpm check:changed` - blocked by unrelated current-main `no-floating-promises` lint in `src/agents/pi-embedded-runner/run/assistant-failover.ts`

## Real behavior proof

- Behavior or issue addressed: macOS LaunchAgent gateway startup and heartbeat timers can stall because generated plists omit `ProcessType=Interactive`.
- Real environment tested: macOS 26.1 arm64, OpenClaw 2026.3.28, Node `/opt/homebrew/opt/node@24/bin/node`, LaunchAgent label `ai.openclaw.cleancheck`, Gateway port `19011`.
- Exact steps or command run after this patch: Applied the same LaunchAgent plist change produced by this PR (`<key>ProcessType</key><string>Interactive</string>`), restarted the launchd job, and probed the gateway socket once per second until the listener appeared.
- Evidence after fix: Copied live output from #58061 after adding the plist key:

```text
t=0s pid present, no listener yet
t=1s no listener
t=2s no listener
t=3s no listener
t=4s listener present, TCP probe succeeded
09:58:31.802 [gateway] signal SIGTERM received
09:58:31.805 [gateway] received SIGTERM; shutting down
09:58:35.471 [agents/auth-profiles] auth-store stage=external-cli-sync elapsedMs=41 mutated=true
09:58:35.635 [canvas] host mounted at http://127.0.0.1:19011/__openclaw__/canvas/
09:58:35.720 [gateway] listening on ws://127.0.0.1:19011, ws://[::1]:19011 (PID 55475)
```

- Observed result after fix: The same launchd-managed gateway went from minutes before the websocket listener was reachable to about 4 seconds after restart with `ProcessType=Interactive` in the plist.
- What was not tested: I did not rerun a fresh macOS live LaunchAgent install after rebasing this PR; the rebase kept the same generated plist key and targeted launchd tests now assert it.

Refs: #58061, #62294, #66992
