### PR TITLE
fix(heartbeat): enforce minimum interval for non-interval wake triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/sandbox: include the container workspace path hint in sandbox-root escape errors while preserving shortened host workspace roots. Fixes #79712. Thanks @haumanto and @hclsys.
+- Heartbeat/scheduling: throttle ordinary activity-driven wake bursts to the configured interval while preserving explicit no-argument plugin/system wake-now requests and overdue timer recovery. Fixes #62294. (#62310) Thanks @bryanpearson.
 - QQBot: route gateway WebSocket connections through the ambient proxy agent so deployments with `https_proxy`, `HTTPS_PROXY`, or `HTTP_PROXY` can reach the QQ gateway. (#72961) Thanks @xialonglee.
 - Agents/subagents: treat `sessions_spawn` `model: "default"` as the default-model fallback and ignore ACP-only stream targets for native sub-agent spawns. Fixes #72078. (#72101) Thanks @xialonglee.
 - Agents/failover: stop retrying assistant-prefill format rejections across auth profiles or model fallbacks, surfacing the deterministic provider error instead of requeueing the lane. Fixes #79688. (#79728) Thanks @hclsys.

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -595,6 +595,42 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("preserves immediate delivery for no-argument plugin compatibility wakes", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig(),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat({
+      source: "exec-event",
+      intent: "event",
+      reason: "exec-event",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    requestHeartbeat({
+      source: "other",
+      intent: "immediate",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).toHaveBeenCalledTimes(2);
+    expect(runSpy.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        source: "other",
+        intent: "immediate",
+        reason: "requested",
+      }),
+    );
+    runner.stop();
+  });
+
   it("preserves immediate delivery for repeated background-task wakes", async () => {
     // Task-registry terminal updates wake the heartbeat with reason
     // 'background-task'. Documented as immediate so users don't wait for the


### PR DESCRIPTION
## Summary

- Enforce minimum interval between heartbeat runs for non-interval wake reasons (`exec-event`, `hook`, `cron:*`, `wake`, `background-task`, etc.)
- Add drift detection in `scheduleNext()` so overdue timers fire immediately after process suspension

## Problem

Non-interval heartbeat wake reasons bypass the timing gate in `run()`:

```typescript
if (isInterval && now < agent.nextDueMs) continue;
```

`isInterval` is only true for `reason === "interval"`. All other reasons run immediately and call `advanceAgentSchedule()`, which pushes `nextDueMs` forward — effectively satisfying the interval. This causes:

1. **Burst runs** — multiple events (exec completions, cron results, notifications) triggering in quick succession each fire a heartbeat, producing 15+ runs in 12 minutes
2. **Interval starvation** — activity-driven heartbeats keep advancing the schedule so the interval timer never gets to fire on its own

Additionally, `scheduleNext()` doesn't detect when the timer is already overdue (e.g. from macOS App Nap), so stale timers schedule a 0ms `setTimeout` instead of firing immediately.

## Changes

**`src/infra/heartbeat-runner.ts`:**
- Add minimum-interval enforcement for targeted non-interval wakes (the `requestedSessionKey || requestedAgentId` path)
- Add minimum-interval enforcement for fan-out non-interval wakes (the `for...of state.agents` loop)
- Add overdue detection in `scheduleNext()` — if `delay === 0`, fire immediately instead of scheduling a timer
- Add drift logging when timers fire >5s late

**`src/infra/heartbeat-runner.scheduler.test.ts`:**
- Test: non-interval wake skipped when last run is within interval
- Test: targeted non-interval wake skipped when last run is within interval
- Test: overdue interval fires immediately (drift detection)

## Test plan

- [ ] Existing scheduler tests pass (config updates, error recovery, requests-in-flight, targeted routing, fan-out scoping)
- [ ] New test: untargeted exec-event after recent interval run → skipped
- [ ] New test: targeted exec-event with sessionKey after recent interval run → skipped
- [ ] New test: 90min time jump triggers immediate heartbeat (overdue detection)
- [ ] Manual: monitor `activity-log.jsonl` during active use — verify no burst of >1 heartbeat per interval

Refs: #62294
Companion to #62308 (launchd ProcessType fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)