### PR TITLE
fix: filter phantom provider entries inferred from aggregator model ID prefixes

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -367,6 +367,80 @@ describe("loadModelCatalog", () => {
     expect(matches[0]?.name).toBe("Kilo Auto");
   });
 
+  it("filters phantom provider entries inferred from aggregator model ID prefixes", async () => {
+    // Simulate what pi-coding-agent's ModelRegistry does: when openrouter has a model
+    // "google/gemini-3-flash-preview", the registry emits both an openrouter entry and
+    // a phantom "google" entry with id "gemini-3-flash-preview".
+    mockPiDiscoveryModels([
+      {
+        id: "google/gemini-3-flash-preview",
+        provider: "openrouter",
+        name: "Google Gemini 3 Flash Preview",
+      },
+      {
+        id: "xiaomi/mimo-v2-pro",
+        provider: "openrouter",
+        name: "Xiaomi Mimo V2 Pro",
+      },
+      {
+        id: "gemini-3-flash-preview",
+        provider: "google",
+        name: "Google Gemini 3 Flash Preview",
+      },
+    ]);
+
+    const cfg = {
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            models: [
+              { id: "google/gemini-3-flash-preview", name: "Google Gemini 3 Flash Preview" },
+              { id: "xiaomi/mimo-v2-pro", name: "Xiaomi Mimo V2 Pro" },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await loadModelCatalog({ config: cfg });
+
+    // The phantom "google" provider entry should be filtered out
+    expect(result).not.toContainEqual(
+      expect.objectContaining({ provider: "google", id: "gemini-3-flash-preview" }),
+    );
+    // The legitimate openrouter entries should remain
+    expect(result).toContainEqual(
+      expect.objectContaining({ provider: "openrouter", id: "google/gemini-3-flash-preview" }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({ provider: "openrouter", id: "xiaomi/mimo-v2-pro" }),
+    );
+  });
+
+  it("keeps entries from explicitly configured providers even with slashed model IDs", async () => {
+    // If "google" is an explicitly configured provider, its entries should not be filtered.
+    mockPiDiscoveryModels([
+      { id: "gemini-3-flash-preview", provider: "google", name: "Gemini 3 Flash" },
+    ]);
+
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            models: [{ id: "gemini-3-flash-preview", name: "Gemini 3 Flash" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await loadModelCatalog({ config: cfg });
+
+    expect(result).toContainEqual(
+      expect.objectContaining({ provider: "google", id: "gemini-3-flash-preview" }),
+    );
+  });
+
   it("matches models across canonical provider aliases", () => {
     expect(
       findModelInCatalog([{ provider: "z.ai", id: "glm-5", name: "GLM-5" }], "z-ai", "glm-5"),

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -130,19 +130,49 @@ export async function loadModelCatalog(params?: {
       logStage("registry-ready");
       const entries = Array.isArray(registry) ? registry : registry.getAll();
       logStage("registry-read", `entries=${entries.length}`);
+      // Build a set of explicitly configured provider keys so we can detect phantom
+      // entries inferred from aggregator model-ID prefixes (e.g. openrouter model
+      // "google/gemini-3-flash-preview" causing a phantom "google" provider).
+      const configuredProviders = new Set(
+        Object.keys(cfg.models?.providers ?? {}).map((k) => normalizeProviderId(k)),
+      );
+      // Collect a set of qualified aggregator model IDs (e.g. "openrouter::google/gemini-3-flash-preview")
+      // so we can identify phantom entries whose provider + id were split from these.
+      const aggregatorModelKeys = new Set<string>();
       for (const entry of entries) {
-        const id = String(entry?.id ?? "").trim();
+        try {
+          const id = (entry?.id ?? "").trim();
+          const provider = normalizeProviderId(entry?.provider ?? "");
+          if (id && provider && configuredProviders.has(provider) && id.includes("/")) {
+            aggregatorModelKeys.add(`${id.split("/")[0]}::${id.split("/").slice(1).join("/")}`);
+          }
+        } catch {
+          // Skip entries that throw on property access.
+        }
+      }
+
+      for (const entry of entries) {
+        const id = (entry?.id ?? "").trim();
         if (!id) {
           continue;
         }
-        const provider = String(entry?.provider ?? "").trim();
+        const provider = (entry?.provider ?? "").trim();
         if (!provider) {
           continue;
         }
         if (shouldSuppressBuiltInModel({ provider, id })) {
           continue;
         }
-        const name = String(entry?.name ?? id).trim() || id;
+        // Skip phantom entries: provider not explicitly configured and the entry
+        // matches an aggregator model whose ID was split on "/".
+        const normalizedProvider = normalizeProviderId(provider);
+        if (
+          !configuredProviders.has(normalizedProvider) &&
+          aggregatorModelKeys.has(`${normalizedProvider}::${id}`)
+        ) {
+          continue;
+        }
+        const name = (entry?.name ?? id).trim() || id;
         const contextWindow =
           typeof entry?.contextWindow === "number" && entry.contextWindow > 0
             ? entry.contextWindow


### PR DESCRIPTION
## Summary

- Fixes #62317: `/model status` shows a phantom `[google]` provider entry when an OpenRouter model has an ID like `google/gemini-3-flash-preview`
- The `pi-coding-agent` ModelRegistry splits model IDs on `/` and registers the prefix as a separate native provider, causing duplicate phantom entries
- After collecting registry entries, we now detect and filter entries whose provider was auto-inferred from an aggregator model's ID prefix (e.g., `google` from `openrouter`'s `google/gemini-3-flash-preview`) while keeping entries from explicitly configured providers
- Also fixes pre-existing lint warnings (`no-unnecessary-type-conversion`) in the touched loop

## Test plan

- [x] Added test: phantom provider entries from aggregator model ID prefixes are filtered out
- [x] Added test: entries from explicitly configured providers are preserved even with slashed model IDs
- [x] All 12 existing tests in `model-catalog.test.ts` continue to pass