### PR TITLE
fix(matrix): harden lazy local runtime loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/onboarding: add an invite auto-join setup step with explicit off warnings and strict stable-target validation so new Matrix accounts stop silently ignoring invited rooms and fresh DM-style invites unless operators opt in. (#62168) Thanks @gumadeiras.
 - Telegram/doctor: keep top-level access-control fallback in place during multi-account normalization while still promoting legacy default auth into `accounts.default`, so existing named bots keep inherited allowlists without dropping the legacy default bot. (#62263) Thanks @obviyus.
 - Agents/subagents: honor `sessions_spawn(lightContext: true)` for spawned subagent runs by preserving lightweight bootstrap context through the gateway and embedded runner instead of silently falling back to full workspace bootstrap injection. (#62264) Thanks @theSamPadilla.
+- Matrix/Docker: load bundled Matrix lazy local runtime modules through an alias-safe plugin-local loader so source-checkout and nested-package runtime paths stop failing on `Cannot find package 'openclaw'`. (#62170, #62260)
 
 ## 2026.4.5
 

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -1147,6 +1147,9 @@ authoring plugins:
   `telegram-command-config` is the narrow public seam for Telegram custom
   command normalization/validation and stays available even if the bundled
   Telegram contract surface is temporarily unavailable.
+  `lazy-runtime` also exposes `createLazyPluginLocalModule` for bundled
+  plugins that need alias-safe lazy loading of plugin-local runtime modules
+  under nested package roots.
   `text-runtime` is the shared text/markdown/logging seam, including
   assistant-visible-text stripping, markdown render/chunking helpers, redaction
   helpers, directive-tag helpers, and safe-text utilities.

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -191,7 +191,7 @@ Current bundled provider examples:
   | `plugin-sdk/runtime-env` | Narrow runtime env helpers | Logger/runtime env, timeout, retry, and backoff helpers |
   | `plugin-sdk/plugin-runtime` | Shared plugin runtime helpers | Plugin commands/hooks/http/interactive helpers |
   | `plugin-sdk/hook-runtime` | Hook pipeline helpers | Shared webhook/internal hook pipeline helpers |
-  | `plugin-sdk/lazy-runtime` | Lazy runtime helpers | `createLazyRuntimeModule`, `createLazyRuntimeMethod`, `createLazyRuntimeMethodBinder`, `createLazyRuntimeNamedExport`, `createLazyRuntimeSurface` |
+  | `plugin-sdk/lazy-runtime` | Lazy runtime helpers | `createLazyRuntimeModule`, `createLazyRuntimeMethod`, `createLazyRuntimeMethodBinder`, `createLazyRuntimeNamedExport`, `createLazyRuntimeSurface`, `createLazyPluginLocalModule` |
   | `plugin-sdk/process-runtime` | Process helpers | Shared exec helpers |
   | `plugin-sdk/cli-runtime` | CLI runtime helpers | Command formatting, waits, version helpers |
   | `plugin-sdk/gateway-runtime` | Gateway helpers | Gateway client and channel-status patch helpers |

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -173,7 +173,7 @@ explicitly promotes one as public.
     | `plugin-sdk/runtime-store` | `createPluginRuntimeStore` |
     | `plugin-sdk/plugin-runtime` | Shared plugin command/hook/http/interactive helpers |
     | `plugin-sdk/hook-runtime` | Shared webhook/internal hook pipeline helpers |
-    | `plugin-sdk/lazy-runtime` | Lazy runtime import/binding helpers such as `createLazyRuntimeModule`, `createLazyRuntimeMethod`, and `createLazyRuntimeSurface` |
+    | `plugin-sdk/lazy-runtime` | Lazy runtime import/binding helpers such as `createLazyRuntimeModule`, `createLazyRuntimeMethod`, `createLazyRuntimeSurface`, and `createLazyPluginLocalModule` for plugin-local runtime modules |
     | `plugin-sdk/process-runtime` | Process exec helpers |
     | `plugin-sdk/cli-runtime` | CLI formatting, wait, and version helpers |
     | `plugin-sdk/gateway-runtime` | Gateway client and channel-status patch helpers |

--- a/extensions/matrix/index.ts
+++ b/extensions/matrix/index.ts
@@ -1,6 +1,11 @@
 import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { registerMatrixCliMetadata } from "./cli-metadata.js";
+
+const loadMatrixPluginEntryHandlersRuntime = createLazyPluginLocalModule<
+  typeof import("./plugin-entry.handlers.runtime.js")
+>(import.meta.url, "./plugin-entry.handlers.runtime.js");
 
 export default defineBundledChannelEntry({
   id: "matrix",
@@ -21,7 +26,7 @@ export default defineBundledChannelEntry({
   },
   registerCliMetadata: registerMatrixCliMetadata,
   registerFull(api) {
-    void import("./plugin-entry.handlers.runtime.js")
+    void loadMatrixPluginEntryHandlersRuntime()
       .then(({ ensureMatrixCryptoRuntime }) =>
         ensureMatrixCryptoRuntime({ log: api.logger.info }).catch((err: unknown) => {
           const message = formatErrorMessage(err);
@@ -34,17 +39,17 @@ export default defineBundledChannelEntry({
       });
 
     api.registerGatewayMethod("matrix.verify.recoveryKey", async (ctx) => {
-      const { handleVerifyRecoveryKey } = await import("./plugin-entry.handlers.runtime.js");
+      const { handleVerifyRecoveryKey } = await loadMatrixPluginEntryHandlersRuntime();
       await handleVerifyRecoveryKey(ctx);
     });
 
     api.registerGatewayMethod("matrix.verify.bootstrap", async (ctx) => {
-      const { handleVerificationBootstrap } = await import("./plugin-entry.handlers.runtime.js");
+      const { handleVerificationBootstrap } = await loadMatrixPluginEntryHandlersRuntime();
       await handleVerificationBootstrap(ctx);
     });
 
     api.registerGatewayMethod("matrix.verify.status", async (ctx) => {
-      const { handleVerificationStatus } = await import("./plugin-entry.handlers.runtime.js");
+      const { handleVerificationStatus } = await loadMatrixPluginEntryHandlersRuntime();
       await handleVerificationStatus(ctx);
     });
   },

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { requiresExplicitMatrixDefaultAccount } from "./account-selection.js";
 import { resolveDefaultMatrixAccountId, resolveMatrixAccount } from "./matrix/accounts.js";
@@ -30,6 +31,9 @@ const MATRIX_PLUGIN_HANDLED_ACTIONS = new Set<ChannelMessageActionName>([
   "channel-info",
   "permissions",
 ]);
+const loadMatrixToolActionsRuntime = createLazyPluginLocalModule<
+  typeof import("./tool-actions.runtime.js")
+>(import.meta.url, "./tool-actions.runtime.js");
 
 function createMatrixExposedActions(params: {
   gate: ReturnType<typeof createActionGate>;
@@ -137,7 +141,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
     return extractToolSend(args, "sendMessage");
   },
   handleAction: async (ctx: ChannelMessageActionContext) => {
-    const { handleMatrixAction } = await import("./tool-actions.runtime.js");
+    const { handleMatrixAction } = await loadMatrixToolActionsRuntime();
     const { action, params, cfg, accountId, mediaLocalRoots } = ctx;
     const dispatch = async (actionParams: Record<string, unknown>) =>
       await handleMatrixAction(

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -20,7 +20,10 @@ import {
   createRuntimeDirectoryLiveAdapter,
 } from "openclaw/plugin-sdk/directory-runtime";
 import { buildTrafficStatusSummary } from "openclaw/plugin-sdk/extension-shared";
-import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
+import {
+  createLazyPluginLocalModule,
+  createLazyRuntimeNamedExport,
+} from "openclaw/plugin-sdk/lazy-runtime";
 import { createRuntimeOutboundDelegates } from "openclaw/plugin-sdk/outbound-runtime";
 import {
   buildProbeChannelStatusSummary,
@@ -73,9 +76,15 @@ import type { CoreConfig } from "./types.js";
 let matrixStartupLock: Promise<void> = Promise.resolve();
 
 const loadMatrixChannelRuntime = createLazyRuntimeNamedExport(
-  () => import("./channel.runtime.js"),
+  createLazyPluginLocalModule<typeof import("./channel.runtime.js")>(
+    import.meta.url,
+    "./channel.runtime.js",
+  ),
   "matrixChannelRuntime",
 );
+const loadMatrixMonitorRuntime = createLazyPluginLocalModule<
+  typeof import("./matrix/monitor/index.js")
+>(import.meta.url, "./matrix/monitor/index.js");
 
 const meta = {
   id: "matrix",
@@ -531,7 +540,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
           // Wrap in try/finally to ensure lock is released even if import fails.
           let monitorMatrixProvider: typeof import("./matrix/monitor/index.js").monitorMatrixProvider;
           try {
-            const module = await import("./matrix/monitor/index.js");
+            const module = await loadMatrixMonitorRuntime();
             monitorMatrixProvider = module.monitorMatrixProvider;
           } finally {
             // Release lock after import completes or fails

--- a/extensions/matrix/src/cli-metadata.ts
+++ b/extensions/matrix/src/cli-metadata.ts
@@ -1,9 +1,15 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
+
+const loadMatrixCliModule = createLazyPluginLocalModule<typeof import("./cli.js")>(
+  import.meta.url,
+  "./cli.js",
+);
 
 export function registerMatrixCliMetadata(api: OpenClawPluginApi) {
   api.registerCli(
     async ({ program }) => {
-      const { registerMatrixCli } = await import("./cli.js");
+      const { registerMatrixCli } = await loadMatrixCliModule();
       registerMatrixCli({ program });
     },
     {

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMatrixAccount, resolveMatrixAccountConfig } from "./matrix/accounts.js";
 import { withResolvedActionClient, withStartedActionClient } from "./matrix/actions/client.js";
 import { listMatrixOwnDevices, pruneMatrixStaleGatewayDevices } from "./matrix/actions/devices.js";
@@ -29,6 +30,9 @@ import { matrixSetupAdapter } from "./setup-core.js";
 import type { CoreConfig } from "./types.js";
 
 let matrixCliExitScheduled = false;
+const loadMatrixSetupBootstrapModule = createLazyPluginLocalModule<
+  typeof import("./setup-bootstrap.js")
+>(import.meta.url, "./setup-bootstrap.js");
 
 export function resetMatrixCliStateForTests(): void {
   matrixCliExitScheduled = false;
@@ -221,7 +225,7 @@ async function addMatrixAccount(params: {
     backupVersion: null,
   };
   if (accountConfig.encryption === true) {
-    const { maybeBootstrapNewEncryptedMatrixAccount } = await import("./setup-bootstrap.js");
+    const { maybeBootstrapNewEncryptedMatrixAccount } = await loadMatrixSetupBootstrapModule();
     verificationBootstrap = await maybeBootstrapNewEncryptedMatrixAccount({
       previousCfg: cfg,
       cfg: updated,

--- a/extensions/matrix/src/legacy-crypto.ts
+++ b/extensions/matrix/src/legacy-crypto.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { writeJsonFileAtomically as writeJsonFileAtomicallyImpl } from "openclaw/plugin-sdk/json-store";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { resolveConfiguredMatrixAccountIds } from "./account-selection.js";
 import { formatMatrixErrorMessage } from "./matrix/errors.js";
@@ -14,6 +15,9 @@ import { resolveMatrixLegacyFlatStoragePaths } from "./storage-paths.js";
 
 const MATRIX_LEGACY_CRYPTO_INSPECTOR_UNAVAILABLE_MESSAGE =
   "Legacy Matrix encrypted state was detected, but the Matrix crypto inspector is unavailable.";
+const loadMatrixLegacyCryptoInspectorModule = createLazyPluginLocalModule<
+  typeof import("./matrix/legacy-crypto-inspector.js")
+>(import.meta.url, "./matrix/legacy-crypto-inspector.js");
 
 type MatrixLegacyCryptoCounts = {
   total: number;
@@ -113,7 +117,7 @@ function isMatrixLegacyCryptoInspectorAvailable(): boolean {
 }
 
 async function loadMatrixLegacyCryptoInspector(): Promise<MatrixLegacyCryptoInspector> {
-  const module = await import("./matrix/legacy-crypto-inspector.js");
+  const module = await loadMatrixLegacyCryptoInspectorModule();
   return module.inspectLegacyMatrixCryptoStore as MatrixLegacyCryptoInspector;
 }
 

--- a/extensions/matrix/src/matrix/client-bootstrap.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.ts
@@ -1,3 +1,7 @@
+import {
+  createLazyPluginLocalModule,
+  createLazyRuntimeSurface,
+} from "openclaw/plugin-sdk/lazy-runtime";
 import { getMatrixRuntime } from "../runtime.js";
 import type { CoreConfig } from "../types.js";
 import { getActiveMatrixClient } from "./active-client.js";
@@ -25,16 +29,27 @@ type MatrixSharedClientRuntimeDeps = Pick<
   Pick<typeof import("./client/shared.js"), "releaseSharedClientInstance">;
 
 let matrixSharedClientRuntimeDepsPromise: Promise<MatrixSharedClientRuntimeDeps> | undefined;
-
-async function loadMatrixSharedClientRuntimeDeps(): Promise<MatrixSharedClientRuntimeDeps> {
-  matrixSharedClientRuntimeDepsPromise ??= Promise.all([
-    import("./client.js"),
-    import("./client/shared.js"),
-  ]).then(([clientModule, sharedModule]) => ({
+const loadMatrixClientModule = createLazyPluginLocalModule<typeof import("./client.js")>(
+  import.meta.url,
+  "./client.js",
+);
+const loadMatrixSharedClientModule = createLazyPluginLocalModule<
+  typeof import("./client/shared.js")
+>(import.meta.url, "./client/shared.js");
+const loadMatrixSharedClientRuntimeDepsSurface = createLazyRuntimeSurface(
+  async () => ({
+    clientModule: await loadMatrixClientModule(),
+    sharedModule: await loadMatrixSharedClientModule(),
+  }),
+  ({ clientModule, sharedModule }) => ({
     acquireSharedMatrixClient: clientModule.acquireSharedMatrixClient,
     resolveMatrixAuthContext: clientModule.resolveMatrixAuthContext,
     releaseSharedClientInstance: sharedModule.releaseSharedClientInstance,
-  }));
+  }),
+);
+
+async function loadMatrixSharedClientRuntimeDeps(): Promise<MatrixSharedClientRuntimeDeps> {
+  matrixSharedClientRuntimeDepsPromise ??= loadMatrixSharedClientRuntimeDepsSurface();
   return await matrixSharedClientRuntimeDepsPromise;
 }
 

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -1,4 +1,5 @@
 import { formatErrorMessage, type PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { coerceSecretRef } from "openclaw/plugin-sdk/provider-auth";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
@@ -48,6 +49,23 @@ let matrixAuthClientDepsPromise: Promise<MatrixAuthClientDeps> | undefined;
 let matrixCredentialsReadDepsPromise: Promise<MatrixCredentialsReadDeps> | undefined;
 let matrixSecretInputDepsPromise: Promise<MatrixSecretInputDeps> | undefined;
 let matrixAuthClientDepsForTest: MatrixAuthClientDeps | undefined;
+const loadMatrixCredentialsReadModule = createLazyPluginLocalModule<
+  typeof import("../credentials-read.js")
+>(import.meta.url, "../credentials-read.js");
+const loadMatrixCredentialsWriteModule = createLazyPluginLocalModule<
+  typeof import("../credentials-write.runtime.js")
+>(import.meta.url, "../credentials-write.runtime.js");
+const loadMatrixSecretInputModule = createLazyPluginLocalModule<
+  typeof import("./config-secret-input.runtime.js")
+>(import.meta.url, "./config-secret-input.runtime.js");
+const loadMatrixSdkModule = createLazyPluginLocalModule<typeof import("../sdk.js")>(
+  import.meta.url,
+  "../sdk.js",
+);
+const loadMatrixLoggingModule = createLazyPluginLocalModule<typeof import("./logging.js")>(
+  import.meta.url,
+  "./logging.js",
+);
 
 const MATRIX_AUTH_REQUEST_RETRY_RE =
   /\b(fetch failed|econnreset|econnrefused|enotfound|etimedout|ehostunreach|enetunreach|eai_again|und_err_|socket hang up|network|headers timeout|body timeout|connect timeout)\b/i;
@@ -63,17 +81,18 @@ async function loadMatrixAuthClientDeps(): Promise<MatrixAuthClientDeps> {
   if (matrixAuthClientDepsForTest) {
     return matrixAuthClientDepsForTest;
   }
-  matrixAuthClientDepsPromise ??= Promise.all([import("../sdk.js"), import("./logging.js")]).then(
-    ([sdkModule, loggingModule]) => ({
-      MatrixClient: sdkModule.MatrixClient,
-      ensureMatrixSdkLoggingConfigured: loggingModule.ensureMatrixSdkLoggingConfigured,
-    }),
-  );
+  matrixAuthClientDepsPromise ??= Promise.all([
+    loadMatrixSdkModule(),
+    loadMatrixLoggingModule(),
+  ]).then(([sdkModule, loggingModule]) => ({
+    MatrixClient: sdkModule.MatrixClient,
+    ensureMatrixSdkLoggingConfigured: loggingModule.ensureMatrixSdkLoggingConfigured,
+  }));
   return await matrixAuthClientDepsPromise;
 }
 
 async function loadMatrixCredentialsReadDeps(): Promise<MatrixCredentialsReadDeps> {
-  matrixCredentialsReadDepsPromise ??= import("../credentials-read.js").then(
+  matrixCredentialsReadDepsPromise ??= loadMatrixCredentialsReadModule().then(
     (credentialsReadModule) => ({
       loadMatrixCredentials: credentialsReadModule.loadMatrixCredentials,
       credentialsMatchConfig: credentialsReadModule.credentialsMatchConfig,
@@ -83,7 +102,7 @@ async function loadMatrixCredentialsReadDeps(): Promise<MatrixCredentialsReadDep
 }
 
 async function loadMatrixSecretInputDeps(): Promise<MatrixSecretInputDeps> {
-  matrixSecretInputDepsPromise ??= import("./config-secret-input.runtime.js").then((runtime) => ({
+  matrixSecretInputDepsPromise ??= loadMatrixSecretInputModule().then((runtime) => ({
     resolveConfiguredSecretInputString: runtime.resolveConfiguredSecretInputString,
   }));
   return await matrixSecretInputDepsPromise;
@@ -778,11 +797,6 @@ export async function resolveMatrixAuth(params?: {
   const homeserver = await resolveValidatedMatrixHomeserverUrl(resolved.homeserver, {
     dangerouslyAllowPrivateNetwork: resolved.allowPrivateNetwork,
   });
-  let credentialsWriter: typeof import("../credentials-write.runtime.js") | undefined;
-  const loadCredentialsWriter = async () => {
-    credentialsWriter ??= await import("../credentials-write.runtime.js");
-    return credentialsWriter;
-  };
 
   const { loadMatrixCredentials, credentialsMatchConfig } = await loadMatrixCredentialsReadDeps();
   const cached = loadMatrixCredentials(env, accountId);
@@ -828,7 +842,7 @@ export async function resolveMatrixAuth(params?: {
       cachedCredentials.userId !== userId ||
       (cachedCredentials.deviceId || undefined) !== knownDeviceId;
     if (shouldRefreshCachedCredentials) {
-      const { saveMatrixCredentials } = await loadCredentialsWriter();
+      const { saveMatrixCredentials } = await loadMatrixCredentialsWriteModule();
       await saveMatrixCredentials(
         {
           homeserver,
@@ -840,7 +854,7 @@ export async function resolveMatrixAuth(params?: {
         accountId,
       );
     } else if (hasMatchingCachedToken) {
-      const { touchMatrixCredentials } = await loadCredentialsWriter();
+      const { touchMatrixCredentials } = await loadMatrixCredentialsWriteModule();
       await touchMatrixCredentials(env, accountId);
     }
     return {
@@ -861,7 +875,7 @@ export async function resolveMatrixAuth(params?: {
   }
 
   if (cachedCredentials) {
-    const { touchMatrixCredentials } = await loadCredentialsWriter();
+    const { touchMatrixCredentials } = await loadMatrixCredentialsWriteModule();
     await touchMatrixCredentials(env, accountId);
     return {
       accountId,
@@ -943,7 +957,7 @@ export async function resolveMatrixAuth(params?: {
     }),
   };
 
-  const { saveMatrixCredentials } = await loadCredentialsWriter();
+  const { saveMatrixCredentials } = await loadMatrixCredentialsWriteModule();
   await saveMatrixCredentials(
     {
       homeserver: auth.homeserver,
@@ -1012,7 +1026,7 @@ export async function backfillMatrixAuthDeviceIdAfterStartup(params: {
     return undefined;
   }
 
-  const credentialsWriter = await import("../credentials-write.runtime.js");
+  const credentialsWriter = await loadMatrixCredentialsWriteModule();
   const saved = await credentialsWriter.saveBackfilledMatrixDeviceId(
     {
       homeserver: params.auth.homeserver,

--- a/extensions/matrix/src/matrix/client/create-client.ts
+++ b/extensions/matrix/src/matrix/client/create-client.ts
@@ -1,5 +1,9 @@
 import fs from "node:fs";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  createLazyPluginLocalModule,
+  createLazyRuntimeSurface,
+} from "openclaw/plugin-sdk/lazy-runtime";
 import type { SsrFPolicy } from "../../runtime-api.js";
 import type { MatrixClient } from "../sdk.js";
 import { resolveValidatedMatrixHomeserverUrl } from "./config.js";
@@ -15,15 +19,27 @@ type MatrixCreateClientRuntimeDeps = {
 };
 
 let matrixCreateClientRuntimeDepsPromise: Promise<MatrixCreateClientRuntimeDeps> | undefined;
-
-async function loadMatrixCreateClientRuntimeDeps(): Promise<MatrixCreateClientRuntimeDeps> {
-  matrixCreateClientRuntimeDepsPromise ??= Promise.all([
-    import("../sdk.js"),
-    import("./logging.js"),
-  ]).then(([sdkModule, loggingModule]) => ({
+const loadMatrixSdkModule = createLazyPluginLocalModule<typeof import("../sdk.js")>(
+  import.meta.url,
+  "../sdk.js",
+);
+const loadMatrixLoggingModule = createLazyPluginLocalModule<typeof import("./logging.js")>(
+  import.meta.url,
+  "./logging.js",
+);
+const loadMatrixCreateClientRuntimeDepsSurface = createLazyRuntimeSurface(
+  async () => ({
+    sdkModule: await loadMatrixSdkModule(),
+    loggingModule: await loadMatrixLoggingModule(),
+  }),
+  ({ sdkModule, loggingModule }) => ({
     MatrixClient: sdkModule.MatrixClient,
     ensureMatrixSdkLoggingConfigured: loggingModule.ensureMatrixSdkLoggingConfigured,
-  }));
+  }),
+);
+
+async function loadMatrixCreateClientRuntimeDeps(): Promise<MatrixCreateClientRuntimeDeps> {
+  matrixCreateClientRuntimeDepsPromise ??= loadMatrixCreateClientRuntimeDepsSurface();
   return await matrixCreateClientRuntimeDepsPromise;
 }
 

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-id";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { CoreConfig } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
 import { LogService } from "../sdk/logger.js";
@@ -10,9 +11,12 @@ type MatrixCreateClientDeps = {
 };
 
 let matrixCreateClientDepsPromise: Promise<MatrixCreateClientDeps> | undefined;
+const loadMatrixCreateClientModule = createLazyPluginLocalModule<
+  typeof import("./create-client.js")
+>(import.meta.url, "./create-client.js");
 
 async function loadMatrixCreateClientDeps(): Promise<MatrixCreateClientDeps> {
-  matrixCreateClientDepsPromise ??= import("./create-client.js").then((runtime) => ({
+  matrixCreateClientDepsPromise ??= loadMatrixCreateClientModule().then((runtime) => ({
     createMatrixClient: runtime.createMatrixClient,
   }));
   return await matrixCreateClientDepsPromise;

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   requiresExplicitMatrixDefaultAccount,
   resolveMatrixDefaultOrOnlyAccountId,
@@ -21,6 +22,9 @@ const LEGACY_CRYPTO_MIGRATION_FILENAME = "legacy-crypto-migration.json";
 const RECOVERY_KEY_FILENAME = "recovery-key.json";
 const IDB_SNAPSHOT_FILENAME = "crypto-idb-snapshot.json";
 const STARTUP_VERIFICATION_FILENAME = "startup-verification.json";
+const loadMatrixMigrationSnapshotRuntime = createLazyPluginLocalModule<
+  typeof import("./migration-snapshot.runtime.js")
+>(import.meta.url, "./migration-snapshot.runtime.js");
 
 type LegacyMoveRecord = {
   sourcePath: string;
@@ -366,7 +370,7 @@ export async function maybeMigrateLegacyStorage(params: {
   });
 
   const logger = getMatrixRuntime().logging.getChildLogger({ module: "matrix-storage" });
-  const { maybeCreateMatrixMigrationSnapshot } = await import("./migration-snapshot.runtime.js");
+  const { maybeCreateMatrixMigrationSnapshot } = await loadMatrixMigrationSnapshotRuntime();
   await maybeCreateMatrixMigrationSnapshot({
     trigger: "matrix-client-fallback",
     env: params.env,

--- a/extensions/matrix/src/matrix/credentials-write.runtime.ts
+++ b/extensions/matrix/src/matrix/credentials-write.runtime.ts
@@ -1,26 +1,32 @@
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type {
   saveBackfilledMatrixDeviceId as saveBackfilledMatrixDeviceIdType,
   saveMatrixCredentials as saveMatrixCredentialsType,
   touchMatrixCredentials as touchMatrixCredentialsType,
 } from "./credentials.js";
 
+const loadMatrixCredentialsModule = createLazyPluginLocalModule<typeof import("./credentials.js")>(
+  import.meta.url,
+  "./credentials.js",
+);
+
 export async function saveMatrixCredentials(
   ...args: Parameters<typeof saveMatrixCredentialsType>
 ): ReturnType<typeof saveMatrixCredentialsType> {
-  const runtime = await import("./credentials.js");
+  const runtime = await loadMatrixCredentialsModule();
   return runtime.saveMatrixCredentials(...args);
 }
 
 export async function saveBackfilledMatrixDeviceId(
   ...args: Parameters<typeof saveBackfilledMatrixDeviceIdType>
 ): ReturnType<typeof saveBackfilledMatrixDeviceIdType> {
-  const runtime = await import("./credentials.js");
+  const runtime = await loadMatrixCredentialsModule();
   return runtime.saveBackfilledMatrixDeviceId(...args);
 }
 
 export async function touchMatrixCredentials(
   ...args: Parameters<typeof touchMatrixCredentialsType>
 ): ReturnType<typeof touchMatrixCredentialsType> {
-  const runtime = await import("./credentials.js");
+  const runtime = await loadMatrixCredentialsModule();
   return runtime.touchMatrixCredentials(...args);
 }

--- a/extensions/matrix/src/matrix/monitor/startup.ts
+++ b/extensions/matrix/src/matrix/monitor/startup.ts
@@ -1,3 +1,4 @@
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { RuntimeLogger } from "../../runtime-api.js";
 import type { CoreConfig, MatrixConfig } from "../../types.js";
 import type { MatrixAuth } from "../client.js";
@@ -24,14 +25,30 @@ export type MatrixStartupMaintenanceDeps = {
 };
 
 let matrixStartupMaintenanceDepsPromise: Promise<MatrixStartupMaintenanceDeps> | undefined;
+const loadMatrixConfigUpdateModule = createLazyPluginLocalModule<
+  typeof import("../config-update.js")
+>(import.meta.url, "../config-update.js");
+const loadMatrixDeviceHealthModule = createLazyPluginLocalModule<
+  typeof import("../device-health.js")
+>(import.meta.url, "../device-health.js");
+const loadMatrixProfileModule = createLazyPluginLocalModule<typeof import("../profile.js")>(
+  import.meta.url,
+  "../profile.js",
+);
+const loadMatrixLegacyCryptoRestoreModule = createLazyPluginLocalModule<
+  typeof import("./legacy-crypto-restore.js")
+>(import.meta.url, "./legacy-crypto-restore.js");
+const loadMatrixStartupVerificationModule = createLazyPluginLocalModule<
+  typeof import("./startup-verification.js")
+>(import.meta.url, "./startup-verification.js");
 
 async function loadMatrixStartupMaintenanceDeps(): Promise<MatrixStartupMaintenanceDeps> {
   matrixStartupMaintenanceDepsPromise ??= Promise.all([
-    import("../config-update.js"),
-    import("../device-health.js"),
-    import("../profile.js"),
-    import("./legacy-crypto-restore.js"),
-    import("./startup-verification.js"),
+    loadMatrixConfigUpdateModule(),
+    loadMatrixDeviceHealthModule(),
+    loadMatrixProfileModule(),
+    loadMatrixLegacyCryptoRestoreModule(),
+    loadMatrixStartupVerificationModule(),
   ]).then(
     ([
       configUpdateModule,

--- a/extensions/matrix/src/matrix/monitor/verification-events.ts
+++ b/extensions/matrix/src/matrix/monitor/verification-events.ts
@@ -1,3 +1,4 @@
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { MatrixClient } from "../sdk.js";
 import { resolveMatrixMonitorAccessState } from "./access-state.js";
 import type { MatrixRawEvent } from "./types.js";
@@ -36,11 +37,18 @@ type MatrixDirectRoomDeps = {
 };
 
 let matrixDirectRoomDepsPromise: Promise<MatrixDirectRoomDeps> | undefined;
+const loadMatrixDirectManagementModule = createLazyPluginLocalModule<
+  typeof import("../direct-management.js")
+>(import.meta.url, "../direct-management.js");
+const loadMatrixDirectRoomModule = createLazyPluginLocalModule<typeof import("../direct-room.js")>(
+  import.meta.url,
+  "../direct-room.js",
+);
 
 async function loadMatrixDirectRoomDeps(): Promise<MatrixDirectRoomDeps> {
   matrixDirectRoomDepsPromise ??= Promise.all([
-    import("../direct-management.js"),
-    import("../direct-room.js"),
+    loadMatrixDirectManagementModule(),
+    loadMatrixDirectRoomModule(),
   ]).then(([directManagementModule, directRoomModule]) => ({
     inspectMatrixDirectRooms: directManagementModule.inspectMatrixDirectRooms,
     isStrictDirectRoom: directRoomModule.isStrictDirectRoom,

--- a/extensions/matrix/src/matrix/probe.ts
+++ b/extensions/matrix/src/matrix/probe.ts
@@ -1,4 +1,5 @@
 import { formatErrorMessage, type PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { SsrFPolicy } from "../runtime-api.js";
 import type { BaseProbeResult } from "../runtime-api.js";
 import { isBunRuntime } from "./client/runtime.js";
@@ -6,9 +7,12 @@ import { isBunRuntime } from "./client/runtime.js";
 type MatrixProbeRuntimeDeps = Pick<typeof import("./probe.runtime.js"), "createMatrixClient">;
 
 let matrixProbeRuntimeDepsPromise: Promise<MatrixProbeRuntimeDeps> | undefined;
+const loadMatrixProbeRuntimeModule = createLazyPluginLocalModule<
+  typeof import("./probe.runtime.js")
+>(import.meta.url, "./probe.runtime.js");
 
 async function loadMatrixProbeRuntimeDeps(): Promise<MatrixProbeRuntimeDeps> {
-  matrixProbeRuntimeDepsPromise ??= import("./probe.runtime.js").then((runtimeModule) => ({
+  matrixProbeRuntimeDepsPromise ??= loadMatrixProbeRuntimeModule().then((runtimeModule) => ({
     createMatrixClient: runtimeModule.createMatrixClient,
   }));
   return await matrixProbeRuntimeDepsPromise;

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -10,6 +10,7 @@ import {
 import { VerificationMethod } from "matrix-js-sdk/lib/types.js";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/core";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { normalizeNullableString } from "openclaw/plugin-sdk/text-runtime";
 import type { SsrFPolicy } from "../runtime-api.js";
 import { resolveMatrixRoomKeyBackupReadinessError } from "./backup-health.js";
@@ -169,9 +170,12 @@ type MatrixCryptoRuntime = typeof import("./sdk/crypto-runtime.js");
 
 let loadedMatrixCryptoRuntime: MatrixCryptoRuntime | null = null;
 let matrixCryptoRuntimePromise: Promise<MatrixCryptoRuntime> | null = null;
+const loadMatrixCryptoRuntimeModule = createLazyPluginLocalModule<
+  typeof import("./sdk/crypto-runtime.js")
+>(import.meta.url, "./sdk/crypto-runtime.js");
 
 async function loadMatrixCryptoRuntime(): Promise<MatrixCryptoRuntime> {
-  matrixCryptoRuntimePromise ??= import("./sdk/crypto-runtime.js").then((runtime) => {
+  matrixCryptoRuntimePromise ??= loadMatrixCryptoRuntimeModule().then((runtime) => {
     loadedMatrixCryptoRuntime = runtime;
     return runtime;
   });

--- a/extensions/matrix/src/matrix/sdk/crypto-facade.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-facade.ts
@@ -1,3 +1,4 @@
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { MatrixRecoveryKeyStore } from "./recovery-key-store.js";
 import type { EncryptedFile } from "./types.js";
 import type {
@@ -65,10 +66,13 @@ export type MatrixCryptoFacade = {
 
 type MatrixCryptoNodeRuntime = typeof import("./crypto-node.runtime.js");
 let matrixCryptoNodeRuntimePromise: Promise<MatrixCryptoNodeRuntime> | null = null;
+const loadMatrixCryptoNodeRuntimeModule = createLazyPluginLocalModule<
+  typeof import("./crypto-node.runtime.js")
+>(import.meta.url, "./crypto-node.runtime.js");
 
 async function loadMatrixCryptoNodeRuntime(): Promise<MatrixCryptoNodeRuntime> {
   // Keep the native crypto package out of the main CLI startup graph.
-  matrixCryptoNodeRuntimePromise ??= import("./crypto-node.runtime.js");
+  matrixCryptoNodeRuntimePromise ??= loadMatrixCryptoNodeRuntimeModule();
   return await matrixCryptoNodeRuntimePromise;
 }
 

--- a/extensions/matrix/src/matrix/send/client.ts
+++ b/extensions/matrix/src/matrix/send/client.ts
@@ -1,3 +1,4 @@
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig } from "../../types.js";
 import { resolveMatrixAccountConfig } from "../account-config.js";
@@ -11,9 +12,12 @@ type MatrixSendClientRuntime = Pick<
 >;
 
 let matrixSendClientRuntimePromise: Promise<MatrixSendClientRuntime> | null = null;
+const loadMatrixClientBootstrapModule = createLazyPluginLocalModule<
+  typeof import("../client-bootstrap.js")
+>(import.meta.url, "../client-bootstrap.js");
 
 async function loadMatrixSendClientRuntime(): Promise<MatrixSendClientRuntime> {
-  matrixSendClientRuntimePromise ??= import("../client-bootstrap.js");
+  matrixSendClientRuntimePromise ??= loadMatrixClientBootstrapModule();
   return await matrixSendClientRuntimePromise;
 }
 

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   type ChannelSetupDmPolicy,
   type ChannelSetupWizardAdapter,
@@ -39,6 +40,9 @@ import type { CoreConfig, MatrixConfig } from "./types.js";
 
 const channel = "matrix" as const;
 type MatrixInviteAutoJoinPolicy = NonNullable<MatrixConfig["autoJoin"]>;
+const loadMatrixSetupBootstrapModule = createLazyPluginLocalModule<
+  typeof import("./setup-bootstrap.js")
+>(import.meta.url, "./setup-bootstrap.js");
 
 const matrixInviteAutoJoinOptions: Array<{
   value: MatrixInviteAutoJoinPolicy;
@@ -732,7 +736,7 @@ export const matrixOnboardingAdapter: ChannelSetupWizardAdapter = {
     });
   },
   afterConfigWritten: async ({ previousCfg, cfg, accountId, runtime }) => {
-    const { runMatrixSetupBootstrapAfterConfigWrite } = await import("./setup-bootstrap.js");
+    const { runMatrixSetupBootstrapAfterConfigWrite } = await loadMatrixSetupBootstrapModule();
     await runMatrixSetupBootstrapAfterConfigWrite({
       previousCfg: previousCfg as CoreConfig,
       cfg: cfg as CoreConfig,

--- a/extensions/matrix/src/plugin-entry.runtime.ts
+++ b/extensions/matrix/src/plugin-entry.runtime.ts
@@ -1,5 +1,14 @@
 import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/core";
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { formatMatrixErrorMessage } from "./matrix/errors.js";
+
+const loadMatrixDepsModule = createLazyPluginLocalModule<typeof import("./matrix/deps.js")>(
+  import.meta.url,
+  "./matrix/deps.js",
+);
+const loadMatrixVerificationModule = createLazyPluginLocalModule<
+  typeof import("./matrix/actions/verification.js")
+>(import.meta.url, "./matrix/actions/verification.js");
 
 function sendError(respond: (ok: boolean, payload?: unknown) => void, err: unknown) {
   respond(false, { error: formatMatrixErrorMessage(err) });
@@ -8,7 +17,7 @@ function sendError(respond: (ok: boolean, payload?: unknown) => void, err: unkno
 export async function ensureMatrixCryptoRuntime(
   ...args: Parameters<typeof import("./matrix/deps.js").ensureMatrixCryptoRuntime>
 ): Promise<void> {
-  const { ensureMatrixCryptoRuntime: ensureRuntime } = await import("./matrix/deps.js");
+  const { ensureMatrixCryptoRuntime: ensureRuntime } = await loadMatrixDepsModule();
   await ensureRuntime(...args);
 }
 
@@ -17,7 +26,7 @@ export async function handleVerifyRecoveryKey({
   respond,
 }: GatewayRequestHandlerOptions): Promise<void> {
   try {
-    const { verifyMatrixRecoveryKey } = await import("./matrix/actions/verification.js");
+    const { verifyMatrixRecoveryKey } = await loadMatrixVerificationModule();
     const key = typeof params?.key === "string" ? params.key : "";
     if (!key.trim()) {
       respond(false, { error: "key required" });
@@ -37,7 +46,7 @@ export async function handleVerificationBootstrap({
   respond,
 }: GatewayRequestHandlerOptions): Promise<void> {
   try {
-    const { bootstrapMatrixVerification } = await import("./matrix/actions/verification.js");
+    const { bootstrapMatrixVerification } = await loadMatrixVerificationModule();
     const accountId =
       typeof params?.accountId === "string" ? params.accountId.trim() || undefined : undefined;
     const recoveryKey = typeof params?.recoveryKey === "string" ? params.recoveryKey : undefined;
@@ -58,7 +67,7 @@ export async function handleVerificationStatus({
   respond,
 }: GatewayRequestHandlerOptions): Promise<void> {
   try {
-    const { getMatrixVerificationStatus } = await import("./matrix/actions/verification.js");
+    const { getMatrixVerificationStatus } = await loadMatrixVerificationModule();
     const accountId =
       typeof params?.accountId === "string" ? params.accountId.trim() || undefined : undefined;
     const includeRecoveryKey = params?.includeRecoveryKey === true;

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -1,3 +1,4 @@
+import { createLazyPluginLocalModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
@@ -8,6 +9,9 @@ import { applyMatrixSetupAccountConfig, validateMatrixSetupInput } from "./setup
 import type { CoreConfig } from "./types.js";
 
 const channel = "matrix" as const;
+const loadMatrixSetupBootstrapModule = createLazyPluginLocalModule<
+  typeof import("./setup-bootstrap.js")
+>(import.meta.url, "./setup-bootstrap.js");
 
 function resolveMatrixSetupAccountId(params: { accountId?: string; name?: string }): string {
   return normalizeAccountId(params.accountId?.trim() || params.name?.trim() || DEFAULT_ACCOUNT_ID);
@@ -39,7 +43,7 @@ export const matrixSetupAdapter: ChannelSetupAdapter = {
       input,
     }),
   afterAccountConfigWritten: async ({ previousCfg, cfg, accountId, runtime }) => {
-    const { runMatrixSetupBootstrapAfterConfigWrite } = await import("./setup-bootstrap.js");
+    const { runMatrixSetupBootstrapAfterConfigWrite } = await loadMatrixSetupBootstrapModule();
     await runMatrixSetupBootstrapAfterConfigWrite({
       previousCfg: previousCfg as CoreConfig,
       cfg: cfg as CoreConfig,

--- a/src/channels/plugins/module-loader.test.ts
+++ b/src/channels/plugins/module-loader.test.ts
@@ -51,10 +51,21 @@ describe("channel plugin module loader helpers", () => {
       path.join(rootDir, "src", "checker"),
       path.join(rootDir, "src", "checker.ts"),
       path.join(rootDir, "src", "checker.js"),
+      path.join(rootDir, "src", "checker.mts"),
       path.join(rootDir, "src", "checker.mjs"),
+      path.join(rootDir, "src", "checker.cts"),
       path.join(rootDir, "src", "checker.cjs"),
     ]);
     expect(resolveExistingPluginModulePath(rootDir, "./src/checker")).toBe(expectedPath);
+  });
+
+  it("falls back from .js specifiers to colocated TypeScript sources", () => {
+    const rootDir = createTempDir();
+    const expectedPath = path.join(rootDir, "src", "runtime.ts");
+    fs.mkdirSync(path.dirname(expectedPath), { recursive: true });
+    fs.writeFileSync(expectedPath, "export const ok = true;\n", "utf8");
+
+    expect(resolveExistingPluginModulePath(rootDir, "./src/runtime.js")).toBe(expectedPath);
   });
 
   it("detects JavaScript module paths case-insensitively", () => {

--- a/src/channels/plugins/module-loader.ts
+++ b/src/channels/plugins/module-loader.ts
@@ -1,79 +1,21 @@
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
-import { createJiti } from "jiti";
-import { openBoundaryFileSync } from "../../infra/boundary-file-read.js";
-import {
-  buildPluginLoaderAliasMap,
-  buildPluginLoaderJitiOptions,
-  shouldPreferNativeJiti,
-} from "../../plugins/sdk-alias.js";
-
-const nodeRequire = createRequire(import.meta.url);
-
-function createModuleLoader() {
-  const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
-
-  return (modulePath: string) => {
-    const tryNative =
-      shouldPreferNativeJiti(modulePath) || modulePath.includes(`${path.sep}dist${path.sep}`);
-    const aliasMap = buildPluginLoaderAliasMap(modulePath, process.argv[1], import.meta.url);
-    const cacheKey = JSON.stringify({
-      tryNative,
-      aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),
-    });
-    const cached = jitiLoaders.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-    const loader = createJiti(import.meta.url, {
-      ...buildPluginLoaderJitiOptions(aliasMap),
-      tryNative,
-    });
-    jitiLoaders.set(cacheKey, loader);
-    return loader;
-  };
-}
-
-let loadModule = createModuleLoader();
-
-export function isJavaScriptModulePath(modulePath: string): boolean {
-  return [".js", ".mjs", ".cjs"].includes(path.extname(modulePath).toLowerCase());
-}
+import { loadPluginLocalModule } from "../../plugins/local-module-loader.js";
+export {
+  isJavaScriptModulePath,
+  resolveExistingPluginModulePath,
+  resolvePluginModuleCandidates,
+} from "../../plugins/local-module-loader.js";
 
 export function resolveCompiledBundledModulePath(modulePath: string): string {
+  const distRuntimeSegment = `${path.sep}dist-runtime${path.sep}`;
   const compiledDistModulePath = modulePath.replace(
-    `${path.sep}dist-runtime${path.sep}`,
+    distRuntimeSegment,
     `${path.sep}dist${path.sep}`,
   );
   return compiledDistModulePath !== modulePath && fs.existsSync(compiledDistModulePath)
     ? compiledDistModulePath
     : modulePath;
-}
-
-export function resolvePluginModuleCandidates(rootDir: string, specifier: string): string[] {
-  const normalizedSpecifier = specifier.replace(/\\/g, "/");
-  const resolvedPath = path.resolve(rootDir, normalizedSpecifier);
-  const ext = path.extname(resolvedPath);
-  if (ext) {
-    return [resolvedPath];
-  }
-  return [
-    resolvedPath,
-    `${resolvedPath}.ts`,
-    `${resolvedPath}.js`,
-    `${resolvedPath}.mjs`,
-    `${resolvedPath}.cjs`,
-  ];
-}
-
-export function resolveExistingPluginModulePath(rootDir: string, specifier: string): string {
-  for (const candidate of resolvePluginModuleCandidates(rootDir, specifier)) {
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  return path.resolve(rootDir, specifier);
 }
 
 export function loadChannelPluginModule(params: {
@@ -83,26 +25,5 @@ export function loadChannelPluginModule(params: {
   boundaryLabel?: string;
   shouldTryNativeRequire?: (safePath: string) => boolean;
 }): unknown {
-  const opened = openBoundaryFileSync({
-    absolutePath: params.modulePath,
-    rootPath: params.boundaryRootDir ?? params.rootDir,
-    boundaryLabel: params.boundaryLabel ?? "plugin root",
-    rejectHardlinks: false,
-    skipLexicalRootCheck: true,
-  });
-  if (!opened.ok) {
-    throw new Error(
-      `${params.boundaryLabel ?? "plugin"} module path escapes plugin root or fails alias checks`,
-    );
-  }
-  const safePath = opened.path;
-  fs.closeSync(opened.fd);
-  if (process.platform === "win32" && params.shouldTryNativeRequire?.(safePath)) {
-    try {
-      return nodeRequire(safePath);
-    } catch {
-      // Fall back to the Jiti loader path when require() cannot handle the entry.
-    }
-  }
-  return loadModule(safePath)(safePath);
+  return loadPluginLocalModule(params);
 }

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -20,7 +20,6 @@ import {
 import { resolveBundledPluginPublicSurfacePath } from "../plugins/public-surface-runtime.js";
 import { resolveLoaderPackageRoot } from "../plugins/sdk-alias.js";
 import {
-  loadBundledPluginPublicSurfaceModuleSync as loadBundledPluginPublicSurfaceModuleSyncLight,
   loadFacadeModuleAtLocationSync as loadFacadeModuleAtLocationSyncShared,
   resetFacadeLoaderStateForTest,
   type FacadeModuleLocation,
@@ -531,8 +530,14 @@ function resolveActivatedBundledPluginPublicSurfaceAccessOrThrow(
 export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(
   params: BundledPluginPublicSurfaceParams,
 ): T {
-  return loadBundledPluginPublicSurfaceModuleSyncLight<T>({
-    ...params,
+  const location = resolveFacadeModuleLocation(params);
+  if (!location) {
+    throw new Error(
+      `Unable to resolve bundled plugin public surface ${params.dirName}/${params.artifactBasename}`,
+    );
+  }
+  return loadFacadeModuleAtLocationSync({
+    location,
     trackedPluginId: () => resolveTrackedFacadePluginId(params),
   });
 }

--- a/src/plugin-sdk/lazy-runtime.test.ts
+++ b/src/plugin-sdk/lazy-runtime.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, expect, it } from "vitest";
+import { createLazyPluginLocalModule } from "./lazy-runtime.js";
+
+const tempDirs: string[] = [];
+
+function makeFixtureRoot(prefix: string): string {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(fixtureRoot);
+  return fixtureRoot;
+}
+
+function writeFixtureFile(fixtureRoot: string, relativePath: string, value: string): string {
+  const fullPath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, value, "utf8");
+  return fullPath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+it("loads nested-package local runtime modules through plugin-sdk aliases", async () => {
+  const fixtureRoot = makeFixtureRoot("openclaw-lazy-runtime-");
+  const entryPath = writeFixtureFile(
+    fixtureRoot,
+    "extensions/matrix/src/entry.js",
+    'export const fixture = "entry";\n',
+  );
+  writeFixtureFile(
+    fixtureRoot,
+    "extensions/matrix/package.json",
+    JSON.stringify({
+      name: "@openclaw/matrix",
+      version: "0.0.0",
+      type: "module",
+    }) + "\n",
+  );
+  writeFixtureFile(
+    fixtureRoot,
+    "extensions/matrix/src/helper.ts",
+    [
+      'import { normalizeNullableString } from "openclaw/plugin-sdk/text-runtime";',
+      'export const marker = normalizeNullableString("  matrix-ok  ");',
+      "",
+    ].join("\n"),
+  );
+
+  const loadHelper = createLazyPluginLocalModule<{ marker: string | null }>(
+    pathToFileURL(entryPath).href,
+    "./helper.js",
+  );
+  const previousVitestEnv = process.env.VITEST;
+  try {
+    delete process.env.VITEST;
+    const helperModule = await loadHelper();
+    expect(helperModule.marker).toBe("matrix-ok");
+  } finally {
+    if (previousVitestEnv === undefined) {
+      delete process.env.VITEST;
+    } else {
+      process.env.VITEST = previousVitestEnv;
+    }
+  }
+});

--- a/src/plugin-sdk/lazy-runtime.ts
+++ b/src/plugin-sdk/lazy-runtime.ts
@@ -1,3 +1,11 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findNearestPackageRoot,
+  loadPluginLocalModule,
+  resolveExistingPluginModulePath,
+} from "../plugins/local-module-loader.js";
+
 export {
   createLazyRuntimeModule,
   createLazyRuntimeMethod,
@@ -5,3 +13,36 @@ export {
   createLazyRuntimeNamedExport,
   createLazyRuntimeSurface,
 } from "../shared/lazy-runtime.js";
+
+export function createLazyPluginLocalModule<TModule>(
+  importMetaUrl: string,
+  specifier: string,
+): () => Promise<TModule> {
+  let cached: Promise<TModule> | null = null;
+
+  return () => {
+    cached ??= Promise.resolve().then(() => {
+      if (process.env.VITEST) {
+        return import(new URL(specifier, importMetaUrl).href) as Promise<TModule>;
+      }
+      const importerPath = fileURLToPath(importMetaUrl);
+      const importerDir = path.dirname(importerPath);
+      const pluginRoot =
+        findNearestPackageRoot(importerDir) ??
+        (() => {
+          throw new Error(
+            `Could not resolve plugin package root for ${importerPath} while loading ${specifier}`,
+          );
+        })();
+
+      return loadPluginLocalModule({
+        modulePath: resolveExistingPluginModulePath(importerDir, specifier),
+        rootDir: importerDir,
+        boundaryRootDir: pluginRoot,
+        boundaryLabel: "plugin package root",
+        executionMode: "transpiled",
+      }) as TModule;
+    });
+    return cached;
+  };
+}

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -744,7 +744,11 @@ describe("plugin-sdk subpath exports", () => {
       "mergeAllowFromEntries",
     ]);
     expectSourceMentions("setup-tools", ["formatCliCommand", "detectBinary", "formatDocsLink"]);
-    expectSourceMentions("lazy-runtime", ["createLazyRuntimeSurface", "createLazyRuntimeModule"]);
+    expectSourceMentions("lazy-runtime", [
+      "createLazyPluginLocalModule",
+      "createLazyRuntimeSurface",
+      "createLazyRuntimeModule",
+    ]);
     expectSourceContract("self-hosted-provider-setup", {
       mentions: [
         "applyProviderDefaultModel",

--- a/src/plugins/local-module-loader.ts
+++ b/src/plugins/local-module-loader.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { createJiti } from "jiti";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import {
+  buildPluginLoaderAliasMap,
+  buildPluginLoaderJitiOptions,
+  shouldPreferNativeJiti,
+} from "./sdk-alias.js";
+
+const nodeRequire = createRequire(import.meta.url);
+const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
+
+type LocalModuleExecutionMode = "auto" | "transpiled";
+
+function createModuleLoader() {
+  return (modulePath: string, executionMode: LocalModuleExecutionMode) => {
+    const tryNative =
+      executionMode === "transpiled"
+        ? false
+        : shouldPreferNativeJiti(modulePath) || modulePath.includes(`${path.sep}dist${path.sep}`);
+    const aliasMap = buildPluginLoaderAliasMap(modulePath, process.argv[1], import.meta.url);
+    const cacheKey = JSON.stringify({
+      tryNative,
+      aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),
+    });
+    const cached = jitiLoaders.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const loader = createJiti(import.meta.url, {
+      ...buildPluginLoaderJitiOptions(aliasMap),
+      tryNative,
+    });
+    jitiLoaders.set(cacheKey, loader);
+    return loader;
+  };
+}
+
+const loadModule = createModuleLoader();
+
+function resolveJsSpecifierCandidates(resolvedPath: string): string[] {
+  return [
+    resolvedPath,
+    `${resolvedPath.slice(0, -3)}.ts`,
+    `${resolvedPath.slice(0, -3)}.mts`,
+    `${resolvedPath.slice(0, -3)}.cts`,
+  ];
+}
+
+function resolveMjsSpecifierCandidates(resolvedPath: string): string[] {
+  return [resolvedPath, `${resolvedPath.slice(0, -4)}.mts`];
+}
+
+function resolveCjsSpecifierCandidates(resolvedPath: string): string[] {
+  return [resolvedPath, `${resolvedPath.slice(0, -4)}.cts`];
+}
+
+export function findNearestPackageRoot(startDir: string, maxDepth = 12): string | null {
+  let cursor = path.resolve(startDir);
+  for (let i = 0; i < maxDepth; i += 1) {
+    if (fs.existsSync(path.join(cursor, "package.json"))) {
+      return cursor;
+    }
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+  return null;
+}
+
+export function isJavaScriptModulePath(modulePath: string): boolean {
+  return [".js", ".mjs", ".cjs"].includes(path.extname(modulePath).toLowerCase());
+}
+
+export function resolvePluginModuleCandidates(rootDir: string, specifier: string): string[] {
+  const normalizedSpecifier = specifier.replace(/\\/g, "/");
+  const resolvedPath = path.resolve(rootDir, normalizedSpecifier);
+  const ext = path.extname(resolvedPath).toLowerCase();
+  if (!ext) {
+    return [
+      resolvedPath,
+      `${resolvedPath}.ts`,
+      `${resolvedPath}.js`,
+      `${resolvedPath}.mts`,
+      `${resolvedPath}.mjs`,
+      `${resolvedPath}.cts`,
+      `${resolvedPath}.cjs`,
+    ];
+  }
+  if (ext === ".js") {
+    return resolveJsSpecifierCandidates(resolvedPath);
+  }
+  if (ext === ".mjs") {
+    return resolveMjsSpecifierCandidates(resolvedPath);
+  }
+  if (ext === ".cjs") {
+    return resolveCjsSpecifierCandidates(resolvedPath);
+  }
+  return [resolvedPath];
+}
+
+export function resolveExistingPluginModulePath(rootDir: string, specifier: string): string {
+  for (const candidate of resolvePluginModuleCandidates(rootDir, specifier)) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return path.resolve(rootDir, specifier);
+}
+
+export function loadPluginLocalModule(params: {
+  modulePath: string;
+  rootDir: string;
+  boundaryRootDir?: string;
+  boundaryLabel?: string;
+  executionMode?: LocalModuleExecutionMode;
+  shouldTryNativeRequire?: (safePath: string) => boolean;
+}): unknown {
+  const opened = openBoundaryFileSync({
+    absolutePath: params.modulePath,
+    rootPath: params.boundaryRootDir ?? params.rootDir,
+    boundaryLabel: params.boundaryLabel ?? "plugin root",
+    rejectHardlinks: false,
+    skipLexicalRootCheck: true,
+  });
+  if (!opened.ok) {
+    throw new Error(
+      `${params.boundaryLabel ?? "plugin"} module path escapes plugin root or fails alias checks`,
+    );
+  }
+  const safePath = opened.path;
+  fs.closeSync(opened.fd);
+  const executionMode = params.executionMode ?? "auto";
+  if (
+    executionMode !== "transpiled" &&
+    process.platform === "win32" &&
+    params.shouldTryNativeRequire?.(safePath)
+  ) {
+    try {
+      return nodeRequire(safePath);
+    } catch {
+      // Fall back to the Jiti loader path when require() cannot handle the entry.
+    }
+  }
+  return loadModule(safePath, executionMode)(safePath);
+}


### PR DESCRIPTION
## Summary

- add a shared alias-safe plugin-local lazy loader for bundled plugin runtime modules
- move Matrix lazy local runtime imports onto that shared seam across auth, bootstrap, send, monitor, and runtime entry paths
- add nested-package regression coverage plus plugin-sdk/docs updates for the new lazy-runtime helper

## Why

This branch hardens the source-tree / nested-package runtime seam that showed up in the Matrix Docker reports (#62170, #62260).

The root issue is not Matrix auth logic itself; it is raw lazy `import("./...")` hops inside a bundled plugin package whose lazily loaded modules import `openclaw/plugin-sdk/*`. In nested package roots, that can fall off the alias-aware loader seam and fail with `Cannot find package 'openclaw'`.

PR #62316 should address the official Docker runtime path by restoring packaged `dist/extensions` resolution. This draft keeps the broader source-runtime seam fix separate so we can decide whether we want the extra hardening or just the Docker fix.

## Scope boundary

- no repo-wide plugin migration
- no Dockerfile changes here
- Matrix only, plus the shared helper needed to avoid repeating Matrix-specific runtime shims

## Testing

- `pnpm build`
- `OPENCLAW_LOCAL_CHECK=0 pnpm test extensions/matrix/src/plugin-entry.runtime.test.ts extensions/matrix/src/matrix/client.test.ts extensions/matrix/src/matrix/client-bootstrap.test.ts extensions/matrix/src/matrix/send/client.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm test src/plugin-sdk/lazy-runtime.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm test src/plugins/contracts/runtime-seams.contract.test.ts -t "allows activated runtime facades when the resolved plugin root matches an installed-style manifest record"`

## Notes

- `src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts` still reports pre-existing extension import leaks in Discord/Slack/Telegram doctor-contract files; not introduced by this branch.
