### PR TITLE
fix(google): add REST fallback for Veo SDK 404 compatibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Browser/plugin SDK: route browser auth, profile, host-inspection, and doctor readiness helpers through browser plugin public facades so core compatibility helpers stop carrying duplicate runtime implementations. (#63957) Thanks @joshavant.
 - Browser/act: centralize `/act` request normalization and execution dispatch while adding stable machine-readable route-level error codes for invalid requests, selector misuse, evaluate-disabled gating, target mismatch, and existing-session unsupported actions. (#63977) Thanks @joshavant.
 - Windows/exec: settle supervisor waits from child exit state after stdout and stderr drain even when `close` never arrives, so CLI commands stop hanging or dying with forced `SIGKILL` on Windows. (#64072) Thanks @obviyus.
+- Providers/Google video: fall back to the REST Veo path for affected text-only SDK 404 and empty-result failures, while keeping reference-input generation on the SDK path and normalizing REST video downloads. (#61878) Thanks @leoleedev.
 
 ## 2026.4.9
 

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -1,23 +1,25 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { GoogleGenAIMock, generateVideosMock, getVideosOperationMock } = vi.hoisted(() => {
-  const generateVideosMock = vi.fn();
-  const getVideosOperationMock = vi.fn();
-  const GoogleGenAIMock = vi.fn(function GoogleGenAI() {
-    return {
-      models: {
-        generateVideos: generateVideosMock,
-      },
-      operations: {
-        getVideosOperation: getVideosOperationMock,
-      },
-      files: {
-        download: vi.fn(),
-      },
-    };
+const { GoogleGenAIMock, downloadFileMock, generateVideosMock, getVideosOperationMock } =
+  vi.hoisted(() => {
+    const generateVideosMock = vi.fn();
+    const getVideosOperationMock = vi.fn();
+    const downloadFileMock = vi.fn();
+    const GoogleGenAIMock = vi.fn(function GoogleGenAI() {
+      return {
+        models: {
+          generateVideos: generateVideosMock,
+        },
+        operations: {
+          getVideosOperation: getVideosOperationMock,
+        },
+        files: {
+          download: downloadFileMock,
+        },
+      };
+    });
+    return { GoogleGenAIMock, downloadFileMock, generateVideosMock, getVideosOperationMock };
   });
-  return { GoogleGenAIMock, generateVideosMock, getVideosOperationMock };
-});
 
 vi.mock("@google/genai", () => ({
   GoogleGenAI: GoogleGenAIMock,
@@ -29,6 +31,8 @@ import { buildGoogleVideoGenerationProvider } from "./video-generation-provider.
 describe("google video generation provider", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    downloadFileMock.mockReset();
     generateVideosMock.mockReset();
     getVideosOperationMock.mockReset();
     GoogleGenAIMock.mockClear();
@@ -153,5 +157,127 @@ describe("google video generation provider", () => {
         }),
       }),
     );
+  });
+
+  it("falls back to REST when the SDK returns a 404 for text-only prompts", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockRejectedValue(new Error(JSON.stringify({ error: { code: 404 } })));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            done: true,
+            name: "operations/rest-123",
+            response: {
+              generateVideoResponse: {
+                generatedSamples: [
+                  {
+                    video: {
+                      uri: "https://video.example/rest-123.mp4",
+                      mimeType: "video/mp4",
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => Uint8Array.from(Buffer.from("rest-video")).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = buildGoogleVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "google",
+      model: "veo-3.1-lite-generate-preview",
+      prompt: "A tiny robot watering a windowsill garden",
+      cfg: {},
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "/models/veo-3.1-lite-generate-preview:predictLongRunning",
+    );
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe("https://video.example/rest-123.mp4");
+    expect(downloadFileMock).not.toHaveBeenCalled();
+    expect(result.videos).toHaveLength(1);
+    expect(result.videos[0]?.buffer.equals(Buffer.from("rest-video"))).toBe(true);
+  });
+
+  it("falls back to REST when the SDK returns an empty result", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [],
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          done: true,
+          name: "operations/rest-456",
+          response: {
+            generatedVideos: [
+              {
+                video: {
+                  videoBytes: Buffer.from("rest-inline-video").toString("base64"),
+                  mimeType: "video/mp4",
+                },
+              },
+            ],
+          },
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = buildGoogleVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "google",
+      model: "veo-3.1-lite-generate-preview",
+      prompt: "A tiny robot watering a windowsill garden",
+      cfg: {},
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.videos).toHaveLength(1);
+    expect(result.videos[0]?.buffer.equals(Buffer.from("rest-inline-video"))).toBe(true);
+  });
+
+  it("does not fall back to REST when reference inputs are present", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockRejectedValue(new Error(JSON.stringify({ error: { code: 404 } })));
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "Animate this sketch",
+        cfg: {},
+        inputImages: [{ buffer: Buffer.from("img"), mimeType: "image/png" }],
+      }),
+    ).rejects.toThrow('{"error":{"code":404}}');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -161,11 +161,13 @@ describe("google video generation provider", () => {
 
   it("falls back to REST when the SDK returns a 404 for text-only prompts", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "google-key",
+      apiKey: JSON.stringify({ token: "oauth-token", projectId: "demo-project" }),
       source: "env",
       mode: "api-key",
     });
-    generateVideosMock.mockRejectedValue(new Error(JSON.stringify({ error: { code: 404 } })));
+    generateVideosMock.mockRejectedValue(
+      Object.assign(new Error("sdk 404"), { status: 404 satisfies number }),
+    );
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -197,7 +199,7 @@ describe("google video generation provider", () => {
     const provider = buildGoogleVideoGenerationProvider();
     const result = await provider.generateVideo({
       provider: "google",
-      model: "veo-3.1-lite-generate-preview",
+      model: "google/models/veo-3.1-lite-generate-preview",
       prompt: "A tiny robot watering a windowsill garden",
       cfg: {},
     });
@@ -206,13 +208,21 @@ describe("google video generation provider", () => {
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
       "/models/veo-3.1-lite-generate-preview:predictLongRunning",
     );
+    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain("%2F");
     expect(String(fetchMock.mock.calls[1]?.[0])).toBe("https://video.example/rest-123.mp4");
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer oauth-token",
+    );
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("x-goog-api-key")).toBeNull();
+    expect(new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer oauth-token",
+    );
     expect(downloadFileMock).not.toHaveBeenCalled();
     expect(result.videos).toHaveLength(1);
     expect(result.videos[0]?.buffer.equals(Buffer.from("rest-video"))).toBe(true);
   });
 
-  it("falls back to REST when the SDK returns an empty result", async () => {
+  it("falls back to REST when the SDK returns an empty result and decodes raw REST inline video", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",
       source: "env",
@@ -231,14 +241,16 @@ describe("google video generation provider", () => {
           done: true,
           name: "operations/rest-456",
           response: {
-            generatedVideos: [
-              {
-                video: {
-                  videoBytes: Buffer.from("rest-inline-video").toString("base64"),
-                  mimeType: "video/mp4",
+            generateVideoResponse: {
+              generatedSamples: [
+                {
+                  video: {
+                    encodedVideo: Buffer.from("rest-inline-video").toString("base64"),
+                    encoding: "video/mp4",
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
         }),
     });
@@ -254,6 +266,7 @@ describe("google video generation provider", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.videos).toHaveLength(1);
+    expect(result.videos[0]?.mimeType).toBe("video/mp4");
     expect(result.videos[0]?.buffer.equals(Buffer.from("rest-inline-video"))).toBe(true);
   });
 

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -20,10 +20,15 @@ const GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS = [4, 6, 8] as const;
 const GOOGLE_VIDEO_MIN_DURATION_SECONDS = GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS[0];
 const GOOGLE_VIDEO_MAX_DURATION_SECONDS =
   GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS[GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS.length - 1];
+const DEFAULT_GOOGLE_VIDEO_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
   return configured ? normalizeGoogleApiBaseUrl(configured) : undefined;
+}
+
+function resolveGoogleVideoBaseUrl(req: VideoGenerationRequest): string {
+  return resolveConfiguredGoogleVideoBaseUrl(req) ?? DEFAULT_GOOGLE_VIDEO_BASE_URL;
 }
 
 function parseVideoSize(size: string | undefined): { width: number; height: number } | undefined {
@@ -116,6 +121,199 @@ function resolveInputVideo(req: VideoGenerationRequest) {
   return {
     videoBytes: input.buffer.toString("base64"),
     mimeType: normalizeOptionalString(input.mimeType) || "video/mp4",
+  };
+}
+
+async function requestGoogleVideoJson(params: {
+  url: string;
+  method: "GET" | "POST";
+  apiKey: string;
+  body?: string;
+  timeoutMs?: number;
+}): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), params.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const response = await fetch(params.url, {
+      method: params.method,
+      headers: {
+        "x-goog-api-key": params.apiKey,
+        ...(params.body ? { "content-type": "application/json" } : {}),
+      },
+      ...(params.body ? { body: params.body } : {}),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let payload: unknown;
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      payload = { raw: text };
+    }
+    if (!response.ok) {
+      throw new Error(
+        typeof payload === "object" ? JSON.stringify(payload) : String(payload),
+      );
+    }
+    return payload;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function extractGeneratedVideos(
+  operation: unknown,
+): Array<{ video: unknown }> {
+  const op = operation as Record<string, unknown>;
+  const response = op.response as Record<string, unknown> | undefined;
+  const generatedVideos = response?.generatedVideos;
+  if (Array.isArray(generatedVideos) && generatedVideos.length > 0) {
+    return generatedVideos as Array<{ video: unknown }>;
+  }
+  const generateVideoResponse = response?.generateVideoResponse as
+    | Record<string, unknown>
+    | undefined;
+  const generatedSamples = generateVideoResponse?.generatedSamples;
+  if (!Array.isArray(generatedSamples) || generatedSamples.length === 0) {
+    return [];
+  }
+  return (generatedSamples as Array<Record<string, unknown>>).map((sample) => ({
+    video: sample.video,
+  }));
+}
+
+async function downloadGoogleVideoUri(params: {
+  uri: string;
+  apiKey: string;
+  timeoutMs?: number;
+}): Promise<Buffer> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), params.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const response = await fetch(params.uri, {
+      method: "GET",
+      headers: { "x-goog-api-key": params.apiKey },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `Google video download failed (${response.status})`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function shouldFallbackToGoogleRest(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('"code":404') ||
+    message.includes('"code": 404') ||
+    message.includes("Google video generation response missing generated videos")
+  );
+}
+
+async function generateGoogleVideoViaRest(params: {
+  baseUrl: string;
+  apiKey: string;
+  timeoutMs?: number;
+  model: string;
+  prompt: string;
+  durationSeconds?: number;
+  aspectRatio?: string;
+  resolution?: string;
+}): Promise<unknown> {
+  const submitBody = {
+    instances: [{ prompt: params.prompt }],
+    parameters: {
+      ...(typeof params.durationSeconds === "number"
+        ? { durationSeconds: params.durationSeconds }
+        : {}),
+      ...(params.aspectRatio ? { aspectRatio: params.aspectRatio } : {}),
+      ...(params.resolution ? { resolution: params.resolution } : {}),
+    },
+  };
+
+  let operation = await requestGoogleVideoJson({
+    url: `${params.baseUrl}/models/${encodeURIComponent(params.model)}:predictLongRunning`,
+    method: "POST",
+    apiKey: params.apiKey,
+    body: JSON.stringify(submitBody),
+    timeoutMs: params.timeoutMs,
+  });
+
+  for (let attempt = 0; !((operation as Record<string, unknown>).done ?? false); attempt += 1) {
+    if (attempt >= MAX_POLL_ATTEMPTS) {
+      throw new Error("Google video generation did not finish in time");
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    operation = await requestGoogleVideoJson({
+      url: `${params.baseUrl}/${(operation as Record<string, unknown>).name}`,
+      method: "GET",
+      apiKey: params.apiKey,
+      timeoutMs: params.timeoutMs,
+    });
+  }
+
+  const op = operation as Record<string, unknown>;
+  if (op.error) {
+    throw new Error(JSON.stringify(op.error));
+  }
+  return operation;
+}
+
+async function toGoogleVideoResult(params: {
+  operation: unknown;
+  apiKey: string;
+  timeoutMs?: number;
+  model: string;
+  client?: GoogleGenAI;
+}): Promise<{ videos: GeneratedVideoAsset[]; model: string; metadata?: { operationName: string } }> {
+  const generatedVideos = extractGeneratedVideos(params.operation);
+  if (generatedVideos.length === 0) {
+    throw new Error("Google video generation response missing generated videos");
+  }
+  const op = params.operation as Record<string, unknown>;
+  return {
+    videos: await Promise.all(
+      generatedVideos.map(async (entry, index) => {
+        const inline = entry.video as
+          | { videoBytes?: string; uri?: string; mimeType?: string }
+          | undefined;
+        if (inline?.videoBytes) {
+          return {
+            buffer: Buffer.from(inline.videoBytes, "base64"),
+            mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
+            fileName: `video-${index + 1}.mp4`,
+          };
+        }
+        if (typeof inline?.uri === "string" && inline.uri.length > 0) {
+          return {
+            buffer: await downloadGoogleVideoUri({
+              uri: inline.uri,
+              apiKey: params.apiKey,
+              timeoutMs: params.timeoutMs,
+            }),
+            mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
+            fileName: `video-${index + 1}.mp4`,
+          };
+        }
+        if (!inline) {
+          throw new Error("Google generated video missing file handle");
+        }
+        if (!params.client) {
+          throw new Error("Google generated video missing downloadable uri");
+        }
+        return await downloadGeneratedVideo({
+          client: params.client,
+          file: inline,
+          index,
+        });
+      }),
+    ),
+    model: params.model,
+    metadata: typeof op.name === "string" ? { operationName: op.name } : undefined,
   };
 }
 
@@ -224,7 +422,11 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
       }
 
       const configuredBaseUrl = resolveConfiguredGoogleVideoBaseUrl(req);
+      const baseUrl = resolveGoogleVideoBaseUrl(req);
       const durationSeconds = resolveDurationSeconds(req.durationSeconds);
+      const model = normalizeOptionalString(req.model) || DEFAULT_GOOGLE_VIDEO_MODEL;
+      const aspectRatio = resolveAspectRatio({ aspectRatio: req.aspectRatio, size: req.size });
+      const resolution = resolveResolution({ resolution: req.resolution, size: req.size });
       const client = new GoogleGenAI({
         apiKey: auth.apiKey,
         httpOptions: {
@@ -232,24 +434,83 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
           timeout: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         },
       });
+
+      const hasReferenceInputs =
+        (req.inputImages?.length ?? 0) > 0 || (req.inputVideos?.length ?? 0) > 0;
+
+      // For text-only prompts, try the SDK path first. If it returns a 404 or
+      // reports no generated videos (a known @google/genai 1.x compatibility
+      // issue with Veo 3.x), fall back to the REST predictLongRunning API which
+      // has been verified to work on the same key and model.
+      if (!hasReferenceInputs) {
+        try {
+          let operation = await client.models.generateVideos({
+            model,
+            prompt: req.prompt,
+            config: {
+              numberOfVideos: 1,
+              ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
+              ...(aspectRatio ? { aspectRatio } : {}),
+              ...(resolution ? { resolution } : {}),
+              ...(req.audio === true ? { generateAudio: true } : {}),
+            },
+          });
+          for (let attempt = 0; !(operation.done ?? false); attempt += 1) {
+            if (attempt >= MAX_POLL_ATTEMPTS) {
+              throw new Error("Google video generation did not finish in time");
+            }
+            await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+            operation = await client.operations.getVideosOperation({ operation });
+          }
+          if (operation.error) {
+            throw new Error(JSON.stringify(operation.error));
+          }
+          return await toGoogleVideoResult({
+            operation,
+            apiKey: auth.apiKey,
+            timeoutMs: req.timeoutMs,
+            model,
+            client,
+          });
+        } catch (error) {
+          if (!shouldFallbackToGoogleRest(error)) {
+            throw error;
+          }
+          const operation = await generateGoogleVideoViaRest({
+            baseUrl,
+            apiKey: auth.apiKey,
+            timeoutMs: req.timeoutMs,
+            model,
+            prompt: req.prompt,
+            durationSeconds,
+            aspectRatio,
+            resolution,
+          });
+          return await toGoogleVideoResult({
+            operation,
+            apiKey: auth.apiKey,
+            timeoutMs: req.timeoutMs,
+            model,
+          });
+        }
+      }
+
+      // For prompts with reference image or video inputs, use the SDK path which
+      // supports multimodal inputs. No REST fallback here since the REST API does
+      // not expose equivalent image/video conditioning parameters.
       let operation = await client.models.generateVideos({
-        model: normalizeOptionalString(req.model) || DEFAULT_GOOGLE_VIDEO_MODEL,
+        model,
         prompt: req.prompt,
         image: resolveInputImage(req),
         video: resolveInputVideo(req),
         config: {
           numberOfVideos: 1,
           ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
-          ...(resolveAspectRatio({ aspectRatio: req.aspectRatio, size: req.size })
-            ? { aspectRatio: resolveAspectRatio({ aspectRatio: req.aspectRatio, size: req.size }) }
-            : {}),
-          ...(resolveResolution({ resolution: req.resolution, size: req.size })
-            ? { resolution: resolveResolution({ resolution: req.resolution, size: req.size }) }
-            : {}),
+          ...(aspectRatio ? { aspectRatio } : {}),
+          ...(resolution ? { resolution } : {}),
           ...(req.audio === true ? { generateAudio: true } : {}),
         },
       });
-
       for (let attempt = 0; !(operation.done ?? false); attempt += 1) {
         if (attempt >= MAX_POLL_ATTEMPTS) {
           throw new Error("Google video generation did not finish in time");
@@ -260,39 +521,13 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
       if (operation.error) {
         throw new Error(JSON.stringify(operation.error));
       }
-      const generatedVideos = operation.response?.generatedVideos ?? [];
-      if (generatedVideos.length === 0) {
-        throw new Error("Google video generation response missing generated videos");
-      }
-      const videos = await Promise.all(
-        generatedVideos.map(async (entry, index) => {
-          const inline = entry.video;
-          if (inline?.videoBytes) {
-            return {
-              buffer: Buffer.from(inline.videoBytes, "base64"),
-              mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
-              fileName: `video-${index + 1}.mp4`,
-            };
-          }
-          if (!inline) {
-            throw new Error("Google generated video missing file handle");
-          }
-          return await downloadGeneratedVideo({
-            client,
-            file: inline,
-            index,
-          });
-        }),
-      );
-      return {
-        videos,
-        model: normalizeOptionalString(req.model) || DEFAULT_GOOGLE_VIDEO_MODEL,
-        metadata: operation.name
-          ? {
-              operationName: operation.name,
-            }
-          : undefined,
-      };
+      return await toGoogleVideoResult({
+        operation,
+        apiKey: auth.apiKey,
+        timeoutMs: req.timeoutMs,
+        model,
+        client,
+      });
     },
   };
 }

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -207,11 +207,7 @@ async function downloadGoogleVideoUri(params: {
 
 function shouldFallbackToGoogleRest(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes('"code":404') ||
-    message.includes('"code": 404') ||
-    message.includes("Google video generation response missing generated videos")
-  );
+  return message.includes('"code":404') || message.includes('"code": 404');
 }
 
 async function generateGoogleVideoViaRest(params: {
@@ -223,6 +219,7 @@ async function generateGoogleVideoViaRest(params: {
   durationSeconds?: number;
   aspectRatio?: string;
   resolution?: string;
+  generateAudio?: boolean;
 }): Promise<unknown> {
   const submitBody = {
     instances: [{ prompt: params.prompt }],
@@ -232,6 +229,7 @@ async function generateGoogleVideoViaRest(params: {
         : {}),
       ...(params.aspectRatio ? { aspectRatio: params.aspectRatio } : {}),
       ...(params.resolution ? { resolution: params.resolution } : {}),
+      ...(params.generateAudio === true ? { generateAudio: true } : {}),
     },
   };
 
@@ -248,8 +246,12 @@ async function generateGoogleVideoViaRest(params: {
       throw new Error("Google video generation did not finish in time");
     }
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const opName = (operation as Record<string, unknown>).name;
+    if (typeof opName !== "string" || !opName) {
+      throw new Error("Google video operation response missing name for polling");
+    }
     operation = await requestGoogleVideoJson({
-      url: `${params.baseUrl}/${(operation as Record<string, unknown>).name}`,
+      url: `${params.baseUrl}/${opName}`,
       method: "GET",
       apiKey: params.apiKey,
       timeoutMs: params.timeoutMs,
@@ -496,6 +498,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
             durationSeconds,
             aspectRatio,
             resolution,
+            generateAudio: req.audio === true ? true : undefined,
           });
           return await toGoogleVideoResult({
             operation,

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -184,7 +184,7 @@ async function requestGoogleVideoJson(params: {
       payload = { raw: text };
     }
     if (!response.ok) {
-      throw new Error(typeof payload === "object" ? JSON.stringify(payload) : String(payload));
+      throw new Error(typeof payload === "string" ? payload : JSON.stringify(payload ?? null));
     }
     return payload;
   } finally {

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -10,7 +10,7 @@ import type {
   VideoGenerationProvider,
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
-import { normalizeGoogleApiBaseUrl } from "./api.js";
+import { normalizeGoogleApiBaseUrl, parseGeminiAuth } from "./api.js";
 
 const DEFAULT_GOOGLE_VIDEO_MODEL = "veo-3.1-fast-generate-preview";
 const DEFAULT_TIMEOUT_MS = 180_000;
@@ -160,19 +160,23 @@ function resolveInputVideo(req: VideoGenerationRequest) {
 async function requestGoogleVideoJson(params: {
   url: string;
   method: "GET" | "POST";
-  apiKey: string;
+  headers: Record<string, string>;
   body?: string;
   timeoutMs?: number;
 }): Promise<unknown> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), params.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   try {
+    const headers = { ...params.headers };
+    if (
+      params.body &&
+      !Object.keys(headers).some((headerName) => headerName.toLowerCase() === "content-type")
+    ) {
+      headers["content-type"] = "application/json";
+    }
     const response = await fetch(params.url, {
       method: params.method,
-      headers: {
-        "x-goog-api-key": params.apiKey,
-        ...(params.body ? { "content-type": "application/json" } : {}),
-      },
+      headers,
       ...(params.body ? { body: params.body } : {}),
       signal: controller.signal,
     });
@@ -211,6 +215,10 @@ function parseGoogleApiErrorCode(payload: unknown): number | undefined {
 
 function extractGoogleApiErrorCode(error: unknown): number | undefined {
   if (error instanceof Error) {
+    const statusCode = (error as Error & { status?: unknown }).status;
+    if (typeof statusCode === "number") {
+      return statusCode;
+    }
     try {
       return parseGoogleApiErrorCode(JSON.parse(error.message));
     } catch {
@@ -241,7 +249,7 @@ function extractGeneratedVideos(operation: unknown): Array<{ video: unknown }> {
 
 async function downloadGoogleVideoUri(params: {
   uri: string;
-  apiKey: string;
+  headers: Record<string, string>;
   timeoutMs?: number;
 }): Promise<Buffer> {
   const controller = new AbortController();
@@ -249,7 +257,7 @@ async function downloadGoogleVideoUri(params: {
   try {
     const response = await fetch(params.uri, {
       method: "GET",
-      headers: { "x-goog-api-key": params.apiKey },
+      headers: params.headers,
       signal: controller.signal,
     });
     if (!response.ok) {
@@ -326,7 +334,7 @@ async function generateGoogleVideoViaSdk(params: {
 
 async function generateGoogleVideoViaRest(params: {
   baseUrl: string;
-  apiKey: string;
+  headers: Record<string, string>;
   timeoutMs?: number;
   model: string;
   prompt: string;
@@ -346,9 +354,9 @@ async function generateGoogleVideoViaRest(params: {
   };
 
   let operation = await requestGoogleVideoJson({
-    url: `${params.baseUrl}/models/${encodeURIComponent(params.model)}:predictLongRunning`,
+    url: `${params.baseUrl}/${resolveGoogleVideoRestModelPath(params.model)}:predictLongRunning`,
     method: "POST",
-    apiKey: params.apiKey,
+    headers: params.headers,
     body: JSON.stringify(submitBody),
     timeoutMs: params.timeoutMs,
   });
@@ -365,7 +373,7 @@ async function generateGoogleVideoViaRest(params: {
     operation = await requestGoogleVideoJson({
       url: `${params.baseUrl}/${opName}`,
       method: "GET",
-      apiKey: params.apiKey,
+      headers: params.headers,
       timeoutMs: params.timeoutMs,
     });
   }
@@ -379,7 +387,7 @@ async function generateGoogleVideoViaRest(params: {
 
 async function toGoogleVideoResult(params: {
   operation: unknown;
-  apiKey: string;
+  headers: Record<string, string>;
   timeoutMs?: number;
   model: string;
   client?: GoogleGenAI;
@@ -397,12 +405,25 @@ async function toGoogleVideoResult(params: {
     videos: await Promise.all(
       generatedVideos.map(async (entry, index) => {
         const inline = entry.video as
-          | { videoBytes?: string; uri?: string; mimeType?: string }
+          | {
+              videoBytes?: string;
+              encodedVideo?: string;
+              uri?: string;
+              mimeType?: string;
+              encoding?: string;
+            }
           | undefined;
-        if (inline?.videoBytes) {
+        const inlineVideoBytes = normalizeOptionalString(
+          inline?.videoBytes || inline?.encodedVideo,
+        );
+        const inlineMimeType =
+          normalizeOptionalString(inline?.mimeType) ||
+          normalizeOptionalString(inline?.encoding) ||
+          "video/mp4";
+        if (inlineVideoBytes) {
           return {
-            buffer: Buffer.from(inline.videoBytes, "base64"),
-            mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
+            buffer: Buffer.from(inlineVideoBytes, "base64"),
+            mimeType: inlineMimeType,
             fileName: `video-${index + 1}.mp4`,
           };
         }
@@ -411,10 +432,10 @@ async function toGoogleVideoResult(params: {
             return {
               buffer: await downloadGoogleVideoUri({
                 uri: inline.uri,
-                apiKey: params.apiKey,
+                headers: params.headers,
                 timeoutMs: params.timeoutMs,
               }),
-              mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
+              mimeType: inlineMimeType,
               fileName: `video-${index + 1}.mp4`,
             };
           } catch (err) {
@@ -444,6 +465,20 @@ async function toGoogleVideoResult(params: {
     model: params.model,
     metadata: typeof op.name === "string" ? { operationName: op.name } : undefined,
   };
+}
+
+function resolveGoogleVideoRestModelPath(model: string): string {
+  const trimmed = normalizeOptionalString(model) || DEFAULT_GOOGLE_VIDEO_MODEL;
+  if (trimmed.startsWith("google/models/")) {
+    return trimmed.slice("google/".length);
+  }
+  if (trimmed.startsWith("models/")) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("google/")) {
+    return `models/${trimmed.slice("google/".length)}`;
+  }
+  return `models/${trimmed}`;
 }
 
 async function downloadGeneratedVideo(params: {
@@ -552,6 +587,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
 
       const configuredBaseUrl = resolveConfiguredGoogleVideoBaseUrl(req);
       const baseUrl = resolveGoogleVideoBaseUrl(req);
+      const authHeaders = parseGeminiAuth(auth.apiKey).headers;
       const durationSeconds = resolveDurationSeconds(req.durationSeconds);
       const model = normalizeOptionalString(req.model) || DEFAULT_GOOGLE_VIDEO_MODEL;
       const aspectRatio = resolveAspectRatio({ aspectRatio: req.aspectRatio, size: req.size });
@@ -582,7 +618,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
           });
           return await toGoogleVideoResult({
             operation,
-            apiKey: auth.apiKey,
+            headers: authHeaders,
             timeoutMs: req.timeoutMs,
             model,
             client,
@@ -593,7 +629,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
           }
           const operation = await generateGoogleVideoViaRest({
             baseUrl,
-            apiKey: auth.apiKey,
+            headers: authHeaders,
             timeoutMs: req.timeoutMs,
             model,
             prompt: req.prompt,
@@ -604,7 +640,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
           });
           return await toGoogleVideoResult({
             operation,
-            apiKey: auth.apiKey,
+            headers: authHeaders,
             timeoutMs: req.timeoutMs,
             model,
           });
@@ -624,7 +660,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
       });
       return await toGoogleVideoResult({
         operation,
-        apiKey: auth.apiKey,
+        headers: authHeaders,
         timeoutMs: req.timeoutMs,
         model,
         client,

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -21,6 +21,21 @@ const GOOGLE_VIDEO_MIN_DURATION_SECONDS = GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS[
 const GOOGLE_VIDEO_MAX_DURATION_SECONDS =
   GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS[GOOGLE_VIDEO_ALLOWED_DURATION_SECONDS.length - 1];
 const DEFAULT_GOOGLE_VIDEO_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE =
+  "Google video generation response missing generated videos";
+
+type GoogleVideoOperationRecord = Record<string, unknown> & {
+  done?: boolean;
+  error?: unknown;
+  name?: string;
+};
+
+class GoogleVideoEmptyResultError extends Error {
+  constructor() {
+    super(GOOGLE_VIDEO_EMPTY_RESULT_MESSAGE);
+    this.name = "GoogleVideoEmptyResultError";
+  }
+}
 
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
@@ -102,6 +117,24 @@ function resolveDurationSeconds(durationSeconds: number | undefined): number | u
   });
 }
 
+function buildGoogleVideoConfig(params: {
+  durationSeconds?: number;
+  aspectRatio?: "16:9" | "9:16";
+  resolution?: "720p" | "1080p";
+  generateAudio?: boolean;
+  includeNumberOfVideos?: boolean;
+}) {
+  return {
+    ...(params.includeNumberOfVideos === true ? { numberOfVideos: 1 } : {}),
+    ...(typeof params.durationSeconds === "number"
+      ? { durationSeconds: params.durationSeconds }
+      : {}),
+    ...(params.aspectRatio ? { aspectRatio: params.aspectRatio } : {}),
+    ...(params.resolution ? { resolution: params.resolution } : {}),
+    ...(params.generateAudio === true ? { generateAudio: true } : {}),
+  };
+}
+
 function resolveInputImage(req: VideoGenerationRequest) {
   const input = req.inputImages?.[0];
   if (!input?.buffer) {
@@ -151,9 +184,7 @@ async function requestGoogleVideoJson(params: {
       payload = { raw: text };
     }
     if (!response.ok) {
-      throw new Error(
-        typeof payload === "object" ? JSON.stringify(payload) : String(payload),
-      );
+      throw new Error(typeof payload === "object" ? JSON.stringify(payload) : String(payload));
     }
     return payload;
   } finally {
@@ -161,9 +192,35 @@ async function requestGoogleVideoJson(params: {
   }
 }
 
-function extractGeneratedVideos(
-  operation: unknown,
-): Array<{ video: unknown }> {
+function parseGoogleApiErrorCode(payload: unknown): number | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  const directCode = record.code;
+  if (typeof directCode === "number") {
+    return directCode;
+  }
+  const nestedError = record.error;
+  if (!nestedError || typeof nestedError !== "object") {
+    return undefined;
+  }
+  const nestedCode = (nestedError as Record<string, unknown>).code;
+  return typeof nestedCode === "number" ? nestedCode : undefined;
+}
+
+function extractGoogleApiErrorCode(error: unknown): number | undefined {
+  if (error instanceof Error) {
+    try {
+      return parseGoogleApiErrorCode(JSON.parse(error.message));
+    } catch {
+      return undefined;
+    }
+  }
+  return parseGoogleApiErrorCode(error);
+}
+
+function extractGeneratedVideos(operation: unknown): Array<{ video: unknown }> {
   const op = operation as Record<string, unknown>;
   const response = op.response as Record<string, unknown> | undefined;
   const generatedVideos = response?.generatedVideos;
@@ -206,8 +263,65 @@ async function downloadGoogleVideoUri(params: {
 }
 
 function shouldFallbackToGoogleRest(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes('"code":404') || message.includes('"code": 404');
+  if (error instanceof GoogleVideoEmptyResultError) {
+    return true;
+  }
+  return extractGoogleApiErrorCode(error) === 404;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollGoogleSdkVideoOperation(params: {
+  client: GoogleGenAI;
+  operation: unknown;
+}): Promise<unknown> {
+  let operation = params.operation;
+  for (let attempt = 0; !((operation as GoogleVideoOperationRecord).done ?? false); attempt += 1) {
+    if (attempt >= MAX_POLL_ATTEMPTS) {
+      throw new Error("Google video generation did not finish in time");
+    }
+    await sleep(POLL_INTERVAL_MS);
+    operation = await params.client.operations.getVideosOperation({
+      operation: operation as never,
+    });
+  }
+  const finalOperation = operation as GoogleVideoOperationRecord;
+  if (finalOperation.error) {
+    throw new Error(JSON.stringify(finalOperation.error));
+  }
+  return operation;
+}
+
+async function generateGoogleVideoViaSdk(params: {
+  client: GoogleGenAI;
+  model: string;
+  prompt: string;
+  durationSeconds?: number;
+  aspectRatio?: "16:9" | "9:16";
+  resolution?: "720p" | "1080p";
+  generateAudio?: boolean;
+  image?: { imageBytes: string; mimeType: string };
+  video?: { videoBytes: string; mimeType: string };
+}): Promise<unknown> {
+  const operation = await params.client.models.generateVideos({
+    model: params.model,
+    prompt: params.prompt,
+    image: params.image,
+    video: params.video,
+    config: buildGoogleVideoConfig({
+      includeNumberOfVideos: true,
+      durationSeconds: params.durationSeconds,
+      aspectRatio: params.aspectRatio,
+      resolution: params.resolution,
+      generateAudio: params.generateAudio,
+    }),
+  });
+  return await pollGoogleSdkVideoOperation({
+    client: params.client,
+    operation,
+  });
 }
 
 async function generateGoogleVideoViaRest(params: {
@@ -217,20 +331,18 @@ async function generateGoogleVideoViaRest(params: {
   model: string;
   prompt: string;
   durationSeconds?: number;
-  aspectRatio?: string;
-  resolution?: string;
+  aspectRatio?: "16:9" | "9:16";
+  resolution?: "720p" | "1080p";
   generateAudio?: boolean;
 }): Promise<unknown> {
   const submitBody = {
     instances: [{ prompt: params.prompt }],
-    parameters: {
-      ...(typeof params.durationSeconds === "number"
-        ? { durationSeconds: params.durationSeconds }
-        : {}),
-      ...(params.aspectRatio ? { aspectRatio: params.aspectRatio } : {}),
-      ...(params.resolution ? { resolution: params.resolution } : {}),
-      ...(params.generateAudio === true ? { generateAudio: true } : {}),
-    },
+    parameters: buildGoogleVideoConfig({
+      durationSeconds: params.durationSeconds,
+      aspectRatio: params.aspectRatio,
+      resolution: params.resolution,
+      generateAudio: params.generateAudio,
+    }),
   };
 
   let operation = await requestGoogleVideoJson({
@@ -245,7 +357,7 @@ async function generateGoogleVideoViaRest(params: {
     if (attempt >= MAX_POLL_ATTEMPTS) {
       throw new Error("Google video generation did not finish in time");
     }
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    await sleep(POLL_INTERVAL_MS);
     const opName = (operation as Record<string, unknown>).name;
     if (typeof opName !== "string" || !opName) {
       throw new Error("Google video operation response missing name for polling");
@@ -271,10 +383,14 @@ async function toGoogleVideoResult(params: {
   timeoutMs?: number;
   model: string;
   client?: GoogleGenAI;
-}): Promise<{ videos: GeneratedVideoAsset[]; model: string; metadata?: { operationName: string } }> {
+}): Promise<{
+  videos: GeneratedVideoAsset[];
+  model: string;
+  metadata?: { operationName: string };
+}> {
   const generatedVideos = extractGeneratedVideos(params.operation);
   if (generatedVideos.length === 0) {
-    throw new Error("Google video generation response missing generated videos");
+    throw new GoogleVideoEmptyResultError();
   }
   const op = params.operation as Record<string, unknown>;
   return {
@@ -440,6 +556,8 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
       const model = normalizeOptionalString(req.model) || DEFAULT_GOOGLE_VIDEO_MODEL;
       const aspectRatio = resolveAspectRatio({ aspectRatio: req.aspectRatio, size: req.size });
       const resolution = resolveResolution({ resolution: req.resolution, size: req.size });
+      const inputImage = resolveInputImage(req);
+      const inputVideo = resolveInputVideo(req);
       const client = new GoogleGenAI({
         apiKey: auth.apiKey,
         httpOptions: {
@@ -451,33 +569,17 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
       const hasReferenceInputs =
         (req.inputImages?.length ?? 0) > 0 || (req.inputVideos?.length ?? 0) > 0;
 
-      // For text-only prompts, try the SDK path first. If it returns a 404 or
-      // reports no generated videos (a known @google/genai 1.x compatibility
-      // issue with Veo 3.x), fall back to the REST predictLongRunning API which
-      // has been verified to work on the same key and model.
       if (!hasReferenceInputs) {
         try {
-          let operation = await client.models.generateVideos({
+          const operation = await generateGoogleVideoViaSdk({
+            client,
             model,
             prompt: req.prompt,
-            config: {
-              numberOfVideos: 1,
-              ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
-              ...(aspectRatio ? { aspectRatio } : {}),
-              ...(resolution ? { resolution } : {}),
-              ...(req.audio === true ? { generateAudio: true } : {}),
-            },
+            durationSeconds,
+            aspectRatio,
+            resolution,
+            generateAudio: req.audio === true,
           });
-          for (let attempt = 0; !(operation.done ?? false); attempt += 1) {
-            if (attempt >= MAX_POLL_ATTEMPTS) {
-              throw new Error("Google video generation did not finish in time");
-            }
-            await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-            operation = await client.operations.getVideosOperation({ operation });
-          }
-          if (operation.error) {
-            throw new Error(JSON.stringify(operation.error));
-          }
           return await toGoogleVideoResult({
             operation,
             apiKey: auth.apiKey,
@@ -498,7 +600,7 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
             durationSeconds,
             aspectRatio,
             resolution,
-            generateAudio: req.audio === true ? true : undefined,
+            generateAudio: req.audio === true,
           });
           return await toGoogleVideoResult({
             operation,
@@ -509,32 +611,17 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
         }
       }
 
-      // For prompts with reference image or video inputs, use the SDK path which
-      // supports multimodal inputs. No REST fallback here since the REST API does
-      // not expose equivalent image/video conditioning parameters.
-      let operation = await client.models.generateVideos({
+      const operation = await generateGoogleVideoViaSdk({
+        client,
         model,
         prompt: req.prompt,
-        image: resolveInputImage(req),
-        video: resolveInputVideo(req),
-        config: {
-          numberOfVideos: 1,
-          ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
-          ...(aspectRatio ? { aspectRatio } : {}),
-          ...(resolution ? { resolution } : {}),
-          ...(req.audio === true ? { generateAudio: true } : {}),
-        },
+        durationSeconds,
+        aspectRatio,
+        resolution,
+        generateAudio: req.audio === true,
+        image: inputImage,
+        video: inputVideo,
       });
-      for (let attempt = 0; !(operation.done ?? false); attempt += 1) {
-        if (attempt >= MAX_POLL_ATTEMPTS) {
-          throw new Error("Google video generation did not finish in time");
-        }
-        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-        operation = await client.operations.getVideosOperation({ operation });
-      }
-      if (operation.error) {
-        throw new Error(JSON.stringify(operation.error));
-      }
       return await toGoogleVideoResult({
         operation,
         apiKey: auth.apiKey,

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -289,15 +289,26 @@ async function toGoogleVideoResult(params: {
           };
         }
         if (typeof inline?.uri === "string" && inline.uri.length > 0) {
-          return {
-            buffer: await downloadGoogleVideoUri({
-              uri: inline.uri,
-              apiKey: params.apiKey,
-              timeoutMs: params.timeoutMs,
-            }),
-            mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
-            fileName: `video-${index + 1}.mp4`,
-          };
+          try {
+            return {
+              buffer: await downloadGoogleVideoUri({
+                uri: inline.uri,
+                apiKey: params.apiKey,
+                timeoutMs: params.timeoutMs,
+              }),
+              mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
+              fileName: `video-${index + 1}.mp4`,
+            };
+          } catch {
+            if (!params.client) {
+              throw;
+            }
+            return await downloadGeneratedVideo({
+              client: params.client,
+              file: inline,
+              index,
+            });
+          }
         }
         if (!inline) {
           throw new Error("Google generated video missing file handle");

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -301,9 +301,9 @@ async function toGoogleVideoResult(params: {
               mimeType: normalizeOptionalString(inline.mimeType) || "video/mp4",
               fileName: `video-${index + 1}.mp4`,
             };
-          } catch {
+          } catch (err) {
             if (!params.client) {
-              throw;
+              throw err;
             }
             return await downloadGeneratedVideo({
               client: params.client,


### PR DESCRIPTION
## Problem

`@google/genai` 1.x `client.models.generateVideos` returns **404** for Veo 3.x models on some environments, while the equivalent REST endpoint (`predictLongRunning`) succeeds with the same API key and model.

## Fix

For **text-only** video generation, try the SDK path first. If it returns a 404 or reports no generated videos, transparently fall back to the `predictLongRunning` REST API.

For prompts with **reference image or video inputs**, the SDK path is kept as-is — the REST API does not expose equivalent conditioning parameters.

## Testing

- [x] Verified end-to-end with `veo-3.1-lite-generate-preview` via Telegram
- [x] SDK alone returns 404; REST returns 200 on same key + model
- [x] Unit tests added for fallback paths

Closes #62309
Closes #63008