### PR TITLE
Avoid prefilling incomplete assistant text during recovery

### DIFF
--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -135,7 +135,7 @@ describe("sanitizeThinkingForRecovery", () => {
     expect(result.prefill).toBe(false);
   });
 
-  it("marks signed thinking without text as a prefill recovery case", () => {
+  it("drops incomplete assistant text instead of prefilling it during recovery", () => {
     const messages = castAgentMessages([
       { role: "user", content: "hello" },
       {
@@ -145,8 +145,9 @@ describe("sanitizeThinkingForRecovery", () => {
     ]);
 
     const result = sanitizeThinkingForRecovery(messages);
-    expect(result.messages).toBe(messages);
-    expect(result.prefill).toBe(true);
+    expect(result.prefill).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({ role: "user" });
   });
 
   it("marks signed thinking with an empty text block as incomplete text", () => {

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -206,7 +206,13 @@ export function sanitizeThinkingForRecovery(messages: AgentMessage[]): {
     return { messages, prefill: false };
   }
   if (assessment === "incomplete-text") {
-    return { messages, prefill: true };
+    return {
+      messages: [
+        ...messages.slice(0, lastAssistantIndex),
+        ...messages.slice(lastAssistantIndex + 1),
+      ],
+      prefill: false,
+    };
   }
 
   return {

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -205,16 +205,8 @@ export function sanitizeThinkingForRecovery(messages: AgentMessage[]): {
   if (assessment === "valid") {
     return { messages, prefill: false };
   }
-  if (assessment === "incomplete-text") {
-    return {
-      messages: [
-        ...messages.slice(0, lastAssistantIndex),
-        ...messages.slice(lastAssistantIndex + 1),
-      ],
-      prefill: false,
-    };
-  }
 
+  // assessment is "incomplete-text" or "incomplete-thinking" — drop it either way.
   return {
     messages: [...messages.slice(0, lastAssistantIndex), ...messages.slice(lastAssistantIndex + 1)],
     prefill: false,


### PR DESCRIPTION
## Summary

When the last assistant turn is classified as `incomplete-text`, the current recovery behavior keeps that partial assistant body and sets `prefill: true`.

This PR changes that path to:

- drop the incomplete assistant message from recovery input
- return `prefill: false`

The goal is to avoid feeding the next turn a partial assistant body in aborted/incomplete recovery situations, which can otherwise contribute to unstable next-turn state semantics.

## Why

Local controlled experiments reproduced a recovery inconsistency after aborted runs:

- sometimes the next turn claims the previous aborted output completed
- sometimes it cannot reliably identify the previous aborted output as its own last turn
- different models expose the issue differently, but the runtime recovery chain appears to be the common factor

Relevant issue: #62322

## Tests

Targeted test updated and passing:

```bash
node node_modules/vitest/vitest.mjs run src/agents/pi-embedded-runner/thinking.test.ts
```

Observed result: 15/15 passing.

## Notes

This is intentionally a small behavior change focused on the `incomplete-text` recovery path only. It does not attempt to redesign `abortedLastRun` persistence or broader reply/session recovery semantics in this PR.
