### PR TITLE
fix(logging): invalidate cached subsystem file loggers on date roll

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -245,8 +245,14 @@ export function getLogger(): TsLogger<LogObj> {
   if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
     loggingState.cachedLogger = buildLogger(settings);
     loggingState.cachedSettings = settings;
+    loggingState.loggerGeneration += 1;
   }
   return loggingState.cachedLogger as TsLogger<LogObj>;
+}
+
+/** Read by subsystem loggers to detect when their cached child logger is stale. */
+export function getLoggerGeneration(): number {
+  return loggingState.loggerGeneration;
 }
 
 export function getChildLogger(
@@ -313,6 +319,7 @@ export function resetLogger() {
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
+  loggingState.loggerGeneration = 0;
 }
 
 export function registerLogTransport(transport: LogTransport): () => void {

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -1,6 +1,8 @@
 export const loggingState = {
   cachedLogger: null as unknown,
   cachedSettings: null as unknown,
+  /** Tracks root logger rebuilds so subsystem caches can invalidate (e.g. on date roll). */
+  loggerGeneration: 0,
   cachedConsoleSettings: null as unknown,
   overrideSettings: null as unknown,
   invalidEnvLogLevelValue: null as string | null,

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setConsoleSubsystemFilter } from "./console.js";
+import * as loggerModule from "./logger.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
 import { loggingState } from "./state.js";
 import { createSubsystemLogger } from "./subsystem.js";
@@ -143,5 +144,28 @@ describe("createSubsystemLogger().isEnabled", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("subsystem file logger generation tracking", () => {
+  it("re-creates child file logger when root logger is rebuilt", () => {
+    setLoggerOverride({ level: "debug", consoleLevel: "silent" });
+    const spy = vi.spyOn(loggerModule, "getChildLogger");
+    const log = createSubsystemLogger("test-subsystem");
+
+    log.debug("first message");
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Same subsystem reuses cached child on next call
+    log.debug("second message, same generation");
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Simulate root logger rebuild (e.g. date roll)
+    resetLogger();
+    setLoggerOverride({ level: "debug", consoleLevel: "silent" });
+    log.debug("third message after rebuild");
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    spy.mockRestore();
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -10,7 +10,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { getChildLogger, getLoggerGeneration, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -301,6 +301,15 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerGeneration = -1;
+
+  function getFileLogger(): TsLogger<LogObj> {
+    if (!fileLogger || fileLoggerGeneration !== getLoggerGeneration()) {
+      fileLogger = getChildLogger({ subsystem });
+      fileLoggerGeneration = getLoggerGeneration();
+    }
+    return fileLogger;
+  }
 
   const emitLog = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
     const consoleSettings = getConsoleSettings();
@@ -323,10 +332,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       fileMeta = Object.keys(rest).length > 0 ? rest : undefined;
     }
     if (fileEnabled) {
-      if (!fileLogger) {
-        fileLogger = getChildLogger({ subsystem });
-      }
-      logToFile(fileLogger, level, message, fileMeta);
+      logToFile(getFileLogger(), level, message, fileMeta);
     }
     if (!consoleEnabled) {
       return;
@@ -389,10 +395,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     },
     raw(message) {
       if (isFileLogLevelEnabled("info")) {
-        if (!fileLogger) {
-          fileLogger = getChildLogger({ subsystem });
-        }
-        logToFile(fileLogger, "info", message, { raw: true });
+        logToFile(getFileLogger(), "info", message, { raw: true });
       }
       if (
         shouldLogToConsole("info", { level: getConsoleSettings().level }) &&


### PR DESCRIPTION
## Summary

- Subsystem loggers cached their tslog child logger once and never refreshed it when the root logger was rebuilt (e.g. on midnight date roll). All file log entries kept writing to yesterday's rolling log while `openclaw logs --follow` read from today's empty file.
- Fix: add a generation counter (`loggerGeneration` in `loggingState`) that increments when the root logger is rebuilt. Subsystem loggers check the generation before reusing their cached child and re-create it when stale.
- Files changed: `src/logging/state.ts`, `src/logging/logger.ts`, `src/logging/subsystem.ts`, `src/logging/subsystem.test.ts`

## Test plan

- [x] New test in `subsystem.test.ts` verifies that subsystem loggers pick up a new file logger after the generation counter increments
- [ ] Verify `pnpm test src/logging/subsystem.test.ts` passes
- [ ] Verify no regressions with `pnpm check`
- [ ] Manual verification: run gateway across midnight boundary and confirm `openclaw logs --follow` picks up new entries in the rolled log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)