### PR TITLE
fix(ui): refresh avatar when switching chat sessions

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,8 +1,38 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const {
+  refreshChatAvatarMock,
+  loadChatHistoryMock,
+  loadSessionsMock,
+  syncUrlWithSessionKeyMock,
+} = vi.hoisted(() => ({
+  refreshChatAvatarMock: vi.fn(),
+  loadChatHistoryMock: vi.fn(),
+  loadSessionsMock: vi.fn(),
+  syncUrlWithSessionKeyMock: vi.fn(),
+}));
+
+vi.mock("./app-chat.ts", () => ({
+  refreshChat: vi.fn(),
+  refreshChatAvatar: refreshChatAvatarMock,
+}));
+
+vi.mock("./controllers/chat.ts", () => ({
+  loadChatHistory: loadChatHistoryMock,
+}));
+
+vi.mock("./controllers/sessions.ts", () => ({
+  loadSessions: loadSessionsMock,
+}));
+
+vi.mock("./app-settings.ts", () => ({
+  syncUrlWithSessionKey: syncUrlWithSessionKeyMock,
+}));
 import {
   isCronSessionKey,
   parseSessionKey,
   resolveSessionDisplayName,
+  switchChatSession,
 } from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
 
@@ -267,6 +297,45 @@ describe("resolveSessionDisplayName", () => {
         row({ key: "agent:main:bluebubbles:direct:+19257864429", label: "Tyler" }),
       ),
     ).toBe("Tyler");
+  });
+});
+
+describe("switchChatSession", () => {
+  it("refreshes the avatar when switching sessions", () => {
+    refreshChatAvatarMock.mockReset();
+    loadChatHistoryMock.mockReset();
+    loadSessionsMock.mockReset();
+    syncUrlWithSessionKeyMock.mockReset();
+
+    const state = {
+      sessionKey: "agent:main:main",
+      chatMessage: "draft",
+      chatStream: "streaming",
+      chatRunId: "run-1",
+      settings: {
+        sessionKey: "agent:main:main",
+        lastActiveSessionKey: "agent:main:main",
+      },
+      chatQueue: [{ id: "queued" }],
+      chatAvatarUrl: "/avatar/old",
+      applySettings: vi.fn(),
+      loadAssistantIdentity: vi.fn(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+    } as const;
+
+    switchChatSession(state as never, "agent:ops:main");
+
+    expect(state.applySettings).toHaveBeenCalledWith({
+      ...state.settings,
+      sessionKey: "agent:ops:main",
+      lastActiveSessionKey: "agent:ops:main",
+    });
+    expect(state.loadAssistantIdentity).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
+    expect(refreshChatAvatarMock).toHaveBeenCalledWith(state);
+    expect(loadSessionsMock).toHaveBeenCalledTimes(1);
+    expect(syncUrlWithSessionKeyMock).toHaveBeenCalledWith(state, "agent:ops:main", true);
   });
 });
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
-import { refreshChat } from "./app-chat.ts";
+import { refreshChat, refreshChatAvatar } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
@@ -514,6 +514,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
     true,
   );
   void loadChatHistory(state as unknown as ChatState);
+  void refreshChatAvatar(state);
   void refreshSessionOptions(state);
 }
 

--- a/vitest.unit-paths.mjs
+++ b/vitest.unit-paths.mjs
@@ -6,6 +6,7 @@ export const unitTestIncludePatterns = [
   "packages/**/*.test.ts",
   "test/**/*.test.ts",
   "ui/src/ui/app-chat.test.ts",
+  "ui/src/ui/app-render.helpers.node.test.ts",
   "ui/src/ui/chat/**/*.test.ts",
   "ui/src/ui/views/agents-utils.test.ts",
   "ui/src/ui/views/channels.test.ts",


### PR DESCRIPTION
## Summary

This fixes a UI regression where switching chat sessions refreshed the conversation state and history but left the previous session's avatar in place.

## What Changed

- call `refreshChatAvatar(state)` during the session-switch render path
- add a focused regression test covering avatar refresh on session switch
- include the new test file in `vitest.unit-paths.mjs`

## Testing

- [x] This PR fixes a bug or regression
- `corepack pnpm exec vitest run ui/src/ui/app-render.helpers.node.test.ts --config vitest.unit.config.ts`

Closes #60348