### PR TITLE
fix: allow symlinked SKILL.md in bundled skills (dist-runtime)

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -336,7 +336,10 @@ describe("loadWorkspaceSkillEntries", () => {
     "calls out bundled symlink escapes as likely local checkout mutations",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
-      const bundledDir = path.join(workspaceDir, ".bundled");
+      // Use a deeper bundled dir structure to match real layout:
+      // <base>/dist-runtime/extensions — 2 levels up gives <base>/
+      // The outsideDir must be outside <base>/ to trigger the escape.
+      const bundledDir = path.join(workspaceDir, "dist-runtime", "extensions");
       const outsideDir = await createTempWorkspaceDir();
       const escapedSkillDir = path.join(outsideDir, "outside-bundled-skill");
       await writeSkill({
@@ -376,10 +379,14 @@ describe("loadWorkspaceSkillEntries", () => {
   it.runIf(process.platform !== "win32")(
     "uses compact home-relative paths in escaped skill console warnings",
     async () => {
+      // Use a deeper bundled dir structure (dist-runtime/extensions) so the
+      // outsideDir truly escapes the allowed symlink-target boundary.
+      // 2 levels up from workspace/dist-runtime/extensions = workspace/,
+      // and outside/ is NOT inside workspace/.
       const workspaceDir = path.join(fakeHome, "workspace");
       const outsideDir = path.join(fakeHome, "outside");
       tempDirs.push(workspaceDir, outsideDir);
-      const bundledDir = path.join(workspaceDir, ".bundled");
+      const bundledDir = path.join(workspaceDir, "dist-runtime", "extensions");
       const escapedSkillDir = path.join(outsideDir, "outside-bundled-skill");
       await writeSkill({
         dir: escapedSkillDir,
@@ -405,8 +412,10 @@ describe("loadWorkspaceSkillEntries", () => {
 
       const [line] = warn.mock.calls[0] ?? [];
       const warningLine = String(line);
-      expect(warningLine).toContain("root=~/workspace/.bundled");
-      expect(warningLine).toContain("requested=~/workspace/.bundled/escaped-bundled-skill");
+      expect(warningLine).toContain("root=~/workspace/dist-runtime/extensions");
+      expect(warningLine).toContain(
+        "requested=~/workspace/dist-runtime/extensions/escaped-bundled-skill",
+      );
       expect(warningLine).toContain("resolved=~/outside/outside-bundled-skill");
     },
   );

--- a/src/agents/skills.symlink-containment.test.ts
+++ b/src/agents/skills.symlink-containment.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadWorkspaceSkillEntries } from "./skills.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-symlink-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("resolveContainedSkillPath symlink fallback", () => {
+  it.runIf(process.platform !== "win32")(
+    "loads bundled skills when SKILL.md is a symlink pointing outside the resolved root",
+    async () => {
+      // Simulate dist-runtime/extensions layout:
+      //   base/dist/extensions/my-skill/SKILL.md  (real file)
+      //   base/dist-runtime/extensions/my-skill/SKILL.md -> symlink to dist version
+      //
+      // The bundled root is dist-runtime/extensions (a real directory).
+      // realpathSync(SKILL.md) lands in dist/ which is outside the resolved root.
+      // The logical-path fallback should accept it because the bundled root is trusted.
+
+      const base = await createTempDir();
+
+      const realSkillDir = path.join(base, "dist", "extensions", "my-skill");
+      await fs.mkdir(realSkillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(realSkillDir, "SKILL.md"),
+        `---
+name: my-skill
+description: A test skill behind a symlink
+---
+# My Skill
+`,
+      );
+
+      const runtimeSkillDir = path.join(base, "dist-runtime", "extensions", "my-skill");
+      await fs.mkdir(runtimeSkillDir, { recursive: true });
+      await fs.symlink(path.join(realSkillDir, "SKILL.md"), path.join(runtimeSkillDir, "SKILL.md"));
+
+      const workspaceDir = path.join(base, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      const entries = loadWorkspaceSkillEntries(workspaceDir, {
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(base, "dist-runtime", "extensions"),
+      });
+
+      const names = entries.map((entry) => entry.skill.name);
+      expect(names).toContain("my-skill");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects symlinked SKILL.md in workspace skills pointing outside the root",
+    async () => {
+      // Workspace skills do NOT get allowSymlinks, so symlinks pointing
+      // outside the resolved root should still be rejected.
+
+      const base = await createTempDir();
+      const outsideBase = await createTempDir();
+
+      const outsideSkillDir = path.join(outsideBase, "evil-skill");
+      await fs.mkdir(outsideSkillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(outsideSkillDir, "SKILL.md"),
+        `---
+name: evil-skill
+description: Should not be loaded
+---
+# Evil
+`,
+      );
+
+      const workspaceDir = path.join(base, "workspace");
+      const skillsDir = path.join(workspaceDir, "skills", "evil-skill");
+      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.symlink(path.join(outsideSkillDir, "SKILL.md"), path.join(skillsDir, "SKILL.md"));
+
+      const entries = loadWorkspaceSkillEntries(workspaceDir, {
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+      });
+
+      const names = entries.map((entry) => entry.skill.name);
+      expect(names).not.toContain("evil-skill");
+    },
+  );
+});

--- a/src/agents/skills/local-loader.ts
+++ b/src/agents/skills/local-loader.ts
@@ -14,12 +14,16 @@ function isPathWithinRoot(rootRealPath: string, candidatePath: string): boolean 
 
 function readSkillFileSync(params: {
   rootRealPath: string;
+  rootDir?: string;
   filePath: string;
   maxBytes?: number;
+  allowSymlinks?: boolean;
+  /** When allowSymlinks is true, the resolved symlink target must also be inside this directory. */
+  allowedSymlinkTarget?: string;
 }): string | null {
   const opened = openVerifiedFileSync({
     filePath: params.filePath,
-    rejectPathSymlink: true,
+    rejectPathSymlink: !params.allowSymlinks,
     maxBytes: params.maxBytes,
   });
   if (!opened.ok) {
@@ -27,7 +31,17 @@ function readSkillFileSync(params: {
   }
   try {
     if (!isPathWithinRoot(params.rootRealPath, opened.path)) {
-      return null;
+      // Fallback: accept if the logical (non-resolved) path is inside the logical root
+      // AND the resolved path is within the allowed symlink target boundary.
+      if (
+        !params.allowSymlinks ||
+        !params.rootDir ||
+        !params.allowedSymlinkTarget ||
+        !isPathWithinRoot(path.resolve(params.rootDir), path.resolve(params.filePath)) ||
+        !isPathWithinRoot(path.resolve(params.allowedSymlinkTarget), opened.path)
+      ) {
+        return null;
+      }
     }
     return fs.readFileSync(opened.fd, "utf8");
   } finally {
@@ -39,13 +53,19 @@ function loadSingleSkillDirectory(params: {
   skillDir: string;
   source: string;
   rootRealPath: string;
+  rootDir?: string;
   maxBytes?: number;
+  allowSymlinks?: boolean;
+  allowedSymlinkTarget?: string;
 }): Skill | null {
   const skillFilePath = path.join(params.skillDir, "SKILL.md");
   const raw = readSkillFileSync({
     rootRealPath: params.rootRealPath,
+    rootDir: params.rootDir,
     filePath: skillFilePath,
     maxBytes: params.maxBytes,
+    allowSymlinks: params.allowSymlinks,
+    allowedSymlinkTarget: params.allowedSymlinkTarget,
   });
   if (!raw) {
     return null;
@@ -99,7 +119,13 @@ function listCandidateSkillDirs(dir: string): string[] {
   }
 }
 
-export function loadSkillsFromDirSafe(params: { dir: string; source: string; maxBytes?: number }): {
+export function loadSkillsFromDirSafe(params: {
+  dir: string;
+  source: string;
+  maxBytes?: number;
+  allowSymlinks?: boolean;
+  allowedSymlinkTarget?: string;
+}): {
   skills: Skill[];
 } {
   const rootDir = path.resolve(params.dir);
@@ -114,7 +140,10 @@ export function loadSkillsFromDirSafe(params: { dir: string; source: string; max
     skillDir: rootDir,
     source: params.source,
     rootRealPath,
+    rootDir,
     maxBytes: params.maxBytes,
+    allowSymlinks: params.allowSymlinks,
+    allowedSymlinkTarget: params.allowedSymlinkTarget,
   });
   if (rootSkill) {
     return { skills: [rootSkill] };
@@ -126,7 +155,10 @@ export function loadSkillsFromDirSafe(params: { dir: string; source: string; max
         skillDir,
         source: params.source,
         rootRealPath,
+        rootDir,
         maxBytes: params.maxBytes,
+        allowSymlinks: params.allowSymlinks,
+        allowedSymlinkTarget: params.allowedSymlinkTarget,
       }),
     )
     .filter((skill): skill is Skill => skill !== null);

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -251,6 +251,9 @@ function resolveContainedSkillPath(params: {
   rootDir: string;
   rootRealPath: string;
   candidatePath: string;
+  allowSymlinks?: boolean;
+  /** When allowSymlinks is true, the resolved symlink target must also be inside this directory. */
+  allowedSymlinkTarget?: string;
 }): string | null {
   const candidateRealPath = tryRealpath(params.candidatePath);
   if (!candidateRealPath) {
@@ -258,6 +261,20 @@ function resolveContainedSkillPath(params: {
   }
   if (isPathInside(params.rootRealPath, candidateRealPath)) {
     return candidateRealPath;
+  }
+  // Fallback: accept paths that are logically inside the root even when
+  // internal symlinks (e.g. dist-runtime SKILL.md → dist/) cause the
+  // resolved path to land outside the resolved root.
+  // Security: also verify the resolved symlink target is within the allowed boundary.
+  if (params.allowSymlinks && params.allowedSymlinkTarget) {
+    const resolvedCandidate = path.resolve(params.candidatePath);
+    const resolvedTarget = path.resolve(params.allowedSymlinkTarget);
+    if (
+      isPathInside(params.rootDir, resolvedCandidate) &&
+      isPathInside(resolvedTarget, candidateRealPath)
+    ) {
+      return candidateRealPath;
+    }
   }
   warnEscapedSkillPath({
     source: params.source,
@@ -274,6 +291,8 @@ function filterLoadedSkillsInsideRoot(params: {
   source: string;
   rootDir: string;
   rootRealPath: string;
+  allowSymlinks?: boolean;
+  allowedSymlinkTarget?: string;
 }): Skill[] {
   return params.skills.filter((skill) => {
     const baseDirRealPath = resolveContainedSkillPath({
@@ -281,6 +300,8 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.baseDir,
+      allowSymlinks: params.allowSymlinks,
+      allowedSymlinkTarget: params.allowedSymlinkTarget,
     });
     if (!baseDirRealPath) {
       return false;
@@ -290,6 +311,8 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.filePath,
+      allowSymlinks: params.allowSymlinks,
+      allowedSymlinkTarget: params.allowedSymlinkTarget,
     });
     return Boolean(skillFileRealPath);
   });
@@ -348,7 +371,12 @@ function loadSkillEntries(
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config);
 
-  const loadSkills = (params: { dir: string; source: string }): Skill[] => {
+  const loadSkills = (params: {
+    dir: string;
+    source: string;
+    allowSymlinks?: boolean;
+    allowedSymlinkTarget?: string;
+  }): Skill[] => {
     const rootDir = path.resolve(params.dir);
     const rootRealPath = tryRealpath(rootDir) ?? rootDir;
     const resolved = resolveNestedSkillsRoot(params.dir, {
@@ -360,6 +388,8 @@ function loadSkillEntries(
       rootDir,
       rootRealPath,
       candidatePath: baseDir,
+      allowSymlinks: params.allowSymlinks,
+      allowedSymlinkTarget: params.allowedSymlinkTarget,
     });
     if (!baseDirRealPath) {
       return [];
@@ -373,6 +403,8 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: rootSkillMd,
+        allowSymlinks: params.allowSymlinks,
+        allowedSymlinkTarget: params.allowedSymlinkTarget,
       });
       if (!rootSkillRealPath) {
         return [];
@@ -396,12 +428,16 @@ function loadSkillEntries(
         dir: baseDir,
         source: params.source,
         maxBytes: limits.maxSkillFileBytes,
+        allowSymlinks: params.allowSymlinks,
+        allowedSymlinkTarget: params.allowedSymlinkTarget,
       });
       return filterLoadedSkillsInsideRoot({
         skills: unwrapLoadedSkills(loaded),
         source: params.source,
         rootDir,
         rootRealPath: baseDirRealPath,
+        allowSymlinks: params.allowSymlinks,
+        allowedSymlinkTarget: params.allowedSymlinkTarget,
       });
     }
 
@@ -438,6 +474,8 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillDir,
+        allowSymlinks: params.allowSymlinks,
+        allowedSymlinkTarget: params.allowedSymlinkTarget,
       });
       if (!skillDirRealPath) {
         continue;
@@ -451,6 +489,8 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillMd,
+        allowSymlinks: params.allowSymlinks,
+        allowedSymlinkTarget: params.allowedSymlinkTarget,
       });
       if (!skillMdRealPath) {
         continue;
@@ -474,6 +514,8 @@ function loadSkillEntries(
         dir: skillDir,
         source: params.source,
         maxBytes: limits.maxSkillFileBytes,
+        allowSymlinks: params.allowSymlinks,
+        allowedSymlinkTarget: params.allowedSymlinkTarget,
       });
       loadedSkills.push(
         ...filterLoadedSkillsInsideRoot({
@@ -481,6 +523,8 @@ function loadSkillEntries(
           source: params.source,
           rootDir,
           rootRealPath: baseDirRealPath,
+          allowSymlinks: params.allowSymlinks,
+          allowedSymlinkTarget: params.allowedSymlinkTarget,
         }),
       );
 
@@ -514,6 +558,11 @@ function loadSkillEntries(
     ? loadSkills({
         dir: bundledSkillsDir,
         source: "openclaw-bundled",
+        allowSymlinks: true,
+        // The bundled dir is typically <package>/dist-runtime/extensions.
+        // Symlinks may point to <package>/dist/extensions. The common ancestor
+        // (package root) is two levels up from the bundled dir.
+        allowedSymlinkTarget: path.resolve(bundledSkillsDir, "..", ".."),
       })
     : [];
   const extraSkills = mergedExtraDirs.flatMap((dir) => {


### PR DESCRIPTION
## Problem

In `dist-runtime/extensions/`, SKILL.md files are symlinks pointing to `../dist/extensions/...`. Two separate containment checks rejected these symlinks:

1. **`resolveContainedSkillPath`** in `workspace.ts`: Resolves symlinks via `realpathSync` and checks if the real path is inside the root's real path. Fails because `dist/` is not inside `dist-runtime/`.

2. **`readSkillFileSync`** in `local-loader.ts`: Uses `rejectPathSymlink: true` which rejects any symlinked SKILL.md outright. Additionally, `isPathWithinRoot` fails for the same reason as above.

## Fix

### workspace.ts
Added a logical-path fallback to `resolveContainedSkillPath`: when the realpath containment check fails and `allowSymlinks` is enabled, accept the path if:
1. `path.resolve(candidatePath)` is logically inside `rootDir` (without symlink resolution)
2. The resolved real path is inside `allowedSymlinkTarget` (the package root, 2 levels up from the bundled dir)

Both conditions must hold — the logical path check alone is insufficient as it could allow symlinks pointing to arbitrary locations.

### local-loader.ts
Added `allowSymlinks` + `allowedSymlinkTarget` options flowing through `loadSkillsFromDirSafe` → `loadSingleSkillDirectory` → `readSkillFileSync`:
- Disables `rejectPathSymlink` when symlinks are allowed
- Falls back to dual containment check (logical path + resolved target boundary)

### Security
- `allowSymlinks: true` is only passed for **bundled skills** (trusted, part of the OpenClaw installation)
- `allowedSymlinkTarget` constrains where resolved paths can land (package root)
- Workspace skills and extra dirs retain strict symlink rejection
- Test verifies both: symlinked bundled skills load, symlinked workspace skills are rejected
- Existing escape-detection tests updated to use realistic directory structure matching the `allowedSymlinkTarget` boundary

## Test Plan
- Added `src/agents/skills.symlink-containment.test.ts` with 2 test cases
- All 18 related tests pass (2 new + 16 existing loadWorkspaceSkillEntries)

Fixes #61585