### PR TITLE
fix(build): enable clean dist to prevent stale hashed chunks

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -76,6 +76,7 @@ function buildInputOptions(options: InputOptionsArg): InputOptionsReturn {
 function nodeBuildConfig(config: UserConfig): UserConfig {
   return {
     ...config,
+    clean: true,
     env,
     fixedExtension: false,
     platform: "node",


### PR DESCRIPTION
## Summary

- Adds `clean: true` to the tsdown build config so `dist/` is wiped before each build
- Prevents stale content-hashed chunks from lingering across rebuilds, which causes `Cannot find module` errors (e.g. `pi-tools.before-tool-call.runtime-CevWLrox.js`)
- Primarily affects source/dev installs where `pnpm build` runs locally after pulling new code

## Root cause

tsdown produces content-hashed filenames for code-split chunks (e.g. `foo.runtime-CevWLrox.js`). The importing file hardcodes the hash at build time. Without `clean: true`, old chunks survive across rebuilds. If a build is interrupted, or the hash changes due to source changes, the importing file references a hash that no longer exists in `dist/`.

The repo already mitigates this for specific modules by pinning them as stable entries (e.g. `memory-cli` per #51676), but `clean: true` is the general solution that protects all chunks.

## Test plan

- [x] `pnpm build` passes with the change
- [x] Verified dist chunk references are consistent after a clean rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)