### PR TITLE
fix: sanitize control characters in Anthropic streaming JSON parse

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -10,6 +10,28 @@ import {
   type SimpleStreamOptions,
   type ThinkingLevel,
 } from "@mariozechner/pi-ai";
+
+/**
+ * Wrapper around parseStreamingJson that sanitizes C0 control characters
+ * (U+0000–U+001F) on SyntaxError. Anthropic's streaming API occasionally
+ * emits unescaped control characters in SSE data lines, causing JSON.parse
+ * to throw. This defense-in-depth fallback strips them and retries.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/14321
+ * See: https://github.com/openclaw/openclaw/issues/32179
+ */
+function safeParseStreamingJson(json: string): unknown {
+  try {
+    return parseStreamingJson(json);
+  } catch (e) {
+    if (e instanceof SyntaxError && typeof json === "string") {
+      // Strip C0 control characters and retry
+      return parseStreamingJson(json.replace(/[\x00-\x1f]/g, ""));
+    }
+    throw e;
+  }
+}
+
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
@@ -759,7 +781,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               typeof delta.partial_json === "string"
             ) {
               block.partialJson += delta.partial_json;
-              block.arguments = parseStreamingJson(block.partialJson);
+              block.arguments = safeParseStreamingJson(block.partialJson);
               stream.push({
                 type: "toolcall_delta",
                 contentIndex: index,
@@ -804,7 +826,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             }
             if (block.type === "toolCall") {
               if (typeof block.partialJson === "string" && block.partialJson.length > 0) {
-                block.arguments = parseStreamingJson(block.partialJson);
+                block.arguments = safeParseStreamingJson(block.partialJson);
               }
               delete block.partialJson;
               stream.push({

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -10,28 +10,6 @@ import {
   type SimpleStreamOptions,
   type ThinkingLevel,
 } from "@mariozechner/pi-ai";
-
-/**
- * Wrapper around parseStreamingJson that sanitizes C0 control characters
- * (U+0000–U+001F) on SyntaxError. Anthropic's streaming API occasionally
- * emits unescaped control characters in SSE data lines, causing JSON.parse
- * to throw. This defense-in-depth fallback strips them and retries.
- *
- * See: https://github.com/openclaw/openclaw/issues/14321
- * See: https://github.com/openclaw/openclaw/issues/32179
- */
-function safeParseStreamingJson(json: string | undefined): unknown {
-  try {
-    return parseStreamingJson(json);
-  } catch (e) {
-    if (e instanceof SyntaxError && typeof json === "string") {
-      // Strip C0 control characters and retry
-      return parseStreamingJson(json.replace(/[\x00-\x1f]/g, ""));
-    }
-    throw e;
-  }
-}
-
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
@@ -47,6 +25,27 @@ import {
   mergeTransportHeaders,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
+
+/**
+ * Wrapper around parseStreamingJson that sanitizes C0 control characters
+ * (U+0000–U+001F) on SyntaxError. Anthropic's streaming API occasionally
+ * emits unescaped control characters in SSE data lines, causing JSON.parse
+ * to throw. This defense-in-depth fallback strips them and retries.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/14321
+ * See: https://github.com/openclaw/openclaw/issues/32179
+ */
+function safeParseStreamingJson(json: string | undefined): unknown {
+  try {
+    return parseStreamingJson(json);
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      // Strip C0 control characters and retry
+      return parseStreamingJson(json?.replace(/[\x00-\x1f]/g, ""));
+    }
+    throw e;
+  }
+}
 
 const CLAUDE_CODE_VERSION = "2.1.75";
 const CLAUDE_CODE_TOOLS = [

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -35,13 +35,13 @@ import {
  * See: https://github.com/openclaw/openclaw/issues/14321
  * See: https://github.com/openclaw/openclaw/issues/32179
  */
-function safeParseStreamingJson(json: string | undefined): unknown {
+function safeParseStreamingJson(json: string): unknown {
   try {
     return parseStreamingJson(json);
   } catch (e) {
     if (e instanceof SyntaxError) {
       // Strip C0 control characters and retry
-      return parseStreamingJson(json?.replace(/[\x00-\x1f]/g, ""));
+      return parseStreamingJson(json.replace(/[\x00-\x1f]/g, ""));
     }
     throw e;
   }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -20,7 +20,7 @@ import {
  * See: https://github.com/openclaw/openclaw/issues/14321
  * See: https://github.com/openclaw/openclaw/issues/32179
  */
-function safeParseStreamingJson(json: string): unknown {
+function safeParseStreamingJson(json: string | undefined): unknown {
   try {
     return parseStreamingJson(json);
   } catch (e) {


### PR DESCRIPTION
## Problem

Anthropic's streaming API occasionally emits unescaped C0 control characters (U+0000–U+001F) in SSE `data:` lines containing tool call partial JSON. This causes `JSON.parse()` inside `parseStreamingJson()` to throw a `SyntaxError`, which propagates as a raw error message to the user and kills the entire agent run.

**Error seen by users:**
```
Expected "," or "}" after property value in JSON at position N (line 1 column N+1)
```

**Impact:** 19 occurrences over 7 days on v2026.4.5, averaging 2–3/day. Each occurrence terminates the agent run with `isError=true` and surfaces the raw parse error to the end user.

## Fix

Add `safeParseStreamingJson()` wrapper in `anthropic-transport-stream.ts` that:
1. Tries normal `parseStreamingJson()` first
2. On `SyntaxError`, strips C0 control characters (`/[\x00-\x1f]/g`) and retries
3. Re-throws non-SyntaxError exceptions unchanged

This is a defense-in-depth fix — the upstream Anthropic SDK should also handle this (`anthropic-sdk-typescript#882`), but OpenClaw should not surface raw parse errors to users.

## Changes

- `src/agents/anthropic-transport-stream.ts`: Add `safeParseStreamingJson()`, replace 2 call sites

## Related Issues

- Fixes #14321
- Ref #32179
- Upstream: anthropics/anthropic-sdk-typescript#882
