### PR TITLE
fix(discord): handle gateway registration failures

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -24,6 +24,7 @@ type DiscordGatewayFetch = (
 
 type DiscordGatewayMetadataError = Error & { transient?: boolean };
 type DiscordGatewayWebSocketCtor = new (url: string, options?: { agent?: unknown }) => ws.WebSocket;
+const registrationPromises = new WeakMap<carbonGateway.GatewayPlugin, Promise<void>>();
 
 export function resolveDiscordGatewayIntents(
   intentsConfig?: import("openclaw/plugin-sdk/config-runtime").DiscordIntentsConfig,
@@ -246,7 +247,16 @@ function createGatewayPlugin(params: {
       super(params.options);
     }
 
-    override async registerClient(
+    override registerClient(client: Parameters<carbonGateway.GatewayPlugin["registerClient"]>[0]) {
+      const registration = this.registerClientInternal(client);
+      // Carbon 0.14 invokes async plugin hooks from its constructor without awaiting them.
+      // Mark the promise handled immediately, then let OpenClaw startup await it explicitly.
+      registration.catch(() => {});
+      registrationPromises.set(this, registration);
+      return registration;
+    }
+
+    private async registerClientInternal(
       client: Parameters<carbonGateway.GatewayPlugin["registerClient"]>[0],
     ) {
       if (!this.gatewayInfo || this.gatewayInfoUsedFallback) {
@@ -291,6 +301,15 @@ function createGatewayPlugin(params: {
   }
 
   return new SafeGatewayPlugin();
+}
+
+export function waitForDiscordGatewayPluginRegistration(
+  plugin: unknown,
+): Promise<void> | undefined {
+  if (typeof plugin !== "object" || plugin === null) {
+    return undefined;
+  }
+  return registrationPromises.get(plugin as carbonGateway.GatewayPlugin);
 }
 
 export function createDiscordGatewayPlugin(params: {

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -113,9 +113,11 @@ vi.mock("ws", () => ({
 
 describe("createDiscordGatewayPlugin", () => {
   let createDiscordGatewayPlugin: typeof import("./gateway-plugin.js").createDiscordGatewayPlugin;
+  let waitForDiscordGatewayPluginRegistration: typeof import("./gateway-plugin.js").waitForDiscordGatewayPluginRegistration;
 
   beforeAll(async () => {
-    ({ createDiscordGatewayPlugin } = await import("./gateway-plugin.js"));
+    ({ createDiscordGatewayPlugin, waitForDiscordGatewayPluginRegistration } =
+      await import("./gateway-plugin.js"));
   });
 
   function createRuntime() {
@@ -154,6 +156,22 @@ describe("createDiscordGatewayPlugin", () => {
 
   async function registerGatewayClient(plugin: unknown) {
     await (
+      plugin as {
+        registerClient: (client: {
+          options: { token: string };
+          registerListener: typeof baseRegisterClientSpy;
+          unregisterListener: ReturnType<typeof vi.fn>;
+        }) => Promise<void>;
+      }
+    ).registerClient({
+      options: { token: "token-123" },
+      registerListener: baseRegisterClientSpy,
+      unregisterListener: vi.fn(),
+    });
+  }
+
+  function startIgnoredGatewayRegistration(plugin: unknown) {
+    void (
       plugin as {
         registerClient: (client: {
           options: { token: string };
@@ -274,6 +292,39 @@ describe("createDiscordGatewayPlugin", () => {
       status: 401,
       text: async () => "401: Unauthorized",
     } as Response);
+  });
+
+  it("keeps Carbon-ignored fatal metadata failures handled for supervised startup", async () => {
+    const runtime = createRuntime();
+    const unhandledReasons: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledReasons.push(reason);
+    };
+    globalFetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "401: Unauthorized",
+    } as Response);
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      startIgnoredGatewayRegistration(plugin);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(unhandledReasons).toHaveLength(0);
+      const registration = waitForDiscordGatewayPluginRegistration(plugin);
+      if (!registration) {
+        throw new Error("expected Discord gateway registration promise");
+      }
+      await expect(registration).rejects.toThrow("Failed to get gateway information from Discord");
+      expect(baseRegisterClientSpy).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
   });
 
   it("uses proxy agent for gateway WebSocket when configured", async () => {

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -17,7 +17,10 @@ import type { DiscordGuildEntryResolved } from "./allow-list.js";
 import { createDiscordAutoPresenceController } from "./auto-presence.js";
 import type { DiscordDmPolicy } from "./dm-command-auth.js";
 import type { MutableDiscordGateway } from "./gateway-handle.js";
-import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
+import {
+  createDiscordGatewayPlugin,
+  waitForDiscordGatewayPluginRegistration,
+} from "./gateway-plugin.js";
 import { createDiscordGatewaySupervisor } from "./gateway-supervisor.js";
 import {
   DiscordMessageListener,
@@ -67,7 +70,7 @@ export function createDiscordStatusReadyListener(params: {
   })();
 }
 
-export function createDiscordMonitorClient(params: {
+export async function createDiscordMonitorClient(params: {
   accountId: string;
   applicationId: string;
   token: string;
@@ -132,6 +135,7 @@ export function createDiscordMonitorClient(params: {
     });
   }
   const gateway = client.getPlugin<GatewayPlugin>("gateway") as MutableDiscordGateway | undefined;
+  await waitForDiscordGatewayPluginRegistration(gateway);
   const gatewaySupervisor = params.createGatewaySupervisor({
     gateway,
     isDisallowedIntentsError: params.isDisallowedIntentsError,

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -796,8 +796,8 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   let lifecycleStarted = false;
   let gatewaySupervisor: ReturnType<typeof createDiscordGatewaySupervisor> | undefined;
   let deactivateMessageHandler: (() => void) | undefined;
-  let autoPresenceController: ReturnType<
-    typeof createDiscordMonitorClient
+  let autoPresenceController: Awaited<
+    ReturnType<typeof createDiscordMonitorClient>
   >["autoPresenceController"] = null;
   let lifecycleGateway: MutableDiscordGateway | undefined;
   let earlyGatewayEmitter = gatewaySupervisor?.emitter;
@@ -904,7 +904,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       gatewaySupervisor: createdGatewaySupervisor,
       autoPresenceController: createdAutoPresenceController,
       eventQueueOpts,
-    } = createDiscordMonitorClient({
+    } = await createDiscordMonitorClient({
       accountId: account.accountId,
       applicationId,
       token,

--- a/extensions/discord/src/test-support/provider.test-support.ts
+++ b/extensions/discord/src/test-support/provider.test-support.ts
@@ -455,6 +455,7 @@ vi.mock(buildDiscordSourceModuleId("monitor/exec-approvals.js"), () => ({
 
 vi.mock(buildDiscordSourceModuleId("monitor/gateway-plugin.js"), () => ({
   createDiscordGatewayPlugin: () => ({ id: "gateway-plugin" }),
+  waitForDiscordGatewayPluginRegistration: () => undefined,
 }));
 
 vi.mock(buildDiscordSourceModuleId("monitor/listeners.js"), () => ({


### PR DESCRIPTION
## Summary
- handle Discord gateway plugin registration promises that Carbon invokes without awaiting
- keep fatal Discord gateway metadata failures fatal, but surface them through supervised Discord startup instead of process-level unhandled rejection
- add regression coverage for Carbon-ignored fatal metadata failures

## Testing
- node scripts/run-vitest.mjs run --config vitest.extension-channels.config.ts extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/monitor/provider.test.ts
- pnpm exec oxlint extensions/discord/src/monitor/gateway-plugin.ts extensions/discord/src/monitor/provider.startup.ts extensions/discord/src/monitor/provider.ts extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/test-support/provider.test-support.ts
- pnpm exec oxfmt --check extensions/discord/src/monitor/gateway-plugin.ts extensions/discord/src/monitor/provider.startup.ts extensions/discord/src/monitor/provider.ts extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/test-support/provider.test-support.ts
- git diff --check
- node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc -p tsconfig.json --noEmit --pretty false

## Notes
Full Discord channel lane was also run on Windows. It had an unrelated path-separator expectation failure in extensions/discord/src/voice-message.test.ts; the model-picker timeouts seen in the full lane passed when rerun in isolation.