### PR TITLE
fix: write JSON envelope to stdout in local agent --json mode

### DIFF
--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -20,7 +20,7 @@ import {
   normalizeOutboundPayloadsForJson,
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import type { RuntimeEnv, OutputRuntimeEnv } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -268,15 +268,11 @@ export async function deliverAgentCommandResult(params: {
   });
   const normalizedPayloads = normalizeOutboundPayloadsForJson(normalizedReplyPayloads);
   if (opts.json) {
-    runtime.log(
-      JSON.stringify(
-        buildOutboundResultEnvelope({
-          payloads: normalizedPayloads,
-          meta: result.meta,
-        }),
-        null,
-        2,
-      ),
+    (runtime as OutputRuntimeEnv).writeJson(
+      buildOutboundResultEnvelope({
+        payloads: normalizedPayloads,
+        meta: result.meta,
+      }),
     );
     if (!deliver) {
       return { payloads: normalizedPayloads, meta: result.meta };

--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -4,7 +4,7 @@ import type { ReplyPayload } from "../auto-reply/types.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
-import type { RuntimeEnv } from "../runtime.js";
+import type { RuntimeEnv, OutputRuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(async () => []),
@@ -33,11 +33,12 @@ vi.mock("../infra/outbound/targets.js", async () => {
 });
 
 describe("deliverAgentCommandResult", () => {
-  function createRuntime(): RuntimeEnv {
+  function createRuntime(): OutputRuntimeEnv {
     return {
       log: vi.fn(),
       error: vi.fn(),
-    } as unknown as RuntimeEnv;
+      writeJson: vi.fn(),
+    } as unknown as OutputRuntimeEnv;
   }
 
   function createResult(text = "hi") {
@@ -304,10 +305,8 @@ describe("deliverAgentCommandResult", () => {
       },
     });
 
-    expect(runtime.log).toHaveBeenCalledTimes(1);
-    expect(
-      JSON.parse(String((runtime.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0])),
-    ).toEqual({
+    expect(runtime.writeJson).toHaveBeenCalledTimes(1);
+    expect((runtime.writeJson as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toEqual({
       payloads: [
         {
           text: "voice caption",


### PR DESCRIPTION
## Summary

Fix for openclaw/openclaw#62440: the local-mode `agent --local --json` command writes JSON output to stderr instead of stdout. Changed `runtime.log(JSON.stringify(buildOutboundResultEnvelope(...), null, 2))` to `(runtime as OutputRuntimeEnv).writeJson(buildOutboundResultEnvelope(...))` which writes directly to stdout, matching gateway-mode behavior.

## Changes

- `src/agents/command/delivery.ts`: replace `runtime.log(JSON.stringify(buildOutboundResultEnvelope(...), null, 2))` with `(runtime as OutputRuntimeEnv).writeJson(buildOutboundResultEnvelope(...))`. Also added `OutputRuntimeEnv` import.
- `src/commands/agent.delivery.test.ts`: update mock to include `writeJson` and update test assertions to verify `writeJson` is called correctly.

## Testing

- `pnpm test src/commands/agent.delivery.test.ts` — 11 tests pass
- `pnpm test src/agents/command/delivery.test.ts` — 4 tests pass

Fixes openclaw/openclaw#62440