### PR TITLE
atlascloud: add Atlas Cloud video generation provider plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -261,6 +261,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/arcee/**"
+"extensions: atlascloud":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/atlascloud/**"
 "extensions: byteplus":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/atlascloud/body-builder.ts
+++ b/extensions/atlascloud/body-builder.ts
@@ -1,0 +1,172 @@
+// extensions/atlascloud/body-builder.ts
+// Schema-driven request body builder for the Atlas Cloud video generation
+// provider. Kept in a separate file from the HTTP/auth runtime so it has
+// ZERO runtime imports from the SDK and can be tested standalone (Node's
+// `--experimental-strip-types` strips all `import type` statements).
+import type {
+  VideoGenerationRequest,
+  VideoGenerationSourceAsset,
+} from "openclaw/plugin-sdk/video-generation";
+import { resolveAtlasSchema } from "./model-schemas.js";
+
+const DEFAULT_ATLASCLOUD_VIDEO_MODEL = "google/veo3.1-fast/text-to-video";
+
+function toDataUrl(buffer: Buffer, mimeType: string): string {
+  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+}
+
+function sourceAssetToDataString(asset: VideoGenerationSourceAsset): string | undefined {
+  if (asset.url?.trim()) return asset.url.trim();
+  if (asset.buffer) return toDataUrl(asset.buffer, asset.mimeType?.trim() || "image/png");
+  return undefined;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Per-model / per-prefix passthrough parameters from
+ * `models.providers.atlascloud.extraParams`. Exact keys override prefix keys
+ * (longest prefix wins among prefixes).
+ */
+function resolveExtraParams(req: VideoGenerationRequest): Record<string, unknown> {
+  const config = (req.cfg?.models?.providers as Record<string, unknown> | undefined)?.atlascloud;
+  const extraMap = (
+    config as { extraParams?: Record<string, Record<string, unknown>> } | undefined
+  )?.extraParams;
+  if (!extraMap || typeof extraMap !== "object") return {};
+  const exact = extraMap[req.model];
+  const prefixHit = Object.keys(extraMap)
+    .filter((key) => key.endsWith("/") && req.model.startsWith(key))
+    .toSorted((a, b) => b.length - a.length)[0];
+  const prefix = prefixHit ? extraMap[prefixHit] : undefined;
+  return { ...(prefix ?? {}), ...(exact ?? {}) };
+}
+
+export function buildAtlasCloudVideoBody(req: VideoGenerationRequest): Record<string, unknown> {
+  const model = req.model?.trim() || DEFAULT_ATLASCLOUD_VIDEO_MODEL;
+  const schema = resolveAtlasSchema(model);
+  const body: Record<string, unknown> = {
+    model,
+    prompt: req.prompt,
+    ...(schema.defaults ?? {}),
+  };
+
+  // ---------------- 1. aspect_ratio ----------------
+  if (schema.fields.aspectRatio && req.aspectRatio?.trim()) {
+    const value = req.aspectRatio.trim();
+    if (schema.options?.aspectRatios && !schema.options.aspectRatios.includes(value)) {
+      throw new Error(
+        `Atlas Cloud ${model} does not support aspect_ratio="${value}"; allowed: ${schema.options.aspectRatios.join(", ")}`,
+      );
+    }
+    body[schema.fields.aspectRatio.name] = value;
+  }
+
+  // ---------------- 2. resolution ----------------
+  if (schema.fields.resolution && req.resolution) {
+    const raw = String(req.resolution);
+    const value =
+      schema.fields.resolution.case === "upper" ? raw.toUpperCase() : raw.toLowerCase();
+    if (schema.options?.resolutions && !schema.options.resolutions.includes(value)) {
+      throw new Error(
+        `Atlas Cloud ${model} does not support resolution="${value}"; allowed: ${schema.options.resolutions.join(", ")}`,
+      );
+    }
+    body[schema.fields.resolution.name] = value;
+  }
+
+  // ---------------- 3. size (auto-convert separator across families) ----------------
+  if (schema.fields.size && req.size?.trim()) {
+    const raw = req.size.trim();
+    const sep = schema.fields.size.sep;
+    const value = sep === "*" ? raw.replace(/x/i, "*") : raw.replace(/\*/g, "x");
+    if (schema.options?.sizes && !schema.options.sizes.includes(value)) {
+      throw new Error(
+        `Atlas Cloud ${model} does not support size="${value}"; allowed: ${schema.options.sizes.join(", ")}`,
+      );
+    }
+    body[schema.fields.size.name] = value;
+  }
+
+  // ---------------- 4. duration ----------------
+  if (schema.fields.duration && isFiniteNumber(req.durationSeconds)) {
+    const value = Math.max(1, Math.round(req.durationSeconds));
+    if (schema.options?.durations && !schema.options.durations.includes(value)) {
+      throw new Error(
+        `Atlas Cloud ${model} does not support duration=${value}; allowed: ${schema.options.durations.join(", ")}`,
+      );
+    }
+    body[schema.fields.duration.name] = value;
+  }
+
+  // ---------------- 5. audio (boolean only; URL audio uses extraParams) ----------------
+  if (schema.fields.audio && typeof req.audio === "boolean") {
+    if (schema.fields.audio.type === "boolean") {
+      body[schema.fields.audio.name] = req.audio;
+    }
+  }
+
+  // ---------------- 6. image / images ----------------
+  const images = req.inputImages ?? [];
+  if (schema.fields.image && images.length > 0) {
+    if (schema.fields.image.multi) {
+      const values = images
+        .slice(0, schema.fields.image.max)
+        .map(sourceAssetToDataString)
+        .filter((v): v is string => Boolean(v));
+      if (values.length > 0) body[schema.fields.image.name] = values;
+    } else {
+      const first = sourceAssetToDataString(images[0]);
+      if (first) body[schema.fields.image.name] = first;
+      if (schema.fields.endImage && images[1]) {
+        const last = sourceAssetToDataString(images[1]);
+        if (last) body[schema.fields.endImage.name] = last;
+      }
+    }
+  }
+
+  // ---------------- 7. video / videos ----------------
+  const videos = req.inputVideos ?? [];
+  if (schema.fields.video && videos.length > 0) {
+    if (schema.fields.video.multi) {
+      body[schema.fields.video.name] = videos
+        .map(sourceAssetToDataString)
+        .filter((v): v is string => Boolean(v));
+    } else {
+      const first = sourceAssetToDataString(videos[0]);
+      if (first) body[schema.fields.video.name] = first;
+    }
+  }
+
+  // ---------------- 8. mode-specific required-input checks ----------------
+  switch (schema.mode) {
+    case "image-to-video":
+    case "start-end-frame":
+      if (!body[schema.fields.image?.name ?? "image"]) {
+        throw new Error(`Atlas Cloud ${model} (${schema.mode}) requires inputImages`);
+      }
+      break;
+    case "video-to-video":
+    case "video-edit":
+      if (!body[schema.fields.video?.name ?? "videos"]) {
+        throw new Error(`Atlas Cloud ${model} (${schema.mode}) requires inputVideos`);
+      }
+      break;
+    case "reference-to-video":
+      if (!Array.isArray(body[schema.fields.image?.name ?? "images"])) {
+        throw new Error(
+          `Atlas Cloud ${model} (reference-to-video) requires 1 to N inputImages`,
+        );
+      }
+      break;
+    default:
+      break;
+  }
+
+  // ---------------- 9. user extraParams (highest priority) ----------------
+  Object.assign(body, resolveExtraParams(req));
+
+  return body;
+}

--- a/extensions/atlascloud/index.ts
+++ b/extensions/atlascloud/index.ts
@@ -1,0 +1,51 @@
+// extensions/atlascloud/index.ts
+// Plugin entrypoint. Registers Atlas Cloud as a video generation provider
+// with the public Plugin SDK and exposes its api-key auth method.
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import {
+  ATLASCLOUD_DEFAULT_VIDEO_MODEL_REF,
+  applyAtlasCloudConfig,
+} from "./onboard.js";
+import { buildAtlasCloudVideoGenerationProvider } from "./video-generation-provider.js";
+
+const PROVIDER_ID = "atlascloud";
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "Atlas Cloud Provider",
+  description: "Bundled Atlas Cloud video generation provider",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Atlas Cloud",
+      docsPath: "/providers/models",
+      envVars: ["ATLASCLOUD_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "Atlas Cloud API key",
+          hint: "Video generation API key",
+          optionKey: "atlascloudApiKey",
+          flagName: "--atlascloud-api-key",
+          envVar: "ATLASCLOUD_API_KEY",
+          promptMessage: "Enter Atlas Cloud API key",
+          defaultModel: ATLASCLOUD_DEFAULT_VIDEO_MODEL_REF,
+          expectedProviders: [PROVIDER_ID],
+          applyConfig: (cfg) => applyAtlasCloudConfig(cfg),
+          wizard: {
+            choiceId: "atlascloud-api-key",
+            choiceLabel: "Atlas Cloud API key",
+            choiceHint: "Video generation API key",
+            groupId: "atlascloud",
+            groupLabel: "Atlas Cloud",
+            groupHint: "Video generation",
+            onboardingScopes: ["video-generation"],
+          },
+        }),
+      ],
+    });
+    api.registerVideoGenerationProvider(buildAtlasCloudVideoGenerationProvider());
+  },
+});

--- a/extensions/atlascloud/model-schemas.ts
+++ b/extensions/atlascloud/model-schemas.ts
@@ -1,0 +1,896 @@
+// extensions/atlascloud/model-schemas.ts
+// Per-model schema table for Atlas Cloud video generation.
+//
+// Data sources:
+//   1) Entries with `verified: true` were captured directly from
+//      Atlas Cloud's `/api/v1/models/{id}` endpoint (Veo3.1 t2v/i2v,
+//      Kling v3.0 Pro t2v/i2v, Seedance v1.5 Pro t2v, Wan 2.6 v2v,
+//      Wan 2.7 t2v, Vidu Q3 r2v / Q3-Pro t2v, Sora-2 t2v/i2v,
+//      Hailuo 2.3 t2v-pro/i2v-pro).
+//   2) Entries with `verified: false` are extrapolated from a sibling
+//      verified schema in the same family + mode. The CI refresher
+//      (`scripts/refresh-schemas.ts`) periodically pulls fresh schemas
+//      from the Atlas Cloud OpenAPI and overrides these defaults.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type AtlasFamily =
+  | "google-veo"
+  | "kuaishou-kling"
+  | "bytedance-seedance"
+  | "alibaba-wan"
+  | "vidu"
+  | "openai-sora"
+  | "minimax-hailuo"
+  | "generic";
+
+export type AtlasMode =
+  | "text-to-video"
+  | "image-to-video"
+  | "video-to-video"
+  | "reference-to-video"
+  | "start-end-frame"
+  | "video-edit"
+  | "other";
+
+/** Maps a generic OpenClaw request concept onto the model's actual body field. */
+export type FieldRule<T extends string = string> = { name: T };
+
+export type AspectRatioRule = FieldRule;
+export type ResolutionRule = FieldRule & { case: "lower" | "upper" };
+export type SizeRule = FieldRule & { sep: "x" | "*" };
+export type DurationRule = FieldRule;
+export type AudioRule = FieldRule & { type: "boolean" | "url" };
+export type ImageRule =
+  | (FieldRule & { multi: false })
+  | (FieldRule & { multi: true; max: number });
+export type VideoRule = FieldRule & { multi: boolean };
+export type SeedRule = FieldRule & { randomSentinel?: number };
+export type NegativePromptRule = FieldRule;
+
+/** Full schema for one model: field mapping + value ranges + defaults. */
+export type AtlasModelSchema = {
+  family: AtlasFamily;
+  mode: AtlasMode;
+  fields: {
+    aspectRatio?: AspectRatioRule;
+    resolution?: ResolutionRule;
+    size?: SizeRule;
+    duration?: DurationRule;
+    audio?: AudioRule;
+    image?: ImageRule;
+    /** End-frame image field (image-to-video only). */
+    endImage?: FieldRule;
+    video?: VideoRule;
+    seed?: SeedRule;
+    negativePrompt?: NegativePromptRule;
+  };
+  options?: {
+    aspectRatios?: readonly string[];
+    resolutions?: readonly string[];
+    sizes?: readonly string[];
+    durations?: readonly number[];
+  };
+  defaults?: Readonly<Record<string, unknown>>;
+  verified?: boolean;
+};
+
+// =============================================================================
+// 7 family baselines
+// =============================================================================
+
+export const FAMILY_BASELINES: Record<AtlasFamily, AtlasModelSchema> = {
+  "google-veo": {
+    family: "google-veo",
+    mode: "other",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed" },
+      negativePrompt: { name: "negative_prompt" },
+    },
+    options: {
+      aspectRatios: ["16:9", "9:16"],
+      resolutions: ["720p", "1080p"],
+      durations: [4, 6, 8],
+    },
+  },
+  "kuaishou-kling": {
+    family: "kuaishou-kling",
+    mode: "other",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "sound", type: "boolean" },
+      negativePrompt: { name: "negative_prompt" },
+    },
+    options: { durations: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] },
+    defaults: { cfg_scale: 0.5, sound: true },
+  },
+  "bytedance-seedance": {
+    family: "bytedance-seedance",
+    mode: "other",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+    },
+    options: {
+      aspectRatios: ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+      resolutions: ["480p", "720p"],
+    },
+    defaults: { camera_fixed: false, seed: -1 },
+  },
+  "alibaba-wan": {
+    family: "alibaba-wan",
+    mode: "other",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      negativePrompt: { name: "negative_prompt" },
+    },
+    defaults: { enable_prompt_expansion: true, seed: -1 },
+  },
+  vidu: {
+    family: "vidu",
+    mode: "other",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+    },
+    options: {
+      aspectRatios: ["16:9", "9:16", "3:4", "4:3", "1:1"],
+      resolutions: ["540p", "720p", "1080p"],
+    },
+    defaults: { movement_amplitude: "auto", generate_audio: true },
+  },
+  "openai-sora": {
+    family: "openai-sora",
+    mode: "other",
+    fields: {
+      size: { name: "size", sep: "x" },
+      duration: { name: "duration" },
+    },
+    options: {
+      sizes: ["720x1280", "1280x720"],
+      durations: [4, 8, 12],
+    },
+  },
+  "minimax-hailuo": {
+    family: "minimax-hailuo",
+    mode: "other",
+    fields: {},
+    defaults: { enable_prompt_expansion: true },
+  },
+  generic: {
+    family: "generic",
+    mode: "other",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      seed: { name: "seed" },
+      negativePrompt: { name: "negative_prompt" },
+    },
+  },
+};
+
+// =============================================================================
+// 64 per-model overrides
+// =============================================================================
+
+export const MODEL_OVERRIDES: Readonly<Record<string, Partial<AtlasModelSchema>>> = {
+  // ---------------- Google Veo (8) ----------------
+  "google/veo3.1/text-to-video": {
+    family: "google-veo",
+    mode: "text-to-video",
+    verified: true,
+    defaults: { generate_audio: false, aspect_ratio: "16:9", duration: 4, resolution: "1080p" },
+  },
+  "google/veo3.1/image-to-video": {
+    family: "google-veo",
+    mode: "image-to-video",
+    verified: true,
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed" },
+      negativePrompt: { name: "negative_prompt" },
+      image: { name: "image", multi: false },
+      endImage: { name: "last_image" },
+    },
+    defaults: { generate_audio: false, aspect_ratio: "16:9", duration: 4, resolution: "1080p" },
+  },
+  "google/veo3.1/reference-to-video": {
+    family: "google-veo",
+    mode: "reference-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed" },
+      negativePrompt: { name: "negative_prompt" },
+      image: { name: "images", multi: true, max: 3 },
+    },
+  },
+  "google/veo3.1-fast/text-to-video": {
+    family: "google-veo",
+    mode: "text-to-video",
+    defaults: { generate_audio: false, duration: 4, resolution: "720p" },
+  },
+  "google/veo3.1-fast/image-to-video": {
+    family: "google-veo",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed" },
+      negativePrompt: { name: "negative_prompt" },
+      image: { name: "image", multi: false },
+      endImage: { name: "last_image" },
+    },
+  },
+  "google/veo3.1-lite/text-to-video": {
+    family: "google-veo",
+    mode: "text-to-video",
+    options: { resolutions: ["720p"], durations: [4, 6, 8] },
+    defaults: { generate_audio: false, resolution: "720p" },
+  },
+  "google/veo3.1-lite/image-to-video": {
+    family: "google-veo",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed" },
+      image: { name: "image", multi: false },
+      endImage: { name: "last_image" },
+    },
+    options: { resolutions: ["720p"] },
+  },
+  "google/veo3.1-lite/start-end-frame-to-video": {
+    family: "google-veo",
+    mode: "start-end-frame",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      image: { name: "image", multi: false },
+      endImage: { name: "last_image" },
+    },
+  },
+
+  // ---------------- Kuaishou Kling (16) ----------------
+  "kwaivgi/kling-v3.0-pro/text-to-video": {
+    family: "kuaishou-kling",
+    mode: "text-to-video",
+    verified: true,
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "sound", type: "boolean" },
+      negativePrompt: { name: "negative_prompt" },
+      aspectRatio: { name: "aspect_ratio" },
+    },
+    options: { aspectRatios: ["16:9", "9:16", "1:1"] },
+    defaults: { cfg_scale: 0.5, sound: true, duration: 5, aspect_ratio: "16:9" },
+  },
+  "kwaivgi/kling-v3.0-pro/image-to-video": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    verified: true,
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "sound", type: "boolean" },
+      negativePrompt: { name: "negative_prompt" },
+      image: { name: "image", multi: false },
+      endImage: { name: "end_image" },
+    },
+    defaults: { cfg_scale: 0.5, sound: true, duration: 5 },
+  },
+  "kwaivgi/kling-v3.0-std/text-to-video": {
+    family: "kuaishou-kling",
+    mode: "text-to-video",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "sound", type: "boolean" },
+      negativePrompt: { name: "negative_prompt" },
+      aspectRatio: { name: "aspect_ratio" },
+    },
+    options: { aspectRatios: ["16:9", "9:16", "1:1"] },
+  },
+  "kwaivgi/kling-v3.0-std/image-to-video": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "sound", type: "boolean" },
+      negativePrompt: { name: "negative_prompt" },
+      image: { name: "image", multi: false },
+      endImage: { name: "end_image" },
+    },
+  },
+  "kwaivgi/kling-v2.6-pro/text-to-video": {
+    family: "kuaishou-kling",
+    mode: "text-to-video",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "sound", type: "boolean" },
+      aspectRatio: { name: "aspect_ratio" },
+    },
+  },
+  "kwaivgi/kling-v2.6-pro/image-to-video": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "sound", type: "boolean" },
+      image: { name: "image", multi: false },
+      endImage: { name: "end_image" },
+    },
+  },
+  "kwaivgi/kling-v2.5-turbo-pro/text-to-video": {
+    family: "kuaishou-kling",
+    mode: "text-to-video",
+    fields: { duration: { name: "duration" }, aspectRatio: { name: "aspect_ratio" } },
+  },
+  "kwaivgi/kling-v2.5-turbo-pro/image-to-video": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: { duration: { name: "duration" }, image: { name: "image", multi: false } },
+  },
+  "kwaivgi/kling-v2.1-i2v-pro": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: { duration: { name: "duration" }, image: { name: "image", multi: false } },
+  },
+  "kwaivgi/kling-v2.1-t2v-master": {
+    family: "kuaishou-kling",
+    mode: "text-to-video",
+    fields: { duration: { name: "duration" }, aspectRatio: { name: "aspect_ratio" } },
+  },
+  "kwaivgi/kling-v2.1-i2v-master": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: { duration: { name: "duration" }, image: { name: "image", multi: false } },
+  },
+  "kwaivgi/kling-v1.6-i2v-pro": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: { duration: { name: "duration" }, image: { name: "image", multi: false } },
+  },
+  "kwaivgi/kling-video-o3-pro/text-to-video": {
+    family: "kuaishou-kling",
+    mode: "text-to-video",
+    fields: { duration: { name: "duration" }, aspectRatio: { name: "aspect_ratio" } },
+  },
+  "kwaivgi/kling-video-o3-pro/image-to-video": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: { duration: { name: "duration" }, image: { name: "image", multi: false } },
+  },
+  "kwaivgi/kling-video-o3-pro/reference-to-video": {
+    family: "kuaishou-kling",
+    mode: "reference-to-video",
+    fields: { duration: { name: "duration" }, image: { name: "images", multi: true, max: 4 } },
+  },
+  "kwaivgi/kling-video-o3-pro/video-edit": {
+    family: "kuaishou-kling",
+    mode: "video-edit",
+    fields: { video: { name: "video", multi: false } },
+  },
+  "kwaivgi/kling-v2.6-pro/avatar": {
+    family: "kuaishou-kling",
+    mode: "image-to-video",
+    fields: { image: { name: "image", multi: false } },
+  },
+
+  // ---------------- ByteDance Seedance (12) ----------------
+  "bytedance/seedance-v1.5-pro/text-to-video": {
+    family: "bytedance-seedance",
+    mode: "text-to-video",
+    verified: true,
+    defaults: {
+      generate_audio: true,
+      camera_fixed: false,
+      seed: -1,
+      duration: 5,
+      resolution: "720p",
+    },
+  },
+  "bytedance/seedance-v1.5-pro/image-to-video": {
+    family: "bytedance-seedance",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+      image: { name: "image", multi: false },
+      endImage: { name: "last_image" },
+    },
+    defaults: { generate_audio: true, camera_fixed: false, seed: -1 },
+  },
+  "bytedance/seedance-v1.5-pro/text-to-video-fast": {
+    family: "bytedance-seedance",
+    mode: "text-to-video",
+  },
+  "bytedance/seedance-v1.5-pro/image-to-video-fast": {
+    family: "bytedance-seedance",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+      image: { name: "image", multi: false },
+      endImage: { name: "last_image" },
+    },
+  },
+  "bytedance/seedance-v1.5-pro/image-to-video-spicy": {
+    family: "bytedance-seedance",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+      image: { name: "image", multi: false },
+    },
+  },
+  "bytedance/seedance-v1-pro-fast/text-to-video": {
+    family: "bytedance-seedance",
+    mode: "text-to-video",
+  },
+  "bytedance/seedance-v1-pro-fast/image-to-video": {
+    family: "bytedance-seedance",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+      image: { name: "image", multi: false },
+    },
+  },
+  "bytedance/seedance-v1-pro-t2v-1080p": {
+    family: "bytedance-seedance",
+    mode: "text-to-video",
+    options: { resolutions: ["1080p"] },
+    defaults: { resolution: "1080p" },
+  },
+  "bytedance/seedance-v1-pro-t2v-720p": {
+    family: "bytedance-seedance",
+    mode: "text-to-video",
+    options: { resolutions: ["720p"] },
+    defaults: { resolution: "720p" },
+  },
+  "bytedance/seedance-v1-pro-i2v-1080p": {
+    family: "bytedance-seedance",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+      image: { name: "image", multi: false },
+    },
+    options: { resolutions: ["1080p"] },
+    defaults: { resolution: "1080p" },
+  },
+  "bytedance/seedance-v1-lite-t2v-720p": {
+    family: "bytedance-seedance",
+    mode: "text-to-video",
+    options: { resolutions: ["720p"] },
+  },
+  "bytedance/seedance-v1-lite-i2v-720p": {
+    family: "bytedance-seedance",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      image: { name: "image", multi: false },
+    },
+    options: { resolutions: ["720p"] },
+  },
+
+  // ---------------- Alibaba Wan (10) ----------------
+  // NOTE: Wan 2.7 and Wan 2.6 use very different field names; they MUST be
+  // overridden separately. Do not assume family-level commonality here.
+  "alibaba/wan-2.7/text-to-video": {
+    family: "alibaba-wan",
+    mode: "text-to-video",
+    verified: true,
+    fields: {
+      // Wan 2.7 uses `ratio`, not `aspect_ratio`.
+      aspectRatio: { name: "ratio" },
+      // Wan 2.7 uses uppercase `1080P` / `720P`.
+      resolution: { name: "resolution", case: "upper" },
+      duration: { name: "duration" },
+      // NOTE: Wan 2.7 `audio` is a URL string, not a boolean. The boolean
+      // `req.audio` cannot express that — pass via extraParams instead.
+      seed: { name: "seed", randomSentinel: -1 },
+      negativePrompt: { name: "negative_prompt" },
+    },
+    options: {
+      aspectRatios: ["16:9", "9:16", "1:1", "4:3", "3:4"],
+      resolutions: ["720P", "1080P"],
+    },
+    defaults: {
+      prompt_extend: true,
+      seed: -1,
+      ratio: "16:9",
+      resolution: "1080P",
+      duration: 5,
+    },
+  },
+  "alibaba/wan-2.7/image-to-video": {
+    family: "alibaba-wan",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "ratio" },
+      resolution: { name: "resolution", case: "upper" },
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      negativePrompt: { name: "negative_prompt" },
+      image: { name: "image", multi: false },
+    },
+    options: { resolutions: ["720P", "1080P"] },
+    defaults: { prompt_extend: true, seed: -1 },
+  },
+  "alibaba/wan-2.7/reference-to-video": {
+    family: "alibaba-wan",
+    mode: "reference-to-video",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      image: { name: "images", multi: true, max: 4 },
+    },
+  },
+  "alibaba/wan-2.7/video-edit": {
+    family: "alibaba-wan",
+    mode: "video-edit",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      video: { name: "video", multi: false },
+    },
+  },
+  "alibaba/wan-2.6/text-to-video": {
+    family: "alibaba-wan",
+    mode: "text-to-video",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      negativePrompt: { name: "negative_prompt" },
+      // Wan 2.6 uses `size` with `*` separator.
+      size: { name: "size", sep: "*" },
+    },
+    options: {
+      sizes: [
+        "1280*720",
+        "720*1280",
+        "960*960",
+        "1088*832",
+        "832*1088",
+        "1920*1080",
+        "1080*1920",
+      ],
+      durations: [5, 10],
+    },
+    defaults: { enable_prompt_expansion: true, seed: -1, size: "1280*720", duration: 5 },
+  },
+  "alibaba/wan-2.6/image-to-video": {
+    family: "alibaba-wan",
+    mode: "image-to-video",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      negativePrompt: { name: "negative_prompt" },
+      size: { name: "size", sep: "*" },
+      image: { name: "image", multi: false },
+    },
+    options: { durations: [5, 10] },
+    defaults: { enable_prompt_expansion: true, seed: -1 },
+  },
+  "alibaba/wan-2.6/video-to-video": {
+    family: "alibaba-wan",
+    mode: "video-to-video",
+    verified: true,
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      negativePrompt: { name: "negative_prompt" },
+      size: { name: "size", sep: "*" },
+      video: { name: "videos", multi: true },
+    },
+    options: {
+      sizes: [
+        "1280*720",
+        "720*1280",
+        "960*960",
+        "1088*832",
+        "832*1088",
+        "1920*1080",
+        "1080*1920",
+      ],
+      durations: [5, 10],
+    },
+    defaults: { enable_prompt_expansion: true, shot_type: "multi", seed: -1, size: "1280*720" },
+  },
+  "alibaba/wan-2.6/image-to-video-flash": {
+    family: "alibaba-wan",
+    mode: "image-to-video",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      size: { name: "size", sep: "*" },
+      image: { name: "image", multi: false },
+    },
+  },
+  "alibaba/wan-2.5/text-to-video": {
+    family: "alibaba-wan",
+    mode: "text-to-video",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      negativePrompt: { name: "negative_prompt" },
+      size: { name: "size", sep: "*" },
+    },
+  },
+  "alibaba/wan-2.5/image-to-video": {
+    family: "alibaba-wan",
+    mode: "image-to-video",
+    fields: {
+      duration: { name: "duration" },
+      seed: { name: "seed", randomSentinel: -1 },
+      size: { name: "size", sep: "*" },
+      image: { name: "image", multi: false },
+    },
+  },
+
+  // ---------------- Vidu (10) ----------------
+  "vidu/q3/reference-to-video": {
+    family: "vidu",
+    mode: "reference-to-video",
+    verified: true,
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+      image: { name: "images", multi: true, max: 4 },
+    },
+    defaults: { movement_amplitude: "auto", generate_audio: true, aspect_ratio: "16:9" },
+  },
+  "vidu/q3-pro/text-to-video": {
+    family: "vidu",
+    mode: "text-to-video",
+    verified: true,
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      seed: { name: "seed", randomSentinel: -1 },
+    },
+    options: {
+      aspectRatios: ["16:9", "9:16", "4:3", "3:4", "1:1"],
+      resolutions: ["540p", "720p", "1080p"],
+    },
+    defaults: {
+      style: "general",
+      movement_amplitude: "auto",
+      generate_audio: true,
+      bgm: true,
+      duration: 5,
+      aspect_ratio: "4:3",
+    },
+  },
+  "vidu/q3-pro/image-to-video": {
+    family: "vidu",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      image: { name: "image", multi: false },
+    },
+  },
+  "vidu/q3-pro/start-end-to-video": {
+    family: "vidu",
+    mode: "start-end-frame",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      image: { name: "image", multi: false },
+      endImage: { name: "last_image" },
+    },
+  },
+  "vidu/q3-turbo/text-to-video": {
+    family: "vidu",
+    mode: "text-to-video",
+    options: { resolutions: ["540p", "720p"] },
+  },
+  "vidu/q3-turbo/image-to-video": {
+    family: "vidu",
+    mode: "image-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      image: { name: "image", multi: false },
+    },
+    options: { resolutions: ["540p", "720p"] },
+  },
+  "vidu/q3-mix/reference-to-video": {
+    family: "vidu",
+    mode: "reference-to-video",
+    fields: {
+      aspectRatio: { name: "aspect_ratio" },
+      resolution: { name: "resolution", case: "lower" },
+      duration: { name: "duration" },
+      image: { name: "images", multi: true, max: 4 },
+    },
+  },
+  "vidu/q2-pro-fast/reference-to-video": {
+    family: "vidu",
+    mode: "reference-to-video",
+    fields: { duration: { name: "duration" }, image: { name: "images", multi: true, max: 4 } },
+  },
+  "vidu/q2-pro-fast/reference-to-video-with-audio": {
+    family: "vidu",
+    mode: "reference-to-video",
+    fields: {
+      duration: { name: "duration" },
+      audio: { name: "generate_audio", type: "boolean" },
+      image: { name: "images", multi: true, max: 4 },
+    },
+  },
+  "vidu/reference-to-video-q1": {
+    family: "vidu",
+    mode: "reference-to-video",
+    fields: { image: { name: "images", multi: true, max: 4 } },
+  },
+
+  // ---------------- OpenAI Sora (2) ----------------
+  "openai/sora-2/text-to-video": {
+    family: "openai-sora",
+    mode: "text-to-video",
+    verified: true,
+    defaults: { duration: 4, size: "720x1280" },
+  },
+  "openai/sora-2/image-to-video": {
+    family: "openai-sora",
+    mode: "image-to-video",
+    verified: true,
+    fields: {
+      size: { name: "size", sep: "x" },
+      duration: { name: "duration" },
+      image: { name: "image", multi: false },
+    },
+    defaults: { duration: 4, size: "720x1280" },
+  },
+
+  // ---------------- MiniMax Hailuo (8) ----------------
+  "minimax/hailuo-2.3/t2v-pro": {
+    family: "minimax-hailuo",
+    mode: "text-to-video",
+    verified: true,
+    defaults: { enable_prompt_expansion: true },
+  },
+  "minimax/hailuo-2.3/t2v-standard": {
+    family: "minimax-hailuo",
+    mode: "text-to-video",
+  },
+  "minimax/hailuo-2.3/i2v-pro": {
+    family: "minimax-hailuo",
+    mode: "image-to-video",
+    verified: true,
+    fields: { image: { name: "image", multi: false } },
+    defaults: { enable_prompt_expansion: true },
+  },
+  "minimax/hailuo-2.3/i2v-standard": {
+    family: "minimax-hailuo",
+    mode: "image-to-video",
+    fields: { image: { name: "image", multi: false } },
+  },
+  "minimax/hailuo-2.3/fast": {
+    family: "minimax-hailuo",
+    mode: "text-to-video",
+  },
+  "minimax/hailuo-02/t2v-pro": {
+    family: "minimax-hailuo",
+    mode: "text-to-video",
+  },
+  "minimax/hailuo-02/i2v-pro": {
+    family: "minimax-hailuo",
+    mode: "image-to-video",
+    fields: { image: { name: "image", multi: false } },
+  },
+  "minimax/hailuo-02/fast": {
+    family: "minimax-hailuo",
+    mode: "text-to-video",
+  },
+};
+
+// =============================================================================
+// Schema resolver
+// =============================================================================
+
+function detectFamilyFromId(model: string): AtlasFamily {
+  const id = model.toLowerCase();
+  if (id.startsWith("google/veo")) return "google-veo";
+  if (id.startsWith("kwaivgi/kling")) return "kuaishou-kling";
+  if (id.startsWith("bytedance/seedance")) return "bytedance-seedance";
+  if (
+    id.startsWith("alibaba/wan") ||
+    id.startsWith("atlascloud/wan") ||
+    id.startsWith("atlascloud/van")
+  ) {
+    return "alibaba-wan";
+  }
+  if (id.startsWith("vidu/")) return "vidu";
+  if (id.startsWith("openai/sora")) return "openai-sora";
+  if (id.startsWith("minimax/hailuo")) return "minimax-hailuo";
+  return "generic";
+}
+
+function detectModeFromId(model: string): AtlasMode {
+  const id = model.toLowerCase();
+  if (id.includes("/text-to-video") || id.includes("/t2v")) return "text-to-video";
+  if (id.includes("/image-to-video") || id.includes("/i2v")) return "image-to-video";
+  if (id.includes("/video-to-video")) return "video-to-video";
+  if (id.includes("/reference-to-video") || id.includes("reference-to-video")) {
+    return "reference-to-video";
+  }
+  if (id.includes("/start-end") || id.includes("start-end-frame")) return "start-end-frame";
+  if (id.includes("/video-edit")) return "video-edit";
+  return "other";
+}
+
+/**
+ * Resolve the final schema for a model. Override fields/options/defaults are
+ * shallow-merged on top of the family baseline. Unregistered models fall back
+ * to the family baseline plus generic field detection.
+ */
+export function resolveAtlasSchema(model: string): AtlasModelSchema {
+  const override = MODEL_OVERRIDES[model];
+  const family = override?.family ?? detectFamilyFromId(model);
+  const mode = override?.mode ?? detectModeFromId(model);
+  const baseline = FAMILY_BASELINES[family];
+
+  return {
+    family,
+    mode,
+    verified: override?.verified ?? false,
+    fields: { ...baseline.fields, ...(override?.fields ?? {}) },
+    options: { ...baseline.options, ...(override?.options ?? {}) },
+    defaults: { ...baseline.defaults, ...(override?.defaults ?? {}) },
+  };
+}
+
+/** Registered model list (used by VideoGenerationProvider.models). */
+export const REGISTERED_ATLAS_MODELS: readonly string[] = Object.keys(MODEL_OVERRIDES);

--- a/extensions/atlascloud/onboard.ts
+++ b/extensions/atlascloud/onboard.ts
@@ -1,0 +1,25 @@
+// Onboarding helper for the Atlas Cloud video generation provider.
+// Sets a sensible default video model when the user first adds an Atlas
+// Cloud API key through the wizard, but never overwrites a user choice.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+
+export const ATLASCLOUD_DEFAULT_VIDEO_MODEL_REF =
+  "atlascloud/google/veo3.1-fast/text-to-video";
+
+export function applyAtlasCloudConfig(cfg: OpenClawConfig): OpenClawConfig {
+  if (cfg.agents?.defaults?.videoGenerationModel) {
+    return cfg;
+  }
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        videoGenerationModel: {
+          primary: ATLASCLOUD_DEFAULT_VIDEO_MODEL_REF,
+        },
+      },
+    },
+  };
+}

--- a/extensions/atlascloud/openclaw.plugin.json
+++ b/extensions/atlascloud/openclaw.plugin.json
@@ -1,0 +1,32 @@
+{
+  "id": "atlascloud",
+  "enabledByDefault": true,
+  "providers": ["atlascloud"],
+  "providerAuthEnvVars": {
+    "atlascloud": ["ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "atlascloud",
+      "method": "api-key",
+      "choiceId": "atlascloud-api-key",
+      "choiceLabel": "Atlas Cloud API key",
+      "groupId": "atlascloud",
+      "groupLabel": "Atlas Cloud",
+      "groupHint": "Video generation",
+      "onboardingScopes": ["video-generation"],
+      "optionKey": "atlascloudApiKey",
+      "cliFlag": "--atlascloud-api-key",
+      "cliOption": "--atlascloud-api-key <key>",
+      "cliDescription": "Atlas Cloud API key"
+    }
+  ],
+  "contracts": {
+    "videoGenerationProviders": ["atlascloud"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/atlascloud/package.json
+++ b/extensions/atlascloud/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/atlascloud-provider",
+  "version": "2026.4.6",
+  "private": true,
+  "description": "OpenClaw Atlas Cloud video generation provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/atlascloud/tsconfig.json
+++ b/extensions/atlascloud/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**"
+  ]
+}

--- a/extensions/atlascloud/video-generation-provider.test.ts
+++ b/extensions/atlascloud/video-generation-provider.test.ts
@@ -1,0 +1,190 @@
+// Offline unit tests for the Atlas Cloud schema-driven body builder.
+// No HTTP traffic, no API key, no fixtures. These guard the per-model field
+// mapping that turns generic OpenClaw video generation requests into the
+// per-family request bodies that Atlas Cloud actually expects.
+import { describe, expect, it } from "vitest";
+import type { VideoGenerationRequest } from "openclaw/plugin-sdk/video-generation";
+import { buildAtlasCloudVideoBody } from "./video-generation-provider.js";
+
+function makeReq(overrides: Partial<VideoGenerationRequest> = {}): VideoGenerationRequest {
+  return {
+    provider: "atlascloud",
+    model: "google/veo3.1/text-to-video",
+    prompt: "a calm sunrise over mountains",
+    cfg: {} as VideoGenerationRequest["cfg"],
+    ...overrides,
+  };
+}
+
+describe("buildAtlasCloudVideoBody", () => {
+  it("uses Veo field names for google/veo3.1/text-to-video", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({ aspectRatio: "16:9", durationSeconds: 6, audio: true }),
+    );
+    expect(body).toMatchObject({
+      model: "google/veo3.1/text-to-video",
+      prompt: "a calm sunrise over mountains",
+      aspect_ratio: "16:9",
+      duration: 6,
+      generate_audio: true,
+    });
+  });
+
+  it("uses Kling 'sound' instead of 'generate_audio'", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        model: "kwaivgi/kling-v3.0-pro/text-to-video",
+        audio: false,
+        durationSeconds: 5,
+      }),
+    );
+    expect(body.sound).toBe(false);
+    expect(body).not.toHaveProperty("generate_audio");
+  });
+
+  it("uses Wan 2.7 'ratio' field and uppercase resolution", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        model: "alibaba/wan-2.7/text-to-video",
+        aspectRatio: "9:16",
+        resolution: "1080P",
+      }),
+    );
+    expect(body.ratio).toBe("9:16");
+    expect(body.resolution).toBe("1080P");
+    expect(body).not.toHaveProperty("aspect_ratio");
+  });
+
+  it("converts size separator from 'x' to '*' for Wan 2.6", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({ model: "alibaba/wan-2.6/text-to-video", size: "1280x720" }),
+    );
+    expect(body.size).toBe("1280*720");
+  });
+
+  it("packs Vidu reference-to-video images into an 'images' array", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        model: "vidu/q3/reference-to-video",
+        inputImages: [
+          { url: "https://example.com/a.png" },
+          { url: "https://example.com/b.png" },
+        ],
+      }),
+    );
+    expect(body.images).toEqual(["https://example.com/a.png", "https://example.com/b.png"]);
+  });
+
+  it("uses Veo 'last_image' for the second image (end frame)", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        model: "google/veo3.1/image-to-video",
+        inputImages: [
+          { url: "https://example.com/start.png" },
+          { url: "https://example.com/end.png" },
+        ],
+      }),
+    );
+    expect(body.image).toBe("https://example.com/start.png");
+    expect(body.last_image).toBe("https://example.com/end.png");
+  });
+
+  it("uses Kling 'end_image' for the second image (end frame)", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        model: "kwaivgi/kling-v3.0-pro/image-to-video",
+        inputImages: [
+          { url: "https://example.com/start.png" },
+          { url: "https://example.com/end.png" },
+        ],
+      }),
+    );
+    expect(body.image).toBe("https://example.com/start.png");
+    expect(body.end_image).toBe("https://example.com/end.png");
+    expect(body).not.toHaveProperty("last_image");
+  });
+
+  it("rejects unsupported aspect_ratio against Veo's option list", () => {
+    expect(() =>
+      buildAtlasCloudVideoBody(
+        makeReq({ model: "google/veo3.1/text-to-video", aspectRatio: "3:4" }),
+      ),
+    ).toThrow(/does not support aspect_ratio/);
+  });
+
+  it("requires inputImages for image-to-video models", () => {
+    expect(() =>
+      buildAtlasCloudVideoBody(makeReq({ model: "google/veo3.1/image-to-video" })),
+    ).toThrow(/requires inputImages/);
+  });
+
+  it("requires inputVideos for video-to-video models", () => {
+    expect(() =>
+      buildAtlasCloudVideoBody(
+        makeReq({ model: "alibaba/wan-2.6/video-to-video", prompt: "x" }),
+      ),
+    ).toThrow(/requires inputVideos/);
+  });
+
+  it("packs Wan 2.6 v2v inputVideos into a 'videos' array", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        model: "alibaba/wan-2.6/video-to-video",
+        inputVideos: [{ url: "https://example.com/ref.mp4" }],
+      }),
+    );
+    expect(body.videos).toEqual(["https://example.com/ref.mp4"]);
+  });
+
+  it("merges per-model defaults from the schema table", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({ model: "alibaba/wan-2.7/text-to-video" }),
+    );
+    // Wan 2.7 schema defaults: prompt_extend, seed, ratio, resolution, duration
+    expect(body).toMatchObject({
+      prompt_extend: true,
+      seed: -1,
+      ratio: "16:9",
+      resolution: "1080P",
+      duration: 5,
+    });
+  });
+
+  it("user extraParams override per-model defaults (exact + prefix)", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        model: "kwaivgi/kling-v3.0-pro/text-to-video",
+        cfg: {
+          models: {
+            providers: {
+              atlascloud: {
+                extraParams: {
+                  "kwaivgi/kling-v3.0-pro/": { cfg_scale: 0.7 },
+                  "kwaivgi/kling-v3.0-pro/text-to-video": { seed: 42 },
+                },
+              },
+            },
+          },
+        } as VideoGenerationRequest["cfg"],
+      }),
+    );
+    expect(body.cfg_scale).toBe(0.7);
+    expect(body.seed).toBe(42);
+  });
+
+  it("falls back to family baseline for unregistered model ids", () => {
+    const body = buildAtlasCloudVideoBody(
+      makeReq({
+        // not in MODEL_OVERRIDES; should hit minimax-hailuo baseline
+        model: "minimax/hailuo-99/text-to-video",
+        durationSeconds: 5,
+      }),
+    );
+    expect(body.model).toBe("minimax/hailuo-99/text-to-video");
+    expect(body.prompt).toBe("a calm sunrise over mountains");
+    // hailuo baseline has empty fields {} so no aspect_ratio mapping
+    expect(body).not.toHaveProperty("aspect_ratio");
+    // hailuo baseline default
+    expect(body.enable_prompt_expansion).toBe(true);
+  });
+});

--- a/extensions/atlascloud/video-generation-provider.ts
+++ b/extensions/atlascloud/video-generation-provider.ts
@@ -1,0 +1,453 @@
+// extensions/atlascloud/video-generation-provider.ts
+// Atlas Cloud video generation provider — HTTP transport, auth wiring, and
+// the VideoGenerationProvider factory. The pure schema-driven request body
+// builder lives in `./body-builder.ts` so it can be tested without loading
+// any SDK runtime modules.
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  assertOkOrThrowHttpError,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+import {
+  fetchWithSsrFGuard,
+  type SsrFPolicy,
+  ssrfPolicyFromDangerouslyAllowPrivateNetwork,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import type {
+  GeneratedVideoAsset,
+  VideoGenerationProvider,
+  VideoGenerationRequest,
+  VideoGenerationSourceAsset,
+} from "openclaw/plugin-sdk/video-generation";
+import { buildAtlasCloudVideoBody } from "./body-builder.js";
+import { REGISTERED_ATLAS_MODELS } from "./model-schemas.js";
+
+// Re-export so existing tests and external consumers that imported the body
+// builder from this module keep working.
+export { buildAtlasCloudVideoBody } from "./body-builder.js";
+
+const DEFAULT_BASE_URL = "https://api.atlascloud.ai";
+const SUBMIT_PATH = "/api/v1/model/generateVideo";
+const UPLOAD_PATH = "/api/v1/model/uploadMedia";
+// Different model docs reference different polling paths; try each.
+const RESULT_PATHS = ["/api/v1/model/result", "/api/v1/model/prediction"] as const;
+const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
+const UPLOAD_HTTP_TIMEOUT_MS = 60_000;
+const DEFAULT_OPERATION_TIMEOUT_MS = 600_000;
+const POLL_INTERVAL_MS = 5_000;
+// Inline base64 is fine for small images, but anything larger is wasteful in
+// the request body and starts hitting per-model size limits (Kling: 10MB).
+// Anything at or above this threshold is uploaded via /uploadMedia first.
+const INLINE_BASE64_THRESHOLD_BYTES = 2 * 1024 * 1024; // 2 MiB
+
+const DEFAULT_ATLASCLOUD_VIDEO_MODEL = "google/veo3.1-fast/text-to-video";
+
+// =============================================================================
+// HTTP transport
+// =============================================================================
+let atlasFetchGuard = fetchWithSsrFGuard;
+export function _setAtlasFetchGuardForTesting(
+  impl: typeof fetchWithSsrFGuard | null,
+): void {
+  atlasFetchGuard = impl ?? fetchWithSsrFGuard;
+}
+
+function buildPolicy(allowPrivateNetwork: boolean): SsrFPolicy | undefined {
+  return allowPrivateNetwork ? ssrfPolicyFromDangerouslyAllowPrivateNetwork(true) : undefined;
+}
+
+type AtlasSubmitResponse = {
+  code?: number;
+  message?: string;
+  data?: { id?: string; urls?: { get?: string } & Record<string, string> };
+};
+
+type AtlasResultResponse = {
+  code?: number;
+  message?: string;
+  // Some failure paths surface a numeric vendor error code at the top level.
+  error_code?: number;
+  data?: {
+    id?: string;
+    model?: string;
+    status?: string;
+    outputs?: string[] | null;
+    // The real API returns `null` (not `[]`) when there are no NSFW flags.
+    has_nsfw_contents?: boolean[] | null;
+    created_at?: string;
+    // Failure detail. When the upstream provider rejects a request, this is
+    // the cleanest error string — `message` at the top level wraps the entire
+    // upstream JSON response and is not human-friendly.
+    error?: string;
+    executionTime?: number;
+    timings?: { inference?: number };
+    urls?: { get?: string } & Record<string, string>;
+  };
+};
+
+async function fetchAtlasJson<T>(params: {
+  url: string;
+  init?: RequestInit;
+  timeoutMs: number;
+  policy: SsrFPolicy | undefined;
+  dispatcherPolicy: Parameters<typeof fetchWithSsrFGuard>[0]["dispatcherPolicy"];
+  auditContext: string;
+  errorContext: string;
+}): Promise<T> {
+  const { response, release } = await atlasFetchGuard({
+    url: params.url,
+    init: params.init,
+    timeoutMs: params.timeoutMs,
+    policy: params.policy,
+    dispatcherPolicy: params.dispatcherPolicy,
+    auditContext: params.auditContext,
+  });
+  try {
+    await assertOkOrThrowHttpError(response, params.errorContext);
+    return (await response.json()) as T;
+  } finally {
+    await release();
+  }
+}
+
+async function pollAtlasResult(args: {
+  baseUrl: string;
+  predictionId: string;
+  /** Canonical poll URL returned by the submit response (`data.urls.get`). */
+  preferredUrl?: string;
+  headers: Headers;
+  timeoutMs: number;
+  policy: SsrFPolicy | undefined;
+  dispatcherPolicy: Parameters<typeof fetchWithSsrFGuard>[0]["dispatcherPolicy"];
+}): Promise<AtlasResultResponse["data"]> {
+  const deadline = Date.now() + args.timeoutMs;
+  let lastStatus = "unknown";
+  // Prefer the canonical URL from submit's `data.urls.get`. Fall back to the
+  // documented `result/` and `prediction/` paths in case it is missing.
+  const candidates = [
+    ...(args.preferredUrl ? [args.preferredUrl] : []),
+    ...RESULT_PATHS.map((p) => `${args.baseUrl}${p}/${args.predictionId}`),
+  ];
+  while (Date.now() < deadline) {
+    let payload: AtlasResultResponse | undefined;
+    for (const url of candidates) {
+      try {
+        payload = await fetchAtlasJson<AtlasResultResponse>({
+          url,
+          init: { method: "GET", headers: args.headers },
+          timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
+          policy: args.policy,
+          dispatcherPolicy: args.dispatcherPolicy,
+          auditContext: "atlascloud-video-status",
+          errorContext: "Atlas Cloud video status request failed",
+        });
+        if (payload.data) break;
+      } catch {
+        // Try the next candidate path.
+      }
+    }
+    const data = payload?.data;
+    const status = data?.status?.toLowerCase().trim();
+    if (status) lastStatus = status;
+    if (status === "completed" || status === "succeeded") return data;
+    if (status === "failed" || status === "cancelled") {
+      // Prefer `data.error` (clean upstream message); fall back to top-level
+      // `message` (which on failure wraps the entire upstream JSON body, but
+      // is better than nothing).
+      const detail =
+        data?.error?.trim() ||
+        payload?.message?.trim() ||
+        `Atlas Cloud video generation ${status}`;
+      throw new Error(detail);
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `Atlas Cloud video generation did not finish in time (last status: ${lastStatus})`,
+  );
+}
+
+async function downloadAtlasVideo(
+  url: string,
+  policy: SsrFPolicy | undefined,
+): Promise<GeneratedVideoAsset> {
+  const { response, release } = await atlasFetchGuard({
+    url,
+    timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
+    policy,
+    auditContext: "atlascloud-video-download",
+  });
+  try {
+    await assertOkOrThrowHttpError(response, "Atlas Cloud generated video download failed");
+    const mimeType = response.headers.get("content-type")?.trim() || "video/mp4";
+    const arrayBuffer = await response.arrayBuffer();
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      mimeType,
+      fileName: `video-1.${mimeType.includes("webm") ? "webm" : "mp4"}`,
+    };
+  } finally {
+    await release();
+  }
+}
+
+// =============================================================================
+// Media upload (POST /api/v1/model/uploadMedia)
+//
+// Atlas Cloud accepts both base64 data URLs and public URLs in the image /
+// images / videos request fields. For small images we keep the simple inline
+// path; once a buffer crosses INLINE_BASE64_THRESHOLD_BYTES we POST it to
+// /uploadMedia first and use the returned `download_url` instead — this
+// avoids per-model size limits (Kling: 10 MB) and keeps submit bodies small.
+// =============================================================================
+
+type AtlasUploadResponse = {
+  code?: number;
+  message?: string;
+  data?: {
+    type?: string;
+    download_url?: string;
+    filename?: string;
+    size?: number;
+  };
+};
+
+function pickMimeType(asset: VideoGenerationSourceAsset): string {
+  return asset.mimeType?.trim() || "application/octet-stream";
+}
+
+function pickFilename(asset: VideoGenerationSourceAsset, fallback: string): string {
+  const explicit = asset.fileName?.trim();
+  if (explicit) return explicit;
+  const mime = pickMimeType(asset);
+  if (mime.startsWith("image/")) return `${fallback}.${mime.split("/")[1] ?? "png"}`;
+  if (mime.startsWith("video/")) return `${fallback}.${mime.split("/")[1] ?? "mp4"}`;
+  return fallback;
+}
+
+/**
+ * Upload a single Buffer to Atlas Cloud's `/model/uploadMedia` endpoint and
+ * return the public `download_url`. The endpoint is multipart/form-data with
+ * a single `file` field. The response shape is taken from the official
+ * `AtlasCloudAI/mcp-server` types.
+ */
+async function uploadAtlasCloudMedia(args: {
+  buffer: Buffer;
+  filename: string;
+  mimeType: string;
+  baseUrl: string;
+  headers: Headers;
+  policy: SsrFPolicy | undefined;
+  dispatcherPolicy: Parameters<typeof fetchWithSsrFGuard>[0]["dispatcherPolicy"];
+}): Promise<string> {
+  const form = new FormData();
+  form.append(
+    "file",
+    new Blob([args.buffer], { type: args.mimeType }),
+    args.filename,
+  );
+
+  // Strip the JSON Content-Type header inherited from the submit config so
+  // fetch can set the multipart boundary itself.
+  const uploadHeaders = new Headers(args.headers);
+  uploadHeaders.delete("content-type");
+
+  const { response, release } = await atlasFetchGuard({
+    url: `${args.baseUrl}${UPLOAD_PATH}`,
+    init: { method: "POST", headers: uploadHeaders, body: form },
+    timeoutMs: UPLOAD_HTTP_TIMEOUT_MS,
+    policy: args.policy,
+    dispatcherPolicy: args.dispatcherPolicy,
+    auditContext: "atlascloud-media-upload",
+  });
+  try {
+    await assertOkOrThrowHttpError(response, "Atlas Cloud media upload failed");
+    const payload = (await response.json()) as AtlasUploadResponse;
+    const url = payload.data?.download_url?.trim();
+    if (!url) {
+      throw new Error(
+        `Atlas Cloud upload response missing download_url (code=${payload.code ?? "?"}): ${payload.message ?? ""}`,
+      );
+    }
+    return url;
+  } finally {
+    await release();
+  }
+}
+
+/**
+ * Mutate every input asset in `req` whose buffer exceeds the inline threshold
+ * to use the uploaded `download_url` as its URL. Buffers below the threshold
+ * remain inline (cheaper one-shot path). Returns the same request reference
+ * for chaining.
+ *
+ * Implementation note: we walk both `inputImages` and `inputVideos`. Videos
+ * almost always exceed the threshold and must be uploaded.
+ */
+async function prepareAtlasCloudInputs(
+  req: VideoGenerationRequest,
+  uploadCtx: {
+    baseUrl: string;
+    headers: Headers;
+    policy: SsrFPolicy | undefined;
+    dispatcherPolicy: Parameters<typeof fetchWithSsrFGuard>[0]["dispatcherPolicy"];
+  },
+): Promise<VideoGenerationRequest> {
+  const upload = async (asset: VideoGenerationSourceAsset, fallbackName: string) => {
+    if (asset.url?.trim()) return asset;
+    if (!asset.buffer) return asset;
+    if (asset.buffer.byteLength < INLINE_BASE64_THRESHOLD_BYTES) return asset;
+    const url = await uploadAtlasCloudMedia({
+      buffer: asset.buffer,
+      filename: pickFilename(asset, fallbackName),
+      mimeType: pickMimeType(asset),
+      baseUrl: uploadCtx.baseUrl,
+      headers: uploadCtx.headers,
+      policy: uploadCtx.policy,
+      dispatcherPolicy: uploadCtx.dispatcherPolicy,
+    });
+    return { ...asset, url };
+  };
+
+  const inputImages = req.inputImages
+    ? await Promise.all(req.inputImages.map((a, i) => upload(a, `image-${i + 1}`)))
+    : undefined;
+  const inputVideos = req.inputVideos
+    ? await Promise.all(req.inputVideos.map((a, i) => upload(a, `video-${i + 1}`)))
+    : undefined;
+
+  return { ...req, inputImages, inputVideos };
+}
+
+// =============================================================================
+// Provider factory
+// =============================================================================
+export function buildAtlasCloudVideoGenerationProvider(): VideoGenerationProvider {
+  return {
+    id: "atlascloud",
+    aliases: ["atlas-cloud", "atlas"],
+    label: "Atlas Cloud",
+    defaultModel: DEFAULT_ATLASCLOUD_VIDEO_MODEL,
+    models: [...REGISTERED_ATLAS_MODELS],
+    isConfigured: ({ agentDir }) =>
+      isProviderApiKeyConfigured({ provider: "atlascloud", agentDir }),
+    capabilities: {
+      generate: {
+        maxVideos: 1,
+        supportedDurationSeconds: [3, 4, 5, 6, 7, 8, 9, 10, 12, 15],
+        aspectRatios: ["16:9", "9:16", "1:1", "4:3", "3:4", "21:9"],
+        resolutions: ["480P", "720P", "768P", "1080P"],
+        supportsAspectRatio: true,
+        supportsResolution: true,
+        supportsSize: true,
+        supportsAudio: true,
+      },
+      imageToVideo: {
+        enabled: true,
+        maxVideos: 1,
+        // Vidu reference-to-video accepts 1-4 reference images.
+        maxInputImages: 4,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+        supportsSize: true,
+        supportsAudio: true,
+      },
+      videoToVideo: {
+        enabled: true,
+        maxVideos: 1,
+        maxInputVideos: 1,
+      },
+    },
+
+    async generateVideo(req) {
+      const auth = await resolveApiKeyForProvider({
+        provider: "atlascloud",
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      if (!auth.apiKey) throw new Error("Atlas Cloud API key missing");
+
+      const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+        resolveProviderHttpRequestConfig({
+          baseUrl: (
+            req.cfg?.models?.providers as Record<string, { baseUrl?: string }> | undefined
+          )?.atlascloud?.baseUrl?.trim(),
+          defaultBaseUrl: DEFAULT_BASE_URL,
+          allowPrivateNetwork: false,
+          defaultHeaders: {
+            Authorization: `Bearer ${auth.apiKey}`,
+            "Content-Type": "application/json",
+          },
+          provider: "atlascloud",
+          capability: "video",
+          transport: "http",
+        });
+
+      const policy = buildPolicy(allowPrivateNetwork);
+
+      // Pre-step: upload any large input buffers via /uploadMedia and replace
+      // them with the returned download_url before building the submit body.
+      // Small buffers stay inline (base64) to avoid an extra round trip.
+      const uploadedReq = await prepareAtlasCloudInputs(req, {
+        baseUrl,
+        headers,
+        policy,
+        dispatcherPolicy,
+      });
+      const body = buildAtlasCloudVideoBody(uploadedReq);
+
+      // Step 1: submit the task.
+      const submitted = await fetchAtlasJson<AtlasSubmitResponse>({
+        url: `${baseUrl}${SUBMIT_PATH}`,
+        init: { method: "POST", headers, body: JSON.stringify(body) },
+        timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
+        policy,
+        dispatcherPolicy,
+        auditContext: "atlascloud-video-submit",
+        errorContext: "Atlas Cloud video generation submit failed",
+      });
+      const predictionId = submitted.data?.id?.trim();
+      if (!predictionId) {
+        throw new Error(
+          `Atlas Cloud video submit response missing prediction id (code=${submitted.code ?? "?"}): ${submitted.message ?? ""}`,
+        );
+      }
+
+      // Step 2: poll until completed. Prefer the canonical URL the submit
+      // response gave us; fall back to constructed paths if missing.
+      const result = await pollAtlasResult({
+        baseUrl,
+        predictionId,
+        preferredUrl: submitted.data?.urls?.get?.trim() || undefined,
+        headers,
+        timeoutMs: req.timeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
+        policy,
+        dispatcherPolicy,
+      });
+
+      // Step 3: download the first output. `outputs` is `null` until the
+      // task completes; we should only reach this point on `completed`.
+      const outputUrl = result?.outputs?.find?.((u) => u?.trim());
+      if (!outputUrl) {
+        throw new Error("Atlas Cloud video generation completed but returned no output URL");
+      }
+      const video = await downloadAtlasVideo(outputUrl, policy);
+
+      return {
+        videos: [video],
+        model: result?.model ?? (body.model as string),
+        metadata: {
+          predictionId,
+          ...(result?.created_at ? { createdAt: result.created_at } : {}),
+          // `has_nsfw_contents` is `null` (not `[]`) when there are no flags;
+          // guard against null before reading `.length`.
+          ...(Array.isArray(result?.has_nsfw_contents) && result.has_nsfw_contents.length > 0
+            ? { hasNsfwContents: result.has_nsfw_contents }
+            : {}),
+        },
+      };
+    },
+  };
+}

--- a/extensions/video-generation-providers.live.test.ts
+++ b/extensions/video-generation-providers.live.test.ts
@@ -25,6 +25,7 @@ import {
   requireRegisteredProvider,
 } from "../test/helpers/plugins/provider-registration.js";
 import alibabaPlugin from "./alibaba/index.js";
+import atlascloudPlugin from "./atlascloud/index.js";
 import byteplusPlugin from "./byteplus/index.js";
 import falPlugin from "./fal/index.js";
 import googlePlugin from "./google/index.js";
@@ -56,6 +57,12 @@ const CASES: LiveProviderCase[] = [
     pluginId: "alibaba",
     pluginName: "Alibaba Model Studio Plugin",
     providerId: "alibaba",
+  },
+  {
+    plugin: atlascloudPlugin,
+    pluginId: "atlascloud",
+    pluginName: "Atlas Cloud Provider",
+    providerId: "atlascloud",
   },
   {
     plugin: byteplusPlugin,


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw's video generation provider list does not include Atlas Cloud, an aggregation platform that exposes 100+ models from Kling / Veo / Seedance / Wan / Vidu / Sora / Hailuo and others through a single unified API. Users who want any of those models today have to onboard each upstream provider individually or build their own integration.
- **Why it matters:** Atlas Cloud is a fal-style aggregator, so a single plugin unlocks a very broad set of models without expanding OpenClaw's per-provider auth surface.
- **What changed:** New `extensions/atlascloud` plugin (one provider, one `VideoGenerationProvider`), one new entry in the shared `extensions/video-generation-providers.live.test.ts` CASES array (mirroring the existing 11 providers), and one new alphabetical label entry in `.github/labeler.yml`.
- **What did NOT change (scope boundary):** No `src/` changes, no other extensions touched, no CODEOWNERS-protected paths, no new SDK seams. The plugin only consumes existing public `openclaw/plugin-sdk/*` barrels.

> Tracked under #62456 (proposal issue, filed because `openclaw/openclaw` Discussions are disabled per `hasDiscussionsEnabled: false`).

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #62456

## Root Cause

N/A — this is a new feature, not a bug fix.

## Regression Test Plan

N/A — new surface. New tests added in this PR (see Evidence).

## User-visible / Behavior Changes

- New provider id `atlascloud` (aliases: `atlas-cloud`, `atlas`) registered with the plugin SDK.
- New auth method `--atlascloud-api-key` / `ATLASCLOUD_API_KEY` env var.
- New default video model when the user has no `agents.defaults.videoGenerationModel` set: `atlascloud/google/veo3.1-fast/text-to-video`. Existing user defaults are not overwritten.
- New optional config key `models.providers.atlascloud.extraParams[modelId or modelPrefix]` for per-model field passthrough (`cfg_scale`, `camera_fixed`, `movement_amplitude`, `shot_type`, etc.) without needing to extend OpenClaw's generic `VideoGenerationRequest`.
- Input image / video buffers ≥ 2 MiB are auto-uploaded via `POST /api/v1/model/uploadMedia` and replaced with the returned `download_url` before submit. Smaller buffers stay inline as base64 data URLs (avoids extra round trip and stays under per-model size limits).

## Diagram

```text
User: pnpm openclaw video generate --provider atlascloud --model <id> --image foo.jpg --prompt ...
  │
  ▼
generateVideo(req):
  resolve API key (Bearer <ATLASCLOUD_API_KEY>)
  ─► prepareAtlasCloudInputs(req): walk inputImages/inputVideos
       ├─ asset.url present  → keep as-is
       ├─ asset.buffer < 2 MiB → keep, will inline as base64 in body
       └─ asset.buffer ≥ 2 MiB → POST /api/v1/model/uploadMedia → asset.url = download_url
  ─► buildAtlasCloudVideoBody(req): resolve per-model schema, map fields family-aware
       ├─ aspect_ratio (Veo) vs ratio (Wan 2.7) vs size with * separator (Wan 2.6) vs size with x (Sora)
       ├─ generate_audio (Veo/Seedance/Vidu) vs sound (Kling)
       ├─ image (single) vs images[] (Vidu reference)
       ├─ last_image (Veo) vs end_image (Kling) for end-frame
       ├─ videos[] (Wan v2v)
       └─ merge per-model defaults + user extraParams (highest priority)
  ─► POST /api/v1/model/generateVideo → prediction id
  ─► poll urls.get (preferred) → /result/{id} → /prediction/{id}
       until status in {completed, succeeded}
  ─► download outputs[0] → return GeneratedVideoAsset
```

## Security Impact

- **New permissions/capabilities?** No. Uses the existing `createProviderApiKeyAuthMethod` SDK helper.
- **Secrets/tokens handling changed?** No. The plugin only reads `ATLASCLOUD_API_KEY` via `resolveApiKeyForProvider`, which is the same path every other API-key plugin uses.
- **New/changed network calls?** Yes. Outbound to:
  - `https://api.atlascloud.ai/api/v1/model/generateVideo` (POST submit)
  - `https://api.atlascloud.ai/api/v1/model/uploadMedia` (POST multipart, only when an input buffer ≥ 2 MiB needs uploading)
  - `https://api.atlascloud.ai/api/v1/model/result/{id}` and `/prediction/{id}` (GET poll)
  - The signed `download_url` returned by submit, which lives on `volces.com` (Volcano TOS signed URL, 24h expiry)
  All requests go through `fetchWithSsrFGuard` from `openclaw/plugin-sdk/ssrf-runtime` (not raw `fetch`), so they participate in the standard SSRF guard, dispatcher policy, and audit context machinery.
- **Command/tool execution surface changed?** No.
- **Data access scope changed?** No. The plugin reads input assets the user explicitly passes to `video generate` and writes generated bytes to the standard `GeneratedVideoAsset` return shape.

## Repro + Verification

### Environment
- OS: macOS 15
- Runtime: Node 22.22.1
- Provider/model: `bytedance/seedance-v1.5-pro/text-to-video`, `bytedance/seedance-v1.5-pro/image-to-video`, plus 65 other model overrides registered statically
- Channel: N/A (provider plugin)
- Relevant config (redacted):
  ```json
  {
    "models": { "providers": { "atlascloud": { "extraParams": { "kwaivgi/kling-v3.0-pro/": { "cfg_scale": 0.7 } } } } }
  }
  ```

### Steps
1. `pnpm openclaw login --provider atlascloud --atlascloud-api-key $ATLASCLOUD_API_KEY`
2. `pnpm openclaw video generate --provider atlascloud --model bytedance/seedance-v1.5-pro/text-to-video --prompt "a calm sunrise over mountains" --output /tmp/out.mp4`
3. (Image-to-video) `pnpm openclaw video generate --provider atlascloud --model bytedance/seedance-v1.5-pro/image-to-video --image ./photo.jpg --prompt "subtle camera push-in" --output /tmp/out-i2v.mp4`

### Expected
- Submit returns a prediction id, plugin polls until status is `completed` or `succeeded`, downloads `outputs[0]`, returns a `GeneratedVideoAsset` with `mimeType: video/mp4`.

### Actual
- Verified live (see Evidence).

## Evidence

- **Offline body builder unit tests:** 14-case vitest file `extensions/atlascloud/video-generation-provider.test.ts` covering Veo / Kling / Seedance / Wan / Vidu / Sora field name mapping, end-frame field difference (`last_image` vs `end_image`), `size` separator conversion, mode-required-input checks, per-model defaults, user `extraParams` exact + prefix override, and unregistered-model fallback to family baseline.
- **Live test wiring:** `extensions/video-generation-providers.live.test.ts` updated to include the `atlascloud` entry in the shared `CASES` array, alphabetically between `alibaba` and `byteplus`. This is the same pattern the existing 11 video providers use.
- **Real Atlas Cloud API verification:**
  - **T2V live:** Submit `bytedance/seedance-v1.5-pro/text-to-video` → prediction id → poll returns `status: completed` after ~43s → output URL is a real signed Volcano TOS mp4.
  - **Upload live:** POST a 320×320 PNG (1960 bytes) to `/api/v1/model/uploadMedia` → response includes a public `oss-accelerate-overseas.aliyuncs.com` download URL.
  - **I2V end-to-end live:** Submit `bytedance/seedance-v1.5-pro/image-to-video` with the uploaded URL → poll returns `status: completed` after ~60s → output URL is a real signed Volcano TOS mp4.
  - **Failure path live:** With an intentionally too-small (1×1) input image, Atlas Cloud returned `status: failed` with a clean `data.error` field (`expected the width to be at least 300px, but received a 1x1px image`). The plugin's poll loop now prefers `data.error` over the top-level `message` field, because on failure `message` wraps the entire upstream JSON body and is not human-readable.

## Human Verification

- **Verified scenarios:**
  - 14/14 offline body builder unit tests pass against the real `model-schemas.ts` table.
  - Real T2V end-to-end against Atlas Cloud (Seedance v1.5 Pro).
  - Real upload-media end-to-end (320×320 PNG, returns OSS download URL).
  - Real I2V end-to-end (Seedance v1.5 Pro, uploaded image → completed mp4).
  - Real failure path (1×1 image is rejected upstream and surfaced cleanly).
- **Edge cases checked:**
  - Per-model schema overrides for Veo (`last_image`), Kling (`end_image`, `sound` instead of `generate_audio`), Wan 2.6 (`size` with `*`), Wan 2.7 (`ratio` instead of `aspect_ratio`, uppercase `1080P`), Sora (`size` with `x`), Vidu (multi-image `images[]`).
  - User `extraParams` with both exact key and `prefix/` key (longest prefix wins, exact overrides prefix).
  - Unregistered model id fallback to family baseline (e.g. a hypothetical `minimax/hailuo-99/text-to-video`).

## Compatibility / Migration

- **Backward compatible?** Yes. New plugin, no existing config keys removed or repurposed.
- **Config/env changes?** Yes (new optional). New env var `ATLASCLOUD_API_KEY`, new optional config block `models.providers.atlascloud.{baseUrl,extraParams}`. Default video model is only set when the user has no `agents.defaults.videoGenerationModel` configured.
- **Migration needed?** No.

## Risks and Mitigations

- **Risk:** Unverified per-model schemas (53 of the 67 entries) could have wrong field names if Atlas Cloud changes a model.
  - **Mitigation:** The pure body builder lives behind family baselines plus per-model overrides. Users can override any field via `extraParams[modelId or prefix]` without code changes. A CI refresher script can periodically diff against the real `/api/v1/models/{id}` endpoint and open a follow-up PR.
- **Risk:** The auto-upload threshold (2 MiB) is a heuristic.
  - **Mitigation:** Below threshold, the plugin still works because Atlas Cloud accepts both base64 data URLs and public URLs in image fields (verified against the documented per-model schemas for Hailuo, Vidu, Kling). Above threshold, the upload path is the documented Atlas Cloud `/uploadMedia` endpoint with the multipart shape from the official `AtlasCloudAI/mcp-server` reference implementation.
- **Risk:** The shared file `extensions/video-generation-providers.live.test.ts` is touched.
  - **Mitigation:** The change is one new entry inserted alphabetically in the existing `CASES` array, identical in shape to the 11 sibling entries. No logic added; no rerun semantics changed.