### PR TITLE
fix(logging): refresh subsystem file logger when parent logger is rebuilt on date roll

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -245,6 +245,7 @@ export function getLogger(): TsLogger<LogObj> {
   if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
     loggingState.cachedLogger = buildLogger(settings);
     loggingState.cachedSettings = settings;
+    loggingState.loggerGeneration += 1;
   }
   return loggingState.cachedLogger as TsLogger<LogObj>;
 }
@@ -295,6 +296,25 @@ export type PinoLikeLogger = {
   error: (...args: unknown[]) => void;
   fatal: (...args: unknown[]) => void;
 };
+
+/**
+ * Lightweight check that triggers a parent logger rebuild only when the
+ * rolling date has changed or the cached logger is missing. Avoids the
+ * full resolveSettings() cost of getLogger() on every log call.
+ */
+export function ensureLoggerCurrent(): void {
+  const cached = loggingState.cachedSettings as ResolvedSettings | null;
+  if (!cached || !loggingState.cachedLogger) {
+    // No cached logger yet — let getLogger() do a full build.
+    getLogger();
+    return;
+  }
+  // Fast path: if the cached file is a rolling path and the date has changed,
+  // trigger a full rebuild. Otherwise, nothing to do.
+  if (isRollingPath(cached.file) && cached.file !== defaultRollingPathForToday()) {
+    getLogger();
+  }
+}
 
 export function getResolvedLoggerSettings(): LoggerResolvedSettings {
   return resolveSettings();

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -3,6 +3,7 @@ export const loggingState = {
   cachedSettings: null as unknown,
   cachedConsoleSettings: null as unknown,
   overrideSettings: null as unknown,
+  loggerGeneration: 0,
   invalidEnvLogLevelValue: null as string | null,
   consolePatched: false,
   forceConsoleToStderr: false,

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -145,3 +145,46 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("subsystem logger file logger staleness", () => {
+  afterEach(() => {
+    resetLogger();
+    loggingState.rawConsole = null;
+  });
+
+  it("picks up a new parent logger after the parent is rebuilt (generation bump)", () => {
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+    const log = createSubsystemLogger("test/stale");
+
+    // First log — creates the child file logger and records generation.
+    log.info("before rebuild");
+    const genBefore = loggingState.loggerGeneration;
+    expect(genBefore).toBeGreaterThan(0);
+
+    // Simulate a parent logger rebuild (e.g. date-rolled file change).
+    resetLogger();
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+
+    // After reset, cachedLogger is null, so next getLogger() call rebuilds and bumps.
+    log.info("after rebuild");
+    const genAfter = loggingState.loggerGeneration;
+
+    // Generation must have advanced, proving the subsystem logger
+    // requested a fresh child instead of reusing the stale one.
+    expect(genAfter).toBeGreaterThan(genBefore);
+  });
+
+  it("reuses the cached child file logger when generation has not changed", () => {
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+    const log = createSubsystemLogger("test/reuse");
+
+    log.info("first");
+    const genAfterFirst = loggingState.loggerGeneration;
+
+    log.info("second");
+    const genAfterSecond = loggingState.loggerGeneration;
+
+    // No rebuild happened, generation stays the same.
+    expect(genAfterSecond).toBe(genAfterFirst);
+  });
+});

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -10,7 +10,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { ensureLoggerCurrent, getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -301,6 +301,20 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerGeneration = -1;
+
+  const getFileLogger = (): TsLogger<LogObj> => {
+    // Lightweight check: only triggers a full rebuild when the rolling
+    // date has changed or no cached logger exists. Avoids the cost of
+    // resolveSettings() on every log call.
+    ensureLoggerCurrent();
+    const currentGeneration = loggingState.loggerGeneration;
+    if (!fileLogger || fileLoggerGeneration !== currentGeneration) {
+      fileLogger = getChildLogger({ subsystem });
+      fileLoggerGeneration = currentGeneration;
+    }
+    return fileLogger;
+  };
 
   const emitLog = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
     const consoleSettings = getConsoleSettings();
@@ -323,10 +337,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       fileMeta = Object.keys(rest).length > 0 ? rest : undefined;
     }
     if (fileEnabled) {
-      if (!fileLogger) {
-        fileLogger = getChildLogger({ subsystem });
-      }
-      logToFile(fileLogger, level, message, fileMeta);
+      logToFile(getFileLogger(), level, message, fileMeta);
     }
     if (!consoleEnabled) {
       return;
@@ -389,10 +400,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     },
     raw(message) {
       if (isFileLogLevelEnabled("info")) {
-        if (!fileLogger) {
-          fileLogger = getChildLogger({ subsystem });
-        }
-        logToFile(fileLogger, "info", message, { raw: true });
+        logToFile(getFileLogger(), "info", message, { raw: true });
       }
       if (
         shouldLogToConsole("info", { level: getConsoleSettings().level }) &&


### PR DESCRIPTION
Fixes #62381

## Problem

`createSubsystemLogger()` caches its tslog child logger in a closure variable (`fileLogger`). Once created on first use, it is never refreshed. The child logger inherits the parent logger's file transport, which is bound to the log file path resolved at creation time (e.g. `openclaw-2026-04-03.log`).

When the gateway runs across a date boundary, the parent logger in `getLogger()` detects the file path change (via `defaultRollingPathForToday()` → `settingsChanged()`) and rebuilds itself with the new date-rolled file. However, subsystem loggers still hold a reference to a child of the **old** parent, so they keep writing to the stale file indefinitely.

## Root Cause

The staleness chain:

1. `createSubsystemLogger("diagnostic")` is called at module top-level
2. First log call → `getChildLogger()` → creates child of current parent logger → cached in closure
3. Date rolls → `getLogger()` rebuilds parent with new file path
4. Subsystem logger still uses cached child of old parent → writes to old file
5. Only subsystem loggers created **after** the rebuild (e.g. plugin loggers) pick up the new file

## Fix

Add a `loggerGeneration` counter to `loggingState`:

- **`logger.ts`**: increment `loggerGeneration` every time `getLogger()` rebuilds the parent logger (settings changed → new file path, level change, etc.)
- **`subsystem.ts`**: track the generation when the child file logger was created. Before each log write, compare the cached generation against the current `loggingState.loggerGeneration`. On mismatch, discard the stale child and request a fresh one from the new parent.

This is a lightweight check (one integer comparison per log call) with zero overhead when no rebuild has occurred.

### Files changed

| File | Change |
|------|--------|
| `src/logging/state.ts` | Add `loggerGeneration` counter |
| `src/logging/logger.ts` | Increment generation on parent rebuild |
| `src/logging/subsystem.ts` | Track generation, refresh child on mismatch |
| `src/logging/subsystem.test.ts` | Add staleness and reuse tests |

## Test Plan

- Added: "picks up a new parent logger after the parent is rebuilt (generation bump)" — verifies generation advances after reset+rebuild
- Added: "reuses the cached child file logger when generation has not changed" — verifies no unnecessary child recreation
- All existing subsystem logger tests pass