### PR TITLE
fix(talk): fix ensure permissions on first execution of Talk Mode in MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: honor the configured default account when the active listener helper is used without an explicit account id, so named default accounts do not get registered under `default`. (#53918) Thanks @yhyatt.
 - QA/packaging: stop packaged CLI startup and completion cache generation from reading repo-only QA scenario markdown by routing QA command registration through a narrow facade. (#64648) Thanks @obviyus.
 - Control UI/webchat: persist agent-run TTS audio replies into webchat history before finalization so tool-generated audio reaches webchat clients again. (#63514) thanks @bittoby
+- macOS/Talk Mode: after granting microphone permission on first enable, continue starting Talk Mode instead of requiring a second toggle. (#62459) Thanks @ggarber.
 
 ## 2026.4.10
 

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -128,7 +128,7 @@ actor TalkModeRuntime {
     private func start() async {
         let gen = self.lifecycleGeneration
         guard voiceWakeSupported else { return }
-        
+
         guard await PermissionManager.ensureVoiceWakePermissions(interactive: true) else {
             self.logger.error("talk runtime not starting: permissions missing")
             return

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -128,8 +128,9 @@ actor TalkModeRuntime {
     private func start() async {
         let gen = self.lifecycleGeneration
         guard voiceWakeSupported else { return }
-        guard PermissionManager.voiceWakePermissionsGranted() else {
-            self.logger.debug("talk runtime not starting: permissions missing")
+        
+        guard await PermissionManager.ensureVoiceWakePermissions(interactive: true) else {
+            self.logger.error("talk runtime not starting: permissions missing")
             return
         }
         await self.reloadConfig()

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -21,6 +21,9 @@ describe("memory-wiki plugin", () => {
     expect(registerMemoryPromptSupplement).toHaveBeenCalledTimes(1);
     expect(registerGatewayMethod.mock.calls.map((call) => call[0])).toEqual([
       "wiki.status",
+      "wiki.importRuns",
+      "wiki.importInsights",
+      "wiki.palace",
       "wiki.init",
       "wiki.doctor",
       "wiki.compile",

--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { applyConfigDefaults as applyAnthropicConfigDefaults } from "../../extensions/anthropic/provider-policy-api.js";
 import type { OpenClawConfig } from "./config.js";
+import { applyProviderConfigDefaultsForConfig } from "./provider-policy.js";
 
 function expectAnthropicPruningDefaults(cfg: OpenClawConfig, heartbeatEvery = "30m") {
   expect(cfg.agents?.defaults?.contextPruning?.mode).toBe("cache-ttl");
@@ -8,10 +8,8 @@ function expectAnthropicPruningDefaults(cfg: OpenClawConfig, heartbeatEvery = "3
   expect(cfg.agents?.defaults?.heartbeat?.every).toBe(heartbeatEvery);
 }
 
-function applyAnthropicDefaultsForTest(
-  config: Parameters<typeof applyAnthropicConfigDefaults>[0]["config"],
-) {
-  return applyAnthropicConfigDefaults({ config, env: {} });
+function applyAnthropicDefaultsForTest(config: OpenClawConfig) {
+  return applyProviderConfigDefaultsForConfig({ provider: "anthropic", config, env: {} });
 }
 
 describe("config pruning defaults", () => {

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -23,6 +23,8 @@ vi.mock("../../channels/plugins/index.js", () => ({
 }));
 
 vi.mock("../../plugins/runtime.js", () => ({
+  getActivePluginChannelRegistry: () => null,
+  getActivePluginRegistry: () => null,
   getActivePluginChannelRegistryVersion: () => mocks.getActivePluginChannelRegistryVersion(),
 }));
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

First time you open Talk Mode the application doesn't have permissions to access the microphone so they are requested but after approving it the user needs to enable Talk Mode again because the first attempt only triggers the permission request.

With this change it requests permissions and continues with starting talk mode after that.

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [X] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

## Root Cause (if applicable)

## Regression Test Plan (if applicable)

## User-visible / Behavior Changes

None

## Diagram (if applicable)

## Security Impact (required)

## Repro + Verification

### Environment

- OS: MacOS application

### Steps

1. Start Talk Mode
2. Check microphone permissions request is shown
3. Allow microphone permissions

### Expected

- Talk mode works and you can speaking with openclaw

### Actual

- Talk mode doesn't work and speaking is not recongnized

## Evidence

## Human Verification (required)

- Verified scenarios: Basic scenario
- Edge cases checked: Rejecting microphone permissions

## Review Conversations

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

None
