### PR TITLE
fix: use thinkingBudget: 0 to disable thinking for Gemini 3 Pro models (fixes #62470)

### DIFF
--- a/src/agents/google-transport-stream.ts
+++ b/src/agents/google-transport-stream.ts
@@ -210,10 +210,7 @@ function resolveThinkingLevel(level: ThinkingLevel, modelId: string): GoogleThin
   }
 }
 
-function getDisabledThinkingConfig(modelId: string): Record<string, unknown> {
-  if (isGemini3FlashModel(modelId)) {
-    return { thinkingBudget: 0 };
-  }
+function getDisabledThinkingConfig(_modelId: string): Record<string, unknown> {
   return { thinkingBudget: 0 };
 }
 

--- a/src/agents/google-transport-stream.ts
+++ b/src/agents/google-transport-stream.ts
@@ -211,11 +211,8 @@ function resolveThinkingLevel(level: ThinkingLevel, modelId: string): GoogleThin
 }
 
 function getDisabledThinkingConfig(modelId: string): Record<string, unknown> {
-  if (isGemini3ProModel(modelId)) {
-    return { thinkingLevel: "LOW" };
-  }
   if (isGemini3FlashModel(modelId)) {
-    return { thinkingLevel: "MINIMAL" };
+    return { thinkingBudget: 0 };
   }
   return { thinkingBudget: 0 };
 }
@@ -743,3 +740,4 @@ export function createGoogleGenerativeAiTransportStreamFn(): StreamFn {
     return eventStream as unknown as ReturnType<StreamFn>;
   };
 }
+


### PR DESCRIPTION
## Summary

Fix Gemini 3 Pro/Flash models failing to disable thinking mode. The previous implementation used `thinkingLevel: "LOW"` for Pro and `thinkingLevel: "MINIMAL"` for Flash, but the Gemini API expects `thinkingBudget: 0` to fully disable thinking across all model variants. Fixes #62470.

## Changes

- `src/agents/google-transport-stream.ts`: Simplified `getDisabledThinkingConfig()` to always return `{ thinkingBudget: 0 }`, removing the model-specific branching that was producing incorrect config values.
- Follow-up commit removes the now-dead `isGemini3FlashModel` branch (cosmetic cleanup flagged by Greptile).

## Why this approach

The Gemini API documentation specifies `thinkingBudget: 0` as the canonical way to disable thinking. The previous per-model `thinkingLevel` approach was based on an incorrect assumption about the API surface. A single `thinkingBudget: 0` is simpler, correct, and forward-compatible with future Gemini model variants.

## AI-assisted

This PR was developed with AI assistance (Kiro CLI). All changes have been reviewed, tested, and understood.