### PR TITLE
fix(cli/send-runtime): route to sendMedia when media is present in createChannelOutboundRuntimeSend

### DIFF
--- a/src/cli/send-runtime/channel-outbound-send.ts
+++ b/src/cli/send-runtime/channel-outbound-send.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../../config/config.js";
 type RuntimeSendOpts = {
   cfg?: ReturnType<typeof loadConfig>;
   mediaUrl?: string;
+  mediaUrls?: readonly string[];
   mediaLocalRoots?: readonly string[];
   accountId?: string;
   messageThreadId?: string | number;
@@ -22,14 +23,19 @@ export function createChannelOutboundRuntimeSend(params: {
   return {
     sendMessage: async (to: string, text: string, opts: RuntimeSendOpts = {}) => {
       const outbound = await loadChannelOutboundAdapter(params.channelId);
-      if (!outbound?.sendText) {
+      const hasMedia =
+        Boolean(opts.mediaUrl) ||
+        (Array.isArray(opts.mediaUrls) && opts.mediaUrls.length > 0);
+      const sendFn = hasMedia && outbound?.sendMedia ? outbound.sendMedia : outbound?.sendText;
+      if (!sendFn) {
         throw new Error(params.unavailableMessage);
       }
-      return await outbound.sendText({
+      return await sendFn({
         cfg: opts.cfg ?? loadConfig(),
         to,
         text,
         mediaUrl: opts.mediaUrl,
+        mediaUrls: opts.mediaUrls,
         mediaLocalRoots: opts.mediaLocalRoots,
         accountId: opts.accountId,
         threadId: opts.messageThreadId,


### PR DESCRIPTION
## Problem

`createChannelOutboundRuntimeSend` in `src/cli/send-runtime/channel-outbound-send.ts` always dispatched to `outbound.sendText`, ignoring `opts.mediaUrl` / `opts.mediaUrls`. Channel adapters (e.g. WhatsApp) expose `sendText` and `sendMedia` as separate functions — `sendText` does not accept or forward `mediaUrl`, so media was silently dropped while the CLI returned a successful `messageId`.

This affects **both** code paths that send messages:
1. **CLI** — `openclaw message send --media`, `openclaw message broadcast --media`, etc.
2. **Gateway / agents** — any agent using the `message` tool with media.

Regression introduced in the 2026.4.5 channel seam / outbound deps refactors. Worked correctly through 2026.4.2.

Fixes #62399.

## Fix

- Detect media presence via `opts.mediaUrl` or `opts.mediaUrls` (non-empty array)
- Prefer `outbound.sendMedia` when media is detected and the adapter exposes it; fall back to `outbound.sendText` otherwise (text-only calls are unchanged)
- Forward `mediaUrls` (array form) in addition to `mediaUrl` so multi-media sends are covered
- Extend `RuntimeSendOpts` to type `mediaUrls` correctly

## Testing

Verified locally against WhatsApp: `openclaw message send --channel whatsapp --target "+34x" --message "test" --media /tmp/red.png` now delivers both the text and the image. Gateway log shows `hasMedia: true` and the correct `sendMedia` path is invoked.