### PR TITLE
fix: filter phantom provider groups inferred from OpenRouter model IDs [AI-assisted]

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -1,6 +1,7 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { resetProviderRuntimeHookCacheForTest } from "../plugins/provider-runtime.js";
 
 type PiSdkModule = typeof import("./pi-model-discovery.js");
 
@@ -9,6 +10,28 @@ let findModelInCatalog: typeof import("./model-catalog.js").findModelInCatalog;
 let loadModelCatalog: typeof import("./model-catalog.js").loadModelCatalog;
 let resetModelCatalogCacheForTest: typeof import("./model-catalog.js").resetModelCatalogCacheForTest;
 let augmentCatalogMock: ReturnType<typeof vi.fn>;
+
+const mocks = vi.hoisted(() => ({
+  ensureOpenClawModelsJson: vi.fn().mockResolvedValue({ agentDir: "/tmp/openclaw", wrote: false }),
+  augmentModelCatalogWithProviderPlugins: vi.fn().mockResolvedValue([]),
+  readFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mocks.readFile,
+}));
+
+vi.mock("./models-config.js", () => ({
+  ensureOpenClawModelsJson: mocks.ensureOpenClawModelsJson,
+}));
+
+vi.mock("./agent-paths.js", () => ({
+  resolveOpenClawAgentDir: () => "/tmp/openclaw",
+}));
+
+vi.mock("../plugins/provider-runtime.runtime.js", () => ({
+  augmentModelCatalogWithProviderPlugins: mocks.augmentModelCatalogWithProviderPlugins,
+}));
 
 vi.mock("./model-suppression.runtime.js", () => ({
   shouldSuppressBuiltInModel: (params: { provider?: string; id?: string }) =>
@@ -57,40 +80,31 @@ function mockSingleOpenAiCatalogModel() {
 
 describe("loadModelCatalog", () => {
   beforeAll(async () => {
-    vi.doMock("./models-config.js", () => ({
-      ensureOpenClawModelsJson: vi.fn().mockResolvedValue({ agentDir: "/tmp", wrote: false }),
-    }));
-    vi.doMock("./agent-paths.js", () => ({
-      resolveOpenClawAgentDir: () => "/tmp/openclaw",
-    }));
-    vi.doMock("../plugins/provider-runtime.runtime.js", () => ({
-      augmentModelCatalogWithProviderPlugins: vi.fn().mockResolvedValue([]),
-    }));
-
     ({
       __setModelCatalogImportForTest,
       findModelInCatalog,
       loadModelCatalog,
       resetModelCatalogCacheForTest,
     } = await import("./model-catalog.js"));
-    const providerRuntime = await import("../plugins/provider-runtime.runtime.js");
-    augmentCatalogMock = vi.mocked(providerRuntime.augmentModelCatalogWithProviderPlugins);
+    augmentCatalogMock = mocks.augmentModelCatalogWithProviderPlugins;
   });
 
   beforeEach(() => {
+    mocks.ensureOpenClawModelsJson.mockReset();
+    mocks.ensureOpenClawModelsJson.mockResolvedValue({ agentDir: "/tmp/openclaw", wrote: false });
+    mocks.augmentModelCatalogWithProviderPlugins.mockReset();
+    mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([]);
+    mocks.readFile.mockReset();
+    mocks.readFile.mockRejectedValue(new Error("missing models.json"));
     resetModelCatalogCacheForTest();
+    resetProviderRuntimeHookCacheForTest();
   });
 
   afterEach(() => {
     __setModelCatalogImportForTest();
     resetModelCatalogCacheForTest();
+    resetProviderRuntimeHookCacheForTest();
     vi.restoreAllMocks();
-  });
-
-  afterAll(() => {
-    vi.doUnmock("./models-config.js");
-    vi.doUnmock("./agent-paths.js");
-    vi.doUnmock("../plugins/provider-runtime.runtime.js");
   });
 
   it("retries after import failure without poisoning the cache", async () => {
@@ -375,6 +389,141 @@ describe("loadModelCatalog", () => {
     );
     expect(matches).toHaveLength(1);
     expect(matches[0]?.name).toBe("Kilo Auto");
+  });
+
+  it("filters phantom native providers shadowed by aggregator-qualified model ids", async () => {
+    mockPiDiscoveryModels([
+      {
+        id: "gemini-3-flash-preview",
+        provider: "google",
+        name: "Gemini 3 Flash Preview",
+      },
+      {
+        id: "google/gemini-3-flash-preview",
+        provider: "openrouter",
+        name: "Gemini 3 Flash Preview",
+      },
+    ]);
+
+    mocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        providers: {
+          openrouter: {},
+        },
+      }),
+    );
+
+    const result = await loadModelCatalog({
+      config: {
+        models: {
+          providers: {
+            openrouter: {},
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(result).toEqual([
+      {
+        id: "google/gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "openrouter",
+      },
+    ]);
+  });
+
+  it("keeps direct providers that are explicitly configured alongside aggregators", async () => {
+    mockPiDiscoveryModels([
+      {
+        id: "gemini-3-flash-preview",
+        provider: "google",
+        name: "Gemini 3 Flash Preview",
+      },
+      {
+        id: "google/gemini-3-flash-preview",
+        provider: "openrouter",
+        name: "Gemini 3 Flash Preview",
+      },
+    ]);
+
+    mocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        providers: {
+          google: {},
+          openrouter: {},
+        },
+      }),
+    );
+
+    const result = await loadModelCatalog({
+      config: {
+        models: {
+          providers: {
+            google: {},
+            openrouter: {},
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(result).toEqual([
+      {
+        id: "gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "google",
+      },
+      {
+        id: "google/gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "openrouter",
+      },
+    ]);
+  });
+
+  it("keeps direct providers that are enabled implicitly alongside aggregators", async () => {
+    mockPiDiscoveryModels([
+      {
+        id: "gemini-3-flash-preview",
+        provider: "google",
+        name: "Gemini 3 Flash Preview",
+      },
+      {
+        id: "google/gemini-3-flash-preview",
+        provider: "openrouter",
+        name: "Gemini 3 Flash Preview",
+      },
+    ]);
+    mocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        providers: {
+          google: {},
+          openrouter: {},
+        },
+      }),
+    );
+
+    const result = await loadModelCatalog({
+      config: {
+        models: {
+          providers: {
+            openrouter: {},
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(result).toEqual([
+      {
+        id: "gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "google",
+      },
+      {
+        id: "google/gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "openrouter",
+      },
+    ]);
   });
 
   it("matches models across canonical provider aliases", () => {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -14,6 +14,7 @@ let augmentCatalogMock: ReturnType<typeof vi.fn>;
 const mocks = vi.hoisted(() => ({
   ensureOpenClawModelsJson: vi.fn().mockResolvedValue({ agentDir: "/tmp/openclaw", wrote: false }),
   augmentModelCatalogWithProviderPlugins: vi.fn().mockResolvedValue([]),
+  resolveProvidersForModelsJsonWithDeps: vi.fn().mockResolvedValue({}),
   readFile: vi.fn(),
 }));
 
@@ -31,6 +32,10 @@ vi.mock("./agent-paths.js", () => ({
 
 vi.mock("../plugins/provider-runtime.runtime.js", () => ({
   augmentModelCatalogWithProviderPlugins: mocks.augmentModelCatalogWithProviderPlugins,
+}));
+
+vi.mock("./models-config.plan.js", () => ({
+  resolveProvidersForModelsJsonWithDeps: mocks.resolveProvidersForModelsJsonWithDeps,
 }));
 
 vi.mock("./model-suppression.runtime.js", () => ({
@@ -94,6 +99,8 @@ describe("loadModelCatalog", () => {
     mocks.ensureOpenClawModelsJson.mockResolvedValue({ agentDir: "/tmp/openclaw", wrote: false });
     mocks.augmentModelCatalogWithProviderPlugins.mockReset();
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([]);
+    mocks.resolveProvidersForModelsJsonWithDeps.mockReset();
+    mocks.resolveProvidersForModelsJsonWithDeps.mockResolvedValue({});
     mocks.readFile.mockReset();
     mocks.readFile.mockRejectedValue(new Error("missing models.json"));
     resetModelCatalogCacheForTest();
@@ -412,6 +419,9 @@ describe("loadModelCatalog", () => {
         },
       }),
     );
+    mocks.resolveProvidersForModelsJsonWithDeps.mockResolvedValueOnce({
+      openrouter: {},
+    });
 
     const result = await loadModelCatalog({
       config: {
@@ -454,6 +464,10 @@ describe("loadModelCatalog", () => {
         },
       }),
     );
+    mocks.resolveProvidersForModelsJsonWithDeps.mockResolvedValueOnce({
+      google: {},
+      openrouter: {},
+    });
 
     const result = await loadModelCatalog({
       config: {
@@ -496,11 +510,64 @@ describe("loadModelCatalog", () => {
     mocks.readFile.mockResolvedValueOnce(
       JSON.stringify({
         providers: {
+          openrouter: {},
+        },
+      }),
+    );
+    mocks.resolveProvidersForModelsJsonWithDeps.mockResolvedValueOnce({
+      google: {},
+      openrouter: {},
+    });
+
+    const result = await loadModelCatalog({
+      config: {
+        models: {
+          providers: {
+            openrouter: {},
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(result).toEqual([
+      {
+        id: "gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "google",
+      },
+      {
+        id: "google/gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "openrouter",
+      },
+    ]);
+  });
+
+  it("keeps providers retained from merged models.json before filtering shadows", async () => {
+    mockPiDiscoveryModels([
+      {
+        id: "gemini-3-flash-preview",
+        provider: "google",
+        name: "Gemini 3 Flash Preview",
+      },
+      {
+        id: "google/gemini-3-flash-preview",
+        provider: "openrouter",
+        name: "Gemini 3 Flash Preview",
+      },
+    ]);
+
+    mocks.readFile.mockResolvedValueOnce(
+      JSON.stringify({
+        providers: {
           google: {},
           openrouter: {},
         },
       }),
     );
+    mocks.resolveProvidersForModelsJsonWithDeps.mockResolvedValueOnce({
+      openrouter: {},
+    });
 
     const result = await loadModelCatalog({
       config: {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -11,6 +11,7 @@ import {
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import type { ModelCatalogEntry, ModelInputType } from "./model-catalog.types.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
+import { resolveProvidersForModelsJsonWithDeps } from "./models-config.plan.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 const log = createSubsystemLogger("model-catalog");
@@ -47,12 +48,17 @@ async function getConfiguredProviderIds(
   config: OpenClawConfig,
   agentDir: string,
 ): Promise<Set<string> | null> {
-  const explicitProviderIds = new Set(
-    Object.keys(config.models?.providers ?? {})
-      .map((provider) => normalizeProviderId(provider))
-      .filter(Boolean),
-  );
   try {
+    const resolvedProviders = await resolveProvidersForModelsJsonWithDeps({
+      cfg: config,
+      agentDir,
+      env: process.env,
+    });
+    const configuredProviderIds = new Set(
+      Object.keys(resolvedProviders)
+        .map((provider) => normalizeProviderId(provider))
+        .filter(Boolean),
+    );
     const raw = await readFile(path.join(agentDir, "models.json"), "utf8");
     const parsed = JSON.parse(raw) as { providers?: Record<string, unknown> } | null;
     if (
@@ -61,10 +67,9 @@ async function getConfiguredProviderIds(
       !parsed.providers ||
       typeof parsed.providers !== "object"
     ) {
-      return null;
+      return configuredProviderIds;
     }
 
-    const configuredProviderIds = new Set(explicitProviderIds);
     for (const provider of Object.keys(parsed.providers)) {
       const normalizedProviderId = normalizeProviderId(provider);
       if (normalizedProviderId) {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -40,6 +42,78 @@ let hasLoggedModelCatalogError = false;
 const defaultImportPiSdk = () => import("./pi-model-discovery-runtime.js");
 let importPiSdk = defaultImportPiSdk;
 let modelSuppressionPromise: Promise<typeof import("./model-suppression.runtime.js")> | undefined;
+
+async function getConfiguredProviderIds(
+  config: OpenClawConfig,
+  agentDir: string,
+): Promise<Set<string> | null> {
+  const explicitProviderIds = new Set(
+    Object.keys(config.models?.providers ?? {})
+      .map((provider) => normalizeProviderId(provider))
+      .filter(Boolean),
+  );
+  try {
+    const raw = await readFile(path.join(agentDir, "models.json"), "utf8");
+    const parsed = JSON.parse(raw) as { providers?: Record<string, unknown> } | null;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !parsed.providers ||
+      typeof parsed.providers !== "object"
+    ) {
+      return null;
+    }
+
+    const configuredProviderIds = new Set(explicitProviderIds);
+    for (const provider of Object.keys(parsed.providers)) {
+      const normalizedProviderId = normalizeProviderId(provider);
+      if (normalizedProviderId) {
+        configuredProviderIds.add(normalizedProviderId);
+      }
+    }
+    return configuredProviderIds;
+  } catch {
+    // Fail open when provider metadata is unavailable so we do not hide real models.
+    return null;
+  }
+}
+
+function isShadowedByQualifiedAggregatorEntry(
+  entry: ModelCatalogEntry,
+  candidate: ModelCatalogEntry,
+): boolean {
+  const providerId = normalizeProviderId(entry.provider);
+  if (!providerId || normalizeProviderId(candidate.provider) === providerId) {
+    return false;
+  }
+  const candidateId = candidate.id.trim();
+  const slash = candidateId.indexOf("/");
+  if (slash <= 0) {
+    return false;
+  }
+  const candidatePrefix = normalizeProviderId(candidateId.slice(0, slash));
+  const candidateModelId = candidateId.slice(slash + 1).trim().toLowerCase();
+  return candidatePrefix === providerId && candidateModelId === entry.id.trim().toLowerCase();
+}
+
+function filterShadowedProviderEntries(
+  entries: ModelCatalogEntry[],
+  configuredProviderIds: ReadonlySet<string> | null,
+): ModelCatalogEntry[] {
+  if (entries.length <= 1 || !configuredProviderIds) {
+    return entries;
+  }
+  return entries.filter((entry) => {
+    const providerId = normalizeProviderId(entry.provider);
+    if (!providerId || configuredProviderIds.has(providerId)) {
+      return true;
+    }
+    return !entries.some(
+      (candidate) =>
+        candidate !== entry && isShadowedByQualifiedAggregatorEntry(entry, candidate),
+    );
+  });
+}
 
 function shouldLogModelCatalogTiming(): boolean {
   return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
@@ -116,13 +190,12 @@ export async function loadModelCatalog(params?: {
       const agentDir = resolveOpenClawAgentDir();
       const { shouldSuppressBuiltInModel } = await loadModelSuppression();
       logStage("catalog-deps-ready");
-      const { join } = await import("node:path");
       const authStorage = piSdk.discoverAuthStorage(agentDir);
       logStage("auth-storage-ready");
       const registry = instantiatePiModelRegistry(
         piSdk,
         authStorage,
-        join(agentDir, "models.json"),
+        path.join(agentDir, "models.json"),
       );
       logStage("registry-ready");
       const entries = Array.isArray(registry) ? registry : registry.getAll();
@@ -175,13 +248,16 @@ export async function loadModelCatalog(params?: {
         }
       }
       logStage("plugin-models-merged", `entries=${models.length}`);
+      const configuredProviderIds = await getConfiguredProviderIds(cfg, agentDir);
+      const filteredModels = filterShadowedProviderEntries(models, configuredProviderIds);
+      logStage("provider-shadows-filtered", `entries=${filteredModels.length}`);
 
-      if (models.length === 0) {
+      if (filteredModels.length === 0) {
         // If we found nothing, don't cache this result so we can try again.
         modelCatalogPromise = null;
       }
 
-      const sorted = sortModels(models);
+      const sorted = sortModels(filteredModels);
       logStage("complete", `entries=${sorted.length}`);
       return sorted;
     } catch (error) {

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -614,6 +614,7 @@ describe("subagent registry steer restarts", () => {
 
   it("recovers announce cleanup when completion arrives after a kill marker", async () => {
     const childSessionKey = "agent:main:subagent:kill-race";
+    const initialEndedHookCalls = runSubagentEndedHookMock.mock.calls.length;
     registerRun({
       runId: "run-kill-race",
       childSessionKey,
@@ -641,7 +642,16 @@ describe("subagent registry steer restarts", () => {
     expect(run?.suppressAnnounceReason).toBeUndefined();
     expect(run?.cleanupHandled).toBe(true);
     expect(typeof run?.cleanupCompletedAt).toBe("number");
-    expect(runSubagentEndedHookMock).toHaveBeenCalledTimes(1);
+    const killRaceHookCalls = runSubagentEndedHookMock.mock.calls
+      .slice(initialEndedHookCalls)
+      .filter((call) => ((call[0] ?? {}) as { runId?: string }).runId === "run-kill-race");
+    expect(killRaceHookCalls).toHaveLength(1);
+    expect(killRaceHookCalls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        runId: "run-kill-race",
+        reason: "subagent-killed",
+      }),
+    );
   });
 
   it("retries deferred parent cleanup after a descendant announces", async () => {


### PR DESCRIPTION
## Summary

This PR fixes the phantom native-provider group reported in #62317 when an aggregator model id already includes a provider-like prefix.

## What changed

- filters auto-inferred native-provider entries when the same model is already present under an aggregator-qualified id
- keeps explicitly configured native providers intact, so real multi-provider setups still show both entries
- adds regression coverage for the OpenRouter-prefixed model case

## Why

Before this change, /model status could show a fake [google] provider with missing auth for a model that was only configured under [openrouter].
After this change, the status output keeps the real aggregator entry and suppresses only the shadow native-provider artifact.

## Testing

- [x] Ran corepack pnpm exec vitest run src/agents/model-catalog.test.ts --environment node
- [x] Verified the regression case in model-catalog.test.ts

## AI usage

This PR was AI-assisted.
I reviewed the change manually, understand the implementation, and validated it locally.

Fixes #62317