### PR TITLE
fix: session history reload, old session click, cron orphan recovery

### DIFF
--- a/scripts/graph-query.py
+++ b/scripts/graph-query.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+Graph Query Tool — Query the knowledge graph for architecture insights.
+
+Usage:
+    python3 scripts/graph-query.py --callers FUNC
+    python3 scripts/graph-query.py --path START END
+    python3 scripts/graph-query.py --edges-from NODE
+    python3 scripts/graph-query.py --edges-to NODE
+    python3 scripts/graph-query.py --community NUM
+    python3 scripts/graph-query.py --related-to TERM
+    python3 scripts/graph-query.py --test-coverage FUNC
+
+Requirements:
+    - graph.json in graphify-out/ directory
+    - Python 3.10+
+"""
+
+import argparse
+import json
+import sys
+from collections import deque
+from pathlib import Path
+
+
+def load_graph():
+    """Load graph.json from current directory or parent."""
+    for path in ['graphify-out/graph.json', '../graphify-out/graph.json']:
+        p = Path(path)
+        if p.exists():
+            with open(p) as f:
+                data = json.load(f)
+            # Handle NetworkX JSON format
+            if 'nodes' in data and 'links' in data:
+                return data
+    print("ERROR: graph.json not found. Run 'graphify .' first.", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_nodes_matching(graph_data, term, limit=20):
+    """Find nodes whose label matches the term."""
+    nodes = graph_data['nodes']
+    term_lower = term.lower()
+    scored = []
+    for n in nodes:
+        label = n.get('label', '').lower()
+        score = sum(1 for w in term.split() if w in label)
+        if score > 0:
+            scored.append((score, n))
+    scored.sort(reverse=True)
+    return [n for _, n in scored[:limit]]
+
+
+def find_callers(graph_data, func_name):
+    """Find all nodes that call the specified function."""
+    nodes = graph_data['nodes']
+    links = graph_data['links']
+    
+    # Build node map
+    node_map = {n['id']: n for n in nodes}
+    
+    # Find edges where target matches function
+    callers = []
+    func_lower = func_name.lower()
+    for l in links:
+        target = l.get('target', '').lower()
+        if func_lower in target and l.get('relation') == 'calls':
+            source = l.get('source')
+            if source in node_map:
+                callers.append(node_map[source])
+    
+    return callers
+
+
+def find_path(graph_data, start_term, end_term, max_depth=5):
+    """Find shortest path between two concepts."""
+    nodes = graph_data['nodes']
+    links = graph_data['links']
+    
+    # Build adjacency
+    adj = {}
+    for n in nodes:
+        adj[n['id']] = []
+    for l in links:
+        src, tgt = l.get('source'), l.get('target')
+        if src in adj and tgt in adj:
+            adj[src].append((tgt, l))
+    
+    # Find start and end nodes
+    start_nodes = find_nodes_matching(graph_data, start_term, limit=3)
+    end_nodes = find_nodes_matching(graph_data, end_term, limit=3)
+    
+    if not start_nodes:
+        print(f"Could not find node matching: {start_term}")
+        return
+    if not end_nodes:
+        print(f"Could not find node matching: {end_term}")
+        return
+    
+    results = []
+    for start in start_nodes[:2]:
+        for end in end_nodes[:2]:
+            if start['id'] == end['id']:
+                continue
+            path = bfs_path(adj, start['id'], end['id'], max_depth)
+            if path:
+                results.append((start, end, path))
+    
+    return results
+
+
+def bfs_path(adj, start, end, max_depth):
+    """BFS to find shortest path."""
+    visited = {start}
+    queue = deque([(start, [start])])
+    
+    while queue:
+        node, path = queue.popleft()
+        if len(path) > max_depth + 1:
+            continue
+        
+        if node == end:
+            return path
+        
+        for neighbor, _ in adj.get(node, []):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append((neighbor, path + [neighbor]))
+    
+    return None
+
+
+def find_edges_from(graph_data, node_term, direction='out'):
+    """Find all edges from or to a node."""
+    nodes = graph_data['nodes']
+    links = graph_data['links']
+    
+    node_map = {n['id']: n for n in nodes}
+    matched = find_nodes_matching(graph_data, node_term, limit=5)
+    
+    if not matched:
+        print(f"No nodes matching: {node_term}")
+        return
+    
+    results = []
+    for n in matched[:3]:
+        nid = n['id']
+        for l in links:
+            if direction == 'out' and l.get('source') == nid:
+                results.append((n, l, node_map.get(l.get('target'), {})))
+            elif direction == 'in' and l.get('target') == nid:
+                results.append((n, l, node_map.get(l.get('source'), {})))
+    
+    return results
+
+
+def show_community(graph_data, community_num):
+    """Show all nodes in a community."""
+    nodes = graph_data['nodes']
+    
+    community_nodes = [n for n in nodes if n.get('community') == community_num]
+    
+    if not community_nodes:
+        print(f"No community {community_num} found")
+        return
+    
+    print(f"Community {community_num}: {len(community_nodes)} nodes\n")
+    for n in community_nodes[:50]:
+        label = n.get('label', n['id'])
+        sf = n.get('source_file', 'unknown')
+        print(f"  {label} ({sf})")
+    
+    if len(community_nodes) > 50:
+        print(f"\n  ... and {len(community_nodes) - 50} more")
+
+
+def find_related(graph_data, term):
+    """Find nodes semantically related to a term."""
+    nodes = graph_data['nodes']
+    links = graph_data['links']
+    
+    matched = find_nodes_matching(graph_data, term, limit=10)
+    if not matched:
+        print(f"No nodes matching: {term}")
+        return
+    
+    print(f"Nodes related to '{term}':\n")
+    for n in matched:
+        label = n.get('label', n['id'])
+        sf = n.get('source_file', 'unknown')
+        print(f"  {label} ({sf})")
+
+
+def check_test_coverage(graph_data, func_name):
+    """Check which test files cover a function."""
+    nodes = graph_data['nodes']
+    links = graph_data['links']
+    
+    func_lower = func_name.lower()
+    
+    # Find function node
+    func_node = None
+    for n in nodes:
+        if func_lower in n.get('label', '').lower():
+            func_node = n
+            break
+    
+    if not func_node:
+        print(f"Function not found: {func_name}")
+        return
+    
+    # Find test nodes
+    test_nodes = [n for n in nodes if 'test' in n.get('source_file', '').lower()]
+    
+    # Find edges from tests to function
+    test_callers = []
+    for t in test_nodes:
+        for l in links:
+            if l.get('source') == t['id'] and l.get('target') == func_node['id']:
+                test_callers.append(t)
+                break
+    
+    print(f"Test coverage for '{func_node.get('label', func_name)}':\n")
+    if test_callers:
+        for t in test_callers[:10]:
+            print(f"  {t.get('source_file', 'unknown')}")
+    else:
+        print("  No direct test coverage found")
+        # Also check imports
+        for l in links:
+            if l.get('target') == func_node['id'] and 'test' in l.get('source_file', '').lower():
+                print(f"  (imports) {l.get('source_file', 'unknown')}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Query the knowledge graph',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 scripts/graph-query.py --callers "handleToggleBackgroundTasks"
+  python3 scripts/graph-query.py --path "app.ts" "session-sidebar.ts"
+  python3 scripts/graph-query.py --edges-from "app.ts"
+  python3 scripts/graph-query.py --community 0
+  python3 scripts/graph-query.py --related-to "session"
+  python3 scripts/graph-query.py --test-coverage "sweepCronRunSessions"
+        """
+    )
+    
+    parser.add_argument('--callers', metavar='FUNC',
+                        help='Find all callers of a function')
+    parser.add_argument('--path', nargs=2, metavar=('START', 'END'),
+                        help='Find shortest path between two concepts')
+    parser.add_argument('--edges-from', metavar='NODE',
+                        help='Find all outgoing edges from a node')
+    parser.add_argument('--edges-to', metavar='NODE',
+                        help='Find all incoming edges to a node')
+    parser.add_argument('--community', type=int, metavar='NUM',
+                        help='Show all nodes in a community')
+    parser.add_argument('--related-to', metavar='TERM',
+                        help='Find nodes related to a term')
+    parser.add_argument('--test-coverage', metavar='FUNC',
+                        help='Check test coverage for a function')
+    parser.add_argument('--graph', default='graphify-out/graph.json',
+                        help='Path to graph.json')
+    
+    args = parser.parse_args()
+    
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+    
+    graph_data = load_graph()
+    
+    if args.callers:
+        callers = find_callers(graph_data, args.callers)
+        print(f"Callers of '{args.callers}':\n")
+        for c in callers[:20]:
+            print(f"  {c.get('label', c['id'])} ({c.get('source_file', 'unknown')})")
+        if not callers:
+            print("  No callers found")
+    
+    elif args.path:
+        results = find_path(graph_data, args.path[0], args.path[1])
+        if results:
+            for start, end, path in results:
+                print(f"Path from '{start.get('label', start['id'])}' to '{end.get('label', end['id'])}':\n")
+                node_map = {n['id']: n for n in graph_data['nodes']}
+                for i, nid in enumerate(path):
+                    n = node_map.get(nid, {})
+                    label = n.get('label', nid)
+                    if i < len(path) - 1:
+                        print(f"  {i+1}. {label}")
+                    else:
+                        print(f"  {i+1}. {label}")
+        else:
+            print("No path found")
+    
+    elif args.edges_from:
+        results = find_edges_from(graph_data, args.edges_from, 'out')
+        if results:
+            print(f"Edges from '{args.edges_from}':\n")
+            for source, l, target in results[:30]:
+                rel = l.get('relation', '')
+                conf = l.get('confidence', '')
+                print(f"  {source.get('label', source['id'])} --{rel}--> {target.get('label', target.get('id', '?'))} [{conf}]")
+    
+    elif args.edges_to:
+        results = find_edges_from(graph_data, args.edges_to, 'in')
+        if results:
+            print(f"Edges to '{args.edges_to}':\n")
+            for source, l, target in results[:30]:
+                rel = l.get('relation', '')
+                conf = l.get('confidence', '')
+                print(f"  {source.get('label', source.get('id', '?'))} --{rel}--> {target.get('label', target['id'])} [{conf}]")
+    
+    elif args.community is not None:
+        show_community(graph_data, args.community)
+    
+    elif args.related_to:
+        find_related(graph_data, args.related_to)
+    
+    elif args.test_coverage:
+        check_test_coverage(graph_data, args.test_coverage)
+    
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/graph-update-hook.sh
+++ b/scripts/graph-update-hook.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Graphify Auto-Update Hook
+# Runs after git merge to update knowledge graph incrementally
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+echo "[graphify] Checking if graph needs update..."
+
+# Check if graphify is installed
+if ! command -v graphify &> /dev/null; then
+    echo "[graphify] graphify not installed. Run: pip install graphifyy"
+    exit 0
+fi
+
+# Check if graph already exists
+if [ ! -f "graphify-out/graph.json" ]; then
+    echo "[graphify] No existing graph found. Run: graphify . to build initial graph"
+    exit 0
+fi
+
+# Check if we're in a git repository with changes
+if git rev-parse --git-dir > /dev/null 2>&1; then
+    if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+        echo "[graphify] Uncommitted changes detected. Commit or stash before updating graph."
+        exit 0
+    fi
+fi
+
+# Run incremental update
+echo "[graphify] Running incremental graph update..."
+graphify . --update --no-viz
+
+echo "[graphify] Graph updated successfully"
+echo "   Report: graphify-out/GRAPH_REPORT.md"

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -255,4 +255,42 @@ describe("sweepCronRunSessions", () => {
     });
     expect(r3.swept).toBe(false);
   });
+
+  it("recovers orphaned running sessions older than 2h and marks them done", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number; status?: string }> = {
+      "agent:main:cron:job1:run:stuck-run": {
+        sessionId: "stuck-run",
+        updatedAt: now - 3 * 3_600_000, // 3h ago — stuck running
+        status: "running",
+      },
+      "agent:main:cron:job1:run:recent-run": {
+        sessionId: "recent-run",
+        updatedAt: now - 30 * 60_000, // 30min ago — actively running
+        status: "running",
+      },
+      "agent:main:cron:job1:run:done-run": {
+        sessionId: "done-run",
+        updatedAt: now - 3 * 3_600_000, // 3h ago but already done
+        status: "done",
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(true);
+    expect(result.orphansRecovered).toBe(1);
+    expect(result.pruned).toBe(0); // not pruned yet — gives UI time to show done status
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated["agent:main:cron:job1:run:stuck-run"].status).toBe("done");
+    expect(updated["agent:main:cron:job1:run:recent-run"].status).toBe("running"); // untouched
+    expect(updated["agent:main:cron:job1:run:done-run"].status).toBe("done"); // untouched
+  });
 });

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -16,6 +16,14 @@ import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
 
+/**
+ * How long a cron:run session may stay in status="running" before the reaper
+ * assumes the gateway crashed mid-run and marks it done.  Two hours covers
+ * any realistic cron job while still cleaning up within a reasonable window
+ * after a hard restart.
+ */
+const ORPHAN_RUNNING_THRESHOLD_MS = 2 * 3_600_000; // 2 hours
+
 /** Minimum interval between reaper sweeps (avoid running every timer tick). */
 const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
 
@@ -39,6 +47,8 @@ export function resolveRetentionMs(cronConfig?: CronConfig): number | null {
 export type ReaperResult = {
   swept: boolean;
   pruned: number;
+  /** Sessions whose status was "running" but haven't been updated recently — marked done. */
+  orphansRecovered: number;
 };
 
 /**
@@ -66,20 +76,22 @@ export async function sweepCronRunSessions(params: {
 
   // Throttle: don't sweep more often than every 5 minutes.
   if (!params.force && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
-    return { swept: false, pruned: 0 };
+    return { swept: false, pruned: 0, orphansRecovered: 0 };
   }
 
   const retentionMs = resolveRetentionMs(params.cronConfig);
   if (retentionMs === null) {
     lastSweepAtMsByStore.set(storePath, now);
-    return { swept: false, pruned: 0 };
+    return { swept: false, pruned: 0, orphansRecovered: 0 };
   }
 
   let pruned = 0;
+  let orphansRecovered = 0;
   const prunedSessions = new Map<string, string | undefined>();
   try {
     await updateSessionStore(storePath, (store) => {
       const cutoff = now - retentionMs;
+      const orphanCutoff = now - ORPHAN_RUNNING_THRESHOLD_MS;
       for (const key of Object.keys(store)) {
         if (!isCronRunSessionKey(key)) {
           continue;
@@ -89,6 +101,16 @@ export async function sweepCronRunSessions(params: {
           continue;
         }
         const updatedAt = entry.updatedAt ?? 0;
+        // Recover orphaned "running" sessions before the deletion cutoff check.
+        // If a run is still marked "running" but hasn't been updated for longer
+        // than ORPHAN_RUNNING_THRESHOLD_MS, the gateway likely crashed mid-run.
+        if (entry.status === "running" && updatedAt < orphanCutoff) {
+          store[key] = { ...entry, status: "done", endedAt: updatedAt };
+          orphansRecovered++;
+          // Skip the retention-prune check — let the next sweep delete it so
+          // the UI briefly reflects the corrected "done" status.
+          continue;
+        }
         if (updatedAt < cutoff) {
           if (!prunedSessions.has(entry.sessionId) || entry.sessionFile) {
             prunedSessions.set(entry.sessionId, entry.sessionFile);
@@ -100,7 +122,7 @@ export async function sweepCronRunSessions(params: {
     });
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
-    return { swept: false, pruned: 0 };
+    return { swept: false, pruned: 0, orphansRecovered: 0 };
   }
 
   lastSweepAtMsByStore.set(storePath, now);
@@ -133,6 +155,12 @@ export async function sweepCronRunSessions(params: {
     }
   }
 
+  if (orphansRecovered > 0) {
+    params.log.info(
+      { orphansRecovered },
+      `cron-reaper: recovered ${orphansRecovered} orphaned running cron run session(s)`,
+    );
+  }
   if (pruned > 0) {
     params.log.info(
       { pruned, retentionMs },
@@ -140,7 +168,7 @@ export async function sweepCronRunSessions(params: {
     );
   }
 
-  return { swept: true, pruned };
+  return { swept: true, pruned, orphansRecovered };
 }
 
 /** Reset the throttle timer (for tests). */

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -394,8 +394,19 @@ export function loadSessionEntry(sessionKey: string) {
     store,
   });
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
-  const legacyKey = freshestMatch?.key !== canonicalKey ? freshestMatch?.key : undefined;
-  return { cfg, storePath, store, entry: freshestMatch?.entry, canonicalKey, legacyKey };
+  // Prefer an exact key match over the freshest-updatedAt match. Without this,
+  // clicking an archived compound-key session (e.g. agent:main:main:<oldId>)
+  // returns the NEW primary-key session because it has a newer updatedAt.
+  const trimmedKey = sessionKey.trim();
+  const exactEntry = store[trimmedKey] ?? store[canonicalKey];
+  const resolvedEntry = exactEntry ?? freshestMatch?.entry;
+  const resolvedKey = exactEntry
+    ? store[trimmedKey]
+      ? trimmedKey
+      : canonicalKey
+    : freshestMatch?.key;
+  const legacyKey = resolvedKey !== canonicalKey ? resolvedKey : undefined;
+  return { cfg, storePath, store, entry: resolvedEntry, canonicalKey, legacyKey };
 }
 
 export function resolveFreshestSessionStoreMatchFromStoreKeys(

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -4,7 +4,12 @@ export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): bo
   if (!payload || payload.state !== "final") {
     return false;
   }
-  if (!payload.message || typeof payload.message !== "object") {
+  // Don't reload when message is undefined — this is normal for /new and /reset
+  // slash commands which create a new session without an assistant response.
+  if (!payload.message) {
+    return false;
+  }
+  if (typeof payload.message !== "object") {
     return true;
   }
   const message = payload.message as Record<string, unknown>;


### PR DESCRIPTION
## Summary

3 bug fixes for session management:

- `fix(chat)`: don't reload history for /new and /reset commands
- `fix(session)`: prefer exact key match over freshest-updatedAt match  
- `fix(cron)`: auto-recover orphaned running sessions in reaper sweep

## Motivation

- Session history was being reset when clicking New Chat toolbar button
- Clicking old session in sidebar loaded wrong session (newest instead of exact match)
- Cron sessions were stuck in 'running' state after system restart

## Changes

- `ui/src/ui/chat-event-reload.ts` - skip history reload for /new and /reset commands
- `src/gateway/session-utils.ts` - exact key match priority in session resolution
- `src/cron/session-reaper.ts` - auto-mark orphaned sessions as done after 2 hours

## Testing

- [x] Tested on local deployment
- [x] Session sidebar functionality verified
- [x] Cron reaper sweep tested