### PR TITLE
docs: add CheapestInference as a provider

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1234,6 +1234,7 @@
                   "providers/arcee",
                   "providers/bedrock",
                   "providers/bedrock-mantle",
+                  "providers/cheapestinference",
                   "providers/chutes",
                   "providers/comfy",
                   "providers/claude-max-api-proxy",

--- a/docs/providers/cheapestinference.md
+++ b/docs/providers/cheapestinference.md
@@ -1,0 +1,61 @@
+---
+title: "CheapestInference"
+summary: "Use CheapestInference's unified AI proxy for affordable inference in OpenClaw"
+read_when:
+  - You want the cheapest model pricing for OpenClaw
+  - You want a single API key for many LLMs via CheapestInference
+---
+
+# CheapestInference
+
+[CheapestInference](https://cheapestinference.com) is a unified AI inference proxy that provides access to many models behind a single OpenAI-compatible endpoint. It offers competitive pricing with optional pay-per-request via USDC on Base L2.
+
+## Quick start
+
+```bash
+openclaw onboard --auth-choice cheapestinference-api-key
+```
+
+## Config snippet
+
+```json5
+{
+  env: { CHEAPESTINFERENCE_API_KEY: "sk-..." },
+  models: {
+    providers: {
+      cheapestinference: {
+        baseUrl: "https://api.cheapestinference.com/v1",
+        apiKey: "${CHEAPESTINFERENCE_API_KEY}",
+        api: "openai-completions",
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "cheapestinference/claude-opus-4-6" },
+    },
+  },
+}
+```
+
+## Manual setup
+
+Set the env var directly:
+
+```bash
+export CHEAPESTINFERENCE_API_KEY="sk-..."
+```
+
+## Notes
+
+- Base URL: `https://api.cheapestinference.com/v1`
+- OpenAI-compatible API — works with any OpenAI SDK by switching the base URL
+- Model refs follow the pattern `cheapestinference/<model>` (e.g. `cheapestinference/claude-opus-4-6`, `cheapestinference/gpt-4o`)
+- Supports models from Anthropic, OpenAI, Google, Meta, Mistral, DeepSeek, and others
+- Bearer token authentication with your subscriber API key
+- Browse available models and pricing at [cheapestinference.com](https://cheapestinference.com)
+
+## See also
+
+- [Provider Directory](/providers/index)
+- [Model Providers](/concepts/model-providers)

--- a/docs/providers/cheapestinference.md
+++ b/docs/providers/cheapestinference.md
@@ -10,13 +10,17 @@ read_when:
 
 [CheapestInference](https://cheapestinference.com) is a unified AI inference proxy that provides access to many models behind a single OpenAI-compatible endpoint. It offers competitive pricing with optional pay-per-request via USDC on Base L2.
 
-## Quick start
+## Setup
+
+1. Get an API key at [cheapestinference.com](https://cheapestinference.com)
+
+2. Set the env var:
 
 ```bash
-openclaw onboard --auth-choice cheapestinference-api-key
+export CHEAPESTINFERENCE_API_KEY="sk-..."
 ```
 
-## Config snippet
+3. Add the provider to your OpenClaw config:
 
 ```json5
 {
@@ -36,14 +40,6 @@ openclaw onboard --auth-choice cheapestinference-api-key
     },
   },
 }
-```
-
-## Manual setup
-
-Set the env var directly:
-
-```bash
-export CHEAPESTINFERENCE_API_KEY="sk-..."
 ```
 
 ## Notes

--- a/docs/providers/cheapestinference.md
+++ b/docs/providers/cheapestinference.md
@@ -31,6 +31,7 @@ export CHEAPESTINFERENCE_API_KEY="sk-..."
         baseUrl: "https://api.cheapestinference.com/v1",
         apiKey: "${CHEAPESTINFERENCE_API_KEY}",
         api: "openai-completions",
+        models: [{ id: "claude-opus-4-6", name: "Claude Opus 4.6" }],
       },
     },
   },

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -31,6 +31,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Arcee AI (Trinity models)](/providers/arcee)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
+- [CheapestInference (unified AI proxy)](/providers/cheapestinference)
 - [Chutes](/providers/chutes)
 - [ComfyUI](/providers/comfy)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)


### PR DESCRIPTION
## Summary

- Add CheapestInference unified AI inference proxy to the provider directory
- New provider page with setup instructions, config snippet, and model info
- Update `docs.json` navigation and `providers/index.md` listing

CheapestInference is an OpenAI-compatible inference provider that gives access to open source models through a single endpoint and API key.

- Base URL: `https://api.cheapestinference.com/v1`
- Website: [cheapestinference.com](https://cheapestinference.com)
