### PR TITLE
fix(plugins): avoid loading disabled channel plugins for status

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -37,6 +37,7 @@ import {
   listConfiguredChannelIdsForReadOnlyScope,
   listExplicitConfiguredChannelIdsForConfig,
   resolveConfiguredChannelPresencePolicy,
+  resolveChannelPluginIds,
   resolveConfiguredDeferredChannelPluginIds,
   resolveConfiguredChannelPluginIds,
   resolveGatewayStartupPluginIds,
@@ -1404,5 +1405,31 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         includePersistedAuthState: false,
       }),
     ).toBe(true);
+  });
+});
+
+describe("resolveChannelPluginIds", () => {
+  beforeEach(() => {
+    loadPluginManifestRegistry.mockReset().mockReturnValue(createManifestRegistryFixture());
+  });
+
+  it("skips disabled channel plugins in channel scope", () => {
+    const config = {
+      plugins: {
+        allow: ["demo-channel", "demo-other-channel"],
+        entries: {
+          "demo-channel": { enabled: true },
+          "demo-other-channel": { enabled: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveChannelPluginIds({
+        config,
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual(["demo-channel"]);
   });
 });

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -134,12 +134,28 @@ export function resolveChannelPluginIds(params: {
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
 }): string[] {
+  const pluginsConfig = normalizePluginsConfig(params.config.plugins);
+  const activationSource = createPluginActivationSource({
+    config: params.config,
+  });
   return loadPluginManifestRegistry({
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
   })
-    .plugins.filter((plugin) => plugin.channels.length > 0)
+    .plugins.filter((plugin) => {
+      if (plugin.channels.length === 0) {
+        return false;
+      }
+      return resolveEffectivePluginActivationState({
+        id: plugin.id,
+        origin: plugin.origin,
+        config: pluginsConfig,
+        rootConfig: params.config,
+        enabledByDefault: plugin.enabledByDefault,
+        activationSource,
+      }).enabled;
+    })
     .map((plugin) => plugin.id);
 }
 

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -252,4 +252,30 @@ describe("ensurePluginRegistryLoaded", () => {
       }),
     );
   });
+
+  it("does not treat a warm channel registry as satisfying a new empty channel scope", () => {
+    mocks.getActivePluginRegistry.mockReturnValue({
+      ...createEmptyPluginRegistry(),
+      plugins: [{ id: "demo-channel", status: "loaded" } as never],
+      channels: [
+        {
+          pluginId: "demo-channel",
+          plugin: { id: "demo-channel" } as never,
+          source: "test",
+        },
+      ],
+    });
+    mocks.resolveChannelPluginIds.mockReturnValue([]);
+
+    ensurePluginRegistryLoaded({
+      scope: "channels",
+      config: {} as never,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: [],
+      }),
+    );
+  });
 });

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -312,4 +312,31 @@ describe("ensurePluginRegistryLoaded", () => {
       }),
     );
   });
+
+  it("compares active channel scope by owning plugin ids, not channel registrations", () => {
+    mocks.getActivePluginRegistry.mockReturnValue({
+      ...createEmptyPluginRegistry(),
+      plugins: [{ id: "demo-a", status: "loaded" } as never],
+      channels: [
+        {
+          pluginId: "demo-a",
+          plugin: { id: "demo-a" } as never,
+          source: "test",
+        },
+        {
+          pluginId: "demo-a",
+          plugin: { id: "demo-a" } as never,
+          source: "test",
+        },
+      ],
+    });
+    mocks.resolveChannelPluginIds.mockReturnValue(["demo-a"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "channels",
+      config: {} as never,
+    });
+
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -238,7 +238,7 @@ describe("ensurePluginRegistryLoaded", () => {
     );
   });
 
-  it("does not forward empty channel scopes for broad channel loads", () => {
+  it("preserves empty channel scopes for broad channel loads", () => {
     mocks.resolveChannelPluginIds.mockReturnValue([]);
 
     ensurePluginRegistryLoaded({
@@ -247,12 +247,9 @@ describe("ensurePluginRegistryLoaded", () => {
     });
 
     expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
-      expect.not.objectContaining({
+      expect.objectContaining({
         onlyPluginIds: [],
       }),
     );
-    expect(
-      (mocks.loadOpenClawPlugins.mock.calls[0]?.[0] as { onlyPluginIds?: string[] }).onlyPluginIds,
-    ).toBeUndefined();
   });
 });

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -278,4 +278,38 @@ describe("ensurePluginRegistryLoaded", () => {
       }),
     );
   });
+
+  it("does not treat a warm channel registry as satisfying a smaller channel scope", () => {
+    mocks.getActivePluginRegistry.mockReturnValue({
+      ...createEmptyPluginRegistry(),
+      plugins: [
+        { id: "demo-a", status: "loaded" } as never,
+        { id: "demo-b", status: "loaded" } as never,
+      ],
+      channels: [
+        {
+          pluginId: "demo-a",
+          plugin: { id: "demo-a" } as never,
+          source: "test",
+        },
+        {
+          pluginId: "demo-b",
+          plugin: { id: "demo-b" } as never,
+          source: "test",
+        },
+      ],
+    });
+    mocks.resolveChannelPluginIds.mockReturnValue(["demo-a"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "channels",
+      config: {} as never,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["demo-a"],
+      }),
+    );
+  });
 });

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -59,10 +59,10 @@ function activeRegistrySatisfiesScope(
       if (expectedChannelPluginIds.length === 0) {
         return false;
       }
-      return (
-        active.channels.length > 0 &&
-        expectedChannelPluginIds.every((pluginId) => activeChannelPluginIds.has(pluginId))
-      );
+      if (active.channels.length !== expectedChannelPluginIds.length) {
+        return false;
+      }
+      return expectedChannelPluginIds.every((pluginId) => activeChannelPluginIds.has(pluginId));
     case "all":
       return false;
   }

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -56,6 +56,9 @@ function activeRegistrySatisfiesScope(
   switch (scope) {
     case "configured-channels":
     case "channels":
+      if (expectedChannelPluginIds.length === 0) {
+        return false;
+      }
       return (
         active.channels.length > 0 &&
         expectedChannelPluginIds.every((pluginId) => activeChannelPluginIds.has(pluginId))

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -70,7 +70,9 @@ function shouldForwardChannelScope(params: {
   scope: PluginRegistryScope;
   scopedLoad: boolean;
 }): boolean {
-  return !params.scopedLoad && params.scope === "configured-channels";
+  return (
+    !params.scopedLoad && (params.scope === "configured-channels" || params.scope === "channels")
+  );
 }
 
 export function ensurePluginRegistryLoaded(options?: {

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -53,16 +53,19 @@ function activeRegistrySatisfiesScope(
     return requestedPluginIds.every((pluginId) => activePluginIds.has(pluginId));
   }
   const activeChannelPluginIds = new Set(active.channels.map((entry) => entry.plugin.id));
+  const expectedChannelPluginIdSet = new Set(expectedChannelPluginIds);
   switch (scope) {
     case "configured-channels":
     case "channels":
-      if (expectedChannelPluginIds.length === 0) {
+      if (expectedChannelPluginIdSet.size === 0) {
         return false;
       }
-      if (active.channels.length !== expectedChannelPluginIds.length) {
+      if (activeChannelPluginIds.size !== expectedChannelPluginIdSet.size) {
         return false;
       }
-      return expectedChannelPluginIds.every((pluginId) => activeChannelPluginIds.has(pluginId));
+      return [...expectedChannelPluginIdSet].every((pluginId) =>
+        activeChannelPluginIds.has(pluginId),
+      );
     case "all":
       return false;
   }


### PR DESCRIPTION
## Summary

- Problem: `openclaw status` channel-scoped registry loads treated every channel-capable manifest as eligible, including plugins that were effectively disabled.
- Why it matters: status/health flows could pull in heavy disabled channel plugins, causing slow or hanging CLI runs in constrained environments.
- What changed: channel scope now filters plugin ids through effective activation state, preserves explicit empty scoped loads, and keeps channel-scoped runtime loads scoped even when the resulting id list is empty.
- What did NOT change (scope boundary): this does not change gateway startup plugin selection, provider loading, or general `scope: "all"` registry behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62522
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveChannelPluginIds()` returned every manifest with `plugin.channels.length > 0` without checking effective activation state, and the scoped plugin loader path also collapsed `onlyPluginIds: []` into `undefined`, which degraded empty channel scopes back into full plugin loads.
- Missing detection / guardrail: there was no test asserting that channel scope excludes disabled plugins or that an explicit empty scoped load stays empty all the way through `ensurePluginRegistryLoaded()` and `loadOpenClawPlugins()`.
- Contributing context (if known): status/health CLI paths use `scope: "channels"`, so the issue was amplified on slower filesystems and plugin trees with many disabled channel bundles.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/channel-plugin-ids.test.ts`, `src/cli/plugin-registry.test.ts`
- Scenario the test should lock in: channel scope should exclude disabled channel plugins, and `configured-channels` should preserve `onlyPluginIds: []` instead of falling back to a full load.
- Why this is the smallest reliable guardrail: the regression lives entirely in plugin id resolution and scoped registry loading semantics; these tests exercise the exact boundary without needing real plugin I/O.
- Existing test that already covers this (if any): `src/cli/plugin-registry.test.ts` already covered the empty scoped load expectation once the loader semantics were fixed.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw status` / channel-scoped CLI flows stop loading disabled channel plugins.
- Empty channel scopes remain empty instead of degenerating into full plugin loads.

## Diagram (if applicable)

```text
Before:
[status/health command] -> [resolve all channel-capable manifests] -> [load disabled channel plugins too] -> [slow/hanging CLI]

After:
[status/health command] -> [resolve only effectively enabled channel plugins] -> [preserve empty scoped loads] -> [load only intended plugins]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 24 / local clean worktree
- Model/provider: N/A
- Integration/channel (if any): plugin registry / channel plugin loading
- Relevant config (redacted): plugin entries with enabled and disabled channel plugins

### Steps

1. Configure a channel plugin as enabled and another channel plugin as disabled.
2. Run the channel-scope registry resolution path.
3. Run `ensurePluginRegistryLoaded({ scope: "configured-channels" })` followed by `ensurePluginRegistryLoaded({ scope: "channels" })`.

### Expected

- Disabled channel plugins are excluded from channel scope.
- Explicit empty channel scopes stay empty and do not trigger a full plugin load.

### Actual

- Before this patch, disabled channel plugins were included, and empty channel scopes were treated like no scope.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/cli/plugin-registry.test.ts src/plugins/channel-plugin-ids.test.ts`; `pnpm test src/plugins/loader.test.ts -t cache`; `codex review --base upstream/main`
- Edge cases checked: disabled channel plugin omitted from `resolveChannelPluginIds()`; explicit empty scoped loads remain empty through runtime registry loading; escalation from `configured-channels` to `channels` still reloads with the larger enabled set.
- What you did **not** verify: full `pnpm build` is currently red on clean `upstream/main` due unrelated baseline errors in `src/agents/subagent-control.ts` and `src/auto-reply/reply/commands-subagents.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a caller relying on channel scope to opportunistically load disabled channel plugins will now see a narrower registry.
  - Mitigation: that behavior was the bug; `scope: "all"` remains unchanged for callers that truly need a full registry.
