### PR TITLE
fix(cli): preload configured channels for status paths

### DIFF
--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -10,7 +10,7 @@ vi.mock("./program/config-guard.js", () => ({
 vi.mock("./plugin-registry-loader.js", () => ({
   ensureCliPluginRegistryLoaded: ensureCliPluginRegistryLoadedMock,
   resolvePluginRegistryScopeForCommandPath: vi.fn((commandPath: string[]) =>
-    commandPath[0] === "status" || commandPath[0] === "health" ? "channels" : "all",
+    commandPath[0] === "status" || commandPath[0] === "health" ? "configured-channels" : "all",
   ),
 }));
 
@@ -57,7 +57,7 @@ describe("ensureCliCommandBootstrap", () => {
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
-      scope: "channels",
+      scope: "configured-channels",
       routeLogsToStderr: true,
     });
   });

--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -59,8 +59,8 @@ describe("plugin-registry-loader", () => {
   });
 
   it("maps command paths to plugin registry scopes", () => {
-    expect(resolvePluginRegistryScopeForCommandPath(["status"])).toBe("channels");
-    expect(resolvePluginRegistryScopeForCommandPath(["health"])).toBe("channels");
+    expect(resolvePluginRegistryScopeForCommandPath(["status"])).toBe("configured-channels");
+    expect(resolvePluginRegistryScopeForCommandPath(["health"])).toBe("configured-channels");
     expect(resolvePluginRegistryScopeForCommandPath(["agents"])).toBe("all");
   });
 });

--- a/src/cli/plugin-registry-loader.ts
+++ b/src/cli/plugin-registry-loader.ts
@@ -10,8 +10,8 @@ function loadPluginRegistryModule() {
 
 export function resolvePluginRegistryScopeForCommandPath(
   commandPath: string[],
-): Exclude<PluginRegistryScope, "configured-channels"> {
-  return commandPath[0] === "status" || commandPath[0] === "health" ? "channels" : "all";
+): PluginRegistryScope {
+  return commandPath[0] === "status" || commandPath[0] === "health" ? "configured-channels" : "all";
 }
 
 export async function ensureCliPluginRegistryLoaded(params: {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -209,7 +209,9 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["status"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "configured-channels",
+    });
     expect(processTitleSetSpy).toHaveBeenCalledWith("openclaw-status");
 
     vi.clearAllMocks();

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -88,7 +88,9 @@ describe("tryRouteCli", () => {
       runtime: expect.any(Object),
       commandPath: ["status"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "configured-channels",
+    });
   });
 
   it("routes logs to stderr during plugin loading in --json mode and restores after", async () => {
@@ -139,7 +141,9 @@ describe("tryRouteCli", () => {
       runtime: expect.any(Object),
       commandPath: ["status"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "configured-channels",
+    });
   });
 
   it("respects OPENCLAW_HIDE_BANNER for routed commands", async () => {

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -154,4 +154,15 @@ describe("ensurePluginRegistryLoaded", () => {
       expect.objectContaining({ onlyPluginIds: ["demo-b"] }),
     );
   });
+
+  it("skips plugin loading when no configured channels are present", () => {
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue([]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: {} as never,
+    });
+
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -79,6 +79,10 @@ export function ensurePluginRegistryLoaded(options?: {
             env: context.env,
           })
         : [];
+  if (!scopedLoad && scope === "configured-channels" && expectedChannelPluginIds.length === 0) {
+    pluginRegistryLoaded = scope;
+    return;
+  }
   const active = getActivePluginRegistry();
   if (
     !scopedLoad &&


### PR DESCRIPTION
## Summary
- preload only configured channel plugins for routed `status` and `health` commands
- keep non-status command paths on the existing `all` scope
- update CLI bootstrap and routing tests to lock in the narrower preload scope

## Why
`status` and `health` currently route through CLI bootstrap with `scope: "channels"`, which loads every channel-capable plugin even when the command only needs configured channels. That widens plugin preload unnecessarily and can make these commands much slower in environments with expensive plugin I/O.

Closes #62522
