### PR TITLE
perf: add includeTranscriptUsage opt-in to sessions.list, default off

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -1237,6 +1237,7 @@ export class AcpGatewayAgent implements Agent {
       limit: 200,
       search: sessionKey,
       includeDerivedTitles: true,
+      includeTranscriptUsage: true,
     });
     const session = result.sessions.find((entry) => entry.key === sessionKey);
     if (!session) {

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -51,6 +51,14 @@ export const SessionsListParamsSchema = Type.Object(
      * Performs a file read per session - use `limit` to bound result set on large stores.
      */
     includeLastMessage: Type.Optional(Type.Boolean()),
+    /**
+     * Run the per-session transcript fallback to resolve usage/cost/context data that is
+     * missing from the session store (totalTokens, contextTokens, estimatedCostUsd).
+     * Performs a synchronous full-transcript read per session when the store values are
+     * absent — expensive on large stores.  Default false (opt-in).
+     * Use this flag only when the caller needs token/cost/context enrichment.
+     */
+    includeTranscriptUsage: Type.Optional(Type.Boolean()),
     label: Type.Optional(SessionLabelString),
     spawnedBy: Type.Optional(NonEmptyString),
     agentId: Type.Optional(NonEmptyString),

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -712,6 +712,9 @@ describe("agent event handler", () => {
       new Set(["conn-session"]),
       { dropIfSlow: true },
     );
+    expect(loadGatewaySessionRow).toHaveBeenCalledWith("session-1", {
+      includeTranscriptUsage: true,
+    });
     resetAgentRunContextForTest();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -489,7 +489,7 @@ export function createAgentEventHandler({
   };
 
   const buildSessionEventSnapshot = (sessionKey: string, evt?: AgentEventPayload) => {
-    const row = loadGatewaySessionRow(sessionKey);
+    const row = loadGatewaySessionRow(sessionKey, { includeTranscriptUsage: true });
     const lifecyclePatch = evt
       ? deriveGatewaySessionLifecycleSnapshot({
           session: row

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -637,6 +637,9 @@ describe("gateway agent handler", () => {
       new Set(["conn-1"]),
       { dropIfSlow: true },
     );
+    expect(mocks.loadGatewaySessionRow).toHaveBeenCalledWith("agent:main:main", {
+      includeTranscriptUsage: true,
+    });
   });
 
   it("injects a timestamp into the message passed to agentCommand", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -125,7 +125,9 @@ function emitSessionsChanged(
   if (connIds.size === 0) {
     return;
   }
-  const sessionRow = payload.sessionKey ? loadGatewaySessionRow(payload.sessionKey) : null;
+  const sessionRow = payload.sessionKey
+    ? loadGatewaySessionRow(payload.sessionKey, { includeTranscriptUsage: true })
+    : null;
   context.broadcastToConnIds(
     "sessions.changed",
     {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -144,7 +144,9 @@ function emitSessionsChanged(
   if (connIds.size === 0) {
     return;
   }
-  const sessionRow = payload.sessionKey ? loadGatewaySessionRow(payload.sessionKey) : null;
+  const sessionRow = payload.sessionKey
+    ? loadGatewaySessionRow(payload.sessionKey, { includeTranscriptUsage: true })
+    : null;
   context.broadcastToConnIds(
     "sessions.changed",
     {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1018,7 +1018,9 @@ export async function startGatewayServer(
           const messageSeq = entry?.sessionId
             ? readSessionMessages(entry.sessionId, storePath, entry.sessionFile).length
             : undefined;
-          const sessionRow = loadGatewaySessionRow(sessionKey);
+          const sessionRow = loadGatewaySessionRow(sessionKey, {
+            includeTranscriptUsage: true,
+          });
           const sessionSnapshot = sessionRow
             ? {
                 session: sessionRow,
@@ -1113,7 +1115,9 @@ export async function startGatewayServer(
           if (connIds.size === 0) {
             return;
           }
-          const sessionRow = loadGatewaySessionRow(event.sessionKey);
+          const sessionRow = loadGatewaySessionRow(event.sessionKey, {
+            includeTranscriptUsage: true,
+          });
           broadcastToConnIds(
             "sessions.changed",
             {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -677,7 +677,7 @@ describe("gateway server sessions", () => {
         modelProvider?: string;
         model?: string;
       }>;
-    }>(ws, "sessions.list", {});
+    }>(ws, "sessions.list", { includeTranscriptUsage: true });
 
     expect(listed.ok).toBe(true);
     const parent = listed.payload?.sessions.find((session) => session.key === "agent:main:main");
@@ -692,6 +692,76 @@ describe("gateway server sessions", () => {
     expect(child?.estimatedCostUsd).toBe(0.0042);
     expect(child?.modelProvider).toBe("anthropic");
     expect(child?.model).toBe("claude-sonnet-4-6");
+
+    ws.close();
+  });
+
+  test("sessions.list default path omits transcript usage fallback", async () => {
+    const { dir } = await createSessionStoreDir();
+    testState.agentConfig = {
+      models: {
+        "anthropic/claude-sonnet-4-6": { params: { context1m: true } },
+      },
+    };
+    await fs.writeFile(
+      path.join(dir, "sess-no-usage.jsonl"),
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-no-usage" }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            usage: {
+              input: 2_000,
+              output: 500,
+              cacheRead: 1_000,
+              cost: { total: 0.0042 },
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-no-usage",
+          updatedAt: Date.now(),
+          modelProvider: "anthropic",
+          model: "claude-sonnet-4-6",
+          // Deliberately zeroed so without includeTranscriptUsage the fallback would be needed
+          totalTokens: 0,
+          totalTokensFresh: false,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    // Default call — no includeTranscriptUsage
+    const listed = await rpcReq<{
+      sessions: Array<{
+        key: string;
+        totalTokens?: number;
+        totalTokensFresh?: boolean;
+        contextTokens?: number;
+        estimatedCostUsd?: number;
+      }>;
+    }>(ws, "sessions.list", {});
+
+    expect(listed.ok).toBe(true);
+    const session = listed.payload?.sessions.find((s) => s.key === "agent:main:main");
+    expect(session).toBeDefined();
+    // Without opt-in the transcript fallback must NOT fire — usage fields stay unset
+    expect(session?.totalTokens).toBeUndefined();
+    // totalTokensFresh comes from store metadata, not transcript scan — skip asserting it
+    expect(session?.estimatedCostUsd).toBeUndefined();
+    // contextTokens may still resolve from the model catalog without reading the transcript
+    // so we only assert it is NOT derived from the transcript path (no regression on store-based data)
 
     ws.close();
   });

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -146,6 +146,92 @@ describe("session.message websocket events", () => {
     }
   });
 
+  test("includes live usage metadata on lifecycle sessions.changed events", async () => {
+    const previousMinimalGateway = process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+    delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+    try {
+      const storePath = await createSessionStoreFile();
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+            modelProvider: "openai",
+            model: "gpt-5.4",
+            contextTokens: 123_456,
+            totalTokens: 0,
+            totalTokensFresh: false,
+          },
+        },
+        storePath,
+      });
+      const transcriptPath = path.join(path.dirname(storePath), "sess-main.jsonl");
+      await fs.writeFile(
+        transcriptPath,
+        [
+          JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
+          JSON.stringify({
+            id: "msg-usage",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "usage snapshot" }],
+              provider: "openai",
+              model: "gpt-5.4",
+              usage: {
+                input: 2_000,
+                output: 400,
+                cacheRead: 300,
+                cacheWrite: 100,
+                cost: { total: 0.0042 },
+              },
+              timestamp: Date.now(),
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const harness = await createGatewaySuiteHarness();
+      try {
+        await withOperatorSessionSubscriber(harness, async (ws) => {
+          const changedEvent = onceMessage(
+            ws,
+            (message) =>
+              message.type === "event" &&
+              message.event === "sessions.changed" &&
+              (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
+                "agent:main:main",
+          );
+
+          emitSessionLifecycleEvent({
+            sessionKey: "agent:main:main",
+            reason: "reactivated",
+          });
+
+          const event = await changedEvent;
+          expect(event.payload).toMatchObject({
+            sessionKey: "agent:main:main",
+            reason: "reactivated",
+            totalTokens: 2_400,
+            totalTokensFresh: true,
+            contextTokens: 123_456,
+            estimatedCostUsd: 0.0042,
+            modelProvider: "openai",
+            model: "gpt-5.4",
+          });
+        });
+      } finally {
+        await harness.close();
+      }
+    } finally {
+      if (previousMinimalGateway === undefined) {
+        delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+      } else {
+        process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = previousMinimalGateway;
+      }
+    }
+  });
+
   test("only sends transcript events to subscribed operator clients", async () => {
     const storePath = await createSessionStoreFile();
     await writeSessionStore({

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -293,7 +293,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]?.estimatedCostUsd).toBe(0.1234);
@@ -385,7 +385,7 @@ describe("listSessionsFromStore search", () => {
             cacheWrite: 0,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]?.totalTokens).toBe(6_643);
@@ -449,7 +449,7 @@ describe("listSessionsFromStore search", () => {
             cacheWrite: 0,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]?.totalTokens).toBe(3_200);
@@ -523,7 +523,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]).toMatchObject({
@@ -605,7 +605,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]).toMatchObject({
@@ -673,7 +673,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]).toMatchObject({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1191,6 +1191,12 @@ export function buildGatewaySessionRow(params: {
   now?: number;
   includeDerivedTitles?: boolean;
   includeLastMessage?: boolean;
+  /**
+   * When true, run the expensive per-session transcript scan to resolve
+   * totalTokens / contextTokens / estimatedCostUsd that are absent from the
+   * store.  Default false so the hot listing path stays cheap.
+   */
+  includeTranscriptUsage?: boolean;
 }): GatewaySessionRow {
   const { cfg, storePath, store, key, entry } = params;
   const now = params.now ?? Date.now();
@@ -1249,7 +1255,8 @@ export function buildGatewaySessionRow(params: {
       entry,
     }) === undefined;
   const transcriptUsage =
-    needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd
+    params.includeTranscriptUsage === true &&
+    (needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd)
       ? resolveTranscriptUsageFallback({
           cfg,
           key,
@@ -1378,7 +1385,12 @@ export function buildGatewaySessionRow(params: {
 
 export function loadGatewaySessionRow(
   sessionKey: string,
-  options?: { includeDerivedTitles?: boolean; includeLastMessage?: boolean; now?: number },
+  options?: {
+    includeDerivedTitles?: boolean;
+    includeLastMessage?: boolean;
+    includeTranscriptUsage?: boolean;
+    now?: number;
+  },
 ): GatewaySessionRow | null {
   const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey);
   if (!entry) {
@@ -1393,6 +1405,7 @@ export function loadGatewaySessionRow(
     now: options?.now,
     includeDerivedTitles: options?.includeDerivedTitles,
     includeLastMessage: options?.includeLastMessage,
+    includeTranscriptUsage: options?.includeTranscriptUsage,
   });
 }
 
@@ -1409,6 +1422,7 @@ export function listSessionsFromStore(params: {
   const includeUnknown = opts.includeUnknown === true;
   const includeDerivedTitles = opts.includeDerivedTitles === true;
   const includeLastMessage = opts.includeLastMessage === true;
+  const includeTranscriptUsage = opts.includeTranscriptUsage === true;
   const spawnedBy = typeof opts.spawnedBy === "string" ? opts.spawnedBy : "";
   const label = typeof opts.label === "string" ? opts.label.trim() : "";
   const agentId = typeof opts.agentId === "string" ? normalizeAgentId(opts.agentId) : "";
@@ -1472,6 +1486,7 @@ export function listSessionsFromStore(params: {
         now,
         includeDerivedTitles,
         includeLastMessage,
+        includeTranscriptUsage,
       }),
     )
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));


### PR DESCRIPTION
## Summary

This is the clean standalone PR for the `sessions.list` hot-path mitigation.

It is intentionally separated from the timeout/configuration line (#61591) though has the same purpose of addressing performance-related issues.

The default `sessions.list` hot path was doing synchronous full-transcript reads via `resolveTranscriptUsageFallback` for every session in the store whenever `totalTokens`, `contextTokens`, or `estimatedCostUsd` were absent from the store entry. On large stores this meant hundreds of blocking file reads per `sessions.list` call — a corpus-wide transcript scan triggered by the most common listing path.

## Changes

### Schema (`src/gateway/protocol/schema/sessions.ts`)
- Add `includeTranscriptUsage?: boolean` to `SessionsListParamsSchema`
- Default is **false** (opt-in, not opt-out)
- JSDoc on the new field explains the cost and when to use it

### Core logic (`src/gateway/session-utils.ts`)
- `buildGatewaySessionRow`: gate `resolveTranscriptUsageFallback` behind `params.includeTranscriptUsage === true`
  - Store-present values (`totalTokens`, `estimatedCostUsd`, etc.) still resolve from the store without the flag — only the expensive transcript scan is skipped
- `loadGatewaySessionRow`: add `includeTranscriptUsage` to options signature and pass through
- `listSessionsFromStore`: decode `opts.includeTranscriptUsage` and pass it to `buildGatewaySessionRow`

### Known callers that need enrichment (updated)
- `src/gateway/server-methods/sessions.ts` — `emitSessionsChanged`: pass `includeTranscriptUsage: true` to `loadGatewaySessionRow`
- `src/acp/translator.ts` — `getGatewaySessionRow`: pass `includeTranscriptUsage: true`

### Callers confirmed safe without the flag
- ACP `unstable_listSessions`
- Agent `sessions_list` tool
- TUI `listSessions`

## Tests

- `src/gateway/session-utils.search.test.ts`: update explicit transcript-fallback assertions to pass `includeTranscriptUsage: true`
- `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`:
  - update the transcript-usage test to opt in explicitly
  - add a new test confirming the default path omits transcript-derived usage fields

## Validation

Focused validation on the clean branch:
- `src/gateway/session-utils.search.test.ts` — pass
- `src/acp/translator.session-rate-limit.test.ts` — pass
- `src/gateway/server.sessions.gateway-server-sessions-a.test.ts` — same one pre-existing unrelated timeout in `sessions.create can start the first agent turn from an initial task`; remainder passes

## Compatibility risk

**Contract change:** callers that relied on transcript-derived `totalTokens` / `estimatedCostUsd` / `contextTokens` from default `sessions.list` results must now pass `includeTranscriptUsage: true`.
