### PR TITLE
[codex] Support per-agent TTS voice overrides

### DIFF
--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -1,0 +1,45 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it } from "vitest";
+import { getResolvedSpeechProviderConfig, resolveTtsConfig } from "./tts.js";
+
+describe("resolveTtsConfig", () => {
+  it("merges per-agent provider overrides over global defaults", () => {
+    const cfg = {
+      messages: {
+        tts: {
+          auto: "always",
+          provider: "openai",
+          providers: {
+            openai: {
+              voice: "alloy",
+            },
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "voicey",
+            tts: {
+              providers: {
+                openai: {
+                  voice: "ash",
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const defaultConfig = resolveTtsConfig(cfg);
+    const agentConfig = resolveTtsConfig(cfg, "voicey");
+
+    expect(getResolvedSpeechProviderConfig(defaultConfig, "openai", cfg)).toMatchObject({
+      voice: "alloy",
+    });
+    expect(getResolvedSpeechProviderConfig(agentConfig, "openai", cfg)).toMatchObject({
+      voice: "ash",
+    });
+  });
+});

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -9,6 +9,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { normalizeChannelId, type ChannelId } from "openclaw/plugin-sdk/channel-targets";
 import type {
   OpenClawConfig,
@@ -153,6 +154,34 @@ type TtsStatusEntry = {
 };
 
 let lastTtsAttempt: TtsStatusEntry | undefined;
+
+const BLOCKED_MERGE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepMergeDefined(base: unknown, override: unknown): unknown {
+  if (!isPlainObject(base) || !isPlainObject(override)) {
+    return override === undefined ? base : override;
+  }
+
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (BLOCKED_MERGE_KEYS.has(key) || value === undefined) {
+      continue;
+    }
+    const existing = result[key];
+    result[key] = key in result ? deepMergeDefined(existing, value) : value;
+  }
+  return result;
+}
+
+function resolveRawTtsConfig(cfg: OpenClawConfig, agentId?: string): TtsConfig {
+  const base = cfg.messages?.tts;
+  const override = agentId ? resolveAgentConfig(cfg, agentId)?.tts : undefined;
+  return (deepMergeDefined(base ?? {}, override) as TtsConfig | undefined) ?? {};
+}
 
 function resolveConfiguredTtsAutoMode(raw: TtsConfig): TtsAutoMode {
   return normalizeTtsAutoMode(raw.auto) ?? (raw.enabled ? "always" : "off");
@@ -320,8 +349,8 @@ export function getResolvedSpeechProviderConfig(
   return resolveLazyProviderConfig(config, canonical, cfg);
 }
 
-export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
-  const raw: TtsConfig = cfg.messages?.tts ?? {};
+export function resolveTtsConfig(cfg: OpenClawConfig, agentId?: string): ResolvedTtsConfig {
+  const raw: TtsConfig = resolveRawTtsConfig(cfg, agentId);
   const providerSource = raw.provider ? "config" : "default";
   const timeoutMs = raw.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const auto = resolveConfiguredTtsAutoMode(raw);
@@ -374,11 +403,15 @@ export function resolveTtsAutoMode(params: {
   return params.config.auto;
 }
 
-function resolveEffectiveTtsAutoState(params: { cfg: OpenClawConfig; sessionAuto?: string }): {
+function resolveEffectiveTtsAutoState(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  sessionAuto?: string;
+}): {
   autoMode: TtsAutoMode;
   prefsPath: string;
 } {
-  const raw: TtsConfig = params.cfg.messages?.tts ?? {};
+  const raw: TtsConfig = resolveRawTtsConfig(params.cfg, params.agentId);
   const prefsPath = resolveTtsPrefsPathValue(raw.prefsPath);
   const sessionAuto = normalizeTtsAutoMode(params.sessionAuto);
   if (sessionAuto) {
@@ -394,12 +427,15 @@ function resolveEffectiveTtsAutoState(params: { cfg: OpenClawConfig; sessionAuto
   };
 }
 
-export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefined {
-  const { autoMode, prefsPath } = resolveEffectiveTtsAutoState({ cfg });
+export function buildTtsSystemPromptHint(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): string | undefined {
+  const { autoMode, prefsPath } = resolveEffectiveTtsAutoState({ cfg, agentId });
   if (autoMode === "off") {
     return undefined;
   }
-  const _config = resolveTtsConfig(cfg);
+  const _config = resolveTtsConfig(cfg, agentId);
   const maxLength = getTtsMaxLength(prefsPath);
   const summarize = isSummarizationEnabled(prefsPath) ? "on" : "off";
   const autoHint =
@@ -721,6 +757,7 @@ function resolveReadySpeechProvider(params: {
 function resolveTtsRequestSetup(params: {
   text: string;
   cfg: OpenClawConfig;
+  agentId?: string;
   prefsPath?: string;
   providerOverride?: TtsProvider;
   disableFallback?: boolean;
@@ -732,7 +769,7 @@ function resolveTtsRequestSetup(params: {
   | {
       error: string;
     } {
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfig(params.cfg, params.agentId);
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
   if (params.text.length > config.maxTextLength) {
     return {
@@ -752,6 +789,7 @@ function resolveTtsRequestSetup(params: {
 export async function textToSpeech(params: {
   text: string;
   cfg: OpenClawConfig;
+  agentId?: string;
   prefsPath?: string;
   channel?: string;
   overrides?: TtsDirectiveOverrides;
@@ -790,6 +828,7 @@ export async function textToSpeech(params: {
 export async function synthesizeSpeech(params: {
   text: string;
   cfg: OpenClawConfig;
+  agentId?: string;
   prefsPath?: string;
   channel?: string;
   overrides?: TtsDirectiveOverrides;
@@ -798,6 +837,7 @@ export async function synthesizeSpeech(params: {
   const setup = resolveTtsRequestSetup({
     text: params.text,
     cfg: params.cfg,
+    agentId: params.agentId,
     prefsPath: params.prefsPath,
     providerOverride: params.overrides?.provider,
     disableFallback: params.disableFallback,
@@ -895,11 +935,13 @@ export async function synthesizeSpeech(params: {
 export async function textToSpeechTelephony(params: {
   text: string;
   cfg: OpenClawConfig;
+  agentId?: string;
   prefsPath?: string;
 }): Promise<TtsTelephonyResult> {
   const setup = resolveTtsRequestSetup({
     text: params.text,
     cfg: params.cfg,
+    agentId: params.agentId,
     prefsPath: params.prefsPath,
   });
   if ("error" in setup) {
@@ -1024,6 +1066,7 @@ export async function listSpeechVoices(params: {
 export async function maybeApplyTtsToPayload(params: {
   payload: ReplyPayload;
   cfg: OpenClawConfig;
+  agentId?: string;
   channel?: string;
   kind?: "tool" | "block" | "final";
   inboundAudio?: boolean;
@@ -1034,12 +1077,13 @@ export async function maybeApplyTtsToPayload(params: {
   }
   const { autoMode, prefsPath } = resolveEffectiveTtsAutoState({
     cfg: params.cfg,
+    agentId: params.agentId,
     sessionAuto: params.ttsAuto,
   });
   if (autoMode === "off") {
     return params.payload;
   }
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfig(params.cfg, params.agentId);
 
   const reply = resolveSendableOutboundReplyParts(params.payload);
   const text = reply.text;
@@ -1143,6 +1187,7 @@ export async function maybeApplyTtsToPayload(params: {
   const result = await textToSpeech({
     text: textForAudio,
     cfg: params.cfg,
+    agentId: params.agentId,
     prefsPath,
     channel: params.channel,
     overrides: directives.overrides,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -86,6 +86,31 @@ describe("resolveAgentConfig", () => {
     expect(resolveAgentConfig(cfg, "main")?.verboseDefault).toBe("on");
   });
 
+  it("returns per-agent tts overrides", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            tts: {
+              provider: "openai",
+              providers: {
+                openai: { voice: "ash" },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveAgentConfig(cfg, "main")?.tts).toEqual({
+      provider: "openai",
+      providers: {
+        openai: { voice: "ash" },
+      },
+    });
+  });
+
   it("resolves explicit and effective model primary separately", () => {
     const cfgWithStringDefault = {
       agents: {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -55,6 +55,7 @@ type ResolvedAgentConfig = {
   heartbeat?: AgentEntry["heartbeat"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
+  tts?: AgentEntry["tts"];
   subagents?: AgentEntry["subagents"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
@@ -162,6 +163,7 @@ export function resolveAgentConfig(
     heartbeat: entry.heartbeat,
     identity: entry.identity,
     groupChat: entry.groupChat,
+    tts: entry.tts,
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     sandbox: entry.sandbox,
     tools: entry.tools,

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -95,7 +95,9 @@ export function buildSystemPrompt(params: {
       shell: detectRuntimeShell(),
     },
   });
-  const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+  const ttsHint = params.config
+    ? buildTtsSystemPromptHint(params.config, params.agentId)
+    : undefined;
   const ownerDisplay = resolveOwnerDisplaySetting(params.config);
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -119,6 +119,7 @@ export function createOpenClawTools(
     sessionKey: options?.agentSessionKey,
     config: resolvedConfig,
   });
+  const resolvedAgentId = options?.requesterAgentIdOverride ?? sessionAgentId;
   // Fall back to the session agent workspace so plugin loading stays workspace-stable
   // even when a caller forgets to thread workspaceDir explicitly.
   const inferredWorkspaceDir =
@@ -228,6 +229,7 @@ export function createOpenClawTools(
     }),
     ...(messageTool ? [messageTool] : []),
     createTtsTool({
+      agentId: resolvedAgentId,
       agentChannel: options?.agentChannel,
       config: options?.config,
     }),

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -721,7 +721,9 @@ export async function compactEmbeddedPiSessionDirect(
       cwd: effectiveWorkspace,
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(params.config, sessionAgentId)
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
     const promptContribution = resolveProviderSystemPromptContribution({
       provider,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -753,7 +753,9 @@ export async function runEmbeddedAttempt(
       cwd: effectiveWorkspace,
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(params.config, sessionAgentId)
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
     const heartbeatPrompt = shouldInjectHeartbeatPrompt({
       config: params.config,

--- a/src/agents/tools/tts-tool.test.ts
+++ b/src/agents/tools/tts-tool.test.ts
@@ -41,4 +41,21 @@ describe("createTtsTool", () => {
     });
     expect(JSON.stringify(result.content)).not.toContain("MEDIA:");
   });
+
+  it("forwards agentId to textToSpeech when present", async () => {
+    textToSpeechSpy.mockResolvedValue({
+      success: false,
+      error: "not configured",
+    });
+
+    const tool = createTtsTool({ agentId: "assistant-voice" });
+    await tool.execute("call-2", { text: "hello" });
+
+    expect(textToSpeechSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "hello",
+        agentId: "assistant-voice",
+      }),
+    );
+  });
 });

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -16,6 +16,7 @@ const TtsToolSchema = Type.Object({
 
 export function createTtsTool(opts?: {
   config?: OpenClawConfig;
+  agentId?: string;
   agentChannel?: GatewayMessageChannel;
 }): AnyAgentTool {
   return {
@@ -32,6 +33,7 @@ export function createTtsTool(opts?: {
       const result = await textToSpeech({
         text,
         cfg,
+        agentId: opts?.agentId,
         channel: channel ?? opts?.agentChannel,
       });
 

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -117,7 +117,7 @@ export async function resolveCommandsSystemPromptBundle(
         },
       }
     : { enabled: false };
-  const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
+  const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg, sessionAgentId) : undefined;
 
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -111,7 +111,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     return { shouldContinue: false };
   }
 
-  const config = resolveTtsConfig(params.cfg);
+  const config = resolveTtsConfig(params.cfg, params.agentId);
   const prefsPath = resolveTtsPrefsPath(config);
   const action = parsed.action;
   const args = parsed.args;
@@ -147,6 +147,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     const result = await textToSpeech({
       text: args,
       cfg: params.cfg,
+      agentId: params.agentId,
       channel: params.command.channel,
       prefsPath,
     });

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -91,6 +91,7 @@ async function shouldTreatDeliveredTextAsVisible(params: {
 async function maybeApplyAcpTts(params: {
   payload: ReplyPayload;
   cfg: OpenClawConfig;
+  agentId?: string;
   channel?: string;
   kind: ReplyDispatchKind;
   inboundAudio: boolean;
@@ -102,6 +103,7 @@ async function maybeApplyAcpTts(params: {
   }
   const ttsStatus = resolveStatusTtsSnapshot({
     cfg: params.cfg,
+    agentId: params.agentId,
     sessionAuto: params.ttsAuto,
   });
   if (!ttsStatus) {
@@ -110,13 +112,14 @@ async function maybeApplyAcpTts(params: {
   if (ttsStatus.autoMode === "inbound" && !params.inboundAudio) {
     return params.payload;
   }
-  if (params.kind !== "final" && resolveConfiguredTtsMode(params.cfg) === "final") {
+  if (params.kind !== "final" && resolveConfiguredTtsMode(params.cfg, params.agentId) === "final") {
     return params.payload;
   }
   const { maybeApplyTtsToPayload } = await loadDispatchAcpTtsRuntime();
   return await maybeApplyTtsToPayload({
     payload: params.payload,
     cfg: params.cfg,
+    agentId: params.agentId,
     channel: params.channel,
     kind: params.kind,
     inboundAudio: params.inboundAudio,
@@ -156,6 +159,7 @@ export type AcpDispatchDeliveryCoordinator = {
 
 export function createAcpDispatchDeliveryCoordinator(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   ctx: FinalizedMsgContext;
   dispatcher: ReplyDispatcher;
   inboundAudio: boolean;
@@ -287,6 +291,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     const ttsPayload = await maybeApplyAcpTts({
       payload,
       cfg: params.cfg,
+      agentId: params.agentId,
       channel: params.ttsChannel,
       kind,
       inboundAudio: params.inboundAudio,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -184,6 +184,7 @@ async function maybeUnbindStaleBoundConversations(params: {
 
 async function finalizeAcpTurnOutput(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   sessionKey: string;
   delivery: AcpDispatchDeliveryCoordinator;
   inboundAudio: boolean;
@@ -194,11 +195,12 @@ async function finalizeAcpTurnOutput(params: {
   await params.delivery.settleVisibleText();
   let queuedFinal =
     params.delivery.hasDeliveredVisibleText() && !params.delivery.hasFailedVisibleTextDelivery();
-  const ttsMode = resolveConfiguredTtsMode(params.cfg);
+  const ttsMode = resolveConfiguredTtsMode(params.cfg, params.agentId);
   const accumulatedBlockText = params.delivery.getAccumulatedBlockText();
   const hasAccumulatedBlockText = accumulatedBlockText.trim().length > 0;
   const ttsStatus = resolveStatusTtsSnapshot({
     cfg: params.cfg,
+    agentId: params.agentId,
     sessionAuto: params.sessionTtsAuto,
   });
   const canAttemptFinalTts =
@@ -211,6 +213,7 @@ async function finalizeAcpTurnOutput(params: {
       const ttsSyntheticReply = await maybeApplyTtsToPayload({
         payload: { text: accumulatedBlockText },
         cfg: params.cfg,
+        agentId: params.agentId,
         channel: params.ttsChannel,
         kind: "final",
         inboundAudio: params.inboundAudio,
@@ -305,10 +308,17 @@ export async function tryDispatchAcpReply(params: {
     return null;
   }
   const canonicalSessionKey = acpResolution.sessionKey;
+  const resolvedAcpAgent =
+    acpResolution.kind === "ready"
+      ? (normalizeOptionalString(acpResolution.meta.agent) ??
+        normalizeOptionalString(params.cfg.acp?.defaultAgent) ??
+        resolveAgentIdFromSessionKey(canonicalSessionKey))
+      : resolveAgentIdFromSessionKey(canonicalSessionKey);
 
   let queuedFinal = false;
   const delivery = createAcpDispatchDeliveryCoordinator({
     cfg: params.cfg,
+    agentId: resolvedAcpAgent,
     ctx: params.ctx,
     dispatcher: params.dispatcher,
     inboundAudio: params.inboundAudio,
@@ -337,13 +347,6 @@ export async function tryDispatchAcpReply(params: {
         channelRaw: params.ctx.OriginatingChannel ?? params.ctx.Surface ?? params.ctx.Provider,
         accountIdRaw: params.ctx.AccountId,
       })));
-
-  const resolvedAcpAgent =
-    acpResolution.kind === "ready"
-      ? (normalizeOptionalString(acpResolution.meta.agent) ??
-        normalizeOptionalString(params.cfg.acp?.defaultAgent) ??
-        resolveAgentIdFromSessionKey(canonicalSessionKey))
-      : resolveAgentIdFromSessionKey(canonicalSessionKey);
   const normalizedDispatchChannel = normalizeOptionalLowercaseString(
     params.ctx.OriginatingChannel ?? params.ctx.Surface ?? params.ctx.Provider,
   );
@@ -443,6 +446,7 @@ export async function tryDispatchAcpReply(params: {
     queuedFinal =
       (await finalizeAcpTurnOutput({
         cfg: params.cfg,
+        agentId: resolvedAcpAgent,
         sessionKey: canonicalSessionKey,
         delivery,
         inboundAudio: params.inboundAudio,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -210,6 +210,7 @@ export async function dispatchReplyFromConfig(params: {
   const chatId = ctx.To ?? ctx.From;
   const messageId = ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
   const sessionKey = ctx.SessionKey;
+  const agentId = sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined;
   const startTime = diagnosticsEnabled ? Date.now() : 0;
   const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
 
@@ -575,6 +576,7 @@ export async function dispatchReplyFromConfig(params: {
       const ttsPayload = await maybeApplyTtsToReplyPayload({
         payload,
         cfg,
+        agentId,
         channel: ttsChannel,
         kind: "final",
         inboundAudio,
@@ -979,7 +981,7 @@ export async function dispatchReplyFromConfig(params: {
       routedFinalCount += finalReply.routedFinalCount;
     }
 
-    const ttsMode = resolveConfiguredTtsMode(cfg);
+    const ttsMode = resolveConfiguredTtsMode(cfg, agentId);
     // Generate TTS-only reply after block streaming completes (when there's no final reply).
     // This handles the case where block streaming succeeds and drops final payloads,
     // but we still want TTS audio to be generated from the accumulated block content.
@@ -993,6 +995,7 @@ export async function dispatchReplyFromConfig(params: {
         const ttsSyntheticReply = await maybeApplyTtsToReplyPayload({
           payload: { text: accumulatedBlockText },
           cfg,
+          agentId,
           channel: ttsChannel,
           kind: "final",
           inboundAudio,

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -201,6 +201,35 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Text: low");
   });
 
+  it("shows the active agent-specific voice provider", () => {
+    const text = buildStatusMessage({
+      config: {
+        messages: {
+          tts: {
+            auto: "always",
+            provider: "openai",
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "voicey",
+              tts: {
+                provider: "elevenlabs",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      agent: {},
+      agentId: "voicey",
+      sessionKey: "agent:voicey:session-1",
+      queue: { mode: "none" },
+    });
+
+    expect(normalizeTestText(text)).toContain("Voice: always · provider=elevenlabs");
+  });
+
   it("notes channel model overrides in status output", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -398,12 +398,14 @@ const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandi
 const formatVoiceModeLine = (
   config?: OpenClawConfig,
   sessionEntry?: SessionEntry,
+  agentId?: string,
 ): string | null => {
   if (!config) {
     return null;
   }
   const snapshot = resolveStatusTtsSnapshot({
     cfg: config,
+    agentId,
     sessionAuto: sessionEntry?.ttsAuto,
   });
   if (!snapshot) {
@@ -803,7 +805,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const usageCostLine =
     usagePair && costLine ? `${usagePair} · ${costLine}` : (usagePair ?? costLine);
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
-  const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
+  const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry, args.agentId);
 
   return [
     versionLine,

--- a/src/config/config.agent-tts-validation.test.ts
+++ b/src/config/config.agent-tts-validation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectRaw } from "./validation.ts";
+
+describe("agent tts schema", () => {
+  it("accepts agents.list[].tts overrides", () => {
+    const result = validateConfigObjectRaw({
+      agents: {
+        list: [
+          {
+            id: "eva",
+            tts: {
+              provider: "openai",
+              providers: {
+                openai: {
+                  voice: "ash",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -6025,6 +6025,360 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   },
                   additionalProperties: false,
                 },
+                tts: {
+                  type: "object",
+                  properties: {
+                    auto: {
+                      type: "string",
+                      enum: ["off", "always", "inbound", "tagged"],
+                    },
+                    enabled: {
+                      type: "boolean",
+                    },
+                    mode: {
+                      type: "string",
+                      enum: ["final", "all"],
+                    },
+                    provider: {
+                      type: "string",
+                      minLength: 1,
+                    },
+                    summaryModel: {
+                      type: "string",
+                    },
+                    modelOverrides: {
+                      type: "object",
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                        },
+                        allowText: {
+                          type: "boolean",
+                        },
+                        allowProvider: {
+                          type: "boolean",
+                        },
+                        allowVoice: {
+                          type: "boolean",
+                        },
+                        allowModelId: {
+                          type: "boolean",
+                        },
+                        allowVoiceSettings: {
+                          type: "boolean",
+                        },
+                        allowNormalization: {
+                          type: "boolean",
+                        },
+                        allowSeed: {
+                          type: "boolean",
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    elevenlabs: {
+                      type: "object",
+                      properties: {
+                        apiKey: {
+                          anyOf: [
+                            {
+                              type: "string",
+                            },
+                            {
+                              oneOf: [
+                                {
+                                  type: "object",
+                                  properties: {
+                                    source: {
+                                      type: "string",
+                                      const: "env",
+                                    },
+                                    provider: {
+                                      type: "string",
+                                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                    },
+                                    id: {
+                                      type: "string",
+                                      pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                    },
+                                  },
+                                  required: ["source", "provider", "id"],
+                                  additionalProperties: false,
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    source: {
+                                      type: "string",
+                                      const: "file",
+                                    },
+                                    provider: {
+                                      type: "string",
+                                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                    },
+                                    id: {
+                                      type: "string",
+                                    },
+                                  },
+                                  required: ["source", "provider", "id"],
+                                  additionalProperties: false,
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    source: {
+                                      type: "string",
+                                      const: "exec",
+                                    },
+                                    provider: {
+                                      type: "string",
+                                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                    },
+                                    id: {
+                                      type: "string",
+                                    },
+                                  },
+                                  required: ["source", "provider", "id"],
+                                  additionalProperties: false,
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        baseUrl: {
+                          type: "string",
+                        },
+                        voiceId: {
+                          type: "string",
+                        },
+                        modelId: {
+                          type: "string",
+                        },
+                        seed: {
+                          type: "integer",
+                          minimum: 0,
+                          maximum: 4294967295,
+                        },
+                        applyTextNormalization: {
+                          type: "string",
+                          enum: ["auto", "on", "off"],
+                        },
+                        languageCode: {
+                          type: "string",
+                        },
+                        voiceSettings: {
+                          type: "object",
+                          properties: {
+                            stability: {
+                              type: "number",
+                              minimum: 0,
+                              maximum: 1,
+                            },
+                            similarityBoost: {
+                              type: "number",
+                              minimum: 0,
+                              maximum: 1,
+                            },
+                            style: {
+                              type: "number",
+                              minimum: 0,
+                              maximum: 1,
+                            },
+                            useSpeakerBoost: {
+                              type: "boolean",
+                            },
+                            speed: {
+                              type: "number",
+                              minimum: 0.5,
+                              maximum: 2,
+                            },
+                          },
+                          additionalProperties: false,
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    openai: {
+                      type: "object",
+                      properties: {
+                        apiKey: {
+                          anyOf: [
+                            {
+                              type: "string",
+                            },
+                            {
+                              oneOf: [
+                                {
+                                  type: "object",
+                                  properties: {
+                                    source: {
+                                      type: "string",
+                                      const: "env",
+                                    },
+                                    provider: {
+                                      type: "string",
+                                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                    },
+                                    id: {
+                                      type: "string",
+                                      pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                    },
+                                  },
+                                  required: ["source", "provider", "id"],
+                                  additionalProperties: false,
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    source: {
+                                      type: "string",
+                                      const: "file",
+                                    },
+                                    provider: {
+                                      type: "string",
+                                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                    },
+                                    id: {
+                                      type: "string",
+                                    },
+                                  },
+                                  required: ["source", "provider", "id"],
+                                  additionalProperties: false,
+                                },
+                                {
+                                  type: "object",
+                                  properties: {
+                                    source: {
+                                      type: "string",
+                                      const: "exec",
+                                    },
+                                    provider: {
+                                      type: "string",
+                                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                    },
+                                    id: {
+                                      type: "string",
+                                    },
+                                  },
+                                  required: ["source", "provider", "id"],
+                                  additionalProperties: false,
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        baseUrl: {
+                          type: "string",
+                        },
+                        model: {
+                          type: "string",
+                        },
+                        voice: {
+                          type: "string",
+                        },
+                        speed: {
+                          type: "number",
+                          minimum: 0.25,
+                          maximum: 4,
+                        },
+                        instructions: {
+                          type: "string",
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    edge: {
+                      type: "object",
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                        },
+                        voice: {
+                          type: "string",
+                        },
+                        lang: {
+                          type: "string",
+                        },
+                        outputFormat: {
+                          type: "string",
+                        },
+                        pitch: {
+                          type: "string",
+                        },
+                        rate: {
+                          type: "string",
+                        },
+                        volume: {
+                          type: "string",
+                        },
+                        saveSubtitles: {
+                          type: "boolean",
+                        },
+                        proxy: {
+                          type: "string",
+                        },
+                        timeoutMs: {
+                          type: "integer",
+                          minimum: 1000,
+                          maximum: 120000,
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    microsoft: {
+                      type: "object",
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                        },
+                        voice: {
+                          type: "string",
+                        },
+                        lang: {
+                          type: "string",
+                        },
+                        outputFormat: {
+                          type: "string",
+                        },
+                        pitch: {
+                          type: "string",
+                        },
+                        rate: {
+                          type: "string",
+                        },
+                        volume: {
+                          type: "string",
+                        },
+                        saveSubtitles: {
+                          type: "boolean",
+                        },
+                        proxy: {
+                          type: "string",
+                        },
+                        timeoutMs: {
+                          type: "integer",
+                          minimum: 1000,
+                          maximum: 120000,
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    prefsPath: {
+                      type: "string",
+                    },
+                    maxTextLength: {
+                      type: "integer",
+                      minimum: 1,
+                      maximum: 9007199254740991,
+                    },
+                    timeoutMs: {
+                      type: "integer",
+                      minimum: 1000,
+                      maximum: 120000,
+                    },
+                  },
+                  additionalProperties: false,
+                },
                 subagents: {
                   type: "object",
                   properties: {
@@ -26526,6 +26880,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "agents.list[].memorySearch.remote.apiKey": {
       sensitive: true,
       tags: ["security", "auth"],
+    },
+    "agents.list[].tts.elevenlabs.apiKey": {
+      sensitive: true,
+      tags: ["security", "auth", "media"],
+    },
+    "agents.list[].tts.openai.apiKey": {
+      sensitive: true,
+      tags: ["security", "auth", "media"],
     },
     "agents.list[].sandbox.ssh.identityData": {
       sensitive: true,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -4,6 +4,7 @@ import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
+import type { TtsConfig } from "./types.tts.js";
 
 export type AgentRuntimeAcpConfig = {
   /** ACP harness adapter id (for example codex, claude). */
@@ -84,6 +85,8 @@ export type AgentConfig = {
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
+  /** Optional per-agent TTS overrides merged with messages.tts. */
+  tts?: TtsConfig;
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -8,6 +8,7 @@ import {
   HumanDelaySchema,
   IdentitySchema,
   SecretInputSchema,
+  TtsConfigSchema,
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
@@ -792,6 +793,7 @@ export const AgentEntrySchema = z
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
+    tts: TtsConfigSchema,
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),

--- a/src/tts/status-config.test.ts
+++ b/src/tts/status-config.test.ts
@@ -62,6 +62,39 @@ describe("resolveStatusTtsSnapshot", () => {
     });
   });
 
+  it("prefers per-agent provider overrides over global defaults", async () => {
+    await withTempHome(async () => {
+      expect(
+        resolveStatusTtsSnapshot({
+          cfg: {
+            messages: {
+              tts: {
+                auto: "always",
+                provider: "openai",
+              },
+            },
+            agents: {
+              list: [
+                {
+                  id: "voicey",
+                  tts: {
+                    provider: "elevenlabs",
+                  },
+                },
+              ],
+            },
+          } as OpenClawConfig,
+          agentId: "voicey",
+        }),
+      ).toEqual({
+        autoMode: "always",
+        provider: "elevenlabs",
+        maxLength: 1500,
+        summarize: true,
+      });
+    });
+  });
+
   it("derives the default prefs path from OPENCLAW_CONFIG_PATH when set", async () => {
     await withTempHome(
       async (home) => {

--- a/src/tts/status-config.ts
+++ b/src/tts/status-config.ts
@@ -8,6 +8,7 @@ import {
 } from "../shared/string-coerce.js";
 import { resolveConfigDir, resolveUserPath } from "../utils.js";
 import { normalizeTtsAutoMode } from "./tts-auto-mode.js";
+import { resolveRawTtsConfig } from "./tts-config.js";
 
 const DEFAULT_TTS_MAX_LENGTH = 1500;
 const DEFAULT_TTS_SUMMARIZE = true;
@@ -79,9 +80,10 @@ function resolveTtsAutoModeFromPrefs(prefs: TtsUserPrefs): TtsAutoMode | undefin
 
 export function resolveStatusTtsSnapshot(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   sessionAuto?: string;
 }): TtsStatusSnapshot | null {
-  const raw: TtsConfig = params.cfg.messages?.tts ?? {};
+  const raw: TtsConfig = resolveRawTtsConfig(params.cfg, params.agentId);
   const prefsPath = resolveTtsPrefsPathValue(raw.prefsPath);
   const prefs = readPrefs(prefsPath);
   const autoMode =

--- a/src/tts/tts-config.ts
+++ b/src/tts/tts-config.ts
@@ -1,7 +1,36 @@
+import { resolveAgentConfig } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
-import type { TtsMode } from "../config/types.tts.js";
+import type { TtsConfig, TtsMode } from "../config/types.tts.js";
 export { normalizeTtsAutoMode } from "./tts-auto-mode.js";
 
-export function resolveConfiguredTtsMode(cfg: OpenClawConfig): TtsMode {
-  return cfg.messages?.tts?.mode ?? "final";
+const BLOCKED_MERGE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepMergeDefined(base: unknown, override: unknown): unknown {
+  if (!isPlainObject(base) || !isPlainObject(override)) {
+    return override === undefined ? base : override;
+  }
+
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (BLOCKED_MERGE_KEYS.has(key) || value === undefined) {
+      continue;
+    }
+    const existing = result[key];
+    result[key] = key in result ? deepMergeDefined(existing, value) : value;
+  }
+  return result;
+}
+
+export function resolveRawTtsConfig(cfg: OpenClawConfig, agentId?: string): TtsConfig {
+  const base = cfg.messages?.tts;
+  const override = agentId ? resolveAgentConfig(cfg, agentId)?.tts : undefined;
+  return (deepMergeDefined(base ?? {}, override) as TtsConfig | undefined) ?? {};
+}
+
+export function resolveConfiguredTtsMode(cfg: OpenClawConfig, agentId?: string): TtsMode {
+  return resolveRawTtsConfig(cfg, agentId).mode ?? "final";
 }

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -46,4 +46,17 @@ describe("tts runtime facade", () => {
     expect(loadActivatedBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledTimes(1);
     expect(buildTtsSystemPromptHint).toHaveBeenCalledTimes(1);
   });
+
+  it("forwards agentId through the runtime facade", async () => {
+    const cfg = {} as never;
+    const buildTtsSystemPromptHint = vi.fn().mockReturnValue("hint");
+    loadActivatedBundledPluginPublicSurfaceModuleSync.mockReturnValue({
+      buildTtsSystemPromptHint,
+    });
+
+    const tts = await importTtsModule();
+    tts.buildTtsSystemPromptHint(cfg, "voicey");
+
+    expect(buildTtsSystemPromptHint).toHaveBeenCalledWith(cfg, "voicey");
+  });
 });


### PR DESCRIPTION
## Summary
- add `agents.list[].tts` to the config surface and refresh the generated config baselines
- deep-merge per-agent TTS overrides over global `messages.tts`
- use the active agent's TTS config in reply dispatch, ACP dispatch, `/tts`, status output, system-prompt hints, and the TTS tool

## Why
Per-agent TTS voice configuration is a recurring request, but current `main` rejects `agents.list[].tts` during config validation, so agents cannot keep distinct voices or providers without changing the global TTS settings.

## Impact
Agents can now keep different TTS voices/providers while still inheriting any unset values from `messages.tts`.

This intentionally keeps the voice-call telephony path unchanged because that runtime does not currently carry agent context; this PR stays scoped to agent/session reply flows that already know which agent is active.

## Root Cause
The config schema and types only recognized global `messages.tts`, and the TTS runtime always resolved settings from that global block. That meant per-agent overrides failed validation up front and could never take effect anywhere in the runtime.

## Validation
- `pnpm test -- src/config/config.agent-tts-validation.test.ts src/agents/agent-scope.test.ts src/agents/tools/tts-tool.test.ts src/tts/tts.test.ts src/auto-reply/status.test.ts`
- `pnpm build`
- `pnpm check`

Fixes #11483
Related: #17516, #20451, #20565, #56231, #56701
