### PR TITLE
fix(xai): add explicit return type annotations to fix TS2883 portability errors

### DIFF
--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -20,13 +20,11 @@ export function isModernXaiModel(modelId: string): boolean {
 export function resolveXaiForwardCompatModel(params: {
   providerId: string;
   ctx: ProviderResolveDynamicModelContext;
-}): ProviderRuntimeModel {
+  // eslint-disable-next-line no-redundant-type-constituents -- ProviderRuntimeModel is unresolvable in the extension lint context (treated as `any`), so `| undefined` appears redundant; the union is intentionally correct and required by tsgo for TS2883
+}): ProviderRuntimeModel | undefined {
   const definition = resolveXaiCatalogEntry(params.ctx.modelId);
   if (!definition) {
-    // Double assertion used intentionally: the linter cannot resolve ProviderRuntimeModel
-    // from the workspace path and treats it as `any`, making `| undefined` a redundant-type
-    // constituent error. The double cast avoids the union while keeping tsgo happy.
-    return undefined as unknown as ProviderRuntimeModel;
+    return undefined;
   }
 
   return applyXaiModelCompat(

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -20,10 +20,13 @@ export function isModernXaiModel(modelId: string): boolean {
 export function resolveXaiForwardCompatModel(params: {
   providerId: string;
   ctx: ProviderResolveDynamicModelContext;
-}) {
+}): ProviderRuntimeModel {
   const definition = resolveXaiCatalogEntry(params.ctx.modelId);
   if (!definition) {
-    return undefined;
+    // Double assertion used intentionally: the linter cannot resolve ProviderRuntimeModel
+    // from the workspace path and treats it as `any`, making `| undefined` a redundant-type
+    // constituent error. The double cast avoids the union while keeping tsgo happy.
+    return undefined as unknown as ProviderRuntimeModel;
   }
 
   return applyXaiModelCompat(

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -20,7 +20,6 @@ export function isModernXaiModel(modelId: string): boolean {
 export function resolveXaiForwardCompatModel(params: {
   providerId: string;
   ctx: ProviderResolveDynamicModelContext;
-  // eslint-disable-next-line no-redundant-type-constituents -- ProviderRuntimeModel is unresolvable in the extension lint context (treated as `any`), so `| undefined` appears redundant; the union is intentionally correct and required by tsgo for TS2883
 }): ProviderRuntimeModel | undefined {
   const definition = resolveXaiCatalogEntry(params.ctx.modelId);
   if (!definition) {

--- a/extensions/xai/x-search-tool-shared.ts
+++ b/extensions/xai/x-search-tool-shared.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
+import type { TArray, TBoolean, TObject, TOptional, TString } from "@sinclair/typebox";
 
 export function buildMissingXSearchApiKeyPayload() {
   return {
@@ -10,9 +11,27 @@ export function buildMissingXSearchApiKeyPayload() {
   };
 }
 
+type XSearchToolParameters = TObject<{
+  query: TString;
+  allowed_x_handles: TOptional<TArray<TString>>;
+  excluded_x_handles: TOptional<TArray<TString>>;
+  from_date: TOptional<TString>;
+  to_date: TOptional<TString>;
+  enable_image_understanding: TOptional<TBoolean>;
+  enable_video_understanding: TOptional<TBoolean>;
+}>;
+
+export type XSearchToolDefinition = {
+  label: string;
+  name: string;
+  description: string;
+  parameters: XSearchToolParameters;
+  execute: (toolCallId: string, args: Record<string, unknown>) => Promise<AgentToolResult<unknown>>;
+};
+
 export function createXSearchToolDefinition(
   execute: (toolCallId: string, args: Record<string, unknown>) => Promise<AgentToolResult<unknown>>,
-) {
+): XSearchToolDefinition {
   return {
     label: "X Search",
     name: "x_search",

--- a/extensions/xai/x-search.ts
+++ b/extensions/xai/x-search.ts
@@ -21,6 +21,7 @@ import {
 import {
   buildMissingXSearchApiKeyPayload,
   createXSearchToolDefinition,
+  type XSearchToolDefinition,
 } from "./x-search-tool-shared.js";
 
 class PluginToolInputError extends Error {
@@ -122,7 +123,7 @@ function buildXSearchCacheKey(params: {
 export function createXSearchTool(options?: {
   config?: unknown;
   runtimeConfig?: Record<string, unknown> | null;
-}) {
+}): XSearchToolDefinition | null {
   const xSearchConfig = resolveXSearchConfig(options?.config);
   const runtimeConfig = options?.runtimeConfig ?? getRuntimeConfigSnapshot();
   if (


### PR DESCRIPTION
## Summary

- Problem: `pnpm tsgo` (via `pnpm check`) fails with TS2883 portability errors on `resolveXaiForwardCompatModel` and `createXSearchTool` because TypeScript cannot generate portable `.d.ts` declarations without knowing which external types to reference.
- Why it matters: Blocks source builds running `pnpm check` on 2026.4.6 (closes #62595).
- What changed: Added explicit return type annotations — `ProviderRuntimeModel` on `resolveXaiForwardCompatModel`, and a new exported `XSearchToolDefinition` type (with required TypeBox type imports) used by `createXSearchToolDefinition` and `createXSearchTool`.
- What did NOT change: Runtime behavior, tool schemas, or any logic. Pure type annotation additions.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62595
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveXaiForwardCompatModel` and `createXSearchTool` had inferred return types that expanded to types from external packages (`@mariozechner/pi-ai` via `ProviderRuntimeModel`, and `@sinclair/typebox` via the TypeBox schema generics). TypeScript's declaration emit cannot produce portable `.d.ts` output for these without explicit imports of those external types.
- Missing detection / guardrail: No explicit return type annotations on the affected exported functions.
- Contributing context (if known): The linter cannot resolve `ProviderRuntimeModel` from the workspace path in the extension's lint context (treats it as `any`), so `ProviderRuntimeModel | undefined` is flagged as a redundant union. A double assertion (`undefined as unknown as ProviderRuntimeModel`) is used on the early-return path of `resolveXaiForwardCompatModel` as a workaround; the comment in the code explains why.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: `pnpm tsgo` (part of `pnpm check`)
- Scenario the test should lock in: `pnpm tsgo` exits 0 for the three affected xai files.
- If no new test is added, why not: TS2883 is a declaration-emit error caught directly by `tsgo`. The fix is purely additive type annotations; `tsgo` passing is the correct verification gate.

## User-visible / Behavior Changes

None. Pure type annotation additions with no runtime effect.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: NixOS (x86_64-linux)
- Runtime/container: devenv shell, Node 22.20.0
- Model/provider: N/A
- Integration/channel (if any): N/A

### Steps

1. Check out 2026.4.6 source.
2. Run `pnpm install && pnpm tsgo`.
3. Observe TS2883 errors in `extensions/xai/provider-models.ts` and `extensions/xai/x-search.ts`.
4. Apply this PR.
5. Run `pnpm tsgo` again.

### Expected

`pnpm tsgo` reports no errors in the three xai files.

### Actual (before fix)

Six TS2883 errors across `extensions/xai/provider-models.ts` and `extensions/xai/x-search.ts`.

## Evidence

- [x] `pnpm tsgo` output before: 6 TS2883 errors in xai files. After: 0 TS2883 errors in xai files (only pre-existing unrelated failures in matrix/nextcloud-talk remain, already red on `main`).

## Human Verification (required)

- Verified scenarios: Ran `pnpm tsgo` in devenv shell on NixOS; all xai TS2883 errors gone after the fix.
- Edge cases checked: Confirmed remaining `tsgo` errors (matrix, nextcloud-talk) are pre-existing on `main` and unrelated to this change.
- What you did **not** verify: Full `pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: The `XSearchToolParameters` type alias must stay in sync with the `Type.Object(...)` literal in `createXSearchToolDefinition` if fields are added or removed.
  - Mitigation: Both are in the same file (`x-search-tool-shared.ts`), so drift is immediately visible at the call site.
- Risk: `resolveXaiForwardCompatModel` is typed as returning `ProviderRuntimeModel` (not `| undefined`) due to the linter/tsgo module-resolution discrepancy. Callers that rely on the undefined case must continue to guard against it at runtime.
  - Mitigation: Existing callers already guard against falsy returns; the runtime behavior is unchanged.

---

Tested: `pnpm tsgo`.