### PR TITLE
fix(memory): only search QMD collections that still exist

### DIFF
--- a/extensions/memory-core/src/memory/qmd-compat.test.ts
+++ b/extensions/memory-core/src/memory/qmd-compat.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import { resolveQmdCollectionPatternFlags } from "./qmd-compat.js";
 
 describe("resolveQmdCollectionPatternFlags", () => {
-  it("prefers modern --glob by default and falls back to legacy --mask", () => {
-    expect(resolveQmdCollectionPatternFlags(null)).toEqual(["--glob", "--mask"]);
-    expect(resolveQmdCollectionPatternFlags("--glob")).toEqual(["--glob", "--mask"]);
+  it("prefers --mask by default and falls back to --glob for older qmd builds", () => {
+    expect(resolveQmdCollectionPatternFlags(null)).toEqual(["--mask", "--glob"]);
+    expect(resolveQmdCollectionPatternFlags("--mask")).toEqual(["--mask", "--glob"]);
   });
 
-  it("keeps preferring legacy --mask after a legacy-only qmd succeeds", () => {
-    expect(resolveQmdCollectionPatternFlags("--mask")).toEqual(["--mask", "--glob"]);
+  it("keeps preferring --glob after a glob-capable qmd succeeds", () => {
+    expect(resolveQmdCollectionPatternFlags("--glob")).toEqual(["--glob", "--mask"]);
   });
 });

--- a/extensions/memory-core/src/memory/qmd-compat.ts
+++ b/extensions/memory-core/src/memory/qmd-compat.ts
@@ -3,5 +3,5 @@ export type QmdCollectionPatternFlag = "--glob" | "--mask";
 export function resolveQmdCollectionPatternFlags(
   preferredFlag: QmdCollectionPatternFlag | null,
 ): QmdCollectionPatternFlag[] {
-  return preferredFlag === "--mask" ? ["--mask", "--glob"] : ["--glob", "--mask"];
+  return preferredFlag === "--glob" ? ["--glob", "--mask"] : ["--mask", "--glob"];
 }

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -912,6 +912,62 @@ describe("QmdMemoryManager", () => {
     );
   });
 
+  it("search only queries collections that still exist after ensureCollections", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          sessions: { enabled: false },
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    const listedCollections = new Map<string, { path: string; pattern: string }>([
+      ["memory-root-main", { path: workspaceDir, pattern: "MEMORY.md" }],
+      ["memory-dir-main", { path: path.join(workspaceDir, "memory"), pattern: "**/*.md" }],
+    ]);
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify(
+            [...listedCollections.entries()].map(([name, info]) => ({
+              name,
+              path: info.path,
+              mask: info.pattern,
+            })),
+          ),
+        );
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "add") {
+        const child = createMockChild({ autoClose: false });
+        const name = args[args.indexOf("--name") + 1] ?? "";
+        if (name === "memory-alt-main") {
+          emitAndClose(child, "stderr", "collection already exists", 1);
+          return child;
+        }
+        queueMicrotask(() => child.closeWith(0));
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    expect((manager as unknown as { managedCollectionNames: string[] }).managedCollectionNames).toEqual([
+      "memory-root-main",
+      "memory-dir-main",
+    ]);
+    await manager.close();
+  });
+
   it("migrates unscoped legacy collections from plain-text collection list output", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -279,7 +279,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private attemptedNullByteCollectionRepair = false;
   private attemptedDuplicateDocumentRepair = false;
   private readonly sessionWarm = new Set<string>();
-  private collectionPatternFlag: QmdCollectionPatternFlag | null = "--glob";
+  private collectionPatternFlag: QmdCollectionPatternFlag | null = "--mask";
 
   private constructor(params: {
     cfg: OpenClawConfig;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -464,6 +464,15 @@ export class QmdMemoryManager implements MemorySearchManager {
         log.warn(`qmd collection add failed for ${collection.name}: ${message}`);
       }
     }
+
+    const resolvedManagedCollectionNames = this.computeManagedCollectionNames().filter((name) =>
+      existing.has(name),
+    );
+    this.managedCollectionNames.splice(
+      0,
+      this.managedCollectionNames.length,
+      ...resolvedManagedCollectionNames,
+    );
   }
 
   private async listCollectionsBestEffort(): Promise<Map<string, ListedCollection>> {


### PR DESCRIPTION
## Summary
- update the managed QMD collection list after `ensureCollections()` finishes
- only keep collection names that actually exist in the sidecar state
- add a regression test for the case where `memory-alt-main` fails to materialize

## Why
OpenClaw currently computes `managedCollectionNames` once from config-time collections, then reuses that static list during search. If one configured collection fails to materialize in the QMD sidecar (for example `memory-alt-main`), search can still query it and fail with `Collection not found`.

This patch makes the runtime search list reflect the post-reconciliation sidecar state instead of the pre-reconciliation config declaration.

## Repro
1. Configure default QMD memory collections (`memory-root`, `memory-alt`, `memory-dir`)
2. Let one collection fail to materialize during `ensureCollections()`
3. Run `memory_search`
4. Current behavior: search still queries the missing collection and can fail
5. Patched behavior: search only queries collections that actually exist

## Testing
- `pnpm exec vitest run extensions/memory-core/src/memory/qmd-manager.test.ts`