### PR TITLE
config: fix silent failures and misleading log in config recovery

### DIFF
--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -215,7 +215,11 @@ async function writeConfigHealthState(
       encoding: "utf-8",
       mode: 0o600,
     });
-  } catch {}
+  } catch (err) {
+    deps.logger.warn(
+      `Failed to write config health state: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 function writeConfigHealthStateSync(deps: ObserveRecoveryDeps, state: ConfigHealthState): void {
@@ -226,7 +230,11 @@ function writeConfigHealthStateSync(deps: ObserveRecoveryDeps, state: ConfigHeal
       encoding: "utf-8",
       mode: 0o600,
     });
-  } catch {}
+  } catch (err) {
+    deps.logger.warn(
+      `Failed to write config health state: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 function getConfigHealthEntry(state: ConfigHealthState, configPath: string): ConfigHealthEntry {
@@ -365,7 +373,10 @@ async function persistClobberedConfigSnapshot(params: {
       flag: "wx",
     });
     return targetPath;
-  } catch {
+  } catch (err) {
+    params.deps.logger.warn(
+      `Failed to persist clobbered config snapshot: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return null;
   }
 }
@@ -384,7 +395,10 @@ function persistClobberedConfigSnapshotSync(params: {
       flag: "wx",
     });
     return targetPath;
-  } catch {
+  } catch (err) {
+    params.deps.logger.warn(
+      `Failed to persist clobbered config snapshot: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return null;
   }
 }
@@ -457,10 +471,16 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
   try {
     await params.deps.fs.promises.copyFile(backupPath, params.configPath);
     restoredFromBackup = true;
-  } catch {}
+  } catch (err) {
+    params.deps.logger.warn(
+      `Failed to restore config from backup: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   params.deps.logger.warn(
-    `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
+    restoredFromBackup
+      ? `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`
+      : `Config backup restore failed: ${params.configPath} (${suspicious.join(", ")})`,
   );
   await appendConfigAuditRecord({
     fs: params.deps.fs,
@@ -594,10 +614,16 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
   try {
     params.deps.fs.copyFileSync(backupPath, params.configPath);
     restoredFromBackup = true;
-  } catch {}
+  } catch (err) {
+    params.deps.logger.warn(
+      `Failed to restore config from backup: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   params.deps.logger.warn(
-    `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
+    restoredFromBackup
+      ? `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`
+      : `Config backup restore failed: ${params.configPath} (${suspicious.join(", ")})`,
   );
   appendConfigAuditRecordSync({
     fs: params.deps.fs,


### PR DESCRIPTION
## Summary

- **Fix misleading log message**: `maybeRecoverSuspiciousConfigRead` and its sync variant logged "Config auto-restored from backup" even when the `copyFile` restore actually failed. The message now reflects the actual outcome (`auto-restored` vs `backup restore failed`).
- **Add diagnostic logging to empty catch blocks**: Six `catch {}` blocks in the config health tracking and recovery pipeline now emit `logger.warn()` with the error message, making failures visible in logs instead of silently swallowing them.

### Affected catch blocks

| Function | Issue |
|---|---|
| `writeConfigHealthState` / `Sync` | Health state writes failed silently, losing config health tracking |
| `persistClobberedConfigSnapshot` / `Sync` | Clobbered config snapshots failed to persist with no diagnostic output |
| `maybeRecoverSuspiciousConfigRead` / `Sync` | Backup restore failures were swallowed; log claimed success regardless |

### What is NOT changed

The following `catch {}` blocks are intentionally left as-is — they handle expected conditions (file not found on first run, optional JSON parse fallbacks):
- `readConfigHealthState` / `Sync` — health state file may not exist yet
- Inner `json5.parse` in `readConfigFingerprintForPath` / `Sync` — deliberate fallback to empty parsed object
- Outer catch in `readConfigFingerprintForPath` / `Sync` — target path may not exist

## Test plan

- [x] Existing `io.observe-recovery.test.ts` suite passes (3/3 tests green)
- [x] No new dependencies or imports added
- [x] Behavioral change is limited to log output; recovery control flow is unchanged
- [x] Verified via `pnpm test src/config/io.observe-recovery.test.ts`

[AI-assisted]

🤖 Generated with [Claude Code](https://claude.com/claude-code)