### PR TITLE
fix: forward optional params dropped at the runEmbeddedAttempt call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 - Video generation/live tests: bound provider polling for live video smoke, default to the fast non-FAL text-to-video path, and use a one-second lobster prompt so release validation no longer waits indefinitely on slow provider queues.
 - Memory-core/QMD `memory_get`: reject reads of arbitrary workspace markdown paths and only allow canonical memory files (`MEMORY.md`, `memory.md`, `DREAMS.md`, `dreams.md`, `memory/**`) plus exact paths of active indexed QMD workspace documents, so the QMD memory backend can no longer be used as a generic workspace-file read shim that bypasses `read` tool-policy denials. (#66026) Thanks @eleqtrizit.
+- Cron/agents: forward embedded-run tool policy and internal event params into the attempt layer so `--tools` allowlists, cron-owned message-tool suppression, explicit message targeting, and command-path internal events all take effect at runtime again. (#62675) Thanks @hexsprite.
 
 ## 2026.4.14
 

--- a/src/agents/pi-embedded-runner/run.attempt-param-forwarding.test.ts
+++ b/src/agents/pi-embedded-runner/run.attempt-param-forwarding.test.ts
@@ -1,0 +1,116 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { AgentInternalEvent } from "../internal-events.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+
+// Guardrail tests for RunEmbeddedPiAgentParams optional fields that must flow
+// through to runEmbeddedAttempt. The call site in run.ts hand-enumerates ~85
+// fields into the runEmbeddedAttempt({...}) object literal, which makes it
+// easy to add a new optional field to the params type without wiring it at the
+// call site. Because the type declares these fields as `?:` optional, a missed
+// field is silently undefined in the attempt and TypeScript does not flag it.
+// Previous incidents: bootstrapContextMode/bootstrapContextRunKind (#62264)
+// and toolsAllow / disableMessageTool / requireExplicitMessageTarget /
+// internalEvents (#62569).
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+describe("runEmbeddedPiAgent forwards optional params to runEmbeddedAttempt", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+  });
+
+  it("forwards toolsAllow so the per-job tool allowlist can be honored", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "forward-toolsAllow",
+      toolsAllow: ["exec", "read"],
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ toolsAllow: ["exec", "read"] }),
+    );
+  });
+
+  it("forwards bootstrapContextMode so lightContext cron jobs strip workspace bootstrap files", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "forward-bootstrapContextMode",
+      bootstrapContextMode: "lightweight",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ bootstrapContextMode: "lightweight" }),
+    );
+  });
+
+  it("forwards bootstrapContextRunKind so the bootstrap filter knows the caller context", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "forward-bootstrapContextRunKind",
+      bootstrapContextRunKind: "cron",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ bootstrapContextRunKind: "cron" }),
+    );
+  });
+
+  it("forwards disableMessageTool so cron-owned delivery suppresses the messaging tool", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "forward-disableMessageTool",
+      disableMessageTool: true,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ disableMessageTool: true }),
+    );
+  });
+
+  it("forwards requireExplicitMessageTarget so non-subagent callers can opt in explicitly", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "forward-requireExplicitMessageTarget",
+      requireExplicitMessageTarget: true,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ requireExplicitMessageTarget: true }),
+    );
+  });
+
+  it("forwards internalEvents so the agent command attempt path can deliver internal events", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const internalEvents: AgentInternalEvent[] = [];
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "forward-internalEvents",
+      internalEvents,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ internalEvents }),
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run.attempt-param-forwarding.test.ts
+++ b/src/agents/pi-embedded-runner/run.attempt-param-forwarding.test.ts
@@ -7,18 +7,55 @@ import {
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
+import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 
-// Guardrail tests for RunEmbeddedPiAgentParams optional fields that must flow
-// through to runEmbeddedAttempt. The call site in run.ts hand-enumerates ~85
-// fields into the runEmbeddedAttempt({...}) object literal, which makes it
-// easy to add a new optional field to the params type without wiring it at the
-// call site. Because the type declares these fields as `?:` optional, a missed
-// field is silently undefined in the attempt and TypeScript does not flag it.
-// Previous incidents: bootstrapContextMode/bootstrapContextRunKind (#62264)
-// and toolsAllow / disableMessageTool / requireExplicitMessageTarget /
-// internalEvents (#62569).
+type ForwardingCase = {
+  name: string;
+  runId: string;
+  params: Partial<RunEmbeddedPiAgentParams>;
+  expected: Record<string, unknown>;
+};
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+const internalEvents: AgentInternalEvent[] = [];
+const forwardingCases = [
+  {
+    name: "forwards toolsAllow so the per-job tool allowlist can be honored",
+    runId: "forward-toolsAllow",
+    params: { toolsAllow: ["exec", "read"] },
+    expected: { toolsAllow: ["exec", "read"] },
+  },
+  {
+    name: "forwards bootstrapContextMode so lightContext cron jobs strip workspace bootstrap files",
+    runId: "forward-bootstrapContextMode",
+    params: { bootstrapContextMode: "lightweight" },
+    expected: { bootstrapContextMode: "lightweight" },
+  },
+  {
+    name: "forwards bootstrapContextRunKind so the bootstrap filter knows the caller context",
+    runId: "forward-bootstrapContextRunKind",
+    params: { bootstrapContextRunKind: "cron" },
+    expected: { bootstrapContextRunKind: "cron" },
+  },
+  {
+    name: "forwards disableMessageTool so cron-owned delivery suppresses the messaging tool",
+    runId: "forward-disableMessageTool",
+    params: { disableMessageTool: true },
+    expected: { disableMessageTool: true },
+  },
+  {
+    name: "forwards requireExplicitMessageTarget so non-subagent callers can opt in explicitly",
+    runId: "forward-requireExplicitMessageTarget",
+    params: { requireExplicitMessageTarget: true },
+    expected: { requireExplicitMessageTarget: true },
+  },
+  {
+    name: "forwards internalEvents so the agent command attempt path can deliver internal events",
+    runId: "forward-internalEvents",
+    params: { internalEvents },
+    expected: { internalEvents },
+  },
+] satisfies ForwardingCase[];
 
 describe("runEmbeddedPiAgent forwards optional params to runEmbeddedAttempt", () => {
   beforeAll(async () => {
@@ -29,88 +66,15 @@ describe("runEmbeddedPiAgent forwards optional params to runEmbeddedAttempt", ()
     resetRunOverflowCompactionHarnessMocks();
   });
 
-  it("forwards toolsAllow so the per-job tool allowlist can be honored", async () => {
+  it.each(forwardingCases)("$name", async ({ runId, params, expected }) => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 
     await runEmbeddedPiAgent({
       ...overflowBaseRunParams,
-      runId: "forward-toolsAllow",
-      toolsAllow: ["exec", "read"],
+      ...params,
+      runId,
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
-      expect.objectContaining({ toolsAllow: ["exec", "read"] }),
-    );
-  });
-
-  it("forwards bootstrapContextMode so lightContext cron jobs strip workspace bootstrap files", async () => {
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-
-    await runEmbeddedPiAgent({
-      ...overflowBaseRunParams,
-      runId: "forward-bootstrapContextMode",
-      bootstrapContextMode: "lightweight",
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
-      expect.objectContaining({ bootstrapContextMode: "lightweight" }),
-    );
-  });
-
-  it("forwards bootstrapContextRunKind so the bootstrap filter knows the caller context", async () => {
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-
-    await runEmbeddedPiAgent({
-      ...overflowBaseRunParams,
-      runId: "forward-bootstrapContextRunKind",
-      bootstrapContextRunKind: "cron",
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
-      expect.objectContaining({ bootstrapContextRunKind: "cron" }),
-    );
-  });
-
-  it("forwards disableMessageTool so cron-owned delivery suppresses the messaging tool", async () => {
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-
-    await runEmbeddedPiAgent({
-      ...overflowBaseRunParams,
-      runId: "forward-disableMessageTool",
-      disableMessageTool: true,
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
-      expect.objectContaining({ disableMessageTool: true }),
-    );
-  });
-
-  it("forwards requireExplicitMessageTarget so non-subagent callers can opt in explicitly", async () => {
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-
-    await runEmbeddedPiAgent({
-      ...overflowBaseRunParams,
-      runId: "forward-requireExplicitMessageTarget",
-      requireExplicitMessageTarget: true,
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
-      expect.objectContaining({ requireExplicitMessageTarget: true }),
-    );
-  });
-
-  it("forwards internalEvents so the agent command attempt path can deliver internal events", async () => {
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-
-    const internalEvents: AgentInternalEvent[] = [];
-    await runEmbeddedPiAgent({
-      ...overflowBaseRunParams,
-      runId: "forward-internalEvents",
-      internalEvents,
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
-      expect.objectContaining({ internalEvents }),
-    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(expect.objectContaining(expected));
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -754,6 +754,10 @@ export async function runEmbeddedPiAgent(
             silentExpected: params.silentExpected,
             bootstrapContextMode: params.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,
+            toolsAllow: params.toolsAllow,
+            disableMessageTool: params.disableMessageTool,
+            requireExplicitMessageTarget: params.requireExplicitMessageTarget,
+            internalEvents: params.internalEvents,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],


### PR DESCRIPTION
## Summary

`toolsAllow` set on a cron `agentTurn` payload has no effect at runtime — the model still receives the complete tool catalog (all built-in + all MCP plugin tools) on every run, because `runEmbeddedPiAgent` does not forward `params.toolsAllow` to its `runEmbeddedAttempt` call. The CLI/persistence layers work correctly; only the runtime plumbing was missing.

**Fixes #62569**

## Why it matters

PR #58504 (closes #58435) added `--tools` / `payload.toolsAllow` for per-job tool allowlists, with a stated motivation of making small local models usable for focused cron tasks. The PR's writeup advertised a ~95% input-token reduction (~16K → ~800) when a single-tool restriction is applied. `docs/automation/cron-jobs.md:85` documents the same intent:

> `--tools exec,read`: restrict which tools the job can use

But on the runtime path, the value is silently dropped before reaching the consumer, so the documented behavior never takes effect. Affects every cron `agentTurn` job that sets `toolsAllow` (or uses `--tools`).

## Root cause

`runEmbeddedPiAgent` (in `src/agents/pi-embedded-runner/run.ts`) hand-enumerates ~80 fields when calling `runEmbeddedAttempt({...})`. PR #58504 wired `toolsAllow` through:

- `cron/isolated-agent/run-executor.ts:132` — cron payload → `runEmbeddedPiAgent` ✅
- `pi-embedded-runner/run/params.ts:103` — added to `RunEmbeddedPiAgentParams` ✅
- `pi-embedded-runner/run/attempt.ts:523-525` — consumer filter ready ✅
- **`pi-embedded-runner/run.ts` `runEmbeddedAttempt({...})` call** — **never wired** ❌

`toolsAllow` is declared as `?:` optional on `EmbeddedRunAttemptParams` (via `Omit<RunEmbeddedPiAgentParams, ...>` in `run/types.ts:13-16`), so TypeScript does not flag the missing field at the object literal. The attempt silently receives `undefined` and the filter at `attempt.ts:523-525` is never entered.

This is the same plumbing gap that #62264 (`f1b7dd6c0a`, "fix: honor lightContext in spawned subagents") fixed for `bootstrapContextMode` and `bootstrapContextRunKind` at the same call site. PR #62264 was scoped to subagent `lightContext`; the `toolsAllow` field was adjacent in the same hand-listed object literal but not included in that fix. PRs #60776 and #56484 (now closed) had previously identified the `bootstrap*` half of the same gap.

## Fix

One additional line in the `runEmbeddedAttempt({...})` call in `src/agents/pi-embedded-runner/run.ts`, immediately after the lines added by #62264:

```ts
bootstrapContextMode: params.bootstrapContextMode,
bootstrapContextRunKind: params.bootstrapContextRunKind,
toolsAllow: params.toolsAllow,
```

## Test plan

A new file `src/agents/pi-embedded-runner/run.attempt-param-forwarding.test.ts` exercises the field-forwarding seam end-to-end via the existing `loadRunOverflowCompactionHarness()` (which mocks `runEmbeddedAttempt` and lets us call the real `runEmbeddedPiAgent`). It contains three tests, one per optional param that's been bitten by this class of bug:

- `forwards toolsAllow so the per-job tool allowlist can be honored` — **fails on `main` before the fix**, passes after.
- `forwards bootstrapContextMode so lightContext cron jobs strip workspace bootstrap files` — guardrail for #62264.
- `forwards bootstrapContextRunKind so the bootstrap filter knows the caller context` — guardrail for #62264.

The two `bootstrapContext*` tests are deliberately included so the next `?:` optional field added to `RunEmbeddedPiAgentParams` without wiring at this call site will fail a test instead of silently shipping broken — same gap PR #60776's writeup explicitly called out as missing detection.

### Verified locally

```
pnpm test src/agents/pi-embedded-runner/run.attempt-param-forwarding.test.ts
  ✓ forwards toolsAllow so the per-job tool allowlist can be honored
  ✓ forwards bootstrapContextMode so lightContext cron jobs strip workspace bootstrap files
  ✓ forwards bootstrapContextRunKind so the bootstrap filter knows the caller context
  Test Files  1 passed (1)
       Tests  3 passed (3)

pnpm test src/agents/pi-embedded-runner/run
  Test Files  21 passed (21)
       Tests  258 passed (258)

pnpm test src/cron/isolated-agent
  Test Files  18 passed (18)
       Tests  176 passed (176)

node scripts/run-oxlint.mjs
  Found 0 warnings and 0 errors. (10595 files, 136 rules)

node scripts/run-tsgo.mjs
  exit 0
```

### End-to-end verification on a real cron

Verified against the actual cron path with a haiku probe (so the full request payload could be inspected, since the payload logger only records Anthropic requests). Same `payload.toolsAllow: ["lobster"]` cron, before/after applying the same forwarding gap fix:

| Metric | Before fix | After fix | Notes |
|---|---|---|---|
| System prompt length | 61,954 chars | 31,533 chars | bootstrap files stripped (lightContext working post-#62264) |
| Tool count in request | 72 | **1** (with this PR) | toolsAllow honored |

Without this PR, the `toolsAllow: ["lobster"]` setting is observable in `jobs.json` but ignored at runtime, and the request still ships all 72 registered tools. With this PR applied, only the listed tool reaches the model.

## Scope boundary

Intentionally **not** in this PR:

- **`attempt.ts:549-572` (bundle MCP / LSP tool merge)**: even with this fix, plugin-contributed tools are spread into `effectiveTools` *after* the `toolsAllow` filter, so `--tools exec` would still ship all installed plugin tools (lossless-claw, engram, work, shared, etc.). That's a scope-of-filter design question (should `toolsAllow` restrict plugin tools too?) rather than a plumbing bug, and deserves its own discussion. Filed as a separate concern in issue #62569.
- No changes to the `cron` write path, the `cron edit --tools` schema (#59211 covers that), the bootstrap filter, the system prompt builder, or any plugin SDK surface.

## Linked work

- **Fixes**: #62569 (the issue documenting this bug end-to-end)
- **Related**: #58504 (closed, original `toolsAllow` feature implementation), #58435 (closed, original feature request), #62264 (merged, sister `bootstrapContextMode` / `bootstrapContextRunKind` forwarding fix at the same call site)
- **Superseded by #62264**: #60776, #56484 (both now closed) — same call site, same `?:` optional plumbing gap class

cc @claygeo per the offer in #56484 and @theSamPadilla per the related work in #62264 — feedback welcome from either of you on the regression test shape, since this is the kind of guardrail #60776's writeup explicitly noted as missing.
