### PR TITLE
telegram: cover preview-finalization message hooks

### DIFF
--- a/extensions/reply-boundary-guard/conformance.test.ts
+++ b/extensions/reply-boundary-guard/conformance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReplyBoundaryGuardConformanceContract,
+  getReplyBoundaryGuardConsumedContractMetadata,
+  REPLY_BOUNDARY_GUARD_CONSUMER,
+  runReplyBoundaryGuardConformanceSuite,
+} from "./conformance.ts";
+import { applyReplyBoundaryGuard } from "./policy.ts";
+
+describe("reply-boundary-guard conformance", () => {
+  it("publishes the consumed Moonlight contract metadata explicitly", () => {
+    const metadata = getReplyBoundaryGuardConsumedContractMetadata();
+
+    expect(REPLY_BOUNDARY_GUARD_CONSUMER).toBe("reply-boundary-guard");
+    expect(metadata.contractVersion).toBe(1);
+    expect(metadata.supportedContractVersions).toEqual([1]);
+    expect(metadata.changeTaxonomy.map((entry) => entry.kind)).toEqual([
+      "breaking",
+      "additive",
+      "internal_only",
+    ]);
+  });
+
+  it("passes the shared reply-boundary conformance suite through the consumer bridge", () => {
+    const contract = buildReplyBoundaryGuardConformanceContract();
+    const report = runReplyBoundaryGuardConformanceSuite();
+
+    expect(contract.contractVersion).toBe(1);
+    expect(contract.supportedContractVersions).toEqual([1]);
+    expect(report.contractVersion).toBe(1);
+    expect(report.failedChecks).toBe(0);
+    expect(report.passedChecks).toBe(report.totalChecks);
+    expect(report.failures).toEqual([]);
+  });
+
+  it("supplements bare auto-report-back promises with an explicit non-watcher disclaimer", () => {
+    const result = applyReplyBoundaryGuard("I'll report back after I check it.");
+
+    expect(result.outputChanged).toBe(true);
+    expect(result.usedReportBackSupplement).toBe(true);
+    expect(result.outputText).toContain(
+      "I will not automatically report back after this reply unless I explicitly set up a real reminder or watcher and tell you that I did.",
+    );
+  });
+});

--- a/extensions/reply-boundary-guard/conformance.ts
+++ b/extensions/reply-boundary-guard/conformance.ts
@@ -8,7 +8,7 @@ import {
   rewriteReplyBoundaryText,
   runReplyBoundaryConformanceSuite,
   suggestReplyBoundaryRewrite,
-} from "../../../moonlight/src/pinocchio/reply-boundary/index.ts";
+} from "@luna/moonlight/pinocchio/reply-boundary";
 
 export const REPLY_BOUNDARY_GUARD_CONSUMER = "reply-boundary-guard";
 

--- a/extensions/reply-boundary-guard/conformance.ts
+++ b/extensions/reply-boundary-guard/conformance.ts
@@ -1,0 +1,32 @@
+import {
+  buildReplyBoundaryConformanceContract,
+  buildReplyBoundaryEnforcementDecision,
+  classifyReplyBoundaryClaimFamilies,
+  evaluateReplyBoundaryPolicy,
+  getReplyBoundaryContractMetadata,
+  inferReplyBoundaryWaitingOn,
+  rewriteReplyBoundaryText,
+  runReplyBoundaryConformanceSuite,
+  suggestReplyBoundaryRewrite,
+} from "../../../moonlight/src/pinocchio/reply-boundary/index.ts";
+
+export const REPLY_BOUNDARY_GUARD_CONSUMER = "reply-boundary-guard";
+
+export function getReplyBoundaryGuardConsumedContractMetadata() {
+  return getReplyBoundaryContractMetadata();
+}
+
+export function buildReplyBoundaryGuardConformanceContract() {
+  return buildReplyBoundaryConformanceContract({
+    classifyReplyBoundaryClaimFamilies,
+    evaluateReplyBoundaryPolicy,
+    suggestReplyBoundaryRewrite,
+    rewriteReplyBoundaryText,
+    buildReplyBoundaryEnforcementDecision,
+    inferReplyBoundaryWaitingOn,
+  });
+}
+
+export function runReplyBoundaryGuardConformanceSuite() {
+  return runReplyBoundaryConformanceSuite(buildReplyBoundaryGuardConformanceContract());
+}

--- a/extensions/reply-boundary-guard/index.ts
+++ b/extensions/reply-boundary-guard/index.ts
@@ -1,0 +1,70 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { applyReplyBoundaryGuard } from "./policy.ts";
+
+function rewriteAssistantMessage(message: unknown): unknown {
+  if (!message || typeof message !== "object") {
+    return message;
+  }
+  const candidate = message as { role?: unknown; content?: unknown };
+  if (candidate.role !== "assistant") {
+    return message;
+  }
+
+  let changed = false;
+  const clone = structuredClone(message) as { role?: unknown; content?: unknown };
+
+  if (typeof clone.content === "string") {
+    const result = applyReplyBoundaryGuard(clone.content);
+    if (result.outputChanged) {
+      clone.content = result.outputText;
+      changed = true;
+    }
+  } else if (Array.isArray(clone.content)) {
+    clone.content = clone.content.map((block) => {
+      if (
+        block &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        const original = (block as { text: string }).text;
+        const result = applyReplyBoundaryGuard(original);
+        if (result.outputChanged) {
+          changed = true;
+          return { ...(block as Record<string, unknown>), text: result.outputText };
+        }
+      }
+      return block;
+    });
+  }
+
+  return changed ? clone : message;
+}
+
+export default definePluginEntry({
+  id: "reply-boundary-guard",
+  name: "Reply Boundary Guard",
+  description:
+    "Applies canonical reply-boundary policy to outbound replies and supplements bare auto-report-back promises.",
+  register(api) {
+    api.on("message_sending", async (event, ctx) => {
+      if (ctx.channelId !== "telegram") {
+        return;
+      }
+      const result = applyReplyBoundaryGuard(event.content ?? "");
+      if (result.outputChanged) {
+        api.logger.info?.(
+          `reply-boundary-guard: rewrote outbound Telegram reply-boundary text (canonical=${result.usedCanonicalPolicy} reportBackSupplement=${result.usedReportBackSupplement})`,
+        );
+        return { content: result.outputText };
+      }
+    });
+
+    api.on("before_message_write", (event) => {
+      const rewrittenMessage = rewriteAssistantMessage(event.message);
+      if (rewrittenMessage !== event.message) {
+        return { message: rewrittenMessage as typeof event.message };
+      }
+    });
+  },
+});

--- a/extensions/reply-boundary-guard/openclaw.plugin.json
+++ b/extensions/reply-boundary-guard/openclaw.plugin.json
@@ -1,0 +1,5 @@
+{
+  "id": "reply-boundary-guard",
+  "name": "Reply Boundary Guard",
+  "description": "Applies canonical reply-boundary policy to outbound replies and supplements bare auto-report-back promises."
+}

--- a/extensions/reply-boundary-guard/package.json
+++ b/extensions/reply-boundary-guard/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/reply-boundary-guard",
+  "version": "2026.4.8",
+  "private": true,
+  "description": "OpenClaw reply-boundary guard plugin",
+  "type": "module",
+  "peerDependencies": {
+    "openclaw": "*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/reply-boundary-guard/package.json
+++ b/extensions/reply-boundary-guard/package.json
@@ -7,6 +7,9 @@
   "peerDependencies": {
     "openclaw": "*"
   },
+  "dependencies": {
+    "@luna/moonlight": "file:../../../moonlight"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/reply-boundary-guard/policy.ts
+++ b/extensions/reply-boundary-guard/policy.ts
@@ -2,7 +2,7 @@ import {
   buildReplyBoundaryEnforcementDecision,
   classifyReplyBoundaryClaimFamilies,
   type ReplyBoundaryPolicyInput,
-} from "../../../moonlight/src/pinocchio/reply-boundary/index.ts";
+} from "@luna/moonlight/pinocchio/reply-boundary";
 
 const REPORT_BACK_PATTERNS = [
   /\b(i['’]?ll|i will)\s*(report back|let you know|follow up|circle back)\b/i,

--- a/extensions/reply-boundary-guard/policy.ts
+++ b/extensions/reply-boundary-guard/policy.ts
@@ -1,0 +1,119 @@
+import {
+  buildReplyBoundaryEnforcementDecision,
+  classifyReplyBoundaryClaimFamilies,
+  type ReplyBoundaryPolicyInput,
+} from "../../../moonlight/src/pinocchio/reply-boundary/index.ts";
+
+const REPORT_BACK_PATTERNS = [
+  /\b(i['’]?ll|i will)\s*(report back|let you know|follow up|circle back)\b/i,
+  /\b(i['’]?ll|i will)\s*(keep an eye on|watch for|monitor)\b/i,
+  /\b(report back when|let you know when|follow up when|watch it for you)\b/i,
+];
+
+const TRUTHFUL_BOUNDARY_PATTERNS = [
+  /I am not continuing after this reply unless I explicitly resume or start a real background run\./i,
+  /Stopping here now; no active work is continuing after this reply\./i,
+  /Paused here; no active work is continuing after this reply\./i,
+  /A background run is active after this reply:/i,
+  /Waiting here for:/i,
+  /Waiting here for a required answer before continuing\./i,
+];
+
+const REPORT_BACK_FALLBACK =
+  "I will not automatically report back after this reply unless I explicitly set up a real reminder or watcher and tell you that I did.";
+
+function splitUnits(messageText: string): string[] {
+  return messageText
+    .replace(/\r\n/g, "\n")
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      if (/^(?:\[\[[^\]]+\]\]|(?:[-*•]|\d+\.)\s+)/.test(line)) {
+        return [line];
+      }
+      return line
+        .split(/(?<=[.!?])\s+(?=[A-Z0-9"'([{])/)
+        .map((part) => part.trim())
+        .filter(Boolean);
+    });
+}
+
+function applyReportBackSupplement(messageText: string): string {
+  if (!messageText || !REPORT_BACK_PATTERNS.some((pattern) => pattern.test(messageText))) {
+    return messageText;
+  }
+
+  const units = splitUnits(messageText);
+  const kept = units.filter((unit) => !REPORT_BACK_PATTERNS.some((pattern) => pattern.test(unit)));
+  const keptText = kept.join("\n\n").trim();
+
+  if (!keptText) {
+    return REPORT_BACK_FALLBACK;
+  }
+  return `${keptText}\n\n${REPORT_BACK_FALLBACK}`;
+}
+
+function shouldApplyCanonicalPolicy(messageText: string): boolean {
+  if (!messageText) {
+    return false;
+  }
+  if (TRUTHFUL_BOUNDARY_PATTERNS.some((pattern) => pattern.test(messageText))) {
+    return false;
+  }
+
+  const families = classifyReplyBoundaryClaimFamilies(messageText);
+  return families.includes("active_continuation") || families.includes("background_execution");
+}
+
+function buildBasePolicyInput(messageText: string): ReplyBoundaryPolicyInput {
+  return {
+    messageText,
+    postReplyState: "IDLE",
+    didWorkThisTurn: false,
+    backgroundRunIds: [],
+    waitingOn: null,
+    activityEvidence: [],
+  };
+}
+
+export interface ReplyBoundaryGuardResult {
+  originalText: string;
+  outputText: string;
+  outputChanged: boolean;
+  usedCanonicalPolicy: boolean;
+  usedReportBackSupplement: boolean;
+  canonicalAction: "allow" | "rewrite";
+  canonicalReason: string;
+}
+
+export function applyReplyBoundaryGuard(messageText: string): ReplyBoundaryGuardResult {
+  let afterCanonical = messageText;
+  let canonicalAction: "allow" | "rewrite" = "allow";
+  let canonicalReason = "Canonical policy not invoked for this message.";
+  let usedCanonicalPolicy = false;
+
+  if (shouldApplyCanonicalPolicy(messageText)) {
+    const decision = buildReplyBoundaryEnforcementDecision(buildBasePolicyInput(messageText));
+    afterCanonical = decision.outputText;
+    canonicalAction = decision.action;
+    canonicalReason = decision.reason;
+    usedCanonicalPolicy = decision.outputChanged;
+  }
+
+  const afterSupplement = applyReportBackSupplement(afterCanonical);
+
+  return {
+    originalText: messageText,
+    outputText: afterSupplement,
+    outputChanged: afterSupplement !== messageText,
+    usedCanonicalPolicy,
+    usedReportBackSupplement: afterSupplement !== afterCanonical,
+    canonicalAction,
+    canonicalReason,
+  };
+}
+
+export function rewriteReplyBoundaryText(messageText: string): string {
+  return applyReplyBoundaryGuard(messageText).outputText;
+}

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -58,6 +58,11 @@ const wasSentByBot = vi.hoisted(() => vi.fn(() => false));
 const loadSessionStore = vi.hoisted(() => vi.fn());
 const resolveStorePath = vi.hoisted(() => vi.fn(() => "/tmp/sessions.json"));
 const generateTopicLabel = vi.hoisted(() => vi.fn());
+const getGlobalHookRunner = vi.hoisted(() => vi.fn());
+const messageHookRunner = vi.hoisted(() => ({
+  hasHooks: vi.fn<(name: string) => boolean>(() => false),
+  runMessageSending: vi.fn(),
+}));
 
 vi.mock("./draft-stream.js", () => ({
   createTelegramDraftStream,
@@ -102,6 +107,10 @@ vi.mock("./sticker-cache.js", () => ({
   searchStickers: () => [],
   getAllCachedStickers: () => [],
   describeStickerImage: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getGlobalHookRunner,
 }));
 
 let dispatchTelegramMessage: typeof import("./bot-message-dispatch.js").dispatchTelegramMessage;
@@ -162,6 +171,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     loadSessionStore.mockReset();
     resolveStorePath.mockReset();
     generateTopicLabel.mockReset();
+    getGlobalHookRunner.mockReset();
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.runMessageSending.mockReset();
     loadConfig.mockReturnValue({});
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,
@@ -199,6 +211,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     resolveStorePath.mockReturnValue("/tmp/sessions.json");
     loadSessionStore.mockReturnValue({});
     generateTopicLabel.mockResolvedValue("Topic label");
+    getGlobalHookRunner.mockReturnValue(messageHookRunner);
+    messageHookRunner.hasHooks.mockReturnValue(false);
   });
 
   const createDraftStream = (messageId?: number) => createTestDraftStream({ messageId });
@@ -1739,6 +1753,113 @@ describe("dispatchTelegramMessage draft streaming", () => {
       "Checking the directory...",
       expect.any(Object),
     );
+  });
+
+  it("applies message_sending rewrite before preview-finalized final edit", async () => {
+    const answerDraftStream = createDraftStream(321);
+    const reasoningDraftStream = createDraftStream(111);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    messageHookRunner.runMessageSending.mockResolvedValue({ content: "Hooked final answer" });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledWith(
+      {
+        to: "123",
+        content: "Checking the directory...",
+        metadata: {
+          channel: "telegram",
+          mediaUrls: [],
+          threadId: 777,
+        },
+      },
+      {
+        channelId: "telegram",
+        accountId: "default",
+        conversationId: "123",
+      },
+    );
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      321,
+      "Hooked final answer",
+      expect.any(Object),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("falls back to send once when message_sending rewrite makes the final too long to edit", async () => {
+    const answerDraftStream = createDraftStream(321);
+    const reasoningDraftStream = createDraftStream(111);
+    const rewrittenText = "Hooked final answer ".repeat(300);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    messageHookRunner.runMessageSending.mockResolvedValue({ content: rewrittenText });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skipMessageSendingHooks: true,
+        replies: [expect.objectContaining({ text: rewrittenText })],
+      }),
+    );
+  });
+
+  it("blocks preview-finalized final delivery when message_sending cancels it", async () => {
+    const answerDraftStream = createDraftStream(321);
+    const reasoningDraftStream = createDraftStream(111);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    messageHookRunner.runMessageSending.mockResolvedValue({ cancel: true });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checking the directory..." });
+        await dispatcherOptions.deliver({ text: "Checking the directory..." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "123",
+        content: "Checking the directory...",
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "default",
+        conversationId: "123",
+      }),
+    );
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
   });
 
   it("keeps reasoning and answer streaming in separate preview lanes", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -12,6 +12,7 @@ import type {
   TelegramAccountConfig,
   TelegramDirectConfig,
 } from "openclaw/plugin-sdk/config-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-history";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -487,18 +488,66 @@ export const dispatchTelegramMessage = async ({
     }
     return { ...payload, text };
   };
-  const sendPayload = async (payload: ReplyPayload) => {
+  const sendPayload = async (
+    payload: ReplyPayload,
+    options?: { skipMessageSendingHooks?: boolean },
+  ) => {
     const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
       ...deliveryBaseOptions,
       replies: [payload],
       onVoiceRecording: sendRecordVoice,
       silent: silentErrorReplies && payload.isError === true,
+      skipMessageSendingHooks: options?.skipMessageSendingHooks,
       mediaLoader: telegramDeps.loadWebMedia,
     });
     if (result.delivered) {
       deliveryState.markDelivered();
     }
     return result.delivered;
+  };
+  // Preview finalization can edit the visible Telegram message in place, so apply
+  // message_sending here and mark fallback sends to skip a second hook pass.
+  const preparePreviewFinalization = async (params: {
+    payload: ReplyPayload;
+    text: string;
+  }): Promise<{ cancelled: boolean; text: string; skipMessageSendingHooks: boolean }> => {
+    const hookRunner = getGlobalHookRunner();
+    if (!hookRunner?.hasHooks("message_sending")) {
+      return {
+        cancelled: false,
+        text: params.text,
+        skipMessageSendingHooks: false,
+      };
+    }
+    const reply = resolveSendableOutboundReplyParts(params.payload, { text: params.text });
+    const hookResult = await hookRunner.runMessageSending(
+      {
+        to: deliveryBaseOptions.chatId,
+        content: reply.text,
+        metadata: {
+          channel: "telegram",
+          mediaUrls: reply.mediaUrls,
+          threadId: deliveryBaseOptions.thread?.id,
+        },
+      },
+      {
+        channelId: "telegram",
+        accountId: deliveryBaseOptions.accountId,
+        conversationId: deliveryBaseOptions.chatId,
+      },
+    );
+    if (hookResult?.cancel) {
+      return {
+        cancelled: true,
+        text: reply.text,
+        skipMessageSendingHooks: true,
+      };
+    }
+    return {
+      cancelled: false,
+      text: typeof hookResult?.content === "string" ? hookResult.content : reply.text,
+      skipMessageSendingHooks: true,
+    };
   };
   const emitPreviewFinalizedHook = (result: LaneDeliveryResult) => {
     if (result.kind !== "preview-finalized") {
@@ -523,6 +572,8 @@ export const dispatchTelegramMessage = async ({
     draftMaxChars,
     applyTextToPayload,
     sendPayload,
+    preparePreviewFinalization: async ({ payload, text }) =>
+      await preparePreviewFinalization({ payload, text }),
     flushDraftLane,
     stopDraftLane: async (lane) => {
       await lane.stream?.stop();

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -601,6 +601,8 @@ export async function deliverReplies(params: {
   linkPreview?: boolean;
   /** When true, messages are sent with disable_notification. */
   silent?: boolean;
+  /** When true, assume message_sending already ran upstream for this payload. */
+  skipMessageSendingHooks?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
   /** Override media loader (tests). */
@@ -613,7 +615,8 @@ export async function deliverReplies(params: {
   };
   const mediaLoader = params.mediaLoader ?? loadWebMedia;
   const hookRunner = getGlobalHookRunner();
-  const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
+  const hasMessageSendingHooks =
+    !params.skipMessageSendingHooks && (hookRunner?.hasHooks("message_sending") ?? false);
   const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
   const chunkText = buildChunkTextResolver({
     textLimit: params.textLimit,

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -66,6 +66,16 @@ export type LaneDeliveryResult =
     }
   | { kind: "preview-retained" | "preview-updated" | "sent" | "skipped" };
 
+type SendPayloadOptions = {
+  skipMessageSendingHooks?: boolean;
+};
+
+type PreviewFinalizationPreparation = {
+  cancelled: boolean;
+  text: string;
+  skipMessageSendingHooks: boolean;
+};
+
 type CreateLaneTextDelivererParams = {
   lanes: Record<LaneName, DraftLaneState>;
   archivedAnswerPreviews: ArchivedPreview[];
@@ -73,7 +83,12 @@ type CreateLaneTextDelivererParams = {
   retainPreviewOnCleanupByLane: Record<LaneName, boolean>;
   draftMaxChars: number;
   applyTextToPayload: (payload: ReplyPayload, text: string) => ReplyPayload;
-  sendPayload: (payload: ReplyPayload) => Promise<boolean>;
+  sendPayload: (payload: ReplyPayload, options?: SendPayloadOptions) => Promise<boolean>;
+  preparePreviewFinalization?: (params: {
+    laneName: LaneName;
+    payload: ReplyPayload;
+    text: string;
+  }) => Promise<PreviewFinalizationPreparation>;
   flushDraftLane: (lane: DraftLaneState) => Promise<void>;
   stopDraftLane: (lane: DraftLaneState) => Promise<void>;
   editPreview: (params: {
@@ -482,10 +497,40 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     allowPreviewUpdateForNonFinal = false,
   }: DeliverLaneTextParams): Promise<LaneDeliveryResult> => {
     const lane = params.lanes[laneName];
-    const reply = resolveSendableOutboundReplyParts(payload, { text });
-    const hasMedia = reply.hasMedia;
-    const canEditViaPreview =
-      !hasMedia && text.length > 0 && text.length <= params.draftMaxChars && !payload.isError;
+    let deliveryText = text;
+    let deliveryPayload = params.applyTextToPayload(payload, deliveryText);
+    let reply = resolveSendableOutboundReplyParts(deliveryPayload, { text: deliveryText });
+    let hasMedia = reply.hasMedia;
+    let canEditViaPreview =
+      !hasMedia &&
+      deliveryText.length > 0 &&
+      deliveryText.length <= params.draftMaxChars &&
+      !deliveryPayload.isError;
+    let skipMessageSendingHooks = false;
+
+    if (infoKind === "final" && canEditViaPreview && params.preparePreviewFinalization) {
+      const prepared = await params.preparePreviewFinalization({
+        laneName,
+        payload: deliveryPayload,
+        text: deliveryText,
+      });
+      if (prepared.cancelled) {
+        return result("skipped");
+      }
+      deliveryText = prepared.text;
+      deliveryPayload = params.applyTextToPayload(payload, deliveryText);
+      reply = resolveSendableOutboundReplyParts(deliveryPayload, { text: deliveryText });
+      hasMedia = reply.hasMedia;
+      canEditViaPreview =
+        !hasMedia &&
+        deliveryText.length > 0 &&
+        deliveryText.length <= params.draftMaxChars &&
+        !deliveryPayload.isError;
+      skipMessageSendingHooks = prepared.skipMessageSendingHooks;
+      if (!reply.hasContent) {
+        return result("skipped");
+      }
+    }
 
     if (infoKind === "final") {
       // Transient previews must decide cleanup retention per final attempt.
@@ -497,8 +542,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       if (laneName === "answer") {
         const archivedResult = await consumeArchivedAnswerPreviewForFinal({
           lane,
-          text,
-          payload,
+          text: deliveryText,
+          payload: deliveryPayload,
           previewButtons,
           canEditViaPreview,
         });
@@ -511,8 +556,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         if (laneName === "answer") {
           const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({
             lane,
-            text,
-            payload,
+            text: deliveryText,
+            payload: deliveryPayload,
             previewButtons,
             canEditViaPreview,
           });
@@ -524,12 +569,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           const materializedMessageId = await tryMaterializeDraftPreviewForFinal({
             lane,
             laneName,
-            text,
+            text: deliveryText,
           });
           if (typeof materializedMessageId === "number") {
             markActivePreviewComplete(laneName);
             return result("preview-finalized", {
-              content: text,
+              content: deliveryText,
               messageId: materializedMessageId,
             });
           }
@@ -538,7 +583,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         const finalized = await tryUpdatePreviewForLane({
           lane,
           laneName,
-          text,
+          text: deliveryText,
           previewButtons,
           stopBeforeEdit: true,
           skipRegressive: "existingOnly",
@@ -547,7 +592,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         if (finalized === "edited") {
           markActivePreviewComplete(laneName);
           return result("preview-finalized", {
-            content: text,
+            content: deliveryText,
             messageId: previewMessageId ?? lane.stream?.messageId(),
           });
         }
@@ -562,13 +607,21 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           markActivePreviewComplete(laneName);
           return result("preview-retained");
         }
-      } else if (!hasMedia && !payload.isError && text.length > params.draftMaxChars) {
+      } else if (
+        !hasMedia &&
+        !deliveryPayload.isError &&
+        deliveryText.length > params.draftMaxChars
+      ) {
         params.log(
-          `telegram: preview final too long for edit (${text.length} > ${params.draftMaxChars}); falling back to standard send`,
+          `telegram: preview final too long for edit (${deliveryText.length} > ${params.draftMaxChars}); falling back to standard send`,
         );
       }
       await params.stopDraftLane(lane);
-      const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+      const delivered = skipMessageSendingHooks
+        ? await params.sendPayload(deliveryPayload, {
+            skipMessageSendingHooks: true,
+          })
+        : await params.sendPayload(deliveryPayload);
       return delivered ? result("sent") : result("skipped");
     }
 
@@ -577,24 +630,24 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         // DM draft flow has no message_id to edit; updates are sent via sendMessageDraft.
         // Only mark as updated when the draft flush actually emits an update.
         const previewRevisionBeforeFlush = lane.stream?.previewRevision?.() ?? 0;
-        lane.stream?.update(text);
+        lane.stream?.update(deliveryText);
         await params.flushDraftLane(lane);
         const previewUpdated = (lane.stream?.previewRevision?.() ?? 0) > previewRevisionBeforeFlush;
         if (!previewUpdated) {
           params.log(
             `telegram: ${laneName} draft preview update not emitted; falling back to standard send`,
           );
-          const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+          const delivered = await params.sendPayload(deliveryPayload);
           return delivered ? result("sent") : result("skipped");
         }
-        lane.lastPartialText = text;
+        lane.lastPartialText = deliveryText;
         params.markDelivered();
         return result("preview-updated");
       }
       const updated = await tryUpdatePreviewForLane({
         lane,
         laneName,
-        text,
+        text: deliveryText,
         previewButtons,
         stopBeforeEdit: false,
         updateLaneSnapshot: true,
@@ -606,7 +659,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
     }
 
-    const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+    const delivered = await params.sendPayload(deliveryPayload);
     return delivered ? result("sent") : result("skipped");
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,6 +648,15 @@ importers:
 
   extensions/qwen: {}
 
+  extensions/reply-boundary-guard:
+    dependencies:
+      '@luna/moonlight':
+        specifier: file:../../../moonlight
+        version: file:../moonlight
+      openclaw:
+        specifier: '*'
+        version: 2026.4.9(@napi-rs/canvas@0.1.97)(@types/express@5.0.6)(apache-arrow@18.1.0)(node-llama-cpp@3.18.1(typescript@6.0.2))(typescript@6.0.2)
+
   extensions/runway: {}
 
   extensions/searxng: {}
@@ -1161,6 +1170,9 @@ packages:
   '@buape/carbon@0.0.0-beta-20260406003433':
     resolution: {integrity: sha512-nv3Izl5kk56bSV4yi6au4W9qKMJFHK38euXwesRjwsmGKH0nIghY179Dn1SrYvTKHWUU2mf0mTIl1NoFFgEEIA==}
 
+  '@buape/carbon@0.14.0':
+    resolution: {integrity: sha512-mavllPK2iVpRNRtC4C8JOUdJ1hdV0+LDelFW+pjpJaM31MBLMfIJ+f/LlYTIK5QrEcQsXOC+6lU2e0gmgjWhIQ==}
+
   '@cacheable/memory@2.0.8':
     resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
 
@@ -1181,6 +1193,9 @@ packages:
     resolution: {integrity: sha512-vHrMy4NErcq6suyGByfQSdalnvaMu4dRd10BJdeMp60V6cYtuHJSR2Ay5l0kb4iSPyk4dZKrXNNpLzeqHRcAfA==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@cloudflare/workers-types@4.20260120.0':
+    resolution: {integrity: sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==}
 
   '@cloudflare/workers-types@4.20260405.1':
     resolution: {integrity: sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==}
@@ -1280,6 +1295,10 @@ packages:
   '@discordjs/opus@0.10.0':
     resolution: {integrity: sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==}
     engines: {node: '>=12.0.0'}
+
+  '@discordjs/voice@0.19.0':
+    resolution: {integrity: sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==}
+    engines: {node: '>=22.12.0'}
 
   '@discordjs/voice@0.19.2':
     resolution: {integrity: sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==}
@@ -1902,6 +1921,9 @@ packages:
 
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@luna/moonlight@file:../moonlight':
+    resolution: {directory: ../moonlight, type: directory}
 
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.10':
     resolution: {integrity: sha512-C+eqDyRNHRYvx7RaHj6VVCx6nCpRBPuuxhTcc3JH3GuBMoxTsYeY4GkWH2XOktrgbAq1BG8e/Y8bu/wNQreCEw==}
@@ -3449,6 +3471,9 @@ packages:
   '@types/bun@1.3.11':
     resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
 
+  '@types/bun@1.3.6':
+    resolution: {integrity: sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3979,6 +4004,9 @@ packages:
   bun-types@1.3.11:
     resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
 
+  bun-types@1.3.6:
+    resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4256,6 +4284,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  discord-api-types@0.38.37:
+    resolution: {integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==}
 
   discord-api-types@0.38.44:
     resolution: {integrity: sha512-q91MgBzP/gRaCLIbQTaOrOhbD8uVIaPKxpgX2sfFB2nZ9nSiTYM9P3NFQ7cbO6NCxctI6ODttc67MI+YhIfILg==}
@@ -5516,6 +5547,17 @@ packages:
       zod:
         optional: true
 
+  openclaw@2026.4.9:
+    resolution: {integrity: sha512-w3DMKeVv7BnKmcQvq2Xu+X51HMv02L00YBX4uRDSuAEIgP3Ehm7JlKG9KTbfhAFu93143MqZNqI75/eXjkRO6Q==}
+    engines: {node: '>=22.14.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.18.1
+    peerDependenciesMeta:
+      node-llama-cpp:
+        optional: true
+
   openshell@0.1.0:
     resolution: {integrity: sha512-B7jLewH+d73hraWcrSFgNOjvd+frW5JPejkTpqgj2EJBjX/Yk1Y4blgP5pDl4FwrBxfmwsTKR08Uwgrdo+xpSg==}
     engines: {node: '>=18'}
@@ -6715,6 +6757,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -7616,6 +7670,26 @@ snapshots:
       - opusscript
       - utf-8-validate
 
+  '@buape/carbon@0.14.0(@discordjs/opus@0.10.0)(hono@4.12.10)(opusscript@0.1.1)':
+    dependencies:
+      '@types/node': 25.5.2
+      discord-api-types: 0.38.37
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260120.0
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@hono/node-server': 1.19.10(hono@4.12.10)
+      '@types/bun': 1.3.6
+      '@types/ws': 8.18.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - bufferutil
+      - ffmpeg-static
+      - hono
+      - node-opus
+      - opusscript
+      - utf-8-validate
+
   '@cacheable/memory@2.0.8':
     dependencies:
       '@cacheable/utils': 2.4.1
@@ -7650,6 +7724,9 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       yaml: 2.8.3
+
+  '@cloudflare/workers-types@4.20260120.0':
+    optional: true
 
   '@cloudflare/workers-types@4.20260405.1':
     optional: true
@@ -7757,6 +7834,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    optional: true
+
+  '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)':
+    dependencies:
+      '@types/ws': 8.18.1
+      discord-api-types: 0.38.44
+      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - bufferutil
+      - ffmpeg-static
+      - node-opus
+      - opusscript
+      - utf-8-validate
     optional: true
 
   '@discordjs/voice@0.19.2(@discordjs/opus@0.10.0)(@emnapi/core@1.8.1)(@emnapi/runtime@1.9.1)(opusscript@0.1.1)':
@@ -8392,6 +8485,8 @@ snapshots:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.5.1
 
+  '@luna/moonlight@file:../moonlight': {}
+
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.10':
     optional: true
 
@@ -8722,7 +8817,6 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 0.1.97
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.97
       '@napi-rs/canvas-win32-x64-msvc': 0.1.97
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.8.1)(@emnapi/runtime@1.9.1)':
     dependencies:
@@ -9934,6 +10028,11 @@ snapshots:
       bun-types: 1.3.11
     optional: true
 
+  '@types/bun@1.3.6':
+    dependencies:
+      bun-types: 1.3.6
+    optional: true
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -10501,6 +10600,11 @@ snapshots:
       '@types/node': 25.5.2
     optional: true
 
+  bun-types@1.3.6:
+    dependencies:
+      '@types/node': 25.5.2
+    optional: true
+
   bytes@3.1.2: {}
 
   cac@7.0.0: {}
@@ -10755,6 +10859,8 @@ snapshots:
   diff@8.0.3: {}
 
   diff@8.0.4: {}
+
+  discord-api-types@0.38.37: {}
 
   discord-api-types@0.38.44: {}
 
@@ -12201,6 +12307,99 @@ snapshots:
       ws: 8.20.0
       zod: 4.3.6
 
+  openclaw@2026.4.9(@napi-rs/canvas@0.1.97)(@types/express@5.0.6)(apache-arrow@18.1.0)(node-llama-cpp@3.18.1(typescript@6.0.2))(typescript@6.0.2):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.18.0(zod@4.3.6)
+      '@anthropic-ai/vertex-sdk': 0.14.4(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1024.0
+      '@aws-sdk/client-bedrock-runtime': 3.1024.0
+      '@aws-sdk/credential-provider-node': 3.972.29
+      '@aws/bedrock-token-generator': 1.1.0
+      '@buape/carbon': 0.14.0(@discordjs/opus@0.10.0)(hono@4.12.10)(opusscript@0.1.1)
+      '@clack/prompts': 1.2.0
+      '@google/genai': 1.48.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+      '@grammyjs/runner': 2.0.3(grammy@1.42.0)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.42.0)
+      '@homebridge/ciao': 1.3.6
+      '@lancedb/lancedb': 0.27.2(apache-arrow@18.1.0)
+      '@larksuiteoapi/node-sdk': 1.60.0
+      '@line/bot-sdk': 11.0.0
+      '@lydell/node-pty': 1.2.0-beta.10
+      '@mariozechner/pi-agent-core': 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.65.2
+      '@matrix-org/matrix-sdk-crypto-wasm': 18.0.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.97
+      '@sinclair/typebox': 0.34.49
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.15.0
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.44
+      dotenv: 17.4.0
+      express: 5.2.1
+      file-type: 22.0.0
+      gaxios: 7.1.4
+      google-auth-library: 10.6.2
+      grammy: 1.42.0
+      hono: 4.12.10
+      https-proxy-agent: 9.0.0
+      ipaddr.js: 2.3.0
+      jimp: 1.6.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      matrix-js-sdk: 41.3.0-rc.0
+      mpg123-decoder: 1.0.3
+      node-edge-tts: 1.2.10
+      nostr-tools: 2.23.3(typescript@6.0.2)
+      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.6.205
+      playwright-core: 1.59.1
+      proxy-agent: 8.0.0
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      silk-wasm: 3.7.1
+      sqlite-vec: 0.1.9
+      tar: 7.5.13
+      tslog: 4.10.2
+      undici: 8.0.2
+      uuid: 13.0.0
+      ws: 8.20.0
+      yaml: 2.8.3
+      zod: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
+      '@matrix-org/matrix-sdk-crypto-nodejs': 0.4.0
+      node-llama-cpp: 3.18.1(typescript@6.0.2)
+      openshell: 0.1.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@types/express'
+      - apache-arrow
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - node-opus
+      - supports-color
+      - typescript
+      - utf-8-validate
+
   openshell@0.1.0:
     dependencies:
       dotenv: 16.6.1
@@ -13532,6 +13731,9 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.19.0:
+    optional: true
 
   ws@8.20.0: {}
 


### PR DESCRIPTION
## Summary
- run `message_sending` before Telegram preview-finalized final edits
- reuse the rewritten final text (or cancel delivery) on the assistant-local preview-finalization seam
- skip a second `message_sending` pass if preview finalization falls back to a normal send
- add focused tests for rewrite, cancel, and rewrite-to-too-long fallback behavior

## Why
EPIC-022 needs real consumer-side proof on the visible Telegram reply path, not only Moonlight-side doctrine.

Before this change, Telegram final-send delivery already applied `message_sending`, but the assistant-local preview-finalization seam could still edit the visible final message without running the same hook. That left a real bypass risk on a deployment-relevant surface when Telegram streaming is `partial`.

This PR narrows that gap for the bounded Telegram claim only:
- final-send delivery remains hook-covered
- preview-finalization delivery now also runs through `message_sending`
- fallback sends after an upstream rewrite skip a second hook pass

## Scope / non-claims
- this is about Telegram assistant preview-finalization only
- it does **not** claim universal OpenClaw reply-surface non-bypass coverage
- it does **not** claim transcript/history parity across every persistence path

## Verification
Directly re-run on this branch:
- `node --no-maglev node_modules/vitest/vitest.mjs run --config vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/lane-delivery.test.ts`
- result: 3 files passed, 132 tests passed
