### PR TITLE
fix: suppress non-fatal WhatsApp decrypt races

### DIFF
--- a/extensions/slack/src/approval-handler.runtime.test.ts
+++ b/extensions/slack/src/approval-handler.runtime.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { slackApprovalNativeRuntime } from "./approval-handler.runtime.js";
+
+type SlackActionsBlock = { type?: string; elements?: unknown[] };
+type SlackPendingPayload = { text: string; blocks: SlackActionsBlock[] };
+type SlackResolvedPayload = { text: string; blocks: Array<{ type?: string }> };
+
+function findSlackActionsBlock(blocks: SlackActionsBlock[]) {
+  return blocks.find((block) => block.type === "actions");
+}
+
+describe("slackApprovalNativeRuntime", () => {
+  it("renders only the allowed pending actions", async () => {
+    const payload = (await slackApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        commandText: "echo hi",
+        metadata: [],
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve req-1 allow-once",
+            style: "success",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve req-1 deny",
+            style: "danger",
+          },
+        ],
+      } as never,
+    })) as SlackPendingPayload;
+
+    expect(payload.text).toContain("*Exec approval required*");
+    const actionsBlock = findSlackActionsBlock(payload.blocks);
+    const labels = (actionsBlock?.elements ?? []).map((element) =>
+      typeof element === "object" &&
+      element &&
+      typeof (element as { text?: { text?: unknown } }).text?.text === "string"
+        ? (element as { text: { text: string } }).text.text
+        : "",
+    );
+
+    expect(labels).toEqual(["Allow Once", "Deny"]);
+    expect(JSON.stringify(payload.blocks)).not.toContain("Allow Always");
+  });
+
+  it("renders resolved updates without interactive blocks", async () => {
+    const result = await slackApprovalNativeRuntime.presentation.buildResolvedResult({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      resolved: {
+        id: "req-1",
+        decision: "allow-once",
+        resolvedBy: "U123APPROVER",
+        ts: 0,
+      } as never,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        decision: "allow-once",
+        commandText: "echo hi",
+        resolvedBy: "U123APPROVER",
+      } as never,
+      entry: {
+        channelId: "D123APPROVER",
+        messageTs: "1712345678.999999",
+      },
+    });
+    expect(result.kind).toBe("update");
+    if (result.kind !== "update") {
+      throw new Error("expected Slack resolved update payload");
+    }
+    const resolvedPayload = result.payload as SlackResolvedPayload;
+    expect(resolvedPayload.text).toContain("*Exec approval: Allowed once*");
+    expect(resolvedPayload.text).toContain("Resolved by <@U123APPROVER>.");
+    expect(resolvedPayload.blocks.some((block) => block.type === "actions")).toBe(false);
+  });
+});

--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { telegramApprovalNativeRuntime } from "./approval-handler.runtime.js";
+
+type TelegramPendingPayload = {
+  text: string;
+  buttons?: Array<Array<{ text: string }>>;
+};
+
+describe("telegramApprovalNativeRuntime", () => {
+  it("renders only the allowed pending buttons", async () => {
+    const payload = (await telegramApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        token: "tg-token",
+      },
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        commandText: "echo hi",
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve req-1 allow-once",
+            style: "success",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve req-1 deny",
+            style: "danger",
+          },
+        ],
+      } as never,
+    })) as TelegramPendingPayload;
+
+    expect(payload.text).toContain("/approve req-1 allow-once");
+    expect(payload.text).not.toContain("allow-always");
+    expect(payload.buttons?.[0]?.map((button) => button.text)).toEqual(["Allow Once", "Deny"]);
+  });
+
+  it("passes topic thread ids to typing and message delivery", async () => {
+    const sendTyping = vi.fn().mockResolvedValue({ ok: true });
+    const sendMessage = vi.fn().mockResolvedValue({
+      chatId: "-1003841603622",
+      messageId: "m1",
+    });
+
+    const entry = await telegramApprovalNativeRuntime.transport.deliverPending({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        token: "tg-token",
+        deps: {
+          sendTyping,
+          sendMessage,
+        },
+      },
+      plannedTarget: {
+        surface: "origin",
+        reason: "preferred",
+        target: {
+          to: "-1003841603622",
+          threadId: 928,
+        },
+      },
+      preparedTarget: {
+        chatId: "-1003841603622",
+        messageThreadId: 928,
+      },
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        commandText: "echo hi",
+        actions: [],
+      } as never,
+      pendingPayload: {
+        text: "pending",
+        buttons: [],
+      },
+    });
+
+    expect(sendTyping).toHaveBeenCalledWith(
+      "-1003841603622",
+      expect.objectContaining({
+        token: "tg-token",
+        accountId: "default",
+        messageThreadId: 928,
+      }),
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      "-1003841603622",
+      "pending",
+      expect.objectContaining({
+        token: "tg-token",
+        accountId: "default",
+        messageThreadId: 928,
+        buttons: [],
+      }),
+    );
+    expect(entry).toEqual({
+      chatId: "-1003841603622",
+      messageId: "m1",
+    });
+  });
+});

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -6,6 +6,7 @@ import { setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { withEnvAsync } from "openclaw/plugin-sdk/testing";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";
+import { isUnhandledRejectionHandled } from "../../../src/infra/unhandled-rejections.js";
 import {
   createWebInboundDeliverySpies,
   createMockWebListener,
@@ -186,6 +187,50 @@ describe("web auto-reply connection", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("routes WhatsApp crypto rejections through the extension-owned handler", async () => {
+    const sleep = vi.fn(async () => {});
+    const scripted = createScriptedWebListenerFactory();
+    const { controller, run } = startWebAutoReplyMonitor({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory: scripted.listenerFactory,
+      sleep,
+    });
+
+    await Promise.resolve();
+    expect(scripted.getListenerCount()).toBe(1);
+
+    const err = new Error("Unsupported state or unable to authenticate data");
+    err.stack = [
+      "Error: Unsupported state or unable to authenticate data",
+      "    at aesDecryptGCM (file:///x/@whiskeysockets/baileys/src/Utils/crypto.ts:71:55)",
+      "    at decrypt (file:///x/@whiskeysockets/baileys/src/Utils/noise-handler.ts:49:18)",
+    ].join("\n");
+
+    expect(isUnhandledRejectionHandled(err)).toBe(true);
+    expect(scripted.listeners[0]?.signalClose).toHaveBeenCalledWith({
+      status: 499,
+      isLoggedOut: false,
+      error: err,
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(scripted.getListenerCount()).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 250, interval: 2 },
+    );
+
+    controller.abort();
+    scripted.resolveClose(scripted.getListenerCount() - 1, {
+      status: 499,
+      isLoggedOut: false,
+      error: "aborted",
+    });
+    await run;
+
+    expect(isUnhandledRejectionHandled(err)).toBe(false);
   });
 
   it("gives a reconnected listener a fresh watchdog window", async () => {

--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -7,6 +7,15 @@ import {
   applyLocalOxlintPolicy,
 } from "./local-heavy-check-runtime.mjs";
 
+const PLUGIN_SDK_DTS_STAMP = path.join("dist", "plugin-sdk", ".boundary-entry-shims.stamp");
+const PLUGIN_SDK_DTS_ENTRY = path.join("dist", "plugin-sdk", "index.d.ts");
+const PLUGIN_SDK_DTS_INPUT_FILES = [
+  "tsconfig.plugin-sdk.dts.json",
+  path.join("scripts", "write-plugin-sdk-entry-dts.ts"),
+  path.join("scripts", "lib", "plugin-sdk-entries.mjs"),
+];
+const PLUGIN_SDK_DTS_SOURCE_ROOTS = ["src", path.join("packages", "memory-host-sdk", "src")];
+
 export function runExtensionOxlint(params) {
   const repoRoot = process.cwd();
   const oxlintPath = path.resolve("node_modules", ".bin", "oxlint");
@@ -20,6 +29,8 @@ export function runExtensionOxlint(params) {
   const tempConfigPath = path.join(tempDir, "oxlint.json");
 
   try {
+    ensurePluginSdkDeclarationOutputs({ repoRoot, toolName: params.toolName });
+
     const extensionFiles = params.roots.flatMap((root) =>
       collectTypeScriptFiles(path.resolve(repoRoot, root)),
     );
@@ -47,6 +58,94 @@ export function runExtensionOxlint(params) {
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
     releaseLock();
+  }
+}
+
+export function resolvePluginSdkDeclarationBuildRequirement(params = {}) {
+  const repoRoot = params.repoRoot ?? process.cwd();
+  const fsImpl = params.fs ?? fs;
+  const stampPath = path.join(repoRoot, PLUGIN_SDK_DTS_STAMP);
+  const entryPath = path.join(repoRoot, PLUGIN_SDK_DTS_ENTRY);
+  const stampMtime = readMtimeMs(fsImpl, stampPath);
+  const entryMtime = readMtimeMs(fsImpl, entryPath);
+
+  if (stampMtime == null || entryMtime == null) {
+    return { shouldBuild: true, reason: "missing_declarations" };
+  }
+
+  const latestInputMtime = resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl);
+  if (latestInputMtime != null && latestInputMtime > stampMtime) {
+    return { shouldBuild: true, reason: "stale_declarations" };
+  }
+
+  return { shouldBuild: false, reason: "fresh_declarations" };
+}
+
+function ensurePluginSdkDeclarationOutputs(params = {}) {
+  const repoRoot = params.repoRoot ?? process.cwd();
+  const env = params.env ?? process.env;
+  const spawnSyncImpl = params.spawnSyncImpl ?? spawnSync;
+  const requirement = resolvePluginSdkDeclarationBuildRequirement({ repoRoot });
+  if (!requirement.shouldBuild) {
+    return;
+  }
+
+  const releaseLock = acquireLocalHeavyCheckLockSync({
+    cwd: repoRoot,
+    env: { ...env, OPENCLAW_LOCAL_CHECK: "1" },
+    toolName: `${params.toolName ?? "oxlint"}-plugin-sdk-dts`,
+    lockName: "plugin-sdk-dts",
+  });
+
+  try {
+    const currentRequirement = resolvePluginSdkDeclarationBuildRequirement({ repoRoot });
+    if (!currentRequirement.shouldBuild) {
+      return;
+    }
+
+    console.error(
+      `[${params.toolName ?? "oxlint"}] building plugin-sdk declarations (${currentRequirement.reason})...`,
+    );
+
+    runRequiredCommand({
+      command: path.resolve(
+        repoRoot,
+        "node_modules",
+        ".bin",
+        process.platform === "win32" ? "tsc.cmd" : "tsc",
+      ),
+      args: ["-p", "tsconfig.plugin-sdk.dts.json"],
+      cwd: repoRoot,
+      env,
+      spawnSyncImpl,
+      label: "build:plugin-sdk:dts",
+    });
+    runRequiredCommand({
+      command: process.execPath,
+      args: ["--import", "tsx", "scripts/write-plugin-sdk-entry-dts.ts"],
+      cwd: repoRoot,
+      env,
+      spawnSyncImpl,
+      label: "write-plugin-sdk-entry-dts",
+    });
+  } finally {
+    releaseLock();
+  }
+}
+
+function runRequiredCommand(params) {
+  const result = params.spawnSyncImpl(params.command, params.args, {
+    cwd: params.cwd,
+    env: params.env,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if ((result.status ?? 1) !== 0) {
+    process.exit(result.status ?? 1);
   }
 }
 
@@ -104,4 +203,70 @@ function collectTypeScriptFiles(directoryPath) {
   }
 
   return files;
+}
+
+function resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl) {
+  let latestMtime = null;
+
+  for (const inputPath of PLUGIN_SDK_DTS_INPUT_FILES) {
+    latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, path.join(repoRoot, inputPath)));
+  }
+
+  for (const root of PLUGIN_SDK_DTS_SOURCE_ROOTS) {
+    latestMtime = maxMtime(
+      latestMtime,
+      findLatestMtime(path.join(repoRoot, root), fsImpl, shouldSkipPluginSdkDeclarationInput),
+    );
+  }
+
+  return latestMtime;
+}
+
+function findLatestMtime(directoryPath, fsImpl, shouldSkip) {
+  if (!fsImpl.existsSync(directoryPath)) {
+    return null;
+  }
+
+  const entries = fsImpl.readdirSync(directoryPath, { withFileTypes: true });
+  let latestMtime = null;
+
+  for (const entry of entries) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      latestMtime = maxMtime(latestMtime, findLatestMtime(entryPath, fsImpl, shouldSkip));
+      continue;
+    }
+
+    if (!entry.isFile() || shouldSkip?.(entryPath)) {
+      continue;
+    }
+
+    latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, entryPath));
+  }
+
+  return latestMtime;
+}
+
+function shouldSkipPluginSdkDeclarationInput(entryPath) {
+  return (
+    entryPath.endsWith(".test.ts") ||
+    entryPath.endsWith(".test.tsx") ||
+    entryPath.endsWith(".e2e.test.ts") ||
+    entryPath.endsWith(".live.test.ts")
+  );
+}
+
+function readMtimeMs(fsImpl, filePath) {
+  try {
+    return fsImpl.statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function maxMtime(current, next) {
+  if (next == null) {
+    return current;
+  }
+  return current == null || next > current ? next : current;
 }

--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -9,13 +9,14 @@ import {
 
 const PLUGIN_SDK_DTS_STAMP = path.join("dist", "plugin-sdk", ".boundary-entry-shims.stamp");
 const PLUGIN_SDK_DTS_ENTRY = path.join("dist", "plugin-sdk", "index.d.ts");
+const PLUGIN_SDK_DTS_CONFIG_FILE = "tsconfig.plugin-sdk.dts.json";
 const PLUGIN_SDK_DTS_INPUT_FILES = [
-  "tsconfig.plugin-sdk.dts.json",
   path.join("scripts", "write-plugin-sdk-entry-dts.ts"),
   path.join("scripts", "lib", "plugin-sdk-entries.mjs"),
   path.join("scripts", "lib", "plugin-sdk-entrypoints.json"),
 ];
 const PLUGIN_SDK_DTS_SOURCE_ROOTS = ["src", path.join("packages", "memory-host-sdk", "src")];
+const TYPESCRIPT_SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
 
 export function runExtensionOxlint(params) {
   const repoRoot = process.cwd();
@@ -209,6 +210,10 @@ function collectTypeScriptFiles(directoryPath) {
 function resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl) {
   let latestMtime = null;
 
+  for (const configPath of resolvePluginSdkDeclarationConfigPaths(repoRoot, fsImpl)) {
+    latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, configPath));
+  }
+
   for (const inputPath of PLUGIN_SDK_DTS_INPUT_FILES) {
     latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, path.join(repoRoot, inputPath)));
   }
@@ -221,6 +226,65 @@ function resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl) {
   }
 
   return latestMtime;
+}
+
+function resolvePluginSdkDeclarationConfigPaths(repoRoot, fsImpl) {
+  const visited = new Set();
+  const resolvedPaths = [];
+
+  function visitConfig(filePath) {
+    const normalizedPath = path.normalize(filePath);
+    if (visited.has(normalizedPath) || !fsImpl.existsSync(normalizedPath)) {
+      return;
+    }
+    visited.add(normalizedPath);
+    resolvedPaths.push(normalizedPath);
+
+    let config;
+    try {
+      config = JSON.parse(fsImpl.readFileSync(normalizedPath, "utf8"));
+    } catch {
+      return;
+    }
+
+    const extendsValue = config?.extends;
+    if (typeof extendsValue !== "string" || extendsValue.trim().length === 0) {
+      return;
+    }
+
+    const resolvedBasePath = resolveTsconfigExtendsPath(
+      normalizedPath,
+      extendsValue.trim(),
+      fsImpl,
+    );
+    if (!resolvedBasePath) {
+      return;
+    }
+    visitConfig(resolvedBasePath);
+  }
+
+  visitConfig(path.join(repoRoot, PLUGIN_SDK_DTS_CONFIG_FILE));
+  return resolvedPaths;
+}
+
+function resolveTsconfigExtendsPath(configPath, extendsValue, fsImpl) {
+  if (!extendsValue.startsWith(".") && !extendsValue.startsWith("/")) {
+    return null;
+  }
+
+  const candidateBasePath = path.resolve(path.dirname(configPath), extendsValue);
+  const candidatePaths = [candidateBasePath];
+  if (!path.extname(candidateBasePath)) {
+    candidatePaths.push(`${candidateBasePath}.json`);
+  }
+
+  for (const candidatePath of candidatePaths) {
+    if (fsImpl.existsSync(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return null;
 }
 
 function findLatestMtime(directoryPath, fsImpl, shouldSkip) {
@@ -249,11 +313,23 @@ function findLatestMtime(directoryPath, fsImpl, shouldSkip) {
 }
 
 function shouldSkipPluginSdkDeclarationInput(entryPath) {
+  if (
+    !TYPESCRIPT_SOURCE_EXTENSIONS.some((extension) => entryPath.endsWith(extension)) &&
+    !entryPath.endsWith(".d.ts") &&
+    !entryPath.endsWith(".d.mts") &&
+    !entryPath.endsWith(".d.cts")
+  ) {
+    return true;
+  }
   return (
     entryPath.endsWith(".test.ts") ||
     entryPath.endsWith(".test.tsx") ||
+    entryPath.endsWith(".test.mts") ||
+    entryPath.endsWith(".test.cts") ||
     entryPath.endsWith(".e2e.test.ts") ||
-    entryPath.endsWith(".live.test.ts")
+    entryPath.endsWith(".e2e.test.tsx") ||
+    entryPath.endsWith(".live.test.ts") ||
+    entryPath.endsWith(".live.test.tsx")
   );
 }
 

--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -13,6 +13,7 @@ const PLUGIN_SDK_DTS_INPUT_FILES = [
   "tsconfig.plugin-sdk.dts.json",
   path.join("scripts", "write-plugin-sdk-entry-dts.ts"),
   path.join("scripts", "lib", "plugin-sdk-entries.mjs"),
+  path.join("scripts", "lib", "plugin-sdk-entrypoints.json"),
 ];
 const PLUGIN_SDK_DTS_SOURCE_ROOTS = ["src", path.join("packages", "memory-host-sdk", "src")];
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -978,7 +978,9 @@ describe("fetchWithSsrFGuard hardening", () => {
       fetch: vi.fn(async () => okResponse()),
     };
     const lookupFn: LookupFn = vi.fn(async (hostname: string) => {
-      if (hostname === "localhost") return [{ address: "127.0.0.1", family: 4 }];
+      if (hostname === "localhost") {
+        return [{ address: "127.0.0.1", family: 4 }];
+      }
       return [{ address: "149.154.167.220", family: 4 }];
     }) as unknown as LookupFn;
     const fetchImpl = vi.fn(async () => okResponse());
@@ -1008,7 +1010,9 @@ describe("fetchWithSsrFGuard hardening", () => {
       fetch: vi.fn(async () => okResponse()),
     };
     const lookupFn: LookupFn = vi.fn(async (hostname: string) => {
-      if (hostname === "localhost") return [{ address: "127.0.0.1", family: 4 }];
+      if (hostname === "localhost") {
+        return [{ address: "127.0.0.1", family: 4 }];
+      }
       return [{ address: "149.154.167.220", family: 4 }];
     }) as unknown as LookupFn;
     const fetchImpl = vi.fn();

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -176,6 +176,21 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
       );
     });
 
+    it("does not exit on known Baileys WhatsApp decrypt races", () => {
+      const err = new Error("Unsupported state or unable to authenticate data");
+      err.stack = [
+        "Error: Unsupported state or unable to authenticate data",
+        "    at aesDecryptGCM (file:///x/@whiskeysockets/baileys/src/Utils/crypto.ts:71:55)",
+        "    at decrypt (file:///x/@whiskeysockets/baileys/src/Utils/noise-handler.ts:49:18)",
+      ].join("\n");
+
+      expectExitCodeFromUnhandled(err, []);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Suppressed WhatsApp crypto rejection (continuing):",
+        expect.stringContaining("Unsupported state or unable to authenticate data"),
+      );
+    });
+
     it("exits on generic errors without code", () => {
       const genericErr = new Error("Something went wrong");
 

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -178,21 +178,6 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
       );
     });
 
-    it("does not exit on known Baileys WhatsApp decrypt races", () => {
-      const err = new Error("Unsupported state or unable to authenticate data");
-      err.stack = [
-        "Error: Unsupported state or unable to authenticate data",
-        "    at aesDecryptGCM (file:///x/@whiskeysockets/baileys/src/Utils/crypto.ts:71:55)",
-        "    at decrypt (file:///x/@whiskeysockets/baileys/src/Utils/noise-handler.ts:49:18)",
-      ].join("\n");
-
-      expectExitCodeFromUnhandled(err, []);
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[openclaw] Suppressed WhatsApp crypto rejection (continuing):",
-        expect.stringContaining("Unsupported state or unable to authenticate data"),
-      );
-    });
-
     it("exits on generic errors without code", () => {
       const genericErr = new Error("Something went wrong");
 

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -14,10 +14,11 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   let originalExit: typeof process.exit;
+  let uninstallUnhandledRejectionHandler: (() => void) | undefined;
 
   beforeAll(() => {
     originalExit = process.exit.bind(process);
-    installUnhandledRejectionHandler();
+    uninstallUnhandledRejectionHandler = installUnhandledRejectionHandler();
   });
 
   beforeEach(() => {
@@ -41,6 +42,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
   });
 
   afterAll(() => {
+    uninstallUnhandledRejectionHandler?.();
     process.exit = originalExit;
   });
 

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   isAbortError,
-  isLikelyWhatsAppCryptoError,
   isTransientNetworkError,
   isTransientSqliteError,
   isTransientUnhandledRejectionError,
@@ -255,28 +254,6 @@ describe("isTransientSqliteError", () => {
     const error = new Error("database is locked");
 
     expect(isTransientSqliteError(error)).toBe(false);
-  });
-});
-
-describe("isLikelyWhatsAppCryptoError", () => {
-  it("returns true for Baileys decrypt auth failures", () => {
-    const error = new Error("Unsupported state or unable to authenticate data");
-    error.stack = [
-      "Error: Unsupported state or unable to authenticate data",
-      "    at aesDecryptGCM (file:///x/@whiskeysockets/baileys/src/Utils/crypto.ts:71:55)",
-      "    at decrypt (file:///x/@whiskeysockets/baileys/src/Utils/noise-handler.ts:49:18)",
-    ].join("\n");
-
-    expect(isLikelyWhatsAppCryptoError(error)).toBe(true);
-  });
-
-  it("returns true for bad mac string signatures", () => {
-    expect(isLikelyWhatsAppCryptoError("bad mac in aesDecryptGCM (baileys)")).toBe(true);
-  });
-
-  it("returns false for unrelated authentication errors", () => {
-    expect(isLikelyWhatsAppCryptoError(new Error("unable to authenticate user"))).toBe(false);
-    expect(isLikelyWhatsAppCryptoError("bad mac without provider hint")).toBe(false);
   });
 });
 

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isAbortError,
+  isLikelyWhatsAppCryptoError,
   isTransientNetworkError,
   isTransientSqliteError,
   isTransientUnhandledRejectionError,
@@ -254,6 +255,28 @@ describe("isTransientSqliteError", () => {
     const error = new Error("database is locked");
 
     expect(isTransientSqliteError(error)).toBe(false);
+  });
+});
+
+describe("isLikelyWhatsAppCryptoError", () => {
+  it("returns true for Baileys decrypt auth failures", () => {
+    const error = new Error("Unsupported state or unable to authenticate data");
+    error.stack = [
+      "Error: Unsupported state or unable to authenticate data",
+      "    at aesDecryptGCM (file:///x/@whiskeysockets/baileys/src/Utils/crypto.ts:71:55)",
+      "    at decrypt (file:///x/@whiskeysockets/baileys/src/Utils/noise-handler.ts:49:18)",
+    ].join("\n");
+
+    expect(isLikelyWhatsAppCryptoError(error)).toBe(true);
+  });
+
+  it("returns true for bad mac string signatures", () => {
+    expect(isLikelyWhatsAppCryptoError("bad mac in aesDecryptGCM (baileys)")).toBe(true);
+  });
+
+  it("returns false for unrelated authentication errors", () => {
+    expect(isLikelyWhatsAppCryptoError(new Error("unable to authenticate user"))).toBe(false);
+    expect(isLikelyWhatsAppCryptoError("bad mac without provider hint")).toBe(false);
   });
 });
 

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -314,6 +314,54 @@ export function isTransientSqliteError(err: unknown): boolean {
   return false;
 }
 
+export function isLikelyWhatsAppCryptoError(reason: unknown): boolean {
+  const formatReason = (value: unknown): string => {
+    if (value == null) {
+      return "";
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+    if (value instanceof Error) {
+      return `${value.message}\n${value.stack ?? ""}`;
+    }
+    if (typeof value === "object") {
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return Object.prototype.toString.call(value);
+      }
+    }
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return String(value);
+    }
+    if (typeof value === "symbol") {
+      return value.description ?? value.toString();
+    }
+    if (typeof value === "function") {
+      return value.name ? `[function ${value.name}]` : "[function]";
+    }
+    return Object.prototype.toString.call(value);
+  };
+
+  const raw =
+    reason instanceof Error ? `${reason.message}\n${reason.stack ?? ""}` : formatReason(reason);
+  const haystack = raw.toLowerCase();
+  const hasAuthError =
+    haystack.includes("unsupported state or unable to authenticate data") ||
+    haystack.includes("bad mac");
+  if (!hasAuthError) {
+    return false;
+  }
+
+  return (
+    haystack.includes("@whiskeysockets/baileys") ||
+    haystack.includes("baileys") ||
+    haystack.includes("noise-handler") ||
+    haystack.includes("aesdecryptgcm")
+  );
+}
+
 export function isTransientUnhandledRejectionError(err: unknown): boolean {
   return isTransientNetworkError(err) || isTransientSqliteError(err);
 }
@@ -368,6 +416,14 @@ export function installUnhandledRejectionHandler(): void {
     if (isConfigError(reason)) {
       console.error("[openclaw] CONFIGURATION ERROR - requires fix:", formatUncaughtError(reason));
       exitWithTerminalRestore("configuration error");
+      return;
+    }
+
+    if (isLikelyWhatsAppCryptoError(reason)) {
+      console.warn(
+        "[openclaw] Suppressed WhatsApp crypto rejection (continuing):",
+        formatUncaughtError(reason),
+      );
       return;
     }
 

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -389,13 +389,13 @@ export function isUnhandledRejectionHandled(reason: unknown): boolean {
   return false;
 }
 
-export function installUnhandledRejectionHandler(): void {
+export function installUnhandledRejectionHandler(): () => void {
   const exitWithTerminalRestore = (reason: string) => {
     restoreTerminalState(reason, { resumeStdinIfPaused: false });
     process.exit(1);
   };
 
-  process.on("unhandledRejection", (reason, _promise) => {
+  const handleUnhandledRejection = (reason: unknown, _promise: Promise<unknown>) => {
     if (isUnhandledRejectionHandled(reason)) {
       return;
     }
@@ -437,5 +437,10 @@ export function installUnhandledRejectionHandler(): void {
 
     console.error("[openclaw] Unhandled promise rejection:", formatUncaughtError(reason));
     exitWithTerminalRestore("unhandled rejection");
-  });
+  };
+
+  process.on("unhandledRejection", handleUnhandledRejection);
+  return () => {
+    process.off("unhandledRejection", handleUnhandledRejection);
+  };
 }

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -314,54 +314,6 @@ export function isTransientSqliteError(err: unknown): boolean {
   return false;
 }
 
-export function isLikelyWhatsAppCryptoError(reason: unknown): boolean {
-  const formatReason = (value: unknown): string => {
-    if (value == null) {
-      return "";
-    }
-    if (typeof value === "string") {
-      return value;
-    }
-    if (value instanceof Error) {
-      return `${value.message}\n${value.stack ?? ""}`;
-    }
-    if (typeof value === "object") {
-      try {
-        return JSON.stringify(value);
-      } catch {
-        return Object.prototype.toString.call(value);
-      }
-    }
-    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-      return String(value);
-    }
-    if (typeof value === "symbol") {
-      return value.description ?? value.toString();
-    }
-    if (typeof value === "function") {
-      return value.name ? `[function ${value.name}]` : "[function]";
-    }
-    return Object.prototype.toString.call(value);
-  };
-
-  const raw =
-    reason instanceof Error ? `${reason.message}\n${reason.stack ?? ""}` : formatReason(reason);
-  const haystack = raw.toLowerCase();
-  const hasAuthError =
-    haystack.includes("unsupported state or unable to authenticate data") ||
-    haystack.includes("bad mac");
-  if (!hasAuthError) {
-    return false;
-  }
-
-  return (
-    haystack.includes("@whiskeysockets/baileys") ||
-    haystack.includes("baileys") ||
-    haystack.includes("noise-handler") ||
-    haystack.includes("aesdecryptgcm")
-  );
-}
-
 export function isTransientUnhandledRejectionError(err: unknown): boolean {
   return isTransientNetworkError(err) || isTransientSqliteError(err);
 }
@@ -416,14 +368,6 @@ export function installUnhandledRejectionHandler(): () => void {
     if (isConfigError(reason)) {
       console.error("[openclaw] CONFIGURATION ERROR - requires fix:", formatUncaughtError(reason));
       exitWithTerminalRestore("configuration error");
-      return;
-    }
-
-    if (isLikelyWhatsAppCryptoError(reason)) {
-      console.warn(
-        "[openclaw] Suppressed WhatsApp crypto rejection (continuing):",
-        formatUncaughtError(reason),
-      );
       return;
     }
 

--- a/test/scripts/run-extension-oxlint.test.ts
+++ b/test/scripts/run-extension-oxlint.test.ts
@@ -57,6 +57,34 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
     });
   });
 
+  it("requests a build when plugin-sdk entrypoints change after the declaration stamp", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const entrypointsPath = writeFile(
+      repoRoot,
+      "scripts/lib/plugin-sdk-entrypoints.json",
+      '["index", "core"]\n',
+    );
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:00.000Z\n",
+    );
+
+    setMtime(entryPath, "2026-04-08T10:00:00.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entrypointsPath, "2026-04-08T10:00:05.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "stale_declarations",
+    });
+  });
+
   it("skips the build when declaration shims are present and newer than the inputs", () => {
     const repoRoot = createTempDir("openclaw-extension-oxlint-");
     const sourcePath = writeFile(
@@ -65,6 +93,11 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
       "export type Core = string;\n",
     );
     const tsconfigPath = writeFile(repoRoot, "tsconfig.plugin-sdk.dts.json", "{\n}\n");
+    const entrypointsPath = writeFile(
+      repoRoot,
+      "scripts/lib/plugin-sdk-entrypoints.json",
+      '["index", "core"]\n',
+    );
     const entryPath = writeFile(
       repoRoot,
       "dist/plugin-sdk/index.d.ts",
@@ -78,6 +111,7 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
 
     setMtime(sourcePath, "2026-04-08T10:00:00.000Z");
     setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entrypointsPath, "2026-04-08T10:00:00.000Z");
     setMtime(entryPath, "2026-04-08T10:00:10.000Z");
     setMtime(stampPath, "2026-04-08T10:00:10.000Z");
 

--- a/test/scripts/run-extension-oxlint.test.ts
+++ b/test/scripts/run-extension-oxlint.test.ts
@@ -85,6 +85,68 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
     });
   });
 
+  it("requests a build when extended tsconfig inputs change after the declaration stamp", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const tsconfigPath = writeFile(
+      repoRoot,
+      "tsconfig.plugin-sdk.dts.json",
+      '{\n  "extends": "./tsconfig.json"\n}\n',
+    );
+    const baseTsconfigPath = writeFile(repoRoot, "tsconfig.json", "{\n}\n");
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:00.000Z\n",
+    );
+
+    setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entryPath, "2026-04-08T10:00:00.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:00.000Z");
+    setMtime(baseTsconfigPath, "2026-04-08T10:00:05.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "stale_declarations",
+    });
+  });
+
+  it("ignores non-TypeScript files when checking declaration staleness", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const sourcePath = writeFile(
+      repoRoot,
+      "src/plugin-sdk/core.ts",
+      "export type Core = string;\n",
+    );
+    const tsconfigPath = writeFile(repoRoot, "tsconfig.plugin-sdk.dts.json", "{\n}\n");
+    const notePath = writeFile(repoRoot, "src/plugin-sdk/notes.md", "# note\n");
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:10.000Z\n",
+    );
+
+    setMtime(sourcePath, "2026-04-08T10:00:00.000Z");
+    setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entryPath, "2026-04-08T10:00:10.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:10.000Z");
+    setMtime(notePath, "2026-04-08T10:00:20.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: false,
+      reason: "fresh_declarations",
+    });
+  });
+
   it("skips the build when declaration shims are present and newer than the inputs", () => {
     const repoRoot = createTempDir("openclaw-extension-oxlint-");
     const sourcePath = writeFile(

--- a/test/scripts/run-extension-oxlint.test.ts
+++ b/test/scripts/run-extension-oxlint.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolvePluginSdkDeclarationBuildRequirement } from "../../scripts/lib/run-extension-oxlint.mjs";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+function writeFile(root: string, relativePath: string, content = "") {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+function setMtime(filePath: string, iso: string) {
+  const date = new Date(iso);
+  fs.utimesSync(filePath, date, date);
+}
+
+describe("run-extension-oxlint plugin-sdk declarations", () => {
+  it("requests a build when plugin-sdk declaration shims are missing", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    writeFile(repoRoot, "src/plugin-sdk/core.ts", "export type Core = string;\n");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "missing_declarations",
+    });
+  });
+
+  it("requests a build when plugin-sdk sources are newer than the declaration stamp", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const sourcePath = writeFile(
+      repoRoot,
+      "src/plugin-sdk/core.ts",
+      "export type Core = string;\n",
+    );
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:00.000Z\n",
+    );
+
+    setMtime(entryPath, "2026-04-08T10:00:00.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:00.000Z");
+    setMtime(sourcePath, "2026-04-08T10:00:05.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "stale_declarations",
+    });
+  });
+
+  it("skips the build when declaration shims are present and newer than the inputs", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const sourcePath = writeFile(
+      repoRoot,
+      "src/plugin-sdk/core.ts",
+      "export type Core = string;\n",
+    );
+    const tsconfigPath = writeFile(repoRoot, "tsconfig.plugin-sdk.dts.json", "{\n}\n");
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:10.000Z\n",
+    );
+
+    setMtime(sourcePath, "2026-04-08T10:00:00.000Z");
+    setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entryPath, "2026-04-08T10:00:10.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:10.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: false,
+      reason: "fresh_declarations",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a global `isLikelyWhatsAppCryptoError()` guard in the unhandled rejection infrastructure
- suppress the known Baileys decrypt signature instead of exiting the whole gateway process
- add focused infra tests for detection and non-fatal handling

## Why
OpenClaw already has listener-scoped reconnect handling for this Baileys decrypt race in the WhatsApp channel runtime, but older gateway processes can still die if the same signature reaches the global `unhandledRejection` path.

This keeps the gateway alive for the known WhatsApp/Baileys decrypt race:
- `Unsupported state or unable to authenticate data`
- `bad mac`
- Baileys/noise-handler/aesDecryptGCM stack signatures

## Test
- `PATH=/Users/yo.brain/.node22/current/bin:$PATH pnpm exec vitest run src/infra/unhandled-rejections.test.ts src/infra/unhandled-rejections.fatal-detection.test.ts`
