### PR TITLE
[codex] fix(telegram): restore voice-note TTS delivery

### DIFF
--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -252,6 +252,27 @@ describe("buildMinimaxSpeechProvider", () => {
       expect(body.voice_setting.voice_id).toBe("English_expressive_narrator");
     });
 
+    it("marks voice-note targets as voice compatible", async () => {
+      const hexAudio = Buffer.from("voice-note").toString("hex");
+      const mockFetch = vi.mocked(globalThis.fetch);
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { audio: hexAudio } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await provider.synthesize({
+        text: "Voice note",
+        cfg: {} as never,
+        providerConfig: { apiKey: "sk-test", baseUrl: "https://api.minimaxi.com" },
+        target: "voice-note",
+        timeoutMs: 30000,
+      });
+
+      expect(result.voiceCompatible).toBe(true);
+    });
+
     it("applies overrides", async () => {
       const hexAudio = Buffer.from("audio").toString("hex");
       const mockFetch = vi.mocked(globalThis.fetch);

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -227,7 +227,7 @@ export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
         audioBuffer,
         outputFormat: "mp3",
         fileExtension: ".mp3",
-        voiceCompatible: false,
+        voiceCompatible: req.target === "voice-note",
       };
     },
   };

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -473,10 +473,14 @@ export function setTtsEnabled(prefsPath: string, enabled: boolean): void {
   setTtsAutoMode(prefsPath, enabled ? "always" : "off");
 }
 
-export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): TtsProvider {
+export function getTtsProvider(
+  config: ResolvedTtsConfig,
+  prefsPath: string,
+  cfg?: OpenClawConfig,
+): TtsProvider {
   const prefs = readPrefs(prefsPath);
   const prefsProvider =
-    canonicalizeSpeechProviderId(prefs.tts?.provider) ??
+    canonicalizeSpeechProviderId(prefs.tts?.provider, cfg) ??
     normalizeConfiguredSpeechProviderId(prefs.tts?.provider);
   if (prefsProvider) {
     return prefsProvider;
@@ -485,7 +489,7 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
     return normalizeConfiguredSpeechProviderId(config.provider) ?? config.provider;
   }
 
-  for (const provider of sortSpeechProvidersForAutoSelection()) {
+  for (const provider of sortSpeechProvidersForAutoSelection(cfg)) {
     if (
       provider.isConfigured({
         providerConfig: config.providerConfigs[provider.id] ?? {},
@@ -518,7 +522,7 @@ export function resolveExplicitTtsOverrides(params: {
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
   const selectedProvider =
     canonicalizeSpeechProviderId(providerInput, params.cfg) ??
-    (modelId || voiceId ? getTtsProvider(config, prefsPath) : undefined);
+    (modelId || voiceId ? getTtsProvider(config, prefsPath, params.cfg) : undefined);
 
   if (providerInput && !selectedProvider) {
     throw new Error(`Unknown TTS provider "${providerInput}".`);
@@ -741,7 +745,7 @@ function resolveTtsRequestSetup(params: {
     };
   }
 
-  const userProvider = getTtsProvider(config, prefsPath);
+  const userProvider = getTtsProvider(config, prefsPath, params.cfg);
   const provider =
     canonicalizeSpeechProviderId(params.providerOverride, params.cfg) ?? userProvider;
   return {
@@ -1055,8 +1059,8 @@ export async function maybeApplyTtsToPayload(params: {
   if (isVerbose()) {
     const effectiveProvider = directives.overrides?.provider
       ? (canonicalizeSpeechProviderId(directives.overrides.provider, params.cfg) ??
-        getTtsProvider(config, prefsPath))
-      : getTtsProvider(config, prefsPath);
+        getTtsProvider(config, prefsPath, params.cfg))
+      : getTtsProvider(config, prefsPath, params.cfg);
     logVerbose(
       `TTS: auto mode enabled (${autoMode}), channel=${params.channel}, selected provider=${effectiveProvider}, config.provider=${config.provider}, config.providerSource=${config.providerSource}`,
     );

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -151,6 +151,7 @@ function buildTelegramSendOptions(params: {
   accountId?: string | null;
   replyToId?: string | null;
   threadId?: string | number | null;
+  audioAsVoice?: boolean | null;
   silent?: boolean | null;
   forceDocument?: boolean | null;
   gatewayClientScopes?: readonly string[] | null;
@@ -162,6 +163,7 @@ function buildTelegramSendOptions(params: {
     ...(params.mediaLocalRoots?.length ? { mediaLocalRoots: params.mediaLocalRoots } : {}),
     messageThreadId: parseTelegramThreadId(params.threadId),
     replyToMessageId: parseTelegramReplyToMessageId(params.replyToId),
+    asVoice: params.audioAsVoice === true ? true : undefined,
     accountId: params.accountId ?? undefined,
     silent: params.silent ?? undefined,
     forceDocument: params.forceDocument ?? undefined,
@@ -181,6 +183,7 @@ async function sendTelegramOutbound(params: {
   deps?: OutboundSendDeps;
   replyToId?: string | null;
   threadId?: string | number | null;
+  audioAsVoice?: boolean | null;
   silent?: boolean | null;
   gatewayClientScopes?: readonly string[] | null;
 }) {
@@ -195,6 +198,7 @@ async function sendTelegramOutbound(params: {
       accountId: params.accountId,
       replyToId: params.replyToId,
       threadId: params.threadId,
+      audioAsVoice: params.audioAsVoice,
       silent: params.silent,
       gatewayClientScopes: params.gatewayClientScopes,
     }),
@@ -1052,6 +1056,7 @@ export const telegramPlugin = createChatChannelPlugin({
             accountId,
             replyToId,
             threadId,
+            audioAsVoice: payload.audioAsVoice,
             silent,
             forceDocument,
             gatewayClientScopes,
@@ -1070,6 +1075,7 @@ export const telegramPlugin = createChatChannelPlugin({
         deps,
         replyToId,
         threadId,
+        audioAsVoice,
         silent,
         gatewayClientScopes,
       }) =>
@@ -1081,6 +1087,7 @@ export const telegramPlugin = createChatChannelPlugin({
           deps,
           replyToId,
           threadId,
+          audioAsVoice,
           silent,
           gatewayClientScopes,
         }),
@@ -1094,6 +1101,7 @@ export const telegramPlugin = createChatChannelPlugin({
         deps,
         replyToId,
         threadId,
+        audioAsVoice,
         silent,
         gatewayClientScopes,
       }) =>
@@ -1107,6 +1115,7 @@ export const telegramPlugin = createChatChannelPlugin({
           deps,
           replyToId,
           threadId,
+          audioAsVoice,
           silent,
           gatewayClientScopes,
         }),

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -43,6 +43,28 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-media" });
   });
 
+  it("forwards audioAsVoice for direct media sends", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-voice" });
+
+    await telegramOutbound.sendMedia!({
+      cfg: {} as never,
+      to: "12345",
+      text: "voice note",
+      mediaUrl: "/tmp/note.mp3",
+      audioAsVoice: true,
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "voice note",
+      expect.objectContaining({
+        mediaUrl: "/tmp/note.mp3",
+        asVoice: true,
+      }),
+    );
+  });
+
   it("sends payload media in sequence and keeps buttons on the first message only", async () => {
     sendMessageTelegramMock
       .mockResolvedValueOnce({ messageId: "tg-1", chatId: "12345" })
@@ -93,5 +115,30 @@ describe("telegramOutbound", () => {
       (sendMessageTelegramMock.mock.calls[1]?.[2] as Record<string, unknown>)?.buttons,
     ).toBeUndefined();
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "12345" });
+  });
+
+  it("forwards payload audioAsVoice into Telegram send options", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-voice", chatId: "12345" });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: {
+        text: "Voice payload",
+        mediaUrl: "https://example.com/note.mp3",
+        audioAsVoice: true,
+      },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "Voice payload",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/note.mp3",
+        asVoice: true,
+      }),
+    );
   });
 });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -37,6 +37,7 @@ async function resolveTelegramSendContext(params: {
   accountId?: string | null;
   replyToId?: string | null;
   threadId?: string | number | null;
+  audioAsVoice?: boolean | null;
   gatewayClientScopes?: readonly string[];
 }): Promise<{
   send: TelegramSendFn;
@@ -46,6 +47,7 @@ async function resolveTelegramSendContext(params: {
     textMode: "html";
     messageThreadId?: number;
     replyToMessageId?: number;
+    asVoice?: boolean;
     accountId?: string;
     gatewayClientScopes?: readonly string[];
   };
@@ -61,6 +63,7 @@ async function resolveTelegramSendContext(params: {
       cfg: params.cfg,
       messageThreadId: parseTelegramThreadId(params.threadId),
       replyToMessageId: parseTelegramReplyToMessageId(params.replyToId),
+      asVoice: params.audioAsVoice === true ? true : undefined,
       accountId: params.accountId ?? undefined,
       gatewayClientScopes: params.gatewayClientScopes,
     },
@@ -131,6 +134,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       deps,
       replyToId,
       threadId,
+      audioAsVoice,
       gatewayClientScopes,
     }) => {
       const { send, baseOpts } = await resolveTelegramSendContext({
@@ -139,6 +143,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
         accountId,
         replyToId,
         threadId,
+        audioAsVoice,
         gatewayClientScopes,
       });
       return await send(to, text, {
@@ -156,6 +161,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       deps,
       replyToId,
       threadId,
+      audioAsVoice,
       forceDocument,
       gatewayClientScopes,
     }) => {
@@ -165,6 +171,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
         accountId,
         replyToId,
         threadId,
+        audioAsVoice,
         gatewayClientScopes,
       });
       return await send(to, text, {
@@ -203,6 +210,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       payload,
       baseOpts: {
         ...baseOpts,
+        asVoice: payload.audioAsVoice === true ? true : baseOpts.asVoice,
         mediaLocalRoots,
         mediaReadFile,
         forceDocument: forceDocument ?? false,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1229,6 +1229,7 @@ describe("sendMessageTelegram", () => {
       contentType: string;
       fileName: string;
       asVoice?: boolean;
+      audioAsVoice?: boolean;
       messageThreadId?: number;
       replyToMessageId?: number;
       expectedMethod: "sendAudio" | "sendVoice";
@@ -1286,6 +1287,17 @@ describe("sendMessageTelegram", () => {
         expectedOptions: { caption: "caption", parse_mode: "HTML" },
       },
       {
+        name: "audioAsVoice alias routes compatible audio to sendVoice",
+        chatId: "123",
+        text: "caption",
+        mediaUrl: "https://example.com/clip.mp3",
+        contentType: "audio/mpeg",
+        fileName: "clip.mp3",
+        audioAsVoice: true,
+        expectedMethod: "sendVoice" as const,
+        expectedOptions: { caption: "caption", parse_mode: "HTML" },
+      },
+      {
         name: "normalizes parameterized audio MIME with mixed casing",
         chatId: "123",
         text: "caption",
@@ -1322,6 +1334,9 @@ describe("sendMessageTelegram", () => {
         api,
         mediaUrl: testCase.mediaUrl,
         ...("asVoice" in testCase && testCase.asVoice ? { asVoice: true } : {}),
+        ...("audioAsVoice" in testCase && testCase.audioAsVoice
+          ? { audioAsVoice: true }
+          : {}),
         ...("messageThreadId" in testCase && testCase.messageThreadId !== undefined
           ? { messageThreadId: testCase.messageThreadId }
           : {}),

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -86,6 +86,8 @@ type TelegramSendOpts = {
   plainText?: string;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   asVoice?: boolean;
+  /** Backward-compatible alias for `asVoice`. */
+  audioAsVoice?: boolean;
   /** Send video as video note instead of regular video. Defaults to false. */
   asVideoNote?: boolean;
   /** Send message silently (no notification). Defaults to false. */
@@ -922,7 +924,7 @@ export async function sendMessageTelegram(
       }
       if (kind === "audio") {
         const { useVoice } = resolveTelegramVoiceSend({
-          wantsVoice: opts.asVoice === true, // default false (backward compatible)
+          wantsVoice: opts.asVoice === true || opts.audioAsVoice === true,
           contentType: media.contentType,
           fileName,
           logFallback: logVerbose,

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -183,7 +183,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   }
 
   if (action === "provider") {
-    const currentProvider = getTtsProvider(config, prefsPath);
+    const currentProvider = getTtsProvider(config, prefsPath, params.cfg);
     if (!args.trim()) {
       const providers = listSpeechProviders(params.cfg);
       return {
@@ -289,7 +289,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
 
   if (action === "status") {
     const enabled = isTtsEnabled(config, prefsPath);
-    const provider = getTtsProvider(config, prefsPath);
+    const provider = getTtsProvider(config, prefsPath, params.cfg);
     const hasKey = isTtsProviderConfigured(config, provider, params.cfg);
     const maxLength = getTtsMaxLength(prefsPath);
     const summarize = isSummarizationEnabled(prefsPath);

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -63,6 +63,9 @@ const ttsMocks = vi.hoisted(() => ({
   }),
   resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
 }));
+const ttsProviderRegistryMocks = vi.hoisted(() => ({
+  listSpeechProviders: vi.fn(() => []),
+}));
 
 const mediaUnderstandingMocks = vi.hoisted(() => ({
   applyMediaUnderstanding: vi.fn(async (_params: unknown) => undefined),
@@ -277,6 +280,15 @@ describe("tryDispatchAcpReply", () => {
     vi.doMock("../../tts/tts.runtime.js", () => ({
       maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
     }));
+    vi.doMock("../../tts/provider-registry.js", async () => {
+      const actual = await vi.importActual<typeof import("../../tts/provider-registry.js")>(
+        "../../tts/provider-registry.js",
+      );
+      return {
+        ...actual,
+        listSpeechProviders: (cfg: OpenClawConfig) => ttsProviderRegistryMocks.listSpeechProviders(cfg),
+      };
+    });
     vi.doMock("../../tts/status-config.js", () => ({
       resolveStatusTtsSnapshot: () => ({
         autoMode: "always",
@@ -332,6 +344,8 @@ describe("tryDispatchAcpReply", () => {
     ttsMocks.maybeApplyTtsToPayload.mockClear();
     ttsMocks.resolveTtsConfig.mockReset();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    ttsProviderRegistryMocks.listSpeechProviders.mockReset();
+    ttsProviderRegistryMocks.listSpeechProviders.mockReturnValue([]);
     mediaUnderstandingMocks.applyMediaUnderstanding.mockReset();
     mediaUnderstandingMocks.applyMediaUnderstanding.mockResolvedValue(undefined);
     sessionMetaMocks.readAcpSessionEntry.mockReset();
@@ -1236,6 +1250,19 @@ describe("tryDispatchAcpReply", () => {
     expectRoutedPayload(1, {
       text: "Task completed",
     });
+  });
+
+  it("warms speech providers before accumulated final TTS delivery", async () => {
+    setReadyAcpResolution();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    queueTtsReplies({ text: "Task completed" }, {
+      mediaUrl: "https://example.com/final.mp3",
+      audioAsVoice: true,
+    } as MockTtsReply);
+
+    await runRoutedAcpTextTurn("Task completed");
+
+    expect(ttsProviderRegistryMocks.listSpeechProviders).toHaveBeenCalled();
   });
 
   it("skips fallback when TTS mode is all (blocks already processed with TTS)", async () => {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -21,6 +21,7 @@ import {
 } from "../../shared/string-coerce.js";
 import { resolveStatusTtsSnapshot } from "../../tts/status-config.js";
 import { resolveConfiguredTtsMode } from "../../tts/tts-config.js";
+import { listSpeechProviders } from "../../tts/provider-registry.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import { createAcpReplyProjector } from "./acp-projector.js";
 import { loadDispatchAcpMediaRuntime, resolveAcpAttachments } from "./dispatch-acp-attachments.js";
@@ -52,6 +53,14 @@ function loadDispatchAcpSessionRuntime() {
 function loadDispatchAcpTtsRuntime() {
   dispatchAcpTtsRuntimePromise ??= import("./dispatch-acp-tts.runtime.js");
   return dispatchAcpTtsRuntimePromise;
+}
+
+async function maybeApplyAcpTtsToPayload(
+  params: Parameters<Awaited<ReturnType<typeof loadDispatchAcpTtsRuntime>>["maybeApplyTtsToPayload"]>[0],
+) {
+  listSpeechProviders(params.cfg);
+  const { maybeApplyTtsToPayload } = await loadDispatchAcpTtsRuntime();
+  return maybeApplyTtsToPayload(params);
 }
 
 type DispatchProcessedRecorder = (
@@ -207,8 +216,7 @@ async function finalizeAcpTurnOutput(params: {
   let finalMediaDelivered = false;
   if (ttsMode === "final" && hasAccumulatedBlockText && canAttemptFinalTts) {
     try {
-      const { maybeApplyTtsToPayload } = await loadDispatchAcpTtsRuntime();
-      const ttsSyntheticReply = await maybeApplyTtsToPayload({
+      const ttsSyntheticReply = await maybeApplyAcpTtsToPayload({
         payload: { text: accumulatedBlockText },
         cfg: params.cfg,
         channel: params.ttsChannel,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -142,6 +142,9 @@ const ttsMocks = vi.hoisted(() => {
     resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
   };
 });
+const ttsProviderRegistryMocks = vi.hoisted(() => ({
+  listSpeechProviders: vi.fn(() => []),
+}));
 const threadInfoMocks = vi.hoisted(() => ({
   parseSessionThreadInfo: vi.fn<
     (sessionKey: string | undefined) => {
@@ -324,6 +327,15 @@ vi.mock("../../tts/tts.js", () => ({
 vi.mock("../../tts/tts.runtime.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
 }));
+vi.mock("../../tts/provider-registry.js", async () => {
+  const actual = await vi.importActual<typeof import("../../tts/provider-registry.js")>(
+    "../../tts/provider-registry.js",
+  );
+  return {
+    ...actual,
+    listSpeechProviders: (cfg: OpenClawConfig) => ttsProviderRegistryMocks.listSpeechProviders(cfg),
+  };
+});
 vi.mock("../../tts/status-config.js", () => ({
   resolveStatusTtsSnapshot: () => ({
     autoMode: "always",
@@ -2869,6 +2881,8 @@ describe("before_dispatch hook", () => {
     threadInfoMocks.parseSessionThreadInfo.mockImplementation(parseGenericThreadSessionInfo);
     ttsMocks.state.synthesizeFinalAudio = false;
     ttsMocks.maybeApplyTtsToPayload.mockClear();
+    ttsProviderRegistryMocks.listSpeechProviders.mockReset();
+    ttsProviderRegistryMocks.listSpeechProviders.mockReturnValue([]);
     setNoAbort();
     hookMocks.runner.runBeforeDispatch.mockClear();
     hookMocks.runner.runBeforeDispatch.mockResolvedValue(undefined);
@@ -2951,6 +2965,19 @@ describe("before_dispatch hook", () => {
       }),
     );
     expect(result.queuedFinal).toBe(true);
+  });
+
+  it("warms speech providers before routed final TTS delivery", async () => {
+    ttsMocks.state.synthesizeFinalAudio = true;
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
+
+    await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher: createDispatcher(),
+    });
+
+    expect(ttsProviderRegistryMocks.listSpeechProviders).toHaveBeenCalledWith(emptyConfig);
   });
 
   it("continues default dispatch when hook returns not handled", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -42,6 +42,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { listSpeechProviders } from "../../tts/provider-registry.js";
 import { normalizeTtsAutoMode, resolveConfiguredTtsMode } from "../../tts/tts-config.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -94,6 +95,7 @@ function loadTtsRuntime() {
 async function maybeApplyTtsToReplyPayload(
   params: Parameters<Awaited<ReturnType<typeof loadTtsRuntime>>["maybeApplyTtsToPayload"]>[0],
 ) {
+  listSpeechProviders(params.cfg);
   const { maybeApplyTtsToPayload } = await loadTtsRuntime();
   return maybeApplyTtsToPayload(params);
 }

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -983,7 +983,7 @@ async function runTtsProviders(transport: CapabilityTransport) {
   }
   const config = resolveTtsConfig(cfg);
   const prefsPath = resolveTtsPrefsPath(config);
-  const active = getTtsProvider(config, prefsPath);
+  const active = getTtsProvider(config, prefsPath, cfg);
   return {
     providers: listSpeechProviders(cfg).map((provider) => ({
       available: true,
@@ -1003,7 +1003,7 @@ async function runTtsVoices(providerRaw?: string) {
   const cfg = loadConfig();
   const config = resolveTtsConfig(cfg);
   const prefsPath = resolveTtsPrefsPath(config);
-  const provider = providerRaw?.trim() || getTtsProvider(config, prefsPath);
+  const provider = providerRaw?.trim() || getTtsProvider(config, prefsPath, cfg);
   return await listSpeechVoices({
     provider,
     cfg,

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -25,6 +25,8 @@ const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
+  listSpeechProviders: vi.fn(() => []),
+  maybeApplyTtsToPayload: vi.fn(async (params: { payload: Record<string, unknown> }) => params.payload),
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -90,6 +92,20 @@ vi.mock("../../infra/outbound/channel-selection.js", () => ({
 
 vi.mock("../../infra/outbound/deliver.js", () => ({
   deliverOutboundPayloads: mocks.deliverOutboundPayloads,
+}));
+
+vi.mock("../../tts/provider-registry.js", async () => {
+  const actual = await vi.importActual<typeof import("../../tts/provider-registry.js")>(
+    "../../tts/provider-registry.js",
+  );
+  return {
+    ...actual,
+    listSpeechProviders: mocks.listSpeechProviders,
+  };
+});
+
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
 }));
 
 vi.mock("../../config/sessions.js", async () => {
@@ -199,6 +215,12 @@ describe("gateway send mirroring", () => {
     });
     mocks.sendPoll.mockResolvedValue({ messageId: "poll-1" });
     mocks.getChannelPlugin.mockReturnValue({ outbound: { sendPoll: mocks.sendPoll } });
+    mocks.listSpeechProviders.mockReset();
+    mocks.listSpeechProviders.mockReturnValue([]);
+    mocks.maybeApplyTtsToPayload.mockReset();
+    mocks.maybeApplyTtsToPayload.mockImplementation(
+      async (params: { payload: Record<string, unknown> }) => params.payload,
+    );
     await loadFreshSendHandlersForTest();
   });
 
@@ -214,7 +236,12 @@ describe("gateway send mirroring", () => {
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
-        payloads: [{ text: "", mediaUrl: "https://example.com/a.png", mediaUrls: undefined }],
+        payloads: [
+          expect.objectContaining({
+            text: "",
+            mediaUrl: "https://example.com/a.png",
+          }),
+        ],
       }),
     );
     expect(respond).toHaveBeenCalledWith(
@@ -242,6 +269,42 @@ describe("gateway send mirroring", () => {
       expect.objectContaining({
         channel: "slack",
         gatewayClientScopes: ["operator.write"],
+      }),
+    );
+  });
+
+  it("applies TTS before gateway delivery for send requests", async () => {
+    mockDeliverySuccess("m-tts");
+    mocks.maybeApplyTtsToPayload.mockResolvedValue({
+      text: "hello world",
+      mediaUrl: "file:///tmp/voice.mp3",
+      audioAsVoice: true,
+    });
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello world",
+      channel: "slack",
+      idempotencyKey: "idem-tts",
+    });
+
+    expect(mocks.listSpeechProviders).toHaveBeenCalledWith({});
+    expect(mocks.maybeApplyTtsToPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        kind: "final",
+        payload: expect.objectContaining({ text: "hello world" }),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [
+          expect.objectContaining({
+            text: "hello world",
+            mediaUrl: "file:///tmp/voice.mp3",
+            audioAsVoice: true,
+          }),
+        ],
       }),
     );
   });

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -17,6 +17,7 @@ import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.j
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { normalizePollInput } from "../../polls.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../../shared/string-coerce.js";
+import { listSpeechProviders } from "../../tts/provider-registry.js";
 import {
   ErrorCodes,
   errorShape,
@@ -47,6 +48,37 @@ const getInflightMap = (context: GatewayRequestContext) => {
   }
   return inflight;
 };
+
+let sendTtsRuntimePromise: Promise<typeof import("../../tts/tts.runtime.js")> | null = null;
+
+function loadSendTtsRuntime() {
+  sendTtsRuntimePromise ??= import("../../tts/tts.runtime.js");
+  return sendTtsRuntimePromise;
+}
+
+async function maybeApplyTtsToOutboundPayloads(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  channel: string;
+  payloads: ReturnType<typeof normalizeReplyPayloadsForDelivery>;
+}) {
+  if (params.payloads.length === 0) {
+    return params.payloads;
+  }
+  listSpeechProviders(params.cfg);
+  const { maybeApplyTtsToPayload } = await loadSendTtsRuntime();
+  const nextPayloads: ReturnType<typeof normalizeReplyPayloadsForDelivery> = [];
+  for (const payload of params.payloads) {
+    nextPayloads.push(
+      await maybeApplyTtsToPayload({
+        payload,
+        cfg: params.cfg,
+        channel: params.channel,
+        kind: "final",
+      }),
+    );
+  }
+  return nextPayloads;
+}
 
 async function resolveRequestedChannel(params: {
   requestChannel: unknown;
@@ -289,14 +321,19 @@ export const sendHandlers: GatewayRequestHandlers = {
         });
         const deliveryTarget = idLikeTarget?.to ?? resolvedTarget.to;
         const outboundDeps = context.deps ? createOutboundSendDeps(context.deps) : undefined;
-        const mirrorPayloads = normalizeReplyPayloadsForDelivery([
+        const normalizedPayloads = normalizeReplyPayloadsForDelivery([
           { text: message, mediaUrl, mediaUrls },
         ]);
-        const mirrorText = mirrorPayloads
+        const preparedPayloads = await maybeApplyTtsToOutboundPayloads({
+          cfg,
+          channel: outboundChannel,
+          payloads: normalizedPayloads,
+        });
+        const mirrorText = preparedPayloads
           .map((payload) => payload.text)
           .filter(Boolean)
           .join("\n");
-        const mirrorMediaUrls = mirrorPayloads.flatMap(
+        const mirrorMediaUrls = preparedPayloads.flatMap(
           (payload) => resolveSendableOutboundReplyParts(payload).mediaUrls,
         );
         const providedSessionKey =
@@ -350,7 +387,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           channel: outboundChannel,
           to: deliveryTarget,
           accountId,
-          payloads: [{ text: message, mediaUrl, mediaUrls }],
+          payloads: preparedPayloads,
           session: outboundSession,
           gifPlayback: request.gifPlayback,
           threadId: threadId ?? null,

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -28,7 +28,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const cfg = loadConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
-      const provider = getTtsProvider(config, prefsPath);
+      const provider = getTtsProvider(config, prefsPath, cfg);
       const autoMode = resolveTtsAutoMode({ config, prefsPath });
       const fallbackProviders = resolveTtsProviderOrder(provider, cfg)
         .slice(1)
@@ -173,7 +173,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
           models: [...(provider.models ?? [])],
           voices: [...(provider.voices ?? [])],
         })),
-        active: getTtsProvider(config, prefsPath),
+        active: getTtsProvider(config, prefsPath, cfg),
       });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   resolveOutboundTarget: vi.fn(),
   deliverOutboundPayloads: vi.fn(),
   resolveRuntimePluginRegistry: vi.fn(),
+  listSpeechProviders: vi.fn(() => []),
+  maybeApplyTtsToPayload: vi.fn(async (params: { payload: Record<string, unknown> }) => params.payload),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
@@ -44,6 +46,14 @@ vi.mock("./deliver.js", () => ({
   deliverOutboundPayloads: mocks.deliverOutboundPayloads,
 }));
 
+vi.mock("../../tts/provider-registry.js", () => ({
+  listSpeechProviders: mocks.listSpeechProviders,
+}));
+
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
+}));
+
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 
@@ -63,6 +73,12 @@ describe("sendMessage", () => {
     mocks.resolveOutboundTarget.mockClear();
     mocks.deliverOutboundPayloads.mockClear();
     mocks.resolveRuntimePluginRegistry.mockClear();
+    mocks.listSpeechProviders.mockClear();
+    mocks.listSpeechProviders.mockReturnValue([]);
+    mocks.maybeApplyTtsToPayload.mockClear();
+    mocks.maybeApplyTtsToPayload.mockImplementation(
+      async (params: { payload: Record<string, unknown> }) => params.payload,
+    );
 
     mocks.getChannelPlugin.mockReturnValue({
       outbound: { deliveryMode: "direct" },
@@ -135,5 +151,41 @@ describe("sendMessage", () => {
     });
 
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies TTS to direct outbound payloads before delivery", async () => {
+    mocks.maybeApplyTtsToPayload.mockResolvedValue({
+      text: "hello world",
+      mediaUrl: "file:///tmp/voice.mp3",
+      audioAsVoice: true,
+    });
+
+    const result = await sendMessage({
+      cfg: {},
+      channel: "telegram",
+      to: "123456",
+      content: "hello world",
+    });
+
+    expect(mocks.listSpeechProviders).toHaveBeenCalledWith({});
+    expect(mocks.maybeApplyTtsToPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        kind: "final",
+        payload: expect.objectContaining({ text: "hello world" }),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [
+          expect.objectContaining({
+            text: "hello world",
+            mediaUrl: "file:///tmp/voice.mp3",
+            audioAsVoice: true,
+          }),
+        ],
+      }),
+    );
+    expect(result.mediaUrl).toBe("file:///tmp/voice.mp3");
   });
 });

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -2,6 +2,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import type { OpenClawConfig } from "../../config/config.js";
 import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
+import { listSpeechProviders } from "../../tts/provider-registry.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -24,6 +25,7 @@ let messageConfigRuntimePromise: Promise<typeof import("./message.config.runtime
   null;
 let messageGatewayRuntimePromise: Promise<typeof import("./message.gateway.runtime.js")> | null =
   null;
+let messageTtsRuntimePromise: Promise<typeof import("../../tts/tts.runtime.js")> | null = null;
 
 function loadMessageConfigRuntime() {
   messageConfigRuntimePromise ??= import("./message.config.runtime.js");
@@ -33,6 +35,11 @@ function loadMessageConfigRuntime() {
 function loadMessageGatewayRuntime() {
   messageGatewayRuntimePromise ??= import("./message.gateway.runtime.js");
   return messageGatewayRuntimePromise;
+}
+
+function loadMessageTtsRuntime() {
+  messageTtsRuntimePromise ??= import("../../tts/tts.runtime.js");
+  return messageTtsRuntimePromise;
 }
 
 export type MessageGatewayOptions = {
@@ -217,6 +224,30 @@ async function resolveGatewayIdempotencyKey(idempotencyKey?: string): Promise<st
   return randomIdempotencyKey();
 }
 
+async function maybeApplyTtsToOutboundPayloads(params: {
+  payloads: ReturnType<typeof normalizeReplyPayloadsForDelivery>;
+  cfg: OpenClawConfig;
+  channel: string;
+}): Promise<ReturnType<typeof normalizeReplyPayloadsForDelivery>> {
+  if (params.payloads.length === 0) {
+    return params.payloads;
+  }
+  listSpeechProviders(params.cfg);
+  const { maybeApplyTtsToPayload } = await loadMessageTtsRuntime();
+  const nextPayloads: ReturnType<typeof normalizeReplyPayloadsForDelivery> = [];
+  for (const payload of params.payloads) {
+    nextPayloads.push(
+      await maybeApplyTtsToPayload({
+        payload,
+        cfg: params.cfg,
+        channel: params.channel,
+        kind: "final",
+      }),
+    );
+  }
+  return nextPayloads;
+}
+
 export async function sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
   const cfg = await resolveMessageConfig(params.cfg);
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
@@ -251,6 +282,19 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
 
   if (deliveryMode !== "gateway") {
     const outboundChannel = channel;
+    const ttsPayloads = await maybeApplyTtsToOutboundPayloads({
+      payloads: normalizedPayloads,
+      cfg,
+      channel: outboundChannel,
+    });
+    const ttsMirrorText = ttsPayloads
+      .map((payload) => payload.text)
+      .filter(Boolean)
+      .join("\n");
+    const ttsMirrorMediaUrls = ttsPayloads.flatMap(
+      (payload) => resolveSendableOutboundReplyParts(payload).mediaUrls,
+    );
+    const ttsPrimaryMediaUrl = ttsMirrorMediaUrls[0] ?? primaryMediaUrl;
     const resolvedTarget = resolveOutboundTarget({
       channel: outboundChannel,
       to: params.to,
@@ -273,7 +317,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       to: resolvedTarget.to,
       session: outboundSession,
       accountId: params.accountId,
-      payloads: normalizedPayloads,
+      payloads: ttsPayloads,
       replyToId: params.replyToId,
       threadId: params.threadId,
       gifPlayback: params.gifPlayback,
@@ -285,8 +329,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       mirror: params.mirror
         ? {
             ...params.mirror,
-            text: mirrorText || params.content,
-            mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : undefined,
+            text: ttsMirrorText || params.content,
+            mediaUrls: ttsMirrorMediaUrls.length ? ttsMirrorMediaUrls : undefined,
             idempotencyKey: params.mirror.idempotencyKey ?? params.idempotencyKey,
           }
         : undefined,
@@ -296,8 +340,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       channel,
       to: params.to,
       via: "direct",
-      mediaUrl: primaryMediaUrl,
-      mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : undefined,
+      mediaUrl: ttsPrimaryMediaUrl,
+      mediaUrls: ttsMirrorMediaUrls.length ? ttsMirrorMediaUrls : undefined,
       result: results.at(-1),
     };
   }


### PR DESCRIPTION
Title: fix(telegram): restore voice-note TTS delivery

## Summary

This patch fixes Telegram voice-note delivery for TTS replies across both conversational replies and explicit send paths.

## What changed

- Apply TTS to explicit outbound `sendMessage()` payloads before direct delivery.
- Apply TTS inside the gateway `send` handler before outbound delivery.
- Warm the speech-provider registry before reply-path TTS in both standard reply dispatch and ACP final-delivery TTS.
- Make Telegram outbound adapters preserve the normalized `audioAsVoice` flag and pass it to the low-level sender.
- Let the Telegram sender accept `audioAsVoice` as a backward-compatible alias for `asVoice`.
- Mark MiniMax MP3 output as voice-compatible when the target is a voice note.
- Make speech-core provider auto-selection use the active config when resolving the current provider.
- Update CLI and gateway TTS status/provider commands to use the config-aware provider resolver.

## Regression coverage

- `extensions/telegram/src/outbound-adapter.test.ts`
- `extensions/telegram/src/send.test.ts`
- `extensions/minimax/speech-provider.test.ts`
- `src/infra/outbound/message.test.ts`
- `src/gateway/server-methods/send.test.ts`
- `src/auto-reply/reply/dispatch-from-config.test.ts`
- `src/auto-reply/reply/dispatch-acp.test.ts`

## Validation

Targeted tests passed locally:

- `node --no-maglev node_modules/vitest/vitest.mjs run extensions/telegram/src/outbound-adapter.test.ts`
- `node --no-maglev node_modules/vitest/vitest.mjs run extensions/telegram/src/send.test.ts extensions/minimax/speech-provider.test.ts`
- `node --no-maglev node_modules/vitest/vitest.mjs run src/infra/outbound/message.test.ts src/gateway/server-methods/send.test.ts`
- `node --no-maglev node_modules/vitest/vitest.mjs run src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-acp.test.ts`
