### PR TITLE
[AI-assisted] fix(discord): normalize channel: prefix in ACP thread binding REST lookups

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -410,6 +410,42 @@ describe("discordPlugin bindings", () => {
   });
 });
 
+describe("discordPlugin messaging", () => {
+  it("resolveInboundConversation returns channel: prefix for group channels", () => {
+    // Regression guard: ACP thread binding reads this value and normalizes the channel: prefix
+    // before passing it to Discord REST. If this format changes, the normalization in
+    // normalizeDiscordBindingChannelRef() becomes a silent no-op and the binding breaks.
+    const resolve = discordPlugin.messaging?.resolveInboundConversation;
+    if (!resolve) {
+      throw new Error("resolveInboundConversation unavailable");
+    }
+
+    const result = resolve({
+      to: "123456789012345678",
+      conversationId: "123456789012345678",
+      isGroup: true,
+    });
+
+    expect(result).toEqual({ conversationId: "channel:123456789012345678" });
+  });
+
+  it("resolveInboundConversation returns user: prefix for DM sender", () => {
+    const resolve = discordPlugin.messaging?.resolveInboundConversation;
+    if (!resolve) {
+      throw new Error("resolveInboundConversation unavailable");
+    }
+
+    const result = resolve({
+      from: "987654321098765432",
+      to: "987654321098765432",
+      conversationId: "987654321098765432",
+      isGroup: false,
+    });
+
+    expect(result).toEqual({ conversationId: "user:987654321098765432" });
+  });
+});
+
 describe("discordPlugin security", () => {
   it("normalizes dm allowlist entries with trimmed prefixes and mentions", () => {
     const resolveDmPolicy = discordPlugin.security?.resolveDmPolicy;

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
@@ -180,6 +180,19 @@ describe("resolveChannelIdForBinding", () => {
 
     expect(resolved).toBe("forum-1");
   });
+
+  it("returns null without REST lookup when threadId normalizes to empty", async () => {
+    // Regression guard: a blank threadId should short-circuit before hitting Discord REST.
+    // Previously the guard was missing and Routes.channel("") produced an invalid path.
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "   ",
+    });
+
+    expect(resolved).toBeNull();
+    expect(createDiscordRestClient).not.toHaveBeenCalled();
+    expect(restGet).not.toHaveBeenCalled();
+  });
 });
 
 describe("maybeSendBindingMessage", () => {

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
@@ -23,11 +23,28 @@ const createDiscordRestClient = vi.fn<typeof discordClientModule.createDiscordRe
 );
 
 let maybeSendBindingMessage: typeof import("./thread-bindings.discord-api.js").maybeSendBindingMessage;
+let normalizeDiscordBindingChannelRef: typeof import("./thread-bindings.discord-api.js").normalizeDiscordBindingChannelRef;
 let resolveChannelIdForBinding: typeof import("./thread-bindings.discord-api.js").resolveChannelIdForBinding;
 
 beforeAll(async () => {
-  ({ maybeSendBindingMessage, resolveChannelIdForBinding } =
+  ({ maybeSendBindingMessage, normalizeDiscordBindingChannelRef, resolveChannelIdForBinding } =
     await import("./thread-bindings.discord-api.js"));
+});
+
+describe("normalizeDiscordBindingChannelRef", () => {
+  it("strips OpenClaw conversation prefixes from numeric snowflakes", () => {
+    expect(normalizeDiscordBindingChannelRef("channel:1234567890")).toBe("1234567890");
+    expect(normalizeDiscordBindingChannelRef("user:9876543210")).toBe("9876543210");
+    expect(normalizeDiscordBindingChannelRef("  CHANNEL:55555  ")).toBe("55555");
+  });
+
+  it("keeps non-prefixed or non-numeric refs unchanged", () => {
+    expect(normalizeDiscordBindingChannelRef("thread-1")).toBe("thread-1");
+    expect(normalizeDiscordBindingChannelRef("channel:not-a-snowflake")).toBe(
+      "channel:not-a-snowflake",
+    );
+    expect(normalizeDiscordBindingChannelRef(undefined)).toBe("");
+  });
 });
 
 describe("resolveChannelIdForBinding", () => {
@@ -70,6 +87,18 @@ describe("resolveChannelIdForBinding", () => {
     expect(restGet).not.toHaveBeenCalled();
   });
 
+  it("normalizes explicit prefixed channel ids without resolving route", async () => {
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "thread-1",
+      channelId: "channel:1234567890",
+    });
+
+    expect(resolved).toBe("1234567890");
+    expect(createDiscordRestClient).not.toHaveBeenCalled();
+    expect(restGet).not.toHaveBeenCalled();
+  });
+
   it("returns parent channel for thread channels", async () => {
     restGet.mockResolvedValueOnce({
       id: "thread-1",
@@ -83,6 +112,23 @@ describe("resolveChannelIdForBinding", () => {
     });
 
     expect(resolved).toBe("channel-parent");
+  });
+
+  it("normalizes prefixed thread ids before Discord lookup", async () => {
+    restGet.mockResolvedValueOnce({
+      id: "1234567890",
+      type: ChannelType.PublicThread,
+      parent_id: "channel-parent",
+    });
+
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "channel:1234567890",
+    });
+
+    expect(resolved).toBe("channel-parent");
+    expect(restGet).toHaveBeenCalledTimes(1);
+    expect(restGet.mock.calls[0]?.[0]).toBe("/channels/1234567890");
   });
 
   it("forwards cfg when resolving channel id through Discord client", async () => {

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -21,6 +21,13 @@ function buildThreadTarget(threadId: string): string {
   return /^(channel:|user:)/i.test(threadId) ? threadId : `channel:${threadId}`;
 }
 
+/** Strip OpenClaw conversation-id prefixes (`channel:`, `user:`) so bare Discord snowflake IDs reach the REST layer. */
+export function normalizeDiscordBindingChannelRef(raw: string | undefined): string {
+  const trimmed = raw?.trim() || "";
+  const match = trimmed.match(/^(?:channel|user):(\d+)$/i);
+  return match?.[1] ?? trimmed;
+}
+
 export function isThreadArchived(raw: unknown): boolean {
   if (!raw || typeof raw !== "object") {
     return false;
@@ -233,9 +240,13 @@ export async function resolveChannelIdForBinding(params: {
   threadId: string;
   channelId?: string;
 }): Promise<string | null> {
-  const explicit = params.channelId?.trim();
+  const explicit = normalizeDiscordBindingChannelRef(params.channelId);
   if (explicit) {
     return explicit;
+  }
+  const lookupId = normalizeDiscordBindingChannelRef(params.threadId);
+  if (!lookupId) {
+    return null;
   }
   try {
     const rest = createDiscordRestClient(
@@ -245,7 +256,7 @@ export async function resolveChannelIdForBinding(params: {
       },
       params.cfg,
     ).rest;
-    const channel = (await rest.get(Routes.channel(params.threadId))) as {
+    const channel = (await rest.get(Routes.channel(lookupId))) as {
       id?: string;
       type?: number;
       parent_id?: string;
@@ -267,7 +278,7 @@ export async function resolveChannelIdForBinding(params: {
     return channelId || null;
   } catch (err) {
     logVerbose(
-      `discord thread binding channel resolve failed for ${params.threadId}: ${summarizeDiscordError(err)}`,
+      `discord thread binding channel resolve failed for ${lookupId}: ${summarizeDiscordError(err)}`,
     );
     return null;
   }


### PR DESCRIPTION
## Summary

Fix Discord ACP child thread binding failure caused by conversation ID format mismatch.

Closes #62685

## Problem

When spawning an ACP session with \`thread: true\` from a Discord text channel, the thread binding fails with:

```
Session binding adapter failed to bind target conversation
```

## Root Cause

The ACP thread-binding flow resolves Discord conversation IDs in the format \`channel:<snowflake>\` (via \`resolveDiscordInboundConversation()\` in the Discord plugin). However, \`resolveChannelIdForBinding()\` passed these prefixed values directly to \`Routes.channel()\`, producing invalid REST paths like \`/channels/channel%3A<id>\` instead of \`/channels/<id>\`.

## Fix

- Add \`normalizeDiscordBindingChannelRef()\` to strip \`channel:\` / \`user:\` prefixes before passing IDs to Discord REST endpoints
- Hoist \`lookupId\` before the try/catch so it is computed once and reused in both the REST call and the error log
- Add an early-return guard for empty \`lookupId\`

## Testing

- [x] Verified locally: ACP thread binding succeeds after patch (thread created and session bound)
- [x] Unit tests added for \`normalizeDiscordBindingChannelRef()\`: raw snowflake passthrough, \`channel:\` prefix stripping, \`user:\` prefix stripping, empty/undefined inputs, case insensitivity
- [x] Unit tests added for \`resolveChannelIdForBinding()\` with prefixed \`channelId\` (no REST call) and prefixed \`threadId\` (correct REST path used)
- [x] \`pnpm test:extension discord\` — 112 files, 932 tests, all passing

## AI Disclosure

- [x] AI-assisted (Claude via OpenClaw)
- [x] Fully tested locally and with the extension test suite
- [x] Code reviewed and understood by the author
- [x] Greptile finding (redundant \`lookupId\` computation) addressed and conversation replied to