### PR TITLE
test: unblock check baseline

### DIFF
--- a/extensions/slack/src/approval-handler.runtime.test.ts
+++ b/extensions/slack/src/approval-handler.runtime.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { slackApprovalNativeRuntime } from "./approval-handler.runtime.js";
 
-function findSlackActionsBlock(blocks: Array<{ type?: string; elements?: unknown[] }>) {
+type SlackActionsBlock = { type?: string; elements?: unknown[] };
+type SlackPendingPayload = { text: string; blocks: SlackActionsBlock[] };
+type SlackResolvedPayload = { text: string; blocks: Array<{ type?: string }> };
+
+function findSlackActionsBlock(blocks: SlackActionsBlock[]) {
   return blocks.find((block) => block.type === "actions");
 }
 
 describe("slackApprovalNativeRuntime", () => {
   it("renders only the allowed pending actions", async () => {
-    const payload = await slackApprovalNativeRuntime.presentation.buildPendingPayload({
+    const payload = (await slackApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
       accountId: "default",
       context: {
@@ -44,12 +48,10 @@ describe("slackApprovalNativeRuntime", () => {
           },
         ],
       } as never,
-    });
+    })) as SlackPendingPayload;
 
     expect(payload.text).toContain("*Exec approval required*");
-    const actionsBlock = findSlackActionsBlock(
-      payload.blocks as Array<{ type?: string; elements?: unknown[] }>,
-    );
+    const actionsBlock = findSlackActionsBlock(payload.blocks);
     const labels = (actionsBlock?.elements ?? []).map((element) =>
       typeof element === "object" &&
       element &&
@@ -96,15 +98,13 @@ describe("slackApprovalNativeRuntime", () => {
         messageTs: "1712345678.999999",
       },
     });
-
     expect(result.kind).toBe("update");
     if (result.kind !== "update") {
       throw new Error("expected Slack resolved update payload");
     }
-    expect(result.payload.text).toContain("*Exec approval: Allowed once*");
-    expect(result.payload.text).toContain("Resolved by <@U123APPROVER>.");
-    expect(
-      (result.payload.blocks as Array<{ type?: string }>).some((block) => block.type === "actions"),
-    ).toBe(false);
+    const resolvedPayload = result.payload as SlackResolvedPayload;
+    expect(resolvedPayload.text).toContain("*Exec approval: Allowed once*");
+    expect(resolvedPayload.text).toContain("Resolved by <@U123APPROVER>.");
+    expect(resolvedPayload.blocks.some((block) => block.type === "actions")).toBe(false);
   });
 });

--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { telegramApprovalNativeRuntime } from "./approval-handler.runtime.js";
 
+type TelegramPendingPayload = {
+  text: string;
+  buttons?: Array<Array<{ text: string }>>;
+};
+
 describe("telegramApprovalNativeRuntime", () => {
   it("renders only the allowed pending buttons", async () => {
-    const payload = await telegramApprovalNativeRuntime.presentation.buildPendingPayload({
+    const payload = (await telegramApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
       accountId: "default",
       context: {
@@ -38,7 +43,7 @@ describe("telegramApprovalNativeRuntime", () => {
           },
         ],
       } as never,
-    });
+    })) as TelegramPendingPayload;
 
     expect(payload.text).toContain("/approve req-1 allow-once");
     expect(payload.text).not.toContain("allow-always");

--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -7,6 +7,15 @@ import {
   applyLocalOxlintPolicy,
 } from "./local-heavy-check-runtime.mjs";
 
+const PLUGIN_SDK_DTS_STAMP = path.join("dist", "plugin-sdk", ".boundary-entry-shims.stamp");
+const PLUGIN_SDK_DTS_ENTRY = path.join("dist", "plugin-sdk", "index.d.ts");
+const PLUGIN_SDK_DTS_INPUT_FILES = [
+  "tsconfig.plugin-sdk.dts.json",
+  path.join("scripts", "write-plugin-sdk-entry-dts.ts"),
+  path.join("scripts", "lib", "plugin-sdk-entries.mjs"),
+];
+const PLUGIN_SDK_DTS_SOURCE_ROOTS = ["src", path.join("packages", "memory-host-sdk", "src")];
+
 export function runExtensionOxlint(params) {
   const repoRoot = process.cwd();
   const oxlintPath = path.resolve("node_modules", ".bin", "oxlint");
@@ -20,6 +29,8 @@ export function runExtensionOxlint(params) {
   const tempConfigPath = path.join(tempDir, "oxlint.json");
 
   try {
+    ensurePluginSdkDeclarationOutputs({ repoRoot, toolName: params.toolName });
+
     const extensionFiles = params.roots.flatMap((root) =>
       collectTypeScriptFiles(path.resolve(repoRoot, root)),
     );
@@ -47,6 +58,94 @@ export function runExtensionOxlint(params) {
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
     releaseLock();
+  }
+}
+
+export function resolvePluginSdkDeclarationBuildRequirement(params = {}) {
+  const repoRoot = params.repoRoot ?? process.cwd();
+  const fsImpl = params.fs ?? fs;
+  const stampPath = path.join(repoRoot, PLUGIN_SDK_DTS_STAMP);
+  const entryPath = path.join(repoRoot, PLUGIN_SDK_DTS_ENTRY);
+  const stampMtime = readMtimeMs(fsImpl, stampPath);
+  const entryMtime = readMtimeMs(fsImpl, entryPath);
+
+  if (stampMtime == null || entryMtime == null) {
+    return { shouldBuild: true, reason: "missing_declarations" };
+  }
+
+  const latestInputMtime = resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl);
+  if (latestInputMtime != null && latestInputMtime > stampMtime) {
+    return { shouldBuild: true, reason: "stale_declarations" };
+  }
+
+  return { shouldBuild: false, reason: "fresh_declarations" };
+}
+
+function ensurePluginSdkDeclarationOutputs(params = {}) {
+  const repoRoot = params.repoRoot ?? process.cwd();
+  const env = params.env ?? process.env;
+  const spawnSyncImpl = params.spawnSyncImpl ?? spawnSync;
+  const requirement = resolvePluginSdkDeclarationBuildRequirement({ repoRoot });
+  if (!requirement.shouldBuild) {
+    return;
+  }
+
+  const releaseLock = acquireLocalHeavyCheckLockSync({
+    cwd: repoRoot,
+    env: { ...env, OPENCLAW_LOCAL_CHECK: "1" },
+    toolName: `${params.toolName ?? "oxlint"}-plugin-sdk-dts`,
+    lockName: "plugin-sdk-dts",
+  });
+
+  try {
+    const currentRequirement = resolvePluginSdkDeclarationBuildRequirement({ repoRoot });
+    if (!currentRequirement.shouldBuild) {
+      return;
+    }
+
+    console.error(
+      `[${params.toolName ?? "oxlint"}] building plugin-sdk declarations (${currentRequirement.reason})...`,
+    );
+
+    runRequiredCommand({
+      command: path.resolve(
+        repoRoot,
+        "node_modules",
+        ".bin",
+        process.platform === "win32" ? "tsc.cmd" : "tsc",
+      ),
+      args: ["-p", "tsconfig.plugin-sdk.dts.json"],
+      cwd: repoRoot,
+      env,
+      spawnSyncImpl,
+      label: "build:plugin-sdk:dts",
+    });
+    runRequiredCommand({
+      command: process.execPath,
+      args: ["--import", "tsx", "scripts/write-plugin-sdk-entry-dts.ts"],
+      cwd: repoRoot,
+      env,
+      spawnSyncImpl,
+      label: "write-plugin-sdk-entry-dts",
+    });
+  } finally {
+    releaseLock();
+  }
+}
+
+function runRequiredCommand(params) {
+  const result = params.spawnSyncImpl(params.command, params.args, {
+    cwd: params.cwd,
+    env: params.env,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if ((result.status ?? 1) !== 0) {
+    process.exit(result.status ?? 1);
   }
 }
 
@@ -104,4 +203,70 @@ function collectTypeScriptFiles(directoryPath) {
   }
 
   return files;
+}
+
+function resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl) {
+  let latestMtime = null;
+
+  for (const inputPath of PLUGIN_SDK_DTS_INPUT_FILES) {
+    latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, path.join(repoRoot, inputPath)));
+  }
+
+  for (const root of PLUGIN_SDK_DTS_SOURCE_ROOTS) {
+    latestMtime = maxMtime(
+      latestMtime,
+      findLatestMtime(path.join(repoRoot, root), fsImpl, shouldSkipPluginSdkDeclarationInput),
+    );
+  }
+
+  return latestMtime;
+}
+
+function findLatestMtime(directoryPath, fsImpl, shouldSkip) {
+  if (!fsImpl.existsSync(directoryPath)) {
+    return null;
+  }
+
+  const entries = fsImpl.readdirSync(directoryPath, { withFileTypes: true });
+  let latestMtime = null;
+
+  for (const entry of entries) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      latestMtime = maxMtime(latestMtime, findLatestMtime(entryPath, fsImpl, shouldSkip));
+      continue;
+    }
+
+    if (!entry.isFile() || shouldSkip?.(entryPath)) {
+      continue;
+    }
+
+    latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, entryPath));
+  }
+
+  return latestMtime;
+}
+
+function shouldSkipPluginSdkDeclarationInput(entryPath) {
+  return (
+    entryPath.endsWith(".test.ts") ||
+    entryPath.endsWith(".test.tsx") ||
+    entryPath.endsWith(".e2e.test.ts") ||
+    entryPath.endsWith(".live.test.ts")
+  );
+}
+
+function readMtimeMs(fsImpl, filePath) {
+  try {
+    return fsImpl.statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function maxMtime(current, next) {
+  if (next == null) {
+    return current;
+  }
+  return current == null || next > current ? next : current;
 }

--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -9,13 +9,14 @@ import {
 
 const PLUGIN_SDK_DTS_STAMP = path.join("dist", "plugin-sdk", ".boundary-entry-shims.stamp");
 const PLUGIN_SDK_DTS_ENTRY = path.join("dist", "plugin-sdk", "index.d.ts");
+const PLUGIN_SDK_DTS_CONFIG_FILE = "tsconfig.plugin-sdk.dts.json";
 const PLUGIN_SDK_DTS_INPUT_FILES = [
-  "tsconfig.plugin-sdk.dts.json",
   path.join("scripts", "write-plugin-sdk-entry-dts.ts"),
   path.join("scripts", "lib", "plugin-sdk-entries.mjs"),
   path.join("scripts", "lib", "plugin-sdk-entrypoints.json"),
 ];
 const PLUGIN_SDK_DTS_SOURCE_ROOTS = ["src", path.join("packages", "memory-host-sdk", "src")];
+const TYPESCRIPT_SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
 
 export function runExtensionOxlint(params) {
   const repoRoot = process.cwd();
@@ -209,6 +210,10 @@ function collectTypeScriptFiles(directoryPath) {
 function resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl) {
   let latestMtime = null;
 
+  for (const configPath of resolvePluginSdkDeclarationConfigPaths(repoRoot, fsImpl)) {
+    latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, configPath));
+  }
+
   for (const inputPath of PLUGIN_SDK_DTS_INPUT_FILES) {
     latestMtime = maxMtime(latestMtime, readMtimeMs(fsImpl, path.join(repoRoot, inputPath)));
   }
@@ -221,6 +226,65 @@ function resolveLatestPluginSdkDeclarationInputMtime(repoRoot, fsImpl) {
   }
 
   return latestMtime;
+}
+
+function resolvePluginSdkDeclarationConfigPaths(repoRoot, fsImpl) {
+  const visited = new Set();
+  const resolvedPaths = [];
+
+  function visitConfig(filePath) {
+    const normalizedPath = path.normalize(filePath);
+    if (visited.has(normalizedPath) || !fsImpl.existsSync(normalizedPath)) {
+      return;
+    }
+    visited.add(normalizedPath);
+    resolvedPaths.push(normalizedPath);
+
+    let config;
+    try {
+      config = JSON.parse(fsImpl.readFileSync(normalizedPath, "utf8"));
+    } catch {
+      return;
+    }
+
+    const extendsValue = config?.extends;
+    if (typeof extendsValue !== "string" || extendsValue.trim().length === 0) {
+      return;
+    }
+
+    const resolvedBasePath = resolveTsconfigExtendsPath(
+      normalizedPath,
+      extendsValue.trim(),
+      fsImpl,
+    );
+    if (!resolvedBasePath) {
+      return;
+    }
+    visitConfig(resolvedBasePath);
+  }
+
+  visitConfig(path.join(repoRoot, PLUGIN_SDK_DTS_CONFIG_FILE));
+  return resolvedPaths;
+}
+
+function resolveTsconfigExtendsPath(configPath, extendsValue, fsImpl) {
+  if (!extendsValue.startsWith(".") && !extendsValue.startsWith("/")) {
+    return null;
+  }
+
+  const candidateBasePath = path.resolve(path.dirname(configPath), extendsValue);
+  const candidatePaths = [candidateBasePath];
+  if (!path.extname(candidateBasePath)) {
+    candidatePaths.push(`${candidateBasePath}.json`);
+  }
+
+  for (const candidatePath of candidatePaths) {
+    if (fsImpl.existsSync(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return null;
 }
 
 function findLatestMtime(directoryPath, fsImpl, shouldSkip) {
@@ -249,11 +313,23 @@ function findLatestMtime(directoryPath, fsImpl, shouldSkip) {
 }
 
 function shouldSkipPluginSdkDeclarationInput(entryPath) {
+  if (
+    !TYPESCRIPT_SOURCE_EXTENSIONS.some((extension) => entryPath.endsWith(extension)) &&
+    !entryPath.endsWith(".d.ts") &&
+    !entryPath.endsWith(".d.mts") &&
+    !entryPath.endsWith(".d.cts")
+  ) {
+    return true;
+  }
   return (
     entryPath.endsWith(".test.ts") ||
     entryPath.endsWith(".test.tsx") ||
+    entryPath.endsWith(".test.mts") ||
+    entryPath.endsWith(".test.cts") ||
     entryPath.endsWith(".e2e.test.ts") ||
-    entryPath.endsWith(".live.test.ts")
+    entryPath.endsWith(".e2e.test.tsx") ||
+    entryPath.endsWith(".live.test.ts") ||
+    entryPath.endsWith(".live.test.tsx")
   );
 }
 

--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -13,6 +13,7 @@ const PLUGIN_SDK_DTS_INPUT_FILES = [
   "tsconfig.plugin-sdk.dts.json",
   path.join("scripts", "write-plugin-sdk-entry-dts.ts"),
   path.join("scripts", "lib", "plugin-sdk-entries.mjs"),
+  path.join("scripts", "lib", "plugin-sdk-entrypoints.json"),
 ];
 const PLUGIN_SDK_DTS_SOURCE_ROOTS = ["src", path.join("packages", "memory-host-sdk", "src")];
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -978,7 +978,9 @@ describe("fetchWithSsrFGuard hardening", () => {
       fetch: vi.fn(async () => okResponse()),
     };
     const lookupFn: LookupFn = vi.fn(async (hostname: string) => {
-      if (hostname === "localhost") return [{ address: "127.0.0.1", family: 4 }];
+      if (hostname === "localhost") {
+        return [{ address: "127.0.0.1", family: 4 }];
+      }
       return [{ address: "149.154.167.220", family: 4 }];
     }) as unknown as LookupFn;
     const fetchImpl = vi.fn(async () => okResponse());
@@ -1008,7 +1010,9 @@ describe("fetchWithSsrFGuard hardening", () => {
       fetch: vi.fn(async () => okResponse()),
     };
     const lookupFn: LookupFn = vi.fn(async (hostname: string) => {
-      if (hostname === "localhost") return [{ address: "127.0.0.1", family: 4 }];
+      if (hostname === "localhost") {
+        return [{ address: "127.0.0.1", family: 4 }];
+      }
       return [{ address: "149.154.167.220", family: 4 }];
     }) as unknown as LookupFn;
     const fetchImpl = vi.fn();

--- a/test/scripts/run-extension-oxlint.test.ts
+++ b/test/scripts/run-extension-oxlint.test.ts
@@ -57,6 +57,34 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
     });
   });
 
+  it("requests a build when plugin-sdk entrypoints change after the declaration stamp", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const entrypointsPath = writeFile(
+      repoRoot,
+      "scripts/lib/plugin-sdk-entrypoints.json",
+      '["index", "core"]\n',
+    );
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:00.000Z\n",
+    );
+
+    setMtime(entryPath, "2026-04-08T10:00:00.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entrypointsPath, "2026-04-08T10:00:05.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "stale_declarations",
+    });
+  });
+
   it("skips the build when declaration shims are present and newer than the inputs", () => {
     const repoRoot = createTempDir("openclaw-extension-oxlint-");
     const sourcePath = writeFile(
@@ -65,6 +93,11 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
       "export type Core = string;\n",
     );
     const tsconfigPath = writeFile(repoRoot, "tsconfig.plugin-sdk.dts.json", "{\n}\n");
+    const entrypointsPath = writeFile(
+      repoRoot,
+      "scripts/lib/plugin-sdk-entrypoints.json",
+      '["index", "core"]\n',
+    );
     const entryPath = writeFile(
       repoRoot,
       "dist/plugin-sdk/index.d.ts",
@@ -78,6 +111,7 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
 
     setMtime(sourcePath, "2026-04-08T10:00:00.000Z");
     setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entrypointsPath, "2026-04-08T10:00:00.000Z");
     setMtime(entryPath, "2026-04-08T10:00:10.000Z");
     setMtime(stampPath, "2026-04-08T10:00:10.000Z");
 

--- a/test/scripts/run-extension-oxlint.test.ts
+++ b/test/scripts/run-extension-oxlint.test.ts
@@ -85,6 +85,68 @@ describe("run-extension-oxlint plugin-sdk declarations", () => {
     });
   });
 
+  it("requests a build when extended tsconfig inputs change after the declaration stamp", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const tsconfigPath = writeFile(
+      repoRoot,
+      "tsconfig.plugin-sdk.dts.json",
+      '{\n  "extends": "./tsconfig.json"\n}\n',
+    );
+    const baseTsconfigPath = writeFile(repoRoot, "tsconfig.json", "{\n}\n");
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:00.000Z\n",
+    );
+
+    setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entryPath, "2026-04-08T10:00:00.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:00.000Z");
+    setMtime(baseTsconfigPath, "2026-04-08T10:00:05.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "stale_declarations",
+    });
+  });
+
+  it("ignores non-TypeScript files when checking declaration staleness", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const sourcePath = writeFile(
+      repoRoot,
+      "src/plugin-sdk/core.ts",
+      "export type Core = string;\n",
+    );
+    const tsconfigPath = writeFile(repoRoot, "tsconfig.plugin-sdk.dts.json", "{\n}\n");
+    const notePath = writeFile(repoRoot, "src/plugin-sdk/notes.md", "# note\n");
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:10.000Z\n",
+    );
+
+    setMtime(sourcePath, "2026-04-08T10:00:00.000Z");
+    setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entryPath, "2026-04-08T10:00:10.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:10.000Z");
+    setMtime(notePath, "2026-04-08T10:00:20.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: false,
+      reason: "fresh_declarations",
+    });
+  });
+
   it("skips the build when declaration shims are present and newer than the inputs", () => {
     const repoRoot = createTempDir("openclaw-extension-oxlint-");
     const sourcePath = writeFile(

--- a/test/scripts/run-extension-oxlint.test.ts
+++ b/test/scripts/run-extension-oxlint.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolvePluginSdkDeclarationBuildRequirement } from "../../scripts/lib/run-extension-oxlint.mjs";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+function writeFile(root: string, relativePath: string, content = "") {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+function setMtime(filePath: string, iso: string) {
+  const date = new Date(iso);
+  fs.utimesSync(filePath, date, date);
+}
+
+describe("run-extension-oxlint plugin-sdk declarations", () => {
+  it("requests a build when plugin-sdk declaration shims are missing", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    writeFile(repoRoot, "src/plugin-sdk/core.ts", "export type Core = string;\n");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "missing_declarations",
+    });
+  });
+
+  it("requests a build when plugin-sdk sources are newer than the declaration stamp", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const sourcePath = writeFile(
+      repoRoot,
+      "src/plugin-sdk/core.ts",
+      "export type Core = string;\n",
+    );
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:00.000Z\n",
+    );
+
+    setMtime(entryPath, "2026-04-08T10:00:00.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:00.000Z");
+    setMtime(sourcePath, "2026-04-08T10:00:05.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: true,
+      reason: "stale_declarations",
+    });
+  });
+
+  it("skips the build when declaration shims are present and newer than the inputs", () => {
+    const repoRoot = createTempDir("openclaw-extension-oxlint-");
+    const sourcePath = writeFile(
+      repoRoot,
+      "src/plugin-sdk/core.ts",
+      "export type Core = string;\n",
+    );
+    const tsconfigPath = writeFile(repoRoot, "tsconfig.plugin-sdk.dts.json", "{\n}\n");
+    const entryPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/index.d.ts",
+      'export * from "./src/plugin-sdk/core.js";\n',
+    );
+    const stampPath = writeFile(
+      repoRoot,
+      "dist/plugin-sdk/.boundary-entry-shims.stamp",
+      "2026-04-08T10:00:10.000Z\n",
+    );
+
+    setMtime(sourcePath, "2026-04-08T10:00:00.000Z");
+    setMtime(tsconfigPath, "2026-04-08T10:00:00.000Z");
+    setMtime(entryPath, "2026-04-08T10:00:10.000Z");
+    setMtime(stampPath, "2026-04-08T10:00:10.000Z");
+
+    expect(resolvePluginSdkDeclarationBuildRequirement({ repoRoot })).toEqual({
+      shouldBuild: false,
+      reason: "fresh_declarations",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- narrow approval runtime test payloads in Slack and Telegram so current `unknown` return types type-check cleanly
- satisfy the existing `oxlint` curly rule in `fetch-guard.ssrf.test.ts`
- keep this separate from #62683 so the WhatsApp decrypt hotfix PR stays focused

## Verification
- `PATH=/Users/yo.brain/.node22/current/bin:$PATH pnpm check`