### PR TITLE
fix(agents): prevent gateway crash on concurrent channel sessions (#62670)

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -580,26 +580,34 @@ export async function runExecProcess(opts: {
   };
   addSession(session);
 
+  let emitUpdateSuppressed = false;
   const emitUpdate = () => {
     if (!opts.onUpdate) {
       return;
     }
-    if (session.backgrounded || session.exited) {
+    if (session.backgrounded || session.exited || emitUpdateSuppressed) {
       return;
     }
     const tailText = session.tail || session.aggregated;
     const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
-    opts.onUpdate({
-      content: [{ type: "text", text: warningText + (tailText || "") }],
-      details: {
-        status: "running",
-        sessionId,
-        pid: session.pid ?? undefined,
-        startedAt,
-        cwd: session.cwd,
-        tail: session.tail,
-      },
-    });
+    try {
+      opts.onUpdate({
+        content: [{ type: "text", text: warningText + (tailText || "") }],
+        details: {
+          status: "running",
+          sessionId,
+          pid: session.pid ?? undefined,
+          startedAt,
+          cwd: session.cwd,
+          tail: session.tail,
+        },
+      });
+    } catch {
+      // The agent session may have been deactivated while the tool process
+      // was still running (e.g., concurrent channel sessions racing).
+      // Suppress further updates for this process rather than crashing.
+      emitUpdateSuppressed = true;
+    }
   };
 
   const handleStdout = (data: string) => {


### PR DESCRIPTION
## Summary

Fixes #62670 — gateway crashes with unhandled `"Agent listener invoked outside active run"` rejection when WhatsApp + Telegram (or any two channels) run concurrently.

### Root cause

In `bash-tools.exec-runtime.ts`, the `emitUpdate()` function calls `opts.onUpdate()` — a callback into pi-agent-core's event system — without any error handling. When concurrent channel sessions race, one session's agent context can be deactivated while a tool process is still emitting stdout. The `onUpdate()` callback throws synchronously, propagating up through `handleStdout` → `emitUpdate` as an unhandled rejection that kills the gateway process.

### Fix

Wrap `opts.onUpdate()` in a try/catch. On first failure, set an `emitUpdateSuppressed` flag to skip all future update attempts for that process, avoiding repeated throws on every subsequent stdout chunk.

This is safe because tool output streaming is best-effort — the tool process continues running and will return its final result regardless. Losing intermediate streaming updates for a detached session is infinitely preferable to crashing the entire gateway and losing ALL active sessions.

### Why not fix in pi-agent-core?

The `"Agent listener invoked outside active run"` error is thrown by the dependency `@mariozechner/pi-agent-core`. Even if that library is eventually fixed to handle this more gracefully, openclaw should defend against synchronous throws from callbacks at trust boundaries — the pattern of calling an external callback without error handling is itself a bug.

## Test plan

- [x] All 26 tests in `bash-tools.exec-runtime.test.ts` pass
- [x] Minimal change — adds try/catch + boolean flag, no control flow changes
- [x] The `emitUpdateSuppressed` flag prevents repeated try/catch overhead on every stdout chunk after the first failure

[AI-assisted]

🤖 Generated with [Claude Code](https://claude.com/claude-code)