### PR TITLE
fix(memory-lancedb): guard against empty embeddings response

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -172,6 +172,9 @@ class Embeddings {
     }
     ensureGlobalUndiciEnvProxyDispatcher();
     const response = await this.client.embeddings.create(params);
+    if (!response.data || response.data.length === 0) {
+      throw new Error("Embeddings API returned empty data array");
+    }
     return response.data[0].embedding;
   }
 }


### PR DESCRIPTION
## Summary
- `embed()` in `extensions/memory-lancedb/index.ts` accesses `response.data[0].embedding` without checking if `data` is empty
- If the OpenAI-compatible embeddings API returns an empty data array, this throws an unhelpful `TypeError: Cannot read properties of undefined`
- Fix: add bounds check before array access, throw descriptive error

## Test plan
- [ ] Verify embeddings still work normally with OpenAI/compatible APIs
- [ ] Verify empty response produces clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)