### PR TITLE
fix: pass threadId through sessions_send announce delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 - Git/env sanitization: block additional Git repository-plumbing env variables such as `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, and `GIT_NAMESPACE` so host-run Git commands cannot be redirected to attacker-chosen repository state through inherited or request-scoped env. (#62002) Thanks @eleqtrizit.
 - Host exec/env sanitization: block additional request-scoped credential and config-path overrides such as `KUBECONFIG`, cloud credential-path env, `CARGO_HOME`, and `HELM_HOME` so host-run tools can no longer be redirected to attacker-chosen config or state. (#59119) Thanks @eleqtrizit.
 - Logging: make `logging.level` and `logging.consoleLevel` honor the documented severity threshold ordering again, and keep child loggers inheriting the parent `minLevel`. (#44646) Thanks @zhumengzhu.
+- Agents/sessions_send: pass `threadId` through announce delivery so cross-session notifications land in the correct Telegram forum topic instead of the group's general thread. (#62758) Thanks @jalehman.
 
 ## 2026.4.5
 

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import { runSessionsSendA2AFlow, __testing } from "./sessions-send-tool.a2a.js";
+
+vi.mock("../run-wait.js", () => ({
+  waitForAgentRun: vi.fn().mockResolvedValue({ status: "ok" }),
+  readLatestAssistantReply: vi.fn().mockResolvedValue("Test announce reply"),
+}));
+
+vi.mock("./agent-step.js", () => ({
+  runAgentStep: vi.fn().mockResolvedValue("Test announce reply"),
+}));
+
+describe("runSessionsSendA2AFlow announce delivery", () => {
+  let mockCallGateway: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActivePluginRegistry(createSessionConversationTestRegistry());
+    mockCallGateway = vi.fn().mockResolvedValue({});
+    __testing.setDepsForTest({ callGateway: mockCallGateway });
+  });
+
+  afterEach(() => {
+    __testing.setDepsForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("passes threadId through to gateway send for Telegram forum topics", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:telegram:group:-100123:topic:554",
+      displayKey: "agent:main:telegram:group:-100123:topic:554",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      roundOneReply: "Worker completed successfully",
+    });
+
+    // Find the gateway send call (not the waitForAgentRun call)
+    const sendCall = mockCallGateway.mock.calls.find(
+      (call: unknown[]) => (call[0] as { method: string }).method === "send",
+    );
+    expect(sendCall).toBeDefined();
+    const sendParams = (sendCall![0] as { params: Record<string, unknown> }).params;
+    expect(sendParams.to).toBe("-100123");
+    expect(sendParams.channel).toBe("telegram");
+    expect(sendParams.threadId).toBe("554");
+  });
+
+  it("omits threadId for non-topic sessions", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:group:dev",
+      displayKey: "agent:main:discord:group:dev",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      roundOneReply: "Worker completed successfully",
+    });
+
+    const sendCall = mockCallGateway.mock.calls.find(
+      (call: unknown[]) => (call[0] as { method: string }).method === "send",
+    );
+    expect(sendCall).toBeDefined();
+    const sendParams = (sendCall![0] as { params: Record<string, unknown> }).params;
+    expect(sendParams.channel).toBe("discord");
+    expect(sendParams.threadId).toBeUndefined();
+  });
+});

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -134,6 +134,7 @@ export async function runSessionsSendA2AFlow(params: {
             message: announceReply.trim(),
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,


### PR DESCRIPTION
## What
Pass `threadId` from the resolved announce target through to the gateway `send` call in `sessions_send` announce delivery, so Telegram forum topic messages land in the correct topic thread.

## Why
`resolveAnnounceTargetFromKey` correctly parses Telegram topic session keys like `agent:main:telegram:group:-100123:topic:554` into `{ to, channel, threadId }`, but `runSessionsSendA2AFlow` was dropping `threadId` when calling gateway `send`. The gateway `send` method already supports `threadId` and forwards it to the Telegram API as `message_thread_id`, so the fix is passing the already-resolved value through.

## Changes
- Add `threadId: announceTarget.threadId` to the gateway send call in `sessions-send-tool.a2a.ts`
- Add regression tests verifying threadId is passed for Telegram forum topics and omitted for non-topic sessions

## Testing
```bash
pnpm test src/agents/tools/sessions-send-tool.a2a.test.ts
# 2 passed
pnpm test src/agents/tools/sessions-send-helpers.test.ts
# 5 passed (existing, still green)
```

| File | Change |
|------|--------|
| `src/agents/tools/sessions-send-tool.a2a.ts` | Add `threadId` to gateway send params |
| `src/agents/tools/sessions-send-tool.a2a.test.ts` | New: regression tests for announce threadId delivery |