### PR TITLE
fix(gateway): normalize model/provider IDs in image capability lookup

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -974,4 +974,55 @@ describe("resolveGatewayModelSupportsImages", () => {
       }),
     ).resolves.toBe(true);
   });
+
+  test("matches catalog entry when provider ID differs only by case", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "qwen2.5-vl-72b-instruct",
+        provider: "OpenRouter",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "qwen2.5-vl-72b-instruct",
+            name: "Qwen 2.5 VL 72B",
+            provider: "openrouter",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("matches catalog entry when model ID differs only by case", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "GPT-5.4",
+        provider: "openai",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "gpt-5.4",
+            name: "GPT-5.4",
+            provider: "openai",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("matches catalog entry when provider alias is used", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "glm-5",
+        provider: "z.ai",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "glm-5",
+            name: "GLM-5",
+            provider: "zai",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -8,7 +8,7 @@ import {
 } from "../agents/agent-scope.js";
 import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { findModelInCatalog, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
   parseModelRef,
@@ -1076,10 +1076,13 @@ export async function resolveGatewayModelSupportsImages(params: {
 
   try {
     const catalog = await params.loadGatewayModelCatalog();
-    const modelEntry = catalog.find(
-      (entry) =>
-        entry.id === params.model && (!params.provider || entry.provider === params.provider),
-    );
+    const modelEntry = params.provider
+      ? findModelInCatalog(catalog, params.provider, params.model)
+      : catalog.find(
+          (entry) =>
+            normalizeLowercaseStringOrEmpty(entry.id) ===
+            normalizeLowercaseStringOrEmpty(params.model),
+        );
     const normalizedProvider = normalizeOptionalLowercaseString(params.provider);
     const normalizedCandidates = [
       normalizeLowercaseStringOrEmpty(params.model),


### PR DESCRIPTION
## Summary

`resolveGatewayModelSupportsImages()` uses strict `===` to match the session model against the catalog. When the runtime provider or model ID differs by case (e.g. `"OpenRouter"` vs `"openrouter"`) or by known alias (e.g. `"z.ai"` vs `"zai"`), the lookup misses the catalog entry entirely. The function then returns `false`, and `parseMessageWithAttachments()` silently drops all inline image attachments — even though the model actually supports images.

The codebase already has `findModelInCatalog()` which normalizes both provider (via `normalizeProviderId`) and model ID (via `normalizeLowercaseStringOrEmpty`) before comparison. This change replaces the raw `catalog.find()` with that existing helper.

## Before

```
user sends image → resolveGatewayModelSupportsImages({ provider: "OpenRouter", model: "qwen2.5-vl-72b-instruct" })
  → catalog.find: entry.provider ("openrouter") === "OpenRouter" → false
  → modelEntry = undefined → returns false
  → images dropped
```

## After

```
user sends image → resolveGatewayModelSupportsImages({ provider: "OpenRouter", model: "qwen2.5-vl-72b-instruct" })
  → findModelInCatalog: normalizeProviderId("OpenRouter") === normalizeProviderId("openrouter") → true
  → modelEntry found, input includes "image" → returns true
  → images kept
```

## What changed

- `src/gateway/session-utils.ts`: Replace strict `===` catalog lookup with `findModelInCatalog()` (provider present) or normalized `normalizeLowercaseStringOrEmpty` comparison (provider absent).
- `src/gateway/session-utils.test.ts`: Three new test cases covering case-differing provider, case-differing model ID, and provider alias lookup.

## Test plan

- [x] Existing `resolveGatewayModelSupportsImages` tests pass (Foundry shim, claude-cli shim, subagent miss/throw)
- [x] New tests: case-different provider, case-different model, provider alias (`z.ai` → `zai`)
- [x] `pnpm check` passes