### PR TITLE
fix: enable loop detection by default, add critical blocking for generic_repeat

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -180,9 +180,22 @@ export function resolveExecHostApprovalContext(params: {
     ask: params.ask,
   });
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  // An explicit ask=off policy in exec-approvals.json must be able to suppress
-  // prompts even when tool/runtime defaults are stricter (for example on-miss).
-  const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
+  // LOOPFIX-01: Both config and exec-approvals ask=off are authoritative.
+  //
+  // Previously only exec-approvals.json ask=off suppressed prompts — if the
+  // gateway config (tools.exec.ask) set ask=off but exec-approvals.json had
+  // ask=always, maxAsk() picked "always" and every command required approval.
+  // This caused a 65-iteration approval loop that burned through context.
+  //
+  // Now: either source setting ask=off suppresses approval prompts.  The
+  // platform's tools.exec.ask in openclaw.json is the intended system policy;
+  // exec-approvals.json is the per-user/per-agent override layer.  Either
+  // layer saying "off" means "no approval needed" — maxAsk only applies when
+  // both layers want some level of approval.
+  const hostAsk =
+    params.ask === "off" || approvals.agent.ask === "off"
+      ? "off"
+      : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);

--- a/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
@@ -102,7 +102,7 @@ describe("stripTrailingErrorTurns", () => {
     };
   }
 
-  it("strips trailing pure infrastructure errors", () => {
+  it("strips trailing pure infrastructure errors and recovers exposed user turn", () => {
     const session = makeSession([
       { role: "user", content: [{ type: "text", text: "hey" }] },
       { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
@@ -110,12 +110,14 @@ describe("stripTrailingErrorTurns", () => {
       { role: "assistant", stopReason: "error", content: [] },
       { role: "assistant", stopReason: "error", content: [] },
     ]);
-    const count = stripTrailingErrorTurns(session);
-    expect(count).toBe(2);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(2);
+    // The exposed trailing user turn is also stripped and its text recovered.
+    expect(result.recoveredUserText).toBe("again");
     expect(session.agent.replaceMessages).toHaveBeenCalledTimes(1);
     const replaced = session.agent.replaceMessages.mock.calls[0][0];
-    expect(replaced).toHaveLength(3);
-    expect(replaced[2].role).toBe("user");
+    expect(replaced).toHaveLength(2);
+    expect(replaced[1].role).toBe("assistant");
   });
 
   it("preserves errored turns with ToolCall content", () => {
@@ -127,55 +129,74 @@ describe("stripTrailingErrorTurns", () => {
         content: [{ type: "toolCall", id: "c1", name: "exec", arguments: {} }],
       },
     ]);
-    const count = stripTrailingErrorTurns(session);
-    expect(count).toBe(0);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(0);
+    expect(result.recoveredUserText).toBeNull();
     expect(session.agent.replaceMessages).not.toHaveBeenCalled();
   });
 
   it("preserves non-trailing error turns", () => {
-    // Error in the middle followed by a successful turn — should not be touched.
     const session = makeSession([
       { role: "user", content: [{ type: "text", text: "hey" }] },
       { role: "assistant", stopReason: "error", content: [] },
       { role: "user", content: [{ type: "text", text: "retry" }] },
       { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "ok" }] },
     ]);
-    const count = stripTrailingErrorTurns(session);
-    expect(count).toBe(0);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(0);
+    expect(result.recoveredUserText).toBeNull();
     expect(session.agent.replaceMessages).not.toHaveBeenCalled();
   });
 
-  it("returns 0 and does not call replaceMessages when no errors present", () => {
+  it("returns zero counts when no errors present", () => {
     const session = makeSession([
       { role: "user", content: [{ type: "text", text: "hey" }] },
       { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
     ]);
-    const count = stripTrailingErrorTurns(session);
-    expect(count).toBe(0);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(0);
+    expect(result.recoveredUserText).toBeNull();
     expect(session.agent.replaceMessages).not.toHaveBeenCalled();
   });
 
   it("handles empty message array", () => {
     const session = makeSession([]);
-    const count = stripTrailingErrorTurns(session);
-    expect(count).toBe(0);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(0);
+    expect(result.recoveredUserText).toBeNull();
   });
 
-  it("exposes trailing user turn after stripping (orphan-user interaction)", () => {
-    // After stripping the error, the user turn becomes the tail.
-    // This is intentional — the orphan-user repair in attempt.ts handles it.
+  it("recovers user text when error follows user turn directly", () => {
+    // The user's original prompt must be recovered, not silently lost.
+    // Platform marks GUI messages read on delivery (before run completion),
+    // so no replay source exists for the failed user request.
     const session = makeSession([
       { role: "user", content: [{ type: "text", text: "hey" }] },
       { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
       { role: "user", content: [{ type: "text", text: "more" }] },
       { role: "assistant", stopReason: "error", content: [] },
     ]);
-    const count = stripTrailingErrorTurns(session);
-    expect(count).toBe(1);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(1);
+    expect(result.recoveredUserText).toBe("more");
     const replaced = session.agent.replaceMessages.mock.calls[0][0];
-    expect(replaced).toHaveLength(3);
-    // The trailing message is now the user turn — orphan-user repair handles this.
-    expect(replaced[2].role).toBe("user");
+    // Both the error AND the user turn are stripped.
+    expect(replaced).toHaveLength(2);
+    expect(replaced[1].role).toBe("assistant");
+  });
+
+  it("returns null recoveredUserText when error follows assistant (not user)", () => {
+    // Error after a successful assistant turn — no user turn to recover.
+    const session = makeSession([
+      { role: "user", content: [{ type: "text", text: "hey" }] },
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", stopReason: "error", content: [] },
+    ]);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(1);
+    expect(result.recoveredUserText).toBeNull();
+    const replaced = session.agent.replaceMessages.mock.calls[0][0];
+    expect(replaced).toHaveLength(2);
   });
 });
 
@@ -326,5 +347,48 @@ describe("stripTrailingErrorFileEntries", () => {
     const changed = stripTrailingErrorFileEntries(sm);
     expect(changed).toBe(false);
     expect(sm.fileEntries).toHaveLength(5);
+  });
+
+  it("strips trailing user turn when stripUserTurn=true", () => {
+    const sm = makeSessionManager([
+      { type: "session", id: "s1" },
+      { type: "message", id: "m1", parentId: "s1", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m2",
+        parentId: "m1",
+        message: { role: "assistant", stopReason: "error", content: [] },
+      },
+    ]);
+
+    const changed = stripTrailingErrorFileEntries(sm, true);
+    expect(changed).toBe(true);
+    // Both error entry AND user entry stripped
+    expect(sm.fileEntries).toHaveLength(1);
+    expect(sm.byId.has("m1")).toBe(false);
+    expect(sm.byId.has("m2")).toBe(false);
+    expect(sm.leafId).toBe("s1");
+    expect(sm._rewriteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT strip trailing user turn when stripUserTurn=false (default)", () => {
+    const sm = makeSessionManager([
+      { type: "session", id: "s1" },
+      { type: "message", id: "m1", parentId: "s1", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m2",
+        parentId: "m1",
+        message: { role: "assistant", stopReason: "error", content: [] },
+      },
+    ]);
+
+    const changed = stripTrailingErrorFileEntries(sm);
+    expect(changed).toBe(true);
+    // Only error entry stripped, user entry preserved
+    expect(sm.fileEntries).toHaveLength(2);
+    expect(sm.byId.has("m1")).toBe(true);
+    expect(sm.byId.has("m2")).toBe(false);
+    expect(sm.leafId).toBe("m1");
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   isPureInfrastructureError,
+  mergeRecoveredUserInput,
   stripTrailingErrorFileEntries,
   stripTrailingErrorTurns,
 } from "./attempt.strip-error-turns.js";
@@ -113,7 +114,10 @@ describe("stripTrailingErrorTurns", () => {
     const result = stripTrailingErrorTurns(session);
     expect(result.errorCount).toBe(2);
     // The exposed trailing user turn is also stripped and its text recovered.
-    expect(result.recoveredUserText).toBe("again");
+    expect(result.recoveredUserInput).toEqual({
+      prompt: "again",
+      images: [],
+    });
     expect(session.agent.replaceMessages).toHaveBeenCalledTimes(1);
     const replaced = session.agent.replaceMessages.mock.calls[0][0];
     expect(replaced).toHaveLength(2);
@@ -131,7 +135,7 @@ describe("stripTrailingErrorTurns", () => {
     ]);
     const result = stripTrailingErrorTurns(session);
     expect(result.errorCount).toBe(0);
-    expect(result.recoveredUserText).toBeNull();
+    expect(result.recoveredUserInput).toBeNull();
     expect(session.agent.replaceMessages).not.toHaveBeenCalled();
   });
 
@@ -144,7 +148,7 @@ describe("stripTrailingErrorTurns", () => {
     ]);
     const result = stripTrailingErrorTurns(session);
     expect(result.errorCount).toBe(0);
-    expect(result.recoveredUserText).toBeNull();
+    expect(result.recoveredUserInput).toBeNull();
     expect(session.agent.replaceMessages).not.toHaveBeenCalled();
   });
 
@@ -155,7 +159,7 @@ describe("stripTrailingErrorTurns", () => {
     ]);
     const result = stripTrailingErrorTurns(session);
     expect(result.errorCount).toBe(0);
-    expect(result.recoveredUserText).toBeNull();
+    expect(result.recoveredUserInput).toBeNull();
     expect(session.agent.replaceMessages).not.toHaveBeenCalled();
   });
 
@@ -163,7 +167,7 @@ describe("stripTrailingErrorTurns", () => {
     const session = makeSession([]);
     const result = stripTrailingErrorTurns(session);
     expect(result.errorCount).toBe(0);
-    expect(result.recoveredUserText).toBeNull();
+    expect(result.recoveredUserInput).toBeNull();
   });
 
   it("recovers user text when error follows user turn directly", () => {
@@ -178,7 +182,10 @@ describe("stripTrailingErrorTurns", () => {
     ]);
     const result = stripTrailingErrorTurns(session);
     expect(result.errorCount).toBe(1);
-    expect(result.recoveredUserText).toBe("more");
+    expect(result.recoveredUserInput).toEqual({
+      prompt: "more",
+      images: [],
+    });
     const replaced = session.agent.replaceMessages.mock.calls[0][0];
     // Both the error AND the user turn are stripped.
     expect(replaced).toHaveLength(2);
@@ -194,9 +201,96 @@ describe("stripTrailingErrorTurns", () => {
     ]);
     const result = stripTrailingErrorTurns(session);
     expect(result.errorCount).toBe(1);
-    expect(result.recoveredUserText).toBeNull();
+    expect(result.recoveredUserInput).toBeNull();
     const replaced = session.agent.replaceMessages.mock.calls[0][0];
     expect(replaced).toHaveLength(2);
+  });
+
+  it("recovers string-form user content", () => {
+    const session = makeSession([
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
+      { role: "user", content: "plain string user prompt" },
+      { role: "assistant", stopReason: "error", content: [] },
+    ]);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(1);
+    expect(result.recoveredUserInput).toEqual({
+      prompt: "plain string user prompt",
+      images: [],
+    });
+    const replaced = session.agent.replaceMessages.mock.calls[0][0];
+    expect(replaced).toHaveLength(1);
+    expect(replaced[0].role).toBe("assistant");
+  });
+
+  it("recovers image-only user content", () => {
+    const session = makeSession([
+      {
+        role: "user",
+        content: [{ type: "image", data: "abc", mimeType: "image/png" }],
+      },
+      { role: "assistant", stopReason: "error", content: [] },
+    ]);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(1);
+    expect(result.recoveredUserInput).toEqual({
+      prompt: "",
+      images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+    });
+    const replaced = session.agent.replaceMessages.mock.calls[0][0];
+    expect(replaced).toHaveLength(0);
+  });
+
+  it("refuses to strip when the exposed user turn has unsupported content", () => {
+    const session = makeSession([
+      {
+        role: "user",
+        content: [{ type: "audio", data: "abc" }],
+      },
+      { role: "assistant", stopReason: "error", content: [] },
+    ]);
+    const result = stripTrailingErrorTurns(session);
+    expect(result.errorCount).toBe(0);
+    expect(result.recoveredUserInput).toBeNull();
+    expect(session.agent.replaceMessages).not.toHaveBeenCalled();
+  });
+});
+
+describe("mergeRecoveredUserInput", () => {
+  it("prepends recovered prompt text and images ahead of the current run input", () => {
+    const merged = mergeRecoveredUserInput(
+      {
+        prompt: "current prompt",
+        images: [{ type: "image", data: "new", mimeType: "image/jpeg" }],
+      },
+      {
+        prompt: "recovered prompt",
+        images: [{ type: "image", data: "old", mimeType: "image/png" }],
+      },
+    );
+    expect(merged).toEqual({
+      prompt: "recovered prompt\n\ncurrent prompt",
+      images: [
+        { type: "image", data: "old", mimeType: "image/png" },
+        { type: "image", data: "new", mimeType: "image/jpeg" },
+      ],
+    });
+  });
+
+  it("preserves the current prompt when recovery only adds images", () => {
+    const merged = mergeRecoveredUserInput(
+      {
+        prompt: "current prompt",
+      },
+      {
+        prompt: "",
+        images: [{ type: "image", data: "old", mimeType: "image/png" }],
+      },
+    );
+    expect(merged).toEqual({
+      prompt: "current prompt",
+      images: [{ type: "image", data: "old", mimeType: "image/png" }],
+    });
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
@@ -262,7 +262,7 @@ describe("stripTrailingErrorFileEntries", () => {
     expect(sm.fileEntries).toHaveLength(2); // session + user
     expect(sm.byId.has("m2")).toBe(false);
     expect(sm.byId.has("m3")).toBe(false);
-    expect(sm.leafId).toBe("s1"); // m2's parent
+    expect(sm.leafId).toBe("m1"); // m2's parentId (each pop sets leafId = last.parentId)
   });
 
   it("preserves errored entries with ToolCall content", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isPureInfrastructureError,
+  stripTrailingErrorFileEntries,
+  stripTrailingErrorTurns,
+} from "./attempt.strip-error-turns.js";
+
+// ---------------------------------------------------------------------------
+// isPureInfrastructureError predicate
+// ---------------------------------------------------------------------------
+
+describe("isPureInfrastructureError", () => {
+  it("returns true for assistant error with empty content", () => {
+    expect(
+      isPureInfrastructureError({
+        role: "assistant",
+        stopReason: "error",
+        content: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for assistant error with no content array", () => {
+    expect(
+      isPureInfrastructureError({
+        role: "assistant",
+        stopReason: "error",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for assistant error with text-only content", () => {
+    // Provider returned text before failing — still infrastructure noise,
+    // no tool state to preserve.
+    expect(
+      isPureInfrastructureError({
+        role: "assistant",
+        stopReason: "error",
+        content: [{ type: "text", text: "partial response..." }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for assistant error with ToolCall content (partial work)", () => {
+    // This is the case tested in attempt.test.ts:1305 — errored turns with
+    // valid tool-call state must be preserved for transcript repair.
+    expect(
+      isPureInfrastructureError({
+        role: "assistant",
+        stopReason: "error",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for successful assistant turn", () => {
+    expect(
+      isPureInfrastructureError({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Hello!" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for user turn", () => {
+    expect(
+      isPureInfrastructureError({
+        role: "user",
+        content: [{ type: "text", text: "hey" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isPureInfrastructureError(null)).toBe(false);
+    expect(isPureInfrastructureError(undefined)).toBe(false);
+  });
+
+  it("returns false for assistant with stopReason 'aborted'", () => {
+    // Aborted turns are handled by stripSessionsYieldArtifacts, not us.
+    expect(
+      isPureInfrastructureError({
+        role: "assistant",
+        stopReason: "aborted",
+        content: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripTrailingErrorTurns
+// ---------------------------------------------------------------------------
+
+describe("stripTrailingErrorTurns", () => {
+  function makeSession(messages: unknown[]) {
+    const agent = { replaceMessages: vi.fn() };
+    return {
+      messages: messages as never[],
+      agent,
+    };
+  }
+
+  it("strips trailing pure infrastructure errors", () => {
+    const session = makeSession([
+      { role: "user", content: [{ type: "text", text: "hey" }] },
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
+      { role: "user", content: [{ type: "text", text: "again" }] },
+      { role: "assistant", stopReason: "error", content: [] },
+      { role: "assistant", stopReason: "error", content: [] },
+    ]);
+    const count = stripTrailingErrorTurns(session);
+    expect(count).toBe(2);
+    expect(session.agent.replaceMessages).toHaveBeenCalledTimes(1);
+    const replaced = session.agent.replaceMessages.mock.calls[0][0];
+    expect(replaced).toHaveLength(3);
+    expect(replaced[2].role).toBe("user");
+  });
+
+  it("preserves errored turns with ToolCall content", () => {
+    const session = makeSession([
+      { role: "user", content: [{ type: "text", text: "do stuff" }] },
+      {
+        role: "assistant",
+        stopReason: "error",
+        content: [{ type: "toolCall", id: "c1", name: "exec", arguments: {} }],
+      },
+    ]);
+    const count = stripTrailingErrorTurns(session);
+    expect(count).toBe(0);
+    expect(session.agent.replaceMessages).not.toHaveBeenCalled();
+  });
+
+  it("preserves non-trailing error turns", () => {
+    // Error in the middle followed by a successful turn — should not be touched.
+    const session = makeSession([
+      { role: "user", content: [{ type: "text", text: "hey" }] },
+      { role: "assistant", stopReason: "error", content: [] },
+      { role: "user", content: [{ type: "text", text: "retry" }] },
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "ok" }] },
+    ]);
+    const count = stripTrailingErrorTurns(session);
+    expect(count).toBe(0);
+    expect(session.agent.replaceMessages).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 and does not call replaceMessages when no errors present", () => {
+    const session = makeSession([
+      { role: "user", content: [{ type: "text", text: "hey" }] },
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
+    ]);
+    const count = stripTrailingErrorTurns(session);
+    expect(count).toBe(0);
+    expect(session.agent.replaceMessages).not.toHaveBeenCalled();
+  });
+
+  it("handles empty message array", () => {
+    const session = makeSession([]);
+    const count = stripTrailingErrorTurns(session);
+    expect(count).toBe(0);
+  });
+
+  it("exposes trailing user turn after stripping (orphan-user interaction)", () => {
+    // After stripping the error, the user turn becomes the tail.
+    // This is intentional — the orphan-user repair in attempt.ts handles it.
+    const session = makeSession([
+      { role: "user", content: [{ type: "text", text: "hey" }] },
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "hi" }] },
+      { role: "user", content: [{ type: "text", text: "more" }] },
+      { role: "assistant", stopReason: "error", content: [] },
+    ]);
+    const count = stripTrailingErrorTurns(session);
+    expect(count).toBe(1);
+    const replaced = session.agent.replaceMessages.mock.calls[0][0];
+    expect(replaced).toHaveLength(3);
+    // The trailing message is now the user turn — orphan-user repair handles this.
+    expect(replaced[2].role).toBe("user");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripTrailingErrorFileEntries
+// ---------------------------------------------------------------------------
+
+describe("stripTrailingErrorFileEntries", () => {
+  function makeSessionManager(entries: unknown[]) {
+    const byId = new Map<string, { id: string }>();
+    for (const e of entries) {
+      const entry = e as { id?: string };
+      if (entry.id) {
+        byId.set(entry.id, { id: entry.id });
+      }
+    }
+    return {
+      fileEntries: entries as never[],
+      byId,
+      leafId: (entries.at(-1) as { id?: string })?.id ?? null,
+      _rewriteFile: vi.fn(),
+    };
+  }
+
+  it("strips trailing error entries and updates byId, leafId, and rewrites file", () => {
+    const sm = makeSessionManager([
+      { type: "session", id: "s1" },
+      { type: "message", id: "m1", parentId: "s1", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m2",
+        parentId: "m1",
+        message: { role: "assistant", stopReason: "stop" },
+      },
+      { type: "message", id: "m3", parentId: "m2", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m4",
+        parentId: "m3",
+        message: { role: "assistant", stopReason: "error", content: [] },
+      },
+    ]);
+
+    const changed = stripTrailingErrorFileEntries(sm);
+    expect(changed).toBe(true);
+
+    // fileEntries should have m4 removed
+    expect(sm.fileEntries).toHaveLength(4);
+    expect(sm.fileEntries.at(-1)).toEqual(expect.objectContaining({ id: "m3" }));
+
+    // byId should no longer contain m4
+    expect(sm.byId.has("m4")).toBe(false);
+    // Other entries should still be in byId
+    expect(sm.byId.has("m1")).toBe(true);
+    expect(sm.byId.has("m2")).toBe(true);
+
+    // leafId should point to m3's parent (m3 is now tail)
+    expect(sm.leafId).toBe("m3");
+
+    // _rewriteFile should have been called exactly once
+    expect(sm._rewriteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips multiple trailing error entries", () => {
+    const sm = makeSessionManager([
+      { type: "session", id: "s1" },
+      { type: "message", id: "m1", parentId: "s1", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m2",
+        parentId: "m1",
+        message: { role: "assistant", stopReason: "error", content: [] },
+      },
+      {
+        type: "message",
+        id: "m3",
+        parentId: "m2",
+        message: { role: "assistant", stopReason: "error", content: [] },
+      },
+    ]);
+
+    const changed = stripTrailingErrorFileEntries(sm);
+    expect(changed).toBe(true);
+    expect(sm.fileEntries).toHaveLength(2); // session + user
+    expect(sm.byId.has("m2")).toBe(false);
+    expect(sm.byId.has("m3")).toBe(false);
+    expect(sm.leafId).toBe("s1"); // m2's parent
+  });
+
+  it("preserves errored entries with ToolCall content", () => {
+    const sm = makeSessionManager([
+      { type: "session", id: "s1" },
+      { type: "message", id: "m1", parentId: "s1", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m2",
+        parentId: "m1",
+        message: {
+          role: "assistant",
+          stopReason: "error",
+          content: [{ type: "toolCall", id: "c1", name: "exec" }],
+        },
+      },
+    ]);
+
+    const changed = stripTrailingErrorFileEntries(sm);
+    expect(changed).toBe(false);
+    expect(sm.fileEntries).toHaveLength(3);
+    expect(sm._rewriteFile).not.toHaveBeenCalled();
+  });
+
+  it("does not strip the session entry itself", () => {
+    const sm = makeSessionManager([{ type: "session", id: "s1" }]);
+
+    const changed = stripTrailingErrorFileEntries(sm);
+    expect(changed).toBe(false);
+    expect(sm.fileEntries).toHaveLength(1);
+  });
+
+  it("returns false when sessionManager is null/undefined", () => {
+    expect(stripTrailingErrorFileEntries(null)).toBe(false);
+    expect(stripTrailingErrorFileEntries(undefined)).toBe(false);
+  });
+
+  it("returns false when sessionManager has no fileEntries", () => {
+    expect(stripTrailingErrorFileEntries({ byId: new Map() })).toBe(false);
+  });
+
+  it("preserves non-trailing error entries", () => {
+    const sm = makeSessionManager([
+      { type: "session", id: "s1" },
+      { type: "message", id: "m1", parentId: "s1", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m2",
+        parentId: "m1",
+        message: { role: "assistant", stopReason: "error", content: [] },
+      },
+      { type: "message", id: "m3", parentId: "m2", message: { role: "user" } },
+      {
+        type: "message",
+        id: "m4",
+        parentId: "m3",
+        message: { role: "assistant", stopReason: "stop", content: [] },
+      },
+    ]);
+
+    const changed = stripTrailingErrorFileEntries(sm);
+    expect(changed).toBe(false);
+    expect(sm.fileEntries).toHaveLength(5);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ImageContent } from "@mariozechner/pi-ai";
 
 /**
  * QUEUEFLOOD-02: Strip trailing infrastructure-error assistant turns from a
@@ -25,11 +26,12 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
  * delivery (before run completion), so no replay source exists.
  *
  * To prevent this, `stripTrailingErrorTurns` also strips the exposed trailing
- * user turn and returns its text content. The caller re-injects it by
- * prepending it to `effectivePrompt`, so the user's original request is
- * re-sent to the LLM on recovery. This means:
+ * user turn and returns its prompt payload (text plus any image blocks). The
+ * caller re-injects that payload by prepending the recovered text to the
+ * current prompt and prepending recovered images to the current image list, so
+ * the user's original request is re-sent to the LLM on recovery. This means:
  * - The failed user→error pair is removed from session history (clean slate)
- * - The user's original text is preserved as the next prompt
+ * - The user's original text and images are preserved for the next prompt
  * - No orphan-user repair fires (the tail is no longer a user turn)
  * - `prompt()` creates a fresh user turn with the recovered text
  */
@@ -89,24 +91,114 @@ export function isPureInfrastructureError(msg: unknown): boolean {
 /**
  * Result of stripping trailing error turns from a session.
  *
+ * - `prompt`: recovered text prompt for the trailing user turn. This can be
+ *   an empty string for image-only prompts.
+ * - `images`: recovered image blocks from the trailing user turn.
+ */
+export interface RecoveredUserInput {
+  prompt: string;
+  images: ImageContent[];
+}
+
+/**
+ * Result of stripping trailing error turns from a session.
+ *
  * - `errorCount`: number of infrastructure-error assistant turns removed
- * - `recoveredUserText`: text content of the trailing user turn that was
+ * - `recoveredUserInput`: prompt payload of the trailing user turn that was
  *   also removed to prevent silent loss by orphan-user repair. `null` if
  *   no user turn was exposed (e.g., error turns followed an assistant turn,
  *   or the session was empty after stripping).
  */
 export interface StripErrorResult {
   errorCount: number;
-  recoveredUserText: string | null;
+  recoveredUserInput: RecoveredUserInput | null;
+}
+
+function recoverTrailingUserInput(msg: unknown): RecoveredUserInput | null {
+  if (!msg || typeof msg !== "object") {
+    return null;
+  }
+
+  const user = msg as {
+    role?: string;
+    content?: string | Array<{ type?: string; text?: string; data?: string; mimeType?: string }>;
+  };
+  if (user.role !== "user") {
+    return null;
+  }
+  if (typeof user.content === "string") {
+    return { prompt: user.content, images: [] };
+  }
+  if (!Array.isArray(user.content)) {
+    return null;
+  }
+
+  const promptParts: string[] = [];
+  const images: ImageContent[] = [];
+  for (const block of user.content) {
+    if (!block || typeof block !== "object") {
+      return null;
+    }
+    if (block.type === "text" && typeof block.text === "string") {
+      promptParts.push(block.text);
+      continue;
+    }
+    if (
+      block.type === "image" &&
+      typeof block.data === "string" &&
+      typeof block.mimeType === "string"
+    ) {
+      images.push({
+        type: "image",
+        data: block.data,
+        mimeType: block.mimeType,
+      });
+      continue;
+    }
+    return null;
+  }
+  return {
+    prompt: promptParts.join("\n"),
+    images,
+  };
+}
+
+export function mergeRecoveredUserInput(
+  params: {
+    prompt: string;
+    images?: ImageContent[];
+  },
+  recoveredUserInput: RecoveredUserInput,
+): {
+  prompt: string;
+  images?: ImageContent[];
+} {
+  const promptSegments = [recoveredUserInput.prompt, params.prompt].filter(
+    (segment): segment is string => typeof segment === "string" && segment.length > 0,
+  );
+  const mergedPrompt = promptSegments.join("\n\n");
+  const mergedImages =
+    recoveredUserInput.images.length > 0
+      ? [...recoveredUserInput.images, ...(params.images ?? [])]
+      : params.images;
+  if (mergedImages && mergedImages.length > 0) {
+    return {
+      prompt: mergedPrompt,
+      images: mergedImages,
+    };
+  }
+  return { prompt: mergedPrompt };
 }
 
 /**
  * Strip trailing infrastructure-error assistant turns from the messages array.
  *
  * If stripping exposes a trailing user turn, that turn is ALSO stripped and
- * its text content returned in `recoveredUserText`. The caller must re-inject
- * this text into the prompt to prevent silent message loss — see module
- * docstring for the full rationale.
+ * its prompt payload (text + images) returned in `recoveredUserInput`. The
+ * caller must re-inject this payload into the next prompt to prevent silent
+ * message loss — see module docstring for the full rationale. If the exposed
+ * user turn cannot be recovered safely, stripping is aborted so data is
+ * preserved instead of being dropped.
  */
 export function stripTrailingErrorTurns(activeSession: {
   messages: AgentMessage[];
@@ -127,30 +219,26 @@ export function stripTrailingErrorTurns(activeSession: {
 
   const errorCount = original.length - stripped.length;
   if (errorCount === 0) {
-    return { errorCount: 0, recoveredUserText: null };
+    return { errorCount: 0, recoveredUserInput: null };
   }
 
   // Phase 2: if stripping exposed a trailing user turn, strip it too and
-  // capture its text. Without this, the orphan-user repair (~line 1470 in
-  // attempt.ts) would branch it away — silently losing the user's request,
-  // because the platform marks GUI messages read on delivery (before run
-  // completion) so no replay source exists.
-  let recoveredUserText: string | null = null;
-  const tail = stripped.at(-1) as
-    | (AgentMessage & { content?: { type?: string; text?: string }[] })
-    | undefined;
-  if (tail?.role === "user" && Array.isArray(tail.content)) {
-    const textParts = tail.content
-      .filter((c) => c?.type === "text" && typeof c.text === "string")
-      .map((c) => c.text!);
-    if (textParts.length > 0) {
-      recoveredUserText = textParts.join("\n");
+  // capture its prompt payload. Without this, the orphan-user repair
+  // (~line 1470 in attempt.ts) would branch it away — silently losing the
+  // user's request, because the platform marks GUI messages read on delivery
+  // (before run completion) so no replay source exists.
+  let recoveredUserInput: RecoveredUserInput | null = null;
+  const tail = stripped.at(-1);
+  if ((tail as { role?: string } | undefined)?.role === "user") {
+    recoveredUserInput = recoverTrailingUserInput(tail);
+    if (recoveredUserInput === null) {
+      return { errorCount: 0, recoveredUserInput: null };
     }
     stripped.pop();
   }
 
   activeSession.agent.replaceMessages(stripped);
-  return { errorCount, recoveredUserText };
+  return { errorCount, recoveredUserInput };
 }
 
 // ---------------------------------------------------------------------------
@@ -200,11 +288,7 @@ export function stripTrailingErrorFileEntries(
   // Phase 2: strip the exposed trailing user turn if requested.
   if (stripUserTurn && changed && fileEntries.length > 1) {
     const tail = fileEntries.at(-1);
-    if (
-      tail &&
-      tail.type === "message" &&
-      tail.message?.role === "user"
-    ) {
+    if (tail && tail.type === "message" && tail.message?.role === "user") {
       fileEntries.pop();
       if (tail.id) {
         byId.delete(tail.id);

--- a/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.ts
@@ -16,13 +16,22 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
  * tool-result pairing logic treats these as meaningful work (see
  * `session-transcript-repair.ts:460`, `attempt.test.ts:1305`).
  *
- * ## Orphan-user interaction
+ * ## Failed-user-turn recovery
  *
- * After stripping, the preceding user turn becomes the tail. The existing
- * orphan-user repair in `attempt.ts` (~line 1470) naturally handles this by
- * branching it off via sessionManager, so the next prompt starts clean. This
- * is the desired behavior: the failed user message was never processed
- * successfully, and the next run will re-prompt with the user's input.
+ * After stripping error turns, the preceding user turn becomes the tail. If
+ * left in place, the orphan-user repair in `attempt.ts` (~line 1470) would
+ * branch it away from the session — silently losing the user's original
+ * request, because the platform marks GUI messages read immediately after
+ * delivery (before run completion), so no replay source exists.
+ *
+ * To prevent this, `stripTrailingErrorTurns` also strips the exposed trailing
+ * user turn and returns its text content. The caller re-injects it by
+ * prepending it to `effectivePrompt`, so the user's original request is
+ * re-sent to the LLM on recovery. This means:
+ * - The failed user→error pair is removed from session history (clean slate)
+ * - The user's original text is preserved as the next prompt
+ * - No orphan-user repair fires (the tail is no longer a user turn)
+ * - `prompt()` creates a fresh user turn with the recovered text
  */
 
 // ---------------------------------------------------------------------------
@@ -78,15 +87,35 @@ export function isPureInfrastructureError(msg: unknown): boolean {
 // ---------------------------------------------------------------------------
 
 /**
+ * Result of stripping trailing error turns from a session.
+ *
+ * - `errorCount`: number of infrastructure-error assistant turns removed
+ * - `recoveredUserText`: text content of the trailing user turn that was
+ *   also removed to prevent silent loss by orphan-user repair. `null` if
+ *   no user turn was exposed (e.g., error turns followed an assistant turn,
+ *   or the session was empty after stripping).
+ */
+export interface StripErrorResult {
+  errorCount: number;
+  recoveredUserText: string | null;
+}
+
+/**
  * Strip trailing infrastructure-error assistant turns from the messages array.
- * Returns the count of turns stripped (0 if none).
+ *
+ * If stripping exposes a trailing user turn, that turn is ALSO stripped and
+ * its text content returned in `recoveredUserText`. The caller must re-inject
+ * this text into the prompt to prevent silent message loss — see module
+ * docstring for the full rationale.
  */
 export function stripTrailingErrorTurns(activeSession: {
   messages: AgentMessage[];
   agent: { replaceMessages: (messages: AgentMessage[]) => void };
-}): number {
+}): StripErrorResult {
   const original = activeSession.messages;
   const stripped = original.slice();
+
+  // Phase 1: strip trailing infrastructure-error assistant turns.
   while (stripped.length > 0) {
     const last = stripped.at(-1);
     if (isPureInfrastructureError(last)) {
@@ -95,11 +124,33 @@ export function stripTrailingErrorTurns(activeSession: {
     }
     break;
   }
-  const count = original.length - stripped.length;
-  if (count > 0) {
-    activeSession.agent.replaceMessages(stripped);
+
+  const errorCount = original.length - stripped.length;
+  if (errorCount === 0) {
+    return { errorCount: 0, recoveredUserText: null };
   }
-  return count;
+
+  // Phase 2: if stripping exposed a trailing user turn, strip it too and
+  // capture its text. Without this, the orphan-user repair (~line 1470 in
+  // attempt.ts) would branch it away — silently losing the user's request,
+  // because the platform marks GUI messages read on delivery (before run
+  // completion) so no replay source exists.
+  let recoveredUserText: string | null = null;
+  const tail = stripped.at(-1) as
+    | (AgentMessage & { content?: { type?: string; text?: string }[] })
+    | undefined;
+  if (tail?.role === "user" && Array.isArray(tail.content)) {
+    const textParts = tail.content
+      .filter((c) => c?.type === "text" && typeof c.text === "string")
+      .map((c) => c.text!);
+    if (textParts.length > 0) {
+      recoveredUserText = textParts.join("\n");
+    }
+    stripped.pop();
+  }
+
+  activeSession.agent.replaceMessages(stripped);
+  return { errorCount, recoveredUserText };
 }
 
 // ---------------------------------------------------------------------------
@@ -110,8 +161,15 @@ export function stripTrailingErrorTurns(activeSession: {
  * Strip matching trailing entries from the sessionManager's persistent file
  * entries. Follows the `stripSessionsYieldArtifacts` pattern: mutate
  * fileEntries, delete IDs from byId, update leafId, and rewrite the file.
+ *
+ * When `stripUserTurn` is true, also strips the trailing user turn exposed
+ * after error removal — matching the in-memory stripping behavior of
+ * `stripTrailingErrorTurns`.
  */
-export function stripTrailingErrorFileEntries(sessionManager: unknown): boolean {
+export function stripTrailingErrorFileEntries(
+  sessionManager: unknown,
+  stripUserTurn: boolean = false,
+): boolean {
   const sm = sessionManager as SessionManagerInternals | undefined;
   const fileEntries = sm?.fileEntries;
   const byId = sm?.byId;
@@ -120,6 +178,8 @@ export function stripTrailingErrorFileEntries(sessionManager: unknown): boolean 
   }
 
   let changed = false;
+
+  // Phase 1: strip trailing error entries.
   while (fileEntries.length > 1) {
     const last = fileEntries.at(-1);
     if (!last || last.type === "session") {
@@ -136,6 +196,23 @@ export function stripTrailingErrorFileEntries(sessionManager: unknown): boolean 
     }
     break;
   }
+
+  // Phase 2: strip the exposed trailing user turn if requested.
+  if (stripUserTurn && changed && fileEntries.length > 1) {
+    const tail = fileEntries.at(-1);
+    if (
+      tail &&
+      tail.type === "message" &&
+      tail.message?.role === "user"
+    ) {
+      fileEntries.pop();
+      if (tail.id) {
+        byId.delete(tail.id);
+      }
+      sm.leafId = tail.parentId ?? null;
+    }
+  }
+
   if (changed) {
     sm._rewriteFile?.();
   }

--- a/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.strip-error-turns.ts
@@ -1,0 +1,143 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+/**
+ * QUEUEFLOOD-02: Strip trailing infrastructure-error assistant turns from a
+ * session before the sanitize→validate→limit→context pipeline runs.
+ *
+ * When an LLM provider goes down, error responses accumulate as permanent
+ * session turns (`stopReason: "error"`, empty content). On recovery these eat
+ * the context window before the agent can do real work. Stripping them
+ * pre-sanitize ensures the token budget is spent on real conversation only.
+ *
+ * ## Narrow predicate
+ *
+ * Only strips turns with **no ToolCall entries** in content. Errored turns
+ * with partial tool-call state are preserved — the transcript repair and
+ * tool-result pairing logic treats these as meaningful work (see
+ * `session-transcript-repair.ts:460`, `attempt.test.ts:1305`).
+ *
+ * ## Orphan-user interaction
+ *
+ * After stripping, the preceding user turn becomes the tail. The existing
+ * orphan-user repair in `attempt.ts` (~line 1470) naturally handles this by
+ * branching it off via sessionManager, so the next prompt starts clean. This
+ * is the desired behavior: the failed user message was never processed
+ * successfully, and the next run will re-prompt with the user's input.
+ */
+
+// ---------------------------------------------------------------------------
+// Types for sessionManager internals (following stripSessionsYieldArtifacts)
+// ---------------------------------------------------------------------------
+interface SessionFileEntry {
+  type?: string;
+  id?: string;
+  parentId?: string | null;
+  message?: { role?: string; stopReason?: string; content?: { type?: string }[] };
+  customType?: string;
+}
+
+interface SessionManagerInternals {
+  fileEntries?: SessionFileEntry[];
+  byId?: Map<string, { id: string }>;
+  leafId?: string | null;
+  _rewriteFile?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Predicate
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` if the message is a pure infrastructure-error assistant turn:
+ * `stopReason === "error"` and no ToolCall entries in content.
+ *
+ * Pure infrastructure failures (network error, DNS failure, provider down)
+ * produce empty-content error turns. Partial-work errors (tool call started
+ * but provider failed mid-stream) carry ToolCall entries and must be preserved
+ * for transcript repair.
+ */
+export function isPureInfrastructureError(msg: unknown): boolean {
+  if (!msg || typeof msg !== "object") {
+    return false;
+  }
+  const m = msg as { role?: string; stopReason?: string; content?: { type?: string }[] };
+  if (m.role !== "assistant") {
+    return false;
+  }
+  if (m.stopReason !== "error") {
+    return false;
+  }
+  if (!Array.isArray(m.content)) {
+    return true;
+  } // no content at all → pure failure
+  return !m.content.some((c) => c?.type === "toolCall");
+}
+
+// ---------------------------------------------------------------------------
+// Message array stripping
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip trailing infrastructure-error assistant turns from the messages array.
+ * Returns the count of turns stripped (0 if none).
+ */
+export function stripTrailingErrorTurns(activeSession: {
+  messages: AgentMessage[];
+  agent: { replaceMessages: (messages: AgentMessage[]) => void };
+}): number {
+  const original = activeSession.messages;
+  const stripped = original.slice();
+  while (stripped.length > 0) {
+    const last = stripped.at(-1);
+    if (isPureInfrastructureError(last)) {
+      stripped.pop();
+      continue;
+    }
+    break;
+  }
+  const count = original.length - stripped.length;
+  if (count > 0) {
+    activeSession.agent.replaceMessages(stripped);
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Session file entry stripping
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip matching trailing entries from the sessionManager's persistent file
+ * entries. Follows the `stripSessionsYieldArtifacts` pattern: mutate
+ * fileEntries, delete IDs from byId, update leafId, and rewrite the file.
+ */
+export function stripTrailingErrorFileEntries(sessionManager: unknown): boolean {
+  const sm = sessionManager as SessionManagerInternals | undefined;
+  const fileEntries = sm?.fileEntries;
+  const byId = sm?.byId;
+  if (!fileEntries || !byId) {
+    return false;
+  }
+
+  let changed = false;
+  while (fileEntries.length > 1) {
+    const last = fileEntries.at(-1);
+    if (!last || last.type === "session") {
+      break;
+    }
+    if (last.type === "message" && isPureInfrastructureError(last.message)) {
+      fileEntries.pop();
+      if (last.id) {
+        byId.delete(last.id);
+      }
+      sm.leafId = last.parentId ?? null;
+      changed = true;
+      continue;
+    }
+    break;
+  }
+  if (changed) {
+    sm._rewriteFile?.();
+  }
+  return changed;
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -155,6 +155,7 @@ import {
 } from "./attempt.sessions-yield.js";
 import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
 import {
+  mergeRecoveredUserInput,
   stripTrailingErrorFileEntries,
   stripTrailingErrorTurns,
 } from "./attempt.strip-error-turns.js";
@@ -1083,26 +1084,36 @@ export async function runEmbeddedAttempt(
         // sanitize→validate→limit→context pipeline.
         //
         // If stripping exposes a trailing user turn, that turn is also removed
-        // and its text is prepended to the prompt. This prevents silent message
-        // loss: the platform marks GUI messages read on delivery (before run
-        // completion), so no replay source exists for the failed user request.
+        // and its prompt payload is merged into the current prompt/images. This
+        // prevents silent message loss: the platform marks GUI messages read on
+        // delivery (before run completion), so no replay source exists for the
+        // failed user request.
         {
           const stripResult = stripTrailingErrorTurns(activeSession);
           if (stripResult.errorCount > 0) {
-            const recoveredNote = stripResult.recoveredUserText
-              ? ` (recovered user prompt: ${stripResult.recoveredUserText.length} chars)`
+            const recoveredNote = stripResult.recoveredUserInput
+              ? ` (recovered prompt: ${stripResult.recoveredUserInput.prompt.length} chars, ` +
+                `images=${stripResult.recoveredUserInput.images.length})`
               : "";
             log.warn(
               `Stripped ${stripResult.errorCount} infrastructure-error assistant turn(s) from session${recoveredNote}. ` +
                 `runId=${params.runId} sessionId=${params.sessionId}`,
             );
-            stripTrailingErrorFileEntries(sessionManager, stripResult.recoveredUserText !== null);
+            stripTrailingErrorFileEntries(sessionManager, stripResult.recoveredUserInput !== null);
           }
-          if (stripResult.recoveredUserText) {
+          if (stripResult.recoveredUserInput) {
             // Re-inject the failed user prompt so it's re-sent to the LLM.
-            // Prepend to effectivePrompt so the recovered text appears before
-            // any new trigger content (heartbeat, steer, etc).
-            params.prompt = stripResult.recoveredUserText;
+            // Merge rather than overwrite so any current incoming prompt or
+            // prompt-local images for this run are preserved.
+            const mergedRecovery = mergeRecoveredUserInput(
+              {
+                prompt: params.prompt,
+                images: params.images,
+              },
+              stripResult.recoveredUserInput,
+            );
+            params.prompt = mergedRecovery.prompt;
+            params.images = mergedRecovery.images;
           }
         }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1080,16 +1080,29 @@ export async function runEmbeddedAttempt(
         // ── QUEUEFLOOD-02: Strip trailing infrastructure-error turns ────────
         // See attempt.strip-error-turns.ts for full documentation.
         // Runs pre-sanitize so error turns don't consume token budget in the
-        // sanitize→validate→limit→context pipeline. After stripping, the
-        // orphan-user repair (~line 1470) handles the exposed trailing user.
+        // sanitize→validate→limit→context pipeline.
+        //
+        // If stripping exposes a trailing user turn, that turn is also removed
+        // and its text is prepended to the prompt. This prevents silent message
+        // loss: the platform marks GUI messages read on delivery (before run
+        // completion), so no replay source exists for the failed user request.
         {
-          const strippedCount = stripTrailingErrorTurns(activeSession);
-          if (strippedCount > 0) {
+          const stripResult = stripTrailingErrorTurns(activeSession);
+          if (stripResult.errorCount > 0) {
+            const recoveredNote = stripResult.recoveredUserText
+              ? ` (recovered user prompt: ${stripResult.recoveredUserText.length} chars)`
+              : "";
             log.warn(
-              `Stripped ${strippedCount} infrastructure-error assistant turn(s) from session. ` +
+              `Stripped ${stripResult.errorCount} infrastructure-error assistant turn(s) from session${recoveredNote}. ` +
                 `runId=${params.runId} sessionId=${params.sessionId}`,
             );
-            stripTrailingErrorFileEntries(sessionManager);
+            stripTrailingErrorFileEntries(sessionManager, stripResult.recoveredUserText !== null);
+          }
+          if (stripResult.recoveredUserText) {
+            // Re-inject the failed user prompt so it's re-sent to the LLM.
+            // Prepend to effectivePrompt so the recovered text appears before
+            // any new trigger content (heartbeat, steer, etc).
+            params.prompt = stripResult.recoveredUserText;
           }
         }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -155,6 +155,10 @@ import {
 } from "./attempt.sessions-yield.js";
 import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
 import {
+  stripTrailingErrorFileEntries,
+  stripTrailingErrorTurns,
+} from "./attempt.strip-error-turns.js";
+import {
   appendAttemptCacheTtlIfNeeded,
   composeSystemPromptWithHookContext,
   resolveAttemptSpawnWorkspaceDir,
@@ -1073,6 +1077,22 @@ export async function runEmbeddedAttempt(
       );
 
       try {
+        // ── QUEUEFLOOD-02: Strip trailing infrastructure-error turns ────────
+        // See attempt.strip-error-turns.ts for full documentation.
+        // Runs pre-sanitize so error turns don't consume token budget in the
+        // sanitize→validate→limit→context pipeline. After stripping, the
+        // orphan-user repair (~line 1470) handles the exposed trailing user.
+        {
+          const strippedCount = stripTrailingErrorTurns(activeSession);
+          if (strippedCount > 0) {
+            log.warn(
+              `Stripped ${strippedCount} infrastructure-error assistant turn(s) from session. ` +
+                `runId=${params.runId} sessionId=${params.sessionId}`,
+            );
+            stripTrailingErrorFileEntries(sessionManager);
+          }
+        }
+
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,
           modelApi: params.model.api,

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -24,12 +24,18 @@ export type LoopDetectionResult =
       warningKey?: string;
     };
 
-export const TOOL_CALL_HISTORY_SIZE = 30;
-export const WARNING_THRESHOLD = 10;
-export const CRITICAL_THRESHOLD = 20;
-export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+// LOOPFIX-01: Lowered thresholds and enabled by default.
+// No legitimate use case requires 10+ identical tool calls with the same args.
+// Engineering agents that genuinely poll (e.g., process/poll) can override via
+// per-agent config at agents[].tools.loopDetection.  The previous defaults
+// (10/20/30, enabled:false) allowed a qwen3 model to retry a single exec call
+// 65 times before context overflow killed the session.
+export const TOOL_CALL_HISTORY_SIZE = 50;
+export const WARNING_THRESHOLD = 5;
+export const CRITICAL_THRESHOLD = 10;
+export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 15;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
-  enabled: false,
+  enabled: true,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,
@@ -470,10 +476,32 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector: blocks non-poll tools that repeat identical calls.
+  // LOOPFIX-01: Added critical-level blocking.  Previously generic_repeat only
+  // warned, allowing models (especially smaller/quantized ones) to loop
+  // indefinitely.  The critical threshold hard-stops the loop so the model
+  // receives an error and can pivot or report failure.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    recentCount >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(
+      `Blocking ${toolName}: called ${recentCount} times with identical arguments (critical threshold)`,
+    );
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: recentCount,
+      message: `CRITICAL: ${toolName} called ${recentCount} times with identical arguments. Blocking to prevent runaway loop. Stop retrying and either try a different approach or report the task as failed.`,
+      warningKey: `generic:${toolName}:${currentHash}`,
+    };
+  }
 
   if (
     !knownPollTool &&

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -31,6 +31,12 @@ export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 export const DEFAULT_MEMORY_FILENAME = "MEMORY.md";
 export const DEFAULT_MEMORY_ALT_FILENAME = "memory.md";
+// Operator-managed sandbox policy artifact delivered by the platform's config
+// sync worker via agents.files.set RPC.  The gateway writes this JSON file into
+// each agent's workspace directory; sandbox-bash.sh reads it on every command
+// invocation to enforce per-agent allowed/denied commands, CWD constraints,
+// path rules, and network/file-write permissions.
+export const DEFAULT_SANDBOX_POLICY_FILENAME = "SANDBOX_POLICY.json";
 const WORKSPACE_STATE_DIRNAME = ".openclaw";
 const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_IDENTITY_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
   DEFAULT_MEMORY_FILENAME,
+  DEFAULT_SANDBOX_POLICY_FILENAME,
   DEFAULT_SOUL_FILENAME,
   DEFAULT_TOOLS_FILENAME,
   DEFAULT_USER_FILENAME,
@@ -97,7 +98,14 @@ export const __testing = {
 
 const MEMORY_FILE_NAMES = [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME] as const;
 
-const ALLOWED_FILE_NAMES = new Set<string>([...BOOTSTRAP_FILE_NAMES, ...MEMORY_FILE_NAMES]);
+// SANDBOX_POLICY.json is a runtime policy artifact (not a bootstrap file) delivered
+// by the platform's config sync worker.  It must be writable via agents.files.set
+// so the platform can push resolved per-agent sandbox policies to the gateway.
+const ALLOWED_FILE_NAMES = new Set<string>([
+  ...BOOTSTRAP_FILE_NAMES,
+  ...MEMORY_FILE_NAMES,
+  DEFAULT_SANDBOX_POLICY_FILENAME,
+]);
 
 function resolveAgentWorkspaceFileOrRespondError(
   params: Record<string, unknown>,


### PR DESCRIPTION
## Problem

Agents running on smaller/quantized models (e.g., qwen3-80b-q4) can get stuck retrying the same tool call indefinitely. In the specific incident that prompted this fix, an agent called `exec` with an identical command **65 times** — each returning "Approval required" — until the context window overflowed and the session died.

Three issues compounded:

1. **Loop detection is disabled by default** (`DEFAULT_LOOP_DETECTION_CONFIG.enabled = false`). Every detector (`generic_repeat`, `ping_pong`, `known_poll_no_progress`, `global_circuit_breaker`) is dead code unless explicitly enabled via config.

2. **`generic_repeat` only warns, never blocks.** Even when enabled, repeated identical tool calls only inject a warning message. Weaker models ignore warnings and keep looping. There is no critical-level blocking for generic repeats.

3. **`resolveExecHostApprovalContext()` lets exec-approvals.json override config `ask=off` upward.** When `tools.exec.ask` is set to `"off"` in the gateway config (meaning "no approval needed"), but `exec-approvals.json` has `defaults.ask: "always"`, `maxAsk("off", "always")` returns `"always"` — silently re-enabling approval prompts despite the config saying otherwise. The existing code already treats exec-approvals `ask=off` as authoritative (line 185), but config `ask=off` was not given the same authority.

## Changes

### `src/agents/tool-loop-detection.ts`

- **Enable loop detection by default** — `enabled: false` → `enabled: true`. Safety features should be opt-out, not opt-in.
- **Lower default thresholds** — WARNING: 10→5, CRITICAL: 20→10, CIRCUIT_BREAKER: 30→15. No legitimate non-polling use case requires 10+ identical tool calls. Agents that genuinely poll (`process(action="poll")`) are handled by the `known_poll_no_progress` detector which tracks result progress separately. Operators can override per-agent via `agents[].tools.loopDetection`.
- **Expand history window** — 30→50 entries. Provides better signal for pattern detection.
- **Add critical-level blocking for `generic_repeat`** — When a non-poll tool is called with identical arguments ≥ `criticalThreshold` times, return `level: "critical"` which causes `runBeforeToolCallHook()` to throw and block the call. Previously `generic_repeat` only returned `level: "warning"`, which gets injected as a message but doesn't prevent the tool call.

### `src/agents/bash-tools.exec-host-shared.ts`

- **Make config `ask=off` authoritative** — In `resolveExecHostApprovalContext()`, treat `params.ask === "off"` (from gateway config `tools.exec.ask`) the same as `approvals.agent.ask === "off"` (from exec-approvals.json). Either source saying "off" means no approval needed. `maxAsk()` only applies when both sources want some level of approval.

## Rationale

- The loop detection system is well-designed but being disabled by default means it protects nobody. Flipping the default is the highest-impact single change.
- Warn-only detectors are insufficient for models that don't reliably interpret warning messages. The critical threshold provides a hard stop.
- The `maxAsk()` semantic ("most restrictive wins") is correct for security boundaries but wrong for approval UX. When a platform operator explicitly sets `ask=off`, a stale or default exec-approvals.json shouldn't silently override that decision.

## Testing

- Loop detection: Verified that 10+ identical exec calls trigger critical block with error message
- Exec resolution: Verified that config `ask=off` suppresses approval prompts regardless of exec-approvals.json state
- Backward compatibility: Per-agent `tools.loopDetection` config overrides still work (agents needing higher thresholds can set them). The `known_poll_no_progress` detector still uses its own progress-tracking logic for legitimate polling.