### PR TITLE
fix(openai): handle legacy reasoning.effort=none for GPT-5 Responses

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -458,8 +458,9 @@ returns the session to the configured default.
 OpenClaw treats direct OpenAI, Codex, and Azure OpenAI endpoints differently
 from generic OpenAI-compatible `/v1` proxies:
 
-- native `openai/*`, `openai-codex/*`, and Azure OpenAI routes keep
-  `reasoning: { effort: "none" }` intact when you explicitly disable reasoning
+- native `openai/*`, `openai-codex/*`, and Azure OpenAI routes treat legacy
+  `reasoning: { effort: "none" }` (and `reasoning: "none"`) as disabled reasoning and
+  rewrite it to the lowest supported effort (currently `minimal`) to avoid API 400s
 - native OpenAI-family routes default tool schemas to strict mode
 - hidden OpenClaw attribution headers (`originator`, `version`, and
   `User-Agent`) are only attached on verified native OpenAI hosts

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -58,7 +58,7 @@ describe("openai responses payload policy", () => {
     expect(payload).not.toHaveProperty("prompt_cache_retention");
   });
 
-  it("keeps disabled reasoning payloads on native OpenAI responses routes", () => {
+  it("rewrites disabled reasoning payloads on native OpenAI responses routes", () => {
     const payload = {
       reasoning: {
         effort: "none",
@@ -79,7 +79,7 @@ describe("openai responses payload policy", () => {
 
     expect(payload).toEqual({
       reasoning: {
-        effort: "none",
+        effort: "minimal",
       },
       store: false,
     });

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -20,7 +20,11 @@ export type OpenAIResponsesPayloadPolicy = {
   allowsServiceTier: boolean;
   compactThreshold: number;
   explicitStore: boolean | undefined;
-  shouldStripDisabledReasoningPayload: boolean;
+  /**
+   * How to handle disabled reasoning payloads that use legacy `reasoning: "none"` or
+   * `reasoning.effort: "none"` values.
+   */
+  disabledReasoningEffortMode?: "strip" | "rewrite-minimal";
   shouldStripPromptCache: boolean;
   shouldStripStore: boolean;
   useServerCompaction: boolean;
@@ -71,22 +75,35 @@ function shouldEnableOpenAIResponsesServerCompaction(
   return provider === "openai";
 }
 
-function stripDisabledOpenAIReasoningPayload(payloadObj: Record<string, unknown>): void {
+function normalizeDisabledOpenAIReasoningPayload(
+  payloadObj: Record<string, unknown>,
+  mode: NonNullable<OpenAIResponsesPayloadPolicy["disabledReasoningEffortMode"]>,
+): void {
   const reasoning = payloadObj.reasoning;
-  if (reasoning === "none") {
-    delete payloadObj.reasoning;
-    return;
-  }
-  if (!reasoning || typeof reasoning !== "object" || Array.isArray(reasoning)) {
+
+  const isDisabledReasoningString = reasoning === "none";
+  const isDisabledReasoningObject =
+    !!reasoning &&
+    typeof reasoning === "object" &&
+    !Array.isArray(reasoning) &&
+    (reasoning as Record<string, unknown>).effort === "none";
+
+  if (!isDisabledReasoningString && !isDisabledReasoningObject) {
     return;
   }
 
-  // Proxy/OpenAI-compat routes can reject `reasoning.effort: "none"`. Treat the
-  // disabled effort as "reasoning omitted" instead of forwarding an unsupported value.
-  const reasoningObj = reasoning as Record<string, unknown>;
-  if (reasoningObj.effort === "none") {
-    delete payloadObj.reasoning;
+  if (mode === "rewrite-minimal") {
+    const nextReasoning =
+      reasoning && typeof reasoning === "object" && !Array.isArray(reasoning)
+        ? { ...(reasoning as Record<string, unknown>) }
+        : {};
+    nextReasoning.effort = "minimal";
+    payloadObj.reasoning = nextReasoning;
+    return;
   }
+
+  // Default: strip.
+  delete payloadObj.reasoning;
 }
 
 export function resolveOpenAIResponsesPayloadPolicy(
@@ -120,7 +137,11 @@ export function resolveOpenAIResponsesPayloadPolicy(
       parsePositiveInteger(options.extraParams?.responsesCompactThreshold) ??
       resolveOpenAIResponsesCompactThreshold(model),
     explicitStore,
-    shouldStripDisabledReasoningPayload: isResponsesApi && !capabilities.usesKnownNativeOpenAIRoute,
+    disabledReasoningEffortMode: isResponsesApi
+      ? capabilities.usesKnownNativeOpenAIRoute
+        ? "rewrite-minimal"
+        : "strip"
+      : undefined,
     shouldStripPromptCache:
       options.enablePromptCacheStripping === true && capabilities.shouldStripResponsesPromptCache,
     shouldStripStore:
@@ -157,7 +178,7 @@ export function applyOpenAIResponsesPayloadPolicy(
       },
     ];
   }
-  if (policy.shouldStripDisabledReasoningPayload) {
-    stripDisabledOpenAIReasoningPayload(payloadObj);
+  if (policy.disabledReasoningEffortMode) {
+    normalizeDisabledOpenAIReasoningPayload(payloadObj, policy.disabledReasoningEffortMode);
   }
 }

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -196,7 +196,7 @@ export function createOpenAIResponsesContextManagementWrapper(
       !policy.useServerCompaction &&
       !policy.shouldStripStore &&
       !policy.shouldStripPromptCache &&
-      !policy.shouldStripDisabledReasoningPayload
+      !policy.disabledReasoningEffortMode
     ) {
       return underlying(model, context, options);
     }


### PR DESCRIPTION
## Problem
OpenAI GPT-5 Responses models (e.g. `gpt-5-mini`) now reject `reasoning.effort: "none"` with a 400:

> Unsupported value: 'none' is not supported with the 'gpt-5-mini' model. Supported values are: 'minimal', 'low', 'medium', and 'high'.

OpenClaw can emit legacy disabled-reasoning payloads (`reasoning: "none"` or `reasoning: { effort: "none" }`) which historically worked (and is still used as an internal sentinel), causing hard failures after upgrading.

## Fix
- Extend the OpenAI Responses payload policy to normalize disabled reasoning payloads:
  - **Native OpenAI/Codex/Azure Responses routes**: rewrite `effort: "none"` -> `effort: "minimal"`
  - **Proxy/OpenAI-compat routes**: strip the legacy disabled reasoning field entirely (existing behavior)
- Update docs to reflect the new normalization behavior.

## Tests
- Updated `openai-responses-payload-policy` unit test coverage for native vs proxy routes.
