### PR TITLE
fix(whatsapp): add audio preflight transcription for inbound voice notes

### DIFF
--- a/extensions/whatsapp/src/inbound.media.test.ts
+++ b/extensions/whatsapp/src/inbound.media.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockExtractMessageContent,
   mockGetContentType,
@@ -12,9 +12,36 @@ import {
 
 type MockMessageInput = Parameters<typeof mockNormalizeMessageContent>[0];
 
-const readAllowFromStoreMock = vi.fn().mockResolvedValue([]);
-const upsertPairingRequestMock = vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true });
-const saveMediaBufferSpy = vi.fn();
+const {
+  readAllowFromStoreMock,
+  upsertPairingRequestMock,
+  saveMediaBufferSpy,
+  transcribeFirstAudioMock,
+} = vi.hoisted(() => ({
+  readAllowFromStoreMock: vi.fn().mockResolvedValue([]),
+  upsertPairingRequestMock: vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true }),
+  saveMediaBufferSpy: vi.fn(),
+  transcribeFirstAudioMock: vi.fn(),
+}));
+
+const DEFAULT_TEST_CONFIG = {
+  channels: {
+    whatsapp: {
+      allowFrom: ["*"],
+    },
+  },
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+      },
+    },
+  },
+  messages: {
+    messagePrefix: undefined,
+    responsePrefix: undefined,
+  },
+};
 let currentMockSocket:
   | {
       ev: import("node:events").EventEmitter;
@@ -35,19 +62,13 @@ vi.mock("openclaw/plugin-sdk/config-runtime", async () => {
   );
   return {
     ...actual,
-    loadConfig: vi.fn().mockReturnValue({
-      channels: {
-        whatsapp: {
-          allowFrom: ["*"], // Allow all in tests
-        },
-      },
-      messages: {
-        messagePrefix: undefined,
-        responsePrefix: undefined,
-      },
-    }),
+    loadConfig: vi.fn().mockReturnValue(DEFAULT_TEST_CONFIG),
   };
 });
+
+vi.mock("./inbound/preflight-audio.runtime.js", () => ({
+  transcribeFirstAudio: transcribeFirstAudioMock,
+}));
 
 vi.mock("../../../src/pairing/pairing-store.js", () => {
   return {
@@ -151,7 +172,13 @@ describe("web inbound media saves with extension", () => {
     vi.useRealTimers();
     currentMockSocket = undefined;
     saveMediaBufferSpy.mockClear();
+    transcribeFirstAudioMock.mockReset();
     resetWebInboundDedupe();
+  });
+
+  afterEach(async () => {
+    const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+    vi.mocked(loadConfig).mockReturnValue(DEFAULT_TEST_CONFIG as ReturnType<typeof loadConfig>);
   });
 
   beforeAll(async () => {
@@ -242,6 +269,151 @@ describe("web inbound media saves with extension", () => {
     expect(saveMediaBufferSpy).toHaveBeenCalled();
     const lastCall = saveMediaBufferSpy.mock.calls.at(-1);
     expect(lastCall?.[3]).toBe(1 * 1024 * 1024);
+
+    await listener.close();
+  });
+
+  it("pretranscribes inbound audio before forwarding to the agent", async () => {
+    transcribeFirstAudioMock.mockResolvedValue("hello from a voice note");
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "aud1", fromMe: false, remoteJid: "444@s.whatsapp.net" },
+          message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+          messageTimestamp: 1_700_000_005,
+        },
+      ],
+    });
+
+    const inbound = await waitForMessage(onMessage);
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(inbound.body).toBe("hello from a voice note");
+    // Audio consumed — media fields should be cleared
+    expect(inbound.mediaPath).toBeUndefined();
+    expect(inbound.mediaType).toBeUndefined();
+
+    await listener.close();
+  });
+
+  it("preserves <media:audio> body when transcription is disabled", async () => {
+    const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+    vi.mocked(loadConfig).mockReturnValue({
+      ...DEFAULT_TEST_CONFIG,
+      tools: { media: { audio: { enabled: false } } },
+    } as ReturnType<typeof loadConfig>);
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "aud2", fromMe: false, remoteJid: "555@s.whatsapp.net" },
+          message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+          messageTimestamp: 1_700_000_006,
+        },
+      ],
+    });
+
+    const inbound = await waitForMessage(onMessage);
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(inbound.body).toBe("<media:audio>");
+
+    await listener.close();
+  });
+
+  it("echoes transcript when echoTranscript is enabled", async () => {
+    transcribeFirstAudioMock.mockResolvedValue("echoed voice note");
+
+    const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+    vi.mocked(loadConfig).mockReturnValue({
+      ...DEFAULT_TEST_CONFIG,
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            echoTranscript: true,
+            echoFormat: "Transcript: {transcript}",
+          },
+        },
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "aud3", fromMe: false, remoteJid: "666@s.whatsapp.net" },
+          message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+          messageTimestamp: 1_700_000_007,
+        },
+      ],
+    });
+
+    await waitForMessage(onMessage);
+    const sock = currentMockSocket!;
+    expect(sock.sendMessage).toHaveBeenCalledWith("666@s.whatsapp.net", {
+      text: "Transcript: echoed voice note",
+    });
+
+    await listener.close();
+  });
+
+  it("does not echo transcript when echoTranscript is false", async () => {
+    transcribeFirstAudioMock.mockResolvedValue("no echo voice note");
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "aud4", fromMe: false, remoteJid: "777@s.whatsapp.net" },
+          message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+          messageTimestamp: 1_700_000_008,
+        },
+      ],
+    });
+
+    const inbound = await waitForMessage(onMessage);
+    expect(inbound.body).toBe("no echo voice note");
+    const sock = currentMockSocket!;
+    // sendMessage should not have been called for echo (only read receipts may call it)
+    expect(sock.sendMessage).not.toHaveBeenCalled();
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1,5 +1,6 @@
 import type { AnyMessageContent, proto, WAMessage } from "@whiskeysockets/baileys";
 import { createInboundDebouncer, formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
+import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -360,6 +361,48 @@ export async function monitorWebInbox(options: {
       }
     } catch (err) {
       logVerbose(`Inbound media download failed: ${String(err)}`);
+    }
+
+    // Preflight audio transcription: if the body is just <media:audio> and we have
+    // an audio file, transcribe it before handing off to the agent — same approach
+    // as Telegram and Discord.
+    if (body === "<media:audio>" && mediaPath && mediaType?.startsWith("audio/")) {
+      const cfg = loadConfig();
+      if (cfg.tools?.media?.audio?.enabled !== false) {
+        try {
+          const { transcribeFirstAudio } = await import("./preflight-audio.runtime.js");
+          const transcript = await transcribeFirstAudio({
+            ctx: {
+              MediaPaths: [mediaPath],
+              MediaTypes: [mediaType],
+            },
+            cfg,
+            agentDir: undefined,
+          });
+          if (transcript) {
+            body = transcript;
+            // Echo transcript back to chat if configured
+            const audioCfg = cfg.tools?.media?.audio;
+            if (audioCfg?.echoTranscript) {
+              const chatJid = msg.key?.remoteJid;
+              if (chatJid) {
+                const format = audioCfg.echoFormat ?? '📝 "{transcript}"';
+                const echoText = format.replaceAll("{transcript}", transcript);
+                await sock.sendMessage(chatJid, { text: echoText });
+              }
+            }
+            if (shouldLogVerbose()) {
+              logVerbose(`whatsapp: preflight audio transcribed (${transcript.length} chars)`);
+            }
+            // Clear media fields — audio has been consumed as text
+            mediaPath = undefined;
+            mediaType = undefined;
+            mediaFileName = undefined;
+          }
+        } catch (err) {
+          logVerbose(`whatsapp: preflight audio transcription failed: ${String(err)}`);
+        }
+      }
     }
 
     return {

--- a/extensions/whatsapp/src/inbound/preflight-audio.runtime.ts
+++ b/extensions/whatsapp/src/inbound/preflight-audio.runtime.ts
@@ -1,0 +1,9 @@
+import { transcribeFirstAudio as transcribeFirstAudioImpl } from "openclaw/plugin-sdk/media-runtime";
+
+type TranscribeFirstAudio = typeof import("openclaw/plugin-sdk/media-runtime").transcribeFirstAudio;
+
+export async function transcribeFirstAudio(
+  ...args: Parameters<TranscribeFirstAudio>
+): ReturnType<TranscribeFirstAudio> {
+  return await transcribeFirstAudioImpl(...args);
+}


### PR DESCRIPTION
## Summary

WhatsApp voice notes are delivered as `<media:audio>` placeholders without transcript injection, so the agent never sees the actual spoken content. Telegram and Discord already perform preflight transcription via `transcribeFirstAudio` before context assembly — this adds the same behavior for WhatsApp.

### What this PR does
- Adds preflight audio transcription in `enrichInboundMessage()` — after media download, before agent handoff
- Uses the **provider-agnostic** `transcribeFirstAudio` pipeline (works with OpenAI, Groq, local Whisper, or any configured provider)
- Respects existing `tools.media.audio` config (`enabled`, `echoTranscript`, `echoFormat`)
- Clears media fields after successful transcription (audio consumed as text)
- Graceful fallback on failure — keeps `<media:audio>` placeholder, logs error

### How it differs from #54038
PR #54038 calls `transcribeOpenAiCompatibleAudio` directly, which only works with OpenAI-compatible providers and hardcodes an `OPENAI_API_KEY` check. This PR uses `transcribeFirstAudio` (same as Telegram and Discord), which routes through the general media understanding pipeline and supports any configured provider.

### Files changed
- **`extensions/whatsapp/src/inbound/preflight-audio.runtime.ts`** (new) — thin runtime wrapper, same pattern as Telegram and Discord
- **`extensions/whatsapp/src/inbound/monitor.ts`** — preflight transcription + echo in `enrichInboundMessage()`
- **`extensions/whatsapp/src/inbound.media.test.ts`** — 4 new regression tests

## Test plan
- [x] Inbound `.ogg` voice note → body is transcript, not `<media:audio>`
- [x] Transcription disabled in config → body stays `<media:audio>`, `transcribeFirstAudio` not called
- [x] `echoTranscript: true` → transcript echoed back to chat via `sock.sendMessage`
- [x] `echoTranscript: false` (default) → no echo sent
- [x] All 427 existing WhatsApp extension tests pass (53 test files, zero failures)

## Validation
```bash
pnpm exec vitest run extensions/whatsapp/src/inbound.media.test.ts
pnpm exec vitest run --config vitest.extension-whatsapp.config.ts
```

Closes #44908, closes #54030, closes #52213

🤖 Generated with [Claude Code](https://claude.com/claude-code)