### PR TITLE
fix(browser): use numeric refs for --format ai snapshots instead of role refs

### DIFF
--- a/src/browser/pw-ai.e2e.test.ts
+++ b/src/browser/pw-ai.e2e.test.ts
@@ -103,10 +103,15 @@ describe("pw-ai", () => {
     });
 
     expect(res.refs).toMatchObject({
-      e1: { role: "button", name: "OK" },
-      e2: { role: "link", name: "Docs" },
+      1: { role: "button", name: "OK" },
+      2: { role: "link", name: "Docs" },
     });
+    // Snapshot text should use numeric refs instead of [ref=e1]
+    expect(res.snapshot).toContain("[1]");
+    expect(res.snapshot).toContain("[2]");
+    expect(res.snapshot).not.toContain("[ref=e1]");
 
+    // Internal aria-ref resolution still works with e-prefixed refs
     await clickViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
       targetId: "T1",

--- a/src/browser/pw-session.ts
+++ b/src/browser/pw-session.ts
@@ -523,15 +523,28 @@ export function refLocator(page: Page, ref: string) {
       ? ref.slice(4)
       : ref;
 
-  if (/^e\d+$/.test(normalized)) {
+  // Support both e-prefixed refs (e1, e2, ...) from aria snapshots and numeric refs (1, 2, ...)
+  // that are returned to users via --format ai snapshots after remapping.
+  if (/^e?\d+$/.test(normalized)) {
     const state = pageStates.get(page);
+    // First try to look up by the ref as-given (supports both e-prefixed and numeric)
+    let info = state?.roleRefs?.[normalized];
+    // If not found and ref is numeric-only, try e-prefixed version (internal cache uses e-prefix)
+    if (!info && /^\d+$/.test(normalized)) {
+      info = state?.roleRefs?.[`e${normalized}`];
+    }
+    // If not found and ref is e-prefixed, try numeric version (in case cache uses numeric)
+    if (!info && /^e\d+$/.test(normalized)) {
+      info = state?.roleRefs?.[normalized.slice(1)];
+    }
     if (state?.roleRefsMode === "aria") {
       const scope = state.roleRefsFrameSelector
         ? page.frameLocator(state.roleRefsFrameSelector)
         : page;
-      return scope.locator(`aria-ref=${normalized}`);
+      // For aria mode, always use the e-prefixed form for aria-ref locator
+      const ariaRef = /^e\d+$/.test(normalized) ? normalized : `e${normalized}`;
+      return scope.locator(`aria-ref=${ariaRef}`);
     }
-    const info = state?.roleRefs?.[normalized];
     if (!info) {
       throw new Error(
         `Unknown ref "${normalized}". Run a new snapshot and use a ref from that snapshot.`,

--- a/src/browser/pw-tools-core.snapshot.ts
+++ b/src/browser/pw-tools-core.snapshot.ts
@@ -91,7 +91,23 @@ export async function snapshotAiViaPlaywright(opts: {
     refs: built.refs,
     mode: "aria",
   });
-  return truncated ? { snapshot, truncated, refs: built.refs } : { snapshot, refs: built.refs };
+
+  // Remap e-prefixed refs (e1, e2, ...) to numeric refs (1, 2, ...) for user-facing output.
+  const numericRefs: RoleRefMap = {};
+  let numericSnapshot = snapshot;
+  for (const [key, value] of Object.entries(built.refs)) {
+    if (/^e\d+$/.test(key)) {
+      const num = key.slice(1);
+      numericRefs[num] = value;
+      numericSnapshot = numericSnapshot.replaceAll(`[ref=${key}]`, `[${num}]`);
+    } else {
+      numericRefs[key] = value;
+    }
+  }
+
+  return truncated
+    ? { snapshot: numericSnapshot, truncated, refs: numericRefs }
+    : { snapshot: numericSnapshot, refs: numericRefs };
 }
 
 export async function snapshotRoleViaPlaywright(opts: {


### PR DESCRIPTION
Fixes #62607. Ensures ref remapping stays aligned with action resolvers and uses replaceAll for defensive correctness.