### PR TITLE
Discord: preserve normalized explicit targets in parseExplicitTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Logging: make `logging.level` and `logging.consoleLevel` honor the documented severity threshold ordering again, and keep child loggers inheriting the parent `minLevel`. (#44646) Thanks @zhumengzhu.
 - Agents/sessions_send: pass `threadId` through announce delivery so cross-session notifications land in the correct Telegram forum topic instead of the group's general thread. (#62758) Thanks @jalehman.
 - Daemon/systemd: keep sudo systemctl calls scoped to the invoking user when machine-scoped systemctl fails, while still avoiding machine fallback for permission-denied user bus errors. (#62337) Thanks @Aftabbs.
+- Discord/messaging: preserve normalized explicit targets (`user:` / `channel:`) in `parseExplicitTarget` so cron and other explicit delivery paths keep DM vs channel intent instead of collapsing to bare IDs. (#62777) Thanks @neeravmakwana.
 
 ## 2026.4.5
 

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -479,3 +479,27 @@ describe("discordPlugin groups", () => {
     ).toEqual({ allow: ["message.channel"] });
   });
 });
+
+describe("discordPlugin.messaging.parseExplicitTarget", () => {
+  it("returns normalized targets so user vs channel intent survives explicit delivery resolution", () => {
+    const parse = discordPlugin.messaging?.parseExplicitTarget;
+    expect(parse).toBeDefined();
+
+    expect(parse!({ raw: "user:111222333444555666" })).toEqual({
+      to: "user:111222333444555666",
+      chatType: "direct",
+    });
+    expect(parse!({ raw: "channel:777888999000111222" })).toEqual({
+      to: "channel:777888999000111222",
+      chatType: "channel",
+    });
+    expect(parse!({ raw: "general" })).toEqual({
+      to: "channel:general",
+      chatType: "channel",
+    });
+    expect(parse!({ raw: "1479668391169097891" })).toEqual({
+      to: "channel:1479668391169097891",
+      chatType: "channel",
+    });
+  });
+});

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -429,7 +429,7 @@ function parseDiscordExplicitTarget(raw: string) {
       return null;
     }
     return {
-      to: target.id,
+      to: target.normalized,
       chatType: target.kind === "user" ? ("direct" as const) : ("channel" as const),
     };
   } catch {


### PR DESCRIPTION
## Summary

- Problem: `parseDiscordExplicitTarget` returned bare `target.id`, dropping `user:` / `channel:` prefixes before session and outbound resolution. Bare numeric targets are then treated as guild channels, which misroutes DMs and can break explicit cron/outbound delivery.
- Why it matters: Cron `to` values like `user:…` or `channel:…` must keep canonical form through explicit-target parsing (see #62777).
- What changed: Return `target.normalized` from `parseDiscordExplicitTarget`; add regression tests on `discordPlugin.messaging.parseExplicitTarget`.
- What did NOT change: Discord send paths, ACP thread binding, and unrelated channel plugins.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #62777
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: Explicit-target parsing used `target.id` (numeric or slug only) instead of the canonical normalized string, so user vs channel intent was lost before `normalizeDiscordOutboundTarget` and related resolution.
- Missing detection / guardrail: Unit coverage for `parseExplicitTarget` on the Discord plugin.

## Regression Test Plan

- Coverage level: Unit test
- Target test or file: `extensions/discord/src/channel.test.ts`
- Scenario: `user:`, `channel:`, slug, and default-kind numeric inputs resolve to normalized `to` values with correct `chatType`.

## User-visible / Behavior Changes

- Explicit Discord targets in configs that use `user:` or `channel:` prefixes (including cron delivery and failure alerts) now retain the intended routing.

## Security Impact

- New permissions/capabilities? No

## Testing

- `pnpm test extensions/discord/src/channel.test.ts -t parseExplicitTarget`
- `pnpm check` (pre-commit via `scripts/committer`)

---

<details>
<summary>Contributor checklist</summary>

- [x] Confirmed behavior matches the described fix
- [x] Ran scoped tests and `pnpm check` before push

</details>

Made with [Cursor](https://cursor.com)