### PR TITLE
fix: subagent runTimeoutSeconds default fallback resolves to infinite timeout

### DIFF
--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -814,7 +814,7 @@ export async function steerControlledSubagentRun(params: {
     previousRunId: params.entry.runId,
     nextRunId: runId,
     fallback: params.entry,
-    runTimeoutSeconds: params.entry.runTimeoutSeconds ?? 0,
+    runTimeoutSeconds: params.entry.runTimeoutSeconds,
   });
   if (!replaced) {
     clearSubagentRunSteerRestart(params.entry.runId);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -834,7 +834,10 @@ function resolveSubagentWaitTimeoutMs(
   cfg: ReturnType<typeof loadConfig>,
   runTimeoutSeconds?: number,
 ) {
-  return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds ?? 0 });
+  // Pass undefined through so resolveAgentTimeoutMs falls back to the configured default.
+  // Only coerce 0 (explicit "no timeout") — leave undefined as "use default".
+  const overrideSeconds = runTimeoutSeconds === 0 ? 0 : runTimeoutSeconds;
+  return resolveAgentTimeoutMs({ cfg, overrideSeconds: overrideSeconds ?? undefined });
 }
 
 function startSweeper() {
@@ -1344,7 +1347,7 @@ export function replaceSubagentRunAfterSteer(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const preserveFrozenResultFallback = params.preserveFrozenResultFallback === true;
   const sessionStartedAt = resolveSubagentSessionStartedAt(source) ?? now;
@@ -1421,7 +1424,7 @@ export function registerSubagentRun(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   subagentRuns.set(params.runId, {

--- a/src/gateway/session-subagent-reactivation.ts
+++ b/src/gateway/session-subagent-reactivation.ts
@@ -19,6 +19,6 @@ export function reactivateCompletedSubagentSession(params: {
     previousRunId: existing.runId,
     nextRunId: runId,
     fallback: existing,
-    runTimeoutSeconds: existing.runTimeoutSeconds ?? 0,
+    runTimeoutSeconds: existing.runTimeoutSeconds,
   });
 }


### PR DESCRIPTION
Fixes #61870.

When runTimeoutSeconds is undefined (not explicitly set), the previous code coerced it to 0 via ?? 0 at multiple points. Since resolveAgentTimeoutMs treats 0 as "no timeout" (MAX_SAFE_TIMEOUT_MS), subagents without an explicit timeout would silently get infinite timeout instead of the configured default.

Changes:
- Remove ?? 0 coercions in resolveSubagentWaitTimeoutMs, replaceSubagentRunAfterSteer, registerSubagentRun
- Remove ?? 0 in steer control path (subagent-control.ts) and session reactivation path (session-subagent-reactivation.ts)
- undefined now propagates to resolveAgentTimeoutMs which correctly falls back to the configured default timeout
- Only explicitly-set 0 retains its "no timeout" semantics