### PR TITLE
fix(msteams): send pairing challenge reply on unpaired DMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions_send: pass `threadId` through announce delivery so cross-session notifications land in the correct Telegram forum topic instead of the group's general thread. (#62758) Thanks @jalehman.
 - Daemon/systemd: keep sudo systemctl calls scoped to the invoking user when machine-scoped systemctl fails, while still avoiding machine fallback for permission-denied user bus errors. (#62337) Thanks @Aftabbs.
 - Docs/i18n: relocalize final localized-page links after translation and remove the zh-CN homepage redirect override so localized Mintlify pages resolve to the correct language roots again. (#61796) Thanks @hxy91819.
+- MS Teams: send the standard pairing instructions on first DM when `dmPolicy=pairing`, and log pairing metadata (including the code) when a request is created. (#62765) Thanks @neeravmakwana.
 
 ## 2026.4.5
 

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -65,7 +65,7 @@ vi.mock("../reply-dispatcher.js", () => ({
 describe("msteams monitor handler authz", () => {
   function createDeps(cfg: OpenClawConfig) {
     const readAllowFromStore = vi.fn(async () => ["attacker-aad"]);
-    const upsertPairingRequest = vi.fn(async () => null);
+    const upsertPairingRequest = vi.fn(async () => ({ code: "MOCKPAIR01", created: true }));
     const recordInboundSession = vi.fn(async () => undefined);
     setMSTeamsRuntime({
       logging: { shouldLogVerbose: () => false },
@@ -244,6 +244,7 @@ describe("msteams monitor handler authz", () => {
       },
     } as OpenClawConfig);
 
+    const sendActivity = vi.fn(async () => undefined);
     const handler = createMSTeamsMessageHandler(deps);
     await handler({
       activity: {
@@ -276,7 +277,7 @@ describe("msteams monitor handler authz", () => {
         ],
         attachments: [],
       },
-      sendActivity: vi.fn(async () => undefined),
+      sendActivity,
     } as unknown as Parameters<typeof handler>[0]);
 
     expect(upsertPairingRequest).toHaveBeenCalledWith({
@@ -285,6 +286,15 @@ describe("msteams monitor handler authz", () => {
       id: "new-user-aad",
       meta: { name: "New User" },
     });
+    expect(sendActivity).toHaveBeenCalledWith(expect.stringMatching(/MOCKPAIR01/s));
+    expect(deps.log.info).toHaveBeenCalledWith(
+      "msteams pairing request",
+      expect.objectContaining({
+        sender: "new-user-aad",
+        code: "MOCKPAIR01",
+        label: "New User",
+      }),
+    );
     expect(conversationStore.upsert).toHaveBeenCalledWith("a:personal-chat", {
       activityId: "msg-pairing",
       user: {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -257,16 +257,27 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
             error: formatUnknownError(err),
           });
         });
-        const request = await pairing.upsertPairingRequest({
-          id: senderId,
+        await pairing.issueChallenge({
+          senderId,
+          senderIdLine: `Your Microsoft Teams user id: ${senderId}`,
           meta: { name: senderName },
+          sendPairingReply: async (text) => {
+            await context.sendActivity(text);
+          },
+          onCreated: ({ code }) => {
+            log.info("msteams pairing request", {
+              sender: senderId,
+              code,
+              label: senderName,
+            });
+          },
+          onReplyError: (err) => {
+            log.error("msteams pairing reply failed", {
+              sender: senderId,
+              error: formatUnknownError(err),
+            });
+          },
         });
-        if (request) {
-          log.info("msteams pairing request created", {
-            sender: senderId,
-            label: senderName,
-          });
-        }
       }
       log.debug?.("dropping dm (not allowlisted)", {
         sender: senderId,


### PR DESCRIPTION
## Summary

- Problem: With `channels.msteams.dmPolicy=pairing`, unpaired users had pairing requests recorded on disk but received no Teams message with the pair code, making first-time setup depend on host access to `msteams-pairing.json` or CLI listing.
- Why it matters: Operators could see HTTP 200 on the Bot Framework webhook and no agent reply, with little in-channel or structured feedback to distinguish pairing from connectivity or auth failures.
- What changed: The MS Teams monitor now uses the shared `issuePairingChallenge` path (`pairing.issueChallenge`): on the first pairing upsert for a sender it sends the standard pairing text via `context.sendActivity`, and logs `msteams pairing request` with `sender`, `code`, and `label` at info; reply failures are logged at error.
- What did NOT change: Group/channel routing, allowlists, HTTP adapter behavior, or pairing store format; repeat messages from the same unpaired sender still do not re-send the challenge (same as other channels using `issuePairingChallenge`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62765
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The MS Teams DM gate called `upsertPairingRequest` directly and never invoked the shared pairing challenge flow that sends the in-channel reply on newly created requests.
- Missing detection / guardrail: N/A (behavior was intentional omission; parity with Signal/Mattermost-style pairing replies was missing).
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`
- Scenario the test should lock in: Unpaired personal DM under `dmPolicy=pairing` triggers `sendActivity` with the mocked pair code and logs `msteams pairing request` with that code.
- Why this is the smallest reliable guardrail: Asserts the wiring from access resolution through `issueChallenge` to the Bot Framework reply path without needing a live Teams tenant.
- Existing test that already covers this (if any): The same file’s pairing path test was updated; it previously only asserted `upsertPairingRequest`.
- If no new test is added, why not: N/A — test expectations were extended.

## User-visible / Behavior Changes

- Unpaired MS Teams users who DM the bot while `dmPolicy=pairing` receive the standard OpenClaw pairing message in Teams on first contact (with the pair code and approve instructions), consistent with other channels using `issuePairingChallenge`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No` — uses existing Bot Framework `sendActivity` for the active turn)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node via repo `pnpm`
- Model/provider: N/A
- Integration/channel (if any): MS Teams extension unit tests
- Relevant config (redacted): `channels.msteams.dmPolicy=pairing`

### Steps

1. Run `pnpm test:extension msteams` and scoped `pnpm test extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`
2. Run `pnpm check`

### Expected

- Tests pass; lint/typecheck pass.

### Actual

- Completed successfully in this workspace before push.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Unit tests for the pairing DM path; `pnpm check` after changes.
- Edge cases checked: Mock covers first-time `created: true` pairing upsert; repeat `created: false` continues to skip duplicate pairing replies per shared `issuePairingChallenge` behavior.
- What I did **not** verify: Live Microsoft Teams/Bot Framework tenant end-to-end message delivery.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `sendActivity` could fail for misconfigured bots or transient Teams errors.
  - Mitigation: Errors are logged at error severity with sender context; operators still have pairing store and CLI as before.
