### PR TITLE
fix(exec): disable onUpdate after run settlement to prevent gateway crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Gemini: strip orphaned `required` entries from Gemini tool schemas so provider validation no longer rejects tools after schema cleanup or union flattening. (#64284) Thanks @xxxxxmax.
 - Assistant text: strip Qwen-style XML tool call payloads from visible replies so web and channel messages no longer show raw `<tool_call><function=...>` output. (#64214) Thanks @MoerAI.
 - Daemon/gateway: prevent systemd restart storms on configuration errors by exiting with `EX_CONFIG` and adding generated unit restart-prevention guards. (#63913) Thanks @neo1027144-creator.
+- Agents/exec: prevent gateway crash ("Agent listener invoked outside active run") when a subagent exec tool produces stdout/stderr after the agent run has ended or been aborted. (#62821) Thanks @openperf.
 
 ## 2026.4.9
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -23,7 +23,7 @@ export {
   normalizeExecSecurity,
   normalizeExecTarget,
 } from "../infra/exec-approvals.js";
-import { logWarn } from "../logger.js";
+import { logDebug, logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit, TerminationReason } from "../process/supervisor/types.js";
@@ -580,26 +580,46 @@ export async function runExecProcess(opts: {
   };
   addSession(session);
 
+  // Tracks whether the exec run's promise has settled (process exited or
+  // spawn failed).  Once settled the agent-loop no longer expects
+  // tool_execution_update events, so emitUpdate must become a no-op to
+  // prevent calling into a disposed agent run (the "Agent listener invoked
+  // outside active run" crash — see #62520).
+  let updatesDisabled = false;
+
   const emitUpdate = () => {
     if (!opts.onUpdate) {
       return;
     }
-    if (session.backgrounded || session.exited) {
+    if (session.backgrounded || session.exited || updatesDisabled) {
       return;
     }
     const tailText = session.tail || session.aggregated;
     const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
-    opts.onUpdate({
-      content: [{ type: "text", text: warningText + (tailText || "") }],
-      details: {
-        status: "running",
-        sessionId,
-        pid: session.pid ?? undefined,
-        startedAt,
-        cwd: session.cwd,
-        tail: session.tail,
-      },
-    });
+    try {
+      opts.onUpdate({
+        content: [{ type: "text", text: warningText + (tailText || "") }],
+        details: {
+          status: "running",
+          sessionId,
+          pid: session.pid ?? undefined,
+          startedAt,
+          cwd: session.cwd,
+          tail: session.tail,
+        },
+      });
+    } catch {
+      // The agent run may have ended (e.g. subagent abort/timeout) while
+      // the exec process is still producing output.  In that case
+      // pi-agent-core's processEvents() throws because activeRun is
+      // already cleared.  Suppress all further updates for this session
+      // rather than propagating the error as an unhandled rejection that
+      // would crash the gateway.
+      updatesDisabled = true;
+      logDebug(
+        `[exec] onUpdate suppressed for session ${sessionId}: agent run is no longer active`,
+      );
+    }
   };
 
   const handleStdout = (data: string) => {
@@ -776,6 +796,11 @@ export async function runExecProcess(opts: {
   const promise = managedRun
     .wait()
     .then(async (exit): Promise<ExecProcessOutcome> => {
+      // Disable updates *before* markExited so that any late stdout/stderr
+      // data events queued in the same event-loop tick cannot sneak through
+      // the `session.exited` guard before it flips to true.
+      updatesDisabled = true;
+
       const durationMs = Date.now() - startedAt;
       const outcome = buildExecExitOutcome({
         exit,
@@ -800,6 +825,7 @@ export async function runExecProcess(opts: {
       return outcome;
     })
     .catch((err): ExecProcessOutcome => {
+      updatesDisabled = true;
       markExited(session, null, null, "failed");
       maybeNotifyOnExit(session, "failed");
       return buildExecRuntimeErrorOutcome({

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -23,7 +23,7 @@ export {
   normalizeExecSecurity,
   normalizeExecTarget,
 } from "../infra/exec-approvals.js";
-import { logDebug, logWarn } from "../logger.js";
+import { logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit, TerminationReason } from "../process/supervisor/types.js";
@@ -207,6 +207,8 @@ export type ExecProcessHandle = {
   pid?: number;
   promise: Promise<ExecProcessOutcome>;
   kill: () => void;
+  /** Immediately suppress all future `onUpdate` calls for this handle. */
+  disableUpdates: () => void;
 };
 
 export function renderExecHostLabel(host: ExecHost) {
@@ -596,30 +598,26 @@ export async function runExecProcess(opts: {
     }
     const tailText = session.tail || session.aggregated;
     const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
-    try {
-      opts.onUpdate({
-        content: [{ type: "text", text: warningText + (tailText || "") }],
-        details: {
-          status: "running",
-          sessionId,
-          pid: session.pid ?? undefined,
-          startedAt,
-          cwd: session.cwd,
-          tail: session.tail,
-        },
-      });
-    } catch {
-      // The agent run may have ended (e.g. subagent abort/timeout) while
-      // the exec process is still producing output.  In that case
-      // pi-agent-core's processEvents() throws because activeRun is
-      // already cleared.  Suppress all further updates for this session
-      // rather than propagating the error as an unhandled rejection that
-      // would crash the gateway.
-      updatesDisabled = true;
-      logDebug(
-        `[exec] onUpdate suppressed for session ${sessionId}: agent run is no longer active`,
-      );
-    }
+    // Note: opts.onUpdate() is provided by pi-agent-core's agent-loop and
+    // internally pushes Promise.resolve(emit(event)) into an updateEvents
+    // array.  Because emit → processEvents is async, any failure (e.g.
+    // activeRun cleared) produces a *rejected Promise*, not a synchronous
+    // throw — so a try-catch here would be ineffective.  Instead we rely
+    // on the `updatesDisabled` flag being set proactively: by the promise
+    // chain on process exit (Layer 1) and by `disableUpdates()` on abort
+    // signal (Layer 2) — both of which prevent this call from ever being
+    // reached after the agent run has ended.
+    opts.onUpdate({
+      content: [{ type: "text", text: warningText + (tailText || "") }],
+      details: {
+        status: "running",
+        sessionId,
+        pid: session.pid ?? undefined,
+        startedAt,
+        cwd: session.cwd,
+        tail: session.tail,
+      },
+    });
   };
 
   const handleStdout = (data: string) => {
@@ -842,6 +840,9 @@ export async function runExecProcess(opts: {
     promise,
     kill: () => {
       managedRun?.cancel("manual-cancel");
+    },
+    disableUpdates: () => {
+      updatesDisabled = true;
     },
   };
 }

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1742,6 +1742,10 @@ export function createExecTool(
 
       // Tool-call abort should not kill backgrounded sessions; timeouts still must.
       const onAbortSignal = () => {
+        // Immediately suppress onUpdate calls so that any late stdout/stderr
+        // from the still-running process cannot push a rejected Promise into
+        // pi-agent-core's updateEvents after the agent run has ended (#62520).
+        run.disableUpdates();
         if (yielded || run.session.backgrounded) {
           return;
         }

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1745,6 +1745,10 @@ export function createExecTool(
         // Immediately suppress onUpdate calls so that any late stdout/stderr
         // from the still-running process cannot push a rejected Promise into
         // pi-agent-core's updateEvents after the agent run has ended (#62520).
+        // Intentionally placed *before* the yielded/backgrounded guard: the
+        // agent run is ending regardless, so no consumer exists for further
+        // tool_execution_update events even for backgrounded sessions (which
+        // retrieve output via process poll/log instead of onUpdate callbacks).
         run.disableUpdates();
         if (yielded || run.session.backgrounded) {
           return;

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -749,33 +749,31 @@ describe("exec backgrounded onUpdate suppression", () => {
   );
 
   it(
-    "does not crash when onUpdate throws (simulates agent run ended)",
+    "suppresses onUpdate after abort signal fires",
     async () => {
-      let callCount = 0;
-      const throwingOnUpdate = () => {
-        callCount++;
-        if (callCount > 1) {
-          throw new Error("Agent listener invoked outside active run");
-        }
-      };
-      // Run a command that produces multiple output chunks.
+      const onUpdateSpy = vi.fn();
+      const abortController = new AbortController();
+      // Run a command that produces output over time.
       const command = joinCommands([
-        shellEcho("chunk1"),
+        shellEcho("before-abort"),
         shortDelayCmd,
-        shellEcho("chunk2"),
-        shortDelayCmd,
-        shellEcho("chunk3"),
+        shellEcho("after-abort"),
       ]);
-      // Must not throw — the error should be caught internally and
-      // subsequent updates suppressed.
+      // Abort almost immediately so the signal fires while the command
+      // is still producing output.
+      setTimeout(() => abortController.abort(), 10);
       const result = await execTool.execute(
         nextCallId(),
         { command },
-        undefined,
-        throwingOnUpdate as never,
+        abortController.signal,
+        onUpdateSpy,
       );
+      const callsAtAbort = onUpdateSpy.mock.calls.length;
+      // Allow extra time for any straggling stdout data events.
+      await new Promise((r) => setTimeout(r, 100));
+      // After abort, no new onUpdate calls should have been made.
+      expect(onUpdateSpy.mock.calls.length).toBe(callsAtAbort);
       expect(result).toBeDefined();
-      expect(result.details).toBeDefined();
     },
     isWin ? 10_000 : 5_000,
   );

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -732,4 +732,51 @@ describe("exec backgrounded onUpdate suppression", () => {
     },
     isWin ? 15_000 : 5_000,
   );
+
+  it(
+    "does not invoke onUpdate after the foreground exec process exits",
+    async () => {
+      const onUpdateSpy = vi.fn();
+      // Run a foreground command that produces output then exits.
+      const command = joinCommands([shellEcho("line1"), shellEcho("line2")]);
+      await execTool.execute(nextCallId(), { command }, undefined, onUpdateSpy);
+      const callsAtExit = onUpdateSpy.mock.calls.length;
+      // Allow a tick for any straggling stdout data events.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(onUpdateSpy.mock.calls.length).toBe(callsAtExit);
+    },
+    isWin ? 10_000 : 5_000,
+  );
+
+  it(
+    "does not crash when onUpdate throws (simulates agent run ended)",
+    async () => {
+      let callCount = 0;
+      const throwingOnUpdate = () => {
+        callCount++;
+        if (callCount > 1) {
+          throw new Error("Agent listener invoked outside active run");
+        }
+      };
+      // Run a command that produces multiple output chunks.
+      const command = joinCommands([
+        shellEcho("chunk1"),
+        shortDelayCmd,
+        shellEcho("chunk2"),
+        shortDelayCmd,
+        shellEcho("chunk3"),
+      ]);
+      // Must not throw — the error should be caught internally and
+      // subsequent updates suppressed.
+      const result = await execTool.execute(
+        nextCallId(),
+        { command },
+        undefined,
+        throwingOnUpdate as never,
+      );
+      expect(result).toBeDefined();
+      expect(result.details).toBeDefined();
+    },
+    isWin ? 10_000 : 5_000,
+  );
 });


### PR DESCRIPTION
### Summary

- **Problem**: When a subagent exec tool (`tsc --noEmit`, `npm run build`, etc.) produces stdout/stderr output after the agent run has already ended (via normal completion, abort, or timeout), `emitUpdate()` in `bash-tools.exec-runtime.ts` (line 583–603) calls `opts.onUpdate()` which propagates to `pi-agent-core`'s `processEvents()`. Since `finishRun()` has already cleared `activeRun` to `undefined`, `processEvents()` throws `"Agent listener invoked outside active run"`, resulting in an unhandled Promise rejection that crashes the gateway process.

- **Root Cause**: `emitUpdate()` guards only check `session.backgrounded || session.exited` — both reflect the exec session's own lifecycle, not the agent run's lifecycle. These two lifecycles are independent and have a race window:

  i. **Post-exit race**: `managedRun.wait()` resolves (process exits) → `.then()` callback starts executing → but `markExited()` hasn't flipped `session.exited` yet → a queued stdout `data` event fires in the same event-loop tick → `emitUpdate()` passes the guard → calls `onUpdate()` into a potentially disposed agent run.
  ii. **Subagent abort/timeout race**: The parent agent run ends (`finishRun()` clears `activeRun`) while the exec process is still running (`session.exited = false`, `session.backgrounded = false`) → stdout arrives → `emitUpdate()` passes all guards → `onUpdate()` produces a rejected Promise that becomes an unhandled rejection.

  The existing [fix(exec): stop emitting tool updates after session is backgrounded #61627](https://github.com/openclaw/openclaw/pull/61627) fix (merged Apr 6) only covered the `backgrounded || exited` path and cannot reach these two race windows.

- **Fix**: Two-layer approach targeting the root cause at different lifecycle boundaries:

  i. **Layer 1 — deterministic cutoff on process exit**: Set `updatesDisabled = true` at the top of `.then()` and `.catch()` in the `managedRun.wait()` promise chain, *before* `markExited()`. This closes race window 1 by ensuring no `emitUpdate()` can fire during the micro-tick gap between promise settlement and `session.exited` flipping.
  ii. **Layer 2 — abort-signal cutoff**: Expose `disableUpdates()` on `ExecProcessHandle` and call it from `onAbortSignal()` in `bash-tools.exec.ts`. When the agent run ends (abort/timeout), the signal fires and immediately suppresses all future `onUpdate` calls, preventing any late stdout/stderr from producing a rejected Promise inside `pi-agent-core`'s `updateEvents` array.

  **Why not try-catch?** `pi-agent-core`'s `onUpdate` closure internally calls `updateEvents.push(Promise.resolve(emit(event)))` where `emit` → `processEvents` is an `async` function. When `activeRun` is `undefined`, `processEvents` throws synchronously inside the async body, but per ES2017 semantics this is converted to a *rejected Promise*, not a synchronous exception. A try-catch around `opts.onUpdate()` would never catch anything — the rejected Promise escapes into `updateEvents` and becomes an Unhandled Promise Rejection that crashes the Gateway. The correct fix is to prevent the call from ever happening, which is what `updatesDisabled` achieves.

- **What changed**:
  - `src/agents/bash-tools.exec-runtime.ts`:
    - Added `updatesDisabled` flag and `|| updatesDisabled` guard in `emitUpdate()`
    - Added `disableUpdates()` method to `ExecProcessHandle` type and return value, exposing the internal `updatesDisabled` flag to callers
    - Set `updatesDisabled = true` in `.then()` and `.catch()` of the promise chain before `markExited()`
  - `src/agents/bash-tools.exec.ts`:
    - Added `run.disableUpdates()` as first statement in `onAbortSignal()` to suppress updates immediately when abort signal fires
  - `src/agents/bash-tools.test.ts`:
    - Added two regression tests in the existing "exec backgrounded onUpdate suppression" describe block: (1) foreground exec does not invoke `onUpdate` after process exits, (2) `onUpdate` is suppressed after abort signal fires

- **What did NOT change (scope boundary)**:
  - `handleStdout` / `handleStderr` / `onSupervisorStdout` output accumulation logic — unaffected
  - `bash-process-registry.ts` — `markExited()` and `markBackgrounded()` remain unchanged
  - `supervisor.ts`, `child.ts` adapter lifecycle — not touched
  - `pi-agent-core` (`agent.js`, `agent-loop.js`) — external dependency, not modified; `processEvents()` contract preserved
  - No changes to PTY-specific code paths (PTY adapter already disposes listeners on exit)
  - Backgrounded session `process poll/log` output retrieval — `disableUpdates` only affects `onUpdate` callback, not output buffers
  - `onAbortSignal` kill/background logic — preserved exactly, `disableUpdates()` is additive
  - No CHANGELOG entry (left for maintainers per project convention)

### Reproduction
1. Configure a subagent with an exec tool
2. Run a command that produces output over time (e.g., `tsc --noEmit` on a large project, or `npm run build`)
3. Have the subagent complete its run while the process is still producing output
4. Observe gateway crash with: `Error: Agent listener invoked outside active run`

Alternatively, simulate with a long-running command and abort the agent run mid-execution.

### Risk / Mitigation
- **Risk**: `updatesDisabled` could suppress legitimate updates if set too early.
- **Mitigation**: In Layer 1, the flag is only set in `.then()`/`.catch()` after the process has exited and the promise is settling. In Layer 2, the flag is set when the abort signal fires, meaning the agent run is ending and no consumer exists for `tool_execution_update` events. No legitimate update path is affected.
- **Risk**: `disableUpdates()` in `onAbortSignal` fires unconditionally (including for backgrounded sessions that survive abort). Could this suppress legitimate updates?
- **Mitigation**: After abort, the agent run is ending — no consumer exists for `tool_execution_update` events. Backgrounded sessions use `process poll/log` for output retrieval, which reads from `session.tail`/`session.aggregated` (unaffected by `updatesDisabled`). The flag only suppresses the `onUpdate` callback path.

### Change Type (select all)
- [x] Bug fix

### Scope (select all touched areas)
- [x] Gateway
- [x] Agents
- [x] Exec runtime
- [x] Exec tool

### Linked Issue/PR

Fixes #62520
