### PR TITLE
Fix: exec approval origin uses turn-source session metadata (#62718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions_send: pass `threadId` through announce delivery so cross-session notifications land in the correct Telegram forum topic instead of the group's general thread. (#62758) Thanks @jalehman.
 - Daemon/systemd: keep sudo systemctl calls scoped to the invoking user when machine-scoped systemctl fails, while still avoiding machine fallback for permission-denied user bus errors. (#62337) Thanks @Aftabbs.
 - Docs/i18n: relocalize final localized-page links after translation and remove the zh-CN homepage redirect override so localized Mintlify pages resolve to the correct language roots again. (#61796) Thanks @hxy91819.
+- Exec approvals: resolve native approval origin targets using turn-source-aware session delivery metadata so stale session `lastChannel`/`lastTo` cannot disagree with the initiating turn and force fallback delivery (for example Telegram exec approvals fanning out to other approver DMs). (#62718)
 
 ## 2026.4.5
 

--- a/src/infra/exec-approval-session-target.test.ts
+++ b/src/infra/exec-approval-session-target.test.ts
@@ -446,7 +446,7 @@ describe("exec approval session target", () => {
     });
   });
 
-  it("returns null when explicit turn source conflicts with the session-bound origin target", () => {
+  it("prefers turn-source routing when session store lastTo disagrees with the approval turn", () => {
     withTempDirSync({ prefix: "openclaw-exec-approval-session-target-" }, (tmpDir) => {
       const storePath = path.join(tmpDir, "sessions.json");
       const cfg = writeStoreFile(storePath, {
@@ -474,7 +474,7 @@ describe("exec approval session target", () => {
         targetsMatch: (a, b) => a.to === b.to,
       });
 
-      expect(target).toBeNull();
+      expect(target).toEqual({ to: "channel:C999" });
     });
   });
 

--- a/src/infra/exec-approval-session-target.ts
+++ b/src/infra/exec-approval-session-target.ts
@@ -168,17 +168,6 @@ export function resolveApprovalRequestSessionTarget(params: {
   });
 }
 
-function resolveApprovalRequestStoredSessionTarget(params: {
-  cfg: OpenClawConfig;
-  request: ApprovalRequestLike;
-}): ExecApprovalSessionTarget | null {
-  const execLikeRequest = toExecLikeApprovalRequest(params.request);
-  return resolveExecApprovalSessionTarget({
-    cfg: params.cfg,
-    request: execLikeRequest,
-  });
-}
-
 export function resolveApprovalRequestOriginTarget<TTarget>(
   params: ApprovalRequestOriginTargetResolver<TTarget>,
 ): TTarget | null {
@@ -195,7 +184,9 @@ export function resolveApprovalRequestOriginTarget<TTarget>(
 
   const turnSourceTarget = params.resolveTurnSourceTarget(params.request);
   const expectedChannel = normalizeOptionalChannel(params.channel);
-  const sessionTargetBinding = resolveApprovalRequestStoredSessionTarget({
+  // Use turn-source-aware session resolution so stale lastChannel/lastTo cannot disagree
+  // with the live approval request metadata (same path as exec approval forwarding).
+  const sessionTargetBinding = resolveApprovalRequestSessionTarget({
     cfg: params.cfg,
     request: params.request,
   });


### PR DESCRIPTION
## Summary

- Problem: `resolveApprovalRequestOriginTarget` resolved the session side of native approval routing without passing turn-source fields into `resolveExecApprovalSessionTarget`, so session `lastChannel`/`lastTo` could disagree with the live approval request turn metadata.
- Why it matters: A turn vs session mismatch nulls origin resolution and can widen delivery (for example Telegram native exec approvals falling back toward approver-DM surfaces), matching cross-DM leakage described in #62718.
- What changed: Reuse `resolveApprovalRequestSessionTarget` (turn-source-aware) when computing the session binding for origin routing; remove the redundant stored-only helper.
- What did NOT change: Broad exec-approval policy, Telegram plugin wiring, or multi-approver configuration semantics beyond this routing consistency fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62718
- Related #62718
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The origin-target helper used a session resolution path that ignored `turnSourceChannel` / `turnSourceTo` (and related fields) already present on the approval request, unlike `resolveApprovalRequestSessionTarget` and the exec-approval forwarder.
- Missing detection / guardrail: Unit coverage assumed mismatched raw session `lastTo` vs turn should yield `null`; updated to expect turn-aligned resolution when turn metadata is present.
- Contributing context (if known): `resolveSessionDeliveryTarget` is designed to prefer turn-source routing over stale session delivery state; the origin path did not apply that consistently.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-approval-session-target.test.ts`
- Scenario the test should lock in: Stale `lastTo` in `sessions.json` with a conflicting `turnSourceTo` on the approval request still resolves origin to the initiating turn chat.
- Why this is the smallest reliable guardrail: Exercises the shared origin resolver with real session store + turn fields without standing up Telegram transport.
- Existing test that already covers this (if any): Updated existing case previously titled “returns null when explicit turn source conflicts with the session-bound origin target”.
- If no new test is added, why not: N/A (existing test updated).

## User-visible / Behavior Changes

Native exec approval prompts that depend on origin resolution should stay aligned with the initiating chat when session delivery metadata is stale but the approval carries correct turn-source fields. Changelog updated under **Unreleased**.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Trust-boundary change? Reduces accidental cross-chat approval prompt delivery when session store lags behind the initiating turn.

## Testing

- `pnpm test src/infra/exec-approval-session-target.test.ts`
- `pnpm check` (pre-commit hook via `scripts/committer`)

## AI-assisted contribution (CONTRIBUTING checklist)

- [x] Note the degree of testing: `pnpm check` and scoped unit tests run locally; full `pnpm test` not re-run after the final commit (hook ran `pnpm check`).
- [x] Confirm you understand what the code does: Yes.
