### PR TITLE
Add Slack Block Kit support for agent messages render blocks/buttons/sections

### DIFF
--- a/packages/slack-blockkit/README.md
+++ b/packages/slack-blockkit/README.md
@@ -1,0 +1,32 @@
+# @openclaw/slack-blockkit
+
+Slack Block Kit renderer for OpenClaw agent messages — converts structured message objects into Slack blocks, buttons, sections, dividers, and context elements.
+
+## Usage
+
+```js
+const { renderAndSend, renderBlocks } = require('@openclaw/slack-blockkit');
+
+// Render and send in one call
+await renderAndSend({
+  text: 'Fallback text',
+  sections: [{ text: '*Hello* from OpenClaw' }],
+  actions: [{ text: 'Click me', url: 'https://example.com' }],
+}, { channel: '#general' });
+
+// Or just render blocks (pure function)
+const blocks = renderBlocks(message);
+```
+
+## Configuration
+
+| Env var | Description |
+|---------|-------------|
+| `SLACK_BOT_TOKEN` | Slack Bot OAuth token |
+| `SLACK_CHANNEL` | Default channel (fallback if not passed in opts) |
+
+## Error handling
+
+- Throws if `channel` is not provided (neither in opts nor env)
+- Wraps Slack API errors with the error code for easier debugging
+- Rate limit errors from Slack are surfaced with the original error code

--- a/packages/slack-blockkit/package.json
+++ b/packages/slack-blockkit/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@openclaw/slack-blockkit",
+  "version": "1.0.0",
+  "description": "Slack Block Kit renderer for OpenClaw agent messages",
+  "main": "src/index.js",
+  "dependencies": {
+    "@slack/web-api": "^6.9.0",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/packages/slack-blockkit/src/index.js
+++ b/packages/slack-blockkit/src/index.js
@@ -1,0 +1,10 @@
+const { renderBlocks } = require('./renderer');
+const { postMessage } = require('./slack');
+
+async function renderAndSend(agentMessage, opts = {}) {
+  const blocks = renderBlocks(agentMessage);
+  const channel = opts.channel || process.env.SLACK_CHANNEL;
+  return postMessage({ channel, text: agentMessage.text || '', blocks });
+}
+
+module.exports = { renderAndSend, renderBlocks };

--- a/packages/slack-blockkit/src/renderer.js
+++ b/packages/slack-blockkit/src/renderer.js
@@ -1,0 +1,47 @@
+function mrkdwn(text) {
+  return { type: 'mrkdwn', text };
+}
+
+function renderSection(s) {
+  if (s.fields) {
+    return { type: 'section', fields: s.fields.map(f => mrkdwn(f)) };
+  }
+  return { type: 'section', text: mrkdwn(s.text) };
+}
+
+function renderButton(a) {
+  const btn = {
+    type: 'button',
+    text: { type: 'plain_text', text: a.text },
+  };
+  if (a.url) btn.url = a.url;
+  if (a.actionId) btn.action_id = a.actionId;
+  else btn.action_id = `action_${a.text.toLowerCase().replace(/\s+/g, '_')}`;
+  if (a.style) btn.style = a.style;
+  if (a.value) btn.value = a.value;
+  return btn;
+}
+
+function renderBlocks(msg) {
+  const blocks = [];
+
+  if (msg.sections) {
+    msg.sections.forEach(s => blocks.push(renderSection(s)));
+  }
+
+  if (msg.divider) {
+    blocks.push({ type: 'divider' });
+  }
+
+  if (msg.actions && msg.actions.length) {
+    blocks.push({ type: 'actions', elements: msg.actions.map(renderButton) });
+  }
+
+  if (msg.context && msg.context.length) {
+    blocks.push({ type: 'context', elements: msg.context.map(c => mrkdwn(c)) });
+  }
+
+  return blocks;
+}
+
+module.exports = { renderBlocks };

--- a/packages/slack-blockkit/src/slack.js
+++ b/packages/slack-blockkit/src/slack.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+const { WebClient } = require('@slack/web-api');
+
+let client;
+function getClient() {
+  if (!client) client = new WebClient(process.env.SLACK_BOT_TOKEN);
+  return client;
+}
+
+async function postMessage({ channel, text, blocks }) {
+  if (!channel) {
+    throw new Error('Slack channel is required — set opts.channel or SLACK_CHANNEL env var');
+  }
+  try {
+    return await getClient().chat.postMessage({ channel, text, blocks });
+  } catch (err) {
+    const code = err.data?.error || err.code || 'unknown';
+    throw new Error(`Slack API error (${code}): ${err.message}`);
+  }
+}
+
+module.exports = { postMessage };


### PR DESCRIPTION
## Summary

Add Slack Block Kit rendering support for agent messages — structured blocks, buttons, sections, dividers, and context elements.

## Changes (v2 — restructured)

Moved to `packages/slack-blockkit/` subpackage (no longer modifies root `package.json` or `README.md`).

- `src/renderer.js`: Pure function converting structured message objects into Slack Block Kit blocks
- `src/slack.js`: WebClient wrapper with channel validation and error handling
- `src/index.js`: `renderAndSend` convenience function

## All review findings fixed

| Severity | Issue | Fix |
|----------|-------|-----|
| P0 | Clobbers root package.json | Moved to `packages/slack-blockkit/` |
| P1 | Template literal bug on action_id | Fixed (was already fixed in prior commit, verified) |
| P2 | Silent undefined channel | Throws early with clear error message |
| P2 | Slack API errors as unhandled rejections | Wrapped with error code extraction |

## Design decisions

1. **Channel validation at `postMessage` level** — fails fast with actionable error instead of silent Slack API failure
2. **Error wrapping preserves Slack error code** — `ratelimited`, `invalid_auth`, etc. are surfaced for caller handling
3. **Subpackage structure** — Slack is an optional integration, should not be in core

## AI-assisted

This PR was developed with AI assistance (Kiro CLI). All changes have been reviewed, tested, and understood.