### PR TITLE
fix(microsoft,elevenlabs): add enabledByDefault so speech providers register at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Ollama/chat: strip the `ollama/` provider prefix from Ollama chat request model ids so configured refs like `ollama/qwen3:14b-q8_0` stop 404ing against the Ollama API. (#67457) Thanks @suboss87.
 - QA/Matrix: split the private QA lab runtime into smaller tested modules, add Matrix media contract coverage for image understanding and generated-image delivery, and update the memory-dreaming QA sweep to assert the separate phase-report layout. (#67430) Thanks @gumadeiras.
 - Agents/tools: resolve non-workspace host tilde paths against the OS home directory and keep edit recovery aligned with that same path target, so `~/...` host edit/write operations stop failing or reading back the wrong file when `OPENCLAW_HOME` differs. (#62804) Thanks @stainlu.
+- Speech/TTS: auto-enable the bundled Microsoft and ElevenLabs speech providers, and route generic TTS directive tokens through the explicit or active provider first so overrides like `[[tts:speed=1.2]]` stop silently landing on the wrong provider. (#62846) Thanks @stainlu.
 
 ## 2026.4.15-beta.1
 

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -18,6 +18,7 @@ import { parseTtsDirectives } from "openclaw/plugin-sdk/speech";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { getTtsProvider, resolveTtsPrefsPath } from "openclaw/plugin-sdk/tts-runtime";
 import { formatMention } from "../mentions.js";
 import { normalizeDiscordSlug, resolveDiscordOwnerAccess } from "../monitor/allow-list.js";
 import { formatDiscordUserTag } from "../monitor/format.js";
@@ -809,6 +810,7 @@ export class DiscordVoiceManager {
     const directive = parseTtsDirectives(replyText, ttsConfig.modelOverrides, {
       cfg: ttsCfg,
       providerConfigs: ttsConfig.providerConfigs,
+      preferredProviderId: getTtsProvider(ttsConfig, resolveTtsPrefsPath(ttsConfig)),
     });
     const rawSpeakText = directive.overrides.ttsText ?? directive.cleanedText.trim();
     const speakText = sanitizeVoiceReplyTextForSpeech(rawSpeakText, speaker.label);

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -5,9 +5,14 @@ import path from "node:path";
 import type { Readable } from "node:stream";
 import { ChannelType, type Client, ReadyListener } from "@buape/carbon";
 import type { VoicePlugin } from "@buape/carbon/voice";
-import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
-import { agentCommandFromIngress } from "openclaw/plugin-sdk/agent-runtime";
-import { resolveTtsConfig, type ResolvedTtsConfig } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  agentCommandFromIngress,
+  getTtsProvider,
+  resolveAgentDir,
+  resolveTtsConfig,
+  resolveTtsPrefsPath,
+  type ResolvedTtsConfig,
+} from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig, TtsConfig } from "openclaw/plugin-sdk/config-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -18,7 +23,6 @@ import { parseTtsDirectives } from "openclaw/plugin-sdk/speech";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { getTtsProvider, resolveTtsPrefsPath } from "openclaw/plugin-sdk/tts-runtime";
 import { formatMention } from "../mentions.js";
 import { normalizeDiscordSlug, resolveDiscordOwnerAccess } from "../monitor/allow-list.js";
 import { formatDiscordUserTag } from "../monitor/format.js";

--- a/extensions/elevenlabs/openclaw.plugin.json
+++ b/extensions/elevenlabs/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "elevenlabs",
+  "enabledByDefault": true,
   "contracts": {
     "speechProviders": ["elevenlabs"]
   },

--- a/extensions/microsoft/openclaw.plugin.json
+++ b/extensions/microsoft/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "microsoft",
+  "enabledByDefault": true,
   "contracts": {
     "speechProviders": ["microsoft"]
   },

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1036,12 +1036,14 @@ export async function maybeApplyTtsToPayload(params: {
     return params.payload;
   }
   const config = resolveTtsConfig(params.cfg);
+  const activeProvider = getTtsProvider(config, prefsPath);
 
   const reply = resolveSendableOutboundReplyParts(params.payload);
   const text = reply.text;
   const directives = parseTtsDirectives(text, config.modelOverrides, {
     cfg: params.cfg,
     providerConfigs: config.providerConfigs,
+    preferredProviderId: activeProvider,
   });
   if (directives.warnings.length > 0) {
     logVerbose(`TTS: ignored directive overrides (${directives.warnings.join("; ")})`);
@@ -1049,9 +1051,8 @@ export async function maybeApplyTtsToPayload(params: {
 
   if (isVerbose()) {
     const effectiveProvider = directives.overrides?.provider
-      ? (canonicalizeSpeechProviderId(directives.overrides.provider, params.cfg) ??
-        getTtsProvider(config, prefsPath))
-      : getTtsProvider(config, prefsPath);
+      ? (canonicalizeSpeechProviderId(directives.overrides.provider, params.cfg) ?? activeProvider)
+      : activeProvider;
     logVerbose(
       `TTS: auto mode enabled (${autoMode}), channel=${params.channel}, selected provider=${effectiveProvider}, config.provider=${config.provider}, config.providerSource=${config.providerSource}`,
     );

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -13,17 +13,20 @@ function makeProvider(
   parse: (ctx: SpeechDirectiveTokenParseContext) => SpeechDirectiveTokenParseResult | undefined,
 ): SpeechProviderPlugin {
   return {
-    id: id,
+    id,
     label: id,
     autoSelectOrder: order,
     parseDirectiveToken: parse,
     isConfigured: () => true,
-    synthesize: async () => ({ audio: Buffer.alloc(0), mimeType: "audio/mp3", voice: "" }),
-  } as unknown as SpeechProviderPlugin;
+    synthesize: async () => ({
+      audioBuffer: Buffer.alloc(0),
+      outputFormat: "mp3",
+      fileExtension: ".mp3",
+      voiceCompatible: false,
+    }),
+  } as SpeechProviderPlugin;
 }
 
-// Two fake providers that both claim the generic `speed` token, matching the
-// real ElevenLabs/MiniMax collision that surfaced the latent routing bug.
 const elevenlabs = makeProvider("elevenlabs", 10, ({ key, value }) => {
   if (key === "speed") {
     return { handled: true, overrides: { speed: Number(value) } };
@@ -53,7 +56,7 @@ const fullPolicy: SpeechModelOverridePolicy = {
 };
 
 describe("parseTtsDirectives provider-aware routing", () => {
-  it("routes generic `speed` to the explicitly declared provider (minimax)", () => {
+  it("routes generic speed to the explicitly declared provider", () => {
     const result = parseTtsDirectives(
       "hello [[tts:provider=minimax speed=1.2]] world",
       fullPolicy,
@@ -67,8 +70,7 @@ describe("parseTtsDirectives provider-aware routing", () => {
     expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
   });
 
-  it("routes correctly even when provider= appears AFTER the generic token", () => {
-    // Token order must not matter: pre-scan captures provider= before walk.
+  it("routes correctly when provider appears after the generic token", () => {
     const result = parseTtsDirectives("[[tts:speed=1.2 provider=minimax]] hi", fullPolicy, {
       providers: [elevenlabs, minimax],
     });
@@ -78,29 +80,28 @@ describe("parseTtsDirectives provider-aware routing", () => {
     expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
   });
 
-  it("routes to the explicit provider when it is elevenlabs", () => {
-    const result = parseTtsDirectives("[[tts:provider=elevenlabs speed=0.9]]", fullPolicy, {
+  it("routes to the preferred provider when no provider token is declared", () => {
+    const result = parseTtsDirectives("[[tts:speed=1.5]]", fullPolicy, {
       providers: [elevenlabs, minimax],
+      preferredProviderId: "minimax",
     });
 
-    expect(result.overrides.provider).toBe("elevenlabs");
-    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ speed: 0.9 });
-    expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
+    expect(result.overrides.provider).toBeUndefined();
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.5 });
+    expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
   });
 
-  it("falls back to autoSelectOrder when no provider= is declared", () => {
+  it("falls back to autoSelectOrder when no provider hint is available", () => {
     const result = parseTtsDirectives("[[tts:speed=1.5]]", fullPolicy, {
       providers: [elevenlabs, minimax],
     });
 
-    // elevenlabs has the lower autoSelectOrder (10 vs 20) so it wins first-match.
     expect(result.overrides.provider).toBeUndefined();
     expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ speed: 1.5 });
     expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
   });
 
-  it("falls through to other providers when the declared one does not handle the key", () => {
-    // minimax does not handle `style`; routing should still succeed via elevenlabs.
+  it("falls through when the preferred provider does not handle the key", () => {
     const result = parseTtsDirectives("[[tts:provider=minimax style=0.4]]", fullPolicy, {
       providers: [elevenlabs, minimax],
     });
@@ -120,29 +121,27 @@ describe("parseTtsDirectives provider-aware routing", () => {
     expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ style: 0.4 });
   });
 
-  it("last-wins semantics for overrides.provider are preserved", () => {
+  it("keeps last-wins provider semantics", () => {
     const result = parseTtsDirectives(
       "[[tts:provider=elevenlabs provider=minimax speed=1.1]]",
       fullPolicy,
       { providers: [elevenlabs, minimax] },
     );
 
-    // overrides.provider reflects the last provider= token (legacy behavior).
     expect(result.overrides.provider).toBe("minimax");
-    // Speed routes to the last-wins provider, not the first.
     expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.1 });
     expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
   });
 
-  it("ignores provider= when policy.allowProvider is false and uses autoSelectOrder", () => {
+  it("ignores provider tokens when provider overrides are disabled", () => {
     const policy: SpeechModelOverridePolicy = { ...fullPolicy, allowProvider: false };
-    const result = parseTtsDirectives("[[tts:provider=minimax speed=1.2]]", policy, {
+    const result = parseTtsDirectives("[[tts:provider=elevenlabs speed=1.2]]", policy, {
       providers: [elevenlabs, minimax],
+      preferredProviderId: "minimax",
     });
 
-    // provider= is not honored → routing falls back to autoSelectOrder (elevenlabs first).
     expect(result.overrides.provider).toBeUndefined();
-    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ speed: 1.2 });
-    expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.2 });
+    expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
   });
 });

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { SpeechProviderPlugin } from "../plugins/types.js";
+import { parseTtsDirectives } from "./directives.js";
+import type {
+  SpeechDirectiveTokenParseContext,
+  SpeechDirectiveTokenParseResult,
+  SpeechModelOverridePolicy,
+} from "./provider-types.js";
+
+function makeProvider(
+  id: string,
+  order: number,
+  parse: (ctx: SpeechDirectiveTokenParseContext) => SpeechDirectiveTokenParseResult | undefined,
+): SpeechProviderPlugin {
+  return {
+    id: id,
+    label: id,
+    autoSelectOrder: order,
+    parseDirectiveToken: parse,
+    isConfigured: () => true,
+    synthesize: async () => ({ audio: Buffer.alloc(0), mimeType: "audio/mp3", voice: "" }),
+  } as unknown as SpeechProviderPlugin;
+}
+
+// Two fake providers that both claim the generic `speed` token, matching the
+// real ElevenLabs/MiniMax collision that surfaced the latent routing bug.
+const elevenlabs = makeProvider("elevenlabs", 10, ({ key, value }) => {
+  if (key === "speed") {
+    return { handled: true, overrides: { speed: Number(value) } };
+  }
+  if (key === "style") {
+    return { handled: true, overrides: { style: Number(value) } };
+  }
+  return undefined;
+});
+
+const minimax = makeProvider("minimax", 20, ({ key, value }) => {
+  if (key === "speed") {
+    return { handled: true, overrides: { speed: Number(value) } };
+  }
+  return undefined;
+});
+
+const fullPolicy: SpeechModelOverridePolicy = {
+  enabled: true,
+  allowText: true,
+  allowProvider: true,
+  allowVoice: true,
+  allowModelId: true,
+  allowVoiceSettings: true,
+  allowNormalization: true,
+  allowSeed: true,
+};
+
+describe("parseTtsDirectives provider-aware routing", () => {
+  it("routes generic `speed` to the explicitly declared provider (minimax)", () => {
+    const result = parseTtsDirectives(
+      "hello [[tts:provider=minimax speed=1.2]] world",
+      fullPolicy,
+      {
+        providers: [elevenlabs, minimax],
+      },
+    );
+
+    expect(result.overrides.provider).toBe("minimax");
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.2 });
+    expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
+  });
+
+  it("routes correctly even when provider= appears AFTER the generic token", () => {
+    // Token order must not matter: pre-scan captures provider= before walk.
+    const result = parseTtsDirectives("[[tts:speed=1.2 provider=minimax]] hi", fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.overrides.provider).toBe("minimax");
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.2 });
+    expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
+  });
+
+  it("routes to the explicit provider when it is elevenlabs", () => {
+    const result = parseTtsDirectives("[[tts:provider=elevenlabs speed=0.9]]", fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.overrides.provider).toBe("elevenlabs");
+    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ speed: 0.9 });
+    expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
+  });
+
+  it("falls back to autoSelectOrder when no provider= is declared", () => {
+    const result = parseTtsDirectives("[[tts:speed=1.5]]", fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    // elevenlabs has the lower autoSelectOrder (10 vs 20) so it wins first-match.
+    expect(result.overrides.provider).toBeUndefined();
+    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ speed: 1.5 });
+    expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
+  });
+
+  it("falls through to other providers when the declared one does not handle the key", () => {
+    // minimax does not handle `style`; routing should still succeed via elevenlabs.
+    const result = parseTtsDirectives("[[tts:provider=minimax style=0.4]]", fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.overrides.provider).toBe("minimax");
+    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ style: 0.4 });
+    expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
+  });
+
+  it("routes mixed tokens independently in the same directive", () => {
+    const result = parseTtsDirectives("[[tts:provider=minimax style=0.4 speed=1.2]]", fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.overrides.provider).toBe("minimax");
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.2 });
+    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ style: 0.4 });
+  });
+
+  it("last-wins semantics for overrides.provider are preserved", () => {
+    const result = parseTtsDirectives(
+      "[[tts:provider=elevenlabs provider=minimax speed=1.1]]",
+      fullPolicy,
+      { providers: [elevenlabs, minimax] },
+    );
+
+    // overrides.provider reflects the last provider= token (legacy behavior).
+    expect(result.overrides.provider).toBe("minimax");
+    // Speed routes to the last-wins provider, not the first.
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.1 });
+    expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
+  });
+
+  it("ignores provider= when policy.allowProvider is false and uses autoSelectOrder", () => {
+    const policy: SpeechModelOverridePolicy = { ...fullPolicy, allowProvider: false };
+    const result = parseTtsDirectives("[[tts:provider=minimax speed=1.2]]", policy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    // provider= is not honored → routing falls back to autoSelectOrder (elevenlabs first).
+    expect(result.overrides.provider).toBeUndefined();
+    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ speed: 1.2 });
+    expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
+  });
+});

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -13,6 +13,7 @@ type ParseTtsDirectiveOptions = {
   cfg?: OpenClawConfig;
   providers?: readonly SpeechProviderPlugin[];
   providerConfigs?: Record<string, SpeechProviderConfig>;
+  preferredProviderId?: string;
 };
 
 function buildProviderOrder(left: SpeechProviderPlugin, right: SpeechProviderPlugin): number {
@@ -36,6 +37,20 @@ function resolveDirectiveProviderConfig(
   options?: ParseTtsDirectiveOptions,
 ): SpeechProviderConfig | undefined {
   return options?.providerConfigs?.[provider.id];
+}
+
+function prioritizeProvider(
+  providers: readonly SpeechProviderPlugin[],
+  providerId: string | undefined,
+): SpeechProviderPlugin[] {
+  if (!providerId) {
+    return [...providers];
+  }
+  const preferredProvider = providers.find((provider) => provider.id === providerId);
+  if (!preferredProvider) {
+    return [...providers];
+  }
+  return [preferredProvider, ...providers.filter((provider) => provider.id !== providerId)];
 }
 
 export function parseTtsDirectives(
@@ -67,12 +82,6 @@ export function parseTtsDirectives(
     hasDirective = true;
     const tokens = body.split(/\s+/).filter(Boolean);
 
-    // Pre-scan for `provider=X` so generic-token routing below can prefer the
-    // user-declared provider. Without this, multiple plugins that claim the
-    // same generic token (e.g. `speed`) are resolved in autoSelectOrder and the
-    // first-match wins regardless of whether the user named a different
-    // provider. Last-wins semantics match the legacy behavior for
-    // `overrides.provider` and its warnings.
     let declaredProviderId: string | undefined;
     if (policy.allowProvider) {
       for (const token of tokens) {
@@ -89,21 +98,19 @@ export function parseTtsDirectives(
           continue;
         }
         const providerId = normalizeLowercaseStringOrEmpty(rawValue);
-        if (providerId) {
-          declaredProviderId = providerId;
-          overrides.provider = providerId;
-        } else {
+        if (!providerId) {
           warnings.push("invalid provider id");
+          continue;
         }
+        declaredProviderId = providerId;
+        overrides.provider = providerId;
       }
     }
 
-    const orderedProviders = declaredProviderId
-      ? [
-          ...providers.filter((p) => p.id === declaredProviderId),
-          ...providers.filter((p) => p.id !== declaredProviderId),
-        ]
-      : providers;
+    const orderedProviders = prioritizeProvider(
+      providers,
+      declaredProviderId ?? normalizeLowercaseStringOrEmpty(options?.preferredProviderId),
+    );
 
     for (const token of tokens) {
       const eqIndex = token.indexOf("=");

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -66,6 +66,45 @@ export function parseTtsDirectives(
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;
     const tokens = body.split(/\s+/).filter(Boolean);
+
+    // Pre-scan for `provider=X` so generic-token routing below can prefer the
+    // user-declared provider. Without this, multiple plugins that claim the
+    // same generic token (e.g. `speed`) are resolved in autoSelectOrder and the
+    // first-match wins regardless of whether the user named a different
+    // provider. Last-wins semantics match the legacy behavior for
+    // `overrides.provider` and its warnings.
+    let declaredProviderId: string | undefined;
+    if (policy.allowProvider) {
+      for (const token of tokens) {
+        const eqIndex = token.indexOf("=");
+        if (eqIndex === -1) {
+          continue;
+        }
+        const rawKey = token.slice(0, eqIndex).trim();
+        if (!rawKey || normalizeLowercaseStringOrEmpty(rawKey) !== "provider") {
+          continue;
+        }
+        const rawValue = token.slice(eqIndex + 1).trim();
+        if (!rawValue) {
+          continue;
+        }
+        const providerId = normalizeLowercaseStringOrEmpty(rawValue);
+        if (providerId) {
+          declaredProviderId = providerId;
+          overrides.provider = providerId;
+        } else {
+          warnings.push("invalid provider id");
+        }
+      }
+    }
+
+    const orderedProviders = declaredProviderId
+      ? [
+          ...providers.filter((p) => p.id === declaredProviderId),
+          ...providers.filter((p) => p.id !== declaredProviderId),
+        ]
+      : providers;
+
     for (const token of tokens) {
       const eqIndex = token.indexOf("=");
       if (eqIndex === -1) {
@@ -78,19 +117,10 @@ export function parseTtsDirectives(
       }
       const key = normalizeLowercaseStringOrEmpty(rawKey);
       if (key === "provider") {
-        if (policy.allowProvider) {
-          const providerId = normalizeLowercaseStringOrEmpty(rawValue);
-          if (providerId) {
-            overrides.provider = providerId;
-          } else {
-            warnings.push("invalid provider id");
-          }
-        }
         continue;
       }
 
-      let handled = false;
-      for (const provider of providers) {
+      for (const provider of orderedProviders) {
         const parsed = provider.parseDirectiveToken?.({
           key,
           value: rawValue,
@@ -101,7 +131,6 @@ export function parseTtsDirectives(
         if (!parsed?.handled) {
           continue;
         }
-        handled = true;
         if (parsed.overrides) {
           overrides.providerOverrides = {
             ...overrides.providerOverrides,
@@ -115,10 +144,6 @@ export function parseTtsDirectives(
           warnings.push(...parsed.warnings);
         }
         break;
-      }
-
-      if (!handled) {
-        continue;
       }
     }
     return "";


### PR DESCRIPTION
## Summary

- **Problem 1 (registration):** Microsoft TTS and ElevenLabs providers are not available at runtime — `/tts provider` only shows OpenAI, and `/tts status` reports `microsoft (not configured)` with `skipped(no_provider_registered)`. Users configuring Microsoft voices (e.g. `zh-CN-XiaoxiaoNeural`) or ElevenLabs get no TTS output despite correct config; the gateway silently falls back to OpenAI.
- **Problem 2 (parser regression):** Once Microsoft and ElevenLabs participate in directive parsing, `parseTtsDirectives` walks providers in `autoSelectOrder` with first-match-wins and does not honor an explicit `provider=X` token when routing generic tokens. Inputs like `[[tts:provider=minimax speed=1.2]]` would silently route `speed` to whichever provider comes first in order, not to the declared MiniMax.
- **What changed:**
  - Added `"enabledByDefault": true` to `extensions/microsoft/openclaw.plugin.json` and `extensions/elevenlabs/openclaw.plugin.json`, matching the pattern of other working bundled speech provider plugins (openai, minimax, vydra).
  - `parseTtsDirectives` now pre-scans for `provider=X` and routes generic tokens to the declared provider first, falling back to `autoSelectOrder` only when the declared provider doesn't handle the key. Token order inside the directive no longer matters.
  - Added `src/tts/directives.test.ts` covering the ElevenLabs/MiniMax `speed` collision and fallback, mixed-token, last-wins, and `allowProvider`-disabled cases. `parseTtsDirectives` previously had no test coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62574
- Fixes #65529
- Closes #65321