### PR TITLE
fix(qqbot): honor audioAsVoice for plain reply TTS

### DIFF
--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -945,7 +945,12 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
               dispatcherOptions: {
                 responsePrefix: messagesConfig.responsePrefix,
                 deliver: async (
-                  payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string },
+                  payload: {
+                    text?: string;
+                    mediaUrls?: string[];
+                    mediaUrl?: string;
+                    audioAsVoice?: boolean;
+                  },
                   info: { kind: string },
                 ) => {
                   hasResponse = true;
@@ -1080,7 +1085,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                     groupOpenid: event.groupOpenid,
                     msgIdx: event.msgIdx,
                   };
-                  const deliverActx: DeliverAccountContext = { account, qualifiedTarget, log };
+                  const deliverActx: DeliverAccountContext = { account, qualifiedTarget, cfg, log };
 
                   const mediaResult = await parseAndSendMediaTags(
                     replyText,

--- a/extensions/qqbot/src/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/outbound-deliver.test.ts
@@ -21,6 +21,14 @@ const runtimeMocks = vi.hoisted(() => ({
   chunkMarkdownText: vi.fn((text: string) => [text]),
 }));
 
+const ttsMocks = vi.hoisted(() => ({
+  synthesizeAndDeliverTtsVoice: vi.fn(async () => false),
+}));
+
+vi.mock("./reply-dispatcher.js", () => ({
+  synthesizeAndDeliverTtsVoice: ttsMocks.synthesizeAndDeliverTtsVoice,
+}));
+
 vi.mock("./api.js", () => ({
   sendC2CMessage: apiMocks.sendC2CMessage,
   sendDmMessage: apiMocks.sendDmMessage,
@@ -71,7 +79,7 @@ function buildEvent(): DeliverEventContext {
   };
 }
 
-function buildAccountContext(markdownSupport: boolean): DeliverAccountContext {
+function buildAccountContext(markdownSupport: boolean, cfg?: unknown): DeliverAccountContext {
   return {
     qualifiedTarget: "qqbot:c2c:user-1",
     account: {
@@ -81,6 +89,7 @@ function buildAccountContext(markdownSupport: boolean): DeliverAccountContext {
       markdownSupport,
       config: {},
     } as DeliverAccountContext["account"],
+    ...(cfg !== undefined ? { cfg } : {}),
     log: {
       info: vi.fn(),
       error: vi.fn(),
@@ -95,6 +104,7 @@ describe("qqbot outbound deliver", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     runtimeMocks.chunkMarkdownText.mockImplementation((text: string) => [text]);
+    ttsMocks.synthesizeAndDeliverTtsVoice.mockResolvedValue(false);
   });
 
   it("sends plain replies through the shared text chunk sender", async () => {
@@ -167,5 +177,66 @@ describe("qqbot outbound deliver", () => {
       undefined,
     );
     expect(outboundMocks.sendPhoto).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips plain text when audioAsVoice TTS succeeds and cfg is present", async () => {
+    ttsMocks.synthesizeAndDeliverTtsVoice.mockResolvedValueOnce(true);
+    await sendPlainReply(
+      { audioAsVoice: true },
+      "spoken reply",
+      buildEvent(),
+      buildAccountContext(false, {}),
+      sendWithRetry,
+      consumeQuoteRef,
+      [],
+    );
+
+    expect(ttsMocks.synthesizeAndDeliverTtsVoice).toHaveBeenCalledTimes(1);
+    expect(apiMocks.sendC2CMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to plain text when audioAsVoice TTS does not send", async () => {
+    ttsMocks.synthesizeAndDeliverTtsVoice.mockResolvedValueOnce(false);
+    await sendPlainReply(
+      { audioAsVoice: true },
+      "still text",
+      buildEvent(),
+      buildAccountContext(false, {}),
+      sendWithRetry,
+      consumeQuoteRef,
+      [],
+    );
+
+    expect(ttsMocks.synthesizeAndDeliverTtsVoice).toHaveBeenCalledTimes(1);
+    expect(apiMocks.sendC2CMessage).toHaveBeenCalledWith(
+      "app-id",
+      "token",
+      "user-1",
+      "still text",
+      "msg-1",
+      undefined,
+    );
+  });
+
+  it("does not synthesize TTS when audioAsVoice is set but cfg is missing", async () => {
+    await sendPlainReply(
+      { audioAsVoice: true },
+      "no cfg",
+      buildEvent(),
+      buildAccountContext(false),
+      sendWithRetry,
+      consumeQuoteRef,
+      [],
+    );
+
+    expect(ttsMocks.synthesizeAndDeliverTtsVoice).not.toHaveBeenCalled();
+    expect(apiMocks.sendC2CMessage).toHaveBeenCalledWith(
+      "app-id",
+      "token",
+      "user-1",
+      "no cfg",
+      "msg-1",
+      undefined,
+    );
   });
 });

--- a/extensions/qqbot/src/outbound-deliver.ts
+++ b/extensions/qqbot/src/outbound-deliver.ts
@@ -400,9 +400,8 @@ export async function sendPlainReply(
   for (const m of bareUrlMatches) {
     speechText = speechText.replace(m[0], "").trim();
   }
-  if (speechText && event.type !== "c2c") {
-    speechText = speechText.replace(/([a-zA-Z0-9])\.([a-zA-Z0-9])/g, "$1_$2");
-  }
+  // Do not apply group plain-text dot→underscore sanitization to TTS input; providers
+  // should speak real hostnames (e.g. openclaw.ai). That workaround stays in sendPlainTextReply.
 
   let voiceHandled = false;
   if (

--- a/extensions/qqbot/src/outbound-deliver.ts
+++ b/extensions/qqbot/src/outbound-deliver.ts
@@ -26,6 +26,7 @@ import {
   sendMedia as sendMediaAuto,
   type MediaTargetContext,
 } from "./outbound.js";
+import { synthesizeAndDeliverTtsVoice, type ReplyContext } from "./reply-dispatcher.js";
 import { getQQBotRuntime } from "./runtime.js";
 import { chunkText, TEXT_CHUNK_LIMIT } from "./text-utils.js";
 import type { ResolvedQQBotAccount } from "./types.js";
@@ -49,6 +50,8 @@ export interface DeliverEventContext {
 export interface DeliverAccountContext {
   account: ResolvedQQBotAccount;
   qualifiedTarget: string;
+  /** OpenClaw config root; required for `audioAsVoice` TTS synthesis. */
+  cfg?: unknown;
   log?: {
     info: (msg: string) => void;
     error: (msg: string) => void;
@@ -61,6 +64,27 @@ export type SendWithRetryFn = <T>(sendFn: (token: string) => Promise<T>) => Prom
 
 /** Consume a quote ref exactly once. */
 export type ConsumeQuoteRefFn = () => string | undefined;
+
+function deliverEventToReplyContext(
+  event: DeliverEventContext,
+  account: ResolvedQQBotAccount,
+  cfg: unknown,
+  log: DeliverAccountContext["log"],
+): ReplyContext {
+  return {
+    target: {
+      type: event.type,
+      senderId: event.senderId,
+      messageId: event.messageId,
+      channelId: event.channelId,
+      guildId: event.guildId,
+      groupOpenid: event.groupOpenid,
+    },
+    account,
+    cfg,
+    log,
+  };
+}
 
 function resolveQQBotMediaTargetContext(
   event: DeliverEventContext,
@@ -269,6 +293,7 @@ export interface PlainReplyPayload {
   text?: string;
   mediaUrls?: string[];
   mediaUrl?: string;
+  audioAsVoice?: boolean;
 }
 
 /**
@@ -368,6 +393,33 @@ export async function sendPlainReply(
     }
   }
 
+  let speechText = textWithoutImages;
+  for (const m of mdMatches) {
+    speechText = speechText.replace(m[0], "").trim();
+  }
+  for (const m of bareUrlMatches) {
+    speechText = speechText.replace(m[0], "").trim();
+  }
+  if (speechText && event.type !== "c2c") {
+    speechText = speechText.replace(/([a-zA-Z0-9])\.([a-zA-Z0-9])/g, "$1_$2");
+  }
+
+  let voiceHandled = false;
+  if (
+    payload.audioAsVoice === true &&
+    speechText.trim() &&
+    actx.cfg !== undefined &&
+    actx.cfg !== null
+  ) {
+    const replyCtx = deliverEventToReplyContext(event, account, actx.cfg, log);
+    voiceHandled = await synthesizeAndDeliverTtsVoice(replyCtx, speechText.trim());
+    if (voiceHandled) {
+      log?.info(
+        `${prefix} audioAsVoice: TTS voice delivered, suppressing duplicate speakable text`,
+      );
+    }
+  }
+
   if (useMarkdown) {
     await sendMarkdownReply(
       textWithoutImages,
@@ -378,6 +430,7 @@ export async function sendPlainReply(
       actx,
       sendWithRetry,
       consumeQuoteRef,
+      voiceHandled,
     );
   } else {
     await sendPlainTextReply(
@@ -389,6 +442,7 @@ export async function sendPlainReply(
       actx,
       sendWithRetry,
       consumeQuoteRef,
+      voiceHandled,
     );
   }
 
@@ -645,6 +699,7 @@ async function sendMarkdownReply(
   actx: DeliverAccountContext,
   sendWithRetry: SendWithRetryFn,
   consumeQuoteRef: ConsumeQuoteRefFn,
+  voiceHandled: boolean,
 ): Promise<void> {
   const { account, log } = actx;
   const prefix = `[qqbot:${account.accountId}]`;
@@ -752,21 +807,24 @@ async function sendMarkdownReply(
     result = result ? result + "\n\n" + imagesToAppend.join("\n") : imagesToAppend.join("\n");
   }
 
-  // Send markdown text.
+  // Send markdown text (skip speakable body when TTS already delivered, unless images remain in markdown).
   if (result.trim()) {
-    const mdChunks = chunkText(result, TEXT_CHUNK_LIMIT);
-    await sendQQBotTextChunksWithRetry({
-      account,
-      event,
-      chunks: mdChunks,
-      sendWithRetry,
-      consumeQuoteRef,
-      allowDm: true,
-      log,
-      onSuccess: (chunk) =>
-        `${prefix} Sent markdown chunk (${chunk.length}/${result.length} chars) with ${httpImageUrls.length} HTTP images (${event.type})`,
-      onError: (err) => `${prefix} Failed to send markdown message chunk: ${String(err)}`,
-    });
+    const skipSpeakableText = voiceHandled && !/!\[/.test(result);
+    if (!skipSpeakableText) {
+      const mdChunks = chunkText(result, TEXT_CHUNK_LIMIT);
+      await sendQQBotTextChunksWithRetry({
+        account,
+        event,
+        chunks: mdChunks,
+        sendWithRetry,
+        consumeQuoteRef,
+        allowDm: true,
+        log,
+        onSuccess: (chunk) =>
+          `${prefix} Sent markdown chunk (${chunk.length}/${result.length} chars) with ${httpImageUrls.length} HTTP images (${event.type})`,
+        onError: (err) => `${prefix} Failed to send markdown message chunk: ${String(err)}`,
+      });
+    }
   }
 }
 
@@ -780,6 +838,7 @@ async function sendPlainTextReply(
   actx: DeliverAccountContext,
   sendWithRetry: SendWithRetryFn,
   consumeQuoteRef: ConsumeQuoteRefFn,
+  voiceHandled: boolean,
 ): Promise<void> {
   const { account, log } = actx;
   const prefix = `[qqbot:${account.accountId}]`;
@@ -811,7 +870,7 @@ async function sendPlainTextReply(
       });
     }
 
-    if (result.trim()) {
+    if (result.trim() && !voiceHandled) {
       const plainChunks = chunkText(result, TEXT_CHUNK_LIMIT);
       await sendQQBotTextChunksWithRetry({
         account,

--- a/extensions/qqbot/src/reply-dispatcher.test.ts
+++ b/extensions/qqbot/src/reply-dispatcher.test.ts
@@ -19,7 +19,11 @@ const apiMocks = vi.hoisted(() => ({
 
 vi.mock("./api.js", () => apiMocks);
 
-import { handleStructuredPayload, type ReplyContext } from "./reply-dispatcher.js";
+import {
+  handleStructuredPayload,
+  synthesizeAndDeliverTtsVoice,
+  type ReplyContext,
+} from "./reply-dispatcher.js";
 
 function buildCtx(): ReplyContext {
   return {
@@ -43,6 +47,28 @@ function buildCtx(): ReplyContext {
 }
 
 describe("qqbot reply dispatcher", () => {
+  it("synthesizeAndDeliverTtsVoice returns false for incomplete group target without calling token API", async () => {
+    const ctx = buildCtx();
+    ctx.target = { type: "group", senderId: "u", messageId: "m" };
+    vi.clearAllMocks();
+
+    const out = await synthesizeAndDeliverTtsVoice(ctx, "hello");
+
+    expect(out).toBe(false);
+    expect(apiMocks.getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("synthesizeAndDeliverTtsVoice returns false for guild target without channelId", async () => {
+    const ctx = buildCtx();
+    ctx.target = { type: "guild", senderId: "u", messageId: "m" };
+    vi.clearAllMocks();
+
+    const out = await synthesizeAndDeliverTtsVoice(ctx, "hello");
+
+    expect(out).toBe(false);
+    expect(apiMocks.getAccessToken).not.toHaveBeenCalled();
+  });
+
   it("allows inline data image URLs for structured image payloads", async () => {
     const ctx = buildCtx();
     const recordActivity = vi.fn();

--- a/extensions/qqbot/src/reply-dispatcher.ts
+++ b/extensions/qqbot/src/reply-dispatcher.ts
@@ -63,6 +63,20 @@ export interface ReplyContext {
   };
 }
 
+/** True when `synthesizeAndDeliverTtsVoice` has a concrete QQ send route (mirrors dispatch branches). */
+function canDeliverSynthesizedTtsVoice(target: MessageTarget): boolean {
+  if (target.type === "c2c") {
+    return true;
+  }
+  if (target.type === "group") {
+    return Boolean(target.groupOpenid);
+  }
+  if (target.type === "dm") {
+    return Boolean(target.guildId);
+  }
+  return Boolean(target.channelId);
+}
+
 /** Send a message and retry once if the token appears to have expired. */
 export async function sendWithTokenRetry<T>(
   appId: string,
@@ -396,6 +410,13 @@ export async function synthesizeAndDeliverTtsVoice(
     return false;
   }
 
+  if (!canDeliverSynthesizedTtsVoice(target)) {
+    log?.error(
+      `[qqbot:${account.accountId}] TTS/voice skipped: incomplete delivery target (type=${target.type})`,
+    );
+    return false;
+  }
+
   try {
     let silkBase64: string | undefined;
     let silkPath: string | undefined;
@@ -459,10 +480,10 @@ export async function synthesizeAndDeliverTtsVoice(
       `[qqbot:${account.accountId}] TTS done (${providerLabel}): ${duration ? formatDuration(duration) : "N/A"}, file: ${silkPath ?? "N/A"}`,
     );
 
-    await sendWithTokenRetry(
+    const delivered = await sendWithTokenRetry(
       account.appId,
       account.clientSecret,
-      async (token) => {
+      async (token): Promise<boolean> => {
         if (target.type === "c2c") {
           await sendC2CVoiceMessage(
             account.appId,
@@ -474,7 +495,9 @@ export async function synthesizeAndDeliverTtsVoice(
             trimmed,
             silkPath,
           );
-        } else if (target.type === "group" && target.groupOpenid) {
+          return true;
+        }
+        if (target.type === "group" && target.groupOpenid) {
           await sendGroupVoiceMessage(
             account.appId,
             token,
@@ -483,21 +506,33 @@ export async function synthesizeAndDeliverTtsVoice(
             undefined,
             target.messageId,
           );
-        } else if (target.type === "dm" && target.guildId) {
+          return true;
+        }
+        if (target.type === "dm" && target.guildId) {
           log?.error(
             `[qqbot:${account.accountId}] Voice not supported in DM, sending text fallback`,
           );
           await sendDmMessage(token, target.guildId, trimmed, target.messageId);
-        } else if (target.channelId) {
+          return true;
+        }
+        if (target.channelId) {
           log?.error(
             `[qqbot:${account.accountId}] Voice not supported in channel, sending text fallback`,
           );
           await sendChannelMessage(token, target.channelId, trimmed, target.messageId);
+          return true;
         }
+        return false;
       },
       log,
       account.accountId,
     );
+    if (!delivered) {
+      log?.error(
+        `[qqbot:${account.accountId}] TTS/voice: no message dispatched (unexpected target shape)`,
+      );
+      return false;
+    }
     log?.info(`[qqbot:${account.accountId}] Voice message sent`);
     return true;
   } catch (err) {

--- a/extensions/qqbot/src/reply-dispatcher.ts
+++ b/extensions/qqbot/src/reply-dispatcher.ts
@@ -382,15 +382,21 @@ async function handleImagePayload(ctx: ReplyContext, payload: MediaPayload): Pro
   }
 }
 
-async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Promise<void> {
+/**
+ * Synthesize TTS for `ttsText` and send a QQ voice message (c2c/group) or text fallback (dm/channel).
+ * @returns true when a message was delivered (voice or fallback text), false otherwise.
+ */
+export async function synthesizeAndDeliverTtsVoice(
+  ctx: ReplyContext,
+  ttsText: string,
+): Promise<boolean> {
   const { target, account, cfg, log } = ctx;
-  try {
-    const ttsText = payload.caption || payload.path;
-    if (!ttsText?.trim()) {
-      log?.error(`[qqbot:${account.accountId}] Voice missing text`);
-      return;
-    }
+  const trimmed = ttsText.trim();
+  if (!trimmed) {
+    return false;
+  }
 
+  try {
     let silkBase64: string | undefined;
     let silkPath: string | undefined;
     let duration: number | undefined;
@@ -400,10 +406,10 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
     const ttsCfg = resolveTTSConfig(cfg as Record<string, unknown>);
     if (ttsCfg) {
       log?.info(
-        `[qqbot:${account.accountId}] TTS (plugin): "${ttsText.slice(0, 50)}..." via ${ttsCfg.model}`,
+        `[qqbot:${account.accountId}] TTS (plugin): "${trimmed.slice(0, 50)}..." via ${ttsCfg.model}`,
       );
       const ttsDir = getQQBotDataDir("tts");
-      const result = await textToSilk(ttsText, ttsCfg, ttsDir);
+      const result = await textToSilk(trimmed, ttsCfg, ttsDir);
       silkBase64 = result.silkBase64;
       silkPath = result.silkPath;
       duration = result.duration;
@@ -414,11 +420,11 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
         log?.error(
           `[qqbot:${account.accountId}] TTS not configured (neither plugin channels.qqbot.tts nor global messages.tts)`,
         );
-        return;
+        return false;
       }
-      log?.info(`[qqbot:${account.accountId}] TTS (global fallback): "${ttsText.slice(0, 50)}..."`);
+      log?.info(`[qqbot:${account.accountId}] TTS (global fallback): "${trimmed.slice(0, 50)}..."`);
       const globalResult = await getQQBotRuntime().tts.textToSpeech({
-        text: ttsText,
+        text: trimmed,
         cfg: cfg as OpenClawConfig,
         channel: "qqbot",
       });
@@ -426,7 +432,7 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
         log?.error(
           `[qqbot:${account.accountId}] Global TTS failed: ${globalResult.error ?? "unknown"}`,
         );
-        return;
+        return false;
       }
       log?.info(
         `[qqbot:${account.accountId}] Global TTS returned: provider=${globalResult.provider}, format=${globalResult.outputFormat}, path=${globalResult.audioPath}`,
@@ -437,7 +443,7 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
       const base64 = await audioFileToSilkBase64(globalResult.audioPath);
       if (!base64) {
         log?.error(`[qqbot:${account.accountId}] Failed to convert global TTS audio to SILK`);
-        return;
+        return false;
       }
       silkBase64 = base64;
       silkPath = globalResult.audioPath;
@@ -446,7 +452,7 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
 
     if (!silkBase64) {
       log?.error(`[qqbot:${account.accountId}] TTS produced no audio output`);
-      return;
+      return false;
     }
 
     log?.info(
@@ -465,7 +471,7 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
             silkBase64,
             undefined,
             target.messageId,
-            ttsText,
+            trimmed,
             silkPath,
           );
         } else if (target.type === "group" && target.groupOpenid) {
@@ -481,25 +487,37 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
           log?.error(
             `[qqbot:${account.accountId}] Voice not supported in DM, sending text fallback`,
           );
-          await sendDmMessage(token, target.guildId, ttsText, target.messageId);
+          await sendDmMessage(token, target.guildId, trimmed, target.messageId);
         } else if (target.channelId) {
           log?.error(
             `[qqbot:${account.accountId}] Voice not supported in channel, sending text fallback`,
           );
-          await sendChannelMessage(token, target.channelId, ttsText, target.messageId);
+          await sendChannelMessage(token, target.channelId, trimmed, target.messageId);
         }
       },
       log,
       account.accountId,
     );
     log?.info(`[qqbot:${account.accountId}] Voice message sent`);
+    return true;
   } catch (err) {
     log?.error(
       `[qqbot:${account.accountId}] TTS/voice send failed: ${
         err instanceof Error ? err.message : JSON.stringify(err)
       }`,
     );
+    return false;
   }
+}
+
+async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Promise<void> {
+  const { account, log } = ctx;
+  const ttsText = payload.caption || payload.path;
+  if (!ttsText?.trim()) {
+    log?.error(`[qqbot:${account.accountId}] Voice missing text`);
+    return;
+  }
+  await synthesizeAndDeliverTtsVoice(ctx, ttsText);
 }
 
 async function handleVideoPayload(ctx: ReplyContext, payload: MediaPayload): Promise<void> {


### PR DESCRIPTION
## Summary

- **Problem:** QQ Bot ignored `audioAsVoice` on normal (non-`QQBOT_PAYLOAD`) agent replies, so TTS never ran and `onMessageSent` saw `mediaType`/`ttsText` undefined even when the flag reached `deliver`.
- **Fix:** Run the same TTS + voice send path as structured audio payloads when `audioAsVoice` is set; pass gateway `cfg` into plain-reply delivery so TTS settings resolve. Extract `synthesizeAndDeliverTtsVoice` for reuse.
- **Scope:** QQ Bot plugin only (`extensions/qqbot`); changelog entry under Unreleased.

Fixes #62831

## Tests

```
pnpm test -- extensions/qqbot/src/outbound-deliver.test.ts extensions/qqbot/src/reply-dispatcher.test.ts
```

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (QQ Bot channel)

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same TTS paths as structured payload)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Compatibility

- Backward compatible: **Yes**
- Config/env changes: **No** (existing TTS config semantics unchanged)
