### PR TITLE
docs: clarify Bun install path in entry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want a personal, single-user assistant that feels local, fast, and always
 
 Preferred setup: run `openclaw onboard` in your terminal.
 OpenClaw Onboard guides you step by step through setting up the gateway, workspace, channels, and skills. It is the recommended CLI setup path and works on **macOS, Linux, and Windows (via WSL2; strongly recommended)**.
-Works with npm, pnpm, or bun.
+Works with npm, pnpm, or bun. For the Gateway runtime, Node remains the recommended daemon runtime.
 New install? Start here: [Getting started](https://docs.openclaw.ai/start/getting-started)
 
 ## Sponsors
@@ -103,6 +103,7 @@ Runtime: **Node 24 (recommended) or Node 22.16+**.
 ```bash
 npm install -g openclaw@latest
 # or: pnpm add -g openclaw@latest
+# or: bun add -g openclaw@latest
 
 openclaw onboard --install-daemon
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,9 +97,25 @@ The Gateway is the single source of truth for sessions, routing, and channel con
 
 <Steps>
   <Step title="Install OpenClaw">
-    ```bash
-    npm install -g openclaw@latest
-    ```
+    <Tabs>
+      <Tab title="npm">
+        ```bash
+        npm install -g openclaw@latest
+        ```
+      </Tab>
+      <Tab title="pnpm">
+        ```bash
+        pnpm add -g openclaw@latest
+        ```
+      </Tab>
+      <Tab title="bun">
+        ```bash
+        bun add -g openclaw@latest
+        ```
+      </Tab>
+    </Tabs>
+
+    For the Gateway runtime, Node remains the recommended daemon runtime.
   </Step>
   <Step title="Onboard and install the service">
     ```bash


### PR DESCRIPTION
## Summary
- add the Bun global install command to the README install snippet
- update the docs landing page quick start to show npm, pnpm, and Bun install options
- clarify that Node remains the recommended Gateway runtime

## Why
The main README and docs landing page were still presenting npm-only or incomplete install guidance, while the install docs already documented Bun support for the global CLI path. Aligning the entry docs removes that mismatch and makes the supported install paths easier to discover.

## Validation
- `git diff --check`
- `node scripts/docs-link-audit.mjs`