### PR TITLE
fix(agents): preserve plugin tools in subagent scopes

### DIFF
--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -49,6 +49,13 @@ export function buildDefaultToolPolicyPipelineSteps(params: {
   agentProviderPolicy?: ToolPolicyLike;
   groupPolicy?: ToolPolicyLike;
   agentId?: string;
+  /**
+   * When true, plugin-only tools are preserved in agent/group policy steps
+   * instead of being stripped. This allows subagent scopes to inherit
+   * plugin tools that were explicitly allowed in the parent agent's config.
+   * @see https://github.com/openclaw/openclaw/issues/50131
+   */
+  preservePluginTools?: boolean;
 }): ToolPolicyPipelineStep[] {
   const agentId = params.agentId?.trim();
   const profile = params.profile?.trim();
@@ -78,14 +85,18 @@ export function buildDefaultToolPolicyPipelineSteps(params: {
     {
       policy: params.agentPolicy,
       label: agentId ? `agents.${agentId}.tools.allow` : "agent tools.allow",
-      stripPluginOnlyAllowlist: true,
+      stripPluginOnlyAllowlist: !params.preservePluginTools,
     },
     {
       policy: params.agentProviderPolicy,
       label: agentId ? `agents.${agentId}.tools.byProvider.allow` : "agent tools.byProvider.allow",
-      stripPluginOnlyAllowlist: true,
+      stripPluginOnlyAllowlist: !params.preservePluginTools,
     },
-    { policy: params.groupPolicy, label: "group tools.allow", stripPluginOnlyAllowlist: true },
+    {
+      policy: params.groupPolicy,
+      label: "group tools.allow",
+      stripPluginOnlyAllowlist: !params.preservePluginTools,
+    },
   ];
 }
 

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -107,6 +107,10 @@ export function resolveGatewayScopedTools(params: {
         agentProviderPolicy,
         groupPolicy,
         agentId,
+        // Preserve plugin tools for subagent scopes so they can inherit
+        // tools explicitly allowed in the parent agent's config.
+        // See: https://github.com/openclaw/openclaw/issues/50131
+        preservePluginTools: isSubagentSessionKey(params.sessionKey),
       }),
       { policy: subagentPolicy, label: "subagent tools.allow" },
     ],


### PR DESCRIPTION
## Summary

- Adds `preservePluginTools` parameter to `buildDefaultToolPolicyPipelineSteps()`
- When resolving tools for subagent sessions, agent/group policy steps no longer strip plugin-only tools
- `resolveGatewayScopedTools()` passes `preservePluginTools: true` when `isSubagentSessionKey()` is true

## Problem

`buildDefaultToolPolicyPipelineSteps()` hardcodes `stripPluginOnlyAllowlist: true` for all 7 pipeline steps. When the pipeline runs for a subagent session, plugin tools are stripped in steps 1-7 before the subagent policy step (step 8) can include them. The subagent inherits an empty plugin tool set regardless of its config.

## Root Cause

The security change in v2026.3.11 was too aggressive — `stripPluginOnlyAllowlist` should be `false` for agent-specific and group policy steps when resolving tools for subagent scopes.

## Files Changed

- `src/agents/tool-policy-pipeline.ts` — new `preservePluginTools` param, conditional flag on agent/group steps
- `src/gateway/tool-resolution.ts` — passes `preservePluginTools: true` for subagent sessions

## Test plan

- [ ] Existing `tool-policy-pipeline.test.ts` tests pass
- [ ] Subagent sessions inherit plugin tools when parent config includes `group:plugins`
- [ ] Non-subagent sessions still strip plugin-only allowlists (no regression)

Fixes #50131

Created by Claude Code on behalf of @kvttvrsis