### PR TITLE
fix(outbound): retry hook runner resolution in delivery pipeline

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -650,7 +650,25 @@ async function deliverOutboundPayloadsCore(
     }
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, handler);
-  const hookRunner = getGlobalHookRunner();
+  // Resolve plugin hook runner for message_sending / message_sent hooks.
+  // getGlobalHookRunner() may return null during cold-start race conditions
+  // where delivery fires before plugins are fully loaded. Retry once after
+  // yielding to the event loop to allow pending plugin initialization to
+  // complete.
+  // See: https://github.com/openclaw/openclaw/issues/32621
+  let hookRunner = getGlobalHookRunner();
+  if (!hookRunner) {
+    // Yield to allow any pending plugin initialization to settle
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    hookRunner = getGlobalHookRunner();
+    if (!hookRunner) {
+      log.warn(
+        "deliverOutboundPayloadsCore: global hook runner is null after retry — " +
+          "plugin message_sending/message_sent hooks will be skipped",
+        { channel, to },
+      );
+    }
+  }
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;


### PR DESCRIPTION
## Summary

- Adds a single retry with event loop yield when `getGlobalHookRunner()` returns null in `deliverOutboundPayloadsCore()`
- Logs a warning when hook runner remains null after retry for production visibility

## Problem

`deliverOutboundPayloadsCore()` calls `getGlobalHookRunner()` to resolve the plugin hook runner for `message_sending` and `message_sent` hooks. During cold-start race conditions — when delivery fires before plugins are fully loaded — the hook runner is null, silently disabling all plugin message hooks for that delivery.

This affects all channels (Slack, Discord, WhatsApp, etc.) when the first message arrives before plugin initialization completes.

## Root Cause

`initializeGlobalHookRunner()` is called in `activatePluginRegistry()` during gateway startup. If an inbound message triggers delivery before this completes, `getGlobalHookRunner()` returns null and `hasMessageSendingHooks` evaluates to false.

## Fix

After getting null from `getGlobalHookRunner()`, yield to the event loop with `setTimeout(0)` to allow any pending plugin initialization to settle, then retry once. If still null, log a warning and proceed without hooks (current behavior, but now visible in logs).

## Files Changed

- `src/infra/outbound/deliver.ts` — retry logic + warning log

## Test plan

- [ ] Existing `deliver.test.ts` tests pass
- [ ] Plugin message_sending hooks fire for first message after cold start
- [ ] Warning appears in logs when hook runner is genuinely unavailable

Fixes #32621

Created by Claude Code on behalf of @kvttvrsis