### PR TITLE
fix(heartbeat): stabilize isolated session keys and transcript paths ( #62869)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Heartbeat: avoid nested `:heartbeat` session keys when targeted wakes reuse an isolated heartbeat session, and clear inherited `sessionFile` on cron-style session rollover so new session ids resolve fresh transcript paths. (#62869)
+
 ## 2026.4.7
 
 ### Changes

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -201,6 +201,22 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.modelOverride).toBe("gpt-5.4");
     });
 
+    it("clears sessionFile when forceNew is true so new sessionId gets a fresh transcript path (#62869)", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-file",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          sessionFile: "/tmp/agents/main/sessions/prior-id.jsonl",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
     it("clears delivery routing metadata when session is stale", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -83,6 +83,9 @@ export function resolveCronSession(params: {
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      // New sessionId must resolve a fresh transcript path; inherited sessionFile
+      // would keep appending to the previous file (isolated heartbeat, forceNew).
+      sessionFile: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -243,6 +243,46 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     });
   });
 
+  it("keeps a single trailing :heartbeat in the forced session key when it is not a duplicate isolated suffix", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const mainKey = resolveMainSessionKey(cfg);
+      const customKeyWithHeartbeatSegment = `${mainKey}:customlane:heartbeat`;
+      await seedSession(customKeyWithHeartbeatSegment, {
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+      });
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: customKeyWithHeartbeatSegment,
+        reason: "cron:test",
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(customKeyWithHeartbeatSegment);
+    });
+  });
+
   it("uses main session key when isolatedSession is not set", async () => {
     await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
       const cfg: OpenClawConfig = {

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -171,6 +171,78 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     });
   });
 
+  it("does not nest :heartbeat when targeted wake passes an isolated session key (#62869)", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: `${sessionKey}:heartbeat`,
+        reason: "cron:test",
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(`${sessionKey}:heartbeat`);
+    });
+  });
+
+  it("normalizes multiply nested :heartbeat suffixes for isolated heartbeats (#62869)", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: `${sessionKey}:heartbeat:heartbeat`,
+        reason: "cron:test",
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(`${sessionKey}:heartbeat`);
+    });
+  });
+
   it("uses main session key when isolatedSession is not set", async () => {
     await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
       const cfg: OpenClawConfig = {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -184,13 +184,26 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatC
 
 const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
 
-/** Strip trailing isolated-heartbeat suffixes so targeted wakes never nest `…:heartbeat:heartbeat`. */
-function stripHeartbeatIsolatedSessionSuffixes(sessionKey: string): string {
+/**
+ * Collapse only *repeated* isolated suffixes (`…:heartbeat:heartbeat` → `…:heartbeat`).
+ * Does not strip a single trailing `:heartbeat`, so keys like `agent:main:foo:heartbeat`
+ * stay intact for preflight and lane checks (#62869).
+ */
+function collapseRedundantIsolatedHeartbeatSuffixes(sessionKey: string): string {
   let key = sessionKey;
-  while (key.endsWith(HEARTBEAT_ISOLATED_SESSION_SUFFIX)) {
+  const doubleSuffix = HEARTBEAT_ISOLATED_SESSION_SUFFIX + HEARTBEAT_ISOLATED_SESSION_SUFFIX;
+  while (key.endsWith(doubleSuffix)) {
     key = key.slice(0, -HEARTBEAT_ISOLATED_SESSION_SUFFIX.length);
   }
   return key;
+}
+
+/** Resolve the store key for an isolated heartbeat run without nesting `…:heartbeat:heartbeat`. */
+function resolveIsolatedHeartbeatRunSessionKey(sessionKey: string): string {
+  const collapsed = collapseRedundantIsolatedHeartbeatSuffixes(sessionKey);
+  return collapsed.endsWith(HEARTBEAT_ISOLATED_SESSION_SUFFIX)
+    ? collapsed
+    : `${collapsed}${HEARTBEAT_ISOLATED_SESSION_SUFFIX}`;
 }
 
 function resolveHeartbeatSession(
@@ -630,24 +643,17 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "requests-in-flight" };
   }
 
-  // Targeted wakes may pass a key that already ends with `:heartbeat` (or nested
-  // suffixes). When isolatedSession is on, normalize before preflight so
-  // peekSystemEventEntries, the session-lane busy check, and the isolated store
-  // key all use the same base session key (#62869).
-  const trimmedForcedSessionKey = opts.sessionKey?.trim();
-  const forcedSessionKeyForPreflight =
-    heartbeat?.isolatedSession === true
-      ? trimmedForcedSessionKey
-        ? stripHeartbeatIsolatedSessionSuffixes(trimmedForcedSessionKey)
-        : undefined
-      : opts.sessionKey;
+  // Preflight must use the same forced session key the run will use for pending-event
+  // inspection and session-lane busy checks. Isolated runs append (or reuse) `…:heartbeat`
+  // later via resolveIsolatedHeartbeatRunSessionKey — do not strip `:heartbeat` here, or
+  // legitimate keys like `agent:main:foo:heartbeat` would preflight under the wrong lane.
 
   // Preflight centralizes trigger classification, event inspection, and HEARTBEAT.md gating.
   const preflight = await resolveHeartbeatPreflight({
     cfg,
     agentId,
     heartbeat,
-    forcedSessionKey: forcedSessionKeyForPreflight,
+    forcedSessionKey: opts.sessionKey,
     reason: opts.reason,
   });
   if (preflight.skipReason) {
@@ -660,10 +666,17 @@ export async function runHeartbeatOnce(opts: {
   }
   const { entry, sessionKey, storePath, suppressOriginatingContext } = preflight.session;
 
+  const useIsolatedSession = heartbeat?.isolatedSession === true;
+  // Busy check must use the same lane as the eventual run. Isolated heartbeats
+  // execute on `…:heartbeat` (or an existing trailing `:heartbeat`), not the base key.
+  const sessionKeyForLane = useIsolatedSession
+    ? resolveIsolatedHeartbeatRunSessionKey(sessionKey)
+    : sessionKey;
+
   // Check the resolved session lane — if it is busy, skip to avoid interrupting
   // an active streaming turn.  The wake-layer retry (heartbeat-wake.ts) will
   // re-schedule this wake automatically.  See #14396 (closed without merge).
-  const sessionLaneKey = resolveEmbeddedSessionLane(sessionKey);
+  const sessionLaneKey = resolveEmbeddedSessionLane(sessionKeyForLane);
   const sessionLaneSize = (opts.deps?.getQueueSize ?? getQueueSize)(sessionLaneKey);
   if (sessionLaneSize > 0) {
     emitHeartbeatEvent({
@@ -681,15 +694,15 @@ export async function runHeartbeatOnce(opts: {
   // a new session ID (empty transcript) each run, avoiding the cost of
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing still uses the main session entry (lastChannel, lastTo).
-  const useIsolatedSession = heartbeat?.isolatedSession === true;
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,
     heartbeat,
     // Isolated runs avoid base-session turnSource routing so delivery does not
     // stick to stale channels while base-session event context remains queued.
-    // Pending system events are still resolved during preflight on the normalized
-    // store session key (same key used for the session-lane busy check).
+    // Pending system events are resolved during preflight on the resolved store
+    // session key; the session-lane busy check uses sessionKeyForLane (isolated
+    // run target when isolatedSession is on).
     turnSource: useIsolatedSession ? undefined : preflight.turnSourceDeliveryContext,
   });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
@@ -740,7 +753,7 @@ export async function runHeartbeatOnce(opts: {
 
   let runSessionKey = sessionKey;
   if (useIsolatedSession) {
-    const isolatedKey = `${sessionKey}:heartbeat`;
+    const isolatedKey = resolveIsolatedHeartbeatRunSessionKey(sessionKey);
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedKey,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -182,6 +182,17 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatC
   );
 }
 
+const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
+
+/** Strip trailing isolated-heartbeat suffixes so targeted wakes never nest `…:heartbeat:heartbeat`. */
+function stripHeartbeatIsolatedSessionSuffixes(sessionKey: string): string {
+  let key = sessionKey;
+  while (key.endsWith(HEARTBEAT_ISOLATED_SESSION_SUFFIX)) {
+    key = key.slice(0, -HEARTBEAT_ISOLATED_SESSION_SUFFIX.length);
+  }
+  return key;
+}
+
 function resolveHeartbeatSession(
   cfg: OpenClawConfig,
   agentId?: string,
@@ -717,7 +728,8 @@ export async function runHeartbeatOnce(opts: {
 
   let runSessionKey = sessionKey;
   if (useIsolatedSession) {
-    const isolatedKey = `${sessionKey}:heartbeat`;
+    const baseSessionKey = stripHeartbeatIsolatedSessionSuffixes(sessionKey);
+    const isolatedKey = `${baseSessionKey}:heartbeat`;
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedKey,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -630,12 +630,24 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "requests-in-flight" };
   }
 
+  // Targeted wakes may pass a key that already ends with `:heartbeat` (or nested
+  // suffixes). When isolatedSession is on, normalize before preflight so
+  // peekSystemEventEntries, the session-lane busy check, and the isolated store
+  // key all use the same base session key (#62869).
+  const trimmedForcedSessionKey = opts.sessionKey?.trim();
+  const forcedSessionKeyForPreflight =
+    heartbeat?.isolatedSession === true
+      ? trimmedForcedSessionKey
+        ? stripHeartbeatIsolatedSessionSuffixes(trimmedForcedSessionKey)
+        : undefined
+      : opts.sessionKey;
+
   // Preflight centralizes trigger classification, event inspection, and HEARTBEAT.md gating.
   const preflight = await resolveHeartbeatPreflight({
     cfg,
     agentId,
     heartbeat,
-    forcedSessionKey: opts.sessionKey,
+    forcedSessionKey: forcedSessionKeyForPreflight,
     reason: opts.reason,
   });
   if (preflight.skipReason) {
@@ -674,10 +686,10 @@ export async function runHeartbeatOnce(opts: {
     cfg,
     entry,
     heartbeat,
-    // Isolated heartbeat runs drain system events from their dedicated
-    // `:heartbeat` session, not from the base session we peek during preflight.
-    // Reusing base-session turnSource routing here can pin later isolated runs
-    // to stale channels/threads because that base-session event context remains queued.
+    // Isolated runs avoid base-session turnSource routing so delivery does not
+    // stick to stale channels while base-session event context remains queued.
+    // Pending system events are still resolved during preflight on the normalized
+    // store session key (same key used for the session-lane busy check).
     turnSource: useIsolatedSession ? undefined : preflight.turnSourceDeliveryContext,
   });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
@@ -728,8 +740,7 @@ export async function runHeartbeatOnce(opts: {
 
   let runSessionKey = sessionKey;
   if (useIsolatedSession) {
-    const baseSessionKey = stripHeartbeatIsolatedSessionSuffixes(sessionKey);
-    const isolatedKey = `${baseSessionKey}:heartbeat`;
+    const isolatedKey = `${sessionKey}:heartbeat`;
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedKey,


### PR DESCRIPTION
## Summary

- Problem: With `heartbeat.isolatedSession`, targeted wakes could pass a session key that already ended in `:heartbeat`, producing nested keys like `…:heartbeat:heartbeat` and deepening session lanes. Separately, `resolveCronSession` reused `sessionFile` from the previous entry when rolling to a new `sessionId`, so isolated heartbeat runs could keep appending to the same transcript file.
- Why it matters: Nested keys amplify failures (timeouts/retries) and inflate monitoring noise; shared transcript paths defeat the purpose of per-run isolated sessions and grow disk/token usage.
- What changed: Strip trailing `:heartbeat` segments before constructing the isolated heartbeat store key; clear `sessionFile` when creating a new session entry in `resolveCronSession`.
- What did NOT change: Subagent routing guards, append-only transcript policy, and non-isolated heartbeat behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #62869

## User-visible / Behavior Changes

- Isolated heartbeat runs normalize away erroneous trailing `:heartbeat` suffixes on the resolved session key before appending a single `:heartbeat` segment.
- New cron-style session rollovers no longer inherit a prior `sessionFile`, so transcript paths align with the new `sessionId`.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux
- Relevant config (redacted): `heartbeat.isolatedSession: true`, periodic heartbeat enabled.

### Steps

1. Enable isolated heartbeat and trigger targeted heartbeat wakes that pass `sessionKey` already suffixed with `:heartbeat` (e.g. exec/cron-scoped wakes mirroring the active isolated session).
2. Observe `SessionKey` / lane keys stay a single `:heartbeat` suffix, not nested.
3. Run `resolveCronSession` with `forceNew: true` and an existing entry carrying `sessionFile`; confirm `sessionFile` is cleared on the new entry.

### Expected

- Stable isolated key `…:heartbeat` without compounding suffixes.
- New session ids resolve transcript paths without reusing the previous file when rolling over.

### Actual (before)

- Nested `…:heartbeat:heartbeat:…` under failure/retry loops.
- Transcript growth on a single file despite new `sessionId`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Ran: `pnpm test -- src/infra/heartbeat-runner.model-override.test.ts src/cron/isolated-agent/session.test.ts`
- Local `pnpm check` via `scripts/committer` hook on commit.


## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- Revert the commit; no config toggle required.

## Risks and Mitigations

- **Risk:** A hypothetical session whose canonical `rest` segment legitimately ends with multiple `:heartbeat` tokens could be normalized. **Mitigation:** Only the dedicated isolated-heartbeat suffix chain is stripped; normal agent session keys are unchanged.