### PR TITLE
fix(outbound): route media sends to sendMedia instead of sendText

### DIFF
--- a/src/cli/send-runtime/channel-outbound-send.ts
+++ b/src/cli/send-runtime/channel-outbound-send.ts
@@ -26,12 +26,11 @@ export function createChannelOutboundRuntimeSend(params: {
       if (!outbound?.sendText) {
         throw new Error(params.unavailableMessage);
       }
-      return await outbound.sendText({
-        cfg: opts.cfg ?? loadConfig(),
+      const cfg = opts.cfg ?? loadConfig();
+      const sharedCtx = {
+        cfg,
         to,
         text,
-        mediaUrl: opts.mediaUrl,
-        mediaLocalRoots: opts.mediaLocalRoots,
         accountId: opts.accountId,
         threadId: opts.messageThreadId,
         replyToId:
@@ -42,7 +41,15 @@ export function createChannelOutboundRuntimeSend(params: {
         forceDocument: opts.forceDocument,
         gifPlayback: opts.gifPlayback,
         gatewayClientScopes: opts.gatewayClientScopes,
-      });
+      };
+      if (opts.mediaUrl && outbound.sendMedia) {
+        return await outbound.sendMedia({
+          ...sharedCtx,
+          mediaUrl: opts.mediaUrl,
+          mediaLocalRoots: opts.mediaLocalRoots,
+        });
+      }
+      return await outbound.sendText(sharedCtx);
     },
   };
 }


### PR DESCRIPTION
## Summary
- `channel-outbound-send.ts` always called `outbound.sendText()` even when `mediaUrl` was present, silently dropping all media attachments (images, PDFs, documents)
- When `opts.mediaUrl` is set and the adapter implements `sendMedia`, now calls `sendMedia` instead

## Test plan
- [ ] `openclaw message send --media <image-url> --message "test"` delivers image as attachment (not text-only)
- [ ] `openclaw message send --media <pdf-url> --message "test"` delivers PDF as document attachment
- [ ] `openclaw message send --message "text only"` still works (no media path)
- [ ] Agent `message` tool with `media` parameter sends attachment via WhatsApp

Fixes #62884

🤖 Generated with [Claude Code](https://claude.com/claude-code)