### PR TITLE
fix(memory): preserve config context in status --deep

### DIFF
--- a/src/agents/memory-search.plugin-provider.test.ts
+++ b/src/agents/memory-search.plugin-provider.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { MemoryEmbeddingProviderAdapter } from "../plugins/memory-embedding-providers.js";
+
+const mocks = vi.hoisted(() => ({
+  getMemoryEmbeddingProvider:
+    vi.fn<(id: string, cfg?: OpenClawConfig) => MemoryEmbeddingProviderAdapter | undefined>(),
+}));
+
+vi.mock("../plugins/memory-embedding-provider-runtime.js", () => ({
+  getMemoryEmbeddingProvider: mocks.getMemoryEmbeddingProvider,
+}));
+
+let resolveMemorySearchConfig: typeof import("./memory-search.js").resolveMemorySearchConfig;
+
+function createAdapter(id: string): MemoryEmbeddingProviderAdapter {
+  return {
+    id,
+    transport: "remote",
+    defaultModel: `${id}-default`,
+    create: async () => ({ provider: null }),
+  };
+}
+
+describe("memory search config plugin capability providers", () => {
+  beforeAll(async () => {
+    ({ resolveMemorySearchConfig } = await import("./memory-search.js"));
+  });
+
+  beforeEach(() => {
+    mocks.getMemoryEmbeddingProvider.mockReset();
+    mocks.getMemoryEmbeddingProvider.mockImplementation((id) => createAdapter(id));
+  });
+
+  it("passes cfg into provider and fallback lookups", () => {
+    const cfg = {
+      plugins: {
+        allow: ["memory-fallback", "memory-lancedb-pro"],
+      },
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "memory-lancedb-pro",
+            fallback: "memory-fallback",
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+
+    expect(resolved?.model).toBe("memory-lancedb-pro-default");
+    expect(mocks.getMemoryEmbeddingProvider).toHaveBeenCalledTimes(3);
+    expect(mocks.getMemoryEmbeddingProvider).toHaveBeenNthCalledWith(1, "memory-lancedb-pro", cfg);
+    expect(mocks.getMemoryEmbeddingProvider).toHaveBeenNthCalledWith(2, "memory-fallback", cfg);
+    expect(mocks.getMemoryEmbeddingProvider).toHaveBeenNthCalledWith(3, "memory-lancedb-pro", cfg);
+  });
+});

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -143,6 +143,7 @@ function resolveStorePath(agentId: string, raw?: string): string {
 }
 
 function mergeConfig(
+  cfg: OpenClawConfig,
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
@@ -151,12 +152,13 @@ function mergeConfig(
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
-  const primaryAdapter = provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider);
+  const primaryAdapter =
+    provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider, cfg);
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
   const fallback = overrides?.fallback ?? defaults?.fallback ?? "none";
   const fallbackAdapter =
-    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback) : undefined;
+    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback, cfg) : undefined;
   const hasRemoteConfig = Boolean(
     overrideRemote?.baseUrl ||
     overrideRemote?.apiKey ||
@@ -382,13 +384,13 @@ export function resolveMemorySearchConfig(
 ): ResolvedMemorySearchConfig | null {
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
-  const resolved = mergeConfig(defaults, overrides, agentId);
+  const resolved = mergeConfig(cfg, defaults, overrides, agentId);
   if (!resolved.enabled) {
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
-    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
+    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider, cfg);
   const builtinMultimodalSupport =
     resolved.provider === "auto"
       ? false

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -3,6 +3,7 @@ import type { HealthSummary } from "./health.js";
 import {
   buildStatusFooterLines,
   buildStatusHealthRows,
+  buildStatusMemoryValue,
   buildStatusPairingRecoveryLines,
   buildStatusPluginCompatibilityLines,
   buildStatusSecurityAuditLines,
@@ -135,6 +136,29 @@ describe("status.command-sections", () => {
       { Item: "Matrix", Status: "ok(LINKED)", Detail: "linked" },
       { Item: "Signal", Status: "warn(UNLINKED)", Detail: "not linked" },
     ]);
+  });
+
+  it("omits undefined memory file and chunk counts", () => {
+    const value = buildStatusMemoryValue({
+      memory: {
+        agentId: "main",
+        backend: "builtin",
+        provider: "memory-lancedb-pro",
+        vector: { enabled: true, available: true },
+        fts: { enabled: true, available: true },
+      },
+      memoryPlugin: { enabled: true, slot: "memory-lancedb-pro" },
+      ok: (value) => `ok(${value})`,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+      resolveMemoryVectorState: () => ({ state: "ready", tone: "ok" }),
+      resolveMemoryFtsState: () => ({ state: "ready", tone: "ok" }),
+      resolveMemoryCacheSummary: () => ({ text: "cache warm", tone: "muted" }),
+    });
+
+    expect(value).toBe(
+      ["plugin memory-lancedb-pro", "ok(vector ready)", "ok(fts ready)"].join(" · "),
+    );
   });
 
   it("builds footer lines from update and reachability state", () => {

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -143,8 +143,19 @@ export function buildStatusMemoryValue(params: {
     return params.muted(`enabled (${slot}) · unavailable`);
   }
   const parts: string[] = [];
-  const dirtySuffix = params.memory.dirty ? ` · ${params.warn("dirty")}` : "";
-  parts.push(`${params.memory.files} files · ${params.memory.chunks} chunks${dirtySuffix}`);
+  if (
+    typeof params.memory.files !== "number" ||
+    !Number.isFinite(params.memory.files) ||
+    typeof params.memory.chunks !== "number" ||
+    !Number.isFinite(params.memory.chunks)
+  ) {
+    if (params.memory.dirty) {
+      parts.push(params.warn("dirty"));
+    }
+  } else {
+    const dirtySuffix = params.memory.dirty ? ` · ${params.warn("dirty")}` : "";
+    parts.push(`${params.memory.files} files · ${params.memory.chunks} chunks${dirtySuffix}`);
+  }
   if (params.memory.sources?.length) {
     parts.push(`sources ${params.memory.sources.join(", ")}`);
   }


### PR DESCRIPTION
﻿## Summary

- Problem: `openclaw status --deep` could resolve plugin-backed memory embedding providers without the active config context, which can surface false `invalid config` / `failed to initialize` diagnostics for healthy memory plugins.
- Why it matters: operators debugging memory plugins get a misleading failure signal even when the plugin is loaded and the memory backend is healthy.
- What changed: thread `cfg` through the memory embedding provider lookups used by `resolveMemorySearchConfig`, and only render `files/chunks` in status output when both counts are actually present.
- What did NOT change (scope boundary): no plugin manifest changes, no memory plugin runtime behavior changes outside this config/status path, and no broader status formatting refactor.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62855
- Related #62855
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveMemorySearchConfig()` called `getMemoryEmbeddingProvider(...)` without passing `cfg` in both the merge path and the later provider capability lookup, so plugin capability fallback could resolve against the wrong config context during `status --deep`.
- Missing detection / guardrail: there was no regression test asserting that plugin-backed memory provider resolution keeps the caller config context, and no status-format test for plugin-backed memory snapshots that omit `files/chunks`.
- Contributing context (if known): plugin-backed memory status objects can legitimately omit count fields, but the command formatter assumed those counts were always present.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/memory-search.plugin-provider.test.ts`, `src/commands/status.command-sections.test.ts`
- Scenario the test should lock in: provider and fallback lookups keep the active `cfg`, and status output stays clean when plugin-backed memory status omits `files/chunks`.
- Why this is the smallest reliable guardrail: the bug lives in pure config/status logic, so direct unit coverage catches the exact regression without needing a full plugin runtime.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw status --deep` no longer loses config context when resolving plugin-backed memory embedding providers.
- Plugin-backed memory status output no longer prints `undefined files · undefined chunks` when those counts are absent.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 10 host for local verification; reported issue on OpenClaw `2026.4.5`
- Runtime/container: local worktree
- Model/provider: plugin-backed memory embedding provider path
- Integration/channel (if any): `openclaw status --deep`
- Relevant config (redacted): memory plugin in `plugins.slots.memory`, plugin-backed embedding provider under `agents.*.memorySearch`

### Steps

1. Configure a plugin-backed memory provider and run `openclaw status --deep`.
2. Trigger the memory status scan when the provider must resolve through the plugin capability fallback path.
3. Observe the memory section and plugin diagnostics.

### Expected

- Healthy memory plugins should stay healthy in diagnostics.
- Status output should omit file/chunk counts when they are unavailable.

### Actual

- A healthy plugin could show false `invalid config` / `failed to initialize` diagnostics.
- Status output could show `undefined files · undefined chunks`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran targeted tests for config-context forwarding and missing-count status rendering.
- Edge cases checked: provider + fallback lookups both receive the same config; dirty/plugin/vector/fts segments still render when counts are absent.
- What you did **not** verify: I did not run a full end-to-end `memory-lancedb-pro` environment locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: threading `cfg` into plugin-backed provider lookup could change fallback resolution for callers that were accidentally relying on missing config context.
  - Mitigation: added a focused regression test that locks the intended provider + fallback lookup behavior.
- Risk: status output could accidentally hide useful information when counts are absent.
  - Mitigation: the formatter still shows dirty/plugin/vector/fts/cache segments, and the new test locks that behavior.
