### PR TITLE
fix(cli): route to sendMedia when mediaUrl is present in CLI runtime send

### DIFF
--- a/src/cli/send-runtime/channel-outbound-send.test.ts
+++ b/src/cli/send-runtime/channel-outbound-send.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChannelOutboundRuntimeSend } from "./channel-outbound-send.js";
+
+const mockSendText = vi.fn(async () => ({ messageId: "mid1" }));
+const mockSendMedia = vi.fn(async () => ({ messageId: "mid2" }));
+
+vi.mock("../../channels/plugins/outbound/load.js", () => ({
+  loadChannelOutboundAdapter: vi.fn(async (channelId: string) => {
+    if (channelId === "telegram") {
+      return {
+        sendText: mockSendText,
+        sendMedia: mockSendMedia,
+      };
+    }
+    if (channelId === "whatsapp") {
+      return {
+        sendText: mockSendText,
+        // whatsapp has no sendMedia — should fall back to sendText
+      };
+    }
+    return undefined;
+  }),
+}));
+
+describe("createChannelOutboundRuntimeSend", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls sendText when no mediaUrl is provided", async () => {
+    const runtime = createChannelOutboundRuntimeSend({
+      channelId: "telegram",
+      unavailableMessage: "telegram unavailable",
+    });
+    await runtime.sendMessage("chat123", "hello world");
+    expect(mockSendText).toHaveBeenCalledOnce();
+    expect(mockSendText).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "chat123", text: "hello world" }),
+    );
+    expect(mockSendMedia).not.toHaveBeenCalled();
+  });
+
+  it("calls sendMedia when mediaUrl is provided and sendMedia exists", async () => {
+    const runtime = createChannelOutboundRuntimeSend({
+      channelId: "telegram",
+      unavailableMessage: "telegram unavailable",
+    });
+    await runtime.sendMessage("chat123", "hello world", {
+      mediaUrl: "https://example.com/image.png",
+    });
+    expect(mockSendMedia).toHaveBeenCalledOnce();
+    expect(mockSendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat123",
+        text: "hello world",
+        mediaUrl: "https://example.com/image.png",
+      }),
+    );
+    expect(mockSendText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to sendText with mediaUrl preserved when sendMedia does not exist", async () => {
+    const runtime = createChannelOutboundRuntimeSend({
+      channelId: "whatsapp",
+      unavailableMessage: "whatsapp unavailable",
+    });
+    await runtime.sendMessage("chat456", "hello", {
+      mediaUrl: "https://example.com/doc.pdf",
+    });
+    expect(mockSendText).toHaveBeenCalledOnce();
+    // mediaUrl is still forwarded in the fallback so adapters that handle it
+    // inside sendText (even if non-standard) continue to receive it
+    expect(mockSendText).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "chat456", text: "hello", mediaUrl: "https://example.com/doc.pdf" }),
+    );
+  });
+});

--- a/src/cli/send-runtime/channel-outbound-send.ts
+++ b/src/cli/send-runtime/channel-outbound-send.ts
@@ -26,11 +26,10 @@ export function createChannelOutboundRuntimeSend(params: {
       if (!outbound?.sendText) {
         throw new Error(params.unavailableMessage);
       }
-      return await outbound.sendText({
+      const sharedCtx = {
         cfg: opts.cfg ?? loadConfig(),
         to,
         text,
-        mediaUrl: opts.mediaUrl,
         mediaLocalRoots: opts.mediaLocalRoots,
         accountId: opts.accountId,
         threadId: opts.messageThreadId,
@@ -42,7 +41,11 @@ export function createChannelOutboundRuntimeSend(params: {
         forceDocument: opts.forceDocument,
         gifPlayback: opts.gifPlayback,
         gatewayClientScopes: opts.gatewayClientScopes,
-      });
+      };
+      if (opts.mediaUrl && outbound.sendMedia) {
+        return await outbound.sendMedia({ ...sharedCtx, mediaUrl: opts.mediaUrl });
+      }
+      return await outbound.sendText({ ...sharedCtx, mediaUrl: opts.mediaUrl });
     },
   };
 }


### PR DESCRIPTION
## Summary
Fixes #62884 — Media attachments (images, PDFs, documents) sent via the CLI `message send --media` or the agent `message` tool with `media` parameter were silently dropped as text-only.

## Root cause
`channel-outbound-send.ts` always called `sendText()`, whose adapters ignore the `mediaUrl` field. Only `sendMedia` handles attachments.

The CLI runtime path through `createChannelOutboundRuntimeSend` was passing `mediaUrl` to `sendText`, which discarded it.

## Changes
- Extract shared context into `sharedCtx` (cfg, to, text, accountId, threadId, replyToId, silent, forceDocument, gifPlayback, gatewayClientScopes)
- When `opts.mediaUrl` is set AND the adapter implements `sendMedia`, call `sendMedia` instead
- Fall back to `sendText` otherwise (preserves behavior for channels without a `sendMedia` implementation)

## Testing
`pnpm test:cli` (vitest.cli.config.ts): 3 passing tests
- `calls sendText when no mediaUrl is provided`
- `calls sendMedia when mediaUrl is provided and sendMedia exists`
- `falls back to sendText when mediaUrl is set but sendMedia does not exist`