### PR TITLE
fix(agents): prevent cross-provider error context leak in fallback chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - Auto-reply/WhatsApp: preserve inbound image attachment notes after media understanding so image edits keep the real saved media path instead of hallucinating a missing local path. (#64918) Thanks @ngutman.
 - Telegram/sessions: keep topic-scoped session initialization on the canonical topic transcript path when inbound turns omit `MessageThreadId`, so one topic session no longer alternates between bare and topic-qualified transcript files. (#64869) thanks @jalehman.
+- Agents/failover: scope assistant-side fallback classification and surfaced provider errors to the current attempt instead of stale session history, so cross-provider fallback runs stop inheriting the previous provider's failure. (#62907) Thanks @stainlu.
 
 ## 2026.4.11-beta.1
 

--- a/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
+++ b/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
@@ -41,6 +41,7 @@ describe("runEmbeddedPiAgent Codex server_error fallback handoff", () => {
       provider: "openai-codex",
       model: "gpt-5.4",
     });
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],

--- a/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
+++ b/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
@@ -35,15 +35,17 @@ describe("runEmbeddedPiAgent Codex server_error fallback handoff", () => {
     mockedFormatAssistantErrorText.mockReturnValue(
       "LLM error server_error: An error occurred while processing your request.",
     );
+    const currentAttemptAssistant = {
+      stopReason: "error",
+      errorMessage: rawCodexError,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"];
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          stopReason: "error",
-          errorMessage: rawCodexError,
-          provider: "openai-codex",
-          model: "gpt-5.4",
-        } as EmbeddedRunAttemptResult["lastAssistant"],
+        lastAssistant: currentAttemptAssistant,
+        currentAttemptAssistant,
       }),
     );
 

--- a/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
+++ b/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -12,7 +13,6 @@ import {
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
-import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 
@@ -35,12 +35,12 @@ describe("runEmbeddedPiAgent Codex server_error fallback handoff", () => {
     mockedFormatAssistantErrorText.mockReturnValue(
       "LLM error server_error: An error occurred while processing your request.",
     );
-    const currentAttemptAssistant = {
+    const currentAttemptAssistant = makeAssistantMessageFixture({
       stopReason: "error",
       errorMessage: rawCodexError,
       provider: "openai-codex",
       model: "gpt-5.4",
-    } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"];
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],

--- a/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
+++ b/src/agents/pi-embedded-runner/run.codex-server-error-fallback.test.ts
@@ -41,7 +41,6 @@ describe("runEmbeddedPiAgent Codex server_error fallback handoff", () => {
       provider: "openai-codex",
       model: "gpt-5.4",
     });
-    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -76,5 +76,25 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
 
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
     await expect(promise).rejects.toThrow("deepseek/deepseek-chat: 429 deepseek rate limit");
+    expect(mockedIsRateLimitAssistantError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        errorMessage: "429 deepseek rate limit",
+      }),
+    );
+    const lastFormattedCall = mockedFormatAssistantErrorText.mock.calls.at(-1) as
+      | unknown[]
+      | undefined;
+    const lastFormattedAssistant = lastFormattedCall?.[0] as
+      | EmbeddedRunAttemptResult["currentAttemptAssistant"]
+      | undefined;
+    expect(lastFormattedAssistant).toEqual(
+      expect.objectContaining({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        errorMessage: "429 deepseek rate limit",
+      }),
+    );
   });
 });

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -1,0 +1,80 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  MockedFailoverError,
+  mockedFormatAssistantErrorText,
+  mockedGlobalHookRunner,
+  mockedIsFailoverAssistantError,
+  mockedIsRateLimitAssistantError,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+  });
+
+  it("uses the current attempt assistant for fallback errors instead of stale session history", async () => {
+    mockedIsFailoverAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0] as EmbeddedRunAttemptResult["currentAttemptAssistant"];
+      return assistant?.provider === "deepseek";
+    });
+    mockedIsRateLimitAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0] as EmbeddedRunAttemptResult["currentAttemptAssistant"];
+      return assistant?.provider === "deepseek";
+    });
+    mockedFormatAssistantErrorText.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0] as EmbeddedRunAttemptResult["currentAttemptAssistant"];
+      return `${assistant?.provider}/${assistant?.model}: ${assistant?.errorMessage}`;
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          stopReason: "error",
+          errorMessage: "You have hit your ChatGPT usage limit (plus plan).",
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: {
+          stopReason: "error",
+          errorMessage: "429 deepseek rate limit",
+          provider: "deepseek",
+          model: "deepseek-chat",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+      }),
+    );
+
+    const promise = runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-cross-provider-fallback-error-context",
+      config: makeModelFallbackCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.4",
+              fallbacks: ["deepseek/deepseek-chat", "google/gemini-2.5-flash"],
+            },
+          },
+        },
+      }),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow("deepseek/deepseek-chat: 429 deepseek rate limit");
+  });
+});

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -107,4 +107,68 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
       }),
     );
   });
+
+  it("falls back to the session assistant when compaction removes the current attempt slice", async () => {
+    mockedIsFailoverAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "deepseek";
+    });
+    mockedIsRateLimitAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "deepseek";
+    });
+    let lastFormattedAssistant: unknown;
+    mockedFormatAssistantErrorText.mockImplementation((...args: unknown[]) => {
+      lastFormattedAssistant = args[0];
+      if (!isCurrentAttemptAssistant(lastFormattedAssistant)) {
+        return String(lastFormattedAssistant);
+      }
+      return `${lastFormattedAssistant.provider}/${lastFormattedAssistant.model}: ${lastFormattedAssistant.errorMessage}`;
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: "429 deepseek rate limit",
+          provider: "deepseek",
+          model: "deepseek-chat",
+          content: [],
+        }),
+        currentAttemptAssistant: undefined,
+      }),
+    );
+
+    const promise = runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-compaction-fallback-error-context",
+      config: makeModelFallbackCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.4",
+              fallbacks: ["deepseek/deepseek-chat", "google/gemini-2.5-flash"],
+            },
+          },
+        },
+      }),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow("deepseek/deepseek-chat: 429 deepseek rate limit");
+    expect(mockedIsRateLimitAssistantError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        errorMessage: "429 deepseek rate limit",
+      }),
+    );
+    expect(lastFormattedAssistant).toEqual(
+      expect.objectContaining({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        errorMessage: "429 deepseek rate limit",
+      }),
+    );
+  });
 });

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -16,6 +17,18 @@ import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 
+function isCurrentAttemptAssistant(
+  value: unknown,
+): value is NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "provider" in value &&
+    "model" in value &&
+    "errorMessage" in value
+  );
+}
+
 describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
   beforeAll(async () => {
     ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
@@ -28,34 +41,38 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
 
   it("uses the current attempt assistant for fallback errors instead of stale session history", async () => {
     mockedIsFailoverAssistantError.mockImplementation((...args: unknown[]) => {
-      const assistant = args[0] as EmbeddedRunAttemptResult["currentAttemptAssistant"];
-      return assistant?.provider === "deepseek";
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "deepseek";
     });
     mockedIsRateLimitAssistantError.mockImplementation((...args: unknown[]) => {
-      const assistant = args[0] as EmbeddedRunAttemptResult["currentAttemptAssistant"];
-      return assistant?.provider === "deepseek";
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "deepseek";
     });
+    let lastFormattedAssistant: unknown;
     mockedFormatAssistantErrorText.mockImplementation((...args: unknown[]) => {
-      const assistant = args[0] as EmbeddedRunAttemptResult["currentAttemptAssistant"];
-      return `${assistant?.provider}/${assistant?.model}: ${assistant?.errorMessage}`;
+      lastFormattedAssistant = args[0];
+      if (!isCurrentAttemptAssistant(lastFormattedAssistant)) {
+        return String(lastFormattedAssistant);
+      }
+      return `${lastFormattedAssistant.provider}/${lastFormattedAssistant.model}: ${lastFormattedAssistant.errorMessage}`;
     });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
+        lastAssistant: makeAssistantMessageFixture({
           stopReason: "error",
           errorMessage: "You have hit your ChatGPT usage limit (plus plan).",
           provider: "openai-codex",
           model: "gpt-5.4",
           content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        currentAttemptAssistant: {
+        }),
+        currentAttemptAssistant: makeAssistantMessageFixture({
           stopReason: "error",
           errorMessage: "429 deepseek rate limit",
           provider: "deepseek",
           model: "deepseek-chat",
           content: [],
-        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+        }),
       }),
     );
 
@@ -83,12 +100,6 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
         errorMessage: "429 deepseek rate limit",
       }),
     );
-    const lastFormattedCall = mockedFormatAssistantErrorText.mock.calls.at(-1) as
-      | unknown[]
-      | undefined;
-    const lastFormattedAssistant = lastFormattedCall?.[0] as
-      | EmbeddedRunAttemptResult["currentAttemptAssistant"]
-      | undefined;
     expect(lastFormattedAssistant).toEqual(
       expect.objectContaining({
         provider: "deepseek",

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -28,7 +28,6 @@ function isCurrentAttemptAssistant(
     "errorMessage" in value
   );
 }
-
 describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
   beforeAll(async () => {
     ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -726,7 +726,8 @@ export async function runEmbeddedPiAgent(
             idleTimedOut,
             timedOutDuringCompaction,
             sessionIdUsed,
-            lastAssistant,
+            lastAssistant: sessionLastAssistant,
+            currentAttemptAssistant,
           } = attempt;
           bootstrapPromptWarningSignaturesSeen =
             attempt.bootstrapPromptWarningSignaturesSeen ??
@@ -738,7 +739,7 @@ export async function runEmbeddedPiAgent(
                   ]),
                 )
               : bootstrapPromptWarningSignaturesSeen);
-          const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+          const lastAssistantUsage = normalizeUsage(sessionLastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
           // Keep prompt size from the latest model call so session totalTokens
@@ -748,7 +749,6 @@ export async function runEmbeddedPiAgent(
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;
           const activeErrorContext = resolveActiveErrorContext({
-            lastAssistant,
             provider,
             model: modelId,
           });
@@ -765,8 +765,8 @@ export async function runEmbeddedPiAgent(
             accumulatedReplayState,
             attempt.replayMetadata,
           );
-          const formattedAssistantErrorText = lastAssistant
-            ? formatAssistantErrorText(lastAssistant, {
+          const formattedAssistantErrorText = sessionLastAssistant
+            ? formatAssistantErrorText(sessionLastAssistant, {
                 cfg: params.config,
                 sessionKey: resolvedSessionKey ?? params.sessionId,
                 provider: activeErrorContext.provider,
@@ -774,8 +774,8 @@ export async function runEmbeddedPiAgent(
               })
             : undefined;
           const assistantErrorText =
-            lastAssistant?.stopReason === "error"
-              ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+            sessionLastAssistant?.stopReason === "error"
+              ? sessionLastAssistant.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
           const canRestartForLiveSwitch =
             !attempt.didSendViaMessagingTool &&
@@ -1140,7 +1140,7 @@ export async function runEmbeddedPiAgent(
                   model: model.id,
                   usageAccumulator,
                   lastRunPromptUsage,
-                  lastAssistant,
+                  lastAssistant: sessionLastAssistant,
                   lastTurnTotal,
                 }),
                 systemPromptReport: attempt.systemPromptReport,
@@ -1194,7 +1194,7 @@ export async function runEmbeddedPiAgent(
                     model: model.id,
                     usageAccumulator,
                     lastRunPromptUsage,
-                    lastAssistant,
+                    lastAssistant: sessionLastAssistant,
                     lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
@@ -1232,7 +1232,7 @@ export async function runEmbeddedPiAgent(
                     model: model.id,
                     usageAccumulator,
                     lastRunPromptUsage,
-                    lastAssistant,
+                    lastAssistant: sessionLastAssistant,
                     lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
@@ -1340,8 +1340,9 @@ export async function runEmbeddedPiAgent(
             throw promptError;
           }
 
+          const assistantForFailover = currentAttemptAssistant;
           const fallbackThinking = pickFallbackThinkingLevel({
-            message: lastAssistant?.errorMessage,
+            message: assistantForFailover?.errorMessage,
             attempted: attemptedThinking,
           });
           if (fallbackThinking && !aborted) {
@@ -1352,26 +1353,28 @@ export async function runEmbeddedPiAgent(
             continue;
           }
 
-          const authFailure = isAuthAssistantError(lastAssistant);
-          const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const billingFailure = isBillingAssistantError(lastAssistant);
-          const failoverFailure = isFailoverAssistantError(lastAssistant);
+          const authFailure = isAuthAssistantError(assistantForFailover);
+          const rateLimitFailure = isRateLimitAssistantError(assistantForFailover);
+          const billingFailure = isBillingAssistantError(assistantForFailover);
+          const failoverFailure = isFailoverAssistantError(assistantForFailover);
           const assistantFailoverReason = classifyFailoverReason(
-            lastAssistant?.errorMessage ?? "",
+            assistantForFailover?.errorMessage ?? "",
             {
-              provider: lastAssistant?.provider,
+              provider: assistantForFailover?.provider,
             },
           );
           const assistantProfileFailureReason =
             resolveAuthProfileFailureReason(assistantFailoverReason);
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
-          const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
+          const imageDimensionError = parseImageDimensionError(
+            assistantForFailover?.errorMessage ?? "",
+          );
           // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
           const failedAssistantProfileId = lastProfileId;
           const logAssistantFailoverDecision = createFailoverDecisionLogger({
             stage: "assistant",
             runId: params.runId,
-            rawError: lastAssistant?.errorMessage?.trim(),
+            rawError: assistantForFailover?.errorMessage?.trim(),
             failoverReason: assistantFailoverReason,
             profileFailureReason: assistantProfileFailureReason,
             provider: activeErrorContext.provider,
@@ -1385,7 +1388,7 @@ export async function runEmbeddedPiAgent(
           if (
             authFailure &&
             (await maybeRefreshRuntimeAuthForAuthError(
-              lastAssistant?.errorMessage ?? "",
+              assistantForFailover?.errorMessage ?? "",
               runtimeAuthRetry,
             ))
           ) {
@@ -1442,7 +1445,7 @@ export async function runEmbeddedPiAgent(
             modelId,
             provider,
             activeErrorContext,
-            lastAssistant,
+            lastAssistant: assistantForFailover,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,
             authFailure,
@@ -1473,20 +1476,20 @@ export async function runEmbeddedPiAgent(
           }
           const usageMeta = buildUsageAgentMetaFields({
             usageAccumulator,
-            lastAssistantUsage: lastAssistant?.usage as UsageLike | undefined,
+            lastAssistantUsage: sessionLastAssistant?.usage as UsageLike | undefined,
             lastRunPromptUsage,
             lastTurnTotal,
           });
           const agentMeta: EmbeddedPiAgentMeta = {
             sessionId: sessionIdUsed,
-            provider: lastAssistant?.provider ?? provider,
-            model: lastAssistant?.model ?? model.id,
+            provider: sessionLastAssistant?.provider ?? provider,
+            model: sessionLastAssistant?.model ?? model.id,
             usage: usageMeta.usage,
             lastCallUsage: usageMeta.lastCallUsage,
             promptTokens: usageMeta.promptTokens,
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
           };
-          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(lastAssistant);
+          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(sessionLastAssistant);
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
@@ -1737,7 +1740,7 @@ export async function runEmbeddedPiAgent(
                 ? "tool_calls"
                 : attempt.yieldDetected
                   ? "end_turn"
-                  : (lastAssistant?.stopReason as string | undefined),
+                  : (sessionLastAssistant?.stopReason as string | undefined),
               pendingToolCalls: attempt.clientToolCall
                 ? [
                     {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1340,7 +1340,7 @@ export async function runEmbeddedPiAgent(
             throw promptError;
           }
 
-          const assistantForFailover = currentAttemptAssistant;
+          const assistantForFailover = currentAttemptAssistant ?? sessionLastAssistant;
           const fallbackThinking = pickFallbackThinkingLevel({
             message: assistantForFailover?.errorMessage,
             attempted: attemptedThinking,

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { MemoryCitationsMode } from "../../../config/types.memory.js";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../../context-engine/types.js";
 import type { NormalizedUsage } from "../../usage.js";
@@ -95,11 +96,11 @@ export function buildContextEnginePromptCacheInfo(params: {
 export function findCurrentAttemptAssistantMessage(params: {
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;
-}): AgentMessage | undefined {
+}): AssistantMessage | undefined {
   return params.messagesSnapshot
     .slice(Math.max(0, params.prePromptMessageCount))
     .toReversed()
-    .find((message) => message.role === "assistant");
+    .find((message): message is AssistantMessage => message.role === "assistant");
 }
 
 export async function runAttemptContextEngineBootstrap(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,
@@ -113,7 +112,7 @@ import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
-import { normalizeUsage, type NormalizedUsage, type UsageLike } from "../../usage.js";
+import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
@@ -1513,7 +1512,7 @@ export async function runEmbeddedAttempt(
         abort: abortRun,
       };
       let lastAssistant: AgentMessage | undefined;
-      let currentAttemptAssistant: AgentMessage | undefined;
+      let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
       let attemptUsage: NormalizedUsage | undefined;
       let cacheBreak: ReturnType<typeof completePromptCacheObservation> = null;
       let promptCache: EmbeddedRunAttemptResult["promptCache"];
@@ -2089,9 +2088,7 @@ export async function runEmbeddedAttempt(
               usage: attemptUsage,
             })
           : null;
-        const lastCallUsage = normalizeUsage(
-          (currentAttemptAssistant as { usage?: UsageLike } | undefined)?.usage,
-        );
+        const lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
         const promptCacheObservation =
           cacheObservabilityEnabled &&
           (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")
@@ -2355,7 +2352,7 @@ export async function runEmbeddedAttempt(
         assistantTexts,
         toolMetas: toolMetasNormalized,
         lastAssistant,
-        currentAttemptAssistant: currentAttemptAssistant as AssistantMessage | undefined,
+        currentAttemptAssistant,
         lastToolError: getLastToolError?.(),
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,
@@ -1512,6 +1513,7 @@ export async function runEmbeddedAttempt(
         abort: abortRun,
       };
       let lastAssistant: AgentMessage | undefined;
+      let currentAttemptAssistant: AgentMessage | undefined;
       let attemptUsage: NormalizedUsage | undefined;
       let cacheBreak: ReturnType<typeof completePromptCacheObservation> = null;
       let promptCache: EmbeddedRunAttemptResult["promptCache"];
@@ -2075,7 +2077,7 @@ export async function runEmbeddedAttempt(
           .slice()
           .toReversed()
           .find((m) => m.role === "assistant");
-        const currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+        currentAttemptAssistant = findCurrentAttemptAssistantMessage({
           messagesSnapshot,
           prePromptMessageCount,
         });
@@ -2353,6 +2355,7 @@ export async function runEmbeddedAttempt(
         assistantTexts,
         toolMetas: toolMetasNormalized,
         lastAssistant,
+        currentAttemptAssistant: currentAttemptAssistant as AssistantMessage | undefined,
         lastToolError: getLastToolError?.(),
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,

--- a/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveActiveErrorContext } from "./helpers.js";
+
+describe("resolveActiveErrorContext", () => {
+  it("uses current provider/model when lastAssistant is undefined", () => {
+    const result = resolveActiveErrorContext({
+      lastAssistant: undefined,
+      provider: "deepseek",
+      model: "deepseek-chat",
+    });
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-chat" });
+  });
+
+  it("uses current provider/model even when lastAssistant has different provider", () => {
+    // This is the core regression: when a fallback attempt inherits a
+    // lastAssistant from the primary provider's error turn in session history,
+    // the error context must still reflect the current attempt's provider.
+    const result = resolveActiveErrorContext({
+      lastAssistant: { provider: "openai-codex", model: "gpt-5.4" },
+      provider: "deepseek",
+      model: "deepseek-chat",
+    });
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-chat" });
+  });
+
+  it("uses current provider/model when lastAssistant has matching provider", () => {
+    const result = resolveActiveErrorContext({
+      lastAssistant: { provider: "deepseek", model: "deepseek-chat" },
+      provider: "deepseek",
+      model: "deepseek-chat",
+    });
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-chat" });
+  });
+
+  it("uses current provider/model when lastAssistant has empty provider", () => {
+    const result = resolveActiveErrorContext({
+      lastAssistant: { provider: undefined, model: undefined },
+      provider: "gemini",
+      model: "gemini-3-pro",
+    });
+    expect(result).toEqual({ provider: "gemini", model: "gemini-3-pro" });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
@@ -2,42 +2,11 @@ import { describe, expect, it } from "vitest";
 import { resolveActiveErrorContext } from "./helpers.js";
 
 describe("resolveActiveErrorContext", () => {
-  it("uses current provider/model when lastAssistant is undefined", () => {
+  it("returns the current provider/model", () => {
     const result = resolveActiveErrorContext({
-      lastAssistant: undefined,
       provider: "deepseek",
       model: "deepseek-chat",
     });
     expect(result).toEqual({ provider: "deepseek", model: "deepseek-chat" });
-  });
-
-  it("uses current provider/model even when lastAssistant has different provider", () => {
-    // This is the core regression: when a fallback attempt inherits a
-    // lastAssistant from the primary provider's error turn in session history,
-    // the error context must still reflect the current attempt's provider.
-    const result = resolveActiveErrorContext({
-      lastAssistant: { provider: "openai-codex", model: "gpt-5.4" },
-      provider: "deepseek",
-      model: "deepseek-chat",
-    });
-    expect(result).toEqual({ provider: "deepseek", model: "deepseek-chat" });
-  });
-
-  it("uses current provider/model when lastAssistant has matching provider", () => {
-    const result = resolveActiveErrorContext({
-      lastAssistant: { provider: "deepseek", model: "deepseek-chat" },
-      provider: "deepseek",
-      model: "deepseek-chat",
-    });
-    expect(result).toEqual({ provider: "deepseek", model: "deepseek-chat" });
-  });
-
-  it("uses current provider/model when lastAssistant has empty provider", () => {
-    const result = resolveActiveErrorContext({
-      lastAssistant: { provider: undefined, model: undefined },
-      provider: "gemini",
-      model: "gemini-3-pro",
-    });
-    expect(result).toEqual({ provider: "gemini", model: "gemini-3-pro" });
   });
 });

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -77,14 +77,10 @@ export function resolveMaxRunRetryIterations(profileCandidateCount: number): num
   return Math.min(MAX_RUN_RETRY_ITERATIONS, Math.max(MIN_RUN_RETRY_ITERATIONS, scaled));
 }
 
-export function resolveActiveErrorContext(params: {
-  lastAssistant: { provider?: string; model?: string } | undefined;
+export function resolveActiveErrorContext(params: { provider: string; model: string }): {
   provider: string;
   model: string;
-}): { provider: string; model: string } {
-  // Always prefer the current attempt's provider/model for error attribution.
-  // lastAssistant may come from session history (a previous provider's error turn)
-  // and must not contaminate the current attempt's error context.
+} {
   return {
     provider: params.provider,
     model: params.model,

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -82,9 +82,12 @@ export function resolveActiveErrorContext(params: {
   provider: string;
   model: string;
 }): { provider: string; model: string } {
+  // Always prefer the current attempt's provider/model for error attribution.
+  // lastAssistant may come from session history (a previous provider's error turn)
+  // and must not contaminate the current attempt's error context.
   return {
-    provider: params.lastAssistant?.provider ?? params.provider,
-    model: params.lastAssistant?.model ?? params.model,
+    provider: params.provider,
+    model: params.model,
   };
 }
 

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -75,6 +75,7 @@ export type EmbeddedRunAttemptResult = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
+  currentAttemptAssistant?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
   didSendViaMessagingTool: boolean;
   didSendDeterministicApprovalPrompt?: boolean;


### PR DESCRIPTION
## Summary

- **Problem:** When the primary model (e.g. openai-codex/gpt-5.4) hits a 429 rate limit, the fallback chain attributes the error to the wrong provider. DeepSeek (fallback #1) receives the identical ChatGPT error message and errorHash as Codex, despite having separate API credentials. The error context from the primary provider leaks into subsequent fallback attempts.
- **Why it matters:** The fallback chain becomes effectively non-functional for the first fallback provider — it gets incorrectly marked as failed with the primary's error, skipping directly to fallback #2. Users must manually intervene.
- **What changed:** `resolveActiveErrorContext()` in `helpers.ts` now always uses the current attempt's `provider`/`model` for error attribution, instead of preferring `lastAssistant.provider` which may come from a previous provider's error turn in session history.
- **What did NOT change (scope boundary):** `lastAssistant` resolution in `attempt.ts` is unchanged. The `lastAssistant` field is still used for usage tracking, metadata, and non-error paths. Only the error context attribution is fixed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

Note: This touches the agent runtime failover logic (`src/agents/pi-embedded-runner/run/`).

## Linked Issue/PR

- Closes #62672
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `resolveActiveErrorContext()` at `src/agents/pi-embedded-runner/run/helpers.ts:82-84` preferred `lastAssistant.provider` over the current `params.provider`. When a fallback attempt inherits a `lastAssistant` from the primary provider's error turn (via shared session history), the error context is attributed to the wrong provider. For example, a DeepSeek 429 error gets attributed to `openai-codex` because `lastAssistant` was the Codex error turn from session history.
- **Missing detection / guardrail:** No test asserted that `resolveActiveErrorContext` returns the current provider when `lastAssistant` has a different provider.
- **Contributing context:** `lastAssistant` at `attempt.ts:2067-2070` searches ALL messages in the session snapshot including history from previous providers. A scoped version (`findCurrentAttemptAssistantMessage` at line 2071) already exists but is only used for usage tracking, not error context.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test:** `src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts`
- **Scenario the test should lock in:** When `lastAssistant` has a different provider than the current attempt (cross-provider fallback), error context must use the current attempt's provider/model.
- **Why this is the smallest reliable guardrail:** Direct unit test on the helper function that determines error attribution. No mocking needed — pure function.

## User-visible / Behavior Changes

- Fallback chain error messages now correctly identify which provider actually failed, instead of propagating the primary provider's identity.
- Users will see accurate provider names in error logs when fallback attempts fail.
- The first fallback provider will no longer be incorrectly skipped due to misattributed errors.

## Diagram (if applicable)

```text
Before:
[Codex 429] -> lastAssistant={provider: "openai-codex"} persisted to session
[DeepSeek attempt] -> resolveActiveErrorContext prefers lastAssistant.provider
  -> error attributed to "openai-codex" ✗ wrong provider

After:
[Codex 429] -> lastAssistant={provider: "openai-codex"} persisted to session
[DeepSeek attempt] -> resolveActiveErrorContext uses current provider
  -> error attributed to "deepseek" ✓ correct provider
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: Multi-provider setup with fallback chain (e.g. Codex → DeepSeek → Gemini)
- Relevant config: `providers` with multiple entries and fallback order

### Steps

1. Configure OpenClaw with primary provider (Codex) and fallback (DeepSeek)
2. Exhaust primary provider's rate limit (trigger 429)
3. Observe logs showing fallback attempt error attribution

### Expected

- DeepSeek attempt's error shows `provider: "deepseek"`

### Actual

- DeepSeek attempt's error shows `provider: "openai-codex"` with identical errorHash as primary

## Evidence

- [x] Failing test/log before + passing after

4 regression tests pass, including the core case:
- `uses current provider/model even when lastAssistant has different provider` — verifies DeepSeek attempt isn't attributed to Codex

## Human Verification (required)

- **Verified scenarios:** `pnpm build` passes, `pnpm lint` passes (0 errors), 4 new unit tests pass, existing failover tests (`failover-policy.test.ts`, `failover-observation.test.ts`) still pass (11 tests).
- **Edge cases checked:** `lastAssistant` undefined, `lastAssistant` with matching provider, `lastAssistant` with empty provider fields.
- **What I did not verify:** End-to-end multi-provider failover with real rate-limited API keys. The fix is a pure function change verified by unit tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** `lastAssistant.provider` was intentionally preferred in some edge case for accurate error reporting when the current provider is generic/unknown.
  - **Mitigation:** `params.provider` and `params.model` are always passed as required `string` parameters from the caller in `run.ts:714-717`. They are never unknown or generic in this call path. The `lastAssistant` fallback was defense-in-depth that became a liability when session history crosses provider boundaries.

AI-assisted: This PR was developed with AI assistance. All code was reviewed, understood, and tested by the author.