### PR TITLE
fix(scripts): avoid DEP0190 when spawning .cmd files on Windows (Node.js v24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
 - Telegram: keep duplicate message-tool-only Codex turns from posting generic silent-reply fallback text, so private finals stay private after inbound dedupe. Thanks @rubencu.
 - Telegram/sessions: gap-fill delivered embedded final replies into the session JSONL even when the runner trace is missing, so Telegram answers after tool calls do not vanish from the durable transcript. Fixes #77814. (#78426) Thanks @obviyus, @ChushulSuri, and @DougButdorf.
+- Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Matrix/approvals: retry approval delivery up to 3 times with a short backoff so transient Matrix send failures do not strand pending approval prompts. (#78179) Thanks @Patrick-Erichsen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,7 +323,6 @@ Docs: https://docs.openclaw.ai
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
 - Telegram: keep duplicate message-tool-only Codex turns from posting generic silent-reply fallback text, so private finals stay private after inbound dedupe. Thanks @rubencu.
 - Telegram/sessions: gap-fill delivered embedded final replies into the session JSONL even when the runner trace is missing, so Telegram answers after tool calls do not vanish from the durable transcript. Fixes #77814. (#78426) Thanks @obviyus, @ChushulSuri, and @DougButdorf.
-- Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Matrix/approvals: retry approval delivery up to 3 times with a short backoff so transient Matrix send failures do not strand pending approval prompts. (#78179) Thanks @Patrick-Erichsen.
@@ -663,6 +662,7 @@ Docs: https://docs.openclaw.ai
 - Agents/reasoning: keep embedded reasoning deltas raw for correct same-line streaming while preserving formatted Telegram, Feishu, Discord, and heartbeat delivery at the channel edge. (#78397) Thanks @medns.
 - Agents/failover: rotate auth profiles before deferred cooldown marking on rate-limit failures, so file-lock contention cannot stall profile failover. Fixes #57281. (#57283) Thanks @jeremyknows.
 - Gateway/sessions: when `session.dmScope: "main"` is configured, route a bare webchat `/new` against the agent's main session (`sessions.create` with `emitCommandHooks=true`) to an in-place reset instead of creating a parallel `dashboard:` child, matching `/new` behavior on Telegram/Discord. Fixes #77434. (#71170) Thanks @statxc.
+- Scripts/UI/Windows: launch `.cmd` and `.bat` UI runners through the shared cmd.exe escaping path with shell mode disabled, avoiding Node.js v24 DEP0190 warnings while preserving argument boundaries. (#62910) Thanks @nandanadileep.
 
 ## 2026.5.3-1
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -4,13 +4,13 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildCmdExeCommandLine } from "./windows-cmd-helpers.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 const uiDir = path.join(repoRoot, "ui");
 
-const WINDOWS_SHELL_EXTENSIONS = new Set([".cmd", ".bat", ".com"]);
-const WINDOWS_UNSAFE_SHELL_ARG_PATTERN = /[\r\n"&|<>^%!]/;
+const WINDOWS_CMD_EXE_EXTENSIONS = new Set([".cmd", ".bat"]);
 
 function usage() {
   // keep this tiny; it's invoked from npm scripts too
@@ -53,50 +53,47 @@ function resolveRunner() {
   return null;
 }
 
-export function shouldUseShellForCommand(cmd, platform = process.platform) {
+export function shouldUseCmdExeForCommand(cmd, platform = process.platform) {
   if (platform !== "win32") {
     return false;
   }
   const extension = path.extname(cmd).toLowerCase();
-  return WINDOWS_SHELL_EXTENSIONS.has(extension);
+  return WINDOWS_CMD_EXE_EXTENSIONS.has(extension);
 }
 
-export function assertSafeWindowsShellArgs(args, platform = process.platform) {
-  if (platform !== "win32") {
-    return;
-  }
-  const unsafeArg = args.find((arg) => WINDOWS_UNSAFE_SHELL_ARG_PATTERN.test(arg));
-  if (!unsafeArg) {
-    return;
-  }
-  // SECURITY: `shell: true` routes through cmd.exe; reject risky metacharacters
-  // in forwarded args to prevent shell control-flow/env-expansion injection.
-  throw new Error(
-    `Unsafe Windows shell argument: ${unsafeArg}. Remove shell metacharacters (" & | < > ^ % !).`,
-  );
-}
-
-export function prepareSpawnCommand(cmd, platform = process.platform) {
-  return shouldUseShellForCommand(cmd, platform) ? `"${cmd}"` : cmd;
-}
-
-function createSpawnOptions(cmd, args, envOverride) {
-  const useShell = shouldUseShellForCommand(cmd);
-  if (useShell) {
-    assertSafeWindowsShellArgs(args);
-  }
-  return {
-    cwd: uiDir,
+export function resolveSpawnCall(cmd, args, envOverride, params = {}) {
+  const platform = params.platform ?? process.platform;
+  const comSpec = params.comSpec ?? process.env.ComSpec ?? "cmd.exe";
+  const options = {
+    cwd: params.cwd ?? uiDir,
     stdio: "inherit",
     env: envOverride ?? process.env,
-    ...(useShell ? { shell: true } : {}),
+    shell: false,
+  };
+
+  if (shouldUseCmdExeForCommand(cmd, platform)) {
+    return {
+      command: comSpec,
+      args: ["/d", "/s", "/c", buildCmdExeCommandLine(cmd, args)],
+      options: {
+        ...options,
+        windowsVerbatimArguments: true,
+      },
+    };
+  }
+
+  return {
+    command: cmd,
+    args,
+    options,
   };
 }
 
 function run(cmd, args) {
+  const { command, args: spawnArgs, options } = resolveSpawnCall(cmd, args);
   let child;
   try {
-    child = spawn(prepareSpawnCommand(cmd), args, createSpawnOptions(cmd, args));
+    child = spawn(command, spawnArgs, options);
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);
@@ -115,9 +112,10 @@ function run(cmd, args) {
 }
 
 function runSync(cmd, args, envOverride) {
+  const { command, args: spawnArgs, options } = resolveSpawnCall(cmd, args, envOverride);
   let result;
   try {
-    result = spawnSync(prepareSpawnCommand(cmd), args, createSpawnOptions(cmd, args, envOverride));
+    result = spawnSync(command, spawnArgs, options);
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -1,49 +1,91 @@
 import { describe, expect, it } from "vitest";
-import {
-  assertSafeWindowsShellArgs,
-  prepareSpawnCommand,
-  shouldUseShellForCommand,
-} from "../../scripts/ui.js";
+import { resolveSpawnCall, shouldUseCmdExeForCommand } from "../../scripts/ui.js";
 
 describe("scripts/ui windows spawn behavior", () => {
-  it("enables shell for Windows command launchers that require cmd.exe", () => {
+  it("wraps Windows command launchers with cmd.exe without enabling shell mode", () => {
     expect(
-      shouldUseShellForCommand("C:\\Users\\dev\\AppData\\Local\\pnpm\\pnpm.CMD", "win32"),
+      shouldUseCmdExeForCommand("C:\\Users\\dev\\AppData\\Local\\pnpm\\pnpm.CMD", "win32"),
     ).toBe(true);
-    expect(shouldUseShellForCommand("C:\\tools\\pnpm.bat", "win32")).toBe(true);
-  });
 
-  it("does not enable shell for non-shell launchers", () => {
-    expect(shouldUseShellForCommand("C:\\Program Files\\nodejs\\node.exe", "win32")).toBe(false);
-    expect(shouldUseShellForCommand("/usr/local/bin/pnpm", "linux")).toBe(false);
-  });
-
-  it("quotes Windows shell launcher paths before passing them to spawn", () => {
-    expect(prepareSpawnCommand("C:\\Program Files\\nodejs\\pnpm.cmd", "win32")).toBe(
-      '"C:\\Program Files\\nodejs\\pnpm.cmd"',
-    );
-    expect(prepareSpawnCommand("C:\\Program Files\\nodejs\\pnpm.exe", "win32")).toBe(
-      "C:\\Program Files\\nodejs\\pnpm.exe",
-    );
-    expect(prepareSpawnCommand("/usr/local/bin/pnpm", "linux")).toBe("/usr/local/bin/pnpm");
-  });
-
-  it("allows safe forwarded args when shell mode is required on Windows", () => {
     expect(
-      assertSafeWindowsShellArgs(["run", "build", "--filter", "@openclaw/ui"], "win32"),
-    ).toBeUndefined();
+      resolveSpawnCall(
+        "C:\\Program Files\\nodejs\\pnpm.cmd",
+        ["run", "build", "-t", "path with spaces"],
+        { PATH: "C:\\bin" },
+        { comSpec: "C:\\Windows\\System32\\cmd.exe", cwd: "C:\\repo\\ui", platform: "win32" },
+      ),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        '"C:\\Program Files\\nodejs\\pnpm.cmd" run build -t "path with spaces"',
+      ],
+      options: {
+        cwd: "C:\\repo\\ui",
+        stdio: "inherit",
+        env: { PATH: "C:\\bin" },
+        shell: false,
+        windowsVerbatimArguments: true,
+      },
+    });
   });
 
-  it("rejects dangerous forwarded args when shell mode is required on Windows", () => {
-    expect(() => assertSafeWindowsShellArgs(["run", "build", "evil&calc"], "win32")).toThrow(
-      /unsafe windows shell argument/i,
-    );
-    expect(() => assertSafeWindowsShellArgs(["run", "build", "%PATH%"], "win32")).toThrow(
-      /unsafe windows shell argument/i,
-    );
+  it("does not use cmd.exe for non-command launchers", () => {
+    expect(shouldUseCmdExeForCommand("C:\\Program Files\\nodejs\\node.exe", "win32")).toBe(false);
+    expect(shouldUseCmdExeForCommand("C:\\tools\\pnpm.com", "win32")).toBe(false);
+    expect(shouldUseCmdExeForCommand("/usr/local/bin/pnpm", "linux")).toBe(false);
+
+    expect(
+      resolveSpawnCall(
+        "C:\\Program Files\\nodejs\\pnpm.exe",
+        ["run", "build"],
+        { PATH: "C:\\bin" },
+        { cwd: "C:\\repo\\ui", platform: "win32" },
+      ),
+    ).toEqual({
+      command: "C:\\Program Files\\nodejs\\pnpm.exe",
+      args: ["run", "build"],
+      options: {
+        cwd: "C:\\repo\\ui",
+        stdio: "inherit",
+        env: { PATH: "C:\\bin" },
+        shell: false,
+      },
+    });
   });
 
-  it("does not reject args on non-windows platforms", () => {
-    expect(assertSafeWindowsShellArgs(["contains&metacharacters"], "linux")).toBeUndefined();
+  it("rejects unsafe cmd.exe arguments before launch", () => {
+    expect(() =>
+      resolveSpawnCall("C:\\tools\\pnpm.cmd", ["run", "build", "evil&calc"], undefined, {
+        platform: "win32",
+      }),
+    ).toThrow(/unsafe windows cmd\.exe argument/i);
+    expect(() =>
+      resolveSpawnCall("C:\\tools\\pnpm.cmd", ["run", "build", "%PATH%"], undefined, {
+        platform: "win32",
+      }),
+    ).toThrow(/unsafe windows cmd\.exe argument/i);
+  });
+
+  it("keeps non-Windows launches direct even with shell metacharacters", () => {
+    expect(
+      resolveSpawnCall(
+        "/usr/local/bin/pnpm",
+        ["run", "build", "contains&metacharacters"],
+        { PATH: "/bin" },
+        { cwd: "/repo/ui", platform: "linux" },
+      ),
+    ).toEqual({
+      command: "/usr/local/bin/pnpm",
+      args: ["run", "build", "contains&metacharacters"],
+      options: {
+        cwd: "/repo/ui",
+        stdio: "inherit",
+        env: { PATH: "/bin" },
+        shell: false,
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #62881

On Node.js v24, `child_process.spawn` / `spawnSync` with **`{ shell: true }` and a separate `args` array** triggers [**DEP0190**](https://nodejs.org/api/deprecations.html#dep0190): Node warns because arguments are only concatenated, not escaped.

In `scripts/ui.js`, Windows UI runners that resolve to `.cmd` / `.bat` launchers (for example `pnpm.cmd`) used to take the guarded `shell: true` path and could hit that pattern.

**Fix (current):** `resolveSpawnCall` detects Windows `.cmd` / `.bat` runner paths (`shouldUseCmdExeForCommand`) and launches them via **`ComSpec` (`cmd.exe`) with `/d /s /c`**, using a single command line from **`buildCmdExeCommandLine`** (`scripts/windows-cmd-helpers.mjs`), with **`shell: false`** and **`windowsVerbatimArguments: true`**. That removes the DEP0190 trigger without ad-hoc string joining and keeps argument boundaries explicit. `.exe` / `.com` launchers and non-Windows paths still spawn the resolved executable directly with `shell: false`.

An earlier revision folded args for `shell: true`; the branch was **rebased onto current `main`** and now follows the shared cmd.exe helper path described in maintainer prep.

## Test plan

- [ ] On Windows with Node.js v24, run `node scripts/ui.js install` — no DEP0190 warning should appear
- [ ] On Windows, run `node scripts/ui.js dev` and `node scripts/ui.js build` — UI builds/serves correctly
- [ ] On non-Windows, no behaviour change (cmd.exe wrapping is never taken)
- [x] `pnpm exec oxfmt --check --threads=1 scripts/ui.js test/scripts/ui.test.ts CHANGELOG.md`
- [x] `pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts test/scripts/ui.test.ts`
- [x] `git diff --check`
