### PR TITLE
fix(cron): dispose MCP runtimes after isolated cron run completes

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -534,6 +534,8 @@ export async function runCronIsolatedAgentTurn(params: {
             // Cron runs execute inside the gateway process and need the same
             // explicit subagent late-binding as other gateway-owned runners.
             allowGatewaySubagentBinding: true,
+            // Dispose MCP runtimes after cron run completes to prevent process accumulation
+            cleanupBundleMcpOnRunEnd: true,
             // Cron jobs are trusted local automation, so isolated runs should
             // inherit owner-only tooling like local `openclaw agent` runs.
             senderIsOwner: true,


### PR DESCRIPTION
## Summary

Add cleanupBundleMcpOnRunEnd: true to cron isolated agent runs to prevent MCP process accumulation.

## Root Cause

When cron jobs run in isolated mode, the runEmbeddedPiAgent call was not passing cleanupBundleMcpOnRunEnd: true, causing MCP runtimes to accumulate over time. Each cron run spawned new MCP processes that were never cleaned up.

- CLI local mode: passes cleanupBundleMcpOnRunEnd: true (agent-via-gateway.ts:186)
- Cron isolated mode: missing

## Fix

Add the same cleanup flag to the cron isolated agent run at src/cron/isolated-agent/run.ts

## Impact

- Before: ~2.1 process pairs/hour accumulated, ~6GB memory growth over 5 days
- After: MCP runtimes properly disposed after each cron run

Fixes #62026