### PR TITLE
fix(slack): resolve file attachments dropped on Node.js 24 + app_mention debounce

### DIFF
--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -1,6 +1,7 @@
 import type { WebClient as SlackWebClient } from "@slack/web-api";
 import { normalizeHostname } from "openclaw/plugin-sdk/host-runtime";
 import { fetchWithRuntimeDispatcher } from "openclaw/plugin-sdk/infra-runtime";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { FetchLike } from "openclaw/plugin-sdk/media-runtime";
 import { fetchRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
@@ -265,7 +266,12 @@ export async function resolveSlackMedia(params: {
           ...(contentType ? { contentType } : {}),
           placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
         };
-      } catch {
+      } catch (err) {
+        logVerbose(
+          `resolveSlackMedia: failed to fetch file ${file.id ?? "unknown"}: ${
+            err instanceof Error ? `${err.message} ${err.cause instanceof Error ? err.cause.message : ""}`.trim() : String(err)
+          }`,
+        );
         return null;
       }
     },

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -129,9 +129,18 @@ export function createSlackMessageHandler(params: {
               .filter(Boolean)
               .join("\n");
       const combinedMentioned = entries.some((entry) => Boolean(entry.opts.wasMentioned));
+      // Merge files from all entries: app_mention events do not carry files,
+      // so we must union files across the debounce window to avoid dropping attachments.
+      const seenFileIds = new Set<string>();
+      const combinedFiles = entries.flatMap((entry) => entry.message.files ?? []).filter((file) => {
+        if (!file.id || seenFileIds.has(file.id)) return false;
+        seenFileIds.add(file.id);
+        return true;
+      });
       const syntheticMessage: SlackMessageEvent = {
         ...last.message,
         text: combinedText,
+        ...(combinedFiles.length > 0 ? { files: combinedFiles } : {}),
       };
       const prepared = await prepareSlackMessage({
         ctx,


### PR DESCRIPTION
## Summary

Two related bugs caused Slack file attachments to be silently dropped and replaced with `[Slack file: image.png]` placeholder text.

## Root Causes

### Bug 1: `app_mention` events do not carry files

When a user sends a message with a file + bot mention, Slack fires:
1. `message` event (first): carries `files`
2. `app_mention` event (second): **no `files`**

The debounce flush logic used the last event's message object, discarding files.

**Fix:** Union `files` across all debounce window entries, deduplicating by `file.id`.

### Bug 2: Silent errors in `resolveSlackMedia`

Errors during media resolution were swallowed by bare `catch {}` blocks.

**Fix:** Log with `logVerbose` for visibility.

## Related

On Node.js 24, `globalThis.fetch` uses undici v7.x while OpenClaw bundles undici v8.x. Passing a v8 `Agent` as `dispatcher` to a v7-backed fetch throws `invalid onRequestStart method`, silently caught. The `dispatcher` check in `createSlackMediaFetch` already handles this; this PR adds the file-union fix and improves error logging.

## Environment

- Node.js v24.14.0 / Raspberry Pi 5 (arm64)
- Reproduced and verified by IoE Business Dept @ KKE