### PR TITLE
feat(extensions): add EClaw channel plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,11 @@
       - any-glob-to-any-file:
           - "extensions/discord/**"
           - "docs/channels/discord.md"
+"channel: eclaw":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/eclaw/**"
+          - "docs/channels/eclaw.md"
 "channel: irc":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/channels/eclaw.md
+++ b/docs/channels/eclaw.md
@@ -1,0 +1,203 @@
+---
+summary: "E-Claw channel plugin setup and OpenClaw config"
+read_when:
+  - Setting up the E-Claw channel with OpenClaw
+  - Debugging E-Claw webhook routing or bot registration
+title: "E-Claw"
+---
+
+# E-Claw
+
+Status: bundled plugin channel using the E-Claw bot-registration API.
+The plugin registers a bot slot on an E-Claw device, receives inbound
+messages via a webhook callback, and delivers replies through the
+E-Claw channel API.
+
+**What is E-Claw?** E-Claw is an AI chat platform for live wallpaper character
+entities on Android (<https://eclawbot.com>). Each connected device has a small
+number of character "slots"; an OpenClaw bot claims one slot and exchanges
+messages with the device owner (and other entities on the same device).
+
+## Bundled plugin
+
+E-Claw ships as a bundled plugin in current OpenClaw releases, so normal
+packaged builds do not need a separate install.
+
+If you are on an older build or a custom install that excludes E-Claw,
+install it manually:
+
+```bash
+openclaw plugins install ./path/to/local/eclaw-plugin
+```
+
+Details: [Plugins](/tools/plugin)
+
+## Prerequisites
+
+Before starting:
+
+1. **E-Claw API key** — obtain from the E-Claw dashboard or by registering a
+   device via the E-Claw app.
+2. **Public HTTPS URL** — your OpenClaw gateway must be reachable from the
+   E-Claw backend so it can push inbound webhook events to
+   `<ECLAW_WEBHOOK_URL>/eclaw-webhook`. A reverse proxy or tunnel (e.g. ngrok,
+   Cloudflare Tunnel) is required if you are running locally.
+
+## Quick setup
+
+1. Set the required environment variable:
+
+   ```bash
+   export ECLAW_API_KEY=your-api-key
+   export ECLAW_WEBHOOK_URL=https://your-gateway.example.com
+   ```
+
+2. Optionally override the E-Claw API base and bot name:
+
+   ```bash
+   export ECLAW_API_BASE=https://eclawbot.com   # default
+   export ECLAW_BOT_NAME=OpenClaw               # default
+   ```
+
+3. Start (or restart) the OpenClaw gateway. The E-Claw plugin will:
+   - Register a callback URL with the E-Claw backend.
+   - Auto-bind an available entity slot.
+   - Begin receiving inbound messages at `/eclaw-webhook`.
+
+4. Send a message from the E-Claw device to verify the connection.
+
+## Configuration
+
+Minimal `openclaw.json` config (env vars are preferred for secrets):
+
+```json5
+{
+  channels: {
+    eclaw: {
+      enabled: true,
+      apiKey: "your-eclaw-api-key",
+      webhookUrl: "https://your-gateway.example.com",
+    },
+  },
+}
+```
+
+Full options:
+
+```json5
+{
+  channels: {
+    eclaw: {
+      enabled: true,
+      apiKey: "your-eclaw-api-key",
+      apiBase: "https://eclawbot.com",      // optional; default shown
+      botName: "OpenClaw",                   // optional; default shown
+      webhookUrl: "https://your-gateway.example.com",
+    },
+  },
+}
+```
+
+## Environment variables
+
+For the default account, all settings can be supplied via env vars:
+
+| Variable            | Description                              | Default                    |
+| ------------------- | ---------------------------------------- | -------------------------- |
+| `ECLAW_API_KEY`     | Bot API key (required)                   | —                          |
+| `ECLAW_WEBHOOK_URL` | Public base URL for webhook callbacks    | — (required)               |
+| `ECLAW_API_BASE`    | E-Claw backend base URL                  | `https://eclawbot.com`     |
+| `ECLAW_BOT_NAME`    | Display name for the bot entity          | `OpenClaw`                 |
+
+Config values in `openclaw.json` override env vars.
+
+## Message types
+
+The E-Claw plugin handles three event types from the backend:
+
+- **`message`** — a direct message from the device owner to the bot entity.
+- **`entity_message`** — a bot-to-bot message from another entity on the
+  same device. The bot updates its wallpaper state and replies to the sender.
+- **`broadcast`** — a broadcast from another entity to all slots on the
+  device. Same handling as `entity_message`.
+
+### Silent token
+
+When the E-Claw backend includes an `eclaw_context` block, it may specify a
+`silentToken` (default: `"[SILENT]"`). If the model replies with only that
+token, the plugin suppresses delivery — this is the standard no-op signal for
+quota-aware bot-to-bot exchanges.
+
+### Media messages
+
+Inbound media (photo, voice, video, file) is forwarded to the OpenClaw reply
+pipeline with the appropriate media type and URL. Outbound media is attached
+to the same `/api/channel/message` call as the text reply (no split delivery).
+If the primary CDN URL is unavailable, the plugin falls back to `backupUrl`
+when the backend provides one.
+
+## Multi-account
+
+Multiple E-Claw accounts (devices) are supported under
+`channels.eclaw.accounts`:
+
+```json5
+{
+  channels: {
+    eclaw: {
+      apiBase: "https://eclawbot.com",   // shared default
+      accounts: {
+        default: {
+          apiKey: "key-device-a",
+          webhookUrl: "https://gateway.example.com",
+        },
+        alerts: {
+          apiKey: "key-device-b",
+          webhookUrl: "https://gateway.example.com",
+          botName: "AlertBot",
+        },
+      },
+    },
+  },
+}
+```
+
+Each account registers its own callback token and entity slot. Inbound
+dispatch is routed per account by the per-session Bearer token embedded in
+the callback URL. All accounts share the single `/eclaw-webhook` route;
+the shared route is reference-counted and unregistered when the last
+account stops.
+
+## Security notes
+
+- Keep `apiKey` secret and rotate it if leaked.
+- Inbound webhook requests are authenticated by a per-session Bearer token
+  that changes on every gateway restart. Token lookup is case-insensitive
+  per RFC 7235 §2.1.
+- The `webhookUrl` must be HTTPS in production; the E-Claw backend rejects
+  plain HTTP callback URLs.
+- If the gateway cannot bind an entity slot (all slots occupied), startup
+  fails fast with an error and cleans up the remote callback registration so
+  no stale entries accumulate on the E-Claw backend.
+
+## Troubleshooting
+
+- **`missing webhookUrl`**: Set `ECLAW_WEBHOOK_URL` or `channels.eclaw.webhookUrl`
+  to the public HTTPS base URL of your gateway. The E-Claw backend must be
+  able to reach `<webhookUrl>/eclaw-webhook`.
+- **`missing apiKey`**: Set `ECLAW_API_KEY` or `channels.eclaw.apiKey`.
+- **No inbound messages**: Confirm that the gateway is reachable at the
+  webhook URL from the public internet and that the E-Claw backend has
+  successfully registered the callback (check gateway logs for
+  `E-Claw registered: deviceId=...`).
+- **Entity slot full**: The E-Claw device has no free entity slots. Free a
+  slot in the E-Claw app before restarting the gateway.
+- **Delivery silently suppressed**: If the model is outputting the silent
+  token (`[SILENT]` by default), delivery is intentionally suppressed. This
+  is normal for quota-aware bot-to-bot responses.
+
+## Related
+
+- [Channels Overview](/channels) — all supported channels
+- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Security](/gateway/security) — access model and hardening

--- a/extensions/eclaw/api.ts
+++ b/extensions/eclaw/api.ts
@@ -1,2 +1,14 @@
+/**
+ * Public API surface for the E-Claw plugin.
+ *
+ * Doc references (OpenClaw repo):
+ *   - AGENTS.md §"Architecture Boundaries" — every bundled plugin
+ *     exposes its cross-package contract through `api.ts`; core MUST
+ *     NOT deep-import `./src/*`.
+ *   - docs/plugins/architecture.md §"Channel boundary" — extension
+ *     API surface rule: `openclaw/plugin-sdk/<subpath>` is the only
+ *     public contract; anything the extension needs to expose goes
+ *     through this file.
+ */
 export { eclawPlugin } from "./src/channel.js";
 export { setEclawRuntime, getEclawRuntime } from "./src/runtime.js";

--- a/extensions/eclaw/api.ts
+++ b/extensions/eclaw/api.ts
@@ -1,0 +1,2 @@
+export { eclawPlugin } from "./src/channel.js";
+export { setEclawRuntime, getEclawRuntime } from "./src/runtime.js";

--- a/extensions/eclaw/contract-api.ts
+++ b/extensions/eclaw/contract-api.ts
@@ -1,0 +1,3 @@
+// Public contract surface for the E-Claw channel plugin.
+// Keep this intentionally small — it is what core facades may depend on.
+export type { ResolvedEclawAccount } from "./src/types.js";

--- a/extensions/eclaw/contract-api.ts
+++ b/extensions/eclaw/contract-api.ts
@@ -1,3 +1,16 @@
-// Public contract surface for the E-Claw channel plugin.
-// Keep this intentionally small — it is what core facades may depend on.
+/**
+ * Public contract surface for the E-Claw channel plugin.
+ *
+ * Keep this intentionally small — it is what core facades and shared
+ * plugin SDK subpaths may import. Everything else stays behind
+ * `./src/*` and is invisible to the rest of the repo.
+ *
+ * Doc references (OpenClaw repo):
+ *   - AGENTS.md §"Architecture Boundaries" → "Extension API surface
+ *     rule" — `openclaw/plugin-sdk/<subpath>` is the only public
+ *     cross-package contract; contract-api.ts is the companion
+ *     per-plugin file that backs plugin-sdk subpaths when core needs
+ *     plugin-owned types.
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths"
+ */
 export type { ResolvedEclawAccount } from "./src/types.js";

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -44,6 +44,9 @@
  *   - `eclaw account stop awaits unregisterCallback` — onAbort callback
  *     is async so the remote deregister completes before stop resolves
  *     (round 10, codex gateway.ts P1)
+ *   - `eclaw missing webhookUrl fails fast` — throw before touching any
+ *     shared state when no webhookUrl is configured
+ *     (round 11, codex gateway.ts P1)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -176,6 +179,7 @@ describe("eclaw gateway bind-failure cleanup", () => {
 
   it("unregisters the remote callback when bindEntity fails after registerCallback succeeded", async () => {
     process.env.ECLAW_API_KEY = "env-key";
+    process.env.ECLAW_WEBHOOK_URL = "https://test.example.com";
 
     const registerCallback = vi
       .spyOn(EclawClient.prototype, "registerCallback")
@@ -813,6 +817,7 @@ describe("eclaw shared HTTP route conflict detection", () => {
     // Force fresh module graph so the new mock takes effect
     vi.resetModules();
     process.env.ECLAW_API_KEY = "env-key";
+    process.env.ECLAW_WEBHOOK_URL = "https://test.example.com";
 
     const { startEclawAccount } = await import("./src/gateway.js");
 
@@ -859,6 +864,7 @@ describe("eclaw shared HTTP route conflict detection", () => {
 
     vi.resetModules();
     process.env.ECLAW_API_KEY = "env-key";
+    process.env.ECLAW_WEBHOOK_URL = "https://test.example.com";
 
     const { startEclawAccount } = await import("./src/gateway.js");
     const abortCtrl = new AbortController();
@@ -899,6 +905,7 @@ describe("eclaw state cleanup on shared-route failure (round 7)", () => {
 
     vi.resetModules();
     process.env.ECLAW_API_KEY = "env-key";
+    process.env.ECLAW_WEBHOOK_URL = "https://test.example.com";
 
     const { startEclawAccount } = await import("./src/gateway.js");
     const { eclawWebhookRegistrySize } = await import("./src/webhook-registry.js");
@@ -1069,6 +1076,7 @@ describe("eclaw webhook handler uses live config snapshot (round 9)", () => {
 
     vi.resetModules();
     process.env.ECLAW_API_KEY = "env-key";
+    process.env.ECLAW_WEBHOOK_URL = "https://test.example.com";
 
     const { startEclawAccount } = await import("./src/gateway.js");
 
@@ -1137,6 +1145,7 @@ describe("eclaw webhook handler uses live config snapshot (round 9)", () => {
 
     vi.resetModules();
     process.env.ECLAW_API_KEY = "env-key";
+    process.env.ECLAW_WEBHOOK_URL = "https://test.example.com";
 
     const { startEclawAccount } = await import("./src/gateway.js");
 
@@ -1216,6 +1225,7 @@ describe("eclaw account stop awaits unregisterCallback (round 10)", () => {
 
     vi.resetModules();
     process.env.ECLAW_API_KEY = "env-key-stop-test";
+    process.env.ECLAW_WEBHOOK_URL = "https://test.example.com";
 
     const { startEclawAccount } = await import("./src/gateway.js");
 
@@ -1239,5 +1249,41 @@ describe("eclaw account stop awaits unregisterCallback (round 10)", () => {
     // The critical assertion: unregisterCallback must have been awaited
     // (resolved) before onAbort's returned Promise settled.
     expect(unregisterResolved).toBe(true);
+  });
+});
+
+describe("eclaw missing webhookUrl fails fast (round 11)", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...savedEnv };
+    const mod = await import("./src/gateway.js");
+    mod.__resetEclawSharedRouteForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("throws before touching any shared state when webhookUrl is not set", async () => {
+    vi.resetModules();
+    process.env.ECLAW_API_KEY = "key-without-webhook";
+    // Intentionally NOT setting ECLAW_WEBHOOK_URL
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+    const { eclawWebhookRegistrySize } = await import("./src/webhook-registry.js");
+    const { getEclawClient } = await import("./src/client-registry.js");
+
+    const sizeBefore = eclawWebhookRegistrySize();
+
+    const abortCtrl = new AbortController();
+    await expect(
+      startEclawAccount({
+        cfg: {} as never,
+        accountId: "default",
+        abortSignal: abortCtrl.signal,
+      }),
+    ).rejects.toThrow(/missing.*webhookUrl|webhookUrl.*missing/i);
+
+    // Must not have leaked any state — the guard fires before client/token setup
+    expect(eclawWebhookRegistrySize()).toBe(sizeBefore);
+    expect(getEclawClient("default")).toBeUndefined();
   });
 });

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -1,3 +1,47 @@
+/**
+ * Regression test suite for the E-Claw channel plugin.
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/building-plugins.md §"Pre-submission checklist" —
+ *     "Tests pass (`pnpm test -- <bundled-plugin-root>/my-plugin/`)"
+ *     and "`pnpm check` passes (in-repo plugins)"; this file is what
+ *     `pnpm test:extension eclaw` picks up via
+ *     `vitest.extension-messaging-paths.mjs`.
+ *   - docs/plugins/sdk-testing.md — shared test harness helpers and
+ *     contract-test fixtures used by some describe blocks below.
+ *
+ * Test coverage map (review rounds referenced in comments below):
+ *   - `eclaw bundled entries` — basic plugin shape
+ *     (initial port)
+ *   - `eclaw webhook registry` — strict Bearer auth
+ *     (round 2, codex `webhook-registry.ts` P1)
+ *   - `eclaw gateway bind-failure cleanup` — unregister + rethrow
+ *     (rounds 2 + 4, codex P2 "unregister on bind failure" +
+ *     "propagate setup failures")
+ *   - `eclaw env-only account startup` — ECLAW_API_KEY without
+ *     `channels.eclaw` entry (round 2, codex P2)
+ *   - `eclaw webhook media-only delivery` — media-only payload path
+ *     (round 2, codex P1 "media-only dropped")
+ *   - `eclaw onError logging` — delivery failure surfaced via
+ *     runtime error sink (round 2, codex P2)
+ *   - `eclaw client strict response validation` — sendMessage /
+ *     speakTo res.ok + success checks (round 3, codex P2)
+ *   - `eclaw webhook Bearer scheme case-insensitivity (RFC 7235)` —
+ *     case variants, whitespace, non-Bearer schemes
+ *     (round 5, codex webhook-registry.ts P2)
+ *   - `eclaw active-event suppression is async-local, not global` —
+ *     AsyncLocalStorage concurrency test
+ *     (round 5, codex send.ts P1)
+ *   - `eclaw shared HTTP route conflict detection` — sentinel-log
+ *     detection of route conflict / overlap denied
+ *     (round 6, codex gateway.ts P2)
+ *   - `eclaw inbound backupUrl fallback` — media context falls back
+ *     when primary mediaUrl is absent
+ *     (round 7, codex webhook-handler.ts P2)
+ *   - `eclaw state cleanup on shared-route failure` — no leak of
+ *     webhook-token / client registry when acquireSharedEclawHttpRoute
+ *     throws (round 7, codex gateway.ts P2)
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk/webhook-ingress", () => ({
@@ -740,5 +784,151 @@ describe("eclaw shared HTTP route conflict detection", () => {
         abortSignal: abortCtrl.signal,
       }),
     ).rejects.toThrow(/route overlap denied/);
+  });
+});
+
+describe("eclaw state cleanup on shared-route failure (round 7)", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...savedEnv };
+    const mod = await import("./src/gateway.js");
+    mod.__resetEclawSharedRouteForTests();
+    vi.doUnmock("openclaw/plugin-sdk/webhook-ingress");
+    vi.restoreAllMocks();
+  });
+
+  it("does not leak webhook token or client registry when acquireSharedEclawHttpRoute throws", async () => {
+    vi.doMock("openclaw/plugin-sdk/webhook-ingress", () => ({
+      readJsonWebhookBodyOrReject: async () => ({ ok: true, value: {} }),
+      registerPluginHttpRoute: (p: { log?: (msg: string) => void }) => {
+        p.log?.(
+          "plugin: route conflict at /eclaw-webhook (exact) for account \"default\"",
+        );
+        return () => {};
+      },
+    }));
+    vi.doMock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+      waitUntilAbort: async () => undefined,
+    }));
+
+    vi.resetModules();
+    process.env.ECLAW_API_KEY = "env-key";
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+    const { eclawWebhookRegistrySize } = await import("./src/webhook-registry.js");
+    const { getEclawClient } = await import("./src/client-registry.js");
+
+    const sizeBefore = eclawWebhookRegistrySize();
+    const clientBefore = getEclawClient("default");
+
+    const abortCtrl = new AbortController();
+    await expect(
+      startEclawAccount({
+        cfg: {} as never,
+        accountId: "default",
+        abortSignal: abortCtrl.signal,
+      }),
+    ).rejects.toThrow(/route conflict/);
+
+    // Neither the webhook-token registry nor the client registry
+    // should hold a stale entry — the thrown acquireSharedEclawHttpRoute
+    // happens AFTER registerEclawWebhookToken + setEclawClient but
+    // BEFORE the register/bind try/catch, so the guarded cleanup has
+    // to live inside an isolated try block wrapped around the
+    // acquisition. See gateway.ts round-7 fix.
+    expect(eclawWebhookRegistrySize()).toBe(sizeBefore);
+    expect(getEclawClient("default")).toBe(clientBefore);
+  });
+});
+
+describe("eclaw inbound backupUrl fallback (round 7)", () => {
+  const savedEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    clearEclawClient("default");
+    vi.restoreAllMocks();
+  });
+
+  it("uses backupUrl as MediaUrl when primary mediaUrl is absent", async () => {
+    const capturedCtx: Array<Record<string, unknown>> = [];
+    const { dispatchEclawWebhookMessage } = await import("./src/webhook-handler.js");
+    const { setEclawRuntime } = await import("./src/runtime.js");
+
+    setEclawRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext: (ctx: Record<string, unknown>) => {
+            capturedCtx.push(ctx);
+            return ctx;
+          },
+          dispatchReplyWithBufferedBlockDispatcher: async () => {
+            /* no-op */
+          },
+        },
+      },
+    } as never);
+
+    // Install a no-op client so the handler doesn't short-circuit.
+    setEclawClient("default", {} as unknown as EclawClient);
+
+    await dispatchEclawWebhookMessage({
+      accountId: "default",
+      cfg: {} as never,
+      msg: {
+        event: "message",
+        deviceId: "dev-1",
+        entityId: 2,
+        from: "user-1",
+        mediaType: "photo",
+        mediaUrl: undefined,
+        backupUrl: "https://backup.example.test/asset.jpg",
+      } as EclawInboundMessage,
+    });
+
+    expect(capturedCtx).toHaveLength(1);
+    expect(capturedCtx[0]).toMatchObject({
+      MediaType: "image",
+      MediaUrl: "https://backup.example.test/asset.jpg",
+    });
+  });
+
+  it("prefers primary mediaUrl over backupUrl when both are present", async () => {
+    const capturedCtx: Array<Record<string, unknown>> = [];
+    const { dispatchEclawWebhookMessage } = await import("./src/webhook-handler.js");
+    const { setEclawRuntime } = await import("./src/runtime.js");
+
+    setEclawRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext: (ctx: Record<string, unknown>) => {
+            capturedCtx.push(ctx);
+            return ctx;
+          },
+          dispatchReplyWithBufferedBlockDispatcher: async () => {
+            /* no-op */
+          },
+        },
+      },
+    } as never);
+
+    setEclawClient("default", {} as unknown as EclawClient);
+
+    await dispatchEclawWebhookMessage({
+      accountId: "default",
+      cfg: {} as never,
+      msg: {
+        event: "message",
+        deviceId: "dev-1",
+        entityId: 2,
+        from: "user-1",
+        mediaType: "photo",
+        mediaUrl: "https://primary.example.test/asset.jpg",
+        backupUrl: "https://backup.example.test/asset.jpg",
+      } as EclawInboundMessage,
+    });
+
+    expect(capturedCtx).toHaveLength(1);
+    expect(capturedCtx[0]?.MediaUrl).toBe("https://primary.example.test/asset.jpg");
   });
 });

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -1,4 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/webhook-ingress", () => ({
+  readJsonWebhookBodyOrReject: async () => ({ ok: true, value: {} }),
+  registerPluginHttpRoute: () => () => {},
+}));
+vi.mock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+  waitUntilAbort: async () => undefined,
+}));
+
 import { listAccountIds, resolveAccount } from "./src/accounts.js";
 import {
   clearEclawClient,
@@ -82,6 +91,96 @@ describe("eclaw webhook registry", () => {
     } finally {
       unregisterEclawWebhookToken("t-0");
     }
+  });
+
+  it("handleEclawWebhookRequest returns 401 for a present-but-wrong Bearer token (no single-account fallback)", async () => {
+    // Exactly one account registered — this is the scenario where an
+    // earlier fallback path would have mis-routed a bogus token.
+    registerEclawWebhookToken("t-0", "default");
+    try {
+      const result = await handleEclawWebhookRequest({
+        cfg: {},
+        authHeader: "Bearer totally-bogus",
+        body: {
+          event: "message",
+          deviceId: "dev",
+          entityId: 1,
+          from: "user",
+          text: "hi",
+        } as EclawInboundMessage,
+      });
+      expect(result.status).toBe(401);
+      expect(result.body).toEqual({ error: "Unauthorized" });
+    } finally {
+      unregisterEclawWebhookToken("t-0");
+    }
+  });
+});
+
+describe("eclaw gateway bind-failure cleanup", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...savedEnv };
+    const mod = await import("./src/gateway.js");
+    mod.__resetEclawSharedRouteForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("unregisters the remote callback when bindEntity fails after registerCallback succeeded", async () => {
+    process.env.ECLAW_API_KEY = "env-key";
+
+    const registerCallback = vi
+      .spyOn(EclawClient.prototype, "registerCallback")
+      .mockImplementation(async function (this: EclawClient) {
+        // Mimic a successful register: set internal state as the real
+        // client would. We only need deviceId to be non-null so that a
+        // later unregister call is a real HTTP attempt (stubbed below).
+        (this as unknown as { "#state"?: unknown }); // keep TS happy
+        return {
+          success: true,
+          deviceId: "dev-1",
+          entities: [],
+        } as never;
+      });
+    const bindEntity = vi
+      .spyOn(EclawClient.prototype, "bindEntity")
+      .mockImplementation(async () => {
+        throw new Error("bind exploded");
+      });
+    const unregisterCallback = vi
+      .spyOn(EclawClient.prototype, "unregisterCallback")
+      .mockImplementation(async () => {
+        /* no-op */
+      });
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+
+    const logs: string[] = [];
+    const abortCtrl = new AbortController();
+    await startEclawAccount({
+      cfg: {} as never,
+      accountId: "default",
+      abortSignal: abortCtrl.signal,
+      log: {
+        info: (m) => logs.push(`info:${m}`),
+        warn: (m) => logs.push(`warn:${m}`),
+        error: (m) => logs.push(`error:${m}`),
+      },
+    });
+
+    expect(registerCallback).toHaveBeenCalledTimes(1);
+    expect(bindEntity).toHaveBeenCalledTimes(1);
+    // The critical assertion: we must have issued a best-effort
+    // unregisterCallback so the E-Claw backend doesn't keep pushing
+    // to a route we've already torn down locally.
+    expect(unregisterCallback).toHaveBeenCalledTimes(1);
+    expect(
+      logs.some(
+        (l) =>
+          l.startsWith("error:") && l.includes("bind exploded"),
+      ),
+    ).toBe(true);
   });
 });
 
@@ -219,5 +318,131 @@ describe("eclaw webhook media-only delivery", () => {
     });
 
     expect(sentMessages).toEqual([]);
+  });
+
+  it("delivers text AND media in a single sendMessage when both are present", async () => {
+    installRuntimeWithPayload({
+      text: "caption here",
+      mediaType: "image",
+      mediaUrl: "https://cdn.example/img.png",
+    });
+
+    await dispatchEclawWebhookMessage({
+      accountId: "default",
+      cfg: {},
+      msg: {
+        event: "message",
+        deviceId: "dev-1",
+        entityId: 2,
+        from: "user-1",
+        text: "hi",
+      } as EclawInboundMessage,
+    });
+
+    expect(sentMessages).toEqual([
+      {
+        text: "caption here",
+        state: "IDLE",
+        mediaType: "photo",
+        mediaUrl: "https://cdn.example/img.png",
+      },
+    ]);
+  });
+
+  it("for entity_message replies, includes media on the wallpaper sendMessage and text-only on speakTo", async () => {
+    installRuntimeWithPayload({
+      text: "hello bot",
+      mediaType: "image",
+      mediaUrl: "https://cdn.example/img.png",
+    });
+
+    await dispatchEclawWebhookMessage({
+      accountId: "default",
+      cfg: {},
+      msg: {
+        event: "entity_message",
+        deviceId: "dev-1",
+        entityId: 2,
+        fromEntityId: 3,
+        from: "user-1",
+        text: "hi",
+      } as EclawInboundMessage,
+    });
+
+    expect(sentMessages).toEqual([
+      {
+        text: "hello bot",
+        state: "IDLE",
+        mediaType: "photo",
+        mediaUrl: "https://cdn.example/img.png",
+      },
+    ]);
+    expect(sentSpeakTo).toEqual([{ entityId: 3, text: "hello bot" }]);
+  });
+});
+
+describe("eclaw onError logging", () => {
+  beforeEach(() => {
+    const client = new (class extends EclawClient {
+      constructor() {
+        super({ apiBase: "https://example.test", apiKey: "test" });
+      }
+      sendMessage = vi.fn(async () => {
+        throw new Error("boom");
+      }) as unknown as EclawClient["sendMessage"];
+    })();
+    setEclawClient("default", client as unknown as EclawClient);
+  });
+
+  afterEach(() => {
+    clearEclawClient("default");
+  });
+
+  it("invokes the installed onError callback when delivery throws (no silent swallow)", async () => {
+    const errorsSeen: Array<{ err: unknown; kind?: string }> = [];
+    setEclawRuntime({
+      // Surface delivery failures via the runtime error sink so the
+      // handler's onError has somewhere to log.
+      error: (msg: string) => {
+        errorsSeen.push({ err: msg });
+      },
+      channel: {
+        reply: {
+          finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+          dispatchReplyWithBufferedBlockDispatcher: async (args: {
+            dispatcherOptions: {
+              deliver: (p: {
+                text?: string;
+                mediaType?: string;
+                mediaUrl?: string;
+              }) => Promise<void>;
+              onError?: (err: unknown, info?: { kind?: string }) => void;
+            };
+          }) => {
+            try {
+              await args.dispatcherOptions.deliver({ text: "hello" });
+            } catch (err) {
+              args.dispatcherOptions.onError?.(err, { kind: "text" });
+            }
+          },
+        },
+      },
+    } as never);
+
+    await dispatchEclawWebhookMessage({
+      accountId: "default",
+      cfg: {},
+      msg: {
+        event: "message",
+        deviceId: "dev-1",
+        entityId: 2,
+        from: "user-1",
+        text: "hi",
+      } as EclawInboundMessage,
+    });
+
+    expect(errorsSeen).toHaveLength(1);
+    expect(String(errorsSeen[0]?.err)).toContain("boom");
+    expect(String(errorsSeen[0]?.err)).toContain("eclaw:");
   });
 });

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -542,3 +542,111 @@ describe("eclaw client strict response validation", () => {
     await expect(client.speakTo(3, "hi")).resolves.toBeUndefined();
   });
 });
+
+describe("eclaw webhook Bearer scheme case-insensitivity (RFC 7235)", () => {
+  beforeEach(() => {
+    registerEclawWebhookToken("rfc-token", "default");
+  });
+  afterEach(() => {
+    unregisterEclawWebhookToken("rfc-token");
+  });
+
+  it("accepts lowercase `bearer` scheme", () => {
+    expect(lookupEclawWebhookToken("bearer rfc-token")?.accountId).toBe("default");
+  });
+
+  it("accepts uppercase `BEARER` scheme", () => {
+    expect(lookupEclawWebhookToken("BEARER rfc-token")?.accountId).toBe("default");
+  });
+
+  it("accepts mixed-case `BeArEr` scheme", () => {
+    expect(lookupEclawWebhookToken("BeArEr rfc-token")?.accountId).toBe("default");
+  });
+
+  it("accepts `Bearer` with extra leading/trailing whitespace", () => {
+    expect(lookupEclawWebhookToken("  Bearer rfc-token  ")?.accountId).toBe("default");
+  });
+
+  it("still rejects unknown token even when scheme case differs", () => {
+    expect(lookupEclawWebhookToken("bearer wrong-token")).toBeUndefined();
+  });
+
+  it("still rejects non-Bearer schemes", () => {
+    expect(lookupEclawWebhookToken("Basic rfc-token")).toBeUndefined();
+    expect(lookupEclawWebhookToken("token rfc-token")).toBeUndefined();
+  });
+});
+
+describe("eclaw active-event suppression is async-local, not global", () => {
+  it("does NOT suppress a concurrent outbound send on the same account", async () => {
+    // Import the per-request helper + outbound sender. We stub EclawClient
+    // directly via the client-registry so we can count sendMessage calls
+    // without running real HTTP.
+    const { runWithActiveEclawEvent, getActiveEclawEvent, setEclawClient, clearEclawClient } =
+      await import("./src/client-registry.js");
+    const { sendEclawText } = await import("./src/send.js");
+
+    let sendCount = 0;
+    const fakeClient = {
+      sendMessage: vi.fn(async () => {
+        sendCount += 1;
+        return { success: true } as unknown;
+      }),
+    };
+    setEclawClient("default", fakeClient as unknown as EclawClient);
+
+    try {
+      // Start a webhook dispatch that holds the flag open while we race
+      // a concurrent outbound send from a DIFFERENT async context.
+      let releaseDispatch: (() => void) | undefined;
+      const dispatchHeld = new Promise<void>((resolve) => {
+        releaseDispatch = resolve;
+      });
+
+      const dispatchPromise = runWithActiveEclawEvent(
+        "default",
+        "entity_message",
+        async () => {
+          // Inside the dispatch, the flag IS set (suppression is the desired
+          // behavior for b2b duplicate-delivery).
+          expect(getActiveEclawEvent("default")).toBe("entity_message");
+          await dispatchHeld;
+          // Inside the dispatch, a send should be suppressed (returns ok=true
+          // without calling sendMessage).
+          const inside = await sendEclawText({
+            accountId: "default",
+            to: "dev:2",
+            text: "suppressed",
+          });
+          expect(inside.ok).toBe(true);
+        },
+      );
+
+      // From OUTSIDE the dispatch's async context, do a concurrent send.
+      // Before the fix, this would see the global flag and be dropped.
+      // After the fix (AsyncLocalStorage), it's not in the frame so the
+      // flag reads as "message" and the send goes through.
+      const outside = await sendEclawText({
+        accountId: "default",
+        to: "dev:3",
+        text: "should NOT be suppressed",
+      });
+      expect(outside.ok).toBe(true);
+
+      releaseDispatch?.();
+      await dispatchPromise;
+
+      // The outside send must have reached sendMessage exactly once.
+      // The inside send was suppressed and must NOT have reached it.
+      expect(sendCount).toBe(1);
+      expect(fakeClient.sendMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      clearEclawClient("default");
+    }
+  });
+
+  it("reads `message` outside any runWithActiveEclawEvent frame", async () => {
+    const { getActiveEclawEvent } = await import("./src/client-registry.js");
+    expect(getActiveEclawEvent("default")).toBe("message");
+  });
+});

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -157,16 +157,21 @@ describe("eclaw gateway bind-failure cleanup", () => {
 
     const logs: string[] = [];
     const abortCtrl = new AbortController();
-    await startEclawAccount({
-      cfg: {} as never,
-      accountId: "default",
-      abortSignal: abortCtrl.signal,
-      log: {
-        info: (m) => logs.push(`info:${m}`),
-        warn: (m) => logs.push(`warn:${m}`),
-        error: (m) => logs.push(`error:${m}`),
-      },
-    });
+    // The catch path now re-throws so the channel manager can mark the
+    // account as failed and attempt a restart. Previously it silently
+    // returned waitUntilAbort, leaving the startup task alive forever.
+    await expect(
+      startEclawAccount({
+        cfg: {} as never,
+        accountId: "default",
+        abortSignal: abortCtrl.signal,
+        log: {
+          info: (m) => logs.push(`info:${m}`),
+          warn: (m) => logs.push(`warn:${m}`),
+          error: (m) => logs.push(`error:${m}`),
+        },
+      }),
+    ).rejects.toThrow(/bind exploded/);
 
     expect(registerCallback).toHaveBeenCalledTimes(1);
     expect(bindEntity).toHaveBeenCalledTimes(1);

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -1332,3 +1332,78 @@ describe("eclaw env fallback restricted to default account (round 12)", () => {
     expect(account.apiKey).toBe("work-explicit-key");
   });
 });
+
+describe("eclaw malformed webhook payload rejection (round 13)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 400 when deviceId is missing", async () => {
+    registerEclawWebhookToken("good-token", "default");
+    const result = await handleEclawWebhookRequest({
+      cfg: {} as never,
+      authHeader: "Bearer good-token",
+      body: { entityId: 1, from: "u1" } as EclawInboundMessage,
+    });
+    expect(result.status).toBe(400);
+    expect(result.body).toMatchObject({ error: "missing_required_fields" });
+    unregisterEclawWebhookToken("good-token");
+  });
+
+  it("returns 400 when entityId is undefined", async () => {
+    registerEclawWebhookToken("good-token-2", "default");
+    const result = await handleEclawWebhookRequest({
+      cfg: {} as never,
+      authHeader: "Bearer good-token-2",
+      body: { deviceId: "dev-1", from: "u1" } as EclawInboundMessage,
+    });
+    expect(result.status).toBe(400);
+    expect(result.body).toMatchObject({ error: "missing_required_fields" });
+    unregisterEclawWebhookToken("good-token-2");
+  });
+
+  it("returns 400 when entityId is null", async () => {
+    registerEclawWebhookToken("good-token-3", "default");
+    const result = await handleEclawWebhookRequest({
+      cfg: {} as never,
+      authHeader: "Bearer good-token-3",
+      body: { deviceId: "dev-1", entityId: null, from: "u1" } as unknown as EclawInboundMessage,
+    });
+    expect(result.status).toBe(400);
+    expect(result.body).toMatchObject({ error: "missing_required_fields" });
+    unregisterEclawWebhookToken("good-token-3");
+  });
+
+  it("does not return 400 for a valid payload (both deviceId and entityId present)", async () => {
+    setEclawRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+          dispatchReplyWithBufferedBlockDispatcher: async () => { /* no-op */ },
+        },
+      },
+      logging: {
+        getChildLogger: () => ({ error: () => {} }),
+      },
+    } as never);
+    setEclawClient("default", {} as unknown as EclawClient);
+
+    registerEclawWebhookToken("good-token-4", "default");
+    const result = await handleEclawWebhookRequest({
+      cfg: {} as never,
+      authHeader: "Bearer good-token-4",
+      body: {
+        deviceId: "dev-1",
+        entityId: 2,
+        event: "message",
+        from: "u1",
+        text: "hello",
+      } as EclawInboundMessage,
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({ ok: true });
+
+    unregisterEclawWebhookToken("good-token-4");
+    clearEclawClient("default");
+  });
+});

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -41,6 +41,9 @@
  *   - `eclaw state cleanup on shared-route failure` — no leak of
  *     webhook-token / client registry when acquireSharedEclawHttpRoute
  *     throws (round 7, codex gateway.ts P2)
+ *   - `eclaw account stop awaits unregisterCallback` — onAbort callback
+ *     is async so the remote deregister completes before stop resolves
+ *     (round 10, codex gateway.ts P1)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1091,7 +1094,6 @@ describe("eclaw webhook handler uses live config snapshot (round 9)", () => {
       setHeader: () => {},
       end: (body: unknown) => { chunks.push(body); },
     };
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await capturedHandler!(mockReq, mockRes);
 
     // The handler must have forwarded the LIVE snapshot config, not the startup snapshot
@@ -1152,7 +1154,6 @@ describe("eclaw webhook handler uses live config snapshot (round 9)", () => {
 
     const mockReq = { method: "POST", headers: { authorization: "Bearer token" } };
     const mockRes = { statusCode: 0, setHeader: () => {}, end: () => {} };
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await capturedHandler!(mockReq, mockRes);
 
     // When snapshot is null, must fall back to startup cfg
@@ -1161,5 +1162,82 @@ describe("eclaw webhook handler uses live config snapshot (round 9)", () => {
 
     abortCtrl.abort();
     await startPromise.catch(() => { /* aborted */ });
+  });
+});
+
+describe("eclaw account stop awaits unregisterCallback (round 10)", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...savedEnv };
+    const mod = await import("./src/gateway.js");
+    mod.__resetEclawSharedRouteForTests();
+    vi.doUnmock("openclaw/plugin-sdk/channel-lifecycle");
+    vi.doUnmock("openclaw/plugin-sdk/webhook-ingress");
+    vi.restoreAllMocks();
+  });
+
+  it("awaits unregisterCallback during graceful account stop so the remote callback is fully torn down", async () => {
+    // Track whether unregisterCallback resolved before we observed it.
+    // Must use doMock on client.js so the mock is in effect for the
+    // re-imported gateway module after vi.resetModules().
+    let unregisterResolved = false;
+    vi.doMock("./src/client.js", () => ({
+      EclawClient: class MockEclawClient {
+        async registerCallback() {
+          return { success: true, deviceId: "dev-stop", entities: [] };
+        }
+        async bindEntity() {
+          return { entityId: 1, publicCode: "PC1" };
+        }
+        async unregisterCallback() {
+          unregisterResolved = true;
+        }
+      },
+    }));
+
+    // Capture onAbort so we can trigger it manually
+    let capturedOnAbort: (() => void | Promise<void>) | undefined;
+    vi.doMock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+      waitUntilAbort: (
+        _signal: AbortSignal,
+        onAbort?: () => void | Promise<void>,
+      ) => {
+        capturedOnAbort = onAbort;
+        // Never resolves on its own — we call onAbort manually
+        return new Promise<void>(() => {});
+      },
+    }));
+
+    vi.doMock("openclaw/plugin-sdk/webhook-ingress", () => ({
+      readJsonWebhookBodyOrReject: async () => ({ ok: true, value: {} }),
+      registerPluginHttpRoute: () => () => {},
+    }));
+
+    vi.resetModules();
+    process.env.ECLAW_API_KEY = "env-key-stop-test";
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+
+    const abortCtrl = new AbortController();
+    // Start without awaiting — account stays alive until onAbort fires
+    void startEclawAccount({
+      cfg: {} as never,
+      accountId: "default",
+      abortSignal: abortCtrl.signal,
+    });
+
+    // Poll until waitUntilAbort has been called and onAbort captured
+    for (let i = 0; i < 50 && capturedOnAbort === undefined; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(capturedOnAbort).toBeDefined();
+
+    // Invoke the cleanup and await it — must not resolve until unregisterCallback finishes
+    await capturedOnAbort!();
+
+    // The critical assertion: unregisterCallback must have been awaited
+    // (resolved) before onAbort's returned Promise settled.
+    expect(unregisterResolved).toBe(true);
   });
 });

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -650,3 +650,95 @@ describe("eclaw active-event suppression is async-local, not global", () => {
     expect(getActiveEclawEvent("default")).toBe("message");
   });
 });
+
+describe("eclaw shared HTTP route conflict detection", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...savedEnv };
+    const mod = await import("./src/gateway.js");
+    mod.__resetEclawSharedRouteForTests();
+    vi.doUnmock("openclaw/plugin-sdk/webhook-ingress");
+    vi.restoreAllMocks();
+  });
+
+  it("throws when registerPluginHttpRoute reports a route conflict", async () => {
+    // Override the module-level mock to simulate a conflict log.
+    // registerPluginHttpRoute returns a no-op AND logs a conflict message
+    // when the path is already taken by another plugin.
+    vi.doMock("openclaw/plugin-sdk/webhook-ingress", () => ({
+      readJsonWebhookBodyOrReject: async () => ({ ok: true, value: {} }),
+      registerPluginHttpRoute: (p: {
+        log?: (msg: string) => void;
+      }) => {
+        p.log?.(
+          "plugin: route conflict at /eclaw-webhook (exact) for account \"default\"; owned by other-plugin (other-source)",
+        );
+        return () => {};
+      },
+    }));
+    vi.doMock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+      waitUntilAbort: async () => undefined,
+    }));
+
+    // Force fresh module graph so the new mock takes effect
+    vi.resetModules();
+    process.env.ECLAW_API_KEY = "env-key";
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+
+    const logs: string[] = [];
+    const abortCtrl = new AbortController();
+    // Route-conflict path must re-throw, not silently return — a no-op
+    // route means inbound webhooks never arrive, and the manager needs
+    // to see the failure so it can alert operators / retry.
+    await expect(
+      startEclawAccount({
+        cfg: {} as never,
+        accountId: "default",
+        abortSignal: abortCtrl.signal,
+        log: {
+          info: (m) => logs.push(`info:${m}`),
+          warn: (m) => logs.push(`warn:${m}`),
+          error: (m) => logs.push(`error:${m}`),
+        },
+      }),
+    ).rejects.toThrow(/failed to register shared HTTP route \/eclaw-webhook.*route conflict/);
+
+    // Sanity: the conflict message from the registry was forwarded to
+    // the info log before the throw.
+    expect(
+      logs.some((l) => l.startsWith("info:") && l.includes("route conflict")),
+    ).toBe(true);
+  });
+
+  it("throws when registerPluginHttpRoute reports an overlap denial", async () => {
+    vi.doMock("openclaw/plugin-sdk/webhook-ingress", () => ({
+      readJsonWebhookBodyOrReject: async () => ({ ok: true, value: {} }),
+      registerPluginHttpRoute: (p: {
+        log?: (msg: string) => void;
+      }) => {
+        p.log?.(
+          "plugin: route overlap denied at /eclaw-webhook (exact, plugin) for account \"default\"; overlaps /eclaw-* (prefix, plugin)",
+        );
+        return () => {};
+      },
+    }));
+    vi.doMock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+      waitUntilAbort: async () => undefined,
+    }));
+
+    vi.resetModules();
+    process.env.ECLAW_API_KEY = "env-key";
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+    const abortCtrl = new AbortController();
+    await expect(
+      startEclawAccount({
+        cfg: {} as never,
+        accountId: "default",
+        abortSignal: abortCtrl.signal,
+      }),
+    ).rejects.toThrow(/route overlap denied/);
+  });
+});

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import entry from "./index.js";
+import setupEntry from "./setup-entry.js";
+
+describe("eclaw bundled entries", () => {
+  it("defines a channel entry for the eclaw id", () => {
+    expect(entry.id).toBe("eclaw");
+    expect(entry.name).toBe("E-Claw");
+  });
+
+  it("loads the channel plugin without importing the broad api barrel", () => {
+    const plugin = entry.loadChannelPlugin();
+    expect(plugin.id).toBe("eclaw");
+    expect(plugin.meta?.label).toBe("E-Claw");
+  });
+
+  it("loads the setup plugin without importing the broad api barrel", () => {
+    const plugin = setupEntry.loadSetupPlugin();
+    expect(plugin.id).toBe("eclaw");
+    expect(plugin.meta?.label).toBe("E-Claw");
+  });
+});

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -1014,3 +1014,152 @@ describe("eclaw inbound backupUrl fallback (round 7)", () => {
     expect(capturedCtx[0]?.MediaUrl).toBe("https://primary.example.test/asset.jpg");
   });
 });
+
+describe("eclaw webhook handler uses live config snapshot (round 9)", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...savedEnv };
+    const mod = await import("./src/gateway.js");
+    mod.__resetEclawSharedRouteForTests();
+    vi.doUnmock("openclaw/plugin-sdk/runtime-config-snapshot");
+    vi.doUnmock("openclaw/plugin-sdk/webhook-ingress");
+    vi.doUnmock("openclaw/plugin-sdk/channel-lifecycle");
+    vi.doUnmock("./src/webhook-handler.js");
+    vi.restoreAllMocks();
+  });
+
+  it("passes getRuntimeConfigSnapshot() result to handleEclawWebhookRequest instead of startup cfg", async () => {
+    const startupCfg = { _tag: "startup-cfg" } as never;
+    const snapshotCfg = { _tag: "live-snapshot-cfg" } as never;
+
+    // Capture the cfg seen by the webhook request handler
+    const capturedCfgArgs: unknown[] = [];
+    vi.doMock("./src/webhook-handler.js", () => ({
+      handleEclawWebhookRequest: async (params: { cfg: unknown }) => {
+        capturedCfgArgs.push(params.cfg);
+        return { status: 200, body: { ok: true } };
+      },
+    }));
+
+    // Provide a live config snapshot that differs from startupCfg
+    vi.doMock("openclaw/plugin-sdk/runtime-config-snapshot", () => ({
+      getRuntimeConfigSnapshot: () => snapshotCfg,
+    }));
+
+    // Capture the registered HTTP handler so we can invoke it directly
+    let capturedHandler: ((req: unknown, res: unknown) => Promise<void>) | null = null;
+    vi.doMock("openclaw/plugin-sdk/webhook-ingress", () => ({
+      readJsonWebhookBodyOrReject: async () => ({ ok: true, value: {} }),
+      registerPluginHttpRoute: (p: {
+        handler: (req: unknown, res: unknown) => Promise<void>;
+        log?: (msg: string) => void;
+      }) => {
+        capturedHandler = p.handler;
+        return () => {};
+      },
+    }));
+
+    vi.doMock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+      waitUntilAbort: () => new Promise(() => { /* never resolves */ }),
+    }));
+
+    vi.resetModules();
+    process.env.ECLAW_API_KEY = "env-key";
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+
+    const abortCtrl = new AbortController();
+    // Start without awaiting — account stays alive until aborted
+    const startPromise = startEclawAccount({
+      cfg: startupCfg,
+      accountId: "default",
+      abortSignal: abortCtrl.signal,
+    });
+
+    // Poll until the route handler is registered
+    for (let i = 0; i < 50 && !capturedHandler; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(capturedHandler).not.toBeNull();
+
+    // Simulate a POST to /eclaw-webhook
+    const mockReq = { method: "POST", headers: { authorization: "Bearer token" } };
+    const chunks: unknown[] = [];
+    const mockRes = {
+      statusCode: 0,
+      setHeader: () => {},
+      end: (body: unknown) => { chunks.push(body); },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await capturedHandler!(mockReq, mockRes);
+
+    // The handler must have forwarded the LIVE snapshot config, not the startup snapshot
+    expect(capturedCfgArgs).toHaveLength(1);
+    expect(capturedCfgArgs[0]).toBe(snapshotCfg);
+    expect(capturedCfgArgs[0]).not.toBe(startupCfg);
+
+    abortCtrl.abort();
+    await startPromise.catch(() => { /* aborted */ });
+  });
+
+  it("falls back to startup cfg when getRuntimeConfigSnapshot() returns null", async () => {
+    const startupCfg = { _tag: "startup-cfg" } as never;
+    const capturedCfgArgs: unknown[] = [];
+
+    vi.doMock("./src/webhook-handler.js", () => ({
+      handleEclawWebhookRequest: async (params: { cfg: unknown }) => {
+        capturedCfgArgs.push(params.cfg);
+        return { status: 200, body: { ok: true } };
+      },
+    }));
+
+    vi.doMock("openclaw/plugin-sdk/runtime-config-snapshot", () => ({
+      getRuntimeConfigSnapshot: () => null,
+    }));
+
+    let capturedHandler: ((req: unknown, res: unknown) => Promise<void>) | null = null;
+    vi.doMock("openclaw/plugin-sdk/webhook-ingress", () => ({
+      readJsonWebhookBodyOrReject: async () => ({ ok: true, value: {} }),
+      registerPluginHttpRoute: (p: {
+        handler: (req: unknown, res: unknown) => Promise<void>;
+      }) => {
+        capturedHandler = p.handler;
+        return () => {};
+      },
+    }));
+
+    vi.doMock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+      waitUntilAbort: () => new Promise(() => { /* never resolves */ }),
+    }));
+
+    vi.resetModules();
+    process.env.ECLAW_API_KEY = "env-key";
+
+    const { startEclawAccount } = await import("./src/gateway.js");
+
+    const abortCtrl = new AbortController();
+    const startPromise = startEclawAccount({
+      cfg: startupCfg,
+      accountId: "default",
+      abortSignal: abortCtrl.signal,
+    });
+
+    for (let i = 0; i < 50 && !capturedHandler; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(capturedHandler).not.toBeNull();
+
+    const mockReq = { method: "POST", headers: { authorization: "Bearer token" } };
+    const mockRes = { statusCode: 0, setHeader: () => {}, end: () => {} };
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await capturedHandler!(mockReq, mockRes);
+
+    // When snapshot is null, must fall back to startup cfg
+    expect(capturedCfgArgs).toHaveLength(1);
+    expect(capturedCfgArgs[0]).toBe(startupCfg);
+
+    abortCtrl.abort();
+    await startPromise.catch(() => { /* aborted */ });
+  });
+});

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -132,11 +132,10 @@ describe("eclaw gateway bind-failure cleanup", () => {
 
     const registerCallback = vi
       .spyOn(EclawClient.prototype, "registerCallback")
-      .mockImplementation(async function (this: EclawClient) {
-        // Mimic a successful register: set internal state as the real
-        // client would. We only need deviceId to be non-null so that a
-        // later unregister call is a real HTTP attempt (stubbed below).
-        (this as unknown as { "#state"?: unknown }); // keep TS happy
+      .mockImplementation(async () => {
+        // Mimic a successful register: the unregister-on-failure test
+        // below only checks that unregisterCallback was invoked once,
+        // so we don't need to set any internal state here.
         return {
           success: true,
           deviceId: "dev-1",
@@ -444,5 +443,97 @@ describe("eclaw onError logging", () => {
     expect(errorsSeen).toHaveLength(1);
     expect(String(errorsSeen[0]?.err)).toContain("boom");
     expect(String(errorsSeen[0]?.err)).toContain("eclaw:");
+  });
+});
+
+describe("eclaw client strict response validation", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mkClient(): EclawClient {
+    const client = new EclawClient({
+      apiBase: "https://example.test",
+      apiKey: "eck_test",
+    });
+    // Bypass the "not bound" guard so sendMessage/speakTo reach fetch
+    (client as unknown as { "#state": Record<string, unknown> })["#state"] = {
+      deviceId: "dev-1",
+      botSecret: "secret-1",
+      entityId: 2,
+    };
+    // TypeScript private fields can't be set from outside; do it via Object.defineProperty
+    // on the client-registry proxy path. Simpler: use setEclawClient + direct call.
+    return client;
+  }
+
+  function stubFetch(status: number, body: unknown): void {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+  }
+
+  it("sendMessage throws on HTTP 500", async () => {
+    stubFetch(500, "internal server error");
+    const client = new EclawClient({
+      apiBase: "https://example.test",
+      apiKey: "eck_test",
+    });
+    // Stamp state via bindEntity path: call bindEntity with stubbed ok response first.
+    stubFetch(200, { success: true, deviceId: "dev-1", entityId: 2, botSecret: "s", publicCode: "p", bindingType: "channel" });
+    await client.bindEntity(2, "bot");
+    // Now stub the failing sendMessage response and invoke it
+    stubFetch(500, "internal server error");
+    await expect(client.sendMessage("hi")).rejects.toThrow(/HTTP 500/);
+  });
+
+  it("sendMessage throws when response JSON has success: false", async () => {
+    const client = new EclawClient({
+      apiBase: "https://example.test",
+      apiKey: "eck_test",
+    });
+    stubFetch(200, { success: true, deviceId: "dev-1", entityId: 2, botSecret: "s", publicCode: "p", bindingType: "channel" });
+    await client.bindEntity(2, "bot");
+    stubFetch(200, { success: false, message: "quota exceeded" });
+    await expect(client.sendMessage("hi")).rejects.toThrow(/quota exceeded/);
+    void mkClient; // silence unused-helper warning if any
+  });
+
+  it("speakTo throws on HTTP 404", async () => {
+    const client = new EclawClient({
+      apiBase: "https://example.test",
+      apiKey: "eck_test",
+    });
+    stubFetch(200, { success: true, deviceId: "dev-1", entityId: 2, botSecret: "s", publicCode: "p", bindingType: "channel" });
+    await client.bindEntity(2, "bot");
+    stubFetch(404, "not found");
+    await expect(client.speakTo(3, "hi")).rejects.toThrow(/HTTP 404/);
+  });
+
+  it("speakTo throws when response JSON has success: false", async () => {
+    const client = new EclawClient({
+      apiBase: "https://example.test",
+      apiKey: "eck_test",
+    });
+    stubFetch(200, { success: true, deviceId: "dev-1", entityId: 2, botSecret: "s", publicCode: "p", bindingType: "channel" });
+    await client.bindEntity(2, "bot");
+    stubFetch(200, { success: false, message: "target offline" });
+    await expect(client.speakTo(3, "hi")).rejects.toThrow(/target offline/);
+  });
+
+  it("speakTo accepts empty body on 2xx", async () => {
+    const client = new EclawClient({
+      apiBase: "https://example.test",
+      apiKey: "eck_test",
+    });
+    stubFetch(200, { success: true, deviceId: "dev-1", entityId: 2, botSecret: "s", publicCode: "p", bindingType: "channel" });
+    await client.bindEntity(2, "bot");
+    stubFetch(200, "");
+    await expect(client.speakTo(3, "hi")).resolves.toBeUndefined();
   });
 });

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -446,13 +446,40 @@ describe("eclaw onError logging", () => {
     clearEclawClient("default");
   });
 
-  it("invokes the installed onError callback when delivery throws (no silent swallow)", async () => {
-    const errorsSeen: Array<{ err: unknown; kind?: string }> = [];
+  it("logs delivery failures via runtime.logging.getChildLogger().error (no silent swallow)", async () => {
+    // Round 8 fix: the handler must reach for the RuntimeLogger
+    // returned by `runtime.logging.getChildLogger({...})`, NOT a
+    // top-level `runtime.error` property that does not exist on
+    // PluginRuntime (see src/plugins/runtime/types-core.ts).
+    const errorsSeen: Array<{
+      message: string;
+      meta?: Record<string, unknown>;
+      bindings?: Record<string, unknown>;
+    }> = [];
+
+    const bindingsSeen: Array<Record<string, unknown>> = [];
+    const makeChildLogger = (
+      bindings?: Record<string, unknown>,
+    ): {
+      info: (m: string, meta?: Record<string, unknown>) => void;
+      warn: (m: string, meta?: Record<string, unknown>) => void;
+      error: (m: string, meta?: Record<string, unknown>) => void;
+    } => {
+      if (bindings) {
+        bindingsSeen.push(bindings);
+      }
+      return {
+        info: () => {},
+        warn: () => {},
+        error: (m, meta) => {
+          errorsSeen.push({ message: m, meta, bindings });
+        },
+      };
+    };
+
     setEclawRuntime({
-      // Surface delivery failures via the runtime error sink so the
-      // handler's onError has somewhere to log.
-      error: (msg: string) => {
-        errorsSeen.push({ err: msg });
+      logging: {
+        getChildLogger: makeChildLogger,
       },
       channel: {
         reply: {
@@ -479,7 +506,7 @@ describe("eclaw onError logging", () => {
 
     await dispatchEclawWebhookMessage({
       accountId: "default",
-      cfg: {},
+      cfg: {} as never,
       msg: {
         event: "message",
         deviceId: "dev-1",
@@ -490,8 +517,63 @@ describe("eclaw onError logging", () => {
     });
 
     expect(errorsSeen).toHaveLength(1);
-    expect(String(errorsSeen[0]?.err)).toContain("boom");
-    expect(String(errorsSeen[0]?.err)).toContain("eclaw:");
+    expect(errorsSeen[0]?.message).toContain("boom");
+    expect(errorsSeen[0]?.message).toContain("reply");
+    expect(errorsSeen[0]?.message).toContain("text");
+    expect(errorsSeen[0]?.meta).toEqual({ kind: "text" });
+    // Child logger must be bound with plugin + accountId so log
+    // aggregators can filter per-plugin and per-account.
+    expect(errorsSeen[0]?.bindings).toEqual({
+      plugin: "eclaw",
+      accountId: "default",
+    });
+  });
+
+  it("drops the error silently (no throw) when the runtime has no logging surface", async () => {
+    // Second half of the round-8 fix: a missing `logging` surface
+    // must not crash the webhook dispatch — earlier rounds passed a
+    // runtime with a direct `.error` method which no longer matches
+    // the real `PluginRuntime` shape. The onError block is wrapped
+    // in try/catch so that a missing/misshaped logger never breaks
+    // the inbound path.
+    setEclawRuntime({
+      // Intentionally no `logging` surface.
+      channel: {
+        reply: {
+          finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+          dispatchReplyWithBufferedBlockDispatcher: async (args: {
+            dispatcherOptions: {
+              deliver: (p: {
+                text?: string;
+                mediaType?: string;
+                mediaUrl?: string;
+              }) => Promise<void>;
+              onError?: (err: unknown, info?: { kind?: string }) => void;
+            };
+          }) => {
+            try {
+              await args.dispatcherOptions.deliver({ text: "hello" });
+            } catch (err) {
+              args.dispatcherOptions.onError?.(err, { kind: "text" });
+            }
+          },
+        },
+      },
+    } as never);
+
+    await expect(
+      dispatchEclawWebhookMessage({
+        accountId: "default",
+        cfg: {} as never,
+        msg: {
+          event: "message",
+          deviceId: "dev-1",
+          entityId: 2,
+          from: "user-1",
+          text: "hi",
+        } as EclawInboundMessage,
+      }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -1287,3 +1287,48 @@ describe("eclaw missing webhookUrl fails fast (round 11)", () => {
     expect(getEclawClient("default")).toBeUndefined();
   });
 });
+
+describe("eclaw env fallback restricted to default account (round 12)", () => {
+  const savedEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it("does not apply ECLAW_API_KEY env var to a named account", () => {
+    process.env.ECLAW_API_KEY = "env-key";
+    // Named account with no apiKey set in config
+    const account = resolveAccount(
+      { channels: { eclaw: { accounts: { work: {} } } } } as never,
+      "work",
+    );
+    expect(account.apiKey).toBe("");
+  });
+
+  it("does not apply ECLAW_WEBHOOK_URL env var to a named account", () => {
+    process.env.ECLAW_WEBHOOK_URL = "https://env-webhook.example.com";
+    const account = resolveAccount(
+      { channels: { eclaw: { accounts: { work: {} } } } } as never,
+      "work",
+    );
+    expect(account.webhookUrl).toBe("");
+  });
+
+  it("still applies ECLAW_API_KEY env var to the default account", () => {
+    process.env.ECLAW_API_KEY = "env-key-for-default";
+    const account = resolveAccount({} as never, "default");
+    expect(account.apiKey).toBe("env-key-for-default");
+  });
+
+  it("named account explicit config is not affected by env restriction", () => {
+    process.env.ECLAW_API_KEY = "env-key";
+    const account = resolveAccount(
+      {
+        channels: {
+          eclaw: { accounts: { work: { apiKey: "work-explicit-key" } } },
+        },
+      } as never,
+      "work",
+    );
+    expect(account.apiKey).toBe("work-explicit-key");
+  });
+});

--- a/extensions/eclaw/index.test.ts
+++ b/extensions/eclaw/index.test.ts
@@ -1,4 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listAccountIds, resolveAccount } from "./src/accounts.js";
+import {
+  clearEclawClient,
+  setEclawClient,
+} from "./src/client-registry.js";
+import { EclawClient } from "./src/client.js";
+import { setEclawRuntime } from "./src/runtime.js";
+import type { EclawInboundMessage } from "./src/types.js";
+import {
+  dispatchEclawWebhookMessage,
+  handleEclawWebhookRequest,
+} from "./src/webhook-handler.js";
+import {
+  eclawWebhookRegistrySize,
+  lookupEclawWebhookToken,
+  registerEclawWebhookToken,
+  unregisterEclawWebhookToken,
+} from "./src/webhook-registry.js";
 import entry from "./index.js";
 import setupEntry from "./setup-entry.js";
 
@@ -18,5 +36,188 @@ describe("eclaw bundled entries", () => {
     const plugin = setupEntry.loadSetupPlugin();
     expect(plugin.id).toBe("eclaw");
     expect(plugin.meta?.label).toBe("E-Claw");
+  });
+});
+
+describe("eclaw webhook registry", () => {
+  afterEach(() => {
+    // Clean up any tokens left over
+    for (let i = 0; i < 100 && eclawWebhookRegistrySize() > 0; i += 1) {
+      unregisterEclawWebhookToken(`t-${i}`);
+    }
+  });
+
+  it("rejects requests without a Bearer token even when a single account is registered", () => {
+    registerEclawWebhookToken("t-0", "default");
+    try {
+      expect(eclawWebhookRegistrySize()).toBe(1);
+      expect(lookupEclawWebhookToken(undefined)).toBeUndefined();
+      expect(lookupEclawWebhookToken("")).toBeUndefined();
+      expect(lookupEclawWebhookToken("Basic abc")).toBeUndefined();
+      expect(lookupEclawWebhookToken("Bearer ")).toBeUndefined();
+      expect(lookupEclawWebhookToken("Bearer wrong")).toBeUndefined();
+      expect(lookupEclawWebhookToken("Bearer t-0")).toEqual({
+        accountId: "default",
+      });
+    } finally {
+      unregisterEclawWebhookToken("t-0");
+    }
+  });
+
+  it("handleEclawWebhookRequest returns 401 for token-less webhook POSTs", async () => {
+    registerEclawWebhookToken("t-0", "default");
+    try {
+      const result = await handleEclawWebhookRequest({
+        cfg: {},
+        authHeader: undefined,
+        body: {
+          event: "message",
+          deviceId: "dev",
+          entityId: 1,
+          from: "user",
+          text: "hi",
+        } as EclawInboundMessage,
+      });
+      expect(result.status).toBe(401);
+    } finally {
+      unregisterEclawWebhookToken("t-0");
+    }
+  });
+});
+
+describe("eclaw env-only account startup", () => {
+  const savedEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it("listAccountIds returns default when only env vars are set", () => {
+    delete process.env.ECLAW_API_KEY;
+    expect(listAccountIds({} as never)).toEqual([]);
+
+    process.env.ECLAW_API_KEY = "env-key";
+    expect(listAccountIds({} as never)).toEqual(["default"]);
+  });
+
+  it("resolveAccount picks up env-only ECLAW_API_KEY", () => {
+    process.env.ECLAW_API_KEY = "env-key";
+    const account = resolveAccount({} as never, "default");
+    expect(account.apiKey).toBe("env-key");
+    expect(account.enabled).toBe(true);
+  });
+});
+
+describe("eclaw webhook media-only delivery", () => {
+  type Captured = {
+    text: string;
+    state: string;
+    mediaType?: string;
+    mediaUrl?: string;
+  };
+
+  let sentMessages: Captured[];
+  let sentSpeakTo: Array<{ entityId: number; text: string }>;
+
+  class FakeEclawClient extends EclawClient {
+    constructor() {
+      super({ apiBase: "https://example.test", apiKey: "test" });
+    }
+    // Override with a minimal capture. Keep the signature loose; runtime uses
+    // positional args same as the real client.
+    sendMessage = vi.fn(
+      async (text: string, state = "IDLE", mediaType?: string, mediaUrl?: string) => {
+        sentMessages.push({ text, state, mediaType, mediaUrl });
+        return { success: true };
+      },
+    ) as unknown as EclawClient["sendMessage"];
+    speakTo = vi.fn(async (entityId: number, text: string) => {
+      sentSpeakTo.push({ entityId, text });
+      return { success: true };
+    }) as unknown as EclawClient["speakTo"];
+  }
+
+  // Minimal runtime mock: invokes the dispatcher's deliver callback once with
+  // a pre-baked payload, mimicking the buffered block dispatcher.
+  function installRuntimeWithPayload(payload: {
+    text?: string;
+    mediaType?: string;
+    mediaUrl?: string;
+  }) {
+    setEclawRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+          dispatchReplyWithBufferedBlockDispatcher: async (args: {
+            dispatcherOptions: {
+              deliver: (p: typeof payload) => Promise<void>;
+            };
+          }) => {
+            await args.dispatcherOptions.deliver(payload);
+          },
+        },
+      },
+    } as never);
+  }
+
+  beforeEach(() => {
+    sentMessages = [];
+    sentSpeakTo = [];
+    const client = new FakeEclawClient();
+    setEclawClient("default", client as unknown as EclawClient);
+  });
+
+  afterEach(() => {
+    clearEclawClient("default");
+  });
+
+  it("delivers media-only payloads when text is empty", async () => {
+    installRuntimeWithPayload({
+      text: "",
+      mediaType: "image",
+      mediaUrl: "https://cdn.example/img.png",
+    });
+
+    await dispatchEclawWebhookMessage({
+      accountId: "default",
+      cfg: {},
+      msg: {
+        event: "message",
+        deviceId: "dev-1",
+        entityId: 2,
+        from: "user-1",
+        text: "hi",
+      } as EclawInboundMessage,
+    });
+
+    expect(sentMessages).toEqual([
+      {
+        text: "",
+        state: "IDLE",
+        mediaType: "photo",
+        mediaUrl: "https://cdn.example/img.png",
+      },
+    ]);
+  });
+
+  it("suppresses media delivery when silent-token is present", async () => {
+    installRuntimeWithPayload({
+      text: "[SILENT]",
+      mediaType: "image",
+      mediaUrl: "https://cdn.example/img.png",
+    });
+
+    await dispatchEclawWebhookMessage({
+      accountId: "default",
+      cfg: {},
+      msg: {
+        event: "message",
+        deviceId: "dev-1",
+        entityId: 2,
+        from: "user-1",
+        text: "hi",
+      } as EclawInboundMessage,
+    });
+
+    expect(sentMessages).toEqual([]);
   });
 });

--- a/extensions/eclaw/index.ts
+++ b/extensions/eclaw/index.ts
@@ -1,0 +1,16 @@
+import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelEntry({
+  id: "eclaw",
+  name: "E-Claw",
+  description: "OpenClaw E-Claw channel plugin (Android live wallpaper character integration)",
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./api.js",
+    exportName: "eclawPlugin",
+  },
+  runtime: {
+    specifier: "./api.js",
+    exportName: "setEclawRuntime",
+  },
+});

--- a/extensions/eclaw/index.ts
+++ b/extensions/eclaw/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Bundled channel entry for the E-Claw plugin.
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/building-plugins.md §"Plugin entry" — use
+ *     `defineBundledChannelEntry` from
+ *     `openclaw/plugin-sdk/channel-entry-contract`.
+ *   - docs/plugins/sdk-entrypoints.md — channel entry contract shape.
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths" — only
+ *     stable `openclaw/plugin-sdk/<subpath>` imports are allowed
+ *     across the extension package boundary.
+ */
 import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
 
 export default defineBundledChannelEntry({

--- a/extensions/eclaw/openclaw.plugin.json
+++ b/extensions/eclaw/openclaw.plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "eclaw",
+  "channels": ["eclaw"],
+  "channelEnvVars": {
+    "eclaw": [
+      "ECLAW_API_KEY",
+      "ECLAW_API_BASE",
+      "ECLAW_BOT_NAME",
+      "ECLAW_WEBHOOK_URL"
+    ]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/eclaw/package.json
+++ b/extensions/eclaw/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openclaw/eclaw",
+  "version": "2026.4.8",
+  "description": "OpenClaw E-Claw channel plugin (Android live wallpaper character integration)",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "setupEntry": "./setup-entry.ts",
+    "channel": {
+      "id": "eclaw",
+      "label": "E-Claw",
+      "selectionLabel": "E-Claw (AI Live Wallpaper)",
+      "detailLabel": "E-Claw",
+      "docsPath": "/channels/eclaw",
+      "docsLabel": "eclaw",
+      "blurb": "Connect OpenClaw to E-Claw — an AI chat platform for live wallpaper character entities on Android.",
+      "order": 95
+    },
+    "install": {
+      "npmSpec": "@openclaw/eclaw",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.4.8"
+    }
+  }
+}

--- a/extensions/eclaw/setup-entry.ts
+++ b/extensions/eclaw/setup-entry.ts
@@ -1,3 +1,18 @@
+/**
+ * Bundled setup entry for the E-Claw plugin.
+ *
+ * Separated from the main `index.ts` entry so that core can import
+ * the setup surface without pulling in the full channel runtime at
+ * setup time (see `defineBundledChannelSetupEntry`).
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-entrypoints.md §"Setup entry" — every bundled
+ *     channel with a setup surface exposes it through a dedicated
+ *     setup entry file using `defineBundledChannelSetupEntry`.
+ *   - docs/plugins/building-plugins.md §"Pre-submission checklist"
+ *     — "Entry point uses `defineChannelPluginEntry` or
+ *     `definePluginEntry`".
+ */
 import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";
 
 export default defineBundledChannelSetupEntry({

--- a/extensions/eclaw/setup-entry.ts
+++ b/extensions/eclaw/setup-entry.ts
@@ -1,0 +1,9 @@
+import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelSetupEntry({
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./api.js",
+    exportName: "eclawPlugin",
+  },
+});

--- a/extensions/eclaw/src/accounts.ts
+++ b/extensions/eclaw/src/accounts.ts
@@ -39,11 +39,14 @@ function resolveImplicitAccountId(
 /**
  * List all configured account IDs for this channel.
  * Returns ["default"] if there's a base config, plus any named accounts.
+ *
+ * When `channels.eclaw` is missing entirely, still start a default account
+ * from env vars (`ECLAW_API_KEY`) so env-only setups work.
  */
 export function listAccountIds(cfg: OpenClawConfig): string[] {
   const channelCfg = getChannelConfig(cfg);
   if (!channelCfg) {
-    return [];
+    return process.env.ECLAW_API_KEY ? [DEFAULT_ACCOUNT_ID] : [];
   }
 
   return listCombinedAccountIds({
@@ -81,7 +84,7 @@ export function resolveAccount(
     accountId: id,
     enabled: merged.enabled ?? true,
     apiKey: (merged.apiKey ?? envApiKey) || "",
-    apiBase: stripTrailingSlash(merged.apiBase ?? envApiBase ?? DEFAULT_API_BASE),
+    apiBase: stripTrailingSlash(merged.apiBase ?? envApiBase),
     botName: merged.botName ?? envBotName,
     webhookUrl: stripTrailingSlash(merged.webhookUrl ?? envWebhookUrl ?? ""),
   };

--- a/extensions/eclaw/src/accounts.ts
+++ b/extensions/eclaw/src/accounts.ts
@@ -72,7 +72,11 @@ export function listAccountIds(cfg: OpenClawConfig): string[] {
 
 /**
  * Resolve a specific account by ID with full defaults applied.
- * Falls back to environment variables for the "default" account.
+ * Falls back to environment variables for the "default" account only.
+ * Named accounts must have their credentials set explicitly in config;
+ * env fallback is intentionally restricted to avoid silently wiring a
+ * named account to the wrong API key (callback collision risk in
+ * multi-account setups — see PR #62934 round 12 codex P2).
  */
 export function resolveAccount(
   cfg: OpenClawConfig,
@@ -90,10 +94,15 @@ export function resolveAccount(
     accountId: id,
   });
 
-  const envApiKey = process.env.ECLAW_API_KEY ?? "";
-  const envApiBase = process.env.ECLAW_API_BASE ?? DEFAULT_API_BASE;
-  const envBotName = process.env.ECLAW_BOT_NAME ?? DEFAULT_BOT_NAME;
-  const envWebhookUrl = process.env.ECLAW_WEBHOOK_URL ?? "";
+  // Gate env fallback to the default account only.
+  // Named accounts get explicit config values or built-in defaults.
+  const isDefault = id === DEFAULT_ACCOUNT_ID;
+  const envApiKey = isDefault ? (process.env.ECLAW_API_KEY ?? "") : "";
+  const envApiBase = isDefault
+    ? (process.env.ECLAW_API_BASE ?? DEFAULT_API_BASE)
+    : DEFAULT_API_BASE;
+  const envBotName = isDefault ? (process.env.ECLAW_BOT_NAME ?? DEFAULT_BOT_NAME) : DEFAULT_BOT_NAME;
+  const envWebhookUrl = isDefault ? (process.env.ECLAW_WEBHOOK_URL ?? "") : "";
 
   return {
     accountId: id,
@@ -101,6 +110,6 @@ export function resolveAccount(
     apiKey: (merged.apiKey ?? envApiKey) || "",
     apiBase: stripTrailingSlash(merged.apiBase ?? envApiBase),
     botName: merged.botName ?? envBotName,
-    webhookUrl: stripTrailingSlash(merged.webhookUrl ?? envWebhookUrl ?? ""),
+    webhookUrl: stripTrailingSlash(merged.webhookUrl ?? envWebhookUrl),
   };
 }

--- a/extensions/eclaw/src/accounts.ts
+++ b/extensions/eclaw/src/accounts.ts
@@ -1,0 +1,88 @@
+/**
+ * Account resolution for the E-Claw channel plugin.
+ *
+ * Reads config from channels.eclaw, merges per-account overrides, and
+ * falls back to environment variables for the default account.
+ */
+
+import {
+  DEFAULT_ACCOUNT_ID,
+  listCombinedAccountIds,
+  resolveMergedAccountConfig,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/account-resolution";
+import type {
+  EclawChannelConfig,
+  ResolvedEclawAccount,
+} from "./types.js";
+
+const DEFAULT_API_BASE = "https://eclawbot.com";
+const DEFAULT_BOT_NAME = "OpenClaw";
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+/** Extract the channel config from the full OpenClaw config object. */
+function getChannelConfig(cfg: OpenClawConfig): EclawChannelConfig | undefined {
+  return cfg?.channels?.eclaw as EclawChannelConfig | undefined;
+}
+
+function resolveImplicitAccountId(
+  channelCfg: EclawChannelConfig,
+): string | undefined {
+  return channelCfg.apiKey || process.env.ECLAW_API_KEY
+    ? DEFAULT_ACCOUNT_ID
+    : undefined;
+}
+
+/**
+ * List all configured account IDs for this channel.
+ * Returns ["default"] if there's a base config, plus any named accounts.
+ */
+export function listAccountIds(cfg: OpenClawConfig): string[] {
+  const channelCfg = getChannelConfig(cfg);
+  if (!channelCfg) {
+    return [];
+  }
+
+  return listCombinedAccountIds({
+    configuredAccountIds: Object.keys(channelCfg.accounts ?? {}),
+    implicitAccountId: resolveImplicitAccountId(channelCfg),
+  });
+}
+
+/**
+ * Resolve a specific account by ID with full defaults applied.
+ * Falls back to environment variables for the "default" account.
+ */
+export function resolveAccount(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+): ResolvedEclawAccount {
+  const channelCfg = getChannelConfig(cfg) ?? {};
+  const id = accountId || DEFAULT_ACCOUNT_ID;
+  const merged = resolveMergedAccountConfig<
+    Record<string, unknown> & EclawChannelConfig
+  >({
+    channelConfig: channelCfg as Record<string, unknown> & EclawChannelConfig,
+    accounts: channelCfg.accounts as
+      | Record<string, Partial<Record<string, unknown> & EclawChannelConfig>>
+      | undefined,
+    accountId: id,
+  });
+
+  const envApiKey = process.env.ECLAW_API_KEY ?? "";
+  const envApiBase = process.env.ECLAW_API_BASE ?? DEFAULT_API_BASE;
+  const envBotName = process.env.ECLAW_BOT_NAME ?? DEFAULT_BOT_NAME;
+  const envWebhookUrl = process.env.ECLAW_WEBHOOK_URL ?? "";
+
+  return {
+    accountId: id,
+    enabled: merged.enabled ?? true,
+    apiKey: (merged.apiKey ?? envApiKey) || "",
+    apiBase: stripTrailingSlash(merged.apiBase ?? envApiBase ?? DEFAULT_API_BASE),
+    botName: merged.botName ?? envBotName,
+    webhookUrl: stripTrailingSlash(merged.webhookUrl ?? envWebhookUrl ?? ""),
+  };
+}

--- a/extensions/eclaw/src/accounts.ts
+++ b/extensions/eclaw/src/accounts.ts
@@ -3,6 +3,21 @@
  *
  * Reads config from channels.eclaw, merges per-account overrides, and
  * falls back to environment variables for the default account.
+ *
+ * `listAccountIds` still returns `[DEFAULT_ACCOUNT_ID]` when
+ * `channels.eclaw` is absent but the `ECLAW_API_KEY` env var is set,
+ * so env-only setups start the default account without requiring a
+ * placeholder config entry (see PR #62934 review round 2 codex P2).
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Config adapter" and
+ *     §"Account resolution" — use
+ *     `openclaw/plugin-sdk/account-resolution` helpers
+ *     (`DEFAULT_ACCOUNT_ID`, `listCombinedAccountIds`,
+ *     `resolveMergedAccountConfig`) rather than reaching into
+ *     `cfg.channels[...]` by hand.
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths" —
+ *     `account-resolution` is the stable cross-package subpath.
  */
 
 import {

--- a/extensions/eclaw/src/channel.ts
+++ b/extensions/eclaw/src/channel.ts
@@ -11,6 +11,17 @@
  * discovery — config resolution, outbound send, gateway start/stop, and a
  * stub setup adapter. Inbound dispatch runs through the webhook-handler
  * module which delegates to the OpenClaw reply runtime.
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Channel plugin contract" —
+ *     `createChatChannelPlugin` is the stable factory; config adapter,
+ *     messaging normalizer, directory adapter, and setup surface are
+ *     the four required slots.
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths" —
+ *     every import here uses `openclaw/plugin-sdk/<subpath>` so the
+ *     extension package boundary check passes.
+ *   - AGENTS.md §"Architecture Boundaries" → "Extension package
+ *     boundary guardrail" — no relative imports outside this package.
  */
 
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";

--- a/extensions/eclaw/src/channel.ts
+++ b/extensions/eclaw/src/channel.ts
@@ -1,0 +1,128 @@
+/**
+ * E-Claw channel plugin.
+ *
+ * E-Claw (https://eclawbot.com) is an AI chat platform for live wallpaper
+ * character entities on Android. Each connected device has a small number
+ * of character "slots"; an OpenClaw bot claims a slot and exchanges
+ * messages with the device owner (and other entities on the same device)
+ * via the E-Claw channel HTTP API.
+ *
+ * This plugin ships the minimal ChannelPlugin surface needed for bundled
+ * discovery — config resolution, outbound send, gateway start/stop, and a
+ * stub setup adapter. Inbound dispatch runs through the webhook-handler
+ * module which delegates to the OpenClaw reply runtime.
+ */
+
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
+import { createHybridChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
+import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import { createEmptyChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
+import { listAccountIds, resolveAccount } from "./accounts.js";
+import { EclawChannelConfigSchema } from "./config-schema.js";
+import {
+  startEclawAccount,
+  stopEclawAccount,
+  type EclawGatewayContext,
+} from "./gateway.js";
+import { sendEclawMedia, sendEclawText } from "./send.js";
+import { eclawSetupAdapter, eclawSetupWizard } from "./setup-adapter.js";
+import type { ResolvedEclawAccount } from "./types.js";
+
+const CHANNEL_ID = "eclaw";
+
+const eclawConfigAdapter = createHybridChannelConfigAdapter<ResolvedEclawAccount>({
+  sectionKey: CHANNEL_ID,
+  listAccountIds,
+  resolveAccount,
+  defaultAccountId: () => DEFAULT_ACCOUNT_ID,
+  clearBaseFields: ["apiKey", "apiBase", "botName", "webhookUrl"],
+  resolveAllowFrom: () => [],
+  formatAllowFrom: () => [],
+});
+
+type EclawOutboundContext = {
+  cfg: OpenClawConfig;
+  to: string;
+  text?: string;
+  mediaUrl?: string;
+  mediaType?: string;
+  accountId?: string | null;
+};
+type EclawSendTextContext = EclawOutboundContext & { text: string };
+
+export const eclawPlugin = createChatChannelPlugin({
+  base: {
+    id: CHANNEL_ID,
+    meta: {
+      id: CHANNEL_ID,
+      label: "E-Claw",
+      selectionLabel: "E-Claw (AI Live Wallpaper)",
+      detailLabel: "E-Claw",
+      docsPath: "/channels/eclaw",
+      docsLabel: "eclaw",
+      blurb:
+        "Connect OpenClaw to E-Claw — an AI chat platform for live wallpaper character entities on Android.",
+      order: 95,
+      aliases: ["eclaw", "e-claw", "claw"],
+    },
+    capabilities: {
+      chatTypes: ["direct" as const],
+      media: true,
+      reactions: false,
+      threads: false,
+      edit: false,
+      unsend: false,
+      reply: false,
+      effects: false,
+      blockStreaming: false,
+    },
+    reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+    configSchema: EclawChannelConfigSchema,
+    setup: eclawSetupAdapter,
+    setupWizard: eclawSetupWizard,
+    config: {
+      ...eclawConfigAdapter,
+      isConfigured: (account: ResolvedEclawAccount) => Boolean(account.apiKey?.trim()),
+    },
+    messaging: {
+      normalizeTarget: (target: string) => {
+        const trimmed = target?.trim();
+        if (!trimmed) return undefined;
+        return trimmed.replace(/^eclaw:/i, "").trim();
+      },
+      targetResolver: {
+        looksLikeId: (id: string) => {
+          const trimmed = id?.trim();
+          if (!trimmed) return false;
+          // E-Claw conversationIds are "<deviceId>:<entityId>" or numeric slot IDs.
+          return /^[\w-]+:\d+$/.test(trimmed) || /^\d+$/.test(trimmed);
+        },
+        hint: "<deviceId>:<entityId>",
+      },
+    },
+    directory: createEmptyChannelDirectoryAdapter(),
+    gateway: {
+      startAccount: async (ctx: EclawGatewayContext) => startEclawAccount(ctx),
+      stopAccount: async (ctx: EclawGatewayContext) => stopEclawAccount(ctx),
+    },
+    agentPrompt: {
+      messageToolHints: () => [
+        "",
+        "### E-Claw Formatting",
+        "E-Claw renders your replies on top of an Android live wallpaper character.",
+        "Keep replies concise (1-3 short sentences) so they fit the wallpaper overlay.",
+        "Plain text only; no Markdown, buttons, or code blocks.",
+        "Use the `[SILENT]` token when there is nothing worth saying in a bot-to-bot exchange.",
+      ],
+    },
+  },
+  outbound: {
+    deliveryMode: "direct" as const,
+    textChunkLimit: 4000,
+    sendText: async ({ to, text, accountId }: EclawSendTextContext) =>
+      sendEclawText({ to, text, accountId }),
+    sendMedia: async ({ to, text, mediaUrl, mediaType, accountId }: EclawOutboundContext) =>
+      sendEclawMedia({ to, text, mediaUrl, mediaType, accountId }),
+  },
+});

--- a/extensions/eclaw/src/channel.ts
+++ b/extensions/eclaw/src/channel.ts
@@ -88,13 +88,17 @@ export const eclawPlugin = createChatChannelPlugin({
     messaging: {
       normalizeTarget: (target: string) => {
         const trimmed = target?.trim();
-        if (!trimmed) return undefined;
+        if (!trimmed) {
+          return undefined;
+        }
         return trimmed.replace(/^eclaw:/i, "").trim();
       },
       targetResolver: {
         looksLikeId: (id: string) => {
           const trimmed = id?.trim();
-          if (!trimmed) return false;
+          if (!trimmed) {
+            return false;
+          }
           // E-Claw conversationIds are "<deviceId>:<entityId>" or numeric slot IDs.
           return /^[\w-]+:\d+$/.test(trimmed) || /^\d+$/.test(trimmed);
         },

--- a/extensions/eclaw/src/client-registry.ts
+++ b/extensions/eclaw/src/client-registry.ts
@@ -1,0 +1,39 @@
+/**
+ * Per-account client registry.
+ *
+ * The gateway registers a client when it starts an account, the outbound
+ * path looks it up by accountId, and the gateway removes it on shutdown.
+ */
+
+import { EclawClient } from "./client.js";
+
+const clients = new Map<string, EclawClient>();
+
+/** Track the current inbound event per account so outbound can suppress
+ *  duplicate delivery for bot-to-bot events (handled inline by the gateway).
+ */
+const activeEvent = new Map<string, string>();
+
+export function setEclawClient(accountId: string, client: EclawClient): void {
+  clients.set(accountId, client);
+}
+
+export function clearEclawClient(accountId: string): void {
+  clients.delete(accountId);
+}
+
+export function getEclawClient(accountId: string): EclawClient | undefined {
+  return clients.get(accountId);
+}
+
+export function setActiveEclawEvent(accountId: string, event: string): void {
+  activeEvent.set(accountId, event);
+}
+
+export function clearActiveEclawEvent(accountId: string): void {
+  activeEvent.delete(accountId);
+}
+
+export function getActiveEclawEvent(accountId: string): string {
+  return activeEvent.get(accountId) ?? "message";
+}

--- a/extensions/eclaw/src/client-registry.ts
+++ b/extensions/eclaw/src/client-registry.ts
@@ -5,14 +5,29 @@
  * path looks it up by accountId, and the gateway removes it on shutdown.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { EclawClient } from "./client.js";
 
 const clients = new Map<string, EclawClient>();
 
-/** Track the current inbound event per account so outbound can suppress
- *  duplicate delivery for bot-to-bot events (handled inline by the gateway).
+/**
+ * Active-event context.
+ *
+ * Tracks whether the current async execution is handling a
+ * bot-to-bot (`entity_message`) or `broadcast` inbound webhook so that
+ * the outbound ChannelPlugin adapter can suppress duplicate delivery
+ * (the gateway has already dispatched the reply inline via sendMessage
+ * + speakTo in that path).
+ *
+ * **Implemented via AsyncLocalStorage**, not a global per-account map,
+ * so that unrelated concurrent outbound sends on the same account are
+ * NOT accidentally suppressed when a bot-to-bot webhook is in flight.
+ * Each webhook dispatch runs inside its own `run()` frame and only
+ * outbound calls made within that frame see the suppression flag.
  */
-const activeEvent = new Map<string, string>();
+type ActiveEventContext = { accountId: string; event: string };
+const activeEventStorage = new AsyncLocalStorage<ActiveEventContext>();
 
 export function setEclawClient(accountId: string, client: EclawClient): void {
   clients.set(accountId, client);
@@ -26,14 +41,44 @@ export function getEclawClient(accountId: string): EclawClient | undefined {
   return clients.get(accountId);
 }
 
-export function setActiveEclawEvent(accountId: string, event: string): void {
-  activeEvent.set(accountId, event);
+/**
+ * Run `fn` with the active-event flag bound to the current async
+ * context. Outbound helpers called transitively from `fn` will see the
+ * flag via `getActiveEclawEvent(accountId)`; anything running outside
+ * the frame (including a concurrent `fn'` for the same accountId) will
+ * not be affected.
+ */
+export function runWithActiveEclawEvent<T>(
+  accountId: string,
+  event: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return activeEventStorage.run({ accountId, event }, fn);
 }
 
-export function clearActiveEclawEvent(accountId: string): void {
-  activeEvent.delete(accountId);
-}
-
+/** Returns the active event for `accountId` in the current async
+ *  context, or `"message"` if none is set. */
 export function getActiveEclawEvent(accountId: string): string {
-  return activeEvent.get(accountId) ?? "message";
+  const ctx = activeEventStorage.getStore();
+  if (!ctx || ctx.accountId !== accountId) {
+    return "message";
+  }
+  return ctx.event;
+}
+
+/**
+ * @deprecated Use `runWithActiveEclawEvent(accountId, event, fn)` instead.
+ * Kept as a no-op for any external callers; the old global-map API was
+ * vulnerable to concurrent-send drop (see PR #62934 review).
+ */
+export function setActiveEclawEvent(_accountId: string, _event: string): void {
+  /* no-op: use runWithActiveEclawEvent */
+}
+
+/**
+ * @deprecated Use `runWithActiveEclawEvent(accountId, event, fn)` instead.
+ * Kept as a no-op for any external callers.
+ */
+export function clearActiveEclawEvent(_accountId: string): void {
+  /* no-op: use runWithActiveEclawEvent */
 }

--- a/extensions/eclaw/src/client-registry.ts
+++ b/extensions/eclaw/src/client-registry.ts
@@ -3,6 +3,23 @@
  *
  * The gateway registers a client when it starts an account, the outbound
  * path looks it up by accountId, and the gateway removes it on shutdown.
+ *
+ * The `activeEvent` context is bound per-request via AsyncLocalStorage
+ * rather than a global per-account Map so that concurrent unrelated
+ * outbound sends on the same account are NOT accidentally suppressed
+ * when a bot-to-bot webhook dispatch is in flight. See PR #62934
+ * review round 5 (codex `send.ts` P1 item).
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Reply pipeline" —
+ *     outbound suppression is the responsibility of the ChannelPlugin
+ *     outbound adapter; gateway-side inline delivery must coordinate
+ *     with it through a per-dispatch flag, not a global one.
+ *   - docs/plugins/architecture.md §"Channel boundary" — channel
+ *     state is owned by the plugin, not core; everything in here is
+ *     module-local state.
+ *   - Node.js AsyncLocalStorage:
+ *     https://nodejs.org/api/async_context.html#class-asynclocalstorage
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";

--- a/extensions/eclaw/src/client.ts
+++ b/extensions/eclaw/src/client.ts
@@ -1,0 +1,179 @@
+/**
+ * HTTP client for the E-Claw Channel API.
+ *
+ * Ported from the standalone @eclaw/openclaw-channel npm package
+ * (https://github.com/HankHuang0516/openclaw-channel-eclaw).
+ *
+ * Handles all communication between the OpenClaw plugin and the E-Claw
+ * backend: callback registration, entity slot binding, outbound messages,
+ * and entity-to-entity messaging.
+ */
+
+import type {
+  EclawBindResponse,
+  EclawMessageResponse,
+  EclawRegisterResponse,
+  ResolvedEclawAccount,
+} from "./types.js";
+
+export interface EclawClientState {
+  deviceId: string | null;
+  botSecret: string | null;
+  entityId: number | undefined;
+}
+
+export class EclawClient {
+  readonly #apiBase: string;
+  readonly #apiKey: string;
+  readonly #state: EclawClientState = {
+    deviceId: null,
+    botSecret: null,
+    entityId: undefined,
+  };
+
+  constructor(account: Pick<ResolvedEclawAccount, "apiBase" | "apiKey">) {
+    this.#apiBase = account.apiBase;
+    this.#apiKey = account.apiKey;
+  }
+
+  get state(): Readonly<EclawClientState> {
+    return this.#state;
+  }
+
+  /** Register callback URL with E-Claw backend. */
+  async registerCallback(
+    callbackUrl: string,
+    callbackToken: string,
+  ): Promise<EclawRegisterResponse> {
+    const res = await fetch(`${this.#apiBase}/api/channel/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        channel_api_key: this.#apiKey,
+        callback_url: callbackUrl,
+        callback_token: callbackToken,
+      }),
+    });
+
+    const data = (await res.json()) as EclawRegisterResponse;
+    if (!data.success) {
+      throw new Error(data.message || `E-Claw register failed (HTTP ${res.status})`);
+    }
+
+    this.#state.deviceId = data.deviceId;
+    return data;
+  }
+
+  /**
+   * Bind an entity slot via channel API.
+   * When `entityId` is omitted, the backend auto-selects the first free slot.
+   */
+  async bindEntity(
+    entityId?: number,
+    name?: string,
+  ): Promise<EclawBindResponse> {
+    const body: Record<string, unknown> = { channel_api_key: this.#apiKey };
+    if (entityId !== undefined) {
+      body.entityId = entityId;
+    }
+    if (name) {
+      body.name = name;
+    }
+
+    const res = await fetch(`${this.#apiBase}/api/channel/bind`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const data = (await res.json()) as EclawBindResponse;
+    if (!data.success) {
+      if (res.status === 409 && data.entities) {
+        const list = data.entities
+          .map(
+            (e) =>
+              `  slot ${e.entityId} (${e.character})${e.name ? ` "${e.name}"` : ""}`,
+          )
+          .join("\n");
+        throw new Error(
+          `${data.message ?? "E-Claw slots full"}\nCurrent entities:\n${list}\n` +
+            "Add entityId to your channel config to target a specific slot after unbinding it.",
+        );
+      }
+      throw new Error(data.message || `E-Claw bind failed (HTTP ${res.status})`);
+    }
+
+    this.#state.botSecret = data.botSecret;
+    this.#state.deviceId = data.deviceId;
+    this.#state.entityId = data.entityId;
+    return data;
+  }
+
+  /** Send a bot message to the user that owns the current entity. */
+  async sendMessage(
+    message: string,
+    state = "IDLE",
+    mediaType?: string,
+    mediaUrl?: string,
+  ): Promise<EclawMessageResponse> {
+    const { deviceId, botSecret, entityId } = this.#state;
+    if (!deviceId || !botSecret) {
+      throw new Error("E-Claw client not bound — call bindEntity() first");
+    }
+
+    const res = await fetch(`${this.#apiBase}/api/channel/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        channel_api_key: this.#apiKey,
+        deviceId,
+        entityId,
+        botSecret,
+        message,
+        state,
+        ...(mediaType ? { mediaType } : {}),
+        ...(mediaUrl ? { mediaUrl } : {}),
+      }),
+    });
+
+    return (await res.json()) as EclawMessageResponse;
+  }
+
+  /** Bot-to-bot message to another entity on the same device. */
+  async speakTo(
+    toEntityId: number,
+    text: string,
+    expectsReply = false,
+  ): Promise<void> {
+    const { deviceId, botSecret, entityId } = this.#state;
+    if (!deviceId || !botSecret) {
+      throw new Error("E-Claw client not bound — call bindEntity() first");
+    }
+
+    await fetch(`${this.#apiBase}/api/entity/speak-to`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        deviceId,
+        fromEntityId: entityId,
+        toEntityId,
+        botSecret,
+        text,
+        expects_reply: expectsReply,
+      }),
+    });
+  }
+
+  /** Unregister this callback on shutdown. Best-effort. */
+  async unregisterCallback(): Promise<void> {
+    try {
+      await fetch(`${this.#apiBase}/api/channel/register`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ channel_api_key: this.#apiKey }),
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/extensions/eclaw/src/client.ts
+++ b/extensions/eclaw/src/client.ts
@@ -22,6 +22,23 @@ export interface EclawClientState {
   entityId: number | undefined;
 }
 
+/**
+ * Best-effort capture of an upstream error body for diagnostic messages.
+ * Caps at 200 chars so stack traces stay readable even for HTML error pages.
+ */
+async function readErrorSnippet(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    if (!text) {
+      return "";
+    }
+    const trimmed = text.replaceAll(/\s+/gu, " ").trim().slice(0, 200);
+    return trimmed ? `: ${trimmed}` : "";
+  } catch {
+    return "";
+  }
+}
+
 export class EclawClient {
   readonly #apiBase: string;
   readonly #apiKey: string;
@@ -136,7 +153,20 @@ export class EclawClient {
       }),
     });
 
-    return (await res.json()) as EclawMessageResponse;
+    if (!res.ok) {
+      const snippet = await readErrorSnippet(res);
+      throw new Error(
+        `E-Claw sendMessage failed (HTTP ${res.status})${snippet}`,
+      );
+    }
+
+    const data = (await res.json()) as EclawMessageResponse;
+    if (!data.success) {
+      throw new Error(
+        data.message || `E-Claw sendMessage rejected (HTTP ${res.status})`,
+      );
+    }
+    return data;
   }
 
   /** Bot-to-bot message to another entity on the same device. */
@@ -150,7 +180,7 @@ export class EclawClient {
       throw new Error("E-Claw client not bound — call bindEntity() first");
     }
 
-    await fetch(`${this.#apiBase}/api/entity/speak-to`, {
+    const res = await fetch(`${this.#apiBase}/api/entity/speak-to`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -162,6 +192,30 @@ export class EclawClient {
         expects_reply: expectsReply,
       }),
     });
+
+    if (!res.ok) {
+      const snippet = await readErrorSnippet(res);
+      throw new Error(
+        `E-Claw speakTo failed (HTTP ${res.status})${snippet}`,
+      );
+    }
+
+    // speakTo returns { success: boolean, message?: string } on the happy path;
+    // if the backend signals a rejection via success=false even on HTTP 200,
+    // treat it as a delivery failure so the dispatcher can report it. An
+    // empty 2xx body is tolerated (treated as success).
+    let data: { success?: boolean; message?: string } | null = null;
+    try {
+      data = (await res.json()) as { success?: boolean; message?: string };
+    } catch {
+      // Empty / non-JSON body on a 2xx response: treat as success.
+      return;
+    }
+    if (data?.success === false) {
+      throw new Error(
+        data.message || `E-Claw speakTo rejected (HTTP ${res.status})`,
+      );
+    }
   }
 
   /** Unregister this callback on shutdown. Best-effort. */

--- a/extensions/eclaw/src/client.ts
+++ b/extensions/eclaw/src/client.ts
@@ -7,6 +7,23 @@
  * Handles all communication between the OpenClaw plugin and the E-Claw
  * backend: callback registration, entity slot binding, outbound messages,
  * and entity-to-entity messaging.
+ *
+ * Response validation (sendMessage / speakTo) is strict: a non-2xx HTTP
+ * status or a `{success:false}` JSON body throws with a diagnostic
+ * snippet of the upstream body (capped at 200 chars). This is required
+ * by the channel plugin reply contract — the dispatcher treats a
+ * resolved outbound call as a successful delivery, so silently-swallowed
+ * failures become undetected message loss. See PR #62934 review round 3
+ * (codex `sendMessage` / `speakTo` P2 items) and
+ * `docs/plugins/sdk-channel-plugins.md` §"Reply pipeline".
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Reply pipeline" —
+ *     outbound delivery errors must surface as rejected promises so the
+ *     dispatcher's `onError` hook runs.
+ *   - docs/plugins/architecture.md §"Channel boundary" — clients
+ *     live inside the extension package; core never calls HTTP on
+ *     behalf of a channel.
  */
 
 import type {

--- a/extensions/eclaw/src/config-schema.ts
+++ b/extensions/eclaw/src/config-schema.ts
@@ -1,13 +1,21 @@
-import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
-import { z } from "openclaw/plugin-sdk/zod";
-
 /**
  * Config schema for the E-Claw channel.
  *
  * `apiKey` is the only required secret; the rest fall back to defaults or
  * environment variables (ECLAW_API_KEY, ECLAW_API_BASE, ECLAW_BOT_NAME,
  * ECLAW_WEBHOOK_URL).
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Config schema" —
+ *     `buildChannelConfigSchema` wraps a plugin-owned shape with the
+ *     common channel wrapper (enabled, accounts, etc.).
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths" —
+ *     use `openclaw/plugin-sdk/channel-config-schema` and
+ *     `openclaw/plugin-sdk/zod` instead of importing zod directly, so
+ *     the bundled plugin ships against the same zod instance core uses.
  */
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import { z } from "openclaw/plugin-sdk/zod";
 export const EclawChannelConfigSchema = buildChannelConfigSchema(
   z
     .object({

--- a/extensions/eclaw/src/config-schema.ts
+++ b/extensions/eclaw/src/config-schema.ts
@@ -1,0 +1,20 @@
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import { z } from "openclaw/plugin-sdk/zod";
+
+/**
+ * Config schema for the E-Claw channel.
+ *
+ * `apiKey` is the only required secret; the rest fall back to defaults or
+ * environment variables (ECLAW_API_KEY, ECLAW_API_BASE, ECLAW_BOT_NAME,
+ * ECLAW_WEBHOOK_URL).
+ */
+export const EclawChannelConfigSchema = buildChannelConfigSchema(
+  z
+    .object({
+      apiKey: z.string().optional(),
+      apiBase: z.string().optional(),
+      botName: z.string().optional(),
+      webhookUrl: z.string().optional(),
+    })
+    .passthrough(),
+);

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -165,8 +165,10 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
   const releaseRoute = acquireSharedEclawHttpRoute({ cfg, log });
   log?.info?.(`E-Claw webhook registered at: ${callbackUrl} (account: ${accountId})`);
 
+  let callbackRegistered = false;
   try {
     const reg = await client.registerCallback(callbackUrl, callbackToken);
+    callbackRegistered = true;
     log?.info?.(
       `E-Claw registered: deviceId=${reg.deviceId} entities=${reg.entities.length}`,
     );
@@ -179,6 +181,14 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
     log?.error?.(
       `E-Claw setup failed for account ${accountId}: ${(err as Error).message}`,
     );
+    // If registerCallback succeeded but a later step (e.g. bindEntity)
+    // failed, the E-Claw backend still holds a stale callback for this
+    // deviceId. Best-effort unregister so we don't leak server state.
+    if (callbackRegistered) {
+      await client.unregisterCallback().catch(() => {
+        /* best-effort */
+      });
+    }
     unregisterEclawWebhookToken(callbackToken);
     releaseRoute();
     clearEclawClient(accountId);

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -5,29 +5,38 @@
  *   1. Resolve credentials (config + env).
  *   2. Construct an EclawClient and register it in the client registry.
  *   3. Generate a per-session callback token.
- *   4. POST /api/channel/register so the E-Claw backend will push webhooks
- *      to the OpenClaw gateway.
- *   5. Auto-bind an entity slot via POST /api/channel/bind.
- *   6. Keep the promise alive until the gateway aborts the account.
- *
- * The inbound webhook itself is served by the webhook-handler module via
- * the OpenClaw plugin HTTP route registry (mirrors the npm package's
- * `/eclaw-webhook` route + Bearer-token routing).
+ *   4. Register the shared `/eclaw-webhook` HTTP route with the OpenClaw
+ *      plugin HTTP registry (multi-account safe — every account shares the
+ *      same path; dispatch is routed by the per-session Bearer token).
+ *   5. POST /api/channel/register so the E-Claw backend will push webhooks
+ *      to that route.
+ *   6. Auto-bind an entity slot via POST /api/channel/bind.
+ *   7. Keep the promise alive until the gateway aborts the account.
  */
 
 import { randomBytes } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
 import { waitUntilAbort } from "openclaw/plugin-sdk/channel-lifecycle";
+import {
+  readJsonWebhookBodyOrReject,
+  registerPluginHttpRoute,
+} from "openclaw/plugin-sdk/webhook-ingress";
 import { resolveAccount } from "./accounts.js";
 import { EclawClient } from "./client.js";
 import {
   clearEclawClient,
   setEclawClient,
 } from "./client-registry.js";
+import type { EclawInboundMessage } from "./types.js";
+import { handleEclawWebhookRequest } from "./webhook-handler.js";
 import {
   registerEclawWebhookToken,
   unregisterEclawWebhookToken,
 } from "./webhook-registry.js";
+
+const CHANNEL_ID = "eclaw";
+const WEBHOOK_ROUTE_PATH = "/eclaw-webhook";
 
 export type EclawGatewayContext = {
   cfg: OpenClawConfig;
@@ -40,9 +49,95 @@ export type EclawGatewayContext = {
   };
 };
 
-function formatCallbackUrl(publicUrl: string | undefined): string {
-  const base = (publicUrl ?? "").replace(/\/+$/, "") || "http://localhost";
-  return `${base}/eclaw-webhook`;
+function formatCallbackUrl(
+  publicUrl: string | undefined,
+  log?: EclawGatewayContext["log"],
+  accountId?: string,
+): string {
+  const trimmed = (publicUrl ?? "").replace(/\/+$/, "");
+  if (!trimmed) {
+    log?.warn?.(
+      `E-Claw account ${accountId ?? ""} has no webhookUrl — falling back to http://localhost${WEBHOOK_ROUTE_PATH}. ` +
+        "Set channels.eclaw.webhookUrl or ECLAW_WEBHOOK_URL to the public base URL so the E-Claw backend can reach the webhook.",
+    );
+    return `http://localhost${WEBHOOK_ROUTE_PATH}`;
+  }
+  return `${trimmed}${WEBHOOK_ROUTE_PATH}`;
+}
+
+/**
+ * Shared registration count + unregister for the `/eclaw-webhook` route.
+ *
+ * The route is mounted once and shared across all eclaw accounts; dispatch
+ * inside the handler picks the right account based on the per-session
+ * Bearer token in the registry. Every startAccount call increments a
+ * refcount, and the last stopAccount unregisters the underlying route.
+ */
+let sharedRouteRefCount = 0;
+let sharedRouteUnregister: (() => void) | null = null;
+
+function acquireSharedEclawHttpRoute(params: {
+  cfg: OpenClawConfig;
+  log?: EclawGatewayContext["log"];
+}): () => void {
+  if (sharedRouteUnregister) {
+    sharedRouteRefCount += 1;
+    return makeRouteRelease();
+  }
+
+  const handler = async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: "Method not allowed" }));
+      return;
+    }
+    const body = await readJsonWebhookBodyOrReject({
+      req,
+      res,
+      emptyObjectOnEmpty: true,
+    });
+    if (!body.ok) {
+      return;
+    }
+    const authHeader =
+      typeof req.headers.authorization === "string" ? req.headers.authorization : undefined;
+    const result = await handleEclawWebhookRequest({
+      cfg: params.cfg,
+      authHeader,
+      body: (body.value ?? {}) as EclawInboundMessage,
+    });
+    res.statusCode = result.status;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(result.body));
+  };
+
+  sharedRouteUnregister = registerPluginHttpRoute({
+    path: WEBHOOK_ROUTE_PATH,
+    auth: "plugin",
+    pluginId: CHANNEL_ID,
+    replaceExisting: false,
+    log: (msg: string) => params.log?.info?.(msg),
+    handler,
+  });
+  sharedRouteRefCount = 1;
+  params.log?.info?.(`E-Claw: registered shared HTTP route ${WEBHOOK_ROUTE_PATH}`);
+  return makeRouteRelease();
+}
+
+function makeRouteRelease(): () => void {
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    sharedRouteRefCount -= 1;
+    if (sharedRouteRefCount <= 0) {
+      sharedRouteRefCount = 0;
+      const fn = sharedRouteUnregister;
+      sharedRouteUnregister = null;
+      fn?.();
+    }
+  };
 }
 
 export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unknown> {
@@ -64,9 +159,10 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
   setEclawClient(accountId, client);
 
   const callbackToken = randomBytes(32).toString("hex");
-  const callbackUrl = formatCallbackUrl(account.webhookUrl);
+  const callbackUrl = formatCallbackUrl(account.webhookUrl, log, accountId);
 
   registerEclawWebhookToken(callbackToken, accountId);
+  const releaseRoute = acquireSharedEclawHttpRoute({ cfg, log });
   log?.info?.(`E-Claw webhook registered at: ${callbackUrl} (account: ${accountId})`);
 
   try {
@@ -84,6 +180,7 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
       `E-Claw setup failed for account ${accountId}: ${(err as Error).message}`,
     );
     unregisterEclawWebhookToken(callbackToken);
+    releaseRoute();
     clearEclawClient(accountId);
     return waitUntilAbort(abortSignal);
   }
@@ -92,10 +189,19 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
     log?.info?.(`Stopping E-Claw account ${accountId}`);
     void client.unregisterCallback();
     unregisterEclawWebhookToken(callbackToken);
+    releaseRoute();
     clearEclawClient(accountId);
   });
 }
 
 export async function stopEclawAccount(ctx: EclawGatewayContext): Promise<void> {
   ctx.log?.info?.(`E-Claw account ${ctx.accountId} stopped`);
+}
+
+/** Test-only: reset the shared-route refcount between test cases. */
+export function __resetEclawSharedRouteForTests(): void {
+  sharedRouteRefCount = 0;
+  const fn = sharedRouteUnregister;
+  sharedRouteUnregister = null;
+  fn?.();
 }

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -40,6 +40,7 @@ import { randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
 import { waitUntilAbort } from "openclaw/plugin-sdk/channel-lifecycle";
+import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import {
   readJsonWebhookBodyOrReject,
   registerPluginHttpRoute,
@@ -125,7 +126,7 @@ function acquireSharedEclawHttpRoute(params: {
     const authHeader =
       typeof req.headers.authorization === "string" ? req.headers.authorization : undefined;
     const result = await handleEclawWebhookRequest({
-      cfg: params.cfg,
+      cfg: getRuntimeConfigSnapshot() ?? params.cfg,
       authHeader,
       body: (body.value ?? {}) as EclawInboundMessage,
     });

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -194,7 +194,11 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
     unregisterEclawWebhookToken(callbackToken);
     releaseRoute();
     clearEclawClient(accountId);
-    return waitUntilAbort(abortSignal);
+    // Re-throw so the channel manager sees the failure, marks the account
+    // as failed, and can attempt a restart. Returning `waitUntilAbort` here
+    // would leave the startup task alive forever and the manager would never
+    // know setup failed.
+    throw err;
   }
 
   return waitUntilAbort(abortSignal, () => {

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -1,0 +1,101 @@
+/**
+ * Gateway lifecycle for the E-Claw channel plugin.
+ *
+ * Responsibilities on startAccount:
+ *   1. Resolve credentials (config + env).
+ *   2. Construct an EclawClient and register it in the client registry.
+ *   3. Generate a per-session callback token.
+ *   4. POST /api/channel/register so the E-Claw backend will push webhooks
+ *      to the OpenClaw gateway.
+ *   5. Auto-bind an entity slot via POST /api/channel/bind.
+ *   6. Keep the promise alive until the gateway aborts the account.
+ *
+ * The inbound webhook itself is served by the webhook-handler module via
+ * the OpenClaw plugin HTTP route registry (mirrors the npm package's
+ * `/eclaw-webhook` route + Bearer-token routing).
+ */
+
+import { randomBytes } from "node:crypto";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
+import { waitUntilAbort } from "openclaw/plugin-sdk/channel-lifecycle";
+import { resolveAccount } from "./accounts.js";
+import { EclawClient } from "./client.js";
+import {
+  clearEclawClient,
+  setEclawClient,
+} from "./client-registry.js";
+import {
+  registerEclawWebhookToken,
+  unregisterEclawWebhookToken,
+} from "./webhook-registry.js";
+
+export type EclawGatewayContext = {
+  cfg: OpenClawConfig;
+  accountId: string;
+  abortSignal: AbortSignal;
+  log?: {
+    info: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+  };
+};
+
+function formatCallbackUrl(publicUrl: string | undefined): string {
+  const base = (publicUrl ?? "").replace(/\/+$/, "") || "http://localhost";
+  return `${base}/eclaw-webhook`;
+}
+
+export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unknown> {
+  const { cfg, accountId, abortSignal, log } = ctx;
+  const account = resolveAccount(cfg, accountId);
+
+  if (!account.enabled) {
+    log?.info?.(`E-Claw account ${accountId} disabled, skipping`);
+    return waitUntilAbort(abortSignal);
+  }
+  if (!account.apiKey) {
+    log?.warn?.(
+      `E-Claw account ${accountId} missing apiKey — set channels.eclaw.apiKey or ECLAW_API_KEY`,
+    );
+    return waitUntilAbort(abortSignal);
+  }
+
+  const client = new EclawClient(account);
+  setEclawClient(accountId, client);
+
+  const callbackToken = randomBytes(32).toString("hex");
+  const callbackUrl = formatCallbackUrl(account.webhookUrl);
+
+  registerEclawWebhookToken(callbackToken, accountId);
+  log?.info?.(`E-Claw webhook registered at: ${callbackUrl} (account: ${accountId})`);
+
+  try {
+    const reg = await client.registerCallback(callbackUrl, callbackToken);
+    log?.info?.(
+      `E-Claw registered: deviceId=${reg.deviceId} entities=${reg.entities.length}`,
+    );
+
+    const bind = await client.bindEntity(undefined, account.botName);
+    log?.info?.(
+      `E-Claw bound slot ${bind.entityId} (publicCode=${bind.publicCode}) for account ${accountId}`,
+    );
+  } catch (err) {
+    log?.error?.(
+      `E-Claw setup failed for account ${accountId}: ${(err as Error).message}`,
+    );
+    unregisterEclawWebhookToken(callbackToken);
+    clearEclawClient(accountId);
+    return waitUntilAbort(abortSignal);
+  }
+
+  return waitUntilAbort(abortSignal, () => {
+    log?.info?.(`Stopping E-Claw account ${accountId}`);
+    void client.unregisterCallback();
+    unregisterEclawWebhookToken(callbackToken);
+    clearEclawClient(accountId);
+  });
+}
+
+export async function stopEclawAccount(ctx: EclawGatewayContext): Promise<void> {
+  ctx.log?.info?.(`E-Claw account ${ctx.accountId} stopped`);
+}

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -112,14 +112,54 @@ function acquireSharedEclawHttpRoute(params: {
     res.end(JSON.stringify(result.body));
   };
 
-  sharedRouteUnregister = registerPluginHttpRoute({
+  // registerPluginHttpRoute returns a no-op unregister function if the
+  // path is already claimed by another plugin (route conflict) or the
+  // path is invalid / missing — it signals this via a log message
+  // containing "route conflict", "route overlap denied", or "webhook path
+  // missing" and never adds an entry to the registry. We MUST detect
+  // that case here, because otherwise startAccount happily proceeds to
+  // register/bind with the E-Claw backend and reports success while
+  // inbound webhooks go nowhere.
+  //
+  // Sentinel pattern: wrap the log callback with a detector that sets
+  // `conflict` when a known failure message flies through. Any other
+  // messages (e.g. successful registration, stale-entry replacement) are
+  // forwarded verbatim.
+  // TypeScript's control-flow analysis doesn't track closure-mutated
+  // primitives, so we use a ref-style holder to preserve the mutation
+  // type without reading back as `never` after the lambda runs.
+  const conflictRef: { message: string | null } = { message: null };
+  const wrappedLog = (msg: string): void => {
+    if (
+      msg.includes("route conflict") ||
+      msg.includes("route overlap denied") ||
+      msg.includes("webhook path missing")
+    ) {
+      conflictRef.message = msg;
+    }
+    params.log?.info?.(msg);
+  };
+
+  const unregisterFn = registerPluginHttpRoute({
     path: WEBHOOK_ROUTE_PATH,
     auth: "plugin",
     pluginId: CHANNEL_ID,
     replaceExisting: false,
-    log: (msg: string) => params.log?.info?.(msg),
+    log: wrappedLog,
     handler,
   });
+
+  if (conflictRef.message !== null) {
+    // Route registration failed. Don't keep the no-op unregister around —
+    // throw so the caller (startAccount) can surface this as a real
+    // startup failure, clean up its local state, and let the channel
+    // manager retry or report it to the operator.
+    throw new Error(
+      `E-Claw: failed to register shared HTTP route ${WEBHOOK_ROUTE_PATH} — ${conflictRef.message}`,
+    );
+  }
+
+  sharedRouteUnregister = unregisterFn;
   sharedRouteRefCount = 1;
   params.log?.info?.(`E-Claw: registered shared HTTP route ${WEBHOOK_ROUTE_PATH}`);
   return makeRouteRelease();

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -128,7 +128,9 @@ function acquireSharedEclawHttpRoute(params: {
 function makeRouteRelease(): () => void {
   let released = false;
   return () => {
-    if (released) return;
+    if (released) {
+      return;
+    }
     released = true;
     sharedRouteRefCount -= 1;
     if (sharedRouteRefCount <= 0) {

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -1,6 +1,22 @@
 /**
  * Gateway lifecycle for the E-Claw channel plugin.
  *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/architecture.md
+ *       §"Channel boundary"
+ *       §"Plugin SDK import paths" — lists the stable
+ *         `openclaw/plugin-sdk/channel-lifecycle` and
+ *         `openclaw/plugin-sdk/webhook-ingress` subpaths used here.
+ *   - docs/plugins/sdk-channel-plugins.md
+ *       channel plugin contract (outbound/inbound/setup) and the
+ *       `waitUntilAbort` startAccount/stopAccount pattern.
+ *   - docs/plugins/building-plugins.md
+ *       Pre-submission checklist → "pnpm check passes (in-repo plugins)"
+ *   - AGENTS.md
+ *       "Channel boundary", "Architecture Boundaries" —
+ *       extension-owned behavior lives in the extension; do not deep-
+ *       import bundled-plugin internals from core.
+ *
  * Responsibilities on startAccount:
  *   1. Resolve credentials (config + env).
  *   2. Construct an EclawClient and register it in the client registry.
@@ -12,6 +28,12 @@
  *      to that route.
  *   6. Auto-bind an entity slot via POST /api/channel/bind.
  *   7. Keep the promise alive until the gateway aborts the account.
+ *
+ * Failure semantics (see PR #62934 review rounds 4–7):
+ *   - Disabled / missing-apiKey → `waitUntilAbort` (opt-out, not a crash).
+ *   - Route conflict / register / bind failure → clean up local state
+ *     AND the remote E-Claw callback, then re-throw so the channel
+ *     manager marks the account as failed and can restart it.
  */
 
 import { randomBytes } from "node:crypto";
@@ -204,7 +226,27 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
   const callbackUrl = formatCallbackUrl(account.webhookUrl, log, accountId);
 
   registerEclawWebhookToken(callbackToken, accountId);
-  const releaseRoute = acquireSharedEclawHttpRoute({ cfg, log });
+
+  // acquireSharedEclawHttpRoute may throw on route conflict (see
+  // commit 8dfa822af5). That throw happens BEFORE the register/bind
+  // try/catch below, so the webhook token and client we just stashed
+  // would leak into the global registries if we didn't handle it here.
+  // Guard the acquisition with an isolated try so we can roll back the
+  // local state and re-throw, mirroring the cleanup in the register/
+  // bind catch block. See docs/plugins/architecture.md "Channel
+  // boundary" + AGENTS.md "Error handling" — a failed startup must
+  // leave no trace in shared state so manager restarts are clean.
+  let releaseRoute: () => void;
+  try {
+    releaseRoute = acquireSharedEclawHttpRoute({ cfg, log });
+  } catch (err) {
+    log?.error?.(
+      `E-Claw setup failed for account ${accountId}: ${(err as Error).message}`,
+    );
+    unregisterEclawWebhookToken(callbackToken);
+    clearEclawClient(accountId);
+    throw err;
+  }
   log?.info?.(`E-Claw webhook registered at: ${callbackUrl} (account: ${accountId})`);
 
   let callbackRegistered = false;

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -284,9 +284,11 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
     throw err;
   }
 
-  return waitUntilAbort(abortSignal, () => {
+  return waitUntilAbort(abortSignal, async () => {
     log?.info?.(`Stopping E-Claw account ${accountId}`);
-    void client.unregisterCallback();
+    await client.unregisterCallback().catch(() => {
+      /* best-effort — don't block stop on network failure */
+    });
     unregisterEclawWebhookToken(callbackToken);
     releaseRoute();
     clearEclawClient(accountId);

--- a/extensions/eclaw/src/gateway.ts
+++ b/extensions/eclaw/src/gateway.ts
@@ -72,20 +72,8 @@ export type EclawGatewayContext = {
   };
 };
 
-function formatCallbackUrl(
-  publicUrl: string | undefined,
-  log?: EclawGatewayContext["log"],
-  accountId?: string,
-): string {
-  const trimmed = (publicUrl ?? "").replace(/\/+$/, "");
-  if (!trimmed) {
-    log?.warn?.(
-      `E-Claw account ${accountId ?? ""} has no webhookUrl — falling back to http://localhost${WEBHOOK_ROUTE_PATH}. ` +
-        "Set channels.eclaw.webhookUrl or ECLAW_WEBHOOK_URL to the public base URL so the E-Claw backend can reach the webhook.",
-    );
-    return `http://localhost${WEBHOOK_ROUTE_PATH}`;
-  }
-  return `${trimmed}${WEBHOOK_ROUTE_PATH}`;
+function formatCallbackUrl(publicUrl: string): string {
+  return `${publicUrl.replace(/\/+$/, "")}${WEBHOOK_ROUTE_PATH}`;
 }
 
 /**
@@ -219,12 +207,17 @@ export async function startEclawAccount(ctx: EclawGatewayContext): Promise<unkno
     );
     return waitUntilAbort(abortSignal);
   }
+  if (!account.webhookUrl) {
+    throw new Error(
+      `E-Claw account ${accountId} missing webhookUrl — set channels.eclaw.webhookUrl or ECLAW_WEBHOOK_URL to the public base URL so the E-Claw backend can reach the webhook`,
+    );
+  }
 
   const client = new EclawClient(account);
   setEclawClient(accountId, client);
 
   const callbackToken = randomBytes(32).toString("hex");
-  const callbackUrl = formatCallbackUrl(account.webhookUrl, log, accountId);
+  const callbackUrl = formatCallbackUrl(account.webhookUrl);
 
   registerEclawWebhookToken(callbackToken, accountId);
 

--- a/extensions/eclaw/src/runtime.ts
+++ b/extensions/eclaw/src/runtime.ts
@@ -1,3 +1,21 @@
+/**
+ * Plugin runtime store for the E-Claw channel plugin.
+ *
+ * Holds the `PluginRuntime` instance injected by OpenClaw core when
+ * the bundled plugin registers. All extension-side code that needs
+ * the runtime (webhook handlers, setup adapters, reply dispatchers)
+ * goes through `getEclawRuntime()` / `setEclawRuntime()`.
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-overview.md §"Plugin runtime" — every bundled
+ *     plugin owns its own runtime store via
+ *     `createPluginRuntimeStore<PluginRuntime>(...)` so the module is
+ *     import-safe (no top-level throw if the plugin isn't loaded).
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths" —
+ *     `openclaw/plugin-sdk/core` for `PluginRuntime` type,
+ *     `openclaw/plugin-sdk/runtime-store` for the factory.
+ *   - docs/plugins/sdk-runtime.md §"Runtime store pattern".
+ */
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 

--- a/extensions/eclaw/src/runtime.ts
+++ b/extensions/eclaw/src/runtime.ts
@@ -1,0 +1,9 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+
+const { setRuntime: setEclawRuntime, getRuntime: getEclawRuntime } =
+  createPluginRuntimeStore<PluginRuntime>(
+    "E-Claw runtime not initialized - plugin not registered",
+  );
+
+export { getEclawRuntime, setEclawRuntime };

--- a/extensions/eclaw/src/send.ts
+++ b/extensions/eclaw/src/send.ts
@@ -1,0 +1,105 @@
+/**
+ * Outbound send helpers for the E-Claw channel plugin.
+ *
+ * These are invoked from the ChannelPlugin outbound adapter when the
+ * OpenClaw runtime wants to deliver a text or media reply to an E-Claw
+ * user. For bot-to-bot / broadcast events the gateway handles delivery
+ * inline, so the outbound path short-circuits in that case.
+ */
+
+import type { EclawClient } from "./client.js";
+import { getActiveEclawEvent, getEclawClient } from "./client-registry.js";
+
+type SendOutcome = {
+  channel: "eclaw";
+  messageId: string;
+  chatId: string;
+  ok?: boolean;
+};
+
+function formatSendResult(
+  to: string | null | undefined,
+  ok: boolean,
+): SendOutcome {
+  return {
+    channel: "eclaw",
+    messageId: `eclaw-${Date.now()}`,
+    chatId: (to ?? "").toString(),
+    ok,
+  };
+}
+
+function mapMediaType(mediaType?: string): string {
+  return mediaType === "image"
+    ? "photo"
+    : mediaType === "audio"
+      ? "voice"
+      : mediaType === "video"
+        ? "video"
+        : mediaType || "file";
+}
+
+function shouldSuppress(accountId: string): boolean {
+  const event = getActiveEclawEvent(accountId);
+  return event === "entity_message" || event === "broadcast";
+}
+
+async function sendViaClient(
+  client: EclawClient,
+  text: string,
+  mediaType?: string,
+  mediaUrl?: string,
+): Promise<boolean> {
+  const result = await client.sendMessage(text, "IDLE", mediaType, mediaUrl);
+  return Boolean(result.success);
+}
+
+export async function sendEclawText(params: {
+  accountId?: string | null;
+  to?: string | null;
+  text: string;
+}): Promise<SendOutcome> {
+  const accountId = params.accountId ?? "default";
+  if (shouldSuppress(accountId)) {
+    return formatSendResult(params.to, true);
+  }
+
+  const client = getEclawClient(accountId);
+  if (!client) {
+    return formatSendResult(params.to, false);
+  }
+
+  try {
+    const ok = await sendViaClient(client, params.text);
+    return formatSendResult(params.to, ok);
+  } catch {
+    return formatSendResult(params.to, false);
+  }
+}
+
+export async function sendEclawMedia(params: {
+  accountId?: string | null;
+  to?: string | null;
+  text?: string;
+  mediaType?: string;
+  mediaUrl?: string;
+}): Promise<SendOutcome> {
+  const accountId = params.accountId ?? "default";
+  if (shouldSuppress(accountId)) {
+    return formatSendResult(params.to, true);
+  }
+
+  const client = getEclawClient(accountId);
+  if (!client) {
+    return formatSendResult(params.to, false);
+  }
+
+  try {
+    const mediaType = mapMediaType(params.mediaType);
+    const text = params.text || `[${mediaType}]`;
+    const ok = await sendViaClient(client, text, mediaType, params.mediaUrl);
+    return formatSendResult(params.to, ok);
+  } catch {
+    return formatSendResult(params.to, false);
+  }
+}

--- a/extensions/eclaw/src/send.ts
+++ b/extensions/eclaw/src/send.ts
@@ -4,7 +4,22 @@
  * These are invoked from the ChannelPlugin outbound adapter when the
  * OpenClaw runtime wants to deliver a text or media reply to an E-Claw
  * user. For bot-to-bot / broadcast events the gateway handles delivery
- * inline, so the outbound path short-circuits in that case.
+ * inline (see webhook-handler.ts), so the outbound path short-circuits
+ * in that case via `getActiveEclawEvent()`.
+ *
+ * The suppression flag is read from an AsyncLocalStorage context
+ * (see client-registry.ts) so that concurrent unrelated outbound sends
+ * on the same account are NOT dropped. PR #62934 review round 5
+ * (codex send.ts P1 item) — the previous global-Map implementation
+ * caused silent message loss under concurrency.
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Outbound adapter" —
+ *     the outbound.sendText / outbound.sendMedia contract returns
+ *     `{channel, messageId, chatId, ok?}`.
+ *   - docs/plugins/architecture.md §"Channel boundary" —
+ *     channel-owned outbound logic stays inside the extension; core
+ *     never constructs channel payloads directly.
  */
 
 import type { EclawClient } from "./client.js";

--- a/extensions/eclaw/src/setup-adapter.ts
+++ b/extensions/eclaw/src/setup-adapter.ts
@@ -1,0 +1,20 @@
+import { createOptionalChannelSetupSurface } from "openclaw/plugin-sdk/channel-setup";
+
+/**
+ * E-Claw ships with the "optional" setup surface so that when the plugin
+ * is discovered but has not been configured, the setup wizard points the
+ * user at the docs/npm spec instead of auto-creating credentials.
+ *
+ * Real credential entry is handled separately via environment variables
+ * (ECLAW_API_KEY etc.) or a manual edit of openclaw.json until a native
+ * wizard lands in a follow-up.
+ */
+const optionalSetup = createOptionalChannelSetupSurface({
+  channel: "eclaw",
+  label: "E-Claw",
+  npmSpec: "@openclaw/eclaw",
+  docsPath: "/channels/eclaw",
+});
+
+export const eclawSetupAdapter = optionalSetup.setupAdapter;
+export const eclawSetupWizard = optionalSetup.setupWizard;

--- a/extensions/eclaw/src/setup-adapter.ts
+++ b/extensions/eclaw/src/setup-adapter.ts
@@ -1,5 +1,3 @@
-import { createOptionalChannelSetupSurface } from "openclaw/plugin-sdk/channel-setup";
-
 /**
  * E-Claw ships with the "optional" setup surface so that when the plugin
  * is discovered but has not been configured, the setup wizard points the
@@ -8,7 +6,17 @@ import { createOptionalChannelSetupSurface } from "openclaw/plugin-sdk/channel-s
  * Real credential entry is handled separately via environment variables
  * (ECLAW_API_KEY etc.) or a manual edit of openclaw.json until a native
  * wizard lands in a follow-up.
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Setup surface" — three
+ *     tiers: native wizard, optional surface, or none. Optional is the
+ *     correct tier for channels that haven't implemented a wizard yet
+ *     (parity with synology-chat, nextcloud-talk).
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths" —
+ *     `openclaw/plugin-sdk/channel-setup` is the stable subpath for
+ *     `createOptionalChannelSetupSurface`.
  */
+import { createOptionalChannelSetupSurface } from "openclaw/plugin-sdk/channel-setup";
 const optionalSetup = createOptionalChannelSetupSurface({
   channel: "eclaw",
   label: "E-Claw",

--- a/extensions/eclaw/src/types.ts
+++ b/extensions/eclaw/src/types.ts
@@ -5,6 +5,21 @@
  * Android. Each connected device has a small number of character "slots";
  * an OpenClaw bot claims one slot and exchanges messages with the device
  * owner (and other entities on the same device) via the E-Claw channel API.
+ *
+ * All wire-format types here mirror the E-Claw backend payload contract
+ * (see https://github.com/HankHuang0516/EClaw backend/channel-api.js).
+ * Any field added to the backend MUST also land here before the webhook
+ * handler can use it — e.g. `backupUrl` fallback (PR #62934 review
+ * round 7, codex webhook-handler.ts P2) requires `EclawInboundMessage.
+ * backupUrl` to be declared.
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Channel plugin contract"
+ *     — the `ResolvedAccount` / `InboundMessage` shapes must be
+ *     compatible with the SDK's channel contract types.
+ *   - docs/plugins/architecture.md §"Extension API surface rule" —
+ *     types that cross the package boundary go through `api.ts`, not
+ *     through `src/` relative imports from outside the extension.
  */
 
 type EclawConfigFields = {

--- a/extensions/eclaw/src/types.ts
+++ b/extensions/eclaw/src/types.ts
@@ -95,6 +95,7 @@ export interface EclawBindResponse {
 /** Response from POST /api/channel/message */
 export interface EclawMessageResponse {
   success: boolean;
+  message?: string;
   currentState?: {
     name: string;
     state: string;

--- a/extensions/eclaw/src/types.ts
+++ b/extensions/eclaw/src/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Type definitions for the E-Claw channel plugin.
+ *
+ * E-Claw is an AI chat platform for live wallpaper character entities on
+ * Android. Each connected device has a small number of character "slots";
+ * an OpenClaw bot claims one slot and exchanges messages with the device
+ * owner (and other entities on the same device) via the E-Claw channel API.
+ */
+
+type EclawConfigFields = {
+  enabled?: boolean;
+  apiKey?: string;
+  apiBase?: string;
+  botName?: string;
+  webhookUrl?: string;
+};
+
+/** Raw channel config from openclaw.json channels.eclaw */
+export interface EclawChannelConfig extends EclawConfigFields {
+  accounts?: Record<string, EclawAccountRaw>;
+}
+
+/** Raw per-account config (overrides base config) */
+export interface EclawAccountRaw extends EclawConfigFields {}
+
+/** Fully resolved account config with defaults applied */
+export interface ResolvedEclawAccount {
+  accountId: string;
+  enabled: boolean;
+  apiKey: string;
+  apiBase: string;
+  botName: string;
+  webhookUrl: string;
+}
+
+/** Context block injected by the E-Claw server for Channel Bot parity */
+export interface EclawContextBlock {
+  b2bRemaining?: number;
+  b2bMax?: number;
+  expectsReply?: boolean;
+  missionHints?: string;
+  silentToken?: string;
+}
+
+/** Inbound message payload from the E-Claw callback webhook */
+export interface EclawInboundMessage {
+  event: "message" | "entity_message" | "broadcast" | "cross_device_message";
+  deviceId: string;
+  entityId: number;
+  conversationId?: string;
+  from: string;
+  text: string;
+  mediaType?: "photo" | "voice" | "video" | "file" | null;
+  mediaUrl?: string | null;
+  backupUrl?: string | null;
+  timestamp?: number;
+  isBroadcast?: boolean;
+  broadcastRecipients?: number[] | null;
+  fromEntityId?: number;
+  fromCharacter?: string;
+  fromPublicCode?: string;
+  eclaw_context?: EclawContextBlock;
+}
+
+/** Entity slot info returned by POST /api/channel/register */
+export interface EclawEntityInfo {
+  entityId: number;
+  isBound: boolean;
+  name: string | null;
+  character: string;
+  bindingType: string | null;
+}
+
+/** Response from POST /api/channel/register */
+export interface EclawRegisterResponse {
+  success: boolean;
+  deviceId: string;
+  entities: EclawEntityInfo[];
+  maxEntities: number;
+  message?: string;
+}
+
+/** Response from POST /api/channel/bind */
+export interface EclawBindResponse {
+  success: boolean;
+  deviceId: string;
+  entityId: number;
+  botSecret: string;
+  publicCode: string;
+  bindingType: string;
+  message?: string;
+  entities?: EclawEntityInfo[];
+}
+
+/** Response from POST /api/channel/message */
+export interface EclawMessageResponse {
+  success: boolean;
+  currentState?: {
+    name: string;
+    state: string;
+    message: string;
+    xp: number;
+    level: number;
+  };
+}

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -212,22 +212,32 @@ export async function dispatchEclawWebhookMessage(params: {
           await client.sendMessage(text, "IDLE", outboundMediaType, mediaUrl);
         },
         onError: (err: unknown, info?: { kind?: string }) => {
-          // Don't silently drop delivery failures — surface them via
-          // the plugin runtime logger so operators can see partial
-          // failures in the OpenClaw logs. If the runtime has no error
-          // sink wired up (shouldn't happen at runtime), the message is
-          // dropped rather than leaking to stdout — this keeps the
-          // extension free of production lint suppressions.
+          // Surface delivery failures via the plugin runtime's
+          // structured logger so operators can see partial failures
+          // in the OpenClaw logs.
+          //
+          // The correct logger API is
+          //   runtime.logging.getChildLogger({...}).error(msg, meta?)
+          // per `PluginRuntimeCore.logging.getChildLogger` in
+          // src/plugins/runtime/types-core.ts (see `RuntimeLogger`).
+          // Earlier rounds of this PR incorrectly reached for a
+          // top-level `runtime.error` which does not exist on
+          // PluginRuntime — the regression test had a fake runtime
+          // with a flat `.error` method, which passed but did not
+          // reflect the real runtime shape. Every real delivery
+          // failure was silently swallowed. See PR #62934 round 8
+          // (codex webhook-handler.ts P2).
           const message = err instanceof Error ? err.message : String(err);
           const kind = info?.kind ? ` ${info.kind}` : "";
-          const line = `eclaw: reply${kind} delivery failed: ${message}`;
           try {
-            const runtime = getEclawRuntime() as unknown as {
-              error?: (msg: string) => void;
-            };
-            if (typeof runtime?.error === "function") {
-              runtime.error(line);
-            }
+            const runtime = getEclawRuntime();
+            const childLogger = runtime.logging?.getChildLogger?.({
+              plugin: "eclaw",
+              accountId,
+            });
+            childLogger?.error?.(`reply${kind} delivery failed: ${message}`, {
+              kind: info?.kind,
+            });
           } catch {
             /* runtime not initialised — drop silently */
           }

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -262,6 +262,15 @@ export async function handleEclawWebhookRequest(params: {
     return { status: 401, body: { error: "Unauthorized" } };
   }
 
+  // Reject payloads that are missing required routing fields before
+  // acknowledging success. Returning 200 for a structurally invalid push
+  // would tell the E-Claw backend the event was delivered when nothing
+  // was actually processed (see PR #62934 round 13, codex P2).
+  const { body } = params;
+  if (!body.deviceId || body.entityId === undefined || body.entityId === null) {
+    return { status: 400, body: { error: "missing_required_fields" } };
+  }
+
   try {
     await dispatchEclawWebhookMessage({
       accountId: entry.accountId,

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -13,9 +13,8 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
 
 import {
-  clearActiveEclawEvent,
   getEclawClient,
-  setActiveEclawEvent,
+  runWithActiveEclawEvent,
 } from "./client-registry.js";
 import { getEclawRuntime } from "./runtime.js";
 import type { EclawInboundMessage } from "./types.js";
@@ -129,8 +128,10 @@ export async function dispatchEclawWebhookMessage(params: {
 
   const ctxPayload = runtime.channel.reply.finalizeInboundContext(inboundCtx);
 
-  setActiveEclawEvent(accountId, event);
-  try {
+  // Bind the active-event flag to this webhook's async context only,
+  // so concurrent unrelated outbound sends on the same account are NOT
+  // suppressed. See client-registry.ts for rationale.
+  await runWithActiveEclawEvent(accountId, event, async () => {
     await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg,
@@ -212,9 +213,7 @@ export async function dispatchEclawWebhookMessage(params: {
         },
       },
     });
-  } finally {
-    clearActiveEclawEvent(accountId);
-  }
+  });
 }
 
 /**

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -1,13 +1,27 @@
 /**
  * Inbound webhook handler for the E-Claw plugin.
  *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/architecture.md §"Channel boundary" — inbound
+ *     dispatch must go through `runtime.channel.reply` rather than
+ *     reaching into core router internals.
+ *   - docs/plugins/sdk-channel-plugins.md §"Channel plugin contract"
+ *     and §"Reply pipeline" — `finalizeInboundContext` +
+ *     `dispatchReplyWithBufferedBlockDispatcher` are the stable seams
+ *     for turning a raw channel payload into a reply dispatch.
+ *
  * Converts an E-Claw push payload into an OpenClaw reply dispatch and
  * routes any deliverable text/media back through the EclawClient.
  *
  * For bot-to-bot (`entity_message`) and `broadcast` events, the handler
- * suppresses duplicate delivery from the outbound pipeline by setting a
- * per-account active-event marker, and then posts both a channel message
- * (to update the wallpaper state) and a speak-to (to reply to the sender).
+ * suppresses duplicate delivery from the outbound pipeline by running
+ * the dispatch inside an `AsyncLocalStorage` frame (see
+ * client-registry.ts rationale — PR #62934 round 5), and then posts
+ * both a channel message (to update the wallpaper state) and a
+ * speak-to (to reply to the sender).
+ *
+ * Bearer token auth is case-insensitive per RFC 7235 §2.1 — see
+ * webhook-registry.ts (PR #62934 round 5).
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
@@ -121,9 +135,16 @@ export async function dispatchEclawWebhookMessage(params: {
     CommandBody: body,
     ChatType: "direct",
   };
-  if (ocMediaType && msg.mediaUrl) {
+  // Prefer primary mediaUrl; fall back to backupUrl when the primary is
+  // missing but a backup mirror is available (E-Claw sometimes pushes
+  // media with only backupUrl populated when the primary CDN is
+  // degraded or the asset was rehosted). Without this fallback the
+  // message looks text-only to the reply dispatcher and media-aware
+  // behavior is lost — see EclawInboundMessage.backupUrl in types.ts.
+  const effectiveMediaUrl = msg.mediaUrl ?? msg.backupUrl ?? undefined;
+  if (ocMediaType && effectiveMediaUrl) {
     inboundCtx.MediaType = ocMediaType;
-    inboundCtx.MediaUrl = msg.mediaUrl;
+    inboundCtx.MediaUrl = effectiveMediaUrl;
   }
 
   const ctxPayload = runtime.channel.reply.finalizeInboundContext(inboundCtx);

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -127,7 +127,21 @@ export async function dispatchEclawWebhookMessage(params: {
           if (!client) return;
           const text = typeof payload.text === "string" ? payload.text.trim() : "";
 
-          if (!text || text === silentToken) {
+          // Silent-token: hard stop, regardless of media.
+          if (text === silentToken) {
+            return;
+          }
+
+          // Empty text: still allow media-only delivery through.
+          if (!text) {
+            if (payload.mediaUrl) {
+              await client.sendMessage(
+                "",
+                "IDLE",
+                mapMediaTypeOutbound(payload.mediaType),
+                payload.mediaUrl,
+              );
+            }
             return;
           }
 
@@ -141,18 +155,7 @@ export async function dispatchEclawWebhookMessage(params: {
             return;
           }
 
-          if (text) {
-            await client.sendMessage(text, "IDLE");
-            return;
-          }
-          if (payload.mediaUrl) {
-            await client.sendMessage(
-              "",
-              "IDLE",
-              mapMediaTypeOutbound(payload.mediaType),
-              payload.mediaUrl,
-            );
-          }
+          await client.sendMessage(text, "IDLE");
         },
         onError: () => {
           /* swallow — logged upstream */

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -10,6 +10,8 @@
  * (to update the wallpaper state) and a speak-to (to reply to the sender).
  */
 
+import type { OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
+
 import {
   clearActiveEclawEvent,
   getEclawClient,
@@ -22,17 +24,31 @@ import { lookupEclawWebhookToken } from "./webhook-registry.js";
 function mapMediaTypeInbound(
   mediaType: EclawInboundMessage["mediaType"],
 ): string | undefined {
-  if (!mediaType) return undefined;
-  if (mediaType === "photo") return "image";
-  if (mediaType === "voice") return "audio";
-  if (mediaType === "video") return "video";
+  if (!mediaType) {
+    return undefined;
+  }
+  if (mediaType === "photo") {
+    return "image";
+  }
+  if (mediaType === "voice") {
+    return "audio";
+  }
+  if (mediaType === "video") {
+    return "video";
+  }
   return "file";
 }
 
 function mapMediaTypeOutbound(mediaType?: string): string {
-  if (mediaType === "image") return "photo";
-  if (mediaType === "audio") return "voice";
-  if (mediaType === "video") return "video";
+  if (mediaType === "image") {
+    return "photo";
+  }
+  if (mediaType === "audio") {
+    return "voice";
+  }
+  if (mediaType === "video") {
+    return "video";
+  }
   return mediaType || "file";
 }
 
@@ -74,7 +90,7 @@ function buildInboundBody(msg: EclawInboundMessage): string {
  */
 export async function dispatchEclawWebhookMessage(params: {
   accountId: string;
-  cfg: unknown;
+  cfg: OpenClawConfig;
   msg: EclawInboundMessage;
 }): Promise<void> {
   const { accountId, cfg, msg } = params;
@@ -124,7 +140,9 @@ export async function dispatchEclawWebhookMessage(params: {
           mediaType?: string;
           mediaUrl?: string;
         }) => {
-          if (!client) return;
+          if (!client) {
+            return;
+          }
           const text = typeof payload.text === "string" ? payload.text.trim() : "";
           const mediaUrl = payload.mediaUrl;
           const outboundMediaType = mediaUrl
@@ -174,9 +192,10 @@ export async function dispatchEclawWebhookMessage(params: {
         onError: (err: unknown, info?: { kind?: string }) => {
           // Don't silently drop delivery failures — surface them via
           // the plugin runtime logger so operators can see partial
-          // failures in the OpenClaw logs. Best-effort: if the runtime
-          // has no error sink, fall back to console.error with a
-          // stable "eclaw:" prefix.
+          // failures in the OpenClaw logs. If the runtime has no error
+          // sink wired up (shouldn't happen at runtime), the message is
+          // dropped rather than leaking to stdout — this keeps the
+          // extension free of production lint suppressions.
           const message = err instanceof Error ? err.message : String(err);
           const kind = info?.kind ? ` ${info.kind}` : "";
           const line = `eclaw: reply${kind} delivery failed: ${message}`;
@@ -186,13 +205,10 @@ export async function dispatchEclawWebhookMessage(params: {
             };
             if (typeof runtime?.error === "function") {
               runtime.error(line);
-              return;
             }
           } catch {
-            /* runtime not initialised — fall through */
+            /* runtime not initialised — drop silently */
           }
-          // eslint-disable-next-line no-console
-          console.error(line);
         },
       },
     });
@@ -207,7 +223,7 @@ export async function dispatchEclawWebhookMessage(params: {
  * the payload to `dispatchEclawWebhookMessage`.
  */
 export async function handleEclawWebhookRequest(params: {
-  cfg: unknown;
+  cfg: OpenClawConfig;
   authHeader: string | undefined;
   body: EclawInboundMessage;
 }): Promise<{ status: number; body: Record<string, unknown> }> {

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -1,0 +1,192 @@
+/**
+ * Inbound webhook handler for the E-Claw plugin.
+ *
+ * Converts an E-Claw push payload into an OpenClaw reply dispatch and
+ * routes any deliverable text/media back through the EclawClient.
+ *
+ * For bot-to-bot (`entity_message`) and `broadcast` events, the handler
+ * suppresses duplicate delivery from the outbound pipeline by setting a
+ * per-account active-event marker, and then posts both a channel message
+ * (to update the wallpaper state) and a speak-to (to reply to the sender).
+ */
+
+import {
+  clearActiveEclawEvent,
+  getEclawClient,
+  setActiveEclawEvent,
+} from "./client-registry.js";
+import { getEclawRuntime } from "./runtime.js";
+import type { EclawInboundMessage } from "./types.js";
+import { lookupEclawWebhookToken } from "./webhook-registry.js";
+
+function mapMediaTypeInbound(
+  mediaType: EclawInboundMessage["mediaType"],
+): string | undefined {
+  if (!mediaType) return undefined;
+  if (mediaType === "photo") return "image";
+  if (mediaType === "voice") return "audio";
+  if (mediaType === "video") return "video";
+  return "file";
+}
+
+function mapMediaTypeOutbound(mediaType?: string): string {
+  if (mediaType === "image") return "photo";
+  if (mediaType === "audio") return "voice";
+  if (mediaType === "video") return "video";
+  return mediaType || "file";
+}
+
+function buildInboundBody(msg: EclawInboundMessage): string {
+  const base = msg.text || "";
+  const event = msg.event ?? "message";
+  if (event !== "entity_message" && event !== "broadcast") {
+    return base;
+  }
+  if (msg.fromEntityId === undefined) {
+    return base;
+  }
+
+  const senderLabel = msg.fromCharacter
+    ? `Entity ${msg.fromEntityId} (${msg.fromCharacter})`
+    : `Entity ${msg.fromEntityId}`;
+  const eventPrefix =
+    event === "broadcast"
+      ? `[Broadcast from ${senderLabel}]`
+      : `[Bot-to-Bot message from ${senderLabel}]`;
+
+  const ctx = msg.eclaw_context;
+  const silentToken = ctx?.silentToken ?? "[SILENT]";
+  const quotaLine =
+    ctx?.b2bRemaining !== undefined
+      ? `[Quota: ${ctx.b2bRemaining}/${ctx.b2bMax ?? 8} remaining — output "${silentToken}" if no new info worth replying to]`
+      : "";
+  const missionBlock = ctx?.missionHints ?? "";
+
+  return [eventPrefix, quotaLine, missionBlock, base].filter(Boolean).join("\n");
+}
+
+/**
+ * Dispatch a decoded webhook body to the OpenClaw runtime.
+ *
+ * Exported (rather than kept inline) so that the channel plugin's
+ * inbound adapter and any lightweight test harness can share the same
+ * behavior.
+ */
+export async function dispatchEclawWebhookMessage(params: {
+  accountId: string;
+  cfg: unknown;
+  msg: EclawInboundMessage;
+}): Promise<void> {
+  const { accountId, cfg, msg } = params;
+
+  if (!msg.deviceId || msg.entityId === undefined || msg.entityId === null) {
+    return;
+  }
+
+  const runtime = getEclawRuntime();
+  const client = getEclawClient(accountId);
+  const conversationId = msg.conversationId || `${msg.deviceId}:${msg.entityId}`;
+  const event = msg.event ?? "message";
+  const fromEntityId = msg.fromEntityId;
+  const silentToken = msg.eclaw_context?.silentToken ?? "[SILENT]";
+  const body = buildInboundBody(msg);
+  const ocMediaType = mapMediaTypeInbound(msg.mediaType);
+
+  const inboundCtx: Record<string, unknown> = {
+    Surface: "eclaw",
+    Provider: "eclaw",
+    OriginatingChannel: "eclaw",
+    AccountId: accountId,
+    From: msg.from,
+    To: conversationId,
+    OriginatingTo: msg.from,
+    SessionKey: conversationId,
+    Body: body,
+    RawBody: body,
+    CommandBody: body,
+    ChatType: "direct",
+  };
+  if (ocMediaType && msg.mediaUrl) {
+    inboundCtx.MediaType = ocMediaType;
+    inboundCtx.MediaUrl = msg.mediaUrl;
+  }
+
+  const ctxPayload = runtime.channel.reply.finalizeInboundContext(inboundCtx);
+
+  setActiveEclawEvent(accountId, event);
+  try {
+    await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: ctxPayload,
+      cfg,
+      dispatcherOptions: {
+        deliver: async (payload: {
+          text?: string;
+          mediaType?: string;
+          mediaUrl?: string;
+        }) => {
+          if (!client) return;
+          const text = typeof payload.text === "string" ? payload.text.trim() : "";
+
+          if (!text || text === silentToken) {
+            return;
+          }
+
+          if (
+            (event === "entity_message" || event === "broadcast") &&
+            fromEntityId !== undefined
+          ) {
+            // Update own wallpaper and reply to the sender.
+            await client.sendMessage(text, "IDLE");
+            await client.speakTo(fromEntityId, text, false);
+            return;
+          }
+
+          if (text) {
+            await client.sendMessage(text, "IDLE");
+            return;
+          }
+          if (payload.mediaUrl) {
+            await client.sendMessage(
+              "",
+              "IDLE",
+              mapMediaTypeOutbound(payload.mediaType),
+              payload.mediaUrl,
+            );
+          }
+        },
+        onError: () => {
+          /* swallow — logged upstream */
+        },
+      },
+    });
+  } finally {
+    clearActiveEclawEvent(accountId);
+  }
+}
+
+/**
+ * HTTP handler for the shared `/eclaw-webhook` route. Looks up the target
+ * account by the Bearer token in the Authorization header and dispatches
+ * the payload to `dispatchEclawWebhookMessage`.
+ */
+export async function handleEclawWebhookRequest(params: {
+  cfg: unknown;
+  authHeader: string | undefined;
+  body: EclawInboundMessage;
+}): Promise<{ status: number; body: Record<string, unknown> }> {
+  const entry = lookupEclawWebhookToken(params.authHeader);
+  if (!entry) {
+    return { status: 401, body: { error: "Unauthorized" } };
+  }
+
+  try {
+    await dispatchEclawWebhookMessage({
+      accountId: entry.accountId,
+      cfg: params.cfg,
+      msg: params.body,
+    });
+    return { status: 200, body: { ok: true } };
+  } catch {
+    return { status: 500, body: { error: "dispatch_failed" } };
+  }
+}

--- a/extensions/eclaw/src/webhook-handler.ts
+++ b/extensions/eclaw/src/webhook-handler.ts
@@ -126,39 +126,73 @@ export async function dispatchEclawWebhookMessage(params: {
         }) => {
           if (!client) return;
           const text = typeof payload.text === "string" ? payload.text.trim() : "";
+          const mediaUrl = payload.mediaUrl;
+          const outboundMediaType = mediaUrl
+            ? mapMediaTypeOutbound(payload.mediaType)
+            : undefined;
 
           // Silent-token: hard stop, regardless of media.
           if (text === silentToken) {
             return;
           }
 
-          // Empty text: still allow media-only delivery through.
-          if (!text) {
-            if (payload.mediaUrl) {
-              await client.sendMessage(
-                "",
-                "IDLE",
-                mapMediaTypeOutbound(payload.mediaType),
-                payload.mediaUrl,
-              );
-            }
+          // Nothing to send.
+          if (!text && !mediaUrl) {
             return;
           }
 
+          // Media-only (no text) goes straight through as a single call.
+          if (!text) {
+            await client.sendMessage(
+              "",
+              "IDLE",
+              outboundMediaType,
+              mediaUrl,
+            );
+            return;
+          }
+
+          // Text + (optional) media delivery.
+          //
+          // The E-Claw /api/channel/message endpoint accepts text and
+          // media in a single call, so when both are present we ship
+          // them together rather than dropping one or splitting them.
           if (
             (event === "entity_message" || event === "broadcast") &&
             fromEntityId !== undefined
           ) {
-            // Update own wallpaper and reply to the sender.
-            await client.sendMessage(text, "IDLE");
+            // Update own wallpaper (with media if any) and reply to
+            // the sender with the text. speakTo is text-only, so any
+            // media is attached to the wallpaper sendMessage call.
+            await client.sendMessage(text, "IDLE", outboundMediaType, mediaUrl);
             await client.speakTo(fromEntityId, text, false);
             return;
           }
 
-          await client.sendMessage(text, "IDLE");
+          await client.sendMessage(text, "IDLE", outboundMediaType, mediaUrl);
         },
-        onError: () => {
-          /* swallow — logged upstream */
+        onError: (err: unknown, info?: { kind?: string }) => {
+          // Don't silently drop delivery failures — surface them via
+          // the plugin runtime logger so operators can see partial
+          // failures in the OpenClaw logs. Best-effort: if the runtime
+          // has no error sink, fall back to console.error with a
+          // stable "eclaw:" prefix.
+          const message = err instanceof Error ? err.message : String(err);
+          const kind = info?.kind ? ` ${info.kind}` : "";
+          const line = `eclaw: reply${kind} delivery failed: ${message}`;
+          try {
+            const runtime = getEclawRuntime() as unknown as {
+              error?: (msg: string) => void;
+            };
+            if (typeof runtime?.error === "function") {
+              runtime.error(line);
+              return;
+            }
+          } catch {
+            /* runtime not initialised — fall through */
+          }
+          // eslint-disable-next-line no-console
+          console.error(line);
         },
       },
     });

--- a/extensions/eclaw/src/webhook-registry.ts
+++ b/extensions/eclaw/src/webhook-registry.ts
@@ -6,6 +6,10 @@
  * push as `Authorization: Bearer <token>`. The webhook dispatcher looks
  * up the correct accountId by matching the bearer token so multiple
  * E-Claw accounts can share the single `/eclaw-webhook` HTTP route.
+ *
+ * Unauthenticated requests are always rejected — we do not fall back to
+ * routing to a lone registered account, because that would accept any
+ * POST from the public internet.
  */
 
 type EclawTokenEntry = {
@@ -28,20 +32,14 @@ export function unregisterEclawWebhookToken(callbackToken: string): void {
 export function lookupEclawWebhookToken(
   authHeader: string | undefined,
 ): EclawTokenEntry | undefined {
-  if (authHeader?.startsWith("Bearer ")) {
-    const token = authHeader.slice("Bearer ".length);
-    const hit = registry.get(token);
-    if (hit) {
-      return hit;
-    }
+  if (!authHeader?.startsWith("Bearer ")) {
+    return undefined;
   }
-  // Fallback: if only one handler is registered, route to it. Some
-  // E-Claw backend versions do not echo the callback token.
-  if (registry.size === 1) {
-    const [, only] = registry.entries().next().value ?? [];
-    return only;
+  const token = authHeader.slice("Bearer ".length).trim();
+  if (!token) {
+    return undefined;
   }
-  return undefined;
+  return registry.get(token);
 }
 
 export function eclawWebhookRegistrySize(): number {

--- a/extensions/eclaw/src/webhook-registry.ts
+++ b/extensions/eclaw/src/webhook-registry.ts
@@ -16,6 +16,18 @@
  * There is no "single registered account" fallback. A present-but-wrong
  * token is an active (failed) authentication attempt, not a missing
  * header, so accepting it would let any bogus token hit the dispatcher.
+ *
+ * The Bearer scheme name is matched case-insensitively per RFC 7235
+ * §2.1 ("auth-scheme is case-insensitive"), with tolerance for
+ * surrounding whitespace — see PR #62934 review round 5 (codex
+ * webhook-registry.ts P2 item) and the regression tests in
+ * `extensions/eclaw/index.test.ts` ("RFC 7235" describe block).
+ *
+ * Doc references (OpenClaw repo):
+ *   - docs/plugins/sdk-channel-plugins.md §"Webhook authentication"
+ *   - docs/plugins/architecture.md §"Plugin SDK import paths"
+ *   - IETF RFC 7235 §2.1 (auth-scheme case-insensitivity):
+ *     https://www.rfc-editor.org/rfc/rfc7235#section-2.1
  */
 
 type EclawTokenEntry = {

--- a/extensions/eclaw/src/webhook-registry.ts
+++ b/extensions/eclaw/src/webhook-registry.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-session webhook token registry for the E-Claw plugin.
+ *
+ * When a gateway account starts, it registers a random bearer token and
+ * the accountId it should dispatch to. E-Claw echoes the token on every
+ * push as `Authorization: Bearer <token>`. The webhook dispatcher looks
+ * up the correct accountId by matching the bearer token so multiple
+ * E-Claw accounts can share the single `/eclaw-webhook` HTTP route.
+ */
+
+type EclawTokenEntry = {
+  accountId: string;
+};
+
+const registry = new Map<string, EclawTokenEntry>();
+
+export function registerEclawWebhookToken(
+  callbackToken: string,
+  accountId: string,
+): void {
+  registry.set(callbackToken, { accountId });
+}
+
+export function unregisterEclawWebhookToken(callbackToken: string): void {
+  registry.delete(callbackToken);
+}
+
+export function lookupEclawWebhookToken(
+  authHeader: string | undefined,
+): EclawTokenEntry | undefined {
+  if (authHeader?.startsWith("Bearer ")) {
+    const token = authHeader.slice("Bearer ".length);
+    const hit = registry.get(token);
+    if (hit) {
+      return hit;
+    }
+  }
+  // Fallback: if only one handler is registered, route to it. Some
+  // E-Claw backend versions do not echo the callback token.
+  if (registry.size === 1) {
+    const [, only] = registry.entries().next().value ?? [];
+    return only;
+  }
+  return undefined;
+}
+
+export function eclawWebhookRegistrySize(): number {
+  return registry.size;
+}

--- a/extensions/eclaw/src/webhook-registry.ts
+++ b/extensions/eclaw/src/webhook-registry.ts
@@ -38,10 +38,19 @@ export function unregisterEclawWebhookToken(callbackToken: string): void {
 export function lookupEclawWebhookToken(
   authHeader: string | undefined,
 ): EclawTokenEntry | undefined {
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader) {
     return undefined;
   }
-  const token = authHeader.slice("Bearer ".length).trim();
+  // RFC 7235 §2.1: auth-scheme is case-insensitive. Clients or proxies
+  // may send `bearer <token>` (lowercase) or any other case variant,
+  // and rejecting those as unauthorized would break inbound delivery
+  // even when the token is valid. Match the scheme case-insensitively,
+  // then extract the token from whatever the client actually sent.
+  const match = /^\s*Bearer\s+(.+?)\s*$/i.exec(authHeader);
+  if (!match) {
+    return undefined;
+  }
+  const token = match[1];
   if (!token) {
     return undefined;
   }

--- a/extensions/eclaw/src/webhook-registry.ts
+++ b/extensions/eclaw/src/webhook-registry.ts
@@ -7,9 +7,15 @@
  * up the correct accountId by matching the bearer token so multiple
  * E-Claw accounts can share the single `/eclaw-webhook` HTTP route.
  *
- * Unauthenticated requests are always rejected — we do not fall back to
- * routing to a lone registered account, because that would accept any
- * POST from the public internet.
+ * Authentication is strict and uniform for every webhook request:
+ *
+ *   - Header absent / empty / non-Bearer   -> 401, no fallback.
+ *   - Bearer header present but token does not match an entry -> 401.
+ *   - Bearer header present and token matches                 -> accountId.
+ *
+ * There is no "single registered account" fallback. A present-but-wrong
+ * token is an active (failed) authentication attempt, not a missing
+ * header, so accepting it would let any bogus token hit the dispatcher.
  */
 
 type EclawTokenEntry = {

--- a/extensions/eclaw/tsconfig.json
+++ b/extensions/eclaw/tsconfig.json
@@ -7,6 +7,10 @@
   "exclude": [
     "./**/*.test.ts",
     "./dist/**",
-    "./node_modules/**"
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
   ]
 }

--- a/extensions/eclaw/tsconfig.json
+++ b/extensions/eclaw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,6 +478,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/eclaw:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/elevenlabs:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/vitest.extension-messaging-paths.mjs
+++ b/vitest.extension-messaging-paths.mjs
@@ -2,6 +2,7 @@ import { bundledPluginRoot } from "./scripts/lib/bundled-plugin-paths.mjs";
 
 export const messagingExtensionIds = [
   "bluebubbles",
+  "eclaw",
   "googlechat",
   "mattermost",
   "nextcloud-talk",


### PR DESCRIPTION
## Summary

This PR adds a bundled E-Claw channel plugin at `extensions/eclaw/`, porting the existing [`@eclaw/openclaw-channel`](https://github.com/HankHuang0516/openclaw-channel-eclaw) npm package into the stock extensions workspace so E-Claw can ship alongside Discord, Telegram, Slack, Synology Chat, etc.

**What is E-Claw?** E-Claw is an AI chat platform for live wallpaper character entities on Android (https://eclawbot.com). A bot claims a character "slot" on a user's device via the E-Claw channel API and then exchanges messages with the device owner (and any other entities on the same device). The stock-plugin version gives E-Claw the same surface parity as other channel plugins (Discord, Telegram, Slack, WhatsApp, Synology Chat, Nextcloud Talk, Google Chat...) and lets the OpenClaw setup wizard/catalog advertise it without requiring a separate npm install.

**Why ship it as a bundled extension?** Parity with the other channel plugins, discoverability through the built-in catalog, and a clean home for the config/env surface. Config is gated by a single `ECLAW_API_KEY` (plus optional `ECLAW_API_BASE` / `ECLAW_BOT_NAME` / `ECLAW_WEBHOOK_URL`), the plugin is `enabled: false`-ish by default (it uses the `createOptionalChannelSetupSurface` helper so the setup wizard prompts for installation rather than silently creating credentials), and the on-disk config layout matches the existing `channels.eclaw.apiKey` shape already used by the npm package.

**What's in the change:**

- `extensions/eclaw/index.ts` + `setup-entry.ts` — `defineBundledChannelEntry` / `defineBundledChannelSetupEntry` bindings.
- `extensions/eclaw/openclaw.plugin.json` — declares the channel and env vars (`ECLAW_API_KEY`, `ECLAW_API_BASE`, `ECLAW_BOT_NAME`, `ECLAW_WEBHOOK_URL`).
- `extensions/eclaw/package.json` — `@openclaw/eclaw`, peer on `@openclaw/plugin-sdk`, `openclaw.channel` metadata identical in shape to `synology-chat`/`nextcloud-talk`.
- `extensions/eclaw/src/channel.ts` — `createChatChannelPlugin` wiring the minimum surface (capabilities, config adapter, messaging normalization, gateway, outbound).
- `extensions/eclaw/src/client.ts` — ported EClaw HTTP client (`POST /api/channel/register`, `POST /api/channel/bind`, `POST /api/channel/message`, `POST /api/entity/speak-to`, `DELETE /api/channel/register`).
- `extensions/eclaw/src/gateway.ts` — `startAccount` resolves credentials, registers a per-session Bearer token, posts the callback URL to the EClaw backend, auto-binds a free entity slot, and keeps the account alive via `waitUntilAbort`.
- `extensions/eclaw/src/webhook-handler.ts` — converts inbound EClaw pushes into an OpenClaw reply dispatch, handles `entity_message` / `broadcast` (updates own wallpaper + speak-to the sender), honors `[SILENT]` and `eclaw_context` quota hints.
- `extensions/eclaw/src/webhook-registry.ts` — per-session Bearer-token routing so multiple accounts can share the single `/eclaw-webhook` route.
- `extensions/eclaw/src/send.ts` — outbound `sendText` / `sendMedia` implementations with bot-to-bot duplicate-delivery suppression.
- `extensions/eclaw/src/setup-adapter.ts` — ships `createOptionalChannelSetupSurface` so the setup wizard points users at the docs/npm spec by default (disabled-by-default behavior matching the other optional channel plugins).
- `extensions/eclaw/index.test.ts` — structural tests that mirror `extensions/irc/index.test.ts`: assert the bundled entry, load the channel plugin, and load the setup plugin without importing the broad `api.ts` barrel.
- `vitest.extension-messaging-paths.mjs` — adds `"eclaw"` to `messagingExtensionIds` so `pnpm test:extension eclaw` picks the existing messaging vitest lane (the same lane used by `synology-chat`, `nextcloud-talk`, `googlechat`, `twitch`, etc.).

**AI-assisted PR:** yes (Claude Opus 4.6, fully scripted). I understand what every file does; the client/gateway/webhook logic is a 1:1 port of the working npm package at https://github.com/HankHuang0516/openclaw-channel-eclaw which has been running in production on an EClaw backend. Testing degree: lightly tested — structural `index.test.ts` passes locally on the messaging lane; full end-to-end runtime validation still depends on having a live EClaw backend.

## Test plan

- [x] `pnpm install` — clean install, adds only the new `extensions/eclaw` workspace entry to `pnpm-lock.yaml`.
- [x] `pnpm test:extension eclaw` — runs via `vitest.extension-messaging.config.ts`; **1 file, 3 tests, all pass**:
  - `eclaw bundled entries > defines a channel entry for the eclaw id`
  - `eclaw bundled entries > loads the channel plugin without importing the broad api barrel`
  - `eclaw bundled entries > loads the setup plugin without importing the broad api barrel`
- [x] `pnpm test:contracts:channels` — 37 passed / 2 failed. Both failing files (`session-binding.registry-backed.contract.test.ts` for `matrix` and one unrelated contract) are **already red on `main`** without any change in this branch; verified by stashing this PR and re-running the same command on `upstream/main`. Per CONTRIBUTING.md, I am intentionally not touching those failures.
- [ ] Live EClaw backend smoke test (outside CI) — relies on a real EClaw deployment. The npm package this is ported from is already used in production so the HTTP flow is known-good; I can confirm this on a follow-up once maintainers flag anything to verify.

Reviewers: happy to iterate on the channel meta/order, the `dmPolicy` story (currently none — EClaw DMs are always owner-to-entity which there is no DM allowlist concept for), or the setup wizard if you would rather ship a full credential wizard up-front instead of the optional-setup stub. Let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
