### PR TITLE
doctor: warn on managed browser readiness gaps

### DIFF
--- a/extensions/browser/src/doctor-browser.test.ts
+++ b/extensions/browser/src/doctor-browser.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { noteChromeMcpBrowserReadiness } from "./doctor-browser.js";
+
+describe("noteChromeMcpBrowserReadiness", () => {
+  it("warns when managed browser profiles have no local executable", async () => {
+    const noteFn = vi.fn();
+
+    await noteChromeMcpBrowserReadiness(
+      {
+        browser: {
+          profiles: {
+            openclaw: { color: "#FF4500" },
+          },
+        },
+      },
+      {
+        noteFn,
+        platform: "linux",
+        resolveManagedExecutable: () => null,
+      },
+    );
+
+    expect(noteFn).toHaveBeenCalledWith(
+      expect.stringContaining("No Chromium-based browser executable was found on this host"),
+      "Browser",
+    );
+  });
+
+  it("warns when managed browser launch needs display and no-sandbox adjustments", async () => {
+    const noteFn = vi.fn();
+
+    await noteChromeMcpBrowserReadiness(
+      {
+        browser: {
+          headless: false,
+          noSandbox: false,
+          profiles: {
+            openclaw: { color: "#FF4500" },
+          },
+        },
+      },
+      {
+        noteFn,
+        platform: "linux",
+        env: {},
+        getUid: () => 0,
+        resolveManagedExecutable: () => ({ kind: "chromium", path: "/usr/bin/chromium" }),
+      },
+    );
+
+    expect(noteFn).toHaveBeenCalledWith(
+      expect.stringContaining("No DISPLAY or WAYLAND_DISPLAY is set"),
+      "Browser",
+    );
+    expect(noteFn).toHaveBeenCalledWith(
+      expect.stringContaining("browser.noSandbox: true"),
+      "Browser",
+    );
+  });
+
+  it("still reports Chrome MCP existing-session readiness", async () => {
+    const noteFn = vi.fn();
+
+    await noteChromeMcpBrowserReadiness(
+      {
+        browser: {
+          profiles: {
+            user: {
+              driver: "existing-session",
+              color: "#00AA00",
+            },
+          },
+        },
+      },
+      {
+        noteFn,
+        platform: "linux",
+        resolveChromeExecutable: () => ({ path: "/usr/bin/google-chrome" }),
+        readVersion: () => "Google Chrome 145.0.0.0",
+      },
+    );
+
+    expect(noteFn).toHaveBeenCalledWith(
+      expect.stringContaining("Chrome MCP existing-session is configured"),
+      "Browser",
+    );
+  });
+});

--- a/extensions/browser/src/doctor-browser.ts
+++ b/extensions/browser/src/doctor-browser.ts
@@ -3,8 +3,10 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import {
   parseBrowserMajorVersion,
   readBrowserVersion,
+  resolveBrowserExecutableForPlatform,
   resolveGoogleChromeExecutableForPlatform,
 } from "./browser/chrome.executables.js";
+import { resolveBrowserConfig } from "./browser/config.js";
 import type { OpenClawConfig } from "./config/config.js";
 import { asRecord } from "./record-shared.js";
 
@@ -18,6 +20,10 @@ const REMOTE_DEBUGGING_PAGES = [
 type ExistingSessionProfile = {
   name: string;
   userDataDir?: string;
+};
+
+type ManagedProfile = {
+  name: string;
 };
 
 function collectChromeMcpProfiles(cfg: OpenClawConfig): ExistingSessionProfile[] {
@@ -51,25 +57,80 @@ function collectChromeMcpProfiles(cfg: OpenClawConfig): ExistingSessionProfile[]
   return [...profiles.values()].toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
+function collectManagedProfiles(cfg: OpenClawConfig): ManagedProfile[] {
+  const resolved = resolveBrowserConfig(cfg.browser, cfg);
+  return Object.entries(resolved.profiles)
+    .filter(([, profile]) => profile.driver !== "existing-session")
+    .map(([name]) => ({ name }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+}
+
 export async function noteChromeMcpBrowserReadiness(
   cfg: OpenClawConfig,
   deps?: {
     platform?: NodeJS.Platform;
     noteFn?: typeof note;
+    env?: NodeJS.ProcessEnv;
+    getUid?: () => number;
+    resolveManagedExecutable?: typeof resolveBrowserExecutableForPlatform;
     resolveChromeExecutable?: (platform: NodeJS.Platform) => { path: string } | null;
     readVersion?: (executablePath: string) => string | null;
   },
 ) {
+  const noteFn = deps?.noteFn ?? note;
+  const platform = deps?.platform ?? process.platform;
+  const env = deps?.env ?? process.env;
+  const getUid = deps?.getUid ?? (() => process.getuid?.() ?? -1);
+  const resolveManagedExecutable =
+    deps?.resolveManagedExecutable ?? resolveBrowserExecutableForPlatform;
+  const resolveChromeExecutable =
+    deps?.resolveChromeExecutable ?? resolveGoogleChromeExecutableForPlatform;
+  const readVersion = deps?.readVersion ?? readBrowserVersion;
+  const managedProfiles = collectManagedProfiles(cfg);
+  const managedProfileLabel = managedProfiles.map((profile) => profile.name).join(", ");
+  const resolved = resolveBrowserConfig(cfg.browser, cfg);
+  const browserExecutable =
+    managedProfiles.length > 0 ? resolveManagedExecutable(resolved, platform) : null;
+  const missingDisplay =
+    platform === "linux" &&
+    managedProfiles.length > 0 &&
+    !resolved.headless &&
+    !normalizeOptionalString(env.DISPLAY) &&
+    !normalizeOptionalString(env.WAYLAND_DISPLAY);
+  const shouldWarnRootNoSandbox =
+    platform === "linux" && managedProfiles.length > 0 && !resolved.noSandbox && getUid() === 0;
+
+  if (!browserExecutable && managedProfiles.length > 0) {
+    noteFn(
+      [
+        `- OpenClaw-managed browser profile(s) are configured: ${managedProfileLabel}.`,
+        "- No Chromium-based browser executable was found on this host for OpenClaw-managed launch.",
+        "- Install Chrome, Chromium, Brave, Edge, or set browser.executablePath explicitly.",
+      ].join("\n"),
+      "Browser",
+    );
+  }
+
+  if (missingDisplay || shouldWarnRootNoSandbox) {
+    const lines = [`- OpenClaw-managed browser profile(s) are configured: ${managedProfileLabel}.`];
+    if (missingDisplay) {
+      lines.push(
+        "- No DISPLAY or WAYLAND_DISPLAY is set, and browser.headless is false. Managed browser launch needs a desktop session, Xvfb, or browser.headless: true.",
+      );
+    }
+    if (shouldWarnRootNoSandbox) {
+      lines.push(
+        "- The Gateway is running as root and browser.noSandbox is false. Chromium commonly requires browser.noSandbox: true in container/root runtimes.",
+      );
+    }
+    noteFn(lines.join("\n"), "Browser");
+  }
+
   const profiles = collectChromeMcpProfiles(cfg);
   if (profiles.length === 0) {
     return;
   }
 
-  const noteFn = deps?.noteFn ?? note;
-  const platform = deps?.platform ?? process.platform;
-  const resolveChromeExecutable =
-    deps?.resolveChromeExecutable ?? resolveGoogleChromeExecutableForPlatform;
-  const readVersion = deps?.readVersion ?? readBrowserVersion;
   const explicitProfiles = profiles.filter((profile) => profile.userDataDir);
   const autoConnectProfiles = profiles.filter((profile) => !profile.userDataDir);
   const profileLabel = profiles.map((profile) => profile.name).join(", ");


### PR DESCRIPTION
## Summary
- extend browser doctor checks beyond Chrome MCP attach mode
- warn when OpenClaw-managed browser profiles have no local Chromium executable
- warn on Linux when managed launch is non-headless without a display or when root/container runtimes likely need `browser.noSandbox: true`

## Testing
- `node scripts/run-vitest.mjs run --config vitest.extensions.config.ts extensions/browser/src/doctor-browser.test.ts`
- `pnpm tsgo`