### PR TITLE
fix(exec-approvals): respect OPENCLAW_STATE_DIR for store paths

### DIFF
--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -260,6 +260,42 @@ describe("exec approvals store helpers", () => {
     expect(fs.existsSync(path.join(realStateRoot, "state"))).toBe(false);
   });
 
+  it("allows darwin system alias prefixes for OPENCLAW_STATE_DIR without masking user symlinks", () => {
+    createHomeDir();
+    const stateDir = createStateDir();
+    const originalPlatform = process.platform;
+    const realpathSync = fs.realpathSync.bind(fs);
+    const lstatSync = fs.lstatSync.bind(fs);
+    const lstatSpy = vi.spyOn(fs, "lstatSync").mockImplementation((targetPath: fs.PathLike) => {
+      const resolved = path.resolve(String(targetPath));
+      if (resolved === "/tmp") {
+        return {
+          isSymbolicLink: () => true,
+        } as unknown as fs.Stats;
+      }
+      return lstatSync(targetPath);
+    });
+    const realpathSpy = vi.spyOn(fs, "realpathSync").mockImplementation((targetPath: fs.PathLike) => {
+      const resolved = path.resolve(String(targetPath));
+      if (resolved === path.resolve(stateDir)) {
+        return `/private${resolved}`;
+      }
+      return realpathSync(targetPath);
+    });
+
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      expect(() =>
+        saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+      ).not.toThrow();
+      expect(fs.existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(true);
+    } finally {
+      realpathSpy.mockRestore();
+      lstatSpy.mockRestore();
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
   it("adds trimmed allowlist entries once and persists generated ids", () => {
     const dir = createHomeDir();
     vi.spyOn(Date, "now").mockReturnValue(123_456);

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTempDir } from "./exec-approvals-test-helpers.js";
 
 const requestJsonlSocketMock = vi.hoisted(() => vi.fn());
@@ -29,6 +29,7 @@ let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
 
 const tempDirs: string[] = [];
 const originalOpenClawHome = process.env.OPENCLAW_HOME;
+const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
 beforeAll(async () => {
   ({
@@ -50,17 +51,29 @@ beforeAll(async () => {
 
 beforeEach(() => {
   requestJsonlSocketMock.mockReset();
+  delete process.env.OPENCLAW_HOME;
+  delete process.env.OPENCLAW_STATE_DIR;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  delete process.env.OPENCLAW_HOME;
+  delete process.env.OPENCLAW_STATE_DIR;
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+afterAll(() => {
   if (originalOpenClawHome === undefined) {
     delete process.env.OPENCLAW_HOME;
   } else {
     process.env.OPENCLAW_HOME = originalOpenClawHome;
   }
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
+  if (originalOpenClawStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
   }
 });
 
@@ -68,6 +81,13 @@ function createHomeDir(): string {
   const dir = makeTempDir();
   tempDirs.push(dir);
   process.env.OPENCLAW_HOME = dir;
+  return dir;
+}
+
+function createStateDir(): string {
+  const dir = makeTempDir();
+  tempDirs.push(dir);
+  process.env.OPENCLAW_STATE_DIR = dir;
   return dir;
 }
 
@@ -88,6 +108,18 @@ describe("exec approvals store helpers", () => {
     );
     expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
       path.normalize(path.join(dir, ".openclaw", "exec-approvals.sock")),
+    );
+  });
+
+  it("prefers OPENCLAW_STATE_DIR over OPENCLAW_HOME for file and socket paths", () => {
+    createHomeDir();
+    const stateDir = createStateDir();
+
+    expect(path.normalize(resolveExecApprovalsPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.json")),
+    );
+    expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.sock")),
     );
   });
 
@@ -156,6 +188,20 @@ describe("exec approvals store helpers", () => {
     expect(ensured.socket?.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
     expect(raw.endsWith("\n")).toBe(true);
     expect(readApprovalsFile(dir).socket).toEqual(ensured.socket);
+  });
+
+  it("writes approvals files directly under OPENCLAW_STATE_DIR", () => {
+    createHomeDir();
+    const stateDir = createStateDir();
+    const approvalsPath = path.join(stateDir, "exec-approvals.json");
+
+    const ensured = ensureExecApprovals();
+    const raw = fs.readFileSync(approvalsPath, "utf8");
+
+    expect(ensured.socket?.path).toBe(path.join(stateDir, "exec-approvals.sock"));
+    expect(raw.endsWith("\n")).toBe(true);
+    expect(JSON.parse(raw) as ExecApprovalsFile).toEqual(ensured);
+    expect(fs.existsSync(path.join(stateDir, ".openclaw", "exec-approvals.json"))).toBe(false);
   });
 
   it("atomically replaces existing approvals files instead of mutating linked inodes", () => {

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -236,7 +236,7 @@ describe("exec approvals store helpers", () => {
   it("refuses to traverse a symlinked parent component in the approvals path", () => {
     const realHome = makeTempDir();
     const linkedHome = `${realHome}-link`;
-    tempDirs.push(realHome);
+    tempDirs.push(realHome, linkedHome);
     fs.symlinkSync(realHome, linkedHome);
     process.env.OPENCLAW_HOME = linkedHome;
 
@@ -244,6 +244,20 @@ describe("exec approvals store helpers", () => {
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/Refusing to traverse symlink in exec approvals path/);
     expect(fs.existsSync(path.join(realHome, ".openclaw"))).toBe(false);
+  });
+
+  it("refuses to traverse a symlinked parent component in OPENCLAW_STATE_DIR", () => {
+    createHomeDir();
+    const realStateRoot = makeTempDir();
+    const linkedStateRoot = `${realStateRoot}-link`;
+    tempDirs.push(realStateRoot, linkedStateRoot);
+    fs.symlinkSync(realStateRoot, linkedStateRoot);
+    process.env.OPENCLAW_STATE_DIR = path.join(linkedStateRoot, "state");
+
+    expect(() =>
+      saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+    ).toThrow(/Refusing to traverse symlink in exec approvals path/);
+    expect(fs.existsSync(path.join(realStateRoot, "state"))).toBe(false);
   });
 
   it("adds trimmed allowlist entries once and persists generated ids", () => {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -12,7 +12,7 @@ import {
 import { resolveAllowAlwaysPatternEntries } from "./exec-approvals-allowlist.js";
 import type { ExecCommandSegment } from "./exec-approvals-analysis.js";
 import type { ExecAllowlistEntry } from "./exec-approvals.types.js";
-import { expandHomePrefix, resolveRequiredHomeDir } from "./home-dir.js";
+import { expandHomePrefix } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
@@ -228,7 +228,7 @@ function mergeLegacyAgent(
 
 function ensureDir(filePath: string) {
   const dir = path.dirname(filePath);
-  assertNoSymlinkPathComponents(dir, resolveRequiredHomeDir());
+  assertNoSymlinkPathComponents(dir);
   fs.mkdirSync(dir, { recursive: true });
   const dirStat = fs.lstatSync(dir);
   if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
@@ -237,20 +237,14 @@ function ensureDir(filePath: string) {
   return dir;
 }
 
-function assertNoSymlinkPathComponents(targetPath: string, trustedRoot: string): void {
+function assertNoSymlinkPathComponents(targetPath: string): void {
   const resolvedTarget = path.resolve(targetPath);
-  const resolvedRoot = path.resolve(trustedRoot);
-  if (resolvedTarget !== resolvedRoot && !resolvedTarget.startsWith(`${resolvedRoot}${path.sep}`)) {
-    return;
-  }
-
-  const relative = path.relative(resolvedRoot, resolvedTarget);
-  const segments = relative && relative !== "." ? relative.split(path.sep) : [];
-  let current = resolvedRoot;
-  for (const segment of [".", ...segments]) {
-    if (segment !== ".") {
-      current = path.join(current, segment);
-    }
+  const parsedTarget = path.parse(resolvedTarget);
+  const relative = path.relative(parsedTarget.root, resolvedTarget);
+  const segments = relative && relative !== "." ? relative.split(path.sep).filter(Boolean) : [];
+  let current = parsedTarget.root;
+  for (const segment of segments) {
+    current = path.join(current, segment);
     try {
       const stat = fs.lstatSync(current);
       if (stat.isSymbolicLink()) {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -239,23 +239,47 @@ function ensureDir(filePath: string) {
 
 function assertNoSymlinkPathComponents(targetPath: string): void {
   const resolvedTarget = path.resolve(targetPath);
-  const parsedTarget = path.parse(resolvedTarget);
-  const relative = path.relative(parsedTarget.root, resolvedTarget);
-  const segments = relative && relative !== "." ? relative.split(path.sep).filter(Boolean) : [];
-  let current = parsedTarget.root;
-  for (const segment of segments) {
-    current = path.join(current, segment);
+  const existingAncestor = findNearestExistingAncestor(resolvedTarget);
+  const relative = path.relative(existingAncestor, resolvedTarget);
+  const realAncestor = fs.realpathSync(existingAncestor);
+  const realTarget = path.resolve(realAncestor, relative);
+  if (
+    normalizeSymlinkComparisonPath(resolvedTarget) !== normalizeSymlinkComparisonPath(realTarget)
+  ) {
+    throw new Error(`Refusing to traverse symlink in exec approvals path: ${existingAncestor}`);
+  }
+}
+
+function findNearestExistingAncestor(targetPath: string): string {
+  let current = targetPath;
+  while (true) {
     try {
-      const stat = fs.lstatSync(current);
-      if (stat.isSymbolicLink()) {
-        throw new Error(`Refusing to traverse symlink in exec approvals path: ${current}`);
-      }
+      fs.lstatSync(current);
+      return current;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         throw err;
       }
     }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return current;
+    }
+    current = parent;
   }
+}
+
+function normalizeSymlinkComparisonPath(targetPath: string): string {
+  const resolvedTarget = path.resolve(targetPath);
+  if (process.platform !== "darwin") {
+    return resolvedTarget;
+  }
+  for (const prefix of ["/private/tmp", "/private/var", "/private/etc"]) {
+    if (resolvedTarget === prefix || resolvedTarget.startsWith(`${prefix}${path.sep}`)) {
+      return resolvedTarget.slice("/private".length);
+    }
+  }
+  return resolvedTarget;
 }
 
 function assertSafeExecApprovalsDestination(filePath: string): void {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -170,8 +171,6 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -181,11 +180,11 @@ function hashExecApprovalsRaw(raw: string | null): string {
 }
 
 export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+  return path.join(resolveStateDir(), "exec-approvals.json");
 }
 
 export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+  return path.join(resolveStateDir(), "exec-approvals.sock");
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {


### PR DESCRIPTION
## Summary
- make exec approvals store paths respect `OPENCLAW_STATE_DIR`
- keep `OPENCLAW_HOME` as the fallback when no explicit state dir is set
- add store-path tests covering `OPENCLAW_STATE_DIR` precedence and file creation

## Why
`exec-approvals` was still resolving `exec-approvals.json` and `exec-approvals.sock` from the legacy home-based path logic, even when the rest of OpenClaw state had been relocated via `OPENCLAW_STATE_DIR`. That left exec-approvals as the odd one out and could trigger repeated `Multiple state directories detected` warnings in `openclaw doctor`.

Closes #62917.

## Validation
- `git diff --check`
- `corepack pnpm vitest run src/infra/exec-approvals-store.test.ts src/infra/exec-approvals-config.test.ts`
- `corepack pnpm vitest run src/commands/doctor-state-integrity.test.ts src/commands/doctor-security.test.ts`
