### PR TITLE
fix: prevent heartbeat isolatedSession key nesting and transcript accumulation

### DIFF
--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -83,6 +83,9 @@ export function resolveCronSession(params: {
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      // Clear sessionFile so the new session gets a fresh transcript file
+      // instead of appending to the previous session's file indefinitely.
+      sessionFile: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -717,7 +717,10 @@ export async function runHeartbeatOnce(opts: {
 
   let runSessionKey = sessionKey;
   if (useIsolatedSession) {
-    const isolatedKey = `${sessionKey}:heartbeat`;
+    // Strip any existing :heartbeat suffix (and deeper nesting) to prevent
+    // infinite session key nesting when targeted wakes pass the previous
+    // isolated session key as forcedSessionKey.
+    const isolatedKey = `${sessionKey.replace(/:heartbeat(:.+)?$/, "")}:heartbeat`;
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedKey,


### PR DESCRIPTION
## Summary

Fixes two related bugs in heartbeat `isolatedSession: true` mode.

### Bug 1: Infinite session key nesting

When a targeted heartbeat wake (e.g. `wakeMode: "next-heartbeat"` cron) passes the previous isolated session key as `forcedSessionKey`, the template literal:
```ts
const isolatedKey = \`\${sessionKey}:heartbeat\`;
```
produces infinitely nested keys: `agent:main:main:heartbeat:heartbeat:heartbeat...`

We observed nesting up to 9 levels deep. Combined with LLM timeouts at depth 5+, this creates a rapid cascade of failed sessions (every 2-4 minutes).

**Fix:** Strip any existing `:heartbeat` suffix before appending:
```ts
const isolatedKey = \`\${sessionKey.replace(/:heartbeat(:.+)?$/, "")}:heartbeat\`;
```

### Bug 2: Transcript file accumulation

`resolveCronSession` spreads the old session entry (`...entry`) into the new one when `forceNew: true`, carrying over `sessionFile`. Since `resolveSessionFilePath` checks `entry.sessionFile` first, all "new" isolated sessions append to the same transcript file.

Over 10 days (498 heartbeat runs), our transcript grew to 7.7MB / 4734 lines / 130K tokens. This is worsened by the fact that `pruneHeartbeatTranscript` is only called on success paths — failed heartbeats (LLM timeouts) permanently grow the file.

**Fix:** Add `sessionFile: undefined` to the `isNewSession` cleanup block in `resolveCronSession`, alongside the existing `lastChannel`, `lastTo`, etc. resets.

### Testing

Both fixes applied locally as dist patches and running stable for 3+ hours. The regex was tested against 7 edge cases (normal keys, nested keys up to depth 3, telegram/cron session keys, keys with "heartbeat" in non-suffix positions) in both Node.js and Python.

Fixes #62869