### PR TITLE
docs: replace anthropic model with openai in getting started example

### DIFF
--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -117,7 +117,7 @@ Example:
 {
   logging: { level: "info" },
   agent: {
-    model: "anthropic/claude-opus-4-6",
+    model: "openai/gpt-5.4",
     workspace: "~/.openclaw/workspace",
     thinkingDefault: "high",
     timeoutSeconds: 1800,


### PR DESCRIPTION
Fixes #62529 - Replace the anthropic/claude-opus-4-6 model in the getting started documentation with openai/gpt-5.4 to avoid pointing new users to a potentially hostile provider on first setup.