### PR TITLE
fix(slack): preserve thread aliases in runtime outbound sends

### DIFF
--- a/src/cli/send-runtime/channel-outbound-send.test.ts
+++ b/src/cli/send-runtime/channel-outbound-send.test.ts
@@ -115,6 +115,63 @@ describe("createChannelOutboundRuntimeSend", () => {
     );
   });
 
+  it("forwards Slack threadTs alias to threadId", async () => {
+    const sendText = vi.fn(async () => ({ channel: "slack", messageId: "slack-1" }));
+    mocks.loadChannelOutboundAdapter.mockResolvedValue({
+      sendText,
+    });
+
+    const { createChannelOutboundRuntimeSend } = await import("./channel-outbound-send.js");
+    const runtimeSend = createChannelOutboundRuntimeSend({
+      channelId: "slack" as never,
+      unavailableMessage: "unavailable",
+    });
+
+    await runtimeSend.sendMessage("C123", "hello", {
+      cfg: {},
+      threadTs: "1712345678.123456",
+    });
+
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: {},
+        to: "C123",
+        text: "hello",
+        threadId: "1712345678.123456",
+      }),
+    );
+  });
+
+  it("prefers canonical thread fields over Slack aliases", async () => {
+    const sendText = vi.fn(async () => ({ channel: "slack", messageId: "slack-2" }));
+    mocks.loadChannelOutboundAdapter.mockResolvedValue({
+      sendText,
+    });
+
+    const { createChannelOutboundRuntimeSend } = await import("./channel-outbound-send.js");
+    const runtimeSend = createChannelOutboundRuntimeSend({
+      channelId: "slack" as never,
+      unavailableMessage: "unavailable",
+    });
+
+    await runtimeSend.sendMessage("C123", "hello", {
+      cfg: {},
+      messageThreadId: "200.000",
+      threadId: "150.000",
+      threadTs: "100.000",
+      replyToMessageId: "400.000",
+      replyToId: "300.000",
+    });
+
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: {},
+        threadId: "200.000",
+        replyToId: "400.000",
+      }),
+    );
+  });
+
   it("falls back to sendText when media is present but sendMedia is unavailable", async () => {
     const sendText = vi.fn(async () => ({ channel: "whatsapp", messageId: "wa-3" }));
     mocks.loadChannelOutboundAdapter.mockResolvedValue({

--- a/src/cli/send-runtime/channel-outbound-send.ts
+++ b/src/cli/send-runtime/channel-outbound-send.ts
@@ -14,6 +14,7 @@ type RuntimeSendOpts = {
   accountId?: string;
   threadId?: string | number | null;
   messageThreadId?: string | number;
+  threadTs?: string | number;
   replyToId?: string | number | null;
   replyToMessageId?: string | number;
   silent?: boolean;
@@ -23,7 +24,7 @@ type RuntimeSendOpts = {
 };
 
 function resolveRuntimeThreadId(opts: RuntimeSendOpts): string | number | undefined {
-  return opts.messageThreadId ?? opts.threadId ?? undefined;
+  return opts.messageThreadId ?? opts.threadId ?? opts.threadTs ?? undefined;
 }
 
 function resolveRuntimeReplyToId(opts: RuntimeSendOpts): string | undefined {


### PR DESCRIPTION
## Summary

- Problem: dep-backed direct sends that go through the generic runtime outbound wrapper could drop Slack thread context when callers passed `threadTs` instead of the generic `threadId` / `messageThreadId` fields.
- Why it matters: subagent completion and other direct-delivery paths could post into the channel instead of the intended Slack thread.
- What changed: the generic runtime sender now treats Slack-style `threadTs` as a fallback alias for the existing thread resolver, while preserving canonical precedence `messageThreadId -> threadId -> threadTs`.
- What did NOT change (scope boundary): no Slack transport behavior changed beyond alias forwarding, and no gateway, schema, or non-thread delivery behavior was modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the generic runtime outbound sender only resolved canonical thread fields and did not fall back to Slack's `threadTs` alias when constructing the outbound send context.
- Missing detection / guardrail: there was no focused regression test covering the dep-backed runtime send path with Slack alias inputs.
- Contributing context (if known): current main already had generalized `threadId` / `replyToId` helpers, so the rebased fix only needed to extend thread resolution to include `threadTs`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/send-runtime/channel-outbound-send.test.ts`
- Scenario the test should lock in: when runtime callers pass `threadTs`, the wrapper forwards that value as the outbound `threadId`, and canonical fields still win when both forms are present.
- Why this is the smallest reliable guardrail: the bug is in the generic runtime send wrapper's option normalization, so a focused unit test on that wrapper isolates the failing behavior without needing a live Slack transport.
- Existing test that already covers this (if any): none before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Slack-threaded direct sends that go through the generic runtime wrapper now stay in the intended thread when the caller supplies `threadTs`.

## Diagram (if applicable)

```text
Before:
[runtime caller passes threadTs] -> [generic wrapper ignores alias] -> [Slack send without thread context]

After:
[runtime caller passes threadTs] -> [generic wrapper resolves threadTs as fallback thread id] -> [Slack send stays in thread]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw repo checkout
- Model/provider: N/A
- Integration/channel (if any): Slack direct-send path, verified via unit coverage
- Relevant config (redacted): none required beyond test defaults

### Steps

1. Call the generic runtime outbound sender with Slack-targeted delivery options and `threadTs` set.
2. Inspect the outbound adapter call arguments.
3. Repeat with canonical thread fields also present.

### Expected

- `threadTs` is forwarded as the effective outbound thread id when no canonical thread field is set.
- Canonical fields still take precedence when both forms are present.

### Actual

- Before the fix, the wrapper dropped the Slack alias and lost thread context.
- After the fix, the focused CLI Vitest lane passes and confirms the expected forwarding and precedence behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification run after rebase:

`node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/send-runtime/channel-outbound-send.test.ts`

Result: `1` test file passed, `6` tests passed.

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: rebased the branch onto current `main`, resolved conflicts against the newer runtime-send helpers, and ran the focused CLI Vitest file covering the changed behavior.
- Edge cases checked: canonical precedence over aliases, Slack `threadTs` fallback, and preservation of existing direct-send media/text behavior in the same test file.
- What I did **not** verify: live Slack delivery against a real workspace, and a clean full-repo `pnpm check` run because current-tree unrelated failures remain in `extensions/discord` and `extensions/qa-lab`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Note: the Greptile thread is addressed in code on the rebased branch. I have not resolved the GitHub thread yet.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another caller may rely on a non-canonical thread alias behavior not covered here.
  - Mitigation: the resolver remains precedence-preserving and the added tests lock the alias handling to the existing generic thread-id surface.

## AI-Assisted

- This PR was updated with AI assistance using Codex.
- Testing level: lightly tested.
- Local `codex review --base origin/main` was run on the rebased diff and did not find a diff-specific regression.
- Session log / prompts: available from the Codex session used to prepare the rebase and validation steps if maintainers want them.
- I understand the code being submitted and validated the final rebased diff before pushing.