### PR TITLE
browser: add a dedicated doctor health probe

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -36,11 +36,14 @@ openclaw browser --browser-profile openclaw snapshot
 ## Lifecycle
 
 ```bash
+openclaw browser doctor
 openclaw browser status
 openclaw browser start
 openclaw browser stop
 openclaw browser --browser-profile openclaw reset-profile
 ```
+
+`openclaw browser doctor` runs a focused health probe for the selected profile and reports browser-control reachability, launch prerequisites, and CDP or Chrome MCP readiness.
 
 Notes:
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -639,6 +639,7 @@ All commands also accept `--json` for machine-readable output (stable payloads).
 
 Basics:
 
+- `openclaw browser doctor`
 - `openclaw browser status`
 - `openclaw browser start`
 - `openclaw browser stop`

--- a/extensions/browser/src/browser-runtime.ts
+++ b/extensions/browser/src/browser-runtime.ts
@@ -15,6 +15,7 @@ export {
   browserOpenTab,
   browserCreateProfile,
   browserDeleteProfile,
+  browserDoctor,
   browserProfiles,
   browserResetProfile,
   browserSnapshot,
@@ -28,6 +29,7 @@ export { runBrowserProxyCommand } from "./node-host/invoke-browser.js";
 export type {
   BrowserCreateProfileResult,
   BrowserDeleteProfileResult,
+  BrowserDoctorReport,
   BrowserResetProfileResult,
   BrowserStatus,
   BrowserTab,

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -16,6 +16,7 @@ const BROWSER_ACT_KINDS = [
 ] as const;
 
 const BROWSER_TOOL_ACTIONS = [
+  "doctor",
   "status",
   "start",
   "stop",

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -2,6 +2,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const browserClientMocks = vi.hoisted(() => ({
   browserCloseTab: vi.fn(async (..._args: unknown[]) => ({})),
+  browserDoctor: vi.fn(async (..._args: unknown[]) => ({
+    ok: true,
+    profile: "openclaw",
+    transport: "cdp",
+    checks: [],
+    status: {
+      enabled: true,
+      running: false,
+      pid: null,
+      cdpPort: 18792,
+      cdpUrl: "http://127.0.0.1:18792",
+      chosenBrowser: null,
+      userDataDir: "/tmp/openclaw",
+      color: "#FF4500",
+      headless: true,
+      attachOnly: false,
+    },
+  })),
   browserFocusTab: vi.fn(async (..._args: unknown[]) => ({})),
   browserOpenTab: vi.fn(async (..._args: unknown[]) => ({})),
   browserProfiles: vi.fn(
@@ -175,6 +193,7 @@ function resetBrowserToolMocks() {
     browserArmDialog: browserActionsMocks.browserArmDialog as never,
     browserArmFileChooser: browserActionsMocks.browserArmFileChooser as never,
     browserCloseTab: browserClientMocks.browserCloseTab as never,
+    browserDoctor: browserClientMocks.browserDoctor as never,
     browserFocusTab: browserClientMocks.browserFocusTab as never,
     browserNavigate: browserActionsMocks.browserNavigate as never,
     browserOpenTab: browserClientMocks.browserOpenTab as never,
@@ -430,6 +449,36 @@ describe("browser tool snapshot maxChars", () => {
       }),
     );
     expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns the browser doctor report on host", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "doctor" });
+
+    expect(browserClientMocks.browserDoctor).toHaveBeenCalledWith(undefined, {
+      profile: undefined,
+    });
+  });
+
+  it("routes browser doctor through the node proxy", async () => {
+    mockSingleBrowserProxyNode();
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "doctor", target: "node" });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 25000 },
+      expect.objectContaining({
+        nodeId: "node-1",
+        command: "browser.proxy",
+        params: expect.objectContaining({
+          method: "GET",
+          path: "/doctor",
+          timeoutMs: 20000,
+        }),
+      }),
+    );
+    expect(browserClientMocks.browserDoctor).not.toHaveBeenCalled();
   });
 
   it("gives node.invoke extra slack beyond the default proxy timeout", async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -16,6 +16,7 @@ import {
   browserArmDialog,
   browserArmFileChooser,
   browserCloseTab,
+  browserDoctor,
   browserFocusTab,
   browserNavigate,
   browserOpenTab,
@@ -47,6 +48,7 @@ const browserToolDeps = {
   browserArmDialog,
   browserArmFileChooser,
   browserCloseTab,
+  browserDoctor,
   browserFocusTab,
   browserNavigate,
   browserOpenTab,
@@ -71,6 +73,7 @@ export const __testing = {
       browserArmDialog: typeof browserArmDialog;
       browserArmFileChooser: typeof browserArmFileChooser;
       browserCloseTab: typeof browserCloseTab;
+      browserDoctor: typeof browserDoctor;
       browserFocusTab: typeof browserFocusTab;
       browserNavigate: typeof browserNavigate;
       browserOpenTab: typeof browserOpenTab;
@@ -93,6 +96,7 @@ export const __testing = {
     browserToolDeps.browserArmFileChooser =
       overrides?.browserArmFileChooser ?? browserArmFileChooser;
     browserToolDeps.browserCloseTab = overrides?.browserCloseTab ?? browserCloseTab;
+    browserToolDeps.browserDoctor = overrides?.browserDoctor ?? browserDoctor;
     browserToolDeps.browserFocusTab = overrides?.browserFocusTab ?? browserFocusTab;
     browserToolDeps.browserNavigate = overrides?.browserNavigate ?? browserNavigate;
     browserToolDeps.browserOpenTab = overrides?.browserOpenTab ?? browserOpenTab;
@@ -455,6 +459,17 @@ export function createBrowserTool(opts?: {
         : null;
 
       switch (action) {
+        case "doctor":
+          if (proxyRequest) {
+            return jsonResult(
+              await proxyRequest({
+                method: "GET",
+                path: "/doctor",
+                profile,
+              }),
+            );
+          }
+          return jsonResult(await browserToolDeps.browserDoctor(baseUrl, { profile }));
         case "status":
           if (proxyRequest) {
             return jsonResult(

--- a/extensions/browser/src/browser/client.ts
+++ b/extensions/browser/src/browser/client.ts
@@ -2,6 +2,16 @@ import { fetchBrowserJson } from "./client-fetch.js";
 
 export type BrowserTransport = "cdp" | "chrome-mcp";
 
+export type BrowserDoctorCheckStatus = "pass" | "warn" | "fail" | "info";
+
+export type BrowserDoctorCheck = {
+  id: string;
+  label: string;
+  status: BrowserDoctorCheckStatus;
+  summary: string;
+  fixHint?: string;
+};
+
 export type BrowserStatus = {
   enabled: boolean;
   profile?: string;
@@ -23,6 +33,14 @@ export type BrowserStatus = {
   noSandbox?: boolean;
   executablePath?: string | null;
   attachOnly: boolean;
+};
+
+export type BrowserDoctorReport = {
+  ok: boolean;
+  profile: string;
+  transport: BrowserTransport;
+  checks: BrowserDoctorCheck[];
+  status: BrowserStatus;
 };
 
 export type ProfileStatus = {
@@ -113,6 +131,16 @@ export async function browserStatus(
   const q = buildProfileQuery(opts?.profile);
   return await fetchBrowserJson<BrowserStatus>(withBaseUrl(baseUrl, `/${q}`), {
     timeoutMs: 1500,
+  });
+}
+
+export async function browserDoctor(
+  baseUrl?: string,
+  opts?: { profile?: string },
+): Promise<BrowserDoctorReport> {
+  const q = buildProfileQuery(opts?.profile);
+  return await fetchBrowserJson<BrowserDoctorReport>(withBaseUrl(baseUrl, `/doctor${q}`), {
+    timeoutMs: 3000,
   });
 }
 

--- a/extensions/browser/src/browser/doctor.test.ts
+++ b/extensions/browser/src/browser/doctor.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { buildBrowserDoctorReport } from "./doctor.js";
+
+describe("buildBrowserDoctorReport", () => {
+  it("reports managed browsers that are not running as launchable info instead of failure", () => {
+    const report = buildBrowserDoctorReport({
+      platform: "linux",
+      env: { DISPLAY: ":99" },
+      uid: 1000,
+      status: {
+        enabled: true,
+        profile: "openclaw",
+        driver: "openclaw",
+        transport: "cdp",
+        running: false,
+        cdpReady: false,
+        cdpHttp: false,
+        pid: null,
+        cdpPort: 18800,
+        cdpUrl: "http://127.0.0.1:18800",
+        chosenBrowser: null,
+        detectedBrowser: "chromium",
+        detectedExecutablePath: "/usr/bin/chromium",
+        detectError: null,
+        userDataDir: "/tmp/openclaw",
+        color: "#FF4500",
+        headless: false,
+        noSandbox: false,
+        executablePath: null,
+        attachOnly: false,
+      },
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((check) => check.id === "cdp-websocket")).toMatchObject({
+      status: "info",
+    });
+  });
+
+  it("fails when Chrome MCP attach is not ready", () => {
+    const report = buildBrowserDoctorReport({
+      status: {
+        enabled: true,
+        profile: "user",
+        driver: "existing-session",
+        transport: "chrome-mcp",
+        running: false,
+        cdpReady: false,
+        cdpHttp: false,
+        pid: null,
+        cdpPort: null,
+        cdpUrl: null,
+        chosenBrowser: null,
+        detectedBrowser: null,
+        detectedExecutablePath: null,
+        detectError: null,
+        userDataDir: null,
+        color: "#00AA00",
+        headless: false,
+        noSandbox: false,
+        executablePath: null,
+        attachOnly: true,
+      },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((check) => check.id === "attach-target")).toMatchObject({
+      status: "fail",
+    });
+  });
+
+  it("fails when Linux managed browser launch lacks a display", () => {
+    const report = buildBrowserDoctorReport({
+      platform: "linux",
+      env: {},
+      uid: 1000,
+      status: {
+        enabled: true,
+        profile: "openclaw",
+        driver: "openclaw",
+        transport: "cdp",
+        running: false,
+        cdpReady: false,
+        cdpHttp: false,
+        pid: null,
+        cdpPort: 18800,
+        cdpUrl: "http://127.0.0.1:18800",
+        chosenBrowser: null,
+        detectedBrowser: "chromium",
+        detectedExecutablePath: "/usr/bin/chromium",
+        detectError: null,
+        userDataDir: "/tmp/openclaw",
+        color: "#FF4500",
+        headless: false,
+        noSandbox: false,
+        executablePath: null,
+        attachOnly: false,
+      },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((check) => check.id === "display")).toMatchObject({
+      status: "fail",
+    });
+  });
+});

--- a/extensions/browser/src/browser/doctor.ts
+++ b/extensions/browser/src/browser/doctor.ts
@@ -1,0 +1,175 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import type { BrowserStatus } from "./client.js";
+
+export type BrowserDoctorCheckStatus = "pass" | "warn" | "fail" | "info";
+
+export type BrowserDoctorCheck = {
+  id: string;
+  label: string;
+  status: BrowserDoctorCheckStatus;
+  summary: string;
+  fixHint?: string;
+};
+
+export type BrowserDoctorReport = {
+  ok: boolean;
+  profile: string;
+  transport: "cdp" | "chrome-mcp";
+  checks: BrowserDoctorCheck[];
+  status: BrowserStatus;
+};
+
+function usesChromeMcp(status: BrowserStatus): boolean {
+  return status.transport === "chrome-mcp" || status.driver === "existing-session";
+}
+
+export function buildBrowserDoctorReport(params: {
+  status: BrowserStatus;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  uid?: number | null;
+}): BrowserDoctorReport {
+  const status = params.status;
+  const platform = params.platform ?? process.platform;
+  const env = params.env ?? process.env;
+  const uid = params.uid ?? process.getuid?.() ?? null;
+  const checks: BrowserDoctorCheck[] = [
+    {
+      id: "control-server",
+      label: "Browser control server",
+      status: "pass",
+      summary: "Browser control server responded.",
+    },
+  ];
+
+  if (!status.enabled) {
+    checks.push({
+      id: "browser-enabled",
+      label: "Browser feature",
+      status: "fail",
+      summary: "Browser tooling is disabled in config.",
+      fixHint: "Enable `browser.enabled: true` and restart the Gateway.",
+    });
+  } else {
+    checks.push({
+      id: "browser-enabled",
+      label: "Browser feature",
+      status: "pass",
+      summary: "Browser tooling is enabled.",
+    });
+  }
+
+  if (usesChromeMcp(status)) {
+    if (status.running) {
+      checks.push({
+        id: "attach-target",
+        label: "Chrome MCP attach target",
+        status: "pass",
+        summary: "Attach target is reachable.",
+      });
+    } else {
+      checks.push({
+        id: "attach-target",
+        label: "Chrome MCP attach target",
+        status: "fail",
+        summary: "Existing-session browser attach is not ready.",
+        fixHint:
+          "Keep the browser open, enable remote debugging in the browser inspect page, accept the attach prompt, and retry.",
+      });
+    }
+  } else {
+    if (status.detectError) {
+      checks.push({
+        id: "browser-executable",
+        label: "Browser executable",
+        status: "fail",
+        summary: `Browser executable detection failed: ${status.detectError}`,
+        fixHint: "Fix browser.executablePath or install a supported Chromium-based browser.",
+      });
+    } else if (status.detectedExecutablePath || status.executablePath) {
+      checks.push({
+        id: "browser-executable",
+        label: "Browser executable",
+        status: "pass",
+        summary: `Detected browser executable at ${status.detectedExecutablePath ?? status.executablePath}.`,
+      });
+    } else {
+      checks.push({
+        id: "browser-executable",
+        label: "Browser executable",
+        status: "fail",
+        summary: "No Chromium-based browser executable was detected for managed browser launch.",
+        fixHint: "Install Chrome, Chromium, Brave, or Edge, or set browser.executablePath.",
+      });
+    }
+
+    if (platform === "linux" && !status.headless) {
+      const display = normalizeOptionalString(env.DISPLAY);
+      const wayland = normalizeOptionalString(env.WAYLAND_DISPLAY);
+      if (display || wayland) {
+        checks.push({
+          id: "display",
+          label: "Display session",
+          status: "pass",
+          summary: `Display session detected via ${display ? "DISPLAY" : "WAYLAND_DISPLAY"}.`,
+        });
+      } else {
+        checks.push({
+          id: "display",
+          label: "Display session",
+          status: "fail",
+          summary: "No DISPLAY or WAYLAND_DISPLAY is set while browser.headless is false.",
+          fixHint: "Run with a desktop session, start Xvfb, or set browser.headless: true.",
+        });
+      }
+    }
+
+    if (platform === "linux" && uid === 0) {
+      checks.push({
+        id: "sandbox",
+        label: "Chromium sandbox",
+        status: status.noSandbox ? "pass" : "warn",
+        summary: status.noSandbox
+          ? "browser.noSandbox is enabled for a root/container runtime."
+          : "Gateway is running as root and browser.noSandbox is false.",
+        fixHint: status.noSandbox
+          ? undefined
+          : "If managed browser launch fails in this runtime, set browser.noSandbox: true.",
+      });
+    }
+
+    if (status.running) {
+      checks.push({
+        id: "cdp-websocket",
+        label: "CDP websocket",
+        status: "pass",
+        summary: "Browser CDP websocket is reachable.",
+      });
+    } else if (status.cdpHttp) {
+      checks.push({
+        id: "cdp-websocket",
+        label: "CDP websocket",
+        status: "fail",
+        summary: "CDP HTTP responded, but the browser websocket is unhealthy.",
+        fixHint:
+          "A stale browser process, port conflict, or broken browser session may be blocking control. Check `openclaw browser status` and retry after cleanup.",
+      });
+    } else {
+      checks.push({
+        id: "cdp-websocket",
+        label: "CDP websocket",
+        status: "info",
+        summary:
+          "Managed browser is not running. OpenClaw can start it on demand if launch prerequisites are satisfied.",
+      });
+    }
+  }
+
+  return {
+    ok: !checks.some((check) => check.status === "fail"),
+    profile: status.profile ?? "openclaw",
+    transport: usesChromeMcp(status) ? "chrome-mcp" : "cdp",
+    checks,
+    status,
+  };
+}

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -1,5 +1,7 @@
 import { getChromeMcpPid } from "../chrome-mcp.js";
 import { resolveBrowserExecutableForPlatform } from "../chrome.executables.js";
+import type { BrowserStatus } from "../client.js";
+import { buildBrowserDoctorReport } from "../doctor.js";
 import { toBrowserErrorResponse } from "../errors.js";
 import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
 import { createBrowserProfilesService } from "../profiles-service.js";
@@ -48,6 +50,57 @@ async function withProfilesServiceMutation(params: {
 }
 
 export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: BrowserRouteContext) {
+  async function collectBrowserStatus(
+    profileCtx: ProfileContext,
+    current: ReturnType<typeof ctx.state>,
+  ): Promise<BrowserStatus> {
+    const [cdpHttp, cdpReady] = await Promise.all([
+      profileCtx.isHttpReachable(300),
+      profileCtx.isReachable(600),
+    ]);
+
+    const profileState = current.profiles.get(profileCtx.profile.name);
+    const capabilities = getBrowserProfileCapabilities(profileCtx.profile);
+    let detectedBrowser: string | null = null;
+    let detectedExecutablePath: string | null = null;
+    let detectError: string | null = null;
+
+    try {
+      const detected = resolveBrowserExecutableForPlatform(current.resolved, process.platform);
+      if (detected) {
+        detectedBrowser = detected.kind;
+        detectedExecutablePath = detected.path;
+      }
+    } catch (err) {
+      detectError = String(err);
+    }
+
+    return {
+      enabled: current.resolved.enabled,
+      profile: profileCtx.profile.name,
+      driver: profileCtx.profile.driver,
+      transport: capabilities.usesChromeMcp ? "chrome-mcp" : "cdp",
+      running: cdpReady,
+      cdpReady,
+      cdpHttp,
+      pid: capabilities.usesChromeMcp
+        ? getChromeMcpPid(profileCtx.profile.name)
+        : (profileState?.running?.pid ?? null),
+      cdpPort: capabilities.usesChromeMcp ? null : profileCtx.profile.cdpPort,
+      cdpUrl: capabilities.usesChromeMcp ? null : profileCtx.profile.cdpUrl,
+      chosenBrowser: profileState?.running?.exe.kind ?? null,
+      detectedBrowser,
+      detectedExecutablePath,
+      detectError,
+      userDataDir: profileState?.running?.userDataDir ?? profileCtx.profile.userDataDir ?? null,
+      color: profileCtx.profile.color,
+      headless: current.resolved.headless,
+      noSandbox: current.resolved.noSandbox,
+      executablePath: current.resolved.executablePath ?? null,
+      attachOnly: profileCtx.profile.attachOnly,
+    };
+  }
+
   // List all profiles with their status
   app.get("/profiles", async (_req, res) => {
     try {
@@ -74,51 +127,39 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
     }
 
     try {
-      const [cdpHttp, cdpReady] = await Promise.all([
-        profileCtx.isHttpReachable(300),
-        profileCtx.isReachable(600),
-      ]);
-
-      const profileState = current.profiles.get(profileCtx.profile.name);
-      const capabilities = getBrowserProfileCapabilities(profileCtx.profile);
-      let detectedBrowser: string | null = null;
-      let detectedExecutablePath: string | null = null;
-      let detectError: string | null = null;
-
-      try {
-        const detected = resolveBrowserExecutableForPlatform(current.resolved, process.platform);
-        if (detected) {
-          detectedBrowser = detected.kind;
-          detectedExecutablePath = detected.path;
-        }
-      } catch (err) {
-        detectError = String(err);
+      res.json(await collectBrowserStatus(profileCtx, current));
+    } catch (err) {
+      const mapped = toBrowserErrorResponse(err);
+      if (mapped) {
+        return jsonError(res, mapped.status, mapped.message);
       }
+      jsonError(res, 500, String(err));
+    }
+  });
 
-      res.json({
-        enabled: current.resolved.enabled,
-        profile: profileCtx.profile.name,
-        driver: profileCtx.profile.driver,
-        transport: capabilities.usesChromeMcp ? "chrome-mcp" : "cdp",
-        running: cdpReady,
-        cdpReady,
-        cdpHttp,
-        pid: capabilities.usesChromeMcp
-          ? getChromeMcpPid(profileCtx.profile.name)
-          : (profileState?.running?.pid ?? null),
-        cdpPort: capabilities.usesChromeMcp ? null : profileCtx.profile.cdpPort,
-        cdpUrl: capabilities.usesChromeMcp ? null : profileCtx.profile.cdpUrl,
-        chosenBrowser: profileState?.running?.exe.kind ?? null,
-        detectedBrowser,
-        detectedExecutablePath,
-        detectError,
-        userDataDir: profileState?.running?.userDataDir ?? profileCtx.profile.userDataDir ?? null,
-        color: profileCtx.profile.color,
-        headless: current.resolved.headless,
-        noSandbox: current.resolved.noSandbox,
-        executablePath: current.resolved.executablePath ?? null,
-        attachOnly: profileCtx.profile.attachOnly,
-      });
+  app.get("/doctor", async (req, res) => {
+    let current: ReturnType<typeof ctx.state>;
+    try {
+      current = ctx.state();
+    } catch {
+      return jsonError(res, 503, "browser server not started");
+    }
+
+    const profileCtx = getProfileContext(req, ctx);
+    if ("error" in profileCtx) {
+      return jsonError(res, profileCtx.status, profileCtx.error);
+    }
+
+    try {
+      const status = await collectBrowserStatus(profileCtx, current);
+      res.json(
+        buildBrowserDoctorReport({
+          status,
+          platform: process.platform,
+          env: process.env,
+          uid: process.getuid?.() ?? null,
+        }),
+      );
     } catch (err) {
       const mapped = toBrowserErrorResponse(err);
       if (mapped) {

--- a/extensions/browser/src/cli/browser-cli-examples.ts
+++ b/extensions/browser/src/cli/browser-cli-examples.ts
@@ -1,4 +1,5 @@
 export const browserCoreExamples = [
+  "openclaw browser doctor",
   "openclaw browser status",
   "openclaw browser start",
   "openclaw browser stop",

--- a/extensions/browser/src/cli/browser-cli-manage.test-helpers.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test-helpers.ts
@@ -29,7 +29,25 @@ const browserManageMocks = vi.hoisted(() => ({
           headless: true,
           attachOnly: false,
         }
-      : {},
+      : req.path === "/doctor"
+        ? {
+            ok: true,
+            profile: "openclaw",
+            transport: "cdp",
+            status: {
+              enabled: true,
+              running: true,
+              pid: 1,
+              cdpPort: 18800,
+              chosenBrowser: "chrome",
+              userDataDir: "/tmp/openclaw",
+              color: "blue",
+              headless: true,
+              attachOnly: false,
+            },
+            checks: [],
+          }
+        : {},
   ),
 }));
 

--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -179,4 +179,45 @@ describe("browser manage output", () => {
     expect(output).not.toContain("supersecretpasswordvalue1234");
     expect(output).not.toContain("supersecrettokenvalue1234567890");
   });
+
+  it("shows doctor output with failing checks and fixes", async () => {
+    getBrowserManageCallBrowserRequestMock().mockImplementation(async (_opts: unknown, req) =>
+      req.path === "/doctor"
+        ? {
+            ok: false,
+            profile: "openclaw",
+            transport: "cdp",
+            status: {},
+            checks: [
+              {
+                id: "control-server",
+                label: "Browser control server",
+                status: "pass",
+                summary: "Browser control server responded.",
+              },
+              {
+                id: "display",
+                label: "Display session",
+                status: "fail",
+                summary: "No DISPLAY or WAYLAND_DISPLAY is set while browser.headless is false.",
+                fixHint: "Run with a desktop session, start Xvfb, or set browser.headless: true.",
+              },
+            ],
+          }
+        : {},
+    );
+
+    const program = createBrowserManageProgram();
+    await program.parseAsync(["browser", "doctor"], { from: "user" });
+
+    const output = getBrowserCliRuntime().log.mock.calls.at(-1)?.[0] as string;
+    expect(output).toContain("ok: false");
+    expect(output).toContain("PASS Browser control server: Browser control server responded.");
+    expect(output).toContain(
+      "FAIL Display session: No DISPLAY or WAYLAND_DISPLAY is set while browser.headless is false.",
+    );
+    expect(output).toContain(
+      "fix: Run with a desktop session, start Xvfb, or set browser.headless: true.",
+    );
+  });
 });

--- a/extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts
@@ -30,6 +30,14 @@ describe("browser manage start timeout option", () => {
     expect(statusCall?.[2]).toEqual({ timeoutMs: 45_000 });
   });
 
+  it("uses a longer built-in timeout for browser doctor", async () => {
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+    await program.parseAsync(["browser", "doctor"], { from: "user" });
+
+    const doctorCall = findBrowserManageCall("/doctor");
+    expect(doctorCall?.[2]).toEqual({ timeoutMs: 45_000 });
+  });
+
   it("uses a longer built-in timeout for browser tabs", async () => {
     const program = createBrowserManageProgram({ withParentTimeout: true });
     await program.parseAsync(["browser", "tabs"], { from: "user" });

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -7,6 +7,7 @@ import {
   info,
   redactCdpUrl,
   shortenHomePath,
+  type BrowserDoctorReport,
   type BrowserCreateProfileResult,
   type BrowserDeleteProfileResult,
   type BrowserResetProfileResult,
@@ -56,6 +57,23 @@ async function fetchBrowserStatus(
     {
       method: "GET",
       path: "/",
+      query: resolveProfileQuery(profile),
+    },
+    {
+      timeoutMs: BROWSER_MANAGE_REQUEST_TIMEOUT_MS,
+    },
+  );
+}
+
+async function fetchBrowserDoctor(
+  parent: BrowserParentOpts,
+  profile?: string,
+): Promise<BrowserDoctorReport> {
+  return await callBrowserRequest<BrowserDoctorReport>(
+    parent,
+    {
+      method: "GET",
+      path: "/doctor",
       query: resolveProfileQuery(profile),
     },
     {
@@ -135,6 +153,38 @@ export function registerBrowserManageCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
 ) {
+  browser
+    .command("doctor")
+    .description("Diagnose browser control and launch readiness")
+    .action(async (_opts, cmd) => {
+      const parent = parentOpts(cmd);
+      await runBrowserCommand(async () => {
+        const report = await fetchBrowserDoctor(parent, parent?.browserProfile);
+        if (printJsonResult(parent, report)) {
+          return;
+        }
+        const icon = (status: BrowserDoctorReport["checks"][number]["status"]) =>
+          status === "pass"
+            ? "PASS"
+            : status === "warn"
+              ? "WARN"
+              : status === "fail"
+                ? "FAIL"
+                : "INFO";
+        defaultRuntime.log(
+          [
+            `profile: ${report.profile}`,
+            `transport: ${report.transport}`,
+            `ok: ${report.ok}`,
+            ...report.checks.flatMap((check) => [
+              `${icon(check.status)} ${check.label}: ${check.summary}`,
+              ...(check.fixHint ? [`  fix: ${check.fixHint}`] : []),
+            ]),
+          ].join("\n"),
+        );
+      });
+    });
+
   browser
     .command("status")
     .description("Show browser status")

--- a/extensions/browser/src/core-api.ts
+++ b/extensions/browser/src/core-api.ts
@@ -9,6 +9,7 @@ export {
   browserCreateProfile,
   browserConsoleMessages,
   browserDeleteProfile,
+  browserDoctor,
   browserFocusTab,
   browserNavigate,
   browserOpenTab,
@@ -52,6 +53,7 @@ export {
 export type {
   BrowserCreateProfileResult,
   BrowserDeleteProfileResult,
+  BrowserDoctorReport,
   BrowserFormField,
   BrowserResetProfileResult,
   BrowserRouteRegistrar,


### PR DESCRIPTION
## Summary
- add a read-only `openclaw browser doctor` command for focused browser-control diagnostics
- expose a structured browser health report that checks browser-control reachability, launch prerequisites, and CDP or Chrome MCP readiness
- document the new command in browser CLI and browser tool docs

## Testing
- `node scripts/run-vitest.mjs run --config vitest.extensions.config.ts extensions/browser/src/browser/doctor.test.ts extensions/browser/src/cli/browser-cli-manage.test.ts extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts`
- `pnpm tsgo`