### PR TITLE
Wake active requester sessions for subagent completion announces

### DIFF
--- a/src/agents/subagent-announce-delivery.runtime.ts
+++ b/src/agents/subagent-announce-delivery.runtime.ts
@@ -11,4 +11,8 @@ export { resolveExternalBestEffortDeliveryTarget } from "../infra/outbound/best-
 export { createBoundDeliveryRouter } from "../infra/outbound/bound-delivery-router.js";
 export { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
 export { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-export { isEmbeddedPiRunActive, queueEmbeddedPiMessage } from "./pi-embedded-runner/runs.js";
+export {
+  isEmbeddedPiRunActive,
+  queueEmbeddedPiMessage,
+  resolveActiveEmbeddedRunSessionId,
+} from "./pi-embedded-runner/runs.js";

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __testing, deliverSubagentAnnouncement } from "./subagent-announce-delivery.js";
 import { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
+
+afterEach(() => {
+  __testing.setDepsForTest();
+});
 
 describe("resolveAnnounceOrigin telegram forum topics", () => {
   it("preserves stored forum topic thread ids when requester origin omits one for the same chat", () => {
@@ -59,5 +64,128 @@ describe("resolveAnnounceOrigin telegram forum topics", () => {
       channel: "telegram",
       to: "telegram:-1001234567890",
     });
+  });
+});
+
+describe("deliverSubagentAnnouncement completion delivery", () => {
+  it("keeps completion announces session-internal while preserving route context", async () => {
+    const callGateway = vi.fn(async () => undefined);
+    __testing.setDepsForTest({
+      callGateway,
+      loadConfig: () => ({}) as never,
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      requesterSessionOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      completionDirectOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      directOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-1",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        delivered: true,
+        path: "direct",
+      }),
+    );
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "agent:main:slack:channel:C123:thread:171.222",
+          deliver: false,
+          channel: "slack",
+          accountId: "acct-1",
+          to: "channel:C123",
+          threadId: "171.222",
+          bestEffortDeliver: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("keeps direct external delivery for non-completion announces", async () => {
+    const callGateway = vi.fn(async () => undefined);
+    __testing.setDepsForTest({
+      callGateway,
+      loadConfig: () => ({}) as never,
+    });
+
+    await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      requesterSessionOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      completionDirectOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      directOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      requesterIsSubagent: false,
+      expectsCompletionMessage: false,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-2",
+    });
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          deliver: true,
+          channel: "slack",
+          accountId: "acct-1",
+          to: "channel:C123",
+          threadId: "171.222",
+          bestEffortDeliver: true,
+        }),
+      }),
+    );
   });
 });

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -69,12 +69,13 @@ describe("resolveAnnounceOrigin telegram forum topics", () => {
 });
 
 describe("deliverSubagentAnnouncement completion delivery", () => {
-  it("keeps completion announces session-internal while preserving route context", async () => {
+  it("keeps completion announces session-internal while preserving route context for active requesters", async () => {
     const callGateway = vi.fn(
       async () => ({}) as Record<string, unknown>,
     ) as unknown as typeof runtimeCallGateway;
     __testing.setDepsForTest({
       callGateway,
+      isRequesterSessionActive: () => true,
       loadConfig: () => ({}) as never,
     });
 
@@ -135,12 +136,73 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("keeps direct external delivery for dormant completion requesters", async () => {
+    const callGateway = vi.fn(
+      async () => ({}) as Record<string, unknown>,
+    ) as unknown as typeof runtimeCallGateway;
+    __testing.setDepsForTest({
+      callGateway,
+      isRequesterSessionActive: () => false,
+      loadConfig: () => ({}) as never,
+    });
+
+    await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      requesterSessionOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      completionDirectOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      directOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "171.222",
+      },
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-1b",
+    });
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          deliver: true,
+          channel: "slack",
+          accountId: "acct-1",
+          to: "channel:C123",
+          threadId: "171.222",
+          bestEffortDeliver: true,
+        }),
+      }),
+    );
+  });
+
   it("keeps direct external delivery for non-completion announces", async () => {
     const callGateway = vi.fn(
       async () => ({}) as Record<string, unknown>,
     ) as unknown as typeof runtimeCallGateway;
     __testing.setDepsForTest({
       callGateway,
+      isRequesterSessionActive: () => true,
       loadConfig: () => ({}) as never,
     });
 

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __testing, deliverSubagentAnnouncement } from "./subagent-announce-delivery.js";
+import { callGateway as runtimeCallGateway } from "./subagent-announce-delivery.runtime.js";
 import { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
 
 afterEach(() => {
@@ -69,7 +70,9 @@ describe("resolveAnnounceOrigin telegram forum topics", () => {
 
 describe("deliverSubagentAnnouncement completion delivery", () => {
   it("keeps completion announces session-internal while preserving route context", async () => {
-    const callGateway = vi.fn(async () => undefined);
+    const callGateway = vi.fn(
+      async () => ({}) as Record<string, unknown>,
+    ) as unknown as typeof runtimeCallGateway;
     __testing.setDepsForTest({
       callGateway,
       loadConfig: () => ({}) as never,
@@ -133,7 +136,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   });
 
   it("keeps direct external delivery for non-completion announces", async () => {
-    const callGateway = vi.fn(async () => undefined);
+    const callGateway = vi.fn(
+      async () => ({}) as Record<string, unknown>,
+    ) as unknown as typeof runtimeCallGateway;
     __testing.setDepsForTest({
       callGateway,
       loadConfig: () => ({}) as never,

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -73,10 +73,15 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     const callGateway = vi.fn(
       async () => ({}) as Record<string, unknown>,
     ) as unknown as typeof runtimeCallGateway;
+    const queueEmbeddedPiMessage = vi.fn(() => true);
     __testing.setDepsForTest({
       callGateway,
-      isRequesterSessionActive: () => true,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-1",
+        isActive: true,
+      }),
       loadConfig: () => ({}) as never,
+      queueEmbeddedPiMessage,
     });
 
     const result = await deliverSubagentAnnouncement({
@@ -117,23 +122,11 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(result).toEqual(
       expect.objectContaining({
         delivered: true,
-        path: "direct",
+        path: "steered",
       }),
     );
-    expect(callGateway).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "agent",
-        params: expect.objectContaining({
-          sessionKey: "agent:main:slack:channel:C123:thread:171.222",
-          deliver: false,
-          channel: "slack",
-          accountId: "acct-1",
-          to: "channel:C123",
-          threadId: "171.222",
-          bestEffortDeliver: undefined,
-        }),
-      }),
-    );
+    expect(queueEmbeddedPiMessage).toHaveBeenCalledWith("requester-session-1", "child done");
+    expect(callGateway).not.toHaveBeenCalled();
   });
 
   it("keeps direct external delivery for dormant completion requesters", async () => {
@@ -142,7 +135,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     ) as unknown as typeof runtimeCallGateway;
     __testing.setDepsForTest({
       callGateway,
-      isRequesterSessionActive: () => false,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-2",
+        isActive: false,
+      }),
       loadConfig: () => ({}) as never,
     });
 
@@ -202,7 +198,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     ) as unknown as typeof runtimeCallGateway;
     __testing.setDepsForTest({
       callGateway,
-      isRequesterSessionActive: () => true,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-3",
+        isActive: false,
+      }),
       loadConfig: () => ({}) as never,
     });
 

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -49,11 +49,17 @@ const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 type SubagentAnnounceDeliveryDeps = {
   callGateway: typeof callGateway;
   loadConfig: typeof loadConfig;
+  isRequesterSessionActive: (requesterSessionKey: string) => boolean;
 };
 
 const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
   callGateway,
   loadConfig,
+  isRequesterSessionActive: (requesterSessionKey: string) => {
+    const { entry } = loadRequesterSessionEntry(requesterSessionKey);
+    const sessionId = entry?.sessionId;
+    return Boolean(sessionId && isEmbeddedPiRunActive(sessionId));
+  },
 };
 
 let subagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps =
@@ -457,12 +463,16 @@ async function sendSubagentAnnounceDirectly(params: {
       isGatewayMessageChannel(normalizedSessionOnlyOriginChannel)
         ? normalizedSessionOnlyOriginChannel
         : undefined;
-    // Completion announces are internal wake events for the requester session.
-    // Preserve the resolved origin so the resumed session knows where to reply,
-    // but do not directly deliver to the user from this announce call. Let the
-    // resumed requester session own the single user-visible response.
-    const shouldDeliverExternally =
-      !params.expectsCompletionMessage && deliveryTarget.deliver;
+    const requesterSessionIsActive = subagentAnnounceDeliveryDeps.isRequesterSessionActive(
+      canonicalRequesterSessionKey,
+    );
+    // Completion announces are internal wake events only when the requester is
+    // already active and can resume through its own reply path. Dormant/manual
+    // requester sessions still need direct external delivery so completion
+    // results are not silently dropped.
+    const shouldDeliverExternally = deliveryTarget.deliver
+      ? !params.expectsCompletionMessage || !requesterSessionIsActive
+      : false;
     if (params.signal?.aborted) {
       return {
         delivered: false,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -25,6 +25,7 @@ import {
   loadConfig,
   loadSessionStore,
   queueEmbeddedPiMessage,
+  resolveActiveEmbeddedRunSessionId,
   resolveAgentIdFromSessionKey,
   resolveConversationIdFromTargets,
   resolveExternalBestEffortDeliveryTarget,
@@ -49,21 +50,43 @@ const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 type SubagentAnnounceDeliveryDeps = {
   callGateway: typeof callGateway;
   loadConfig: typeof loadConfig;
-  isRequesterSessionActive: (requesterSessionKey: string) => boolean;
+  getRequesterSessionActivity: (requesterSessionKey: string) => {
+    sessionId?: string;
+    isActive: boolean;
+  };
+  queueEmbeddedPiMessage: typeof queueEmbeddedPiMessage;
 };
 
 const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
   callGateway,
   loadConfig,
-  isRequesterSessionActive: (requesterSessionKey: string) => {
-    const { entry } = loadRequesterSessionEntry(requesterSessionKey);
-    const sessionId = entry?.sessionId;
-    return Boolean(sessionId && isEmbeddedPiRunActive(sessionId));
+  getRequesterSessionActivity: (requesterSessionKey: string) => {
+    const sessionId =
+      resolveActiveEmbeddedRunSessionId(requesterSessionKey) ??
+      loadRequesterSessionEntry(requesterSessionKey).entry?.sessionId;
+    return {
+      sessionId,
+      isActive: Boolean(sessionId && isEmbeddedPiRunActive(sessionId)),
+    };
   },
+  queueEmbeddedPiMessage,
 };
 
 let subagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps =
   defaultSubagentAnnounceDeliveryDeps;
+
+function resolveRequesterSessionActivity(requesterSessionKey: string) {
+  const activity = subagentAnnounceDeliveryDeps.getRequesterSessionActivity(requesterSessionKey);
+  if (activity.sessionId || activity.isActive) {
+    return activity;
+  }
+  const { entry } = loadRequesterSessionEntry(requesterSessionKey);
+  const sessionId = entry?.sessionId;
+  return {
+    sessionId,
+    isActive: Boolean(sessionId && isEmbeddedPiRunActive(sessionId)),
+  };
+}
 
 function resolveDirectAnnounceTransientRetryDelaysMs() {
   return process.env.OPENCLAW_TEST_FAST === "1"
@@ -354,7 +377,7 @@ async function maybeQueueSubagentAnnounce(params: {
   }
   const { cfg, entry } = loadRequesterSessionEntry(params.requesterSessionKey);
   const canonicalKey = resolveRequesterStoreKey(cfg, params.requesterSessionKey);
-  const sessionId = entry?.sessionId;
+  const { sessionId, isActive } = resolveRequesterSessionActivity(canonicalKey);
   if (!sessionId) {
     return "none";
   }
@@ -364,11 +387,13 @@ async function maybeQueueSubagentAnnounce(params: {
     channel: entry?.channel ?? entry?.lastChannel ?? entry?.origin?.provider,
     sessionEntry: entry,
   });
-  const isActive = isEmbeddedPiRunActive(sessionId);
 
   const shouldSteer = queueSettings.mode === "steer" || queueSettings.mode === "steer-backlog";
   if (shouldSteer) {
-    const steered = queueEmbeddedPiMessage(sessionId, params.steerMessage);
+    const steered = subagentAnnounceDeliveryDeps.queueEmbeddedPiMessage(
+      sessionId,
+      params.steerMessage,
+    );
     if (steered) {
       return "steered";
     }
@@ -463,16 +488,26 @@ async function sendSubagentAnnounceDirectly(params: {
       isGatewayMessageChannel(normalizedSessionOnlyOriginChannel)
         ? normalizedSessionOnlyOriginChannel
         : undefined;
-    const requesterSessionIsActive = subagentAnnounceDeliveryDeps.isRequesterSessionActive(
-      canonicalRequesterSessionKey,
-    );
-    // Completion announces are internal wake events only when the requester is
-    // already active and can resume through its own reply path. Dormant/manual
-    // requester sessions still need direct external delivery so completion
-    // results are not silently dropped.
-    const shouldDeliverExternally = deliveryTarget.deliver
-      ? !params.expectsCompletionMessage || !requesterSessionIsActive
-      : false;
+    const requesterActivity = resolveRequesterSessionActivity(canonicalRequesterSessionKey);
+    if (params.expectsCompletionMessage && requesterActivity.isActive) {
+      const woke = requesterActivity.sessionId
+        ? subagentAnnounceDeliveryDeps.queueEmbeddedPiMessage(
+            requesterActivity.sessionId,
+            params.triggerMessage,
+          )
+        : false;
+      if (woke) {
+        return {
+          delivered: true,
+          path: "steered",
+        };
+      }
+      return {
+        delivered: false,
+        path: "direct",
+        error: "active requester session could not be woken",
+      };
+    }
     if (params.signal?.aborted) {
       return {
         delivered: false,
@@ -490,21 +525,21 @@ async function sendSubagentAnnounceDirectly(params: {
           params: {
             sessionKey: canonicalRequesterSessionKey,
             message: params.triggerMessage,
-            deliver: shouldDeliverExternally,
-            bestEffortDeliver: shouldDeliverExternally ? params.bestEffortDeliver : undefined,
+            deliver: deliveryTarget.deliver,
+            bestEffortDeliver: params.bestEffortDeliver,
             internalEvents: params.internalEvents,
-            channel: shouldDeliverExternally ? deliveryTarget.channel : sessionOnlyOriginChannel,
-            accountId: shouldDeliverExternally
+            channel: deliveryTarget.deliver ? deliveryTarget.channel : sessionOnlyOriginChannel,
+            accountId: deliveryTarget.deliver
               ? deliveryTarget.accountId
               : sessionOnlyOriginChannel
                 ? sessionOnlyOrigin?.accountId
                 : undefined,
-            to: shouldDeliverExternally
+            to: deliveryTarget.deliver
               ? deliveryTarget.to
               : sessionOnlyOriginChannel
                 ? sessionOnlyOrigin?.to
                 : undefined,
-            threadId: shouldDeliverExternally
+            threadId: deliveryTarget.deliver
               ? deliveryTarget.threadId
               : sessionOnlyOriginChannel
                 ? sessionOnlyOrigin?.threadId

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -457,6 +457,12 @@ async function sendSubagentAnnounceDirectly(params: {
       isGatewayMessageChannel(normalizedSessionOnlyOriginChannel)
         ? normalizedSessionOnlyOriginChannel
         : undefined;
+    // Completion announces are internal wake events for the requester session.
+    // Preserve the resolved origin so the resumed session knows where to reply,
+    // but do not directly deliver to the user from this announce call. Let the
+    // resumed requester session own the single user-visible response.
+    const shouldDeliverExternally =
+      !params.expectsCompletionMessage && deliveryTarget.deliver;
     if (params.signal?.aborted) {
       return {
         delivered: false,
@@ -474,21 +480,21 @@ async function sendSubagentAnnounceDirectly(params: {
           params: {
             sessionKey: canonicalRequesterSessionKey,
             message: params.triggerMessage,
-            deliver: deliveryTarget.deliver,
-            bestEffortDeliver: params.bestEffortDeliver,
+            deliver: shouldDeliverExternally,
+            bestEffortDeliver: shouldDeliverExternally ? params.bestEffortDeliver : undefined,
             internalEvents: params.internalEvents,
-            channel: deliveryTarget.deliver ? deliveryTarget.channel : sessionOnlyOriginChannel,
-            accountId: deliveryTarget.deliver
+            channel: shouldDeliverExternally ? deliveryTarget.channel : sessionOnlyOriginChannel,
+            accountId: shouldDeliverExternally
               ? deliveryTarget.accountId
               : sessionOnlyOriginChannel
                 ? sessionOnlyOrigin?.accountId
                 : undefined,
-            to: deliveryTarget.deliver
+            to: shouldDeliverExternally
               ? deliveryTarget.to
               : sessionOnlyOriginChannel
                 ? sessionOnlyOrigin?.to
                 : undefined,
-            threadId: deliveryTarget.deliver
+            threadId: shouldDeliverExternally
               ? deliveryTarget.threadId
               : sessionOnlyOriginChannel
                 ? sessionOnlyOrigin?.threadId

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1702,7 +1702,7 @@ describe("subagent announce formatting", () => {
     expect(new Set(idempotencyKeys).size).toBe(2);
   });
 
-  it("prefers direct delivery first for completion-mode and then queues on direct failure", async () => {
+  it("falls back to queued follow-up delivery when an active completion wake cannot be injected", async () => {
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
     embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
     sessionStore = {
@@ -1729,14 +1729,10 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).not.toHaveBeenCalled();
-    expect(agentSpy).toHaveBeenCalledTimes(2);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(agentSpy.mock.calls[0]?.[0]).toMatchObject({
       method: "agent",
       params: { sessionKey: "agent:main:main", channel: "whatsapp", to: "+1555", deliver: true },
-    });
-    expect(agentSpy.mock.calls[1]?.[0]).toMatchObject({
-      method: "agent",
-      params: { sessionKey: "agent:main:main" },
     });
   });
 


### PR DESCRIPTION
## Summary
- wake active requester sessions for subagent completion announces through the embedded-run queue instead of sending a second external delivery
- keep completion announces externally deliverable for dormant or manual requester sessions that do not have an active turn to resume
- resolve requester activity from the live embedded-run session map before falling back to persisted requester-session metadata
- add regression coverage for active wake, dormant completion delivery, and active-wake fallback behavior

## Why
Subagent completion needs two different paths:
1. If the requester session is actively resumable, the completion announce should wake that session and let the resumed requester own the single user-visible reply.
2. If there is no active requester turn to resume, the announce still needs to remain externally deliverable.

The earlier version of this patch over-applied the session-internal rule and could suppress externally visible completion messages for dormant or manual requester sessions.

## Testing
Lightly tested:
- `pnpm check`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/subagent-announce-delivery.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts --testNamePattern="falls back to queued follow-up delivery when an active completion wake cannot be injected"`

## Metadata
- AI-assisted: yes