### PR TITLE
fix(scripts): avoid Windows oxlint arg overflow

### DIFF
--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -33,7 +33,8 @@ export function runExtensionOxlint(params) {
 
     writeTempOxlintConfig(repoRoot, tempConfigPath);
 
-    const baseArgs = ["-c", tempConfigPath, ...process.argv.slice(2), ...extensionFiles];
+    const lintTargets = resolveLintTargets(repoRoot, params.roots);
+    const baseArgs = ["-c", tempConfigPath, ...process.argv.slice(2), ...lintTargets];
     const { args: finalArgs, env } = applyLocalOxlintPolicy(baseArgs, process.env);
     const result = spawnSync(oxlintPath, finalArgs, {
       stdio: "inherit",
@@ -50,6 +51,14 @@ export function runExtensionOxlint(params) {
     fs.rmSync(tempDir, { recursive: true, force: true });
     releaseLock();
   }
+}
+
+export function resolveLintTargets(repoRoot, roots) {
+  return [
+    ...new Set(
+      roots.map((root) => normalizeRepoPath(path.relative(repoRoot, path.resolve(repoRoot, root)))),
+    ),
+  ];
 }
 
 function prepareExtensionPackageBoundaryArtifacts(repoRoot) {
@@ -137,4 +146,8 @@ function collectTypeScriptFiles(directoryPath) {
   }
 
   return files;
+}
+
+function normalizeRepoPath(value) {
+  return value.split(path.sep).join("/");
 }

--- a/test/scripts/run-extension-oxlint.test.ts
+++ b/test/scripts/run-extension-oxlint.test.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveLintTargets } from "../../scripts/lib/run-extension-oxlint.mjs";
+
+describe("resolveLintTargets", () => {
+  it("keeps extension roots instead of expanding every file path", () => {
+    const repoRoot = path.join("D:", "code", "openclaw", "openclaw");
+
+    expect(
+      resolveLintTargets(repoRoot, [
+        "extensions/discord",
+        path.join(repoRoot, "extensions", "slack"),
+        "extensions/discord",
+      ]),
+    ).toEqual(["extensions/discord", "extensions/slack"]);
+  });
+});


### PR DESCRIPTION
## Summary

- avoid expanding every extension TypeScript file into the Windows `cmd.exe` command line for the focused extension oxlint scripts
- pass normalized extension root directories to `oxlint` instead, while keeping the existing empty-scan guard in place
- add a small regression test for root-target normalization

## Why

On Windows, `pnpm lint:extensions:channels` and `pnpm lint:extensions:bundled` could fail before linting even started with `spawnSync ... ENAMETOOLONG` because the helper expanded thousands of file paths into one shell command. After this change, both commands run normally and surface the real lint findings instead of crashing on command length.

## Verification

- `pnpm.cmd test -- test/scripts/run-extension-oxlint.test.ts`
- `pnpm.cmd lint:extensions:channels`
- `pnpm.cmd lint:extensions:bundled`
- `pnpm.cmd test:extensions:package-boundary`

The two lint commands still report existing extension lint violations on current `main`, but they no longer fail with `ENAMETOOLONG`.
