### PR TITLE
fix(gateway): return real usage for OpenAI-compatible chat completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 - Daemon/gateway: prevent systemd restart storms on configuration errors by exiting with `EX_CONFIG` and adding generated unit restart-prevention guards. (#63913) Thanks @neo1027144-creator.
 - Agents/exec: prevent gateway crash ("Agent listener invoked outside active run") when a subagent exec tool produces stdout/stderr after the agent run has ended or been aborted. (#62821) Thanks @openperf.
 - Browser/tabs: route `/tabs/action` close/select through the same browser endpoint reachability and policy checks as list/new (including Playwright-backed remote tab operations), reject CDP HTTP redirects on probe requests, and sanitize blocked-endpoint error responses so tab list/focus/close flows fail closed without echoing raw policy details back to callers. (#63332)
+- Gateway/OpenAI compat: return real `usage` for non-stream `/v1/chat/completions` responses, emit the final usage chunk when `stream_options.include_usage=true`, and bound usage-gated stream finalization after lifecycle end. (#62986) Thanks @Lellansin.
 
 ## 2026.4.9
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -224,4 +224,63 @@ describe("handleAgentEnd", () => {
     resolveChannelFlush?.();
     await endPromise;
   });
+
+  it("emits lifecycle end after async channel flush completes", async () => {
+    let resolveChannelFlush: (() => void) | undefined;
+    const onAgentEvent = vi.fn();
+    const onBlockReplyFlush = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveChannelFlush = resolve;
+        }),
+    );
+    const ctx = createContext(undefined, { onAgentEvent, onBlockReplyFlush });
+
+    const endPromise = handleAgentEnd(ctx);
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+
+    resolveChannelFlush?.();
+    await endPromise;
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+  });
+
+  it("emits lifecycle error after async channel flush completes", async () => {
+    let resolveChannelFlush: (() => void) | undefined;
+    const onAgentEvent = vi.fn();
+    const onBlockReplyFlush = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveChannelFlush = resolve;
+        }),
+    );
+    const ctx = createContext(
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "connection refused",
+        content: [{ type: "text", text: "" }],
+      },
+      { onAgentEvent, onBlockReplyFlush },
+    );
+
+    const endPromise = handleAgentEnd(ctx);
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+
+    resolveChannelFlush?.();
+    await endPromise;
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        error: "LLM request failed: connection refused by the provider endpoint.",
+      },
+    });
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -38,6 +38,7 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
 export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
+  let lifecycleErrorText: string | undefined;
 
   if (isError && lastAssistant) {
     const friendlyError = formatAssistantErrorText(lastAssistant, {
@@ -54,6 +55,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     const observedError = buildApiErrorObservationFields(rawError);
     const safeErrorText =
       buildTextObservationFields(errorText).textPreview ?? "LLM request failed.";
+    lifecycleErrorText = safeErrorText;
     const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
     const safeModel = sanitizeForConsole(lastAssistant.model) ?? "unknown";
     const safeProvider = sanitizeForConsole(lastAssistant.provider) ?? "unknown";
@@ -71,24 +73,30 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       ...observedError,
       consoleMessage: `embedded run agent end: runId=${safeRunId} isError=true model=${safeModel} provider=${safeProvider} error=${safeErrorText}${rawErrorConsoleSuffix}`,
     });
-    emitAgentEvent({
-      runId: ctx.params.runId,
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        error: safeErrorText,
-        endedAt: Date.now(),
-      },
-    });
-    void ctx.params.onAgentEvent?.({
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        error: safeErrorText,
-      },
-    });
   } else {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
+  }
+
+  const emitLifecycleTerminal = () => {
+    if (isError) {
+      emitAgentEvent({
+        runId: ctx.params.runId,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          error: lifecycleErrorText ?? "LLM request failed.",
+          endedAt: Date.now(),
+        },
+      });
+      void ctx.params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          error: lifecycleErrorText ?? "LLM request failed.",
+        },
+      });
+      return;
+    }
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "lifecycle",
@@ -101,7 +109,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       stream: "lifecycle",
       data: { phase: "end" },
     });
-  }
+  };
 
   const finalizeAgentEnd = () => {
     ctx.state.blockState.thinking = false;
@@ -140,11 +148,14 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
   const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer();
   finalizeAgentEnd();
   if (isPromiseLike<void>(flushBlockReplyBufferResult)) {
-    return flushBlockReplyBufferResult.then(() => flushPendingMediaAndChannel());
+    return flushBlockReplyBufferResult
+      .then(() => flushPendingMediaAndChannel())
+      .then(() => emitLifecycleTerminal());
   }
 
   const flushPendingMediaAndChannelResult = flushPendingMediaAndChannel();
   if (isPromiseLike<void>(flushPendingMediaAndChannelResult)) {
-    return flushPendingMediaAndChannelResult;
+    return flushPendingMediaAndChannelResult.then(() => emitLifecycleTerminal());
   }
+  emitLifecycleTerminal();
 }

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -4,6 +4,7 @@ import {
   hasNonzeroUsage,
   derivePromptTokens,
   deriveSessionTotalTokens,
+  toOpenAiChatCompletionsUsage,
 } from "./usage.js";
 
 describe("normalizeUsage", () => {
@@ -143,6 +144,63 @@ describe("normalizeUsage", () => {
   it("handles undefined input", () => {
     const usage = normalizeUsage(undefined);
     expect(usage).toBeUndefined();
+  });
+});
+
+describe("toOpenAiChatCompletionsUsage", () => {
+  it("uses max(component sum, aggregate total) when breakdown is partial", () => {
+    const usage = normalizeUsage({ output_tokens: 20, total_tokens: 100 });
+    expect(toOpenAiChatCompletionsUsage(usage)).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 20,
+      total_tokens: 100,
+    });
+  });
+
+  it("uses component sum when it exceeds aggregate total", () => {
+    expect(
+      toOpenAiChatCompletionsUsage({
+        input: 30,
+        output: 40,
+        total: 50,
+      }),
+    ).toEqual({
+      prompt_tokens: 30,
+      completion_tokens: 40,
+      total_tokens: 70,
+    });
+  });
+
+  it("uses aggregate total when only total is present", () => {
+    const usage = normalizeUsage({ total_tokens: 42 });
+    expect(toOpenAiChatCompletionsUsage(usage)).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 42,
+    });
+  });
+
+  it("returns zeros for undefined usage", () => {
+    expect(toOpenAiChatCompletionsUsage(undefined)).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+  });
+
+  it("raises total_tokens with aggregate when cache write is excluded from prompt sum", () => {
+    expect(
+      toOpenAiChatCompletionsUsage({
+        input: 10,
+        output: 5,
+        cacheWrite: 100,
+        total: 200,
+      }),
+    ).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 200,
+    });
   });
 });
 

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -202,6 +202,33 @@ describe("toOpenAiChatCompletionsUsage", () => {
       total_tokens: 200,
     });
   });
+
+  it("clamps negative completion before deriving total_tokens", () => {
+    expect(
+      toOpenAiChatCompletionsUsage({
+        input: 3,
+        output: -5,
+      }),
+    ).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 0,
+      total_tokens: 3,
+    });
+  });
+
+  it("preserves aggregate total when components are partially negative", () => {
+    expect(
+      toOpenAiChatCompletionsUsage({
+        input: 3,
+        output: -5,
+        total: 7,
+      }),
+    ).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 0,
+      total_tokens: 7,
+    });
+  });
 });
 
 describe("hasNonzeroUsage", () => {

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -143,6 +143,41 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   };
 }
 
+/**
+ * Maps normalized usage to OpenAI Chat Completions `usage` fields.
+ *
+ * `prompt_tokens` is input + cacheRead (cache write is excluded to match the
+ * OpenAI-style breakdown used by the compat endpoint).
+ *
+ * `total_tokens` is the greater of the component sum and aggregate `total` when
+ * present, so a partial breakdown cannot discard a valid upstream total.
+ */
+export function toOpenAiChatCompletionsUsage(usage: NormalizedUsage | undefined): {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+} {
+  const input = usage?.input ?? 0;
+  const output = usage?.output ?? 0;
+  const cacheRead = usage?.cacheRead ?? 0;
+  const promptTokens = input + cacheRead;
+  const completionTokens = output;
+  const componentTotal = promptTokens + completionTokens;
+  const aggregateRaw = usage?.total;
+  const aggregateTotal =
+    typeof aggregateRaw === "number" && Number.isFinite(aggregateRaw)
+      ? Math.max(0, aggregateRaw)
+      : undefined;
+  const totalTokens =
+    aggregateTotal !== undefined ? Math.max(componentTotal, aggregateTotal) : componentTotal;
+
+  return {
+    prompt_tokens: Math.max(0, promptTokens),
+    completion_tokens: Math.max(0, completionTokens),
+    total_tokens: Math.max(0, totalTokens),
+  };
+}
+
 export function derivePromptTokens(usage?: {
   input?: number;
   cacheRead?: number;

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -160,8 +160,8 @@ export function toOpenAiChatCompletionsUsage(usage: NormalizedUsage | undefined)
   const input = usage?.input ?? 0;
   const output = usage?.output ?? 0;
   const cacheRead = usage?.cacheRead ?? 0;
-  const promptTokens = input + cacheRead;
-  const completionTokens = output;
+  const promptTokens = Math.max(0, input + cacheRead);
+  const completionTokens = Math.max(0, output);
   const componentTotal = promptTokens + completionTokens;
   const aggregateRaw = usage?.total;
   const aggregateTotal =
@@ -172,9 +172,9 @@ export function toOpenAiChatCompletionsUsage(usage: NormalizedUsage | undefined)
     aggregateTotal !== undefined ? Math.max(componentTotal, aggregateTotal) : componentTotal;
 
   return {
-    prompt_tokens: Math.max(0, promptTokens),
-    completion_tokens: Math.max(0, completionTokens),
-    total_tokens: Math.max(0, totalTokens),
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: totalTokens,
   };
 }
 

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1166,6 +1166,54 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
   });
 
   it(
+    "bounds usage-enabled stream finalization when usage never arrives",
+    { timeout: 10_000 },
+    async () => {
+      const port = enabledPort;
+      let serverAbortSignal: AbortSignal | undefined;
+
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce(
+        (opts: unknown) =>
+          new Promise<undefined>((resolve) => {
+            const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+            const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            serverAbortSignal = signal;
+            emitAgentEvent({ runId, stream: "assistant", data: { delta: "hello" } });
+            emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+            if (signal?.aborted) {
+              resolve(undefined);
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+          }),
+      );
+
+      const res = await postChatCompletions(port, {
+        stream: true,
+        stream_options: { include_usage: true },
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+
+      const text = await res.text();
+      const data = parseSseDataLines(text);
+      expect(data[data.length - 1]).toBe("[DONE]");
+      const jsonChunks = data
+        .filter((d) => d !== "[DONE]")
+        .map((d) => JSON.parse(d) as Record<string, unknown>);
+      const usageChunk = jsonChunks.find((chunk) => "usage" in chunk);
+      expect(usageChunk?.usage).toEqual({
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+      });
+      expect(serverAbortSignal?.aborted).toBe(true);
+    },
+  );
+
+  it(
     "cleans up usage-enabled stream when client disconnects before usage arrives",
     { timeout: 15_000 },
     async () => {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -762,7 +762,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(json.usage).toEqual({
           prompt_tokens: 10,
           completion_tokens: 5,
-          total_tokens: 15,
+          total_tokens: 100,
         });
       }
 
@@ -849,7 +849,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(json.usage).toEqual({
           prompt_tokens: 0,
           completion_tokens: 0,
-          total_tokens: 0,
+          total_tokens: 10,
         });
       }
 

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1166,54 +1166,6 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
   });
 
   it(
-    "bounds usage-enabled stream finalization when usage never arrives",
-    { timeout: 10_000 },
-    async () => {
-      const port = enabledPort;
-      let serverAbortSignal: AbortSignal | undefined;
-
-      agentCommand.mockClear();
-      agentCommand.mockImplementationOnce(
-        (opts: unknown) =>
-          new Promise<undefined>((resolve) => {
-            const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-            const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
-            serverAbortSignal = signal;
-            emitAgentEvent({ runId, stream: "assistant", data: { delta: "hello" } });
-            emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-            if (signal?.aborted) {
-              resolve(undefined);
-              return;
-            }
-            signal?.addEventListener("abort", () => resolve(undefined), { once: true });
-          }),
-      );
-
-      const res = await postChatCompletions(port, {
-        stream: true,
-        stream_options: { include_usage: true },
-        model: "openclaw",
-        messages: [{ role: "user", content: "hi" }],
-      });
-      expect(res.status).toBe(200);
-
-      const text = await res.text();
-      const data = parseSseDataLines(text);
-      expect(data[data.length - 1]).toBe("[DONE]");
-      const jsonChunks = data
-        .filter((d) => d !== "[DONE]")
-        .map((d) => JSON.parse(d) as Record<string, unknown>);
-      const usageChunk = jsonChunks.find((chunk) => "usage" in chunk);
-      expect(usageChunk?.usage).toEqual({
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        total_tokens: 0,
-      });
-      expect(serverAbortSignal?.aborted).toBe(true);
-    },
-  );
-
-  it(
     "cleans up usage-enabled stream when client disconnects before usage arrives",
     { timeout: 15_000 },
     async () => {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -702,6 +702,159 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
       {
         agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage basic" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                input: 42,
+                output: 17,
+              },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("usage");
+        expect(json.usage).toEqual({
+          prompt_tokens: 42,
+          completion_tokens: 17,
+          total_tokens: 59,
+        });
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage cache" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                input: 10,
+                output: 5,
+                cacheRead: 20,
+                cacheWrite: 3,
+              },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("usage");
+        expect(json.usage).toEqual({
+          prompt_tokens: 30,
+          completion_tokens: 5,
+          total_tokens: 35,
+        });
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage total" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                input: 10,
+                output: 5,
+                total: 100,
+              },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("usage");
+        expect(json.usage).toEqual({
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+        });
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage total only" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                total: 123,
+              },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("usage");
+        expect(json.usage).toEqual({
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 123,
+        });
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage non-finite" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                input: Number.POSITIVE_INFINITY,
+                output: Number.NaN,
+                cacheRead: 2,
+                cacheWrite: Number.POSITIVE_INFINITY,
+                total: Number.NaN,
+              },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("usage");
+        expect(json.usage).toEqual({
+          prompt_tokens: 2,
+          completion_tokens: 0,
+          total_tokens: 2,
+        });
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage non-finite aggregate fallback" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                input: Number.POSITIVE_INFINITY,
+                output: Number.NaN,
+                total: 123,
+              },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("usage");
+        expect(json.usage).toEqual({
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 123,
+        });
+      }
+
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage cache-write only" }],
+          meta: {
+            agentMeta: {
+              usage: {
+                cacheWrite: 10,
+                total: 10,
+              },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("usage");
+        expect(json.usage).toEqual({
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 0,
+        });
+      }
+
+      {
+        agentCommand.mockClear();
         agentCommand.mockResolvedValueOnce({ payloads: [{ text: "" }] } as never);
         const json = await postSyncUserMessage("hi");
         const choice0 = (json.choices as Array<Record<string, unknown>>)[0] ?? {};
@@ -802,6 +955,8 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           .filter((v): v is string => typeof v === "string")
           .join("");
         expect(allContent).toBe("hello");
+        const usageChunks = jsonChunks.filter((c) => "usage" in c);
+        expect(usageChunks).toHaveLength(0);
       }
 
       {
@@ -877,6 +1032,225 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     } finally {
       // shared server
     }
+  });
+
+  it("includes usage in final stream chunk when stream_options.include_usage=true", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "he" } });
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "llo" } });
+      return {
+        payloads: [{ text: "hello" }],
+        meta: {
+          agentMeta: {
+            usage: {
+              input: 12,
+              output: 5,
+              cacheRead: 3,
+              cacheWrite: 0,
+              total: 20,
+            },
+          },
+        },
+      };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      stream_options: { include_usage: true },
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const data = parseSseDataLines(text);
+    expect(data[data.length - 1]).toBe("[DONE]");
+    const jsonChunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+
+    const usageChunk = jsonChunks.find((chunk) => "usage" in chunk);
+    expect(usageChunk?.usage).toEqual({
+      prompt_tokens: 15,
+      completion_tokens: 5,
+      total_tokens: 20,
+    });
+    expect(usageChunk?.choices).toEqual([]);
+  });
+
+  it("keeps aggregate-only usage total in final stream usage chunk", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "hello" } });
+      return {
+        payloads: [{ text: "hello" }],
+        meta: {
+          agentMeta: {
+            usage: {
+              total: 123,
+            },
+          },
+        },
+      };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      stream_options: { include_usage: true },
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const data = parseSseDataLines(text);
+    expect(data[data.length - 1]).toBe("[DONE]");
+    const jsonChunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const usageChunk = jsonChunks.find((chunk) => "usage" in chunk);
+    expect(usageChunk?.usage).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 123,
+    });
+  });
+
+  it("finalizes stream when lifecycle end arrives before usage is available", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(
+      ((opts: unknown) =>
+        new Promise((resolve) => {
+          const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: "hello" } });
+          emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+          setTimeout(() => {
+            resolve({
+              payloads: [{ text: "hello" }],
+              meta: {
+                agentMeta: {
+                  usage: { input: 7, output: 3, total: 10 },
+                },
+              },
+            });
+          }, 100);
+        })) as never,
+    );
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      stream_options: { include_usage: true },
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const data = parseSseDataLines(text);
+    expect(data[data.length - 1]).toBe("[DONE]");
+    const jsonChunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const usageChunk = jsonChunks.find((chunk) => "usage" in chunk);
+    expect(usageChunk?.usage).toEqual({
+      prompt_tokens: 7,
+      completion_tokens: 3,
+      total_tokens: 10,
+    });
+  });
+
+  it(
+    "cleans up usage-enabled stream when client disconnects before usage arrives",
+    { timeout: 15_000 },
+    async () => {
+      const port = enabledPort;
+      let serverAbortSignal: AbortSignal | undefined;
+
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce(
+        (opts: unknown) =>
+          new Promise<undefined>((resolve) => {
+            const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+            const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            serverAbortSignal = signal;
+            emitAgentEvent({ runId, stream: "assistant", data: { delta: "hello" } });
+            emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+            if (signal?.aborted) {
+              resolve(undefined);
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+          }),
+      );
+
+      const clientReq = http.request({
+        hostname: "127.0.0.1",
+        port,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer secret",
+        },
+      });
+      clientReq.on("error", () => {});
+      clientReq.end(
+        JSON.stringify({
+          stream: true,
+          stream_options: { include_usage: true },
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(agentCommand).toHaveBeenCalledTimes(1);
+      });
+
+      clientReq.destroy();
+
+      await vi.waitFor(
+        () => {
+          expect(serverAbortSignal?.aborted).toBe(true);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+    },
+  );
+
+  it("does not block stream finalization on usage when include_usage is not requested", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(
+      ((opts: unknown) =>
+        new Promise(() => {
+          const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: "hello" } });
+          emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        })) as never,
+    );
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const data = parseSseDataLines(text);
+    expect(data[data.length - 1]).toBe("[DONE]");
+    const jsonChunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const usageChunks = jsonChunks.filter((chunk) => "usage" in chunk);
+    expect(usageChunks).toHaveLength(0);
   });
 
   it("treats shared-secret bearer callers as owner operators", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ImageContent } from "../agents/command/types.js";
-import { normalizeUsage } from "../agents/usage.js";
+import { normalizeUsage, toOpenAiChatCompletionsUsage } from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
@@ -483,29 +483,7 @@ function resolveChatCompletionUsage(result: unknown): {
   completion_tokens: number;
   total_tokens: number;
 } {
-  const usage = normalizeUsage(resolveRawAgentUsage(result));
-
-  // Keep the wire-format aligned with OpenAI chat completions:
-  // prompt_tokens includes prompt input plus cache-read reuse, but not cache-write overhead.
-  const input = usage?.input ?? 0;
-  const output = usage?.output ?? 0;
-  const cacheRead = usage?.cacheRead ?? 0;
-  const promptTokens = input + cacheRead;
-  const completionTokens = output;
-  const hasComponentBreakdown =
-    usage?.input !== undefined ||
-    usage?.output !== undefined ||
-    usage?.cacheRead !== undefined ||
-    usage?.cacheWrite !== undefined;
-  const totalTokens = hasComponentBreakdown
-    ? promptTokens + completionTokens
-    : Math.max(0, usage?.total ?? 0);
-
-  return {
-    prompt_tokens: Math.max(0, promptTokens),
-    completion_tokens: Math.max(0, completionTokens),
-    total_tokens: Math.max(0, totalTokens),
-  };
+  return toOpenAiChatCompletionsUsage(normalizeUsage(resolveRawAgentUsage(result)));
 }
 
 function resolveIncludeUsageForStreaming(payload: OpenAiChatCompletionRequest): boolean {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -693,6 +693,19 @@ export async function handleOpenAiHttpRequest(
     if (closed || !finalizeRequested) {
       return;
     }
+    // This usage gate intentionally mirrors openresponses-http.ts. Once finalize
+    // has been requested, the remaining wait is for the agent command promise to
+    // settle and provide the final usage state for the last SSE chunk.
+    //
+    // Current runner contract:
+    // - success: assigns real finalUsage, then requests finalize
+    // - error/timeout: assigns zeroed finalUsage via the lifecycle:error path,
+    //   then requests finalize
+    // - client disconnect: closes early via abort/watchClientDisconnect
+    //
+    // So this does not create a chat-completions-only infinite wait; a shorter
+    // HTTP-specific bounded fallback would be a shared adapter decision for both
+    // this endpoint and openresponses-http.ts.
     if (streamIncludeUsage && !finalUsage) {
       return;
     }

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ImageContent } from "../agents/command/types.js";
+import { normalizeUsage } from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
@@ -57,6 +58,8 @@ type OpenAiChatMessage = {
 type OpenAiChatCompletionRequest = {
   model?: unknown;
   stream?: unknown;
+  // Naming/style reference: src/agents/openai-transport-stream.ts:1262-1273
+  stream_options?: unknown;
   messages?: unknown;
   user?: unknown;
 };
@@ -160,6 +163,40 @@ function writeAssistantContentChunk(
         finish_reason: params.finishReason,
       },
     ],
+  });
+}
+
+function writeAssistantStopChunk(res: ServerResponse, params: { runId: string; model: string }) {
+  writeSse(res, {
+    id: params.runId,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: params.model,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "stop",
+      },
+    ],
+  });
+}
+
+function writeUsageChunk(
+  res: ServerResponse,
+  params: {
+    runId: string;
+    model: string;
+    usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+  },
+) {
+  writeSse(res, {
+    id: params.runId,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: params.model,
+    choices: [],
+    usage: params.usage,
   });
 }
 
@@ -421,6 +458,66 @@ function resolveAgentResponseText(result: unknown): string {
   return content || "No response from OpenClaw.";
 }
 
+type AgentUsageMeta = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+};
+
+function resolveRawAgentUsage(result: unknown): AgentUsageMeta | undefined {
+  return (
+    result as {
+      meta?: {
+        agentMeta?: {
+          usage?: AgentUsageMeta;
+        };
+      };
+    } | null
+  )?.meta?.agentMeta?.usage;
+}
+
+function resolveChatCompletionUsage(result: unknown): {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+} {
+  const usage = normalizeUsage(resolveRawAgentUsage(result));
+
+  // Keep the wire-format aligned with OpenAI chat completions:
+  // prompt_tokens includes prompt input plus cache-read reuse, but not cache-write overhead.
+  const input = usage?.input ?? 0;
+  const output = usage?.output ?? 0;
+  const cacheRead = usage?.cacheRead ?? 0;
+  const promptTokens = input + cacheRead;
+  const completionTokens = output;
+  const hasComponentBreakdown =
+    usage?.input !== undefined ||
+    usage?.output !== undefined ||
+    usage?.cacheRead !== undefined ||
+    usage?.cacheWrite !== undefined;
+  const totalTokens = hasComponentBreakdown
+    ? promptTokens + completionTokens
+    : Math.max(0, usage?.total ?? 0);
+
+  return {
+    prompt_tokens: Math.max(0, promptTokens),
+    completion_tokens: Math.max(0, completionTokens),
+    total_tokens: Math.max(0, totalTokens),
+  };
+}
+
+function resolveIncludeUsageForStreaming(payload: OpenAiChatCompletionRequest): boolean {
+  // Keep parsing aligned with OpenAI wire-format field names.
+  // Flow reference: src/agents/openai-transport-stream.ts:1262-1273
+  const streamOptions = payload.stream_options;
+  if (!streamOptions || typeof streamOptions !== "object" || Array.isArray(streamOptions)) {
+    return false;
+  }
+  return (streamOptions as { include_usage?: unknown }).include_usage === true;
+}
+
 export async function handleOpenAiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -451,6 +548,7 @@ export async function handleOpenAiHttpRequest(
 
   const payload = coerceRequest(handled.body);
   const stream = Boolean(payload.stream);
+  const streamIncludeUsage = stream && resolveIncludeUsageForStreaming(payload);
   const model = typeof payload.model === "string" ? payload.model : "openclaw";
   const user = typeof payload.user === "string" ? payload.user : undefined;
 
@@ -526,6 +624,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       const content = resolveAgentResponseText(result);
+      const usage = resolveChatCompletionUsage(result);
 
       sendJson(res, 200, {
         id: runId,
@@ -539,7 +638,7 @@ export async function handleOpenAiHttpRequest(
             finish_reason: "stop",
           },
         ],
-        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        usage,
       });
     } catch (err) {
       if (abortController.signal.aborted) {
@@ -558,9 +657,63 @@ export async function handleOpenAiHttpRequest(
   setSseHeaders(res);
 
   let wroteRole = false;
+  let wroteStopChunk = false;
   let sawAssistantDelta = false;
+  let finalUsage:
+    | {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+      }
+    | undefined;
+  let finalizeRequested = false;
   let closed = false;
   let stopWatchingDisconnect = () => {};
+
+  // Streaming finalize gate intentionally mirrors openresponses-http.ts:
+  // lifecycle:end requests finalize, while the command result supplies finalUsage.
+  // When stream_options.include_usage=true, both signals must arrive before the
+  // stream closes so the final usage chunk is emitted before [DONE].
+  //
+  // This does not leave the stream permanently hung waiting for usage. The
+  // agentCommandFromIngress promise always settles via normal completion, timeout,
+  // or abort. On success, the IIFE sets finalUsage from the command result and
+  // calls requestFinalize(); its finally path also emits lifecycle:end, which in
+  // turn calls requestFinalize(). On error or timeout, the catch path sets a
+  // zeroed finalUsage, emits lifecycle:error, and calls requestFinalize(). That
+  // means the same runner-level failure path already produces the fallback final
+  // usage state before this HTTP adapter tries to close the stream.
+  //
+  // Client disconnect is the separate early-exit case: watchClientDisconnect()
+  // marks the stream closed and aborts the runner, then the rejected promise
+  // returns early from catch because closed/aborted is already true.
+  // Whether adapters should also add a shorter HTTP-specific bounded fallback
+  // remains a shared adapter decision rather than a chat-completions-only change.
+  const maybeFinalize = () => {
+    if (closed || !finalizeRequested) {
+      return;
+    }
+    if (streamIncludeUsage && !finalUsage) {
+      return;
+    }
+    closed = true;
+    stopWatchingDisconnect();
+    unsubscribe();
+    if (!wroteStopChunk) {
+      writeAssistantStopChunk(res, { runId, model });
+      wroteStopChunk = true;
+    }
+    if (streamIncludeUsage && finalUsage) {
+      writeUsageChunk(res, { runId, model, usage: finalUsage });
+    }
+    writeDone(res);
+    res.end();
+  };
+
+  const requestFinalize = () => {
+    finalizeRequested = true;
+    maybeFinalize();
+  };
 
   const unsubscribe = onAgentEvent((evt) => {
     if (evt.runId !== runId) {
@@ -594,11 +747,7 @@ export async function handleOpenAiHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        closed = true;
-        stopWatchingDisconnect();
-        unsubscribe();
-        writeDone(res);
-        res.end();
+        requestFinalize();
       }
     }
   });
@@ -616,6 +765,8 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
+      finalUsage = resolveChatCompletionUsage(result);
+
       if (!sawAssistantDelta) {
         if (!wroteRole) {
           wroteRole = true;
@@ -632,6 +783,7 @@ export async function handleOpenAiHttpRequest(
           finishReason: null,
         });
       }
+      requestFinalize();
     } catch (err) {
       if (closed || abortController.signal.aborted) {
         return;
@@ -643,18 +795,25 @@ export async function handleOpenAiHttpRequest(
         content: "Error: internal error",
         finishReason: "stop",
       });
+      wroteStopChunk = true;
+      finalUsage = {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+      };
       emitAgentEvent({
         runId,
         stream: "lifecycle",
         data: { phase: "error" },
       });
+      requestFinalize();
     } finally {
       if (!closed) {
-        closed = true;
-        stopWatchingDisconnect();
-        unsubscribe();
-        writeDone(res);
-        res.end();
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: { phase: "end" },
+        });
       }
     }
   })();

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -68,6 +68,7 @@ const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
 const IMAGE_ONLY_USER_MESSAGE = "User sent image(s) with no text.";
 const DEFAULT_OPENAI_MAX_IMAGE_PARTS = 8;
 const DEFAULT_OPENAI_MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024;
+const STREAM_USAGE_FINALIZE_GRACE_MS = 2_000;
 const DEFAULT_OPENAI_IMAGE_LIMITS: InputImageLimits = {
   allowUrl: false,
   allowedMimes: new Set(DEFAULT_INPUT_IMAGE_MIMES),
@@ -647,47 +648,46 @@ export async function handleOpenAiHttpRequest(
   let finalizeRequested = false;
   let closed = false;
   let stopWatchingDisconnect = () => {};
+  let finalizeTimer: ReturnType<typeof setTimeout> | undefined;
 
-  // Streaming finalize gate intentionally mirrors openresponses-http.ts:
-  // lifecycle:end requests finalize, while the command result supplies finalUsage.
-  // When stream_options.include_usage=true, both signals must arrive before the
-  // stream closes so the final usage chunk is emitted before [DONE].
-  //
-  // This does not leave the stream permanently hung waiting for usage. The
-  // agentCommandFromIngress promise always settles via normal completion, timeout,
-  // or abort. On success, the IIFE sets finalUsage from the command result and
-  // calls requestFinalize(); its finally path also emits lifecycle:end, which in
-  // turn calls requestFinalize(). On error or timeout, the catch path sets a
-  // zeroed finalUsage, emits lifecycle:error, and calls requestFinalize(). That
-  // means the same runner-level failure path already produces the fallback final
-  // usage state before this HTTP adapter tries to close the stream.
-  //
-  // Client disconnect is the separate early-exit case: watchClientDisconnect()
-  // marks the stream closed and aborts the runner, then the rejected promise
-  // returns early from catch because closed/aborted is already true.
-  // Whether adapters should also add a shorter HTTP-specific bounded fallback
-  // remains a shared adapter decision rather than a chat-completions-only change.
+  const clearFinalizeTimer = () => {
+    if (!finalizeTimer) {
+      return;
+    }
+    clearTimeout(finalizeTimer);
+    finalizeTimer = undefined;
+  };
+
+  const armFinalizeTimer = () => {
+    if (!streamIncludeUsage || finalUsage || finalizeTimer || closed) {
+      return;
+    }
+    finalizeTimer = setTimeout(() => {
+      finalizeTimer = undefined;
+      if (closed || finalUsage) {
+        return;
+      }
+      finalUsage = {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+      };
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+      maybeFinalize();
+    }, STREAM_USAGE_FINALIZE_GRACE_MS);
+  };
+
   const maybeFinalize = () => {
     if (closed || !finalizeRequested) {
       return;
     }
-    // This usage gate intentionally mirrors openresponses-http.ts. Once finalize
-    // has been requested, the remaining wait is for the agent command promise to
-    // settle and provide the final usage state for the last SSE chunk.
-    //
-    // Current runner contract:
-    // - success: assigns real finalUsage, then requests finalize
-    // - error/timeout: assigns zeroed finalUsage via the lifecycle:error path,
-    //   then requests finalize
-    // - client disconnect: closes early via abort/watchClientDisconnect
-    //
-    // So this does not create a chat-completions-only infinite wait; a shorter
-    // HTTP-specific bounded fallback would be a shared adapter decision for both
-    // this endpoint and openresponses-http.ts.
     if (streamIncludeUsage && !finalUsage) {
       return;
     }
     closed = true;
+    clearFinalizeTimer();
     stopWatchingDisconnect();
     unsubscribe();
     if (!wroteStopChunk) {
@@ -703,6 +703,7 @@ export async function handleOpenAiHttpRequest(
 
   const requestFinalize = () => {
     finalizeRequested = true;
+    armFinalizeTimer();
     maybeFinalize();
   };
 
@@ -745,6 +746,7 @@ export async function handleOpenAiHttpRequest(
 
   stopWatchingDisconnect = watchClientDisconnect(req, res, abortController, () => {
     closed = true;
+    clearFinalizeTimer();
     unsubscribe();
   });
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -68,7 +68,6 @@ const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
 const IMAGE_ONLY_USER_MESSAGE = "User sent image(s) with no text.";
 const DEFAULT_OPENAI_MAX_IMAGE_PARTS = 8;
 const DEFAULT_OPENAI_MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024;
-const STREAM_USAGE_FINALIZE_GRACE_MS = 2_000;
 const DEFAULT_OPENAI_IMAGE_LIMITS: InputImageLimits = {
   allowUrl: false,
   allowedMimes: new Set(DEFAULT_INPUT_IMAGE_MIMES),
@@ -648,36 +647,6 @@ export async function handleOpenAiHttpRequest(
   let finalizeRequested = false;
   let closed = false;
   let stopWatchingDisconnect = () => {};
-  let finalizeTimer: ReturnType<typeof setTimeout> | undefined;
-
-  const clearFinalizeTimer = () => {
-    if (!finalizeTimer) {
-      return;
-    }
-    clearTimeout(finalizeTimer);
-    finalizeTimer = undefined;
-  };
-
-  const armFinalizeTimer = () => {
-    if (!streamIncludeUsage || finalUsage || finalizeTimer || closed) {
-      return;
-    }
-    finalizeTimer = setTimeout(() => {
-      finalizeTimer = undefined;
-      if (closed || finalUsage) {
-        return;
-      }
-      finalUsage = {
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        total_tokens: 0,
-      };
-      if (!abortController.signal.aborted) {
-        abortController.abort();
-      }
-      maybeFinalize();
-    }, STREAM_USAGE_FINALIZE_GRACE_MS);
-  };
 
   const maybeFinalize = () => {
     if (closed || !finalizeRequested) {
@@ -687,7 +656,6 @@ export async function handleOpenAiHttpRequest(
       return;
     }
     closed = true;
-    clearFinalizeTimer();
     stopWatchingDisconnect();
     unsubscribe();
     if (!wroteStopChunk) {
@@ -703,7 +671,6 @@ export async function handleOpenAiHttpRequest(
 
   const requestFinalize = () => {
     finalizeRequested = true;
-    armFinalizeTimer();
     maybeFinalize();
   };
 
@@ -746,7 +713,6 @@ export async function handleOpenAiHttpRequest(
 
   stopWatchingDisconnect = watchClientDisconnect(req, res, abortController, () => {
     closed = true;
-    clearFinalizeTimer();
     unsubscribe();
   });
 


### PR DESCRIPTION
## Summary

- Problem: `/v1/chat/completions` returned hardcoded zero usage in non-stream responses, and stream responses did not expose usage in an OpenAI-compatible way.
- Why it matters: OpenAI-compatible clients may depend on real usage values for telemetry, metering, assertions, or downstream compatibility behavior.
- What changed: the gateway now derives usage from `result.meta.agentMeta.usage`, returns it for non-stream responses, and emits a final usage chunk for stream responses when `stream_options.include_usage=true`.
- What changed (stream finalization semantics): streaming teardown now uses the same **finalize + usage gate** pattern as `openresponses-http.ts` (wait for the ingress command to settle when usage output is requested) instead of closing the SSE immediately from the prior `lifecycle` / `finally` paths. This is **adapter-level close ordering** so the optional usage chunk can precede `[DONE]`; it is **not** an HTTP-layer `setTimeout` removal relative to `main`.
- What changed (usage mapping): chat-completions usage **clamps non-negative components** before deriving `total_tokens`, and preserves upstream aggregate totals via **`max(componentTotal, aggregateTotal)`** when an aggregate total is present.
- What did NOT change (scope boundary): no auth/model-routing/request-validation/tool-behavior changes; OpenAI-compatible usage mapping keeps `prompt_tokens = input + cacheRead` (cache-write excluded intentionally).


## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38735
- Closes #49753
- Related PR
  - #46293
  - #38893
  - #24604
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the OpenAI-compatible `/v1/chat/completions` adapter hardcoded zero usage for non-stream responses and did not implement a compatible usage-return path for streaming responses.
- Missing detection / guardrail: there was no targeted gateway coverage asserting that non-stream responses propagate real usage or that streaming usage finalization behaves correctly under lifecycle timing races.
- Contributing context (if known): prior attempts addressed parts of the behavior but did not land, so the compatibility gap remained in the adapter layer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/openai-http.test.ts` (endpoint contract) and `src/agents/usage.test.ts` (`toOpenAiChatCompletionsUsage` / normalization edge cases).
- Scenario the test should lock in: non-stream responses return real usage from `agentMeta.usage`; stream responses emit a final usage chunk only when `stream_options.include_usage=true`; normal streaming finalization is not blocked when usage output is not requested.
- Why this is the smallest reliable guardrail: the bug is in the gateway compatibility adapter and response-shaping/finalization logic, so targeted endpoint tests cover the exact contract with minimal surface area.
- Existing test that already covers this (if any): existing streaming/non-stream endpoint tests covered basic response flow, but not usage propagation or finalize race handling.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Non-stream `/v1/chat/completions` responses now return real `usage` values instead of hardcoded zeros when upstream usage metadata exists.
- Stream `/v1/chat/completions` responses now emit a final usage chunk when `stream_options.include_usage=true`.
- Default stream behavior remains compatible for clients that do not request usage.

## Diagram (if applicable)

Before:
```mermaid
flowchart LR
    A["User request"] --> B["/v1/chat/completions adapter"]
    B --> C["Hardcoded usage = 0 / no streaming usage path"]
```

After:
```mermaid
flowchart LR
    A["User request"] --> B["/v1/chat/completions adapter"]
    B --> C["Derive usage from meta.agentMeta.usage<br/>(normalizeUsage → toOpenAiChatCompletionsUsage)"]
    C --> D["Non-stream: usage in JSON body"]
    C --> E["Stream: finalize gate + optional usage chunk<br/>when stream_options.include_usage = true"]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node.js / gateway build
- Model/provider: OpenClaw gateway OpenAI-compatible adapter, validated against agent runs that populate `result.meta.agentMeta.usage`
- Integration/channel (if any): Gateway HTTP `/v1/chat/completions`
- Relevant config (redacted): optional `OPENCLAW_DEBUG_OPENAI_USAGE=1`, gateway OpenAI-compatible endpoint enabled

### Steps

1. Start the gateway with the OpenAI-compatible endpoint enabled.
2. Send a non-stream POST to `/v1/chat/completions` and inspect the `usage` field.
3. Send a stream POST to `/v1/chat/completions` with `stream_options.include_usage=true` and inspect the final SSE usage chunk.

### Expected

- Non-stream responses return real usage values when available.
- Streaming responses emit usage only when explicitly requested.
- Normal streaming finalization still closes promptly when usage output is not requested.

### Actual

- Non-stream responses map real usage from `agentMeta.usage`.
- Streaming responses emit a final usage chunk when requested.
- Finalization race handling is covered so early lifecycle end does not hang usage-enabled streams.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: local endpoint tests for non-stream usage mapping, stream usage chunk emission, lifecycle-end-before-usage race handling, and default stream finalization without usage gating.
- Edge cases checked: cache-read/cache-write usage mapping, explicit total override, stream finalize ordering, and default stream behavior when `include_usage` is absent.
- What you did **not** verify: full provider matrix across every upstream transport and external SDK client behavior outside the gateway test surface.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: upstream usage payloads may vary by provider shape or omit some fields.
  - Mitigation: usage is derived from normalized `agentMeta.usage` fields with existing fallback behavior.
- Risk: streaming finalization can regress if lifecycle timing changes.
  - Mitigation: added targeted tests for lifecycle-end-before-usage and for non-usage stream finalization behavior.

## Trade-offs / Deferred follow-up

- Current decision in this PR: keep `/v1/chat/completions` stream finalization semantics aligned with `openresponses-http.ts` (finalize request + final usage gate), instead of introducing a chat-completions-only fallback.
- Known trade-off: when `stream_options.include_usage=true`, completion latency can still depend on when the ingress command settles on very slow tail/cleanup paths.
- Why this scope boundary: this PR is focused on usage correctness and OpenAI-compatible usage payload behavior, and we want to avoid cross-endpoint semantic divergence in finalize behavior.
- Follow-up direction (shared adapter decision): evaluate a bounded-finalize strategy for both `openai-http` and `openresponses-http` together.

### Evidence links

- `src/gateway/openai-http.ts` — OpenAI-compatible `/v1/chat/completions` adapter: usage mapping, streaming finalize gate, optional usage chunk when `stream_options.include_usage=true`.
- `src/gateway/openai-http.test.ts` — Contract tests for non-stream usage, streaming usage chunk, finalize/lifecycle behavior, and default stream path without usage.
- `src/agents/usage.ts` — `normalizeUsage` + `toOpenAiChatCompletionsUsage` (OpenAI-style `prompt_tokens` / `completion_tokens` / `total_tokens`, including aggregate vs component totals).
- `src/agents/usage.test.ts` — Unit tests for chat-completions usage mapping edge cases.

**Reference (not modified in this PR):** `src/gateway/openresponses-http.ts` — finalize / usage-gating pattern this endpoint mirrors in comments and behavior.

### Related unresolved threads

- https://github.com/openclaw/openclaw/pull/62986#discussion_r3062088677
- https://github.com/openclaw/openclaw/pull/62986#discussion_r3062229527
