### PR TITLE
fix(agents): merge user-configured providers into model catalog

### DIFF
--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -155,6 +155,83 @@ export async function loadModelCatalog(params?: {
         const input = Array.isArray(entry?.input) ? entry.input : undefined;
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
+      // Merge models from user-configured providers in openclaw.json
+      // (`models.providers.<id>.models[]`).
+      //
+      // The Pi SDK registry above only surfaces bundled providers; without this step,
+      // any custom OpenAI-compatible provider declared in `openclaw.json` (e.g. a
+      // local MLX server, packycode, lmstudio-style endpoints) is absent from the
+      // gateway model catalog. Downstream capability checks like
+      // `resolveGatewayModelSupportsImages()` would then return `false` for such
+      // models, causing `parseMessageWithAttachments()` to silently drop every
+      // image attachment with the warning
+      // `parseMessageWithAttachments: N attachment(s) dropped — model does not support images`,
+      // even when the user explicitly declared `"input": ["text", "image"]` on the
+      // configured model entry.
+      //
+      // This restores the behavior of the previous `mergeConfiguredOptInProviderModels`
+      // helper but without its hardcoded provider allowlist — any provider with a
+      // `models[]` array and per-entry `id` is eligible. Fixes #38639.
+      const configuredProviders = cfg.models?.providers;
+      if (configuredProviders && typeof configuredProviders === "object") {
+        const seenForConfigured = new Set(
+          models.map(
+            (entry) =>
+              `${normalizeLowercaseStringOrEmpty(entry.provider)}::${normalizeLowercaseStringOrEmpty(entry.id)}`,
+          ),
+        );
+        for (const [providerKey, providerCfg] of Object.entries(configuredProviders)) {
+          if (!providerCfg || typeof providerCfg !== "object") {
+            continue;
+          }
+          const provider = normalizeOptionalString(String(providerKey)) ?? "";
+          if (!provider) {
+            continue;
+          }
+          const configuredModels = (providerCfg as { models?: unknown }).models;
+          if (!Array.isArray(configuredModels)) {
+            continue;
+          }
+          for (const configuredModel of configuredModels) {
+            if (!configuredModel || typeof configuredModel !== "object") {
+              continue;
+            }
+            const idRaw = (configuredModel as { id?: unknown }).id;
+            const id = normalizeOptionalString(typeof idRaw === "string" ? idRaw : "") ?? "";
+            if (!id) {
+              continue;
+            }
+            const dedupeKey = `${normalizeLowercaseStringOrEmpty(provider)}::${normalizeLowercaseStringOrEmpty(id)}`;
+            if (seenForConfigured.has(dedupeKey)) {
+              continue;
+            }
+            if (shouldSuppressBuiltInModel({ provider, id })) {
+              continue;
+            }
+            const rawName = (configuredModel as { name?: unknown }).name;
+            const name = normalizeOptionalString(typeof rawName === "string" ? rawName : id) || id;
+            const contextWindowRaw = (configuredModel as { contextWindow?: unknown })
+              .contextWindow;
+            const contextWindow =
+              typeof contextWindowRaw === "number" && contextWindowRaw > 0
+                ? contextWindowRaw
+                : undefined;
+            const reasoningRaw = (configuredModel as { reasoning?: unknown }).reasoning;
+            const reasoning = typeof reasoningRaw === "boolean" ? reasoningRaw : undefined;
+            const inputRaw = (configuredModel as { input?: unknown }).input;
+            const inputFiltered = Array.isArray(inputRaw)
+              ? (inputRaw.filter(
+                  (item): item is ModelInputType =>
+                    item === "text" || item === "image" || item === "document",
+                ) as ModelInputType[])
+              : undefined;
+            const input = inputFiltered && inputFiltered.length > 0 ? inputFiltered : undefined;
+            models.push({ id, name, provider, contextWindow, reasoning, input });
+            seenForConfigured.add(dedupeKey);
+          }
+        }
+        logStage("configured-providers-merged", `entries=${models.length}`);
+      }
       const supplemental = await augmentModelCatalogWithProviderPlugins({
         config: cfg,
         env: process.env,


### PR DESCRIPTION
## Summary

Restores the merge of user-configured custom providers (`models.providers.<id>.models[]` from `openclaw.json`) into the gateway model catalog. The previous `mergeConfiguredOptInProviderModels` helper was removed during the model-catalog refactor, but its replacement (`augmentModelCatalogWithProviderPlugins`) only knows about plugin-backed providers — so any custom OpenAI-compatible provider declared in `openclaw.json` is **silently absent** from the catalog returned by `loadModelCatalog()`.

The most user-visible consequence is that `resolveGatewayModelSupportsImages()` then returns `false` for those models, and `parseMessageWithAttachments()` silently drops every image attachment with the gateway warning:

```
parseMessageWithAttachments: N attachment(s) dropped — model does not support images
```

…even though the user explicitly declared `"input": ["text", "image"]` on the configured model entry. The downstream agent then receives a text-only message and either responds blindly or hallucinates a workspace path for an image tool that can't find the file.

This PR adds a new merge step in `loadModelCatalog()` (between the Pi SDK registry loop and the plugin-augmentation step) that walks `cfg.models?.providers` and pushes any entry with a valid `id` into the catalog, applying the same `shouldSuppressBuiltInModel` filter and the same dedupe logic the existing supplemental merge already uses. **There is no provider allowlist** — any provider with a `models[]` array is eligible, matching the suggested fix in #38639.

Fixes #38639.

## Background — how this manifests in practice

I hit this trying to wire a local MLX inference server (`omlx`, OpenAI-compatible on `127.0.0.1:8000`) into openclaw as the default chat backend. Text chat worked perfectly. But every image attachment via the openclaw control UI was silently dropped before reaching the model.

After tracing the call path:

```
control UI image upload
  → server-Cv5hzFG4.js: agentHandlers.agent
  → resolveGatewayModelSupportsImages({ provider: "omlx", model: "Qwen3.5-35B-A3B-8bit" })
  → loadModelCatalog().find(entry.id === ... && entry.provider === ...)
  → catalog has 826 entries from the Pi SDK registry, ZERO with provider "omlx"
  → modelEntry === undefined → returns false
  → parseMessageWithAttachments(..., supportsImages: false)
  → silently drops attachments, returns text-only message
```

The catalog lookup never had a chance because the configured provider was never merged in. `openclaw models list --provider omlx --json` correctly showed the model with `input: "text+image"` (that's a separate code path that reads `openclaw.json` directly), but the gateway capability check uses `loadModelCatalog()`, which doesn't.

I confirmed this is **not** a regression introduced by the model-catalog refactor — the bug existed in `2026.4.5` (when `mergeConfiguredOptInProviderModels` was still around but had a hardcoded `NON_PI_NATIVE_MODEL_PROVIDERS = {deepseek, kilocode, ollama}` allowlist) and persists in `2026.4.8` (where the allowlist is gone but no replacement was added). The original report in #38639 hit the same root cause from a different surface (Telegram `/models` provider listing).

## What changed

- **`src/agents/model-catalog.ts`** — Added a new merge block after the Pi SDK registry loop that iterates `cfg.models?.providers` (when present), per-entry validates `id` / `name` / `contextWindow` / `reasoning` / `input` with the same coercion helpers the existing code uses (`normalizeOptionalString`, `normalizeLowercaseStringOrEmpty`), de-dupes against the entries already pushed by the registry loop, applies `shouldSuppressBuiltInModel`, and only accepts `input` items in `{"text", "image", "document"}`. Logs a `configured-providers-merged` timing stage on success.

- **No imports added**, no schema changes, no behavior change for plugin-backed providers — they still flow through `augmentModelCatalogWithProviderPlugins` exactly as before, and the existing dedupe in that path still wins for collisions.

## Verification

I tested this end-to-end on macOS (Apple Silicon, openclaw `2026.4.8`) by patching the equivalent code in `dist/model-catalog-xMydRuQF.js` and bouncing the gateway:

**Before:**
```
$ openclaw models list --all --json | jq '[.models[] | select(.key | startswith("omlx/"))] | length'
0
$ # Image attachment via dashboard:
$ tail -1 ~/.openclaw/logs/gateway.err.log
[gateway] parseMessageWithAttachments: 1 attachment(s) dropped — model does not support images
```

**After:**
```
$ openclaw models list --all --json | jq '[.models[] | select(.key | startswith("omlx/"))] | length'
2
$ openclaw models list --all --json | jq '.models[] | select(.key | startswith("omlx/")) | {key, input, available}'
{ "key": "omlx/Qwen3.5-35B-A3B-8bit", "input": "text+image", "available": true }
{ "key": "omlx/Qwen3.5-35B-A3B-Uncensored-...", "input": "text+image", "available": true }
$ # Image attachment via dashboard:
$ # (no drop warning, model receives image content parts and describes the image correctly)
```

## Test plan

- [ ] `pnpm tsgo` — typecheck passes (verified locally; my change adds zero TS errors. There are 11 pre-existing errors in `extensions/feishu` and `extensions/nostr` tests on stock `main` that this PR does not touch)
- [ ] Existing `src/agents/model-catalog.test.ts` continues to pass
- [ ] Manual: configure a custom provider in `openclaw.json` with `input: ["text", "image"]` → confirm it appears in `openclaw models list --all --json` and `openclaw models list --provider <name> --json`
- [ ] Manual: send an image to that model via the dashboard control UI → confirm no `parseMessageWithAttachments: dropped` warning in `gateway.err.log` and the model actually receives the image content parts

## Open questions for reviewers

1. **Is the allowlist removal intentional?** The previous allowlist (`{deepseek, kilocode, ollama}` shortly before the refactor; just `{kilocode}` in even earlier versions per #38639's quote) was removed when the merge function was deleted. If there was a reason it existed beyond historical accident — e.g. to gate which providers can self-describe their model list without being a plugin — please flag and I'll add it back, scoped to the new code.
2. **Should plugin-augmented providers take precedence over config-declared ones?** Currently this PR runs the config merge **before** `augmentModelCatalogWithProviderPlugins`, which means a config entry gets in first and any plugin-supplied entry for the same `<provider>::<id>` is then deduped out by the existing `seen` set in the supplemental merge. If you'd prefer the opposite ordering (plugin wins), I'm happy to swap them.
3. **Test coverage.** I'd be glad to add a test case to `src/agents/model-catalog.test.ts` covering "custom user-configured provider surfaces in catalog" — let me know if you'd like that as part of this PR or a follow-up.

🦞 *omlx-related context for completeness: I've been running [oMLX](https://github.com/.../oMLX) (an Apple-Silicon MLX-based vision-language inference server, OpenAI-compatible on port 8000) as the chat backend for my Junco agent. Qwen3.5-35B-A3B serves both text and images natively. None of that is in scope for openclaw — but I mention it because it explains the symptom and confirms the model is genuinely multimodal, ruling out a model-side problem.*
