### PR TITLE
fix(slack): preserve auth on same-origin media redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Slack: honor ambient HTTP(S) proxy settings for Socket Mode WebSocket connections, including NO_PROXY exclusions, so proxy-only deployments can connect without a monkey patch. (#62878) Thanks @mjamiv.
 - Slack/actions: pass the already resolved read token into `downloadFile` so SecretRef-backed bot tokens no longer fail after a raw config re-read. (#62097) Thanks @martingarramon.
 - Network/fetch guard: skip target DNS pinning when trusted env-proxy mode is active so proxy-only sandboxes can let the trusted proxy resolve outbound hosts. (#59007) Thanks @cluster2600.
+- Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
 
 ## 2026.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
+
 ## 2026.4.8
 
 ### Fixes
@@ -16,7 +20,6 @@ Docs: https://docs.openclaw.ai
 - Slack: honor ambient HTTP(S) proxy settings for Socket Mode WebSocket connections, including NO_PROXY exclusions, so proxy-only deployments can connect without a monkey patch. (#62878) Thanks @mjamiv.
 - Slack/actions: pass the already resolved read token into `downloadFile` so SecretRef-backed bot tokens no longer fail after a raw config re-read. (#62097) Thanks @martingarramon.
 - Network/fetch guard: skip target DNS pinning when trusted env-proxy mode is active so proxy-only sandboxes can let the trusted proxy resolve outbound hosts. (#59007) Thanks @cluster2600.
-- Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
 
 ## 2026.4.7
 

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -22,6 +22,11 @@ const createSavedMedia = (filePath: string, contentType: string): SavedMedia => 
   contentType,
 });
 
+function getRequestHeader(callIndex: number, headerName: string): string | null {
+  const init = mockFetch.mock.calls[callIndex]?.[1];
+  return new Headers(init?.headers).get(headerName);
+}
+
 describe("fetchWithSlackAuth", () => {
   beforeEach(() => {
     // Create a new mock for each test
@@ -65,7 +70,7 @@ describe("fetchWithSlackAuth", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("follows redirects without Authorization header", async () => {
+  it("strips Authorization header on cross-origin redirects", async () => {
     // First call: redirect response from Slack
     const redirectResponse = new Response(null, {
       status: 302,
@@ -99,8 +104,7 @@ describe("fetchWithSlackAuth", () => {
     );
   });
 
-  it("handles relative redirect URLs", async () => {
-    // Redirect with relative URL
+  it("preserves Authorization header on same-origin redirects", async () => {
     const redirectResponse = new Response(null, {
       status: 302,
       headers: { location: "/files/redirect-target" },
@@ -115,8 +119,8 @@ describe("fetchWithSlackAuth", () => {
 
     await fetchWithSlackAuth("https://files.slack.com/original.jpg", "xoxb-test-token");
 
-    // Second call should resolve the relative URL against the original
     expect(mockFetch).toHaveBeenNthCalledWith(2, "https://files.slack.com/files/redirect-target", {
+      headers: { Authorization: "Bearer xoxb-test-token" },
       redirect: "follow",
     });
   });
@@ -210,6 +214,74 @@ describe("resolveSlackMedia", () => {
       "https://files.slack.com/download.jpg",
       expect.anything(),
     );
+  });
+
+  it("preserves Authorization on same-origin redirects for private downloads", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
+    );
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "/files/redirect-target" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("image data"), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+
+    const result = await resolveSlackMedia({
+      files: [{ url_private_download: "https://files.slack.com/download.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://files.slack.com/download.jpg");
+    expect(mockFetch.mock.calls[1]?.[0]).toBe("https://files.slack.com/files/redirect-target");
+    expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
+    expect(getRequestHeader(1, "Authorization")).toBe("Bearer xoxb-test-token");
+  });
+
+  it("strips Authorization on cross-origin redirects for private downloads", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
+    );
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://downloads.slack-edge.com/presigned-url?sig=abc123" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("image data"), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+
+    const result = await resolveSlackMedia({
+      files: [{ url_private_download: "https://files.slack.com/download.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://files.slack.com/download.jpg");
+    expect(mockFetch.mock.calls[1]?.[0]).toBe(
+      "https://downloads.slack-edge.com/presigned-url?sig=abc123",
+    );
+    expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
+    expect(getRequestHeader(1, "Authorization")).toBeNull();
   });
 
   it("returns null when download fails", async () => {
@@ -481,9 +553,7 @@ describe("resolveSlackMedia", () => {
     }) as typeof fetch;
     const runtimeFetchSpy = vi
       .spyOn(ssrf, "fetchWithRuntimeDispatcher")
-      .mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
-        expect(init).toMatchObject({ redirect: "manual" });
-        expect(init && "dispatcher" in init).toBe(true);
+      .mockImplementation(async () => {
         return new Response(Buffer.from("image data"), {
           status: 200,
           headers: { "content-type": "image/jpeg" },
@@ -498,6 +568,13 @@ describe("resolveSlackMedia", () => {
 
     expect(result).not.toBeNull();
     expect(runtimeFetchSpy).toHaveBeenCalled();
+    expect(runtimeFetchSpy.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
+    expect(
+      runtimeFetchSpy.mock.calls[0]?.[1] && "dispatcher" in runtimeFetchSpy.mock.calls[0][1],
+    ).toBe(true);
+    expect(new Headers(runtimeFetchSpy.mock.calls[0]?.[1]?.headers).get("Authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
   });
 });
 

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -43,6 +43,26 @@ function assertSlackFileUrl(rawUrl: string): URL {
   return parsed;
 }
 
+function createSlackAuthHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}
+
+function createSlackMediaRequest(
+  url: string,
+  token: string,
+): {
+  url: string;
+  requestInit: RequestInit;
+} {
+  const parsed = assertSlackFileUrl(url);
+  return {
+    url: parsed.href,
+    // Let the shared guarded-fetch redirect logic preserve auth on same-origin
+    // Slack hops and strip it once the redirect crosses origins.
+    requestInit: { headers: createSlackAuthHeaders(token) },
+  };
+}
+
 function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
   if (typeof fetchImpl !== "function") {
     return false;
@@ -50,68 +70,53 @@ function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
   return typeof (fetchImpl as typeof fetch & { mock?: unknown }).mock === "object";
 }
 
-function createSlackMediaFetch(token: string): FetchLike {
-  let includeAuth = true;
+function createSlackMediaFetch(): FetchLike {
   return async (input, init) => {
     const url = resolveRequestUrl(input);
     if (!url) {
       throw new Error("Unsupported fetch input: expected string, URL, or Request");
     }
-    const { headers: initHeaders, redirect: _redirect, ...rest } = init ?? {};
-    const headers = new Headers(initHeaders);
+    const parsed = assertSlackFileUrl(url);
     const fetchImpl =
       "dispatcher" in (init ?? {}) && !isMockedFetch(globalThis.fetch)
         ? fetchWithRuntimeDispatcher
         : globalThis.fetch;
-
-    if (includeAuth) {
-      includeAuth = false;
-      const parsed = assertSlackFileUrl(url);
-      headers.set("Authorization", `Bearer ${token}`);
-      return fetchImpl(parsed.href, { ...rest, headers, redirect: "manual" });
-    }
-
-    headers.delete("Authorization");
-    return fetchImpl(url, { ...rest, headers, redirect: "manual" });
+    return fetchImpl(parsed.href, { ...init, redirect: "manual" });
   };
 }
 
 /**
- * Fetches a URL with Authorization header, handling cross-origin redirects.
- * Node.js fetch strips Authorization headers on cross-origin redirects for security.
- * Slack's file URLs redirect to CDN domains with pre-signed URLs that don't need the
- * Authorization header, so we handle the initial auth request manually.
+ * Fetches a URL with Authorization header while keeping same-origin redirects
+ * authenticated and dropping auth once the redirect crosses origins.
  */
 export async function fetchWithSlackAuth(url: string, token: string): Promise<Response> {
   const parsed = assertSlackFileUrl(url);
+  const authHeaders = createSlackAuthHeaders(token);
 
-  // Initial request with auth and manual redirect handling
   const initialRes = await fetch(parsed.href, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders,
     redirect: "manual",
   });
 
-  // If not a redirect, return the response directly
   if (initialRes.status < 300 || initialRes.status >= 400) {
     return initialRes;
   }
 
-  // Handle redirect - the redirected URL should be pre-signed and not need auth
   const redirectUrl = initialRes.headers.get("location");
   if (!redirectUrl) {
     return initialRes;
   }
 
-  // Resolve relative URLs against the original
   const resolvedUrl = new URL(redirectUrl, parsed.href);
-
-  // Only follow safe protocols (we do NOT include Authorization on redirects).
   if (resolvedUrl.protocol !== "https:") {
     return initialRes;
   }
-
-  // Follow the redirect without the Authorization header
-  // (Slack's CDN URLs are pre-signed and don't need it)
+  if (resolvedUrl.origin === parsed.origin) {
+    return fetch(resolvedUrl.toString(), {
+      headers: authHeaders,
+      redirect: "follow",
+    });
+  }
   return fetch(resolvedUrl.toString(), { redirect: "follow" });
 }
 
@@ -223,13 +228,12 @@ export async function resolveSlackMedia(params: {
         return null;
       }
       try {
-        // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
-        // handles size limits internally. Provide a fetcher that uses auth once, then lets
-        // the redirect chain continue without credentials.
-        const fetchImpl = createSlackMediaFetch(params.token);
+        const { url: slackUrl, requestInit } = createSlackMediaRequest(url, params.token);
+        const fetchImpl = createSlackMediaFetch();
         const fetched = await fetchRemoteMedia({
-          url,
+          url: slackUrl,
           fetchImpl,
+          requestInit,
           filePathHint: file.name,
           maxBytes: params.maxBytes,
           ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
@@ -307,10 +311,12 @@ export async function resolveSlackAttachmentContent(params: {
     const imageUrl = resolveForwardedAttachmentImageUrl(att);
     if (imageUrl) {
       try {
-        const fetchImpl = createSlackMediaFetch(params.token);
+        const { url: slackUrl, requestInit } = createSlackMediaRequest(imageUrl, params.token);
+        const fetchImpl = createSlackMediaFetch();
         const fetched = await fetchRemoteMedia({
-          url: imageUrl,
+          url: slackUrl,
           fetchImpl,
+          requestInit,
           maxBytes: params.maxBytes,
           ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
         });


### PR DESCRIPTION
## Summary

- Problem: Slack `url_private_download` fetches lost `Authorization` on same-origin `files.slack.com` redirects, so image attachments degraded into HTML login pages and were dropped.
- Why it matters: Slack agents on current releases silently miss shared image attachments.
- What changed: moved auth into `requestInit`, kept the guarded fetch wrapper for dispatcher-backed requests, and added regression coverage for same-origin auth preservation plus cross-origin auth stripping.
- What did NOT change (scope boundary): no Slack CDN allowlist expansion, no generic SSRF redirect-policy changes, and no non-Slack media behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62960
- Related #62239
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/slack/src/monitor/media.ts` managed the bearer token outside the shared guarded-fetch redirect flow. It sent auth on the first hop, then unconditionally deleted `Authorization` on every subsequent hop.
- Missing detection / guardrail: we did not have a regression test covering same-origin Slack redirects through the real `resolveSlackMedia` path.
- Contributing context (if known): the regression showed up after the SSRF redirect changes in 2026.4.5, but the actual bug was Slack-specific auth handling layered on top of that shared guard.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/media.test.ts`
- Scenario the test should lock in: same-origin `files.slack.com` redirects keep `Authorization`; cross-origin Slack CDN redirects strip it.
- Why this is the smallest reliable guardrail: it exercises the real Slack media download path without needing a live Slack workspace.
- Existing test that already covers this (if any): none for the same-origin redirect case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Slack image attachments served through `url_private_download` load again instead of being silently dropped after a login-page redirect.

## Diagram (if applicable)

```text
Before:
[Slack image upload] -> [files.slack.com redirect] -> [auth stripped too early] -> [HTML login page] -> [attachment dropped]

After:
[Slack image upload] -> [same-origin redirect keeps auth] -> [cross-origin redirect strips auth] -> [binary media fetched]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: the bearer token now stays attached only on same-origin Slack redirects. Cross-origin redirects still pass through the shared guarded-fetch stripping logic, so we do not widen token exposure beyond Slack's original host.

## Repro + Verification

### Environment

- OS: macOS host worktree verification
- Runtime/container: local Node 25.8.2 / pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): N/A

### Steps

1. Mock a Slack media download that redirects from `https://files.slack.com/...` to a same-origin path.
2. Verify the second request still carries `Authorization`.
3. Mock a redirect to `https://downloads.slack-edge.com/...` and verify auth is stripped there.

### Expected

- Same-origin redirects keep the bearer token.
- Cross-origin Slack CDN redirects strip the bearer token.
- `resolveSlackMedia` returns the saved attachment instead of `null`.

### Actual

- Verified by the new regression tests and the targeted local run below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/slack/src/monitor/media.test.ts`; `pnpm build`; targeted `oxlint` and `oxfmt --check` on the touched files.
- Edge cases checked: same-origin redirect auth preservation, cross-origin redirect auth stripping, dispatcher-backed runtime fetch path.
- What you did **not** verify: I did not get a clean repo-wide `pnpm lint` or `pnpm test` gate because current main has unrelated failures, and the default `core` sparse profile initially hid `ui/`, `packages/`, and OpenClawKit resource paths until I materialized them.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: preserving auth on redirects could accidentally keep tokens on the wrong host if the redirect-origin check were wrong.
  - Mitigation: auth now rides through the shared guarded-fetch flow, which preserves headers only for same-origin redirects and strips them on cross-origin hops.
