### PR TITLE
fix(discord): bridge voice gateway events to @discordjs/voice adapter

### DIFF
--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -1025,7 +1025,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     }
 
     if (voiceEnabled) {
-      const { DiscordVoiceManager, DiscordVoiceReadyListener } = await loadDiscordVoiceRuntime();
+      const {
+        DiscordVoiceManager,
+        DiscordVoiceReadyListener,
+        DiscordVoiceServerUpdateBridge,
+        DiscordVoiceStateUpdateBridge,
+      } = await loadDiscordVoiceRuntime();
       voiceManager = new DiscordVoiceManager({
         client,
         cfg,
@@ -1036,10 +1041,6 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       });
       voiceManagerRef.current = voiceManager;
       registerDiscordListener(client.listeners, new DiscordVoiceReadyListener(voiceManager));
-
-      const { DiscordVoiceServerUpdateBridge, DiscordVoiceStateUpdateBridge } = await import(
-        "../voice/adapter-bridge.js"
-      );
       registerDiscordListener(client.listeners, new DiscordVoiceServerUpdateBridge());
       registerDiscordListener(client.listeners, new DiscordVoiceStateUpdateBridge());
     }

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -1036,6 +1036,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       });
       voiceManagerRef.current = voiceManager;
       registerDiscordListener(client.listeners, new DiscordVoiceReadyListener(voiceManager));
+
+      const { DiscordVoiceServerUpdateBridge, DiscordVoiceStateUpdateBridge } = await import(
+        "../voice/adapter-bridge.js"
+      );
+      registerDiscordListener(client.listeners, new DiscordVoiceServerUpdateBridge());
+      registerDiscordListener(client.listeners, new DiscordVoiceStateUpdateBridge());
     }
 
     const messageHandler = discordProviderSessionRuntime.createDiscordMessageHandler({

--- a/extensions/discord/src/voice/adapter-bridge.ts
+++ b/extensions/discord/src/voice/adapter-bridge.ts
@@ -1,0 +1,44 @@
+import type { Client } from "@buape/carbon";
+import { VoiceServerUpdateListener, VoiceStateUpdateListener } from "@buape/carbon";
+import type { VoicePlugin } from "@buape/carbon/voice";
+import type {
+  GatewayVoiceServerUpdateDispatchData,
+  GatewayVoiceStateUpdateDispatchData,
+} from "discord-api-types/v10";
+
+function getVoiceAdapters(client: Client) {
+  return client.getPlugin<VoicePlugin>("voice")?.adapters;
+}
+
+export class DiscordVoiceServerUpdateBridge extends VoiceServerUpdateListener {
+  async handle(data: Record<string, unknown>, client: Client): Promise<void> {
+    const adapters = getVoiceAdapters(client);
+    if (!adapters) {return;}
+    const guildId = data.guild_id as string | undefined;
+    if (!guildId) {return;}
+    const adapter = adapters.get(guildId);
+    if (!adapter) {return;}
+    adapter.onVoiceServerUpdate({
+      guild_id: guildId,
+      token: data.token,
+      endpoint: data.endpoint ?? null,
+    } as GatewayVoiceServerUpdateDispatchData);
+  }
+}
+
+export class DiscordVoiceStateUpdateBridge extends VoiceStateUpdateListener {
+  async handle(data: Record<string, unknown>, client: Client): Promise<void> {
+    const adapters = getVoiceAdapters(client);
+    if (!adapters) {return;}
+    const guildId = data.guild_id as string | undefined;
+    if (!guildId) {return;}
+    const adapter = adapters.get(guildId);
+    if (!adapter) {return;}
+    // Reconstruct raw payload: strip Carbon-added fields, restore member from rawMember
+    const { guild: _guild, member: _member, rawMember, clientId: _clientId, ...raw } = data;
+    adapter.onVoiceStateUpdate({
+      ...raw,
+      member: rawMember,
+    } as unknown as GatewayVoiceStateUpdateDispatchData);
+  }
+}

--- a/extensions/discord/src/voice/adapter-bridge.ts
+++ b/extensions/discord/src/voice/adapter-bridge.ts
@@ -20,8 +20,8 @@ export class DiscordVoiceServerUpdateBridge extends VoiceServerUpdateListener {
     if (!adapter) {return;}
     adapter.onVoiceServerUpdate({
       guild_id: guildId,
-      token: data.token,
-      endpoint: data.endpoint ?? null,
+      token: typeof data.token === "string" ? data.token : "",
+      endpoint: typeof data.endpoint === "string" ? data.endpoint : null,
     } as GatewayVoiceServerUpdateDispatchData);
   }
 }

--- a/extensions/discord/src/voice/manager.runtime.ts
+++ b/extensions/discord/src/voice/manager.runtime.ts
@@ -2,7 +2,15 @@ import {
   DiscordVoiceManager as DiscordVoiceManagerImpl,
   DiscordVoiceReadyListener as DiscordVoiceReadyListenerImpl,
 } from "./manager.js";
+import {
+  DiscordVoiceServerUpdateBridge as DiscordVoiceServerUpdateBridgeImpl,
+  DiscordVoiceStateUpdateBridge as DiscordVoiceStateUpdateBridgeImpl,
+} from "./adapter-bridge.js";
 
 export class DiscordVoiceManager extends DiscordVoiceManagerImpl {}
 
 export class DiscordVoiceReadyListener extends DiscordVoiceReadyListenerImpl {}
+
+export class DiscordVoiceServerUpdateBridge extends DiscordVoiceServerUpdateBridgeImpl {}
+
+export class DiscordVoiceStateUpdateBridge extends DiscordVoiceStateUpdateBridgeImpl {}


### PR DESCRIPTION
## Summary

- **Problem:** `@buape/carbon@0.14.0`'s `VoicePlugin` stores voice adapter callbacks (`onVoiceStateUpdate`, `onVoiceServerUpdate`) but never invokes them — `@discordjs/voice` never receives the gateway events it needs to complete the voice connection handshake
- **Why it matters:** `/vc join` always times out after 15s with the connection stuck in `Signalling` state, making Discord voice completely unusable
- **What changed:** Two Carbon listener classes (`DiscordVoiceServerUpdateBridge`, `DiscordVoiceStateUpdateBridge`) that forward `VOICE_STATE_UPDATE` and `VOICE_SERVER_UPDATE` from the gateway to the voice adapter. Registered in `provider.ts` when voice is enabled.
- **What did NOT change:** No changes to the voice manager, connection handling, or any other Discord logic. Purely additive glue code.

Carbon has since fixed this on their main (`buape/carbon@ad8a329`), but it's unreleased (npm latest is `0.14.0`, last release Jan 21). This is a stopgap that can be removed once OpenClaw upgrades Carbon.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: `buape/carbon#375`
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `@buape/carbon`'s `VoicePlugin.getGatewayAdapterCreator()` stores adapter methods in `this.adapters`, but no listener forwards `VOICE_STATE_UPDATE` / `VOICE_SERVER_UPDATE` gateway events to `adapters.get(guildId).onVoiceStateUpdate()` / `.onVoiceServerUpdate()`. Without these callbacks, `@discordjs/voice` stays in `Signalling` forever.
- Missing detection / guardrail: No integration test covering the voice join flow end-to-end.
- Contributing context: Carbon added the listeners on their main branch on 2026-04-07 (`ad8a329`), but hasn't published a new npm release since Jan 2026.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/voice/manager.e2e.test.ts`
- Scenario the test should lock in: Voice connection transitions to `Ready` after `joinVoiceChannel` when both gateway events are dispatched
- Why this is the smallest reliable guardrail: The bug is in event routing between Carbon and @discordjs/voice; a unit test can't cover this without mocking the entire event pipeline
- If no new test is added, why not: Would require a significant mock setup for Carbon's event dispatch + @discordjs/voice state machine; verified manually on live Discord

## User-visible / Behavior Changes

`/vc join` works. Previously it always failed with:
> Failed to join voice channel: The operation was aborted

## Diagram (if applicable)

```text
Before:
Discord Gateway → Carbon EventHandler → (nowhere) ✗ @discordjs/voice stays in Signalling → timeout

After:
Discord Gateway → Carbon EventHandler → VoiceStateUpdateBridge/VoiceServerUpdateBridge → VoicePlugin.adapters → @discordjs/voice → Ready
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Hetzner VPS)
- Runtime/container: Node 24.14.1
- Model/provider: N/A (voice infra only)
- Integration/channel: Discord
- Relevant config: `channels.discord.voice.enabled: true`, `daveEncryption: true`

### Steps

1. Configure a Discord bot with voice enabled
2. Run `/vc join` in a voice channel
3. Observe the bot attempting to join but timing out after 15s

### Expected

- Bot joins voice channel and connection reaches `Ready` state

### Actual

- Connection stuck in `Signalling`, times out, Discord shows "Failed to join voice channel: The operation was aborted"

## Evidence

- [x] Trace/log snippets

State transitions before fix:
```
signalling → (timeout 15s) → destroyed
```

State transitions after fix:
```
signalling → connecting → ready
```

## Human Verification (required)

- Verified scenarios: `/vc join` successfully joins voice channel on live Discord server
- Edge cases checked: Multi-account setups where only one account has an active voice adapter — the bridge correctly no-ops for accounts without adapters
- What you did **not** verify: `/vc leave` cleanup, long-running session stability, adapter leak on repeated join/leave

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: When Carbon eventually ships the fix and OpenClaw upgrades, both OpenClaw's bridge listeners and Carbon's built-in listeners will handle the same events (double dispatch).
  - Mitigation: `@discordjs/voice` handles duplicate adapter calls gracefully (idempotent). The bridge can be removed in a follow-up once Carbon >= 0.15.0 is adopted.