### PR TITLE
fix(plugins): preserve explicit provider runtime ownership resolution

### DIFF
--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -937,6 +937,7 @@ describe("memory cli", () => {
         close,
       });
 
+      vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-08T10:00:00.000Z"));
       const writeJson = spyRuntimeJson(defaultRuntime);
       await runMemoryCli(["rem-harness", "--json"]);
 

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -51,6 +51,7 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("qa-lab", "src/gateway-child.ts", 489),
   bundledPluginCallsite("qa-lab", "src/suite.ts", 330),
   bundledPluginCallsite("qa-lab", "src/suite.ts", 341),
+  bundledPluginCallsite("qa-lab", "src/telegram-live.runtime.ts", 295),
   bundledPluginCallsite("qa-lab", "web/src/app.ts", 15),
   bundledPluginCallsite("qa-lab", "web/src/app.ts", 23),
   bundledPluginCallsite("qa-lab", "web/src/app.ts", 31),

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -184,7 +184,14 @@ async function inspectNodeModulesSymlinkTarget(params: {
     );
   }
 
-  const resolvedTargetStats = await fs.stat(resolvedTargetPath);
+  const resolvedTargetStats = await fs.stat(resolvedTargetPath).catch((error) => {
+    throw new Error(
+      `manifest dependency scan could not inspect symlink target ${params.symlinkRelativePath}: ${String(error)}`,
+      {
+        cause: error,
+      },
+    );
+  });
   const resolvedTargetRelativePath = path.relative(params.rootRealPath, resolvedTargetPath);
   const blockedDirectoryFinding = findBlockedPackageDirectoryInPath({
     pathRelativeToRoot: resolvedTargetRelativePath,

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1139,11 +1139,7 @@ describe("installPluginFromArchive", () => {
 
       const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
-        expect(result.error).toContain("symlink target outside install root");
-      }
+      expect(result.ok).toBe(true);
     },
   );
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1115,7 +1115,7 @@ describe("installPluginFromArchive", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "does not block package installs when node_modules symlink targets an allowed scoped package path",
+    "fails package installs when node_modules symlink targets a path outside the staged install root",
     async () => {
       const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
@@ -1139,7 +1139,11 @@ describe("installPluginFromArchive", () => {
 
       const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-      expect(result.ok).toBe(true);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+        expect(result.error).toContain("symlink target outside install root");
+      }
     },
   );
 

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -1,3 +1,4 @@
+import { normalizeProviderId } from "../agents/provider-id.js";
 import { withActivatedPluginIds } from "./activation-context.js";
 import { resolveBundledPluginCompatibleActivationInputs } from "./activation-context.js";
 import {
@@ -14,12 +15,125 @@ import {
   resolveOwningPluginIdsForModelRefs,
   withBundledProviderVitestCompat,
 } from "./providers.js";
-import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
+import { getActivePluginRegistry, getActivePluginRegistryWorkspaceDir } from "./runtime.js";
 import {
   buildPluginRuntimeLoadOptionsFromValues,
   createPluginRuntimeLoaderLogger,
 } from "./runtime/load-context.js";
+import { resolvePluginSetupRegistry } from "./setup-registry.js";
 import type { ProviderPlugin } from "./types.js";
+
+function matchesProviderRef(provider: ProviderPlugin, providerRef: string): boolean {
+  const normalized = normalizeProviderId(providerRef);
+  if (!normalized) {
+    return false;
+  }
+  if (normalizeProviderId(provider.id) === normalized) {
+    return true;
+  }
+  return [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
+    (alias) => normalizeProviderId(alias) === normalized,
+  );
+}
+
+function resolveOwningPluginIdsForProviderRefsFromEntries(params: {
+  providerRefs?: readonly string[];
+  entries: readonly { pluginId: string; provider: ProviderPlugin }[];
+}): Map<string, string[]> {
+  const ownership = new Map<string, string[]>();
+  if (!params.providerRefs?.length || params.entries.length === 0) {
+    return ownership;
+  }
+  for (const providerRef of params.providerRefs) {
+    const pluginIds = [
+      ...new Set(
+        params.entries
+          .filter((entry) => matchesProviderRef(entry.provider, providerRef))
+          .map((entry) => entry.pluginId),
+      ),
+    ].toSorted((left, right) => left.localeCompare(right));
+    if (pluginIds.length > 0) {
+      ownership.set(providerRef, pluginIds);
+    }
+  }
+  return ownership;
+}
+
+function resolvePreferredProviderOwnedPluginIds(params: {
+  providerRefs: readonly string[];
+  manifestOwnedProviderPluginIdsByRef: ReadonlyMap<string, readonly string[]>;
+  setupRegistryOwnedProviderPluginIdsByRef: ReadonlyMap<string, readonly string[]>;
+  activeRuntimeOwnedProviderPluginIdsByRef: ReadonlyMap<string, readonly string[]>;
+}): string[] {
+  if (params.providerRefs.length === 0) {
+    return [];
+  }
+  return [
+    ...new Set(
+      params.providerRefs.flatMap((providerRef) => {
+        const manifestPluginIds = params.manifestOwnedProviderPluginIdsByRef.get(providerRef) ?? [];
+        if (manifestPluginIds.length > 0) {
+          return manifestPluginIds;
+        }
+        const setupRegistryPluginIds =
+          params.setupRegistryOwnedProviderPluginIdsByRef.get(providerRef) ?? [];
+        if (setupRegistryPluginIds.length > 0) {
+          return setupRegistryPluginIds;
+        }
+        return params.activeRuntimeOwnedProviderPluginIdsByRef.get(providerRef) ?? [];
+      }),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
+}
+
+function resolveActiveRuntimeOwningPluginIdsForProviders(params: {
+  providerRefs?: readonly string[];
+  workspaceDir?: string;
+}): Map<string, string[]> {
+  if (!params.providerRefs?.length) {
+    return new Map();
+  }
+  const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();
+  if (params.workspaceDir && activeWorkspaceDir && params.workspaceDir !== activeWorkspaceDir) {
+    return new Map();
+  }
+  const activeRegistry = getActivePluginRegistry();
+  if (!activeRegistry) {
+    return new Map();
+  }
+  return resolveOwningPluginIdsForProviderRefsFromEntries({
+    providerRefs: params.providerRefs,
+    entries: activeRegistry.providers,
+  });
+}
+
+function resolveSetupRegistryOwningPluginIdsForProviders(params: {
+  providerRefs?: readonly string[];
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+}): Map<string, string[]> {
+  if (!params.providerRefs?.length) {
+    return new Map();
+  }
+  const candidatePluginIds = resolveDiscoveredProviderPluginIds({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  if (candidatePluginIds.length === 0) {
+    return new Map();
+  }
+  return resolveOwningPluginIdsForProviderRefsFromEntries({
+    providerRefs: params.providerRefs,
+    entries: resolvePluginSetupRegistry({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      pluginIds: candidatePluginIds,
+    }).providers,
+  });
+}
 
 function resolvePluginProviderLoadBase(params: {
   config?: PluginLoadOptions["config"];
@@ -31,21 +145,37 @@ function resolvePluginProviderLoadBase(params: {
 }) {
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
-  const providerOwnedPluginIds = params.providerRefs?.length
-    ? [
-        ...new Set(
-          params.providerRefs.flatMap(
-            (provider) =>
-              resolveOwningPluginIdsForProvider({
-                provider,
-                config: params.config,
-                workspaceDir,
-                env,
-              }) ?? [],
-          ),
-        ),
-      ]
-    : [];
+  const providerRefs = params.providerRefs ?? [];
+  const manifestOwnedProviderPluginIdsByRef = new Map(
+    providerRefs.map((providerRef) => [
+      providerRef,
+      resolveOwningPluginIdsForProvider({
+        provider: providerRef,
+        config: params.config,
+        workspaceDir,
+        env,
+      }) ?? [],
+    ]),
+  );
+  const activeRuntimeOwnedProviderPluginIdsByRef = resolveActiveRuntimeOwningPluginIdsForProviders({
+    providerRefs,
+    workspaceDir,
+  });
+  const setupFallbackProviderRefs = providerRefs.filter(
+    (providerRef) => (manifestOwnedProviderPluginIdsByRef.get(providerRef)?.length ?? 0) === 0,
+  );
+  const setupRegistryOwnedProviderPluginIdsByRef = resolveSetupRegistryOwningPluginIdsForProviders({
+    providerRefs: setupFallbackProviderRefs,
+    config: params.config,
+    workspaceDir,
+    env,
+  });
+  const providerOwnedPluginIds = resolvePreferredProviderOwnedPluginIds({
+    providerRefs,
+    manifestOwnedProviderPluginIdsByRef,
+    setupRegistryOwnedProviderPluginIdsByRef,
+    activeRuntimeOwnedProviderPluginIdsByRef,
+  });
   const modelOwnedPluginIds = params.modelRefs?.length
     ? resolveOwningPluginIdsForModelRefs({
         models: params.modelRefs,
@@ -146,6 +276,9 @@ function resolveRuntimeProviderPluginLoadState(
     env: base.env,
     onlyPluginIds: base.requestedPluginIds,
   });
+  if (providerPluginIds.length === 0) {
+    return undefined;
+  }
   const loadOptions = buildPluginRuntimeLoadOptionsFromValues(
     {
       config,
@@ -208,6 +341,9 @@ export function resolvePluginProviders(params: {
     }));
   }
   const loadState = resolveRuntimeProviderPluginLoadState(params, base);
+  if (!loadState) {
+    return [];
+  }
   const registry = resolveRuntimePluginRegistry(loadState.loadOptions);
   if (!registry) {
     return [];

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -12,18 +12,22 @@ type LoadPluginManifestRegistry =
   typeof import("./manifest-registry.js").loadPluginManifestRegistry;
 type ApplyPluginAutoEnable = typeof import("../config/plugin-auto-enable.js").applyPluginAutoEnable;
 type SetActivePluginRegistry = typeof import("./runtime.js").setActivePluginRegistry;
+type ResetPluginRuntimeStateForTest = typeof import("./runtime.js").resetPluginRuntimeStateForTest;
+type ResolvePluginSetupRegistry = typeof import("./setup-registry.js").resolvePluginSetupRegistry;
 
 const resolveRuntimePluginRegistryMock = vi.fn<ResolveRuntimePluginRegistry>();
 const loadOpenClawPluginsMock = vi.fn<LoadOpenClawPlugins>();
 const isPluginRegistryLoadInFlightMock = vi.fn<IsPluginRegistryLoadInFlight>((_) => false);
 const loadPluginManifestRegistryMock = vi.fn<LoadPluginManifestRegistry>();
 const applyPluginAutoEnableMock = vi.fn<ApplyPluginAutoEnable>();
+const resolvePluginSetupRegistryMock = vi.fn<ResolvePluginSetupRegistry>();
 
 let resolveOwningPluginIdsForProvider: typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 let resolveOwningPluginIdsForModelRef: typeof import("./providers.js").resolveOwningPluginIdsForModelRef;
 let resolveEnabledProviderPluginIds: typeof import("./providers.js").resolveEnabledProviderPluginIds;
 let resolvePluginProviders: typeof import("./providers.runtime.js").resolvePluginProviders;
 let setActivePluginRegistry: SetActivePluginRegistry;
+let resetPluginRuntimeStateForTest: ResetPluginRuntimeStateForTest;
 
 function createManifestProviderPlugin(params: {
   id: string;
@@ -56,6 +60,20 @@ function setManifestPlugins(plugins: PluginManifestRecord[]) {
   });
 }
 
+function setSetupProviders(
+  providers: Array<{
+    pluginId: string;
+    provider: ProviderPlugin;
+  }>,
+) {
+  resolvePluginSetupRegistryMock.mockReturnValue({
+    providers,
+    cliBackends: [],
+    configMigrations: [],
+    autoEnableProbes: [],
+  });
+}
+
 function setOwningProviderManifestPlugins() {
   setManifestPlugins([
     createManifestProviderPlugin({
@@ -78,6 +96,38 @@ function setOwningProviderManifestPlugins() {
         modelPrefixes: ["claude-"],
       },
     }),
+  ]);
+}
+
+function setHookAliasSetupProviders() {
+  setSetupProviders([
+    {
+      pluginId: "openai",
+      provider: {
+        id: "openai",
+        label: "OpenAI",
+        hookAliases: ["azure-openai", "azure-openai-responses"],
+        auth: [],
+      },
+    },
+    {
+      pluginId: "google",
+      provider: {
+        id: "google",
+        label: "Google",
+        hookAliases: ["google-antigravity", "google-vertex"],
+        auth: [],
+      },
+    },
+    {
+      pluginId: "minimax",
+      provider: {
+        id: "minimax",
+        label: "MiniMax",
+        hookAliases: ["minimax-cn", "minimax-portal-cn"],
+        auth: [],
+      },
+    },
   ]);
 }
 
@@ -279,13 +329,17 @@ describe("resolvePluginProviders", () => {
       loadPluginManifestRegistry: (...args: Parameters<LoadPluginManifestRegistry>) =>
         loadPluginManifestRegistryMock(...args),
     }));
+    vi.doMock("./setup-registry.js", () => ({
+      resolvePluginSetupRegistry: (...args: Parameters<ResolvePluginSetupRegistry>) =>
+        resolvePluginSetupRegistryMock(...args),
+    }));
     ({
       resolveOwningPluginIdsForProvider,
       resolveOwningPluginIdsForModelRef,
       resolveEnabledProviderPluginIds,
     } = await import("./providers.js"));
     ({ resolvePluginProviders } = await import("./providers.runtime.js"));
-    ({ setActivePluginRegistry } = await import("./runtime.js"));
+    ({ setActivePluginRegistry, resetPluginRuntimeStateForTest } = await import("./runtime.js"));
   });
 
   it("maps cli backend ids to owning plugin ids via manifests", () => {
@@ -312,6 +366,8 @@ describe("resolvePluginProviders", () => {
     loadOpenClawPluginsMock.mockReturnValue(registry);
     loadPluginManifestRegistryMock.mockReset();
     applyPluginAutoEnableMock.mockReset();
+    resolvePluginSetupRegistryMock.mockReset();
+    setSetupProviders([]);
     applyPluginAutoEnableMock.mockImplementation(
       (params): PluginAutoEnableResult => ({
         config: params.config ?? ({} as OpenClawConfig),
@@ -509,6 +565,18 @@ describe("resolvePluginProviders", () => {
     expectLastRuntimeRegistryLoad({
       onlyPluginIds: ["google", "kilocode", "moonshot"],
     });
+  });
+
+  it("does not load unrelated plugins when explicit provider refs resolve to no owning plugin", () => {
+    const providers = resolvePluginProviders({
+      config: {},
+      providerRefs: ["openai-compatible"],
+      activate: false,
+      cache: false,
+    });
+
+    expectResolvedProviders(providers, []);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
 
   it("loads all discovered provider plugins in setup mode", () => {
@@ -709,6 +777,265 @@ describe("resolvePluginProviders", () => {
       }),
     );
   });
+
+  it("activates owning plugins for bundled hook alias provider refs", () => {
+    setOwningProviderManifestPlugins();
+    setHookAliasSetupProviders();
+
+    resolvePluginProviders({
+      config: {},
+      providerRefs: ["azure-openai-responses"],
+      activate: true,
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["openai"],
+        activate: true,
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["openai"],
+            entries: {
+              openai: { enabled: true },
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps setup-registry alias ownership reachable when active-runtime ownership is stale", () => {
+    setOwningProviderManifestPluginsWithWorkspace();
+    setSetupProviders([
+      {
+        pluginId: "workspace-provider",
+        provider: {
+          id: "workspace-provider",
+          label: "Workspace Provider",
+          hookAliases: ["workspace-hook-alias"],
+          auth: [],
+        },
+      },
+    ]);
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.providers.push({
+      pluginId: "stale-provider",
+      provider: {
+        id: "stale-provider",
+        label: "Stale Provider",
+        hookAliases: ["workspace-hook-alias"],
+        auth: [],
+      },
+      source: "workspace",
+    });
+    setActivePluginRegistry(activeRegistry, undefined, "default", "/workspace/runtime");
+
+    resolvePluginProviders({
+      config: {},
+      workspaceDir: "/workspace/runtime",
+      providerRefs: ["workspace-hook-alias"],
+      activate: true,
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["workspace-provider"],
+        activate: true,
+        workspaceDir: "/workspace/runtime",
+      }),
+    );
+  });
+
+  it("prefers setup-registry alias ownership over stale active-runtime owners still present in manifests", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "workspace-provider",
+        providerIds: ["workspace-provider"],
+        origin: "workspace",
+      }),
+      createManifestProviderPlugin({
+        id: "stale-provider",
+        providerIds: ["stale-provider"],
+        origin: "workspace",
+      }),
+    ]);
+    setSetupProviders([
+      {
+        pluginId: "workspace-provider",
+        provider: {
+          id: "workspace-provider",
+          label: "Workspace Provider",
+          hookAliases: ["workspace-hook-alias"],
+          auth: [],
+        },
+      },
+    ]);
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.providers.push({
+      pluginId: "stale-provider",
+      provider: {
+        id: "stale-provider",
+        label: "Stale Provider",
+        hookAliases: ["workspace-hook-alias"],
+        auth: [],
+      },
+      source: "workspace",
+    });
+    setActivePluginRegistry(activeRegistry, undefined, "default", "/workspace/runtime");
+
+    resolvePluginProviders({
+      config: {},
+      workspaceDir: "/workspace/runtime",
+      providerRefs: ["workspace-hook-alias"],
+      activate: true,
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["workspace-provider"],
+        activate: true,
+        workspaceDir: "/workspace/runtime",
+      }),
+    );
+    expect(getLastResolvedPluginConfig()).toEqual(
+      expect.objectContaining({
+        plugins: expect.objectContaining({
+          allow: ["workspace-provider"],
+          entries: {
+            "workspace-provider": { enabled: true },
+          },
+        }),
+      }),
+    );
+  });
+
+  it("passes plugin load paths into setup-registry alias ownership fallback", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "loadpath-provider",
+        providerIds: ["loadpath-provider"],
+        origin: "workspace",
+      }),
+    ]);
+    resolvePluginSetupRegistryMock.mockImplementation((params) => {
+      const loadPaths = params?.config?.plugins?.load?.paths;
+      const providers =
+        Array.isArray(loadPaths) && loadPaths.includes("/external/providers")
+          ? [
+              {
+                pluginId: "loadpath-provider",
+                provider: {
+                  id: "loadpath-provider",
+                  label: "LoadPath Provider",
+                  hookAliases: ["loadpath-hook-alias"],
+                  auth: [],
+                },
+              },
+            ]
+          : [];
+      return {
+        providers,
+        cliBackends: [],
+        configMigrations: [],
+        autoEnableProbes: [],
+      };
+    });
+
+    resolvePluginProviders({
+      config: {
+        plugins: {
+          load: {
+            paths: ["/external/providers"],
+          },
+        },
+      },
+      workspaceDir: "/workspace/runtime",
+      providerRefs: ["loadpath-hook-alias"],
+      activate: true,
+    });
+
+    expect(resolvePluginSetupRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            load: {
+              paths: ["/external/providers"],
+            },
+          }),
+        }),
+        workspaceDir: "/workspace/runtime",
+        pluginIds: ["loadpath-provider"],
+      }),
+    );
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["loadpath-provider"],
+        activate: true,
+        workspaceDir: "/workspace/runtime",
+      }),
+    );
+  });
+
+  it("activates owning plugins for active-runtime hook alias provider refs", () => {
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.providers.push({
+      pluginId: "workspace-provider",
+      provider: {
+        id: "workspace-provider",
+        label: "Workspace Provider",
+        hookAliases: ["workspace-hook-alias"],
+        auth: [],
+      },
+      source: "workspace",
+    });
+    setActivePluginRegistry(activeRegistry, undefined, "default", "/workspace/runtime");
+
+    resolvePluginProviders({
+      config: {},
+      workspaceDir: "/workspace/runtime",
+      providerRefs: ["workspace-hook-alias"],
+      activate: true,
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["workspace-provider"],
+        activate: true,
+        workspaceDir: "/workspace/runtime",
+      }),
+    );
+  });
+
+  it("activates owning plugins for cold-start setup-registry hook alias provider refs", () => {
+    resetPluginRuntimeStateForTest();
+    setSetupProviders([
+      {
+        pluginId: "workspace-provider",
+        provider: {
+          id: "workspace-provider",
+          label: "Workspace Provider",
+          hookAliases: ["workspace-cold-start-alias"],
+          auth: [],
+        },
+      },
+    ]);
+
+    resolvePluginProviders({
+      config: {},
+      workspaceDir: "/workspace/runtime",
+      providerRefs: ["workspace-cold-start-alias"],
+      activate: true,
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["workspace-provider"],
+        activate: true,
+        workspaceDir: "/workspace/runtime",
+      }),
+    );
+  });
+
   it.each([
     {
       provider: "minimax-portal",

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -238,7 +238,7 @@ export function resolveOwningPluginIdsForProvider(params: {
     )
     .map((plugin) => plugin.id);
 
-  return pluginIds.length > 0 ? pluginIds : undefined;
+  return pluginIds.length > 0 ? dedupeSortedPluginIds(pluginIds) : undefined;
 }
 
 export function resolveOwningPluginIdsForModelRef(params: {

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -58,6 +58,112 @@ describe("setup-registry getJiti", () => {
     );
   });
 
+  it("forwards config load paths into setup discovery", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
+    mocks.discoverOpenClawPlugins.mockReturnValue({
+      candidates: [],
+      diagnostics: [],
+    });
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "loadpath-provider", rootDir: pluginRoot }],
+      diagnostics: [],
+    });
+
+    resolvePluginSetupRegistry({
+      config: {
+        plugins: {
+          load: {
+            paths: ["/external/providers"],
+          },
+        },
+      } as never,
+      env: {},
+    });
+
+    expect(mocks.discoverOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraPaths: ["/external/providers"],
+        env: {},
+        cache: true,
+      }),
+    );
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            load: {
+              paths: ["/external/providers"],
+            },
+          }),
+        }),
+        env: {},
+        cache: true,
+      }),
+    );
+  });
+
+  it("keys setup-registry cache by install overrides used during manifest resolution", () => {
+    const firstPluginRoot = makeTempDir();
+    const secondPluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(firstPluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
+    fs.writeFileSync(path.join(secondPluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
+    mocks.loadPluginManifestRegistry.mockImplementation((params?: { config?: { plugins?: { installs?: Record<string, { installPath?: string }> } } }) => {
+      const installPath = params?.config?.plugins?.installs?.provider?.installPath;
+      return {
+        plugins: [{ id: "provider", rootDir: installPath === "/installs/second" ? secondPluginRoot : firstPluginRoot }],
+        diagnostics: [],
+      };
+    });
+
+    resolvePluginSetupRegistry({
+      config: {
+        plugins: {
+          installs: {
+            provider: {
+              installPath: "/installs/first",
+            },
+          },
+        },
+      } as never,
+      env: {},
+    });
+
+    resolvePluginSetupRegistry({
+      config: {
+        plugins: {
+          installs: {
+            provider: {
+              installPath: "/installs/second",
+            },
+          },
+        },
+      } as never,
+      env: {},
+    });
+
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
+    expect(mocks.loadPluginManifestRegistry.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: {
+            installs: {
+              provider: {
+                installPath: "/installs/second",
+              },
+            },
+          },
+        }),
+      }),
+    );
+    expect(mocks.createJiti).toHaveBeenNthCalledWith(
+      1,
+      path.join(firstPluginRoot, "setup-api.js"),
+      expect.any(Object),
+    );
+    expect(mocks.createJiti).toHaveBeenCalledTimes(1);
+  });
+
   it("skips setup-api loading when config has no relevant migration triggers", () => {
     const pluginRoot = makeTempDir();
     fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -68,6 +68,44 @@ const jitiLoaders: PluginJitiLoaderCache = new Map();
 const setupRegistryCache = new Map<string, PluginSetupRegistry>();
 const setupProviderCache = new Map<string, ProviderPlugin | null>();
 
+function resolveConfiguredPluginLoadPaths(config?: OpenClawConfig): string[] | undefined {
+  const loadPaths = config?.plugins?.load?.paths;
+  return Array.isArray(loadPaths)
+    ? loadPaths.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+}
+
+function resolveConfiguredPluginInstallCacheEntries(
+  config?: OpenClawConfig,
+): Array<
+  readonly [
+    string,
+    {
+      installPath?: string;
+      sourcePath?: string;
+    },
+  ]
+> | null {
+  const installs = config?.plugins?.installs;
+  if (!installs || typeof installs !== "object") {
+    return null;
+  }
+  const entries = Object.entries(installs)
+    .flatMap(([pluginId, record]) => {
+      if (!record || typeof record !== "object") {
+        return [];
+      }
+      const installPath = typeof record.installPath === "string" ? record.installPath : undefined;
+      const sourcePath = typeof record.sourcePath === "string" ? record.sourcePath : undefined;
+      if (!installPath && !sourcePath) {
+        return [];
+      }
+      return [[pluginId, { installPath, sourcePath }] as const];
+    })
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  return entries.length > 0 ? entries : null;
+}
+
 export function clearPluginSetupRegistryCache(): void {
   jitiLoaders.clear();
   setupRegistryCache.clear();
@@ -83,17 +121,20 @@ function getJiti(modulePath: string) {
 }
 
 function buildSetupRegistryCacheKey(params: {
+  config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];
 }): string {
   const { roots, loadPaths } = resolvePluginCacheInputs({
+    loadPaths: resolveConfiguredPluginLoadPaths(params.config),
     workspaceDir: params.workspaceDir,
     env: params.env,
   });
   return JSON.stringify({
     roots,
     loadPaths,
+    installOverrides: resolveConfiguredPluginInstallCacheEntries(params.config),
     pluginIds: params.pluginIds ? [...new Set(params.pluginIds)].toSorted() : null,
   });
 }
@@ -217,12 +258,15 @@ function matchesProvider(provider: ProviderPlugin, providerId: string): boolean 
 }
 
 export function resolvePluginSetupRegistry(params?: {
+  config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];
 }): PluginSetupRegistry {
   const env = params?.env ?? process.env;
+  const configLoadPaths = resolveConfiguredPluginLoadPaths(params?.config);
   const cacheKey = buildSetupRegistryCacheKey({
+    config: params?.config,
     workspaceDir: params?.workspaceDir,
     env,
     pluginIds: params?.pluginIds,
@@ -254,11 +298,13 @@ export function resolvePluginSetupRegistry(params?: {
   const cliBackendKeys = new Set<string>();
 
   const discovery = discoverOpenClawPlugins({
+    extraPaths: configLoadPaths,
     workspaceDir: params?.workspaceDir,
     env,
     cache: true,
   });
   const manifestRegistry = loadPluginManifestRegistry({
+    config: params?.config,
     workspaceDir: params?.workspaceDir,
     env,
     cache: true,
@@ -571,6 +617,7 @@ export function runPluginSetupConfigMigrations(params: {
   }
 
   for (const entry of resolvePluginSetupRegistry({
+    config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
     pluginIds,
@@ -596,6 +643,7 @@ export function resolvePluginSetupAutoEnableReasons(params: {
   const seen = new Set<string>();
 
   for (const entry of resolvePluginSetupRegistry({
+    config: params.config,
     workspaceDir: params.workspaceDir,
     env,
   }).autoEnableProbes) {


### PR DESCRIPTION
## Summary
- keep the provider runtime path short-circuited when explicit refs resolve to no owner so unrelated plugins do not broad-load under cropped config
- preserve valid hook-only provider refs by resolving owner plugins through bundled alias mappings, active runtime aliases, and cold-start setup-registry provider metadata
- keep explicit provider/model refs activating the owning plugin runtime instead of falling back to unrestricted loads
- add regression coverage for the `memory-lancedb-pro` false-positive path plus bundled, active-runtime, and cold-start hook-alias ownership

## Problem
When OpenClaw resolves explicit provider refs under a narrowed runtime config, `requestedPluginIds` can collapse to an empty array. The provider runtime load path then continues anyway, and that empty restriction behaves like "no restriction", so unrelated plugins get loaded and validated under cropped config.

For `memory-lancedb-pro`, that can surface a false invalid-config error like:
`embedding: must have required property 'embedding'`

The first fix for that false-positive uncovered a follow-on constraint: some valid provider refs are hook-only aliases that are not directly owned by manifest `providers` / `cliBackends`. Those refs still need to resolve back to the correct plugin runtime without reintroducing the unrestricted load path.

## Repro / validation
- observed locally after upgrading to `openclaw 2026.4.8`
- local hotfix removes the false warning from `openclaw health`
- plugin still registers successfully after restart
- lightweight syntax lint on the touched TS files passes locally
- full CI will validate the updated regression matrix on the PR

Fixes #61964
Related to #62855
