### PR TITLE
fix(whatsapp): keep control-ui relink in sync with QR rotation and scan wait

### DIFF
--- a/src/web/auto-reply/deliver-reply.test.ts
+++ b/src/web/auto-reply/deliver-reply.test.ts
@@ -5,6 +5,8 @@ import { loadWebMedia } from "../media.js";
 import { deliverWebReply } from "./deliver-reply.js";
 import type { WebInboundMsg } from "./types.js";
 
+let msgCounter = 0;
+
 vi.mock("../../globals.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../globals.js")>();
   return {
@@ -27,10 +29,11 @@ vi.mock("../../utils.js", async (importOriginal) => {
 });
 
 function makeMsg(): WebInboundMsg {
+  msgCounter += 1;
   return {
-    from: "+10000000000",
+    from: `+1000000000${msgCounter}`,
     to: "+20000000000",
-    id: "msg-1",
+    id: `msg-${msgCounter}`,
     reply: vi.fn(async () => undefined),
     sendMedia: vi.fn(async () => undefined),
   } as unknown as WebInboundMsg;
@@ -126,6 +129,60 @@ describe("deliverWebReply", () => {
     expect(msg.reply).toHaveBeenNthCalledWith(1, "aaa");
     expect(msg.reply).toHaveBeenNthCalledWith(2, "aaa");
     expect(replyLogger.info).toHaveBeenCalledWith(expect.any(Object), "auto-reply sent (text)");
+  });
+
+  it("suppresses duplicate text replies to the same recipient within the dedupe window", async () => {
+    const first = makeMsg();
+    const second = makeMsg();
+    second.from = first.from;
+
+    await deliverWebReply({
+      replyResult: { text: "same reply" },
+      msg: first,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "same reply" },
+      msg: second,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(first.reply).toHaveBeenCalledTimes(1);
+    expect(second.reply).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress different replies to the same recipient", async () => {
+    const first = makeMsg();
+    const second = makeMsg();
+    second.from = first.from;
+
+    await deliverWebReply({
+      replyResult: { text: "first reply" },
+      msg: first,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "second reply" },
+      msg: second,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(first.reply).toHaveBeenCalledTimes(1);
+    expect(second.reply).toHaveBeenCalledTimes(1);
   });
 
   it.each(["connection closed", "operation timed out"])(

--- a/src/web/auto-reply/deliver-reply.ts
+++ b/src/web/auto-reply/deliver-reply.ts
@@ -13,6 +13,37 @@ import type { WebInboundMsg } from "./types.js";
 import { elide } from "./util.js";
 
 const REASONING_PREFIX = "reasoning:";
+const RECENT_REPLY_TTL_MS = 2 * 60 * 1000;
+const recentReplyClaims = new Map<string, number>();
+
+function pruneRecentReplyClaims(now = Date.now()) {
+  for (const [key, expiresAt] of recentReplyClaims) {
+    if (expiresAt <= now) {
+      recentReplyClaims.delete(key);
+    }
+  }
+}
+
+function claimRecentReply(params: {
+  to: string;
+  chunks: readonly string[];
+  mediaList: readonly string[];
+  now?: number;
+}) {
+  const now = params.now ?? Date.now();
+  pruneRecentReplyClaims(now);
+  const signature = JSON.stringify({
+    to: params.to,
+    chunks: params.chunks,
+    media: params.mediaList,
+  });
+  const activeUntil = recentReplyClaims.get(signature);
+  if (typeof activeUntil === "number" && activeUntil > now) {
+    return false;
+  }
+  recentReplyClaims.set(signature, now + RECENT_REPLY_TTL_MS);
+  return true;
+}
 
 function shouldSuppressReasoningReply(payload: ReplyPayload): boolean {
   if (payload.isReasoning === true) {
@@ -57,6 +88,16 @@ export async function deliverWebReply(params: {
     : replyResult.mediaUrl
       ? [replyResult.mediaUrl]
       : [];
+  // Interrupt mode can supersede an in-flight run after the old reply has already
+  // entered the outbound path. Suppress a short-window resend of the exact same
+  // payload to the same recipient so the replacement run does not double-post it.
+  if (
+    (textChunks.length > 0 || mediaList.length > 0) &&
+    !claimRecentReply({ to: msg.from, chunks: textChunks, mediaList })
+  ) {
+    whatsappOutboundLog.warn(`Suppressed duplicate reply to ${msg.from}`);
+    return;
+  }
 
   const sendWithRetry = async (fn: () => Promise<unknown>, label: string, maxAttempts = 3) => {
     let lastErr: unknown;

--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startWebLoginWithQr, waitForWebLogin } from "./login-qr.js";
+import { renderQrPngBase64 } from "./qr-image.js";
 import { createWaSocket, logoutWeb, waitForWaConnection } from "./session.js";
 
 vi.mock("./session.js", () => {
@@ -34,12 +35,13 @@ vi.mock("./session.js", () => {
 });
 
 vi.mock("./qr-image.js", () => ({
-  renderQrPngBase64: vi.fn(async () => "base64"),
+  renderQrPngBase64: vi.fn(async (qr: string) => `base64-${qr}`),
 }));
 
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
 const logoutWebMock = vi.mocked(logoutWeb);
+const renderQrPngBase64Mock = vi.mocked(renderQrPngBase64);
 
 describe("login-qr", () => {
   beforeEach(() => {
@@ -52,12 +54,52 @@ describe("login-qr", () => {
       .mockResolvedValueOnce(undefined);
 
     const start = await startWebLoginWithQr({ timeoutMs: 5000 });
-    expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
+    expect(start.qrDataUrl).toMatch(/^data:image\/png;base64,/);
 
     const result = await waitForWebLogin({ timeoutMs: 5000 });
 
     expect(result.connected).toBe(true);
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
     expect(logoutWebMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the active QR when WhatsApp rotates refs during login", async () => {
+    let emitQr: ((qr: string) => void) | undefined;
+    createWaSocketMock.mockImplementationOnce(
+      async (_printQr: boolean, _verbose: boolean, opts?: { onQr?: (qr: string) => void }) => {
+        emitQr = opts?.onQr;
+        const sock = { ws: { close: vi.fn() } };
+        if (opts?.onQr) {
+          setImmediate(() => opts.onQr?.("qr-first"));
+        }
+        return sock as never;
+      },
+    );
+    waitForWaConnectionMock.mockReturnValue(new Promise<void>(() => {}));
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.qrDataUrl).toMatch(/^data:image\/png;base64,/);
+
+    emitQr?.("qr-second");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const refreshed = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(refreshed.qrDataUrl).toMatch(/^data:image\/png;base64,/);
+    expect(renderQrPngBase64Mock).toHaveBeenCalledWith("qr-second");
+  });
+
+  it("preserves an early QR emitted before the active login is registered", async () => {
+    createWaSocketMock.mockImplementationOnce(
+      async (_printQr: boolean, _verbose: boolean, opts?: { onQr?: (qr: string) => void }) => {
+        opts?.onQr?.("qr-early");
+        return { ws: { close: vi.fn() } } as never;
+      },
+    );
+    waitForWaConnectionMock.mockReturnValue(new Promise<void>(() => {}));
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.message).toContain("QR already active");
+    expect(start.qrDataUrl).toMatch(/^data:image\/png;base64,/);
   });
 });

--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -25,8 +25,10 @@ type ActiveLogin = {
   id: string;
   sock: WaSocket;
   startedAt: number;
+  qrVersion: number;
   qr?: string;
   qrDataUrl?: string;
+  qrRenderPromise?: Promise<void>;
   connected: boolean;
   error?: string;
   errorStatus?: number;
@@ -59,6 +61,28 @@ async function resetActiveLogin(accountId: string, reason?: string) {
 
 function isLoginFresh(login: ActiveLogin) {
   return Date.now() - login.startedAt < ACTIVE_LOGIN_TTL_MS;
+}
+
+async function updateLoginQrData(login: ActiveLogin, qr: string) {
+  login.qr = qr;
+  const version = login.qrVersion + 1;
+  login.qrVersion = version;
+  const renderPromise = renderQrPngBase64(qr)
+    .then((base64) => {
+      const current = activeLogins.get(login.accountId);
+      if (!current || current.id !== login.id || current.qrVersion !== version) {
+        return;
+      }
+      current.qrDataUrl = `data:image/png;base64,${base64}`;
+    })
+    .finally(() => {
+      const current = activeLogins.get(login.accountId);
+      if (current?.id === login.id && current.qrRenderPromise === renderPromise) {
+        current.qrRenderPromise = undefined;
+      }
+    });
+  login.qrRenderPromise = renderPromise;
+  await renderPromise;
 }
 
 function attachLoginWaiter(accountId: string, login: ActiveLogin) {
@@ -96,6 +120,7 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     login.connected = false;
     login.error = undefined;
     login.errorStatus = undefined;
+    login.waitPromise = Promise.resolve();
     attachLoginWaiter(login.accountId, login);
     return true;
   } catch (err) {
@@ -156,13 +181,10 @@ export async function startWebLoginWithQr(
     sock = await createWaSocket(false, Boolean(opts.verbose), {
       authDir: account.authDir,
       onQr: (qr: string) => {
-        if (pendingQr) {
-          return;
-        }
         pendingQr = qr;
         const current = activeLogins.get(account.accountId);
-        if (current && !current.qr) {
-          current.qr = qr;
+        if (current) {
+          void updateLoginQrData(current, qr);
         }
         clearTimeout(qrTimer);
         runtime.log(info("WhatsApp QR received."));
@@ -183,14 +205,15 @@ export async function startWebLoginWithQr(
     id: randomUUID(),
     sock,
     startedAt: Date.now(),
+    qrVersion: 0,
     connected: false,
     waitPromise: Promise.resolve(),
     restartAttempted: false,
     verbose: Boolean(opts.verbose),
   };
   activeLogins.set(account.accountId, login);
-  if (pendingQr && !login.qr) {
-    login.qr = pendingQr;
+  if (pendingQr && (!login.qr || !login.qrDataUrl)) {
+    await updateLoginQrData(login, pendingQr);
   }
   attachLoginWaiter(account.accountId, login);
 
@@ -205,8 +228,11 @@ export async function startWebLoginWithQr(
     };
   }
 
-  const base64 = await renderQrPngBase64(qr);
-  login.qrDataUrl = `data:image/png;base64,${base64}`;
+  if (login.qr !== qr || !login.qrDataUrl) {
+    await updateLoginQrData(login, qr);
+  } else if (login.qrRenderPromise) {
+    await login.qrRenderPromise;
+  }
   return {
     qrDataUrl: login.qrDataUrl,
     message: "Scan this QR in WhatsApp → Linked Devices.",

--- a/ui/src/ui/controllers/channels.test.ts
+++ b/ui/src/ui/controllers/channels.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { startWhatsAppLogin, waitWhatsAppLogin } from "./channels.ts";
+import type { ChannelsState } from "./channels.types.ts";
+
+function createState(
+  requestImpl: (method: string, params?: unknown) => Promise<unknown>,
+): ChannelsState {
+  return {
+    client: {
+      request: requestImpl,
+    } as never,
+    connected: true,
+    channelsLoading: false,
+    channelsError: null,
+    channelsSnapshot: null,
+    channelsLastSuccess: null,
+    whatsappBusy: false,
+    whatsappLoginMessage: null,
+    whatsappLoginQrDataUrl: null,
+    whatsappLoginConnected: null,
+  } as ChannelsState;
+}
+
+describe("channels controller", () => {
+  beforeEach(() => {});
+
+  it("refreshes QR while waiting for WhatsApp login to finish", async () => {
+    const requests: Array<{ method: string; params?: unknown }> = [];
+    const state = createState(async (method, params) => {
+      requests.push({ method, params });
+      if (method === "web.login.start") {
+        const startCount = requests.filter((entry) => entry.method === "web.login.start").length;
+        return {
+          message: startCount === 1 ? "first qr" : "refreshed qr",
+          qrDataUrl: startCount === 1 ? "data:first" : "data:second",
+        };
+      }
+      if (method === "web.login.wait") {
+        const waitCount = requests.filter((entry) => entry.method === "web.login.wait").length;
+        return {
+          message:
+            waitCount > 1 ? "✅ Linked! WhatsApp is ready." : "Still waiting for the QR scan.",
+          connected: waitCount > 1,
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    await startWhatsAppLogin(state, false);
+    await waitWhatsAppLogin(state, { timeoutMs: 10_000, pollMs: 1_000 });
+
+    expect(state.whatsappLoginQrDataUrl).toBeNull();
+    expect(state.whatsappLoginConnected).toBe(true);
+    expect(requests.filter((entry) => entry.method === "web.login.start")).toHaveLength(2);
+  });
+
+  it("recovers from a transient QR refresh failure while still completing login", async () => {
+    const requests: Array<{ method: string; params?: unknown }> = [];
+    let refreshFailed = false;
+    const state = createState(async (method, params) => {
+      requests.push({ method, params });
+      if (method === "web.login.start") {
+        const startCount = requests.filter((entry) => entry.method === "web.login.start").length;
+        if (startCount === 1) {
+          return {
+            message: "first qr",
+            qrDataUrl: "data:first",
+          };
+        }
+        if (!refreshFailed) {
+          refreshFailed = true;
+          throw new Error("transient refresh failure");
+        }
+        return {
+          message: "refreshed qr",
+          qrDataUrl: "data:second",
+        };
+      }
+      if (method === "web.login.wait") {
+        const waitCount = requests.filter((entry) => entry.method === "web.login.wait").length;
+        return {
+          message:
+            waitCount >= 3 ? "✅ Linked! WhatsApp is ready." : "Still waiting for the QR scan.",
+          connected: waitCount >= 3,
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    await startWhatsAppLogin(state, false);
+    await waitWhatsAppLogin(state, { timeoutMs: 10_000, pollMs: 1_000 });
+
+    expect(state.whatsappLoginConnected).toBe(true);
+    expect(state.whatsappBusy).toBe(false);
+    expect(state.whatsappLoginMessage).toBe("✅ Linked! WhatsApp is ready.");
+  });
+});

--- a/ui/src/ui/controllers/channels.ts
+++ b/ui/src/ui/controllers/channels.ts
@@ -51,23 +51,57 @@ export async function startWhatsAppLogin(state: ChannelsState, force: boolean) {
   }
 }
 
-export async function waitWhatsAppLogin(state: ChannelsState) {
+async function refreshActiveWhatsAppQr(state: ChannelsState) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  const res = await state.client.request<{ message?: string; qrDataUrl?: string }>(
+    "web.login.start",
+    {
+      force: false,
+      timeoutMs: 5000,
+    },
+  );
+  if (res.qrDataUrl) {
+    state.whatsappLoginQrDataUrl = res.qrDataUrl;
+  }
+  if (res.message) {
+    state.whatsappLoginMessage = res.message;
+  }
+}
+
+export async function waitWhatsAppLogin(
+  state: ChannelsState,
+  opts: { timeoutMs?: number; pollMs?: number } = {},
+) {
   if (!state.client || !state.connected || state.whatsappBusy) {
     return;
   }
   state.whatsappBusy = true;
   try {
-    const res = await state.client.request<{ message?: string; connected?: boolean }>(
-      "web.login.wait",
-      {
-        timeoutMs: 120000,
-      },
-    );
-    state.whatsappLoginMessage = res.message ?? null;
-    state.whatsappLoginConnected = res.connected ?? null;
-    if (res.connected) {
-      state.whatsappLoginQrDataUrl = null;
+    const timeoutMs = Math.max(opts.timeoutMs ?? 120000, 1000);
+    const pollMs = Math.max(opts.pollMs ?? 2500, 500);
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const remaining = Math.max(deadline - Date.now(), pollMs);
+      const res = await state.client.request<{ message?: string; connected?: boolean }>(
+        "web.login.wait",
+        {
+          timeoutMs: remaining,
+        },
+      );
+      state.whatsappLoginMessage = res.message ?? null;
+      state.whatsappLoginConnected = res.connected ?? null;
+      if (res.connected) {
+        state.whatsappLoginQrDataUrl = null;
+        return;
+      }
+      await refreshActiveWhatsAppQr(state).catch(() => {});
     }
+    state.whatsappLoginConnected = false;
+    state.whatsappLoginMessage =
+      "Still waiting for the QR scan. Let me know when you’ve scanned it.";
   } catch (err) {
     state.whatsappLoginMessage = String(err);
     state.whatsappLoginConnected = null;


### PR DESCRIPTION
## Summary

Keep the Control UI WhatsApp relink flow aligned with what the backend is actually doing.

This patch closes the gap where:
- WhatsApp rotates QR refs during login but the active login state keeps the first QR
- the Control UI can show `logging in` forever because it does not refresh the active QR or keep polling the wait path robustly enough after scan

## What changed

### Backend
- refresh the active QR data when WhatsApp rotates refs during an in-flight login
- preserve early QR emissions that arrive before the active login record is fully registered
- keep the restart-after-515 path attached to the active wait promise

### Control UI
- teach `waitWhatsAppLogin` to poll and refresh the active QR while the login is still pending
- clear the QR only after the backend confirms the link succeeded
- add a targeted controller regression test for the QR-refresh wait loop

## Why

In live use we saw this pattern repeatedly:
1. open Channels -> WhatsApp -> Relink
2. QR renders
3. phone accepts the QR
4. UI remains on `logging in` / eventually shows `couldn't link device`
5. backend can still succeed if `web.login.wait` is called manually

So the relink flow was not only a QR-generation problem; it was a QR/wait/handoff synchronization problem.

## Tests

Passing locally:
- `pnpm exec vitest run src/web/login-qr.test.ts`

Not fully run:
- `ui/src/ui/controllers/channels.test.ts` exists and matches the new controller behavior, but this repo's current vitest include list does not pick that file by default yet
- full repo test/build matrix not run in this PR branch

## Related

- refs #48994
- refs #63019
