### PR TITLE
Browser: disable evaluate action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Groups: `whatsapp.groups`, `telegram.groups`, and `imessage.groups` now act as allowlists when set. Add `"*"` to keep allow-all behavior.
 
 ### Fixes
+- Browser: disable the `browser evaluate` action on the agent route, browser tool, and CLI because it executed arbitrary page JavaScript.
 - Onboarding: write auth profiles to the multi-agent path (`~/.clawdbot/agents/main/agent/`) so the gateway finds credentials on first startup. Thanks @minghinmatthewlam for PR #327.
 - Docs: add missing `ui:install` setup step in the README. Thanks @hugobarauna for PR #300.
 - Build: import tool-display JSON as a module instead of runtime file reads. Thanks @mukhtharcm for PR #312.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -274,8 +274,6 @@ Actions:
 - `clawdbot browser fill --fields '[{\"ref\":\"1\",\"value\":\"Ada\"}]'`
 - `clawdbot browser dialog --accept`
 - `clawdbot browser wait --text "Done"`
-- `clawdbot browser evaluate --fn '(el) => el.textContent' --ref 7`
-- `clawdbot browser evaluate --fn "document.querySelector('.my-class').click()"`
 - `clawdbot browser console --level error`
 - `clawdbot browser pdf`
 

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -86,12 +86,6 @@ const BrowserActSchema = Type.Union([
     targetId: Type.Optional(Type.String()),
   }),
   Type.Object({
-    kind: Type.Literal("evaluate"),
-    fn: Type.String(),
-    ref: Type.Optional(Type.String()),
-    targetId: Type.Optional(Type.String()),
-  }),
-  Type.Object({
     kind: Type.Literal("close"),
     targetId: Type.Optional(Type.String()),
   }),

--- a/src/browser/client-actions-core.ts
+++ b/src/browser/client-actions-core.ts
@@ -49,7 +49,6 @@ export type BrowserActRequest =
       textGone?: string;
       targetId?: string;
     }
-  | { kind: "evaluate"; fn: string; ref?: string; targetId?: string }
   | { kind: "close"; targetId?: string };
 
 export type BrowserActResponse = {

--- a/src/browser/routes/agent.ts
+++ b/src/browser/routes/agent.ts
@@ -145,11 +145,14 @@ export function registerBrowserAgentRoutes(
       return jsonError(res, 400, SELECTOR_UNSUPPORTED_MESSAGE);
     }
 
+    if (kind === "evaluate") {
+      return jsonError(res, 403, "evaluate is disabled for security reasons");
+    }
+
     if (
       kind !== "click" &&
       kind !== "close" &&
       kind !== "drag" &&
-      kind !== "evaluate" &&
       kind !== "fill" &&
       kind !== "hover" &&
       kind !== "press" &&
@@ -322,23 +325,6 @@ export function registerBrowserAgentRoutes(
             textGone,
           });
           return res.json({ ok: true, targetId: tab.targetId });
-        }
-        case "evaluate": {
-          const fn = toStringOrEmpty(body.fn);
-          if (!fn) return jsonError(res, 400, "fn is required");
-          const ref = toStringOrEmpty(body.ref) || undefined;
-          const result = await pw.evaluateViaPlaywright({
-            cdpUrl,
-            targetId: tab.targetId,
-            fn,
-            ref,
-          });
-          return res.json({
-            ok: true,
-            targetId: tab.targetId,
-            url: tab.url,
-            result,
-          });
         }
         case "close": {
           await pw.closePageViaPlaywright({ cdpUrl, targetId: tab.targetId });

--- a/src/browser/server.test.ts
+++ b/src/browser/server.test.ts
@@ -468,19 +468,16 @@ describe("browser control server", () => {
       textGone: undefined,
     });
 
-    const evalRes = (await realFetch(`${base}/act`, {
+    const evalRes = await realFetch(`${base}/act`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ kind: "evaluate", fn: "() => 1" }),
-    }).then((r) => r.json())) as { ok: boolean; result?: unknown };
-    expect(evalRes.ok).toBe(true);
-    expect(evalRes.result).toBe("ok");
-    expect(pwMocks.evaluateViaPlaywright).toHaveBeenCalledWith({
-      cdpUrl: cdpBaseUrl,
-      targetId: "abcd1234",
-      fn: "() => 1",
-      ref: undefined,
     });
+    expect(evalRes.status).toBe(403);
+    await expect(evalRes.json()).resolves.toMatchObject({
+      error: "evaluate is disabled for security reasons",
+    });
+    expect(pwMocks.evaluateViaPlaywright).not.toHaveBeenCalled();
 
     const upload = await realFetch(`${base}/hooks/file-chooser`, {
       method: "POST",

--- a/src/cli/browser-cli-actions-input.ts
+++ b/src/cli/browser-cli-actions-input.ts
@@ -486,40 +486,4 @@ export function registerBrowserActionInputCommands(
       }
     });
 
-  browser
-    .command("evaluate")
-    .description("Evaluate a function against the page or a ref")
-    .option("--fn <code>", "Function source, e.g. (el) => el.textContent")
-    .option("--ref <id>", "ARIA ref from ai snapshot")
-    .option("--target-id <id>", "CDP target id (or unique prefix)")
-    .action(async (opts, cmd) => {
-      const parent = parentOpts(cmd);
-      const baseUrl = resolveBrowserControlUrl(parent?.url);
-      const profile = parent?.browserProfile;
-      if (!opts.fn) {
-        defaultRuntime.error(danger("Missing --fn"));
-        defaultRuntime.exit(1);
-        return;
-      }
-      try {
-        const result = await browserAct(
-          baseUrl,
-          {
-            kind: "evaluate",
-            fn: opts.fn,
-            ref: opts.ref?.trim() || undefined,
-            targetId: opts.targetId?.trim() || undefined,
-          },
-          { profile },
-        );
-        if (parent?.json) {
-          defaultRuntime.log(JSON.stringify(result, null, 2));
-          return;
-        }
-        defaultRuntime.log(JSON.stringify(result.result ?? null, null, 2));
-      } catch (err) {
-        defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
-      }
-    });
 }

--- a/src/cli/browser-cli-examples.ts
+++ b/src/cli/browser-cli-examples.ts
@@ -26,7 +26,6 @@ export const browserActionExamples = [
   'clawdbot browser fill --fields \'[{"ref":"1","value":"Ada"}]\'',
   "clawdbot browser dialog --accept",
   'clawdbot browser wait --text "Done"',
-  "clawdbot browser evaluate --fn '(el) => el.textContent' --ref 7",
   "clawdbot browser console --level error",
   "clawdbot browser pdf",
 ];


### PR DESCRIPTION
## Summary
- disable the exposed browser evaluate action on the agent route with an explicit 403
- remove evaluate from the browser tool schema, typed client action surface, CLI command, and docs/examples
- add a regression test to ensure evaluate requests are rejected and never call Playwright evaluation

## Testing
- pnpm test -- src/browser/server.test.ts
- pnpm build

## Notes
- pnpm lint still fails in this worktree because of pre-existing repo-wide formatting diagnostics unrelated to this change.