### PR TITLE
fix: detect and abort infinite loop when agent repeatedly calls non-existent tools

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -15,6 +15,7 @@ import {
   ensureGlobalUndiciEnvProxyDispatcher,
   ensureGlobalUndiciStreamTimeouts,
 } from "../../../infra/net/undici-global-dispatcher.js";
+import { getDiagnosticSessionState } from "../../../logging/diagnostic-session-state.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import {
   isOllamaCompatProvider,
@@ -1276,6 +1277,33 @@ export async function runEmbeddedAttempt(
           idleTimeoutMs,
           (error) => idleTimeoutTrigger?.(error),
         );
+      }
+
+      // Guard against infinite loops when the LLM repeatedly calls non-existent
+      // tools. The SDK bypasses all OpenClaw tool hooks for unknown tools, so the
+      // detection flag is set by handleToolExecutionEnd via diagnostic session state.
+      if (params.sessionKey) {
+        const innerUnknownGuard = activeSession.agent.streamFn;
+        activeSession.agent.streamFn = (model, context, options) => {
+          const diagState = getDiagnosticSessionState({
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+          });
+          if (diagState.unknownToolLoopDetected) {
+            const toolNames = diagState.unknownToolLoopDetected.toolNames.join(", ");
+            log.error(
+              `Aborting run due to unknown tool loop: tools=[${toolNames}] ` +
+                `runId=${params.runId} sessionKey=${params.sessionKey}`,
+            );
+            runAbortController.abort(
+              new Error(
+                `Run aborted: repeated calls to non-existent tool(s): ${toolNames}. ` +
+                  `The agent was stuck in an infinite retry loop.`,
+              ),
+            );
+          }
+          return innerUnknownGuard(model, context, options);
+        };
       }
 
       try {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1279,6 +1279,16 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      // Store the resolved loop-detection config on diagnostic session state so
+      // that event handlers (which lack direct config access) can use it.
+      if (params.sessionKey && clientToolLoopDetection) {
+        const diagStateForConfig = getDiagnosticSessionState({
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+        });
+        diagStateForConfig.loopDetectionConfig = clientToolLoopDetection;
+      }
+
       // Guard against infinite loops when the LLM repeatedly calls non-existent
       // tools. The SDK bypasses all OpenClaw tool hooks for unknown tools, so the
       // detection flag is set by handleToolExecutionEnd via diagnostic session state.
@@ -1295,12 +1305,14 @@ export async function runEmbeddedAttempt(
               `Aborting run due to unknown tool loop: tools=[${toolNames}] ` +
                 `runId=${params.runId} sessionKey=${params.sessionKey}`,
             );
+            diagState.unknownToolLoopDetected = undefined;
             runAbortController.abort(
               new Error(
                 `Run aborted: repeated calls to non-existent tool(s): ${toolNames}. ` +
                   `The agent was stuck in an infinite retry loop.`,
               ),
             );
+            return innerUnknownGuard(model, context, options);
           }
           return innerUnknownGuard(model, context, options);
         };

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -17,9 +17,11 @@ import {
   buildExecApprovalUnavailableReplyPayload,
 } from "../infra/exec-approval-reply.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { splitMediaFromOutput } from "../media/parse.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
+import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -45,6 +47,13 @@ import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
 import { consumeAdjustedParamsForToolCall } from "./pi-tools.before-tool-call.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
+
+const unknownToolLog = createSubsystemLogger("agents/unknown-tool-loop");
+
+const loadUnknownToolLoopRuntime = createLazyRuntimeSurface(
+  () => import("./pi-tools.before-tool-call.runtime.js"),
+  ({ beforeToolCallRuntime }) => beforeToolCallRuntime,
+);
 
 type ToolStartRecord = {
   startTime: number;
@@ -1096,5 +1105,59 @@ export async function handleToolExecutionEnd(
       .catch((err) => {
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);
       });
+  }
+
+  // Unknown tool loop detection: the SDK bypasses all beforeToolCall/afterToolCall
+  // hooks when a tool is not found, so handleToolExecutionEnd is the only place
+  // we can intercept repeated "Tool X not found" errors.
+  if (isToolError && ctx.params.sessionKey) {
+    const errorText = extractToolResultText(sanitizedResult) ?? "";
+    try {
+      const {
+        getDiagnosticSessionState,
+        isUnknownToolErrorText,
+        recordToolCall: recordCall,
+        recordToolCallOutcome: recordOutcome,
+        detectUnknownToolLoop,
+        logToolLoopAction,
+      } = await loadUnknownToolLoopRuntime();
+      if (isUnknownToolErrorText(errorText)) {
+        const sessionState = getDiagnosticSessionState({
+          sessionKey: ctx.params.sessionKey,
+          sessionId: ctx.params.sessionId,
+        });
+        recordCall(sessionState, toolName, {}, toolCallId, undefined, { unknownTool: true });
+        recordOutcome(sessionState, {
+          toolName,
+          toolParams: {},
+          toolCallId,
+          error: errorText,
+        });
+        const loopResult = detectUnknownToolLoop(sessionState, toolName);
+        if (loopResult.stuck && loopResult.level === "critical") {
+          unknownToolLog.error(
+            `Blocking unknown tool loop: tool=${toolName} count=${loopResult.count}`,
+          );
+          logToolLoopAction({
+            sessionKey: ctx.params.sessionKey,
+            sessionId: ctx.params.sessionId,
+            toolName,
+            level: "critical",
+            action: "block",
+            detector: "unknown_tool",
+            count: loopResult.count,
+            message: loopResult.message,
+          });
+          sessionState.unknownToolLoopDetected = {
+            toolNames: [toolName],
+            message: loopResult.message,
+          };
+        }
+      }
+    } catch (err) {
+      unknownToolLog.warn(
+        `unknown tool loop detection failed: tool=${toolName} error=${String(err)}`,
+      );
+    }
   }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1133,7 +1133,11 @@ export async function handleToolExecutionEnd(
           toolCallId,
           error: errorText,
         });
-        const loopResult = detectUnknownToolLoop(sessionState, toolName);
+        const loopResult = detectUnknownToolLoop(
+          sessionState,
+          toolName,
+          sessionState.loopDetectionConfig,
+        );
         if (loopResult.stuck && loopResult.level === "critical") {
           unknownToolLog.error(
             `Blocking unknown tool loop: tool=${toolName} count=${loopResult.count}`,

--- a/src/agents/pi-tools.before-tool-call.runtime.ts
+++ b/src/agents/pi-tools.before-tool-call.runtime.ts
@@ -2,6 +2,8 @@ import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.j
 import { logToolLoopAction } from "../logging/diagnostic.js";
 import {
   detectToolCallLoop,
+  detectUnknownToolLoop,
+  isUnknownToolErrorText,
   recordToolCall,
   recordToolCallOutcome,
 } from "./tool-loop-detection.js";
@@ -10,6 +12,8 @@ export const beforeToolCallRuntime = {
   getDiagnosticSessionState,
   logToolLoopAction,
   detectToolCallLoop,
+  detectUnknownToolLoop,
+  isUnknownToolErrorText,
   recordToolCall,
   recordToolCallOutcome,
 };

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -5,10 +5,13 @@ import {
   CRITICAL_THRESHOLD,
   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
   TOOL_CALL_HISTORY_SIZE,
+  UNKNOWN_TOOL_CRITICAL_THRESHOLD,
   WARNING_THRESHOLD,
   detectToolCallLoop,
+  detectUnknownToolLoop,
   getToolCallStats,
   hashToolCall,
+  isUnknownToolErrorText,
   recordToolCall,
   recordToolCallOutcome,
 } from "./tool-loop-detection.js";
@@ -589,6 +592,130 @@ describe("tool-loop-detection", () => {
       const stats = getToolCallStats(state);
       expect(stats.mostFrequent?.toolName).toBe("read");
       expect(stats.mostFrequent?.count).toBe(7);
+    });
+  });
+
+  describe("isUnknownToolErrorText", () => {
+    it("matches SDK 'Tool X not found' format", () => {
+      expect(isUnknownToolErrorText("Tool web_search not found")).toBe(true);
+      expect(isUnknownToolErrorText("Tool my_custom_tool not found")).toBe(true);
+    });
+
+    it("rejects unrelated error messages", () => {
+      expect(isUnknownToolErrorText("Permission denied")).toBe(false);
+      expect(isUnknownToolErrorText("Tool execution failed")).toBe(false);
+      expect(isUnknownToolErrorText("")).toBe(false);
+    });
+
+    it("handles whitespace", () => {
+      expect(isUnknownToolErrorText("  Tool foo not found  ")).toBe(true);
+    });
+  });
+
+  describe("detectUnknownToolLoop", () => {
+    function recordUnknownToolCall(state: SessionState, toolName: string, index: number): void {
+      const toolCallId = `unknown-${toolName}-${index}`;
+      recordToolCall(state, toolName, {}, toolCallId, undefined, { unknownTool: true });
+      recordToolCallOutcome(state, {
+        toolName,
+        toolParams: {},
+        toolCallId,
+        error: `Tool ${toolName} not found`,
+      });
+    }
+
+    it("returns not stuck below threshold", () => {
+      const state = createState();
+      for (let i = 0; i < UNKNOWN_TOOL_CRITICAL_THRESHOLD - 1; i += 1) {
+        recordUnknownToolCall(state, "web_search", i);
+      }
+      const result = detectUnknownToolLoop(state, "web_search");
+      expect(result.stuck).toBe(false);
+    });
+
+    it("returns critical at threshold", () => {
+      const state = createState();
+      for (let i = 0; i < UNKNOWN_TOOL_CRITICAL_THRESHOLD; i += 1) {
+        recordUnknownToolCall(state, "web_search", i);
+      }
+      const result = detectUnknownToolLoop(state, "web_search");
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+        expect(result.detector).toBe("unknown_tool");
+        expect(result.count).toBe(UNKNOWN_TOOL_CRITICAL_THRESHOLD);
+        expect(result.message).toContain("web_search");
+        expect(result.message).toContain("does not exist");
+      }
+    });
+
+    it("resets streak when a normal tool call intervenes", () => {
+      const state = createState();
+      recordUnknownToolCall(state, "web_search", 0);
+      recordUnknownToolCall(state, "web_search", 1);
+      // Normal tool call breaks the streak
+      recordSuccessfulCall(state, "read", { path: "/a.txt" }, { ok: true }, 100);
+      recordUnknownToolCall(state, "web_search", 2);
+
+      const result = detectUnknownToolLoop(state, "web_search");
+      expect(result.stuck).toBe(false);
+    });
+
+    it("counts different unknown tool names in the same streak", () => {
+      const state = createState();
+      recordUnknownToolCall(state, "web_search", 0);
+      recordUnknownToolCall(state, "browser", 1);
+      recordUnknownToolCall(state, "web_search", 2);
+
+      const result = detectUnknownToolLoop(state, "web_search");
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+        expect(result.count).toBe(3);
+      }
+    });
+
+    it("can be disabled via detector config", () => {
+      const state = createState();
+      for (let i = 0; i < UNKNOWN_TOOL_CRITICAL_THRESHOLD + 5; i += 1) {
+        recordUnknownToolCall(state, "web_search", i);
+      }
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        detectors: { unknownTool: false },
+      };
+      const result = detectUnknownToolLoop(state, "web_search", config);
+      expect(result.stuck).toBe(false);
+    });
+
+    it("works even when main enabled flag is false", () => {
+      const state = createState();
+      for (let i = 0; i < UNKNOWN_TOOL_CRITICAL_THRESHOLD; i += 1) {
+        recordUnknownToolCall(state, "web_search", i);
+      }
+      const config: ToolLoopDetectionConfig = { enabled: false };
+      const result = detectUnknownToolLoop(state, "web_search", config);
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+        expect(result.detector).toBe("unknown_tool");
+      }
+    });
+
+    it("respects custom unknownToolCriticalThreshold", () => {
+      const state = createState();
+      for (let i = 0; i < 5; i += 1) {
+        recordUnknownToolCall(state, "web_search", i);
+      }
+      const config: ToolLoopDetectionConfig = {
+        enabled: false,
+        unknownToolCriticalThreshold: 5,
+      };
+      const result = detectUnknownToolLoop(state, "web_search", config);
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.count).toBe(5);
+      }
     });
   });
 });

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -10,7 +10,8 @@ export type LoopDetectorKind =
   | "generic_repeat"
   | "known_poll_no_progress"
   | "global_circuit_breaker"
-  | "ping_pong";
+  | "ping_pong"
+  | "unknown_tool";
 
 export type LoopDetectionResult =
   | { stuck: false }
@@ -28,16 +29,19 @@ export const TOOL_CALL_HISTORY_SIZE = 30;
 export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+export const UNKNOWN_TOOL_CRITICAL_THRESHOLD = 3;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
   enabled: false,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,
   globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+  unknownToolCriticalThreshold: UNKNOWN_TOOL_CRITICAL_THRESHOLD,
   detectors: {
     genericRepeat: true,
     knownPollNoProgress: true,
     pingPong: true,
+    unknownTool: true,
   },
 };
 
@@ -47,10 +51,12 @@ type ResolvedLoopDetectionConfig = {
   warningThreshold: number;
   criticalThreshold: number;
   globalCircuitBreakerThreshold: number;
+  unknownToolCriticalThreshold: number;
   detectors: {
     genericRepeat: boolean;
     knownPollNoProgress: boolean;
     pingPong: boolean;
+    unknownTool: boolean;
   };
 };
 
@@ -88,6 +94,10 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     warningThreshold,
     criticalThreshold,
     globalCircuitBreakerThreshold,
+    unknownToolCriticalThreshold: asPositiveInt(
+      config?.unknownToolCriticalThreshold,
+      DEFAULT_LOOP_DETECTION_CONFIG.unknownToolCriticalThreshold,
+    ),
     detectors: {
       genericRepeat:
         config?.detectors?.genericRepeat ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.genericRepeat,
@@ -95,6 +105,8 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
         config?.detectors?.knownPollNoProgress ??
         DEFAULT_LOOP_DETECTION_CONFIG.detectors.knownPollNoProgress,
       pingPong: config?.detectors?.pingPong ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.pingPong,
+      unknownTool:
+        config?.detectors?.unknownTool ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.unknownTool,
     },
   };
 }
@@ -142,6 +154,35 @@ function stableStringifyFallback(value: unknown): string {
     }
     return Object.prototype.toString.call(value);
   }
+}
+
+const UNKNOWN_TOOL_ERROR_RE = /^Tool\s+\S+\s+not\s+found$/;
+
+/**
+ * Check if a tool result error message indicates a non-existent tool.
+ * Matches the SDK's "Tool {name} not found" format from prepareToolCall().
+ */
+export function isUnknownToolErrorText(text: string): boolean {
+  return UNKNOWN_TOOL_ERROR_RE.test(text.trim());
+}
+
+function getUnknownToolStreak(
+  history: Array<{
+    toolName: string;
+    argsHash: string;
+    resultHash?: string;
+    unknownTool?: boolean;
+  }>,
+): number {
+  let streak = 0;
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (!record?.unknownTool) {
+      break;
+    }
+    streak += 1;
+  }
+  return streak;
 }
 
 function isKnownPollToolCall(toolName: string, params: unknown): boolean {
@@ -495,6 +536,40 @@ export function detectToolCallLoop(
 }
 
 /**
+ * Detect if an agent is stuck calling non-existent tools.
+ * Unlike other detectors, this runs regardless of the `enabled` flag because
+ * calling a tool that does not exist is always an error — the SDK bypasses all
+ * OpenClaw beforeToolCall/afterToolCall hooks for unknown tools, so this is the
+ * only guard against infinite retry loops.
+ */
+export function detectUnknownToolLoop(
+  state: SessionState,
+  toolName: string,
+  config?: ToolLoopDetectionConfig,
+): LoopDetectionResult {
+  const resolvedConfig = resolveLoopDetectionConfig(config);
+  if (!resolvedConfig.detectors.unknownTool) {
+    return { stuck: false };
+  }
+  const history = state.toolCallHistory ?? [];
+  const streak = getUnknownToolStreak(history);
+  if (streak >= resolvedConfig.unknownToolCriticalThreshold) {
+    log.error(
+      `Unknown tool loop detected: ${streak} consecutive calls to non-existent tools (latest: ${toolName})`,
+    );
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "unknown_tool",
+      count: streak,
+      message: `CRITICAL: ${streak} consecutive calls to non-existent tools. The tool "${toolName}" does not exist. Do NOT call it again. Use only the tools listed in your tool definitions.`,
+      warningKey: `unknown_tool:${toolName}`,
+    };
+  }
+  return { stuck: false };
+}
+
+/**
  * Record a tool call in the session's history for loop detection.
  * Maintains sliding window of last N calls.
  */
@@ -504,6 +579,7 @@ export function recordToolCall(
   params: unknown,
   toolCallId?: string,
   config?: ToolLoopDetectionConfig,
+  options?: { unknownTool?: boolean },
 ): void {
   const resolvedConfig = resolveLoopDetectionConfig(config);
   if (!state.toolCallHistory) {
@@ -515,6 +591,7 @@ export function recordToolCall(
     argsHash: hashToolCall(toolName, params),
     toolCallId,
     timestamp: Date.now(),
+    ...(options?.unknownTool ? { unknownTool: true } : {}),
   });
 
   if (state.toolCallHistory.length > resolvedConfig.historySize) {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -6890,6 +6890,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           exclusiveMinimum: 0,
                           maximum: 9007199254740991,
                         },
+                        unknownToolCriticalThreshold: {
+                          type: "integer",
+                          exclusiveMinimum: 0,
+                          maximum: 9007199254740991,
+                        },
                         detectors: {
                           type: "object",
                           properties: {
@@ -6900,6 +6905,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                               type: "boolean",
                             },
                             pingPong: {
+                              type: "boolean",
+                            },
+                            unknownTool: {
                               type: "boolean",
                             },
                           },
@@ -16759,6 +16767,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 title: "Tool-loop Global Circuit Breaker Threshold",
                 description: "Global no-progress breaker threshold (default: 30).",
               },
+              unknownToolCriticalThreshold: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 9007199254740991,
+              },
               detectors: {
                 type: "object",
                 properties: {
@@ -16778,6 +16791,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     type: "boolean",
                     title: "Tool-loop Ping-Pong Detection",
                     description: "Enable ping-pong loop detection (default: true).",
+                  },
+                  unknownTool: {
+                    type: "boolean",
                   },
                 },
                 additionalProperties: false,

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -160,6 +160,8 @@ export type ToolLoopDetectionDetectorConfig = {
   knownPollNoProgress?: boolean;
   /** Enable warning/blocking for no-progress ping-pong alternating patterns. */
   pingPong?: boolean;
+  /** Enable blocking when the LLM repeatedly calls tools that do not exist (default: true). */
+  unknownTool?: boolean;
 };
 
 export type ToolLoopDetectionConfig = {
@@ -173,6 +175,8 @@ export type ToolLoopDetectionConfig = {
   criticalThreshold?: number;
   /** Global no-progress breaker threshold (default: 30). */
   globalCircuitBreakerThreshold?: number;
+  /** Consecutive unknown-tool errors before critical block (default: 3). */
+  unknownToolCriticalThreshold?: number;
   /** Detector toggles. */
   detectors?: ToolLoopDetectionDetectorConfig;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -469,6 +469,7 @@ const ToolLoopDetectionDetectorSchema = z
     genericRepeat: z.boolean().optional(),
     knownPollNoProgress: z.boolean().optional(),
     pingPong: z.boolean().optional(),
+    unknownTool: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -480,6 +481,7 @@ const ToolLoopDetectionSchema = z
     warningThreshold: z.number().int().positive().optional(),
     criticalThreshold: z.number().int().positive().optional(),
     globalCircuitBreakerThreshold: z.number().int().positive().optional(),
+    unknownToolCriticalThreshold: z.number().int().positive().optional(),
     detectors: ToolLoopDetectionDetectorSchema,
   })
   .strict()

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -141,7 +141,12 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   toolName: string;
   level: "warning" | "critical";
   action: "warn" | "block";
-  detector: "generic_repeat" | "known_poll_no_progress" | "global_circuit_breaker" | "ping_pong";
+  detector:
+    | "generic_repeat"
+    | "known_poll_no_progress"
+    | "global_circuit_breaker"
+    | "ping_pong"
+    | "unknown_tool";
   count: number;
   message: string;
   pairedToolName?: string;

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -9,6 +9,8 @@ export type SessionState = {
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
+  /** Set by unknown-tool loop detection; checked by streamFn guard to inject stop signals. */
+  unknownToolLoopDetected?: { toolNames: string[]; message: string };
 };
 
 export type ToolCallRecord = {
@@ -17,6 +19,8 @@ export type ToolCallRecord = {
   toolCallId?: string;
   resultHash?: string;
   timestamp: number;
+  /** Set when the tool call targeted a non-existent tool (SDK "Tool X not found" error). */
+  unknownTool?: boolean;
 };
 
 export type SessionRef = {

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -11,6 +11,8 @@ export type SessionState = {
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
   /** Set by unknown-tool loop detection; checked by streamFn guard to inject stop signals. */
   unknownToolLoopDetected?: { toolNames: string[]; message: string };
+  /** Resolved loop-detection config, stored by attempt.ts so event handlers can access it. */
+  loopDetectionConfig?: import("../config/types.tools.js").ToolLoopDetectionConfig;
 };
 
 export type ToolCallRecord = {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -286,7 +286,12 @@ export function logToolLoopAction(
     toolName: string;
     level: "warning" | "critical";
     action: "warn" | "block";
-    detector: "generic_repeat" | "known_poll_no_progress" | "global_circuit_breaker" | "ping_pong";
+    detector:
+      | "generic_repeat"
+      | "known_poll_no_progress"
+      | "global_circuit_breaker"
+      | "ping_pong"
+      | "unknown_tool";
     count: number;
     message: string;
     pairedToolName?: string;


### PR DESCRIPTION
## Summary

Fixes #62971

When the agent calls a tool that doesn't exist in the registered tool set, the `pi-agent-core` SDK returns an immediate error (`"Tool X not found"`) and bypasses all `beforeToolCall`/`afterToolCall` hooks. This means OpenClaw's existing tool-loop-detection framework never sees these failures, causing the agent to retry the same non-existent tool indefinitely — burning tokens and never terminating.

This PR adds a dedicated `unknown_tool` detector that catches this specific failure mode and aborts the run after 3 consecutive unknown-tool errors.

## Root Cause

The SDK's `prepareToolCall()` short-circuits for unknown tools: it returns an error result directly without invoking `beforeToolCall` or `afterToolCall`. The only OpenClaw code path that observes these errors is the `tool_execution_end` event handler (`handleToolExecutionEnd`).

## Changes

### Detection (`tool-loop-detection.ts`)
- Added `"unknown_tool"` to `LoopDetectorKind`
- Added `isUnknownToolErrorText()` to match SDK's `"Tool X not found"` error pattern
- Added `getUnknownToolStreak()` and `detectUnknownToolLoop()` with a critical threshold of 3 consecutive errors
- This detector is **always active** regardless of the main loop-detection `enabled` flag, since unknown-tool loops are always unrecoverable

### Integration (`pi-embedded-subscribe.handlers.tools.ts`)
- In `handleToolExecutionEnd`, when `isToolError` is true: check if the error matches the unknown-tool pattern, record it in diagnostic session state, and run the detector
- If critical threshold is reached, set `sessionState.unknownToolLoopDetected` flag

### Termination (`attempt.ts`)
- Added a `streamFn` wrapper that checks `unknownToolLoopDetected` before each LLM call
- If the flag is set, immediately aborts the run via `runAbortController.abort()` with a descriptive error

### Type Extensions
- `config/types.tools.ts`: added `unknownTool` detector config and `unknownToolCriticalThreshold`
- `logging/diagnostic-session-state.ts`: added `unknownTool` flag on `ToolCallRecord` and `unknownToolLoopDetected` on `SessionState`
- `logging/diagnostic.ts` & `infra/diagnostic-events.ts`: added `"unknown_tool"` to detector kind union
- `pi-tools.before-tool-call.runtime.ts`: exported new detection functions for lazy loading

## Test Plan

- [x] Unit tests for `isUnknownToolErrorText` — matches SDK error format, rejects unrelated errors
- [x] Unit tests for `detectUnknownToolLoop` — threshold detection, streak reset by normal calls, mixed unknown tools, custom threshold, independent of main `enabled` flag
- [x] `pnpm check` (tsgo + oxlint) passes
- [x] Existing tool-loop-detection tests remain green