### PR TITLE
fix(device-pairing): guard against array-typed state files in loadState

### DIFF
--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -101,6 +101,21 @@ const OPERATOR_SCOPE_PREFIX = "operator.";
 
 const withLock = createAsyncLock();
 
+/**
+ * Coerce a value read from a state JSON file to a plain object.
+ * JSON.stringify silently drops all non-numeric keys from arrays, so if
+ * pending.json / paired.json were written as `[]` (e.g. from a corrupted
+ * or migrated init), every persist cycle would write `[]` back — destroying
+ * all pairing state. Treat an array-typed value the same as a missing file
+ * and fall back to an empty object.
+ */
+function toStateRecord<T>(value: Record<string, T> | null | undefined): Record<string, T> {
+  if (value === null || value === undefined || Array.isArray(value)) {
+    return {};
+  }
+  return value;
+}
+
 async function loadState(baseDir?: string): Promise<DevicePairingStateFile> {
   const { pendingPath, pairedPath } = resolvePairingPaths(baseDir, "devices");
   const [pending, paired] = await Promise.all([
@@ -108,8 +123,8 @@ async function loadState(baseDir?: string): Promise<DevicePairingStateFile> {
     readJsonFile<Record<string, PairedDevice>>(pairedPath),
   ]);
   const state: DevicePairingStateFile = {
-    pendingById: pending ?? {},
-    pairedByDeviceId: paired ?? {},
+    pendingById: toStateRecord(pending),
+    pairedByDeviceId: toStateRecord(paired),
   };
   pruneExpiredPending(state.pendingById, Date.now(), PENDING_TTL_MS);
   return state;


### PR DESCRIPTION
## Problem

When `pending.json` or `paired.json` is written as `[]` (e.g. after a corrupted init or migration that serialised an empty array instead of an empty object), `loadState` assigned the raw array directly to `pendingById` / `pairedByDeviceId`.

Because `JSON.stringify` silently drops all non-numeric keys from arrays, every subsequent `persistState` call wrote `[]` back to disk — permanently destroying all pairing state for that installation.

## Fix

Added a `toStateRecord<T>` helper that coerces `null`, `undefined`, and array-typed values to `{}` before they are used as a keyed record. This is applied to both slots in `loadState`:

```ts
function toStateRecord<T>(value: Record<string, T> | null | undefined): Record<string, T> {
  if (value === null || value === undefined || Array.isArray(value)) {
    return {};
  }
  return value;
}
```

All existing behaviour for well-formed state files is unchanged.

## Testing

- Write `[]` to `pending.json` and `paired.json`, then call `requestDevicePairing` — state is no longer wiped on next persist.
- Normal object-typed files continue to work without regression.