### PR TITLE
fix: image tool respects tools.media.image.timeoutSeconds config

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -6,6 +6,7 @@ import {
   resolveDefaultMediaModel,
 } from "../../media-understanding/defaults.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
+import { resolveTimeoutMs } from "../../media-understanding/resolve.js";
 import { buildProviderRegistry } from "../../media-understanding/runner.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import {
@@ -192,6 +193,12 @@ async function runImagePrompt(params: {
   const providerCfg: OpenClawConfig = effectiveCfg ?? {};
   const providerRegistry = imageToolProviderDeps.buildProviderRegistry(undefined, providerCfg);
 
+  const DEFAULT_IMAGE_TIMEOUT_SECONDS = 30;
+  const timeoutMs = resolveTimeoutMs(
+    effectiveCfg?.tools?.media?.image?.timeoutSeconds,
+    DEFAULT_IMAGE_TIMEOUT_SECONDS,
+  );
+
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
@@ -216,7 +223,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -234,7 +241,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -251,7 +258,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });


### PR DESCRIPTION
## Summary

Fixes #62944.

### Problem
The image tool's `runImagePrompt()` had `timeoutMs` hardcoded to `30_000` in three places, ignoring the user-configured `tools.media.image.timeoutSeconds` value. This caused slow image models to always abort after 30 seconds regardless of config.

### Solution
Read the config via `resolveTimeoutMs()` (already used elsewhere in the media-understanding pipeline) and fall back to 30s when unset.

### Changes
- `src/agents/tools/image-tool.ts`: Import `resolveTimeoutMs`, compute `timeoutMs` from `effectiveCfg?.tools?.media?.image?.timeoutSeconds` with 30s default, replace all three hardcoded `30_000` values.

### Testing
- [x] Existing tests pass (35/35)
- [x] Uses the same `resolveTimeoutMs` utility already validated in the media-understanding pipeline

---
<sub>🔧 Generated by [issue-to-pr](https://github.com/4yDX3906/issue-to-pr)</sub>