### PR TITLE
fix: stop sending unsupported reasoning_effort 'none' to OpenAI

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -776,8 +776,6 @@ export function buildOpenAIResponsesParams(
         summary: options?.reasoningSummary || "auto",
       };
       params.include = ["reasoning.encrypted_content"];
-    } else if (model.provider !== "github-copilot") {
-      params.reasoning = { effort: "none" };
     }
   }
   applyOpenAIResponsesPayloadPolicy(params as Record<string, unknown>, payloadPolicy);
@@ -1216,12 +1214,10 @@ type OpenAIResponsesRequestParams = {
   temperature?: number;
   service_tier?: ResponseCreateParamsStreaming["service_tier"];
   tools?: FunctionTool[];
-  reasoning?:
-    | { effort: "none" }
-    | {
-        effort: NonNullable<OpenAIResponsesOptions["reasoningEffort"]>;
-        summary: NonNullable<OpenAIResponsesOptions["reasoningSummary"]>;
-      };
+  reasoning?: {
+    effort: NonNullable<OpenAIResponsesOptions["reasoningEffort"]>;
+    summary: NonNullable<OpenAIResponsesOptions["reasoningSummary"]>;
+  };
   include?: string[];
 };
 


### PR DESCRIPTION
## Summary

Fixes #62967.

### Problem
When a reasoning-capable model like `gpt-5-mini` was used without an explicit `thinkingDefault`, the OpenAI Responses API transport hardcoded `reasoning: { effort: "none" }` in the request payload. `gpt-5-mini` rejects `"none"` with a 400 error — it only accepts `"minimal"`, `"low"`, `"medium"`, and `"high"`.

### Solution
Remove the fallback that forces `effort: "none"`. When no reasoning effort is explicitly configured, the `reasoning` block is now omitted entirely, letting the API use its own default.

### Changes
- `src/agents/openai-transport-stream.ts`: Remove the `else if` branch that sent `{ effort: "none" }`, and clean up the corresponding type union.

### Testing
- [x] Existing tests pass (40/40)
- [x] Matches the workaround described in the issue (omit reasoning when not configured)

---
<sub>🔧 Generated by [issue-to-pr](https://github.com/4yDX3906/issue-to-pr)</sub>