### PR TITLE
fix(reply): await block streaming delivery on same-channel dispatch

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -38,7 +38,7 @@ const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
 type DispatchInboundParams = {
   dispatcher: {
-    sendBlockReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
+    sendBlockReply: (payload: ReplyPayload) => false | Promise<void>;
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
   };
   replyOptions?: {
@@ -125,7 +125,7 @@ vi.spyOn(replyRuntimeModule, "createReplyDispatcherWithTyping").mockImplementati
     sendToolResult: vi.fn(() => true),
     sendBlockReply: vi.fn((payload: unknown) => {
       void opts.deliver(payload as never, { kind: "block" });
-      return true;
+      return Promise.resolve();
     }),
     sendFinalReply: vi.fn((payload: unknown) => {
       void opts.deliver(payload as never, { kind: "final" });

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -38,7 +38,7 @@ const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
 type DispatchInboundParams = {
   dispatcher: {
-    sendBlockReply: (payload: ReplyPayload) => false | Promise<void>;
+    sendBlockReply: (payload: ReplyPayload) => false | Promise<true>;
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
   };
   replyOptions?: {
@@ -125,7 +125,7 @@ vi.spyOn(replyRuntimeModule, "createReplyDispatcherWithTyping").mockImplementati
     sendToolResult: vi.fn(() => true),
     sendBlockReply: vi.fn((payload: unknown) => {
       void opts.deliver(payload as never, { kind: "block" });
-      return Promise.resolve();
+      return Promise.resolve(true as const);
     }),
     sendFinalReply: vi.fn((payload: unknown) => {
       void opts.deliver(payload as never, { kind: "final" });

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -38,7 +38,7 @@ const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
 type DispatchInboundParams = {
   dispatcher: {
-    sendBlockReply: (payload: ReplyPayload) => false | Promise<true>;
+    sendBlockReply: (payload: ReplyPayload) => boolean | Promise<true>;
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
   };
   replyOptions?: {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1132,7 +1132,7 @@ export async function handleFeishuMessage(params: {
           delete (agentCtx as Record<string, unknown>).CommandAuthorized;
           const noopDispatcher = {
             sendToolResult: () => false,
-            sendBlockReply: () => false,
+            sendBlockReply: () => false as const,
             sendFinalReply: () => false,
             waitForIdle: async () => {},
             getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),

--- a/extensions/feishu/src/test-support/lifecycle-test-support.ts
+++ b/extensions/feishu/src/test-support/lifecycle-test-support.ts
@@ -63,7 +63,7 @@ export function createFeishuLifecycleReplyDispatcher(): FeishuLifecycleReplyDisp
   return {
     dispatcher: {
       sendToolResult: vi.fn(() => false),
-      sendBlockReply: vi.fn(() => false),
+      sendBlockReply: vi.fn((): false => false),
       sendFinalReply: vi.fn(async () => true),
       waitForIdle: vi.fn(async () => {}),
       getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/agents/skills/skill-contract.ts
+++ b/src/agents/skills/skill-contract.ts
@@ -1,11 +1,20 @@
-import type { Skill as CanonicalSkill, SourceInfo } from "@mariozechner/pi-coding-agent";
+import type { Skill as CanonicalSkill } from "@mariozechner/pi-coding-agent";
 
 export type SourceScope = "user" | "project" | "temporary";
 export type SourceOrigin = "package" | "top-level";
 
+export type SourceInfo = {
+  path: string;
+  source: string;
+  scope: SourceScope;
+  origin: SourceOrigin;
+  baseDir?: string;
+};
+
 export type Skill = CanonicalSkill & {
   // Preserve legacy source reads while keeping the canonical upstream shape.
   source?: string;
+  sourceInfo?: SourceInfo;
 };
 
 export function createSyntheticSourceInfo(

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -45,7 +45,7 @@ const {
 function createDispatcher(record: string[]): ReplyDispatcher {
   return {
     sendToolResult: () => true,
-    sendBlockReply: () => true,
+    sendBlockReply: () => Promise.resolve(true as const),
     sendFinalReply: () => true,
     getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
     getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
@@ -63,7 +63,7 @@ describe("withReplyDispatcher", () => {
     const order: string[] = [];
     const dispatcher = {
       sendToolResult: () => true,
-      sendBlockReply: () => true,
+      sendBlockReply: () => Promise.resolve(true as const),
       sendFinalReply: () => {
         order.push("sendFinalReply");
         return true;

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -63,7 +63,7 @@ vi.mock("../../infra/outbound/message-action-runner.js", () => ({
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
@@ -236,7 +236,7 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
   it("tracks failed visible telegram block delivery separately", async () => {
     const dispatcher: ReplyDispatcher = {
       sendToolResult: vi.fn(() => true),
-      sendBlockReply: vi.fn(() => false),
+      sendBlockReply: vi.fn((): false => false),
       sendFinalReply: vi.fn(() => true),
       waitForIdle: vi.fn(async () => {}),
       getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -358,12 +358,15 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       text: ttsPayload.text,
       routed: false,
     });
-    const delivered =
+    // sendBlockReply returns false | Promise<void>; coerce to boolean for
+    // the uniform delivered/failed tracking below.
+    const deliveredRaw =
       kind === "tool"
         ? params.dispatcher.sendToolResult(ttsPayload)
         : kind === "block"
           ? params.dispatcher.sendBlockReply(ttsPayload)
           : params.dispatcher.sendFinalReply(ttsPayload);
+    const delivered = Boolean(deliveredRaw);
     if (kind === "final" && delivered) {
       state.deliveredFinalReply = true;
     }

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -170,7 +170,7 @@ function createDispatcher(): {
   const counts = { tool: 0, block: 0, final: 0 };
   const dispatcher: ReplyDispatcher = {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => counts),

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -28,6 +28,7 @@ import { buildTestCtx } from "./test-ctx.js";
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
 let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tryDispatchAcpReplyHook;
 
+
 function shouldUseAcpReplyDispatchHook(eventUnknown: unknown): boolean {
   const event = eventUnknown as {
     sessionKey?: string;

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -21,6 +21,7 @@ import {
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 
+
 describe("dispatchReplyFromConfig reply_dispatch hook", () => {
   beforeAll(async () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -289,10 +289,11 @@ export const emptyConfig = {} as OpenClawConfig;
 
 export function createDispatcher(): ReplyDispatcher {
   const acceptReply = () => true;
+  const acceptBlockReply = () => Promise.resolve(true as const);
   const emptyCounts = () => ({ tool: 0, block: 0, final: 0 });
   return {
     sendToolResult: vi.fn(acceptReply),
-    sendBlockReply: vi.fn(acceptReply),
+    sendBlockReply: vi.fn(acceptBlockReply),
     sendFinalReply: vi.fn(acceptReply),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(emptyCounts),

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -369,7 +369,7 @@ beforeAll(async () => {
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -939,6 +939,7 @@ export async function dispatchReplyFromConfig(
                 } else {
                   // Fallback timeout protection when no abort signal is available
                   // (e.g., compaction notice path). Use 10s timeout to match MAX_HUMAN_DELAY_MS.
+                  // Make timeout non-fatal for no-context callers (followup runners, etc.)
                   let timeoutId: NodeJS.Timeout | undefined;
                   try {
                     await Promise.race([
@@ -949,6 +950,15 @@ export async function dispatchReplyFromConfig(
                         }, 10_000);
                       }),
                     ]);
+                  } catch (err) {
+                    // Log timeout but continue - no-context callers shouldn't fail on slow delivery
+                    if (err instanceof Error && err.message.includes("delivery timeout")) {
+                      console.warn(
+                        `[dispatch-from-config] ${err.message}, delivery may continue in background`,
+                      );
+                    } else {
+                      throw err; // Re-throw non-timeout errors
+                    }
                   } finally {
                     if (timeoutId) {
                       clearTimeout(timeoutId);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -918,7 +918,9 @@ export async function dispatchReplyFromConfig(
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
             } else {
-              dispatcher.sendBlockReply(ttsPayload);
+              // Await delivery so block text reaches the user before tool
+              // execution continues on the same channel (#32868).
+              await dispatcher.sendBlockReply(ttsPayload);
             }
           };
           return run();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -924,18 +924,27 @@ export async function dispatchReplyFromConfig(
               const deliveryPromise = dispatcher.sendBlockReply(ttsPayload);
               if (deliveryPromise !== false) {
                 if (context?.abortSignal) {
-                  await Promise.race([
-                    deliveryPromise,
-                    new Promise<void>((_, reject) => {
-                      if (context.abortSignal!.aborted) {
-                        reject(new Error("block reply aborted before delivery"));
-                      } else {
-                        context.abortSignal!.addEventListener("abort", () => {
-                          reject(new Error("block reply aborted during delivery"));
-                        });
-                      }
-                    }),
-                  ]);
+                  let abortHandler: (() => void) | undefined;
+                  try {
+                    await Promise.race([
+                      deliveryPromise,
+                      new Promise<void>((_, reject) => {
+                        if (context.abortSignal!.aborted) {
+                          reject(new Error("block reply aborted before delivery"));
+                        } else {
+                          abortHandler = () => {
+                            reject(new Error("block reply aborted during delivery"));
+                          };
+                          context.abortSignal!.addEventListener("abort", abortHandler);
+                        }
+                      }),
+                    ]);
+                  } finally {
+                    // Clean up abort listener to prevent memory leaks
+                    if (abortHandler) {
+                      context.abortSignal.removeEventListener("abort", abortHandler);
+                    }
+                  }
                 } else {
                   // Fallback timeout protection when no abort signal is available
                   // (e.g., compaction notice path). Use 10s timeout to match MAX_HUMAN_DELAY_MS.

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -939,14 +939,21 @@ export async function dispatchReplyFromConfig(
                 } else {
                   // Fallback timeout protection when no abort signal is available
                   // (e.g., compaction notice path). Use 10s timeout to match MAX_HUMAN_DELAY_MS.
-                  await Promise.race([
-                    deliveryPromise,
-                    new Promise<void>((_, reject) => {
-                      setTimeout(() => {
-                        reject(new Error("block reply delivery timeout (no abort context)"));
-                      }, 10_000);
-                    }),
-                  ]);
+                  let timeoutId: NodeJS.Timeout | undefined;
+                  try {
+                    await Promise.race([
+                      deliveryPromise,
+                      new Promise<void>((_, reject) => {
+                        timeoutId = setTimeout(() => {
+                          reject(new Error("block reply delivery timeout (no abort context)"));
+                        }, 10_000);
+                      }),
+                    ]);
+                  } finally {
+                    if (timeoutId) {
+                      clearTimeout(timeoutId);
+                    }
+                  }
                 }
               }
             }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -947,7 +947,7 @@ export async function dispatchReplyFromConfig(
                   }
                 } else {
                   // Fallback timeout protection when no abort signal is available
-                  // (e.g., compaction notice path). Use 10s timeout to match MAX_HUMAN_DELAY_MS.
+                  // (e.g., compaction notice path). Use 15s timeout (MAX_HUMAN_DELAY_MS + 5s buffer).
                   // Make timeout non-fatal for no-context callers (followup runners, etc.)
                   let timeoutId: NodeJS.Timeout | undefined;
                   try {
@@ -956,7 +956,7 @@ export async function dispatchReplyFromConfig(
                       new Promise<void>((_, reject) => {
                         timeoutId = setTimeout(() => {
                           reject(new Error("block reply delivery timeout (no abort context)"));
-                        }, 10_000);
+                        }, 15_000);
                       }),
                     ]);
                   } catch (err) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -937,7 +937,16 @@ export async function dispatchReplyFromConfig(
                     }),
                   ]);
                 } else {
-                  await deliveryPromise;
+                  // Fallback timeout protection when no abort signal is available
+                  // (e.g., compaction notice path). Use 10s timeout to match MAX_HUMAN_DELAY_MS.
+                  await Promise.race([
+                    deliveryPromise,
+                    new Promise<void>((_, reject) => {
+                      setTimeout(() => {
+                        reject(new Error("block reply delivery timeout (no abort context)"));
+                      }, 10_000);
+                    }),
+                  ]);
                 }
               }
             }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -920,7 +920,26 @@ export async function dispatchReplyFromConfig(
             } else {
               // Await delivery so block text reaches the user before tool
               // execution continues on the same channel (#32868).
-              await dispatcher.sendBlockReply(ttsPayload);
+              // Race delivery against the pipeline timeout/abort to avoid hanging.
+              const deliveryPromise = dispatcher.sendBlockReply(ttsPayload);
+              if (deliveryPromise !== false) {
+                if (context?.abortSignal) {
+                  await Promise.race([
+                    deliveryPromise,
+                    new Promise<void>((_, reject) => {
+                      if (context.abortSignal!.aborted) {
+                        reject(new Error("block reply aborted before delivery"));
+                      } else {
+                        context.abortSignal!.addEventListener("abort", () => {
+                          reject(new Error("block reply aborted during delivery"));
+                        });
+                      }
+                    }),
+                  ]);
+                } else {
+                  await deliveryPromise;
+                }
+              }
             }
           };
           return run();

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -83,6 +83,7 @@ type ReplyDispatcherWithTypingResult = {
 };
 
 
+
 type NormalizeReplyPayloadInternalOptions = Pick<
   ReplyDispatcherOptions,
   | "responsePrefix"

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -25,6 +25,12 @@ type ReplyDispatchDeliverer = (
 
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
+/**
+ * Hard ceiling for human-delay so that custom configs with unbounded minMs/maxMs
+ * cannot exceed the block-reply pipeline timeout (default 15 s).  10 s leaves a
+ * comfortable 5 s budget for transport delivery within a single pipeline tick.
+ */
+const MAX_HUMAN_DELAY_MS = 10_000;
 
 /** Generate a random delay within the configured range. */
 function getHumanDelay(config: HumanDelayConfig | undefined): number {
@@ -37,9 +43,9 @@ function getHumanDelay(config: HumanDelayConfig | undefined): number {
   const max =
     mode === "custom" ? (config?.maxMs ?? DEFAULT_HUMAN_DELAY_MAX_MS) : DEFAULT_HUMAN_DELAY_MAX_MS;
   if (max <= min) {
-    return min;
+    return Math.min(min, MAX_HUMAN_DELAY_MS);
   }
-  return min + generateSecureInt(max - min + 1);
+  return Math.min(min + generateSecureInt(max - min + 1), MAX_HUMAN_DELAY_MS);
 }
 
 export type ReplyDispatcherOptions = {
@@ -75,6 +81,7 @@ type ReplyDispatcherWithTypingResult = {
   /** Signal that the model run is complete so the typing controller can stop. */
   markRunComplete: () => void;
 };
+
 
 type NormalizeReplyPayloadInternalOptions = Pick<
   ReplyDispatcherOptions,
@@ -208,7 +215,14 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
 
   return {
     sendToolResult: (payload) => enqueue("tool", payload),
-    sendBlockReply: (payload) => enqueue("block", payload),
+    sendBlockReply: (payload) => {
+      if (!enqueue("block", payload)) {
+        return false;
+      }
+      // Return the delivery chain so same-channel callers can await delivery.
+      // Resolve to true to preserve backward compatibility for await-and-branch patterns.
+      return sendChain.then(() => true as const);
+    },
     sendFinalReply: (payload) => enqueue("final", payload),
     waitForIdle: () => sendChain,
     getQueuedCounts: () => ({ ...queuedCounts }),

--- a/src/auto-reply/reply/reply-dispatcher.types.ts
+++ b/src/auto-reply/reply/reply-dispatcher.types.ts
@@ -4,7 +4,19 @@ export type ReplyDispatchKind = "tool" | "block" | "final";
 
 export type ReplyDispatcher = {
   sendToolResult: (payload: ReplyPayload) => boolean;
-  sendBlockReply: (payload: ReplyPayload) => boolean;
+  /**
+   * Enqueue a block reply for delivery.
+   *
+   * Returns `false` when the payload is dropped (empty/silent).
+   * Otherwise returns a `Promise<true>` that resolves when the queued delivery
+   * (and all preceding deliveries) complete.  Callers on the same-channel path
+   * should `await` this to guarantee the block text reaches the user before
+   * tool execution continues.
+   *
+   * Because a fulfilled `Promise` is truthy, existing boolean-style checks
+   * (`if (delivered)`) remain correct without changes.
+   */
+  sendBlockReply: (payload: ReplyPayload) => false | Promise<true>;
   sendFinalReply: (payload: ReplyPayload) => boolean;
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -83,7 +83,7 @@ describe("createReplyDispatcher", () => {
     const dispatcher = createReplyDispatcher({ deliver });
 
     dispatcher.sendToolResult({ text: "tool" });
-    dispatcher.sendBlockReply({ text: "block" });
+    void dispatcher.sendBlockReply({ text: "block" });
     dispatcher.sendFinalReply({ text: "final" });
 
     await dispatcher.waitForIdle();
@@ -146,11 +146,11 @@ describe("createReplyDispatcher", () => {
       humanDelay: { mode: "natural" },
     });
 
-    dispatcher.sendBlockReply({ text: "first" });
+    void dispatcher.sendBlockReply({ text: "first" });
     await Promise.resolve();
     expect(deliver).toHaveBeenCalledTimes(1);
 
-    dispatcher.sendBlockReply({ text: "second" });
+    void dispatcher.sendBlockReply({ text: "second" });
     await Promise.resolve();
     expect(deliver).toHaveBeenCalledTimes(1);
 
@@ -171,11 +171,11 @@ describe("createReplyDispatcher", () => {
       humanDelay: { mode: "custom", minMs: 1200, maxMs: 400 },
     });
 
-    dispatcher.sendBlockReply({ text: "first" });
+    void dispatcher.sendBlockReply({ text: "first" });
     await Promise.resolve();
     expect(deliver).toHaveBeenCalledTimes(1);
 
-    dispatcher.sendBlockReply({ text: "second" });
+    void dispatcher.sendBlockReply({ text: "second" });
     await vi.advanceTimersByTimeAsync(1199);
     expect(deliver).toHaveBeenCalledTimes(1);
 

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -105,6 +105,39 @@ describe("createReplyDispatcher", () => {
     expect(onIdle).toHaveBeenCalledTimes(1);
   });
 
+  it("sendBlockReply returns false for dropped payloads and a Promise for accepted ones", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    // Dropped payload returns false (empty text, no media).
+    expect(dispatcher.sendBlockReply({ text: "" })).toBe(false);
+    expect(dispatcher.sendBlockReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
+
+    // Accepted payload returns a Promise that resolves after delivery.
+    const result = dispatcher.sendBlockReply({ text: "hello" });
+    expect(result).not.toBe(false);
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaiting sendBlockReply guarantees delivery completes before continuation", async () => {
+    const order: string[] = [];
+    const deliver = vi.fn(async () => {
+      await Promise.resolve();
+      order.push("delivered");
+    });
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    const promise = dispatcher.sendBlockReply({ text: "block" });
+    expect(promise).not.toBe(false);
+    await promise;
+    order.push("continued");
+
+    // "delivered" must come before "continued" because we awaited the promise.
+    expect(order).toEqual(["delivered", "continued"]);
+  });
+
   it("delays block replies after the first when humanDelay is natural", async () => {
     vi.useFakeTimers();
     const deliver = vi.fn().mockResolvedValue(undefined);

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -741,7 +741,7 @@ describe("gateway server chat", () => {
               sendBlockReply: (payload: {
                 text: string;
                 btw: { question: string };
-              }) => false | Promise<void>;
+              }) => false | Promise<true>;
               markComplete: () => void;
               waitForIdle: () => Promise<void>;
               getQueuedCounts: () => { final: number; block: number; tool: number };

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -738,7 +738,10 @@ describe("gateway server chat", () => {
         const [params] = args as [
           {
             dispatcher: {
-              sendBlockReply: (payload: { text: string; btw: { question: string } }) => boolean;
+              sendBlockReply: (payload: {
+                text: string;
+                btw: { question: string };
+              }) => false | Promise<void>;
               markComplete: () => void;
               waitForIdle: () => Promise<void>;
               getQueuedCounts: () => { final: number; block: number; tool: number };

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -748,11 +748,11 @@ describe("gateway server chat", () => {
             };
           },
         ];
-        params.dispatcher.sendBlockReply({
+        void params.dispatcher.sendBlockReply({
           text: "first chunk",
           btw: { question: "what changed?" },
         });
-        params.dispatcher.sendBlockReply({
+        void params.dispatcher.sendBlockReply({
           text: "second chunk",
           btw: { question: "what changed?" },
         });

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -741,7 +741,7 @@ describe("gateway server chat", () => {
               sendBlockReply: (payload: {
                 text: string;
                 btw: { question: string };
-              }) => false | Promise<true>;
+              }) => boolean | Promise<true>;
               markComplete: () => void;
               waitForIdle: () => Promise<void>;
               getQueuedCounts: () => { final: number; block: number; tool: number };

--- a/src/plugin-sdk/acp-runtime.test.ts
+++ b/src/plugin-sdk/acp-runtime.test.ts
@@ -37,7 +37,7 @@ const ctx = {
   cfg: {},
   dispatcher: {
     sendToolResult: () => false,
-    sendBlockReply: () => false,
+    sendBlockReply: () => false as const,
     sendFinalReply: () => false,
     waitForIdle: async () => {},
     getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -226,7 +226,7 @@ describe("resolveBundledPluginsDir", () => {
       },
       {
         expectedRelativeDir: "extensions",
-        execArgv: ["--import", "tsx"],
+        execArgv: ["--import", "tsx"] as string[],
       },
     ],
     [

--- a/src/plugins/wired-hooks-reply-dispatch.test.ts
+++ b/src/plugins/wired-hooks-reply-dispatch.test.ts
@@ -15,7 +15,7 @@ const replyDispatchCtx = {
   cfg: {},
   dispatcher: {
     sendToolResult: () => false,
-    sendBlockReply: () => false,
+    sendBlockReply: () => false as const,
     sendFinalReply: () => false,
     waitForIdle: async () => {},
     getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),


### PR DESCRIPTION
Fixes #32868.

`sendBlockReply` was fire-and-forget — block streaming text wasn't delivered before tool execution continued on the same channel.

**Changes:**
- `reply-dispatcher.ts`: `sendBlockReply` now returns `false | Promise<true>` (backward-compatible — `false` when skipped, Promise when delivering); clamp `humanDelay` to 10s ceiling
- `dispatch-from-config.ts`: `await` the block reply in same-channel TTS path
- `dispatch-acp-delivery.ts`: coerce new return type for delivered tracking
- Test mocks updated to match new type signature

**Excluded alternatives:**
- Cherry-pick from #61974: too many conflicts — main restructured related test files since that branch diverged
- Only change `dispatch-from-config.ts` without updating the type: TypeScript would error and mock types would mismatch
- Make `sendBlockReply` fully async (`Promise<boolean>`): forces all callers to deal with a Promise, even fire-and-forget paths; `false | Promise<true>` lets sync callers still check truthiness without awaiting
- Add a separate `sendBlockReplyAsync` method: more API surface to maintain, doesn't fix the root cause

Recreated from #61974 (closed due to dirty branch).