### PR TITLE
fix(ci): split core and sdk node test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,13 +565,6 @@ jobs:
             echo "OPENCLAW_VITEST_MAX_WORKERS=1" >> "$GITHUB_ENV"
           fi
 
-      - name: Download A2UI bundle artifact
-        if: matrix.task == 'test-core' || matrix.task == 'channels'
-        uses: actions/download-artifact@v8
-        with:
-          name: canvas-a2ui-bundle
-          path: src/canvas-host/a2ui/
-
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         if: github.event_name != 'pull_request' || matrix.task != 'compat-node22'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       checks_fast_extensions_matrix: ${{ steps.manifest.outputs.checks_fast_extensions_matrix }}
       run_checks: ${{ steps.manifest.outputs.run_checks }}
       checks_matrix: ${{ steps.manifest.outputs.checks_matrix }}
+      run_checks_sdk: ${{ steps.manifest.outputs.run_checks_sdk }}
+      checks_sdk_matrix: ${{ steps.manifest.outputs.checks_sdk_matrix }}
       run_extension_fast: ${{ steps.manifest.outputs.run_extension_fast }}
       extension_fast_matrix: ${{ steps.manifest.outputs.extension_fast_matrix }}
       run_check: ${{ steps.manifest.outputs.run_check }}
@@ -216,7 +218,7 @@ jobs:
             checks_matrix: createMatrix(
               runNode
                 ? [
-                    { check_name: "checks-node-test", runtime: "node", task: "test" },
+                    { check_name: "checks-node-test", runtime: "node", task: "test-core" },
                     { check_name: "checks-node-channels", runtime: "node", task: "channels" },
                     ...(isPush
                       ? [
@@ -230,6 +232,12 @@ jobs:
                         ]
                       : []),
                   ]
+                : [],
+            ),
+            run_checks_sdk: runNode,
+            checks_sdk_matrix: createMatrix(
+              runNode
+                ? [{ check_name: "checks-node-sdk", runtime: "node", task: "test-sdk" }]
                 : [],
             ),
             run_extension_fast: hasChangedExtensions,
@@ -515,8 +523,8 @@ jobs:
 
   checks:
     name: ${{ matrix.check_name }}
-    needs: [preflight, build-artifacts]
-    if: always() && needs.preflight.outputs.run_checks == 'true' && needs.build-artifacts.result == 'success'
+    needs: [preflight]
+    if: always() && needs.preflight.outputs.run_checks == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 60
     strategy:
@@ -544,27 +552,21 @@ jobs:
           use-sticky-disk: "false"
 
       - name: Configure Node test resources
-        if: (github.event_name != 'pull_request' || matrix.task != 'compat-node22') && matrix.runtime == 'node' && (matrix.task == 'test' || matrix.task == 'channels' || matrix.task == 'compat-node22')
+        if: (github.event_name != 'pull_request' || matrix.task != 'compat-node22') && matrix.runtime == 'node' && (matrix.task == 'test-core' || matrix.task == 'channels' || matrix.task == 'compat-node22')
         env:
           TASK: ${{ matrix.task }}
         run: |
           echo "OPENCLAW_VITEST_MAX_WORKERS=2" >> "$GITHUB_ENV"
-          if [ "$TASK" = "test" ]; then
+          if [ "$TASK" = "test-core" ]; then
             echo "OPENCLAW_TEST_PROJECTS_PARALLEL=6" >> "$GITHUB_ENV"
+            echo "OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP=core" >> "$GITHUB_ENV"
           fi
           if [ "$TASK" = "channels" ]; then
             echo "OPENCLAW_VITEST_MAX_WORKERS=1" >> "$GITHUB_ENV"
           fi
 
-      - name: Download dist artifact
-        if: matrix.task == 'test'
-        uses: actions/download-artifact@v8
-        with:
-          name: dist-build
-          path: dist/
-
       - name: Download A2UI bundle artifact
-        if: matrix.task == 'test' || matrix.task == 'channels'
+        if: matrix.task == 'test-core' || matrix.task == 'channels'
         uses: actions/download-artifact@v8
         with:
           name: canvas-a2ui-bundle
@@ -579,7 +581,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$TASK" in
-            test)
+            test-core)
               pnpm test
               ;;
             channels)
@@ -594,6 +596,66 @@ jobs:
               ;;
             *)
               echo "Unsupported checks task: $TASK" >&2
+              exit 1
+              ;;
+          esac
+
+  checks-sdk:
+    name: ${{ matrix.check_name }}
+    needs: [preflight, build-artifacts]
+    if: always() && needs.preflight.outputs.run_checks_sdk == 'true' && needs.build-artifacts.result == 'success'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.preflight.outputs.checks_sdk_matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: "${{ matrix.node_version || '24.x' }}"
+          cache-key-suffix: "${{ matrix.cache_key_suffix || 'node24' }}"
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Configure Node SDK test resources
+        if: matrix.runtime == 'node' && matrix.task == 'test-sdk'
+        run: |
+          echo "OPENCLAW_VITEST_MAX_WORKERS=2" >> "$GITHUB_ENV"
+          echo "OPENCLAW_TEST_PROJECTS_PARALLEL=6" >> "$GITHUB_ENV"
+          echo "OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP=sdk" >> "$GITHUB_ENV"
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: dist-build
+          path: dist/
+
+      - name: Download A2UI bundle artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: canvas-a2ui-bundle
+          path: src/canvas-host/a2ui/
+
+      - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
+        env:
+          TASK: ${{ matrix.task }}
+          NODE_OPTIONS: --max-old-space-size=6144
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$TASK" in
+            test-sdk)
+              pnpm test
+              ;;
+            *)
+              echo "Unsupported checks sdk task: $TASK" >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       checks_matrix: ${{ steps.manifest.outputs.checks_matrix }}
       run_checks_sdk: ${{ steps.manifest.outputs.run_checks_sdk }}
       checks_sdk_matrix: ${{ steps.manifest.outputs.checks_sdk_matrix }}
+      run_checks_sdk_extensions: ${{ steps.manifest.outputs.run_checks_sdk_extensions }}
+      checks_sdk_extensions_matrix: ${{ steps.manifest.outputs.checks_sdk_extensions_matrix }}
       run_extension_fast: ${{ steps.manifest.outputs.run_extension_fast }}
       extension_fast_matrix: ${{ steps.manifest.outputs.extension_fast_matrix }}
       run_check: ${{ steps.manifest.outputs.run_check }}
@@ -237,7 +239,20 @@ jobs:
             run_checks_sdk: runNode,
             checks_sdk_matrix: createMatrix(
               runNode
-                ? [{ check_name: "checks-node-sdk", runtime: "node", task: "test-sdk" }]
+                ? [{ check_name: "checks-node-sdk-contracts", runtime: "node", task: "test-sdk-contracts" }]
+                : [],
+            ),
+            run_checks_sdk_extensions: runNode,
+            checks_sdk_extensions_matrix: createMatrix(
+              runNode
+                ? createExtensionTestShards({
+                    shardCount: DEFAULT_EXTENSION_TEST_SHARD_COUNT,
+                  }).map((shard) => ({
+                    check_name: `checks-node-sdk-extensions-shard-${shard.index + 1}`,
+                    extensions_csv: shard.extensionIds.join(","),
+                    shard_index: shard.index + 1,
+                    task: "sdk-extensions-batch",
+                  }))
                 : [],
             ),
             run_extension_fast: hasChangedExtensions,
@@ -618,11 +633,11 @@ jobs:
           use-sticky-disk: "false"
 
       - name: Configure Node SDK test resources
-        if: matrix.runtime == 'node' && matrix.task == 'test-sdk'
+        if: matrix.runtime == 'node' && matrix.task == 'test-sdk-contracts'
         run: |
           echo "OPENCLAW_VITEST_MAX_WORKERS=2" >> "$GITHUB_ENV"
           echo "OPENCLAW_TEST_PROJECTS_PARALLEL=6" >> "$GITHUB_ENV"
-          echo "OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP=sdk" >> "$GITHUB_ENV"
+          echo "OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP=sdk-contracts" >> "$GITHUB_ENV"
 
       - name: Download dist artifact
         uses: actions/download-artifact@v8
@@ -644,7 +659,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$TASK" in
-            test-sdk)
+            test-sdk-contracts)
               pnpm test
               ;;
             *)
@@ -652,6 +667,50 @@ jobs:
               exit 1
               ;;
           esac
+
+  checks-sdk-extensions-shard:
+    name: ${{ matrix.check_name }}
+    needs: [preflight]
+    if: needs.preflight.outputs.run_checks_sdk_extensions == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.preflight.outputs.checks_sdk_extensions_matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Run sdk extension shard
+        env:
+          OPENCLAW_VITEST_MAX_WORKERS: 2
+          OPENCLAW_EXTENSION_BATCH: ${{ matrix.extensions_csv }}
+        run: pnpm test:extensions:batch -- "$OPENCLAW_EXTENSION_BATCH"
+
+  checks-sdk-extensions:
+    name: checks-node-sdk-extensions
+    needs: [preflight, checks-sdk-extensions-shard]
+    if: always() && needs.preflight.outputs.run_checks_sdk_extensions == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Verify sdk extension shards
+        env:
+          SHARD_RESULT: ${{ needs.checks-sdk-extensions-shard.result }}
+        run: |
+          if [ "$SHARD_RESULT" != "success" ]; then
+            echo "SDK extension shard checks failed: $SHARD_RESULT" >&2
+            exit 1
+          fi
 
   extension-fast:
     name: "extension-fast"

--- a/scripts/lib/changed-extensions.mjs
+++ b/scripts/lib/changed-extensions.mjs
@@ -70,8 +70,12 @@ function listChangedPaths(base, head = "HEAD") {
     .filter((line) => line.length > 0);
 }
 
-function hasExtensionPackage(extensionId) {
-  return fs.existsSync(path.join(repoRoot, BUNDLED_PLUGIN_ROOT_DIR, extensionId, "package.json"));
+function hasExtensionMetadata(extensionId) {
+  const extensionRoot = path.join(repoRoot, BUNDLED_PLUGIN_ROOT_DIR, extensionId);
+  return (
+    fs.existsSync(path.join(extensionRoot, "package.json")) ||
+    fs.existsSync(path.join(extensionRoot, "openclaw.plugin.json"))
+  );
 }
 
 export function listAvailableExtensionIds() {
@@ -84,7 +88,7 @@ export function listAvailableExtensionIds() {
     .readdirSync(extensionsDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
-    .filter((extensionId) => hasExtensionPackage(extensionId))
+    .filter((extensionId) => hasExtensionMetadata(extensionId))
     .toSorted((left, right) => left.localeCompare(right));
 }
 
@@ -102,14 +106,14 @@ export function detectChangedExtensionIds(changedPaths) {
     );
     if (extensionMatch) {
       const extensionId = extensionMatch[1];
-      if (hasExtensionPackage(extensionId)) {
+      if (hasExtensionMetadata(extensionId)) {
         extensionIds.add(extensionId);
       }
       continue;
     }
 
     const pairedCoreMatch = relativePath.match(/^src\/([^/]+)(?:\/|$)/);
-    if (pairedCoreMatch && hasExtensionPackage(pairedCoreMatch[1])) {
+    if (pairedCoreMatch && hasExtensionMetadata(pairedCoreMatch[1])) {
       extensionIds.add(pairedCoreMatch[1]);
     }
   }

--- a/scripts/lib/extension-test-plan.mjs
+++ b/scripts/lib/extension-test-plan.mjs
@@ -54,14 +54,18 @@ function countTestFiles(rootPath) {
 }
 
 function resolveExtensionDirectory(targetArg, cwd = process.cwd()) {
+  const hasExtensionMetadata = (rootDir) =>
+    fs.existsSync(path.join(rootDir, "package.json")) ||
+    fs.existsSync(path.join(rootDir, "openclaw.plugin.json"));
+
   if (targetArg) {
     const asGiven = path.resolve(cwd, targetArg);
-    if (fs.existsSync(path.join(asGiven, "package.json"))) {
+    if (hasExtensionMetadata(asGiven)) {
       return asGiven;
     }
 
     const byName = path.join(repoRoot, BUNDLED_PLUGIN_ROOT_DIR, targetArg);
-    if (fs.existsSync(path.join(byName, "package.json"))) {
+    if (hasExtensionMetadata(byName)) {
       return byName;
     }
 
@@ -74,7 +78,7 @@ function resolveExtensionDirectory(targetArg, cwd = process.cwd()) {
   while (true) {
     if (
       normalizeRelative(path.relative(repoRoot, current)).startsWith(BUNDLED_PLUGIN_PATH_PREFIX) &&
-      fs.existsSync(path.join(current, "package.json"))
+      hasExtensionMetadata(current)
     ) {
       return current;
     }

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -83,6 +83,7 @@ const UI_VITEST_CONFIG = "vitest.ui.config.ts";
 const UTILS_VITEST_CONFIG = "vitest.utils.config.ts";
 const WIZARD_VITEST_CONFIG = "vitest.wizard.config.ts";
 const INCLUDE_FILE_ENV_KEY = "OPENCLAW_VITEST_INCLUDE_FILE";
+const FULL_SUITE_GROUP_ENV_KEY = "OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP";
 const CHANGED_ARGS_PATTERN = /^--changed(?:=(.+))?$/u;
 const VITEST_CONFIG_BY_KIND = {
   acp: ACP_VITEST_CONFIG,
@@ -620,7 +621,16 @@ export function buildFullSuiteVitestRunPlans(args, cwd = process.cwd()) {
     ];
   }
   const expandToProjectConfigs = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS === "1";
-  return fullSuiteVitestShards.flatMap((shard) => {
+  const requestedGroup = process.env[FULL_SUITE_GROUP_ENV_KEY];
+  if (requestedGroup && requestedGroup !== "core" && requestedGroup !== "sdk") {
+    throw new Error(
+      `${FULL_SUITE_GROUP_ENV_KEY} must be "core" or "sdk", got ${JSON.stringify(requestedGroup)}`,
+    );
+  }
+  const shards = requestedGroup
+    ? fullSuiteVitestShards.filter((shard) => shard.group === requestedGroup)
+    : fullSuiteVitestShards;
+  return shards.flatMap((shard) => {
     const configs = expandToProjectConfigs ? shard.projects : [shard.config];
     return configs.map((config) => ({
       config,

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -622,14 +622,23 @@ export function buildFullSuiteVitestRunPlans(args, cwd = process.cwd()) {
   }
   const expandToProjectConfigs = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS === "1";
   const requestedGroup = process.env[FULL_SUITE_GROUP_ENV_KEY];
-  if (requestedGroup && requestedGroup !== "core" && requestedGroup !== "sdk") {
+  if (
+    requestedGroup &&
+    requestedGroup !== "core" &&
+    requestedGroup !== "sdk" &&
+    requestedGroup !== "sdk-contracts" &&
+    requestedGroup !== "sdk-extensions"
+  ) {
     throw new Error(
-      `${FULL_SUITE_GROUP_ENV_KEY} must be "core" or "sdk", got ${JSON.stringify(requestedGroup)}`,
+      `${FULL_SUITE_GROUP_ENV_KEY} must be "core", "sdk", "sdk-contracts", or "sdk-extensions", got ${JSON.stringify(requestedGroup)}`,
     );
   }
-  const shards = requestedGroup
-    ? fullSuiteVitestShards.filter((shard) => shard.group === requestedGroup)
-    : fullSuiteVitestShards;
+  const shards =
+    requestedGroup === "sdk"
+      ? fullSuiteVitestShards.filter((shard) => shard.group.startsWith("sdk"))
+      : requestedGroup
+        ? fullSuiteVitestShards.filter((shard) => shard.group === requestedGroup)
+        : fullSuiteVitestShards;
   return shards.flatMap((shard) => {
     const configs = expandToProjectConfigs ? shard.projects : [shard.config];
     return configs.map((config) => ({

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -69,7 +69,7 @@ function expectResolvedBundledDir(params: {
   bundledDirOverride?: string;
   disableBundledPlugins?: string;
   vitest?: string;
-  execArgv?: string[];
+  execArgv?: readonly string[];
 }) {
   vi.spyOn(process, "cwd").mockReturnValue(params.cwd);
   process.argv[1] = params.argv1 ?? "/usr/bin/env";
@@ -103,7 +103,7 @@ function expectResolvedBundledDirFromRoot(params: {
   bundledDirOverride?: string;
   vitest?: string;
   cwd?: string;
-  execArgv?: string[];
+  execArgv?: readonly string[];
 }) {
   expectResolvedBundledDir({
     cwd: params.cwd ?? params.repoRoot,
@@ -120,12 +120,14 @@ function expectInstalledBundledDirScenario(params: {
   cwd?: string;
   argv1?: string;
   bundledDirOverride?: string;
+  execArgv?: readonly string[];
 }) {
   expectResolvedBundledDirFromRoot({
     repoRoot: params.installedRoot,
     cwd: params.cwd ?? process.cwd(),
     ...(params.argv1 ? { argv1: params.argv1 } : {}),
     ...(params.bundledDirOverride ? { bundledDirOverride: params.bundledDirOverride } : {}),
+    ...(params.execArgv ? { execArgv: params.execArgv } : {}),
     expectedRelativeDir: path.join("dist", "extensions"),
   });
 }
@@ -136,6 +138,7 @@ function expectInstalledBundledDirScenarioCase(
     cwd?: string;
     argv1?: string;
     bundledDirOverride?: string;
+    execArgv?: readonly string[];
   },
 ) {
   expectInstalledBundledDirScenario(createScenario());

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -211,9 +211,20 @@ describe("scripts/test-extension.mjs", () => {
 
     expect(extensionIds).toContain("slack");
     expect(extensionIds).toContain("firecrawl");
+    expect(extensionIds).toContain("device-pair");
+    expect(extensionIds).toContain("phone-control");
     expect(extensionIds).toEqual(
       [...extensionIds].toSorted((left, right) => left.localeCompare(right)),
     );
+  });
+
+  it("resolves manifest-only bundled plugins onto the default extensions config", () => {
+    const plan = resolveExtensionTestPlan({ targetArg: "device-pair", cwd: process.cwd() });
+
+    expect(plan.extensionId).toBe("device-pair");
+    expect(plan.config).toBe("vitest.extensions.config.ts");
+    expect(plan.roots).toContain(bundledPluginRoot("device-pair"));
+    expect(plan.hasTests).toBe(true);
   });
 
   it("can fail safe to all extensions when the base revision is unavailable", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -196,6 +196,7 @@ describe("scripts/test-projects changed-target routing", () => {
 describe("scripts/test-projects full-suite sharding", () => {
   it("splits untargeted runs into fixed shard configs", () => {
     delete process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
+    delete process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
 
     expect(buildFullSuiteVitestRunPlans([], process.cwd()).map((plan) => plan.config)).toEqual([
       "vitest.full-core-unit-fast.config.ts",
@@ -207,8 +208,50 @@ describe("scripts/test-projects full-suite sharding", () => {
       "vitest.full-core-contracts.config.ts",
       "vitest.full-core-bundled.config.ts",
       "vitest.full-core-runtime.config.ts",
-      "vitest.full-agentic.config.ts",
+      "vitest.full-core-agentic.config.ts",
+      "vitest.full-sdk-surfaces.config.ts",
       "vitest.full-auto-reply.config.ts",
+      "vitest.full-extensions.config.ts",
+    ]);
+  });
+
+  it("can scope untargeted full-suite runs to the core-only lane", () => {
+    const previous = process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = "core";
+    const plans = buildFullSuiteVitestRunPlans([], process.cwd());
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    } else {
+      process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = previous;
+    }
+
+    expect(plans.map((plan) => plan.config)).toEqual([
+      "vitest.full-core-unit-fast.config.ts",
+      "vitest.full-core-unit-src.config.ts",
+      "vitest.full-core-unit-security.config.ts",
+      "vitest.full-core-unit-ui.config.ts",
+      "vitest.full-core-unit-support.config.ts",
+      "vitest.full-core-support-boundary.config.ts",
+      "vitest.full-core-runtime.config.ts",
+      "vitest.full-core-agentic.config.ts",
+      "vitest.full-auto-reply.config.ts",
+    ]);
+  });
+
+  it("can scope untargeted full-suite runs to the sdk-only lane", () => {
+    const previous = process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = "sdk";
+    const plans = buildFullSuiteVitestRunPlans([], process.cwd());
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    } else {
+      process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = previous;
+    }
+
+    expect(plans.map((plan) => plan.config)).toEqual([
+      "vitest.full-core-contracts.config.ts",
+      "vitest.full-core-bundled.config.ts",
+      "vitest.full-sdk-surfaces.config.ts",
       "vitest.full-extensions.config.ts",
     ]);
   });
@@ -216,6 +259,7 @@ describe("scripts/test-projects full-suite sharding", () => {
   it("can expand full-suite shards to project configs for perf experiments", () => {
     const previous = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
     process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS = "1";
+    delete process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
     const plans = buildFullSuiteVitestRunPlans([], process.cwd());
     if (previous === undefined) {
       delete process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -256,6 +256,38 @@ describe("scripts/test-projects full-suite sharding", () => {
     ]);
   });
 
+  it("can scope untargeted full-suite runs to sdk contracts only", () => {
+    const previous = process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = "sdk-contracts";
+    const plans = buildFullSuiteVitestRunPlans([], process.cwd());
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    } else {
+      process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = previous;
+    }
+
+    expect(plans.map((plan) => plan.config)).toEqual([
+      "vitest.full-core-contracts.config.ts",
+      "vitest.full-sdk-surfaces.config.ts",
+    ]);
+  });
+
+  it("can scope untargeted full-suite runs to sdk extensions only", () => {
+    const previous = process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = "sdk-extensions";
+    const plans = buildFullSuiteVitestRunPlans([], process.cwd());
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP;
+    } else {
+      process.env.OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP = previous;
+    }
+
+    expect(plans.map((plan) => plan.config)).toEqual([
+      "vitest.full-core-bundled.config.ts",
+      "vitest.full-extensions.config.ts",
+    ]);
+  });
+
   it("can expand full-suite shards to project configs for perf experiments", () => {
     const previous = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
     process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS = "1";

--- a/vitest.full-agentic.config.ts
+++ b/vitest.full-agentic.config.ts
@@ -1,7 +1,3 @@
-import { createProjectShardVitestConfig } from "./vitest.project-shard-config.ts";
-import { fullSuiteVitestShards } from "./vitest.test-shards.mjs";
+import config from "./vitest.full-core-agentic.config.ts";
 
-export default createProjectShardVitestConfig(
-  fullSuiteVitestShards.find((shard) => shard.config === "vitest.full-agentic.config.ts")
-    ?.projects ?? [],
-);
+export default config;

--- a/vitest.full-core-agentic.config.ts
+++ b/vitest.full-core-agentic.config.ts
@@ -1,0 +1,7 @@
+import { createProjectShardVitestConfig } from "./vitest.project-shard-config.ts";
+import { fullSuiteVitestShards } from "./vitest.test-shards.mjs";
+
+export default createProjectShardVitestConfig(
+  fullSuiteVitestShards.find((shard) => shard.config === "vitest.full-core-agentic.config.ts")
+    ?.projects ?? [],
+);

--- a/vitest.full-sdk-surfaces.config.ts
+++ b/vitest.full-sdk-surfaces.config.ts
@@ -1,0 +1,7 @@
+import { createProjectShardVitestConfig } from "./vitest.project-shard-config.ts";
+import { fullSuiteVitestShards } from "./vitest.test-shards.mjs";
+
+export default createProjectShardVitestConfig(
+  fullSuiteVitestShards.find((shard) => shard.config === "vitest.full-sdk-surfaces.config.ts")
+    ?.projects ?? [],
+);

--- a/vitest.test-shards.mjs
+++ b/vitest.test-shards.mjs
@@ -9,46 +9,55 @@ export const autoReplyReplySubtreeTestInclude = ["src/auto-reply/reply/**/*.test
 export const fullSuiteVitestShards = [
   {
     config: "vitest.full-core-unit-fast.config.ts",
+    group: "core",
     name: "core-unit-fast",
     projects: ["vitest.unit-fast.config.ts"],
   },
   {
     config: "vitest.full-core-unit-src.config.ts",
+    group: "core",
     name: "core-unit-src",
     projects: ["vitest.unit-src.config.ts"],
   },
   {
     config: "vitest.full-core-unit-security.config.ts",
+    group: "core",
     name: "core-unit-security",
     projects: ["vitest.unit-security.config.ts"],
   },
   {
     config: "vitest.full-core-unit-ui.config.ts",
+    group: "core",
     name: "core-unit-ui",
     projects: ["vitest.unit-ui.config.ts"],
   },
   {
     config: "vitest.full-core-unit-support.config.ts",
+    group: "core",
     name: "core-unit-support",
     projects: ["vitest.unit-support.config.ts"],
   },
   {
     config: "vitest.full-core-support-boundary.config.ts",
+    group: "core",
     name: "core-support-boundary",
     projects: ["vitest.boundary.config.ts", "vitest.tooling.config.ts"],
   },
   {
     config: "vitest.full-core-contracts.config.ts",
+    group: "sdk",
     name: "core-contracts",
     projects: ["vitest.contracts.config.ts"],
   },
   {
     config: "vitest.full-core-bundled.config.ts",
+    group: "sdk",
     name: "core-bundled",
     projects: ["vitest.bundled.config.ts"],
   },
   {
     config: "vitest.full-core-runtime.config.ts",
+    group: "core",
     name: "core-runtime",
     projects: [
       "vitest.infra.config.ts",
@@ -70,8 +79,9 @@ export const fullSuiteVitestShards = [
     ],
   },
   {
-    config: "vitest.full-agentic.config.ts",
-    name: "agentic",
+    config: "vitest.full-core-agentic.config.ts",
+    group: "core",
+    name: "core-agentic",
     projects: [
       "vitest.gateway.config.ts",
       "vitest.cli.config.ts",
@@ -79,6 +89,13 @@ export const fullSuiteVitestShards = [
       "vitest.commands.config.ts",
       "vitest.agents.config.ts",
       "vitest.daemon.config.ts",
+    ],
+  },
+  {
+    config: "vitest.full-sdk-surfaces.config.ts",
+    group: "sdk",
+    name: "sdk-surfaces",
+    projects: [
       "vitest.plugin-sdk-light.config.ts",
       "vitest.plugin-sdk.config.ts",
       "vitest.plugins.config.ts",
@@ -87,6 +104,7 @@ export const fullSuiteVitestShards = [
   },
   {
     config: "vitest.full-auto-reply.config.ts",
+    group: "core",
     name: "auto-reply",
     projects: [
       "vitest.auto-reply-core.config.ts",
@@ -96,6 +114,7 @@ export const fullSuiteVitestShards = [
   },
   {
     config: "vitest.full-extensions.config.ts",
+    group: "sdk",
     name: "extensions",
     projects: [
       "vitest.extension-acpx.config.ts",

--- a/vitest.test-shards.mjs
+++ b/vitest.test-shards.mjs
@@ -44,12 +44,16 @@ export const fullSuiteVitestShards = [
     projects: ["vitest.boundary.config.ts", "vitest.tooling.config.ts"],
   },
   {
+    // Historical config name; grouped under sdk because these tests exercise
+    // dist-sensitive plugin contracts rather than source-only core behavior.
     config: "vitest.full-core-contracts.config.ts",
     group: "sdk-contracts",
     name: "core-contracts",
     projects: ["vitest.contracts.config.ts"],
   },
   {
+    // Historical config name; grouped under sdk because bundled plugin loading
+    // depends on built/plugin-packaged surfaces rather than source-only core paths.
     config: "vitest.full-core-bundled.config.ts",
     group: "sdk-extensions",
     name: "core-bundled",

--- a/vitest.test-shards.mjs
+++ b/vitest.test-shards.mjs
@@ -45,13 +45,13 @@ export const fullSuiteVitestShards = [
   },
   {
     config: "vitest.full-core-contracts.config.ts",
-    group: "sdk",
+    group: "sdk-contracts",
     name: "core-contracts",
     projects: ["vitest.contracts.config.ts"],
   },
   {
     config: "vitest.full-core-bundled.config.ts",
-    group: "sdk",
+    group: "sdk-extensions",
     name: "core-bundled",
     projects: ["vitest.bundled.config.ts"],
   },
@@ -93,7 +93,7 @@ export const fullSuiteVitestShards = [
   },
   {
     config: "vitest.full-sdk-surfaces.config.ts",
-    group: "sdk",
+    group: "sdk-contracts",
     name: "sdk-surfaces",
     projects: [
       "vitest.plugin-sdk-light.config.ts",
@@ -114,7 +114,7 @@ export const fullSuiteVitestShards = [
   },
   {
     config: "vitest.full-extensions.config.ts",
-    group: "sdk",
+    group: "sdk-extensions",
     name: "extensions",
     projects: [
       "vitest.extension-acpx.config.ts",


### PR DESCRIPTION
## Summary

- Problem: `checks-node-test` mixes source-only core tests with dist-sensitive plugin/sdk tests, so the whole lane waits on `build-artifacts` and then runs one oversized `pnpm test` plan.
- Why it matters: the generic node test lane has become the slow pole even when the work is core-only.
- What changed: split the full-suite shards into core vs sdk groups, split the mixed `full-agentic` shard into `full-core-agentic` and `full-sdk-surfaces`, and split CI into a core node test job plus a separate sdk node test job.
- What did NOT change (scope boundary): windows/macOS job shapes, the actual test contents, and the dist-sensitive sdk/plugin coverage itself.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the current CI routing treats the whole linux node suite as one mixed lane, and the mixed `full-agentic` shard hides sdk/plugin work inside a broadly named bucket.
- Missing detection / guardrail: there was no planner-level notion of full-suite groups, so CI could not separate source-only core work from sdk/dist-sensitive work.
- Contributing context (if known): the old custom planner runtime was removed, but the replacement full-suite routing stayed monolithic.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/test-projects.test.ts`
- Scenario the test should lock in: full-suite plans expand into the new core/sdk shard order, and the `OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP` filter returns the correct subset.
- Why this is the smallest reliable guardrail: it exercises the planner that both `pnpm test` and CI rely on, without needing to run the entire suite.
- Existing test that already covers this (if any): `test/scripts/test-projects.test.ts`
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[checks-node-test] -> waits for build-artifacts -> runs mixed core+sdk pnpm test lane

After:
[checks-node-test] -> runs core-only pnpm test lane
[checks-node-sdk] -> waits for build-artifacts -> runs sdk/dist-sensitive pnpm test lane
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 local dev env
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run planner assertions against `buildFullSuiteVitestRunPlans` with no group, `core`, and `sdk`.
2. Run formatting on the touched workflow/planner files.
3. Inspect CI workflow routing for the new `checks-node-test` core lane and `checks-node-sdk` lane.

### Expected

- Core lane no longer needs `build-artifacts`.
- SDK lane still runs the dist-sensitive subset.
- Full-suite shard grouping is deterministic and test-covered.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: planner shard expansion, core-only and sdk-only group filtering, workflow split wiring, formatting.
- Edge cases checked: invalid `OPENCLAW_TEST_PROJECTS_FULL_SUITE_GROUP` now fails loudly.
- What you did **not** verify: full GitHub Actions execution of the new split lanes yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (Yes)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a dist-sensitive test could still be sitting in the core lane.
  - Mitigation: the shard split was done at the planner/config layer, and the sdk-heavy shards moved behind the dedicated sdk lane instead of just renaming jobs.
- Risk: CI status expectations may need to account for the new `checks-node-sdk` job.
  - Mitigation: the existing `checks-node-test` name stays in place for the core lane to minimize churn.
