### PR TITLE
fix(ui): preserve OpenRouter model prefix in dropdown values

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -29,6 +29,19 @@ describe("chat-model-ref helpers", () => {
     });
   });
 
+  it("keeps provider prefix for namespaced OpenRouter ids", () => {
+    expect(
+      buildChatModelOption({
+        id: "meta-llama/llama-3.3-70b-instruct",
+        name: "Llama 3.3 70B Instruct",
+        provider: "openrouter",
+      }),
+    ).toEqual({
+      value: "openrouter/meta-llama/llama-3.3-70b-instruct",
+      label: "meta-llama/llama-3.3-70b-instruct · openrouter",
+    });
+  });
+
   it("preserves already-qualified model refs without prepending provider", () => {
     expect(resolveServerChatModelValue("ollama/qwen3:30b", "openai-codex")).toBe(
       "ollama/qwen3:30b",

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -151,8 +151,11 @@ export function formatChatModelDisplay(value: string): string {
 
 export function buildChatModelOption(entry: ModelCatalogEntry): { value: string; label: string } {
   const provider = entry.provider?.trim();
+  const modelId = entry.id.trim();
+  const hasProviderPrefix =
+    !!provider && normalizeLowercaseStringOrEmpty(modelId).startsWith(`${normalizeLowercaseStringOrEmpty(provider)}/`);
   return {
-    value: buildQualifiedChatModelValue(entry.id, provider),
-    label: provider ? `${entry.id} · ${provider}` : entry.id,
+    value: provider && modelId && !hasProviderPrefix ? `${provider}/${modelId}` : modelId,
+    label: provider ? `${modelId} · ${provider}` : modelId,
   };
 }


### PR DESCRIPTION
## Summary
- Fix the Control UI model option builder so dropdown option values keep provider-qualified model IDs for namespaced models.
- Ensure OpenRouter entries like `meta-llama/llama-3.3-70b-instruct` are submitted as `openrouter/meta-llama/llama-3.3-70b-instruct`.

## Root Cause
- `buildChatModelOption` delegated to a helper that treated any slash in a model ID as already provider-qualified.
- OpenRouter catalog IDs are often namespaced (`meta-llama/...`) but not provider-prefixed, so the dropdown value was emitted without `openrouter/`.

## Changes
- `ui/src/ui/chat-model-ref.ts`: build option values by prefixing `provider/` unless the ID already starts with that provider prefix.
- `ui/src/ui/chat-model-ref.test.ts`: add regression coverage for namespaced OpenRouter model IDs.

## Test
- `pnpm test ui/src/ui/chat-model-ref.test.ts`
  - 11 passed

Closes #62405