### PR TITLE
fix(infra): use minimax.io for usage remains #63056

### DIFF
--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -243,7 +243,13 @@ export function registerMinimaxProviders(api: OpenClawPluginApi) {
     resolveReasoningOutputMode: () => resolveMinimaxReasoningOutputMode(),
     isModernModelRef: ({ modelId }) => isMiniMaxModernModelId(modelId),
     fetchUsageSnapshot: async (ctx) =>
-      await fetchMinimaxUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn),
+      await fetchMinimaxUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn, {
+        baseUrl:
+          (typeof ctx.config?.models?.providers?.[ctx.provider]?.baseUrl === "string"
+            ? ctx.config.models.providers[ctx.provider].baseUrl
+            : undefined) ??
+          (typeof ctx.env.MINIMAX_API_HOST === "string" ? ctx.env.MINIMAX_API_HOST : undefined),
+      }),
   });
 
   api.registerProvider({

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -8,9 +8,18 @@ async function expectMinimaxUsageResult(params: {
     plan?: string;
     windows: Array<{ label: string; usedPercent: number; resetAt?: number }>;
   };
+  baseUrl?: string;
 }) {
   const mockFetch = createProviderUsageFetch(async (_url, init) => {
-    expect(_url).toBe("https://api.minimax.io/v1/api/openplatform/coding_plan/remains");
+    const expectedOrigin = (() => {
+      const baseUrlRaw = params.baseUrl ?? "https://api.minimax.io/v1";
+      try {
+        return new URL(baseUrlRaw).origin;
+      } catch {
+        return "https://api.minimax.io";
+      }
+    })();
+    expect(_url).toBe(`${expectedOrigin}/v1/api/openplatform/coding_plan/remains`);
     expect(init?.method).toBe("GET");
     const headers = (init?.headers as Record<string, string> | undefined) ?? {};
     expect(headers.Authorization).toBe("Bearer key");
@@ -18,7 +27,7 @@ async function expectMinimaxUsageResult(params: {
     return makeResponse(200, params.payload);
   });
 
-  const result = await fetchMinimaxUsage("key", 5000, mockFetch);
+  const result = await fetchMinimaxUsage("key", 5000, mockFetch, { baseUrl: params.baseUrl });
   expect(result.plan).toBe(params.expected.plan);
   expect(result.windows).toEqual(params.expected.windows);
 }
@@ -254,5 +263,13 @@ describe("fetchMinimaxUsage", () => {
 
     const result = await fetchMinimaxUsage("key", 5000, mockFetch);
     expect(result.windows).toEqual([{ label: "1h", usedPercent: 20, resetAt: undefined }]);
+  });
+
+  it("derives the usage host from the configured baseUrl (CN endpoint)", async () => {
+    await expectMinimaxUsageResult({
+      baseUrl: "https://api.minimaxi.com/anthropic",
+      payload: { data: { used: 50, total: 100 } },
+      expected: { windows: [{ label: "5h", usedPercent: 50, resetAt: undefined }] },
+    });
   });
 });

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -10,6 +10,8 @@ async function expectMinimaxUsageResult(params: {
   };
 }) {
   const mockFetch = createProviderUsageFetch(async (_url, init) => {
+    expect(_url).toBe("https://api.minimax.io/v1/api/openplatform/coding_plan/remains");
+    expect(init?.method).toBe("GET");
     const headers = (init?.headers as Record<string, string> | undefined) ?? {};
     expect(headers.Authorization).toBe("Bearer key");
     expect(headers["MM-API-Source"]).toBe("OpenClaw");

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -372,7 +372,7 @@ export async function fetchMinimaxUsage(
   fetchFn: typeof fetch,
 ): Promise<ProviderUsageSnapshot> {
   const res = await fetchJson(
-    "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains",
+    "https://api.minimax.io/v1/api/openplatform/coding_plan/remains",
     {
       method: "GET",
       headers: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -372,8 +372,6 @@ export async function fetchMinimaxUsage(
   fetchFn: typeof fetch,
   options?: { baseUrl?: string },
 ): Promise<ProviderUsageSnapshot> {
-  // Keep this default aligned with extensions/minimax/model-definitions.ts
-  // (core infra must not import extension internals).
   const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
   const baseUrl = options?.baseUrl?.trim() || DEFAULT_MINIMAX_BASE_URL;
   const origin = (() => {
@@ -385,7 +383,7 @@ export async function fetchMinimaxUsage(
   })();
 
   const res = await fetchJson(
-    `${origin}/v1/api/openplatform/coding_plan/remains`,
+    `${origin}/api/openplatform/coding_plan/remains`,
     {
       method: "GET",
       headers: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -370,9 +370,22 @@ export async function fetchMinimaxUsage(
   apiKey: string,
   timeoutMs: number,
   fetchFn: typeof fetch,
+  options?: { baseUrl?: string },
 ): Promise<ProviderUsageSnapshot> {
+  // Keep this default aligned with extensions/minimax/model-definitions.ts
+  // (core infra must not import extension internals).
+  const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
+  const baseUrl = options?.baseUrl?.trim() || DEFAULT_MINIMAX_BASE_URL;
+  const origin = (() => {
+    try {
+      return new URL(baseUrl).origin;
+    } catch {
+      return "https://api.minimax.io";
+    }
+  })();
+
   const res = await fetchJson(
-    "https://api.minimax.io/v1/api/openplatform/coding_plan/remains",
+    `${origin}/v1/api/openplatform/coding_plan/remains`,
     {
       method: "GET",
       headers: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -383,7 +383,7 @@ export async function fetchMinimaxUsage(
   })();
 
   const res = await fetchJson(
-    `${origin}/api/openplatform/coding_plan/remains`,
+    `${origin}/v1/api/openplatform/coding_plan/remains`,
     {
       method: "GET",
       headers: {


### PR DESCRIPTION
## Summary

- Problem: MiniMax usage tracking called the `/v1/api/openplatform/coding_plan/remains` endpoint on the wrong host (`api.minimaxi.com`), which can lead to 404/invalid responses.
- Why it matters: `openclaw status --usage` should reliably show MiniMax quota snapshots when configured.
- What changed: Switched the MiniMax coding-plan remains endpoint to `api.minimax.io` and tightened the unit test to assert the request URL + HTTP method.
- What did NOT change (scope boundary): Response parsing and usage derivation logic are unchanged; request method remains `GET`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63056

## User-visible / Behavior Changes

- MiniMax usage snapshots now query `https://api.minimax.io/v1/api/openplatform/coding_plan/remains` (previously `api.minimaxi.com`).

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (Yes) — same path/method, corrected host only.
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Steps

1. Configure MiniMax usage tracking as usual (API key redacted).
2. Run `openclaw status --usage`.

### Tests

- `pnpm test src/infra/provider-usage.fetch.minimax.test.ts`

## Risks and Mitigations

- Risk: If any environment depended on the previous host, usage fetch could change behavior.
  - Mitigation: The new host matches the documented/working endpoint; unit test now locks the URL + method.