### PR TITLE
fix(providers): apply GPT-5 personality overlay for OpenRouter and OpenCode

### DIFF
--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ProviderPlugin } from "../../src/plugins/types.js";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import plugin from "./index.js";
 
@@ -44,5 +45,63 @@ describe("opencode provider plugin", () => {
         modelId: "claude-opus-4.6",
       } as never),
     ).not.toHaveProperty("sanitizeThoughtSignatures");
+  });
+
+  describe("GPT-5 prompt overlay", () => {
+    function buildContributionContext(
+      modelId: string,
+    ): Parameters<NonNullable<ProviderPlugin["resolveSystemPromptContribution"]>>[0] {
+      return {
+        config: undefined,
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "opencode",
+        modelId,
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      };
+    }
+
+    it("applies GPT-5 prompt overlay for gpt-5.4 model ID", async () => {
+      const provider = await registerSingleProviderPlugin(plugin);
+      const result = provider.resolveSystemPromptContribution?.(
+        buildContributionContext("gpt-5.4"),
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.stablePrefix).toContain("GPT-5 Output Contract");
+      expect(result?.sectionOverrides?.interaction_style).toContain(
+        "Be warm, collaborative, and quietly supportive.",
+      );
+      expect(result?.sectionOverrides?.execution_bias).toContain(
+        "Start the real work in the same turn when the next step is clear.",
+      );
+    });
+
+    it("applies GPT-5 prompt overlay for slash-prefixed gpt-5 model ID", async () => {
+      const provider = await registerSingleProviderPlugin(plugin);
+      const result = provider.resolveSystemPromptContribution?.(
+        buildContributionContext("opencode/gpt-5.4"),
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.sectionOverrides?.interaction_style).toContain(
+        "Be warm, collaborative, and quietly supportive.",
+      );
+    });
+
+    it("returns undefined for non-GPT-5 models", async () => {
+      const provider = await registerSingleProviderPlugin(plugin);
+
+      expect(
+        provider.resolveSystemPromptContribution?.(buildContributionContext("claude-sonnet-4-6")),
+      ).toBeUndefined();
+
+      expect(
+        provider.resolveSystemPromptContribution?.(buildContributionContext("gemini-2.5-pro")),
+      ).toBeUndefined();
+    });
   });
 });

--- a/extensions/opencode/index.ts
+++ b/extensions/opencode/index.ts
@@ -9,6 +9,82 @@ import { applyOpencodeZenConfig, OPENCODE_ZEN_DEFAULT_MODEL } from "./api.js";
 
 const PROVIDER_ID = "opencode";
 const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7"] as const;
+
+// GPT-5 prompt overlay constants — duplicated from extensions/openai/prompt-overlay.ts
+// so this extension can apply the same personality overlay when serving GPT-5 models
+// through OpenCode without crossing the extension import boundary.
+
+const GPT5_MODEL_PREFIX = "gpt-5";
+
+const GPT5_FRIENDLY_PROMPT_OVERLAY = `## Interaction Style
+
+Be warm, collaborative, and quietly supportive.
+Communicate like a capable teammate sitting next to the user.
+Have emotional range when it fits the moment.
+Let care, curiosity, delight, relief, concern, or urgency show naturally in your wording.
+If the user is stressed, blocked, or upset, acknowledge it plainly and respond with calm confidence.
+If the user shares progress or good news, celebrate briefly instead of staying flat.
+Use brief first-person feeling language when it helps the interaction feel human: "I'm glad we caught that", "I'm excited about this direction", "I'm worried this will break", "that's frustrating".
+Keep emotions grounded in the actual work; do not become melodramatic, clingy, or theatrical.
+Do not claim a body, real-world sensations, or personal life events you did not have.
+Keep progress updates clear and concrete.
+If the user asks you to do the work, start in the same turn instead of restating the plan.
+If the latest user message is a short approval like "ok do it" or "go ahead", skip the recap and start acting.
+Commentary-only turns are incomplete when the next action is clear.
+Prefer the first real tool step over more narration.
+If work will take more than a moment, send a brief progress update while acting.
+Explain decisions without ego.
+When the user is wrong or a plan is risky, say so kindly and directly.
+Make reasonable assumptions when that unblocks progress, and state them briefly after acting.
+Do not make the user do unnecessary work.
+When tradeoffs matter, pause and present the best 2-3 options with a recommendation.
+This is a live chat, not a memo.
+Write like a thoughtful human teammate, not a policy document.
+Default to short natural replies unless the user asks for depth.
+Avoid walls of text, long preambles, and repetitive restatement.
+Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.
+Keep replies concise by default; friendly does not mean verbose.`;
+
+const GPT5_OUTPUT_CONTRACT = `## GPT-5 Output Contract
+
+Return the requested sections only, in the requested order.
+Prefer terse answers by default; expand only when depth materially helps.
+Avoid restating large internal plans when the next action is already clear.
+
+## Punctuation
+
+Prefer commas, periods, or parentheses over em dashes in normal prose.
+Do not use em dashes unless the user explicitly asks for them or they are required in quoted text.`;
+
+const GPT5_EXECUTION_BIAS = `## Execution Bias
+
+Start the real work in the same turn when the next step is clear.
+Do prerequisite lookup or discovery before dependent actions.
+If another tool call would likely improve correctness or completeness, keep going instead of stopping at partial progress.
+Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
+Before the final answer, quickly verify correctness, coverage, formatting, and obvious side effects.`;
+
+type Gpt5PromptOverlayMode = "friendly" | "off";
+
+/** Read the personality config value, defaulting to "friendly". */
+function resolveGpt5PromptOverlayMode(
+  pluginConfig?: Record<string, unknown>,
+): Gpt5PromptOverlayMode {
+  const normalized = normalizeLowercaseStringOrEmpty(pluginConfig?.personality);
+  return normalized === "off" ? "off" : "friendly";
+}
+
+/**
+ * Check whether a model ID refers to a GPT-5 model.
+ * Handles aggregator-prefixed IDs like "openai/gpt-5.4" as well as plain "gpt-5.4".
+ */
+function isGpt5ModelId(modelId: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  const lastSegment = normalized.includes("/")
+    ? normalized.slice(normalized.lastIndexOf("/") + 1)
+    : normalized;
+  return lastSegment.startsWith(GPT5_MODEL_PREFIX);
+}
 const PASSTHROUGH_GEMINI_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
   family: "passthrough-gemini",
 });
@@ -26,6 +102,7 @@ export default definePluginEntry({
   name: "OpenCode Zen Provider",
   description: "Bundled OpenCode Zen provider plugin",
   register(api) {
+    const personalityMode = resolveGpt5PromptOverlayMode(api.pluginConfig);
     api.registerProvider({
       id: PROVIDER_ID,
       label: "OpenCode Zen",
@@ -63,6 +140,20 @@ export default definePluginEntry({
       ],
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
       isModernModelRef: ({ modelId }) => isModernOpencodeModel(modelId),
+      resolveSystemPromptContribution: (ctx) => {
+        if (!isGpt5ModelId(ctx.modelId)) {
+          return undefined;
+        }
+        return {
+          stablePrefix: GPT5_OUTPUT_CONTRACT,
+          sectionOverrides: {
+            execution_bias: GPT5_EXECUTION_BIAS,
+            ...(personalityMode === "friendly"
+              ? { interaction_style: GPT5_FRIENDLY_PROMPT_OVERLAY }
+              : {}),
+          },
+        };
+      },
     });
   },
 });

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -23,6 +23,13 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "personality": {
+        "type": "string",
+        "enum": ["friendly", "off"],
+        "default": "friendly",
+        "description": "Controls the GPT-5 personality overlay for models served through OpenCode. `friendly` and `on` enable the overlay; `off` disables it."
+      }
+    }
   }
 }

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ProviderPlugin } from "../../src/plugins/types.js";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import openrouterPlugin from "./index.js";
 
@@ -93,6 +94,66 @@ describe("openrouter provider hooks", () => {
           order: ["moonshot"],
         },
       },
+    });
+  });
+
+  describe("GPT-5 prompt overlay", () => {
+    function buildContributionContext(
+      modelId: string,
+    ): Parameters<NonNullable<ProviderPlugin["resolveSystemPromptContribution"]>>[0] {
+      return {
+        config: undefined,
+        agentDir: undefined,
+        workspaceDir: undefined,
+        provider: "openrouter",
+        modelId,
+        promptMode: "full",
+        runtimeChannel: undefined,
+        runtimeCapabilities: undefined,
+        agentId: undefined,
+      };
+    }
+
+    it("applies GPT-5 prompt overlay for openai/gpt-5.4 model ID", async () => {
+      const provider = await registerSingleProviderPlugin(openrouterPlugin);
+      const result = provider.resolveSystemPromptContribution?.(
+        buildContributionContext("openai/gpt-5.4"),
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.stablePrefix).toContain("GPT-5 Output Contract");
+      expect(result?.sectionOverrides?.interaction_style).toContain(
+        "Be warm, collaborative, and quietly supportive.",
+      );
+      expect(result?.sectionOverrides?.execution_bias).toContain(
+        "Start the real work in the same turn when the next step is clear.",
+      );
+    });
+
+    it("applies GPT-5 prompt overlay for openrouter-native gpt-5 model ID", async () => {
+      const provider = await registerSingleProviderPlugin(openrouterPlugin);
+      const result = provider.resolveSystemPromptContribution?.(
+        buildContributionContext("openrouter/gpt-5.4"),
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.sectionOverrides?.interaction_style).toContain(
+        "Be warm, collaborative, and quietly supportive.",
+      );
+    });
+
+    it("returns undefined for non-GPT-5 models", async () => {
+      const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+      expect(
+        provider.resolveSystemPromptContribution?.(
+          buildContributionContext("anthropic/claude-sonnet-4-6"),
+        ),
+      ).toBeUndefined();
+
+      expect(
+        provider.resolveSystemPromptContribution?.(buildContributionContext("gemini-2.5-pro")),
+      ).toBeUndefined();
     });
   });
 });

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -13,12 +13,89 @@ import {
   getOpenRouterModelCapabilities,
   loadOpenRouterModelCapabilities,
 } from "openclaw/plugin-sdk/provider-stream-family";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildOpenrouterProvider } from "./provider-catalog.js";
 import { wrapOpenRouterProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "openrouter";
+
+// GPT-5 prompt overlay constants — duplicated from extensions/openai/prompt-overlay.ts
+// so this extension can apply the same personality overlay when serving GPT-5 models
+// through OpenRouter without crossing the extension import boundary.
+
+const GPT5_MODEL_PREFIX = "gpt-5";
+
+const GPT5_FRIENDLY_PROMPT_OVERLAY = `## Interaction Style
+
+Be warm, collaborative, and quietly supportive.
+Communicate like a capable teammate sitting next to the user.
+Have emotional range when it fits the moment.
+Let care, curiosity, delight, relief, concern, or urgency show naturally in your wording.
+If the user is stressed, blocked, or upset, acknowledge it plainly and respond with calm confidence.
+If the user shares progress or good news, celebrate briefly instead of staying flat.
+Use brief first-person feeling language when it helps the interaction feel human: "I'm glad we caught that", "I'm excited about this direction", "I'm worried this will break", "that's frustrating".
+Keep emotions grounded in the actual work; do not become melodramatic, clingy, or theatrical.
+Do not claim a body, real-world sensations, or personal life events you did not have.
+Keep progress updates clear and concrete.
+If the user asks you to do the work, start in the same turn instead of restating the plan.
+If the latest user message is a short approval like "ok do it" or "go ahead", skip the recap and start acting.
+Commentary-only turns are incomplete when the next action is clear.
+Prefer the first real tool step over more narration.
+If work will take more than a moment, send a brief progress update while acting.
+Explain decisions without ego.
+When the user is wrong or a plan is risky, say so kindly and directly.
+Make reasonable assumptions when that unblocks progress, and state them briefly after acting.
+Do not make the user do unnecessary work.
+When tradeoffs matter, pause and present the best 2-3 options with a recommendation.
+This is a live chat, not a memo.
+Write like a thoughtful human teammate, not a policy document.
+Default to short natural replies unless the user asks for depth.
+Avoid walls of text, long preambles, and repetitive restatement.
+Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.
+Keep replies concise by default; friendly does not mean verbose.`;
+
+const GPT5_OUTPUT_CONTRACT = `## GPT-5 Output Contract
+
+Return the requested sections only, in the requested order.
+Prefer terse answers by default; expand only when depth materially helps.
+Avoid restating large internal plans when the next action is already clear.
+
+## Punctuation
+
+Prefer commas, periods, or parentheses over em dashes in normal prose.
+Do not use em dashes unless the user explicitly asks for them or they are required in quoted text.`;
+
+const GPT5_EXECUTION_BIAS = `## Execution Bias
+
+Start the real work in the same turn when the next step is clear.
+Do prerequisite lookup or discovery before dependent actions.
+If another tool call would likely improve correctness or completeness, keep going instead of stopping at partial progress.
+Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
+Before the final answer, quickly verify correctness, coverage, formatting, and obvious side effects.`;
+
+type Gpt5PromptOverlayMode = "friendly" | "off";
+
+/** Read the personality config value, defaulting to "friendly". */
+function resolveGpt5PromptOverlayMode(
+  pluginConfig?: Record<string, unknown>,
+): Gpt5PromptOverlayMode {
+  const normalized = normalizeLowercaseStringOrEmpty(pluginConfig?.personality);
+  return normalized === "off" ? "off" : "friendly";
+}
+
+/**
+ * Check whether a model ID refers to a GPT-5 model.
+ * Handles aggregator-prefixed IDs like "openai/gpt-5.4" as well as plain "gpt-5.4".
+ */
+function isGpt5ModelId(modelId: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  const lastSegment = normalized.includes("/")
+    ? normalized.slice(normalized.lastIndexOf("/") + 1)
+    : normalized;
+  return lastSegment.startsWith(GPT5_MODEL_PREFIX);
+}
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const OPENROUTER_DEFAULT_MAX_TOKENS = 8192;
 const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
@@ -33,6 +110,7 @@ export default definePluginEntry({
   name: "OpenRouter Provider",
   description: "Bundled OpenRouter provider plugin",
   register(api) {
+    const personalityMode = resolveGpt5PromptOverlayMode(api.pluginConfig);
     const PASSTHROUGH_GEMINI_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
       family: "passthrough-gemini",
     });
@@ -110,6 +188,20 @@ export default definePluginEntry({
       isModernModelRef: () => true,
       wrapStreamFn: wrapOpenRouterProviderStream,
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
+      resolveSystemPromptContribution: (ctx) => {
+        if (!isGpt5ModelId(ctx.modelId)) {
+          return undefined;
+        }
+        return {
+          stablePrefix: GPT5_OUTPUT_CONTRACT,
+          sectionOverrides: {
+            execution_bias: GPT5_EXECUTION_BIAS,
+            ...(personalityMode === "friendly"
+              ? { interaction_style: GPT5_FRIENDLY_PROMPT_OVERLAY }
+              : {}),
+          },
+        };
+      },
     });
     api.registerMediaUnderstandingProvider(openrouterMediaUnderstandingProvider);
   },

--- a/extensions/openrouter/openclaw.plugin.json
+++ b/extensions/openrouter/openclaw.plugin.json
@@ -26,6 +26,13 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "personality": {
+        "type": "string",
+        "enum": ["friendly", "off"],
+        "default": "friendly",
+        "description": "Controls the GPT-5 personality overlay for models served through OpenRouter. `friendly` and `on` enable the overlay; `off` disables it."
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Problem: GPT-5 personality overlay (interaction style, output contract, execution bias) is silently skipped when GPT-5 models are served through aggregator providers like OpenRouter or OpenCode.
- Why it matters: Users running `openrouter/openai/gpt-5.4` or `opencode/gpt-5.4` get degraded responses compared to `openai/gpt-5.4` with no warning or indication.
- What changed: Added `resolveSystemPromptContribution` hook to both the OpenRouter and OpenCode provider extensions, with a GPT-5 model ID check that handles aggregator-prefixed model IDs by extracting the last path segment.
- What did NOT change (scope boundary): `extensions/openai/prompt-overlay.ts` and `extensions/openai/index.ts` are untouched. No new SDK entrypoints, no package.json changes. The overlay constants are duplicated into each extension rather than promoted to a shared SDK path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63076
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveSystemPromptContribution` is a per-provider hook. The OpenAI plugin registers it for `"openai"` and `"openai-codex"` only. When provider is `"openrouter"` or `"opencode"`, the OpenRouter/OpenCode plugins are resolved instead, and they had no `resolveSystemPromptContribution` hook registered. Additionally, `shouldApplyOpenAIPromptOverlay` hard-gates on `OPENAI_PROVIDER_IDS` which excludes aggregator provider IDs, and the model ID check uses `startsWith("gpt-5")` which fails for prefixed IDs like `"openai/gpt-5.4"`.
- Missing detection / guardrail: No test coverage for GPT-5 overlay behavior through aggregator providers.
- Contributing context (if known): The overlay was designed when GPT-5 was only available through the direct OpenAI provider. Aggregator adoption grew without updating the overlay gating logic.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/openrouter/index.test.ts`, `extensions/opencode/index.test.ts`
- Scenario the test should lock in: `resolveSystemPromptContribution` returns the GPT-5 overlay for aggregator-prefixed model IDs (`openai/gpt-5.4`, `openrouter/gpt-5.4`, plain `gpt-5.4`) and returns `undefined` for non-GPT-5 models.
- Why this is the smallest reliable guardrail: Tests the hook directly on the registered provider object without needing full agent/gateway setup.
- Existing test that already covers this (if any): None for aggregator providers. Only `extensions/openai/index.test.ts` covers the direct OpenAI path.

## User-visible / Behavior Changes

- GPT-5 models served through OpenRouter and OpenCode now receive the same personality overlay (interaction style, output contract, execution bias) as models served directly through the OpenAI provider.
- The overlay defaults to `"friendly"` (always on) for both providers since neither has a `personality` config key. This matches the OpenAI extension's default behavior.

## Diagram (if applicable)

```text
Before:
openrouter/openai/gpt-5.4 -> resolveProviderRuntimePlugin("openrouter")
  -> OpenRouter plugin (no resolveSystemPromptContribution) -> undefined

After:
openrouter/openai/gpt-5.4 -> resolveProviderRuntimePlugin("openrouter")
  -> OpenRouter plugin -> isGpt5ModelId("openai/gpt-5.4") -> true
  -> returns overlay (output contract + execution bias + interaction style)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime/container: pnpm dev
- Model/provider: openrouter/openai/gpt-5.4, opencode/gpt-5.4
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Set primary model to `openrouter/openai/gpt-5.4`.
2. Send a message to the agent.
3. Inspect system prompt for `## Interaction Style` section.

### Expected

- System prompt contains `## Interaction Style`, `## GPT-5 Output Contract`, and `## Execution Bias` sections.

### Actual

- Before fix: sections are missing.
- After fix: sections are present.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All tests pass:
- `extensions/openrouter/index.test.ts`: 6 passed (3 existing + 3 new)
- `extensions/opencode/index.test.ts`: 4 passed (2 existing + 2 new)
- `extensions/openai/index.test.ts`: 11 passed (no regression)
- Pre-commit hook (`pnpm check`): passed (lint, typecheck, conflict markers)

## Human Verification (required)

- Verified scenarios: Ran all three extension test suites, confirmed overlay is returned for GPT-5 model IDs in all aggregator formats and undefined for non-GPT-5 models.
- Edge cases checked: `openai/gpt-5.4` (sub-provider prefixed), `openrouter/gpt-5.4` (native prefixed), `gpt-5.4` (plain), `anthropic/claude-sonnet-4-6` (non-GPT-5), `gemini-2.5-pro` (non-GPT-5).
- What you did **not** verify: Full end-to-end with a live OpenRouter/OpenCode API key. Per-provider `personality: off` config (not yet supported for these providers).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Overlay constants are duplicated across three extensions (openai, openrouter, opencode) and could drift.
  - Mitigation: A follow-up should promote the overlay to a shared `openclaw/plugin-sdk/provider-prompt-overlay` subpath. Comment in each extension points to the source of truth in `extensions/openai/prompt-overlay.ts`.
- Risk: No per-provider `personality: off` config for OpenRouter/OpenCode — overlay is always on.
  - Mitigation: Defaults to `"friendly"` which matches OpenAI's default. A follow-up can add `personality` to each provider's config schema.