### PR TITLE
fix: guard loadState against array-typed state files

### DIFF
--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { PAIRING_SETUP_BOOTSTRAP_PROFILE } from "../shared/device-bootstrap-profile.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
@@ -910,5 +910,43 @@ describe("device pairing tokens", () => {
     await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(true);
     await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
     await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(false);
+  });
+
+  test("recovers from array-typed state files in pending.json and paired.json", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const { pendingPath, pairedPath, dir } = resolvePairingPaths(baseDir, "devices");
+    await mkdir(dir, { recursive: true });
+    await writeFile(pendingPath, "[]");
+    await writeFile(pairedPath, "[]");
+
+    const request = await requestDevicePairing(
+      {
+        deviceId: "device-array-recovery",
+        publicKey: "public-key-array-recovery",
+        role: "node",
+        scopes: [],
+      },
+      baseDir,
+    );
+    expect(request.created).toBe(true);
+
+    const result = await approveDevicePairing(
+      request.request.requestId,
+      { callerScopes: [] },
+      baseDir,
+    );
+    expect(result).toMatchObject({
+      status: "approved",
+      requestId: request.request.requestId,
+    });
+
+    const paired = await getPairedDevice("device-array-recovery", baseDir);
+    expect(paired).toBeDefined();
+    expect(paired?.deviceId).toBe("device-array-recovery");
+
+    const rawPending = JSON.parse(await readFile(pendingPath, "utf8"));
+    const rawPaired = JSON.parse(await readFile(pairedPath, "utf8"));
+    expect(Array.isArray(rawPending)).toBe(false);
+    expect(Array.isArray(rawPaired)).toBe(false);
   });
 });

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -108,8 +108,8 @@ async function loadState(baseDir?: string): Promise<DevicePairingStateFile> {
     readJsonFile<Record<string, PairedDevice>>(pairedPath),
   ]);
   const state: DevicePairingStateFile = {
-    pendingById: pending ?? {},
-    pairedByDeviceId: paired ?? {},
+    pendingById: pending && !Array.isArray(pending) ? pending : {},
+    pairedByDeviceId: paired && !Array.isArray(paired) ? paired : {},
   };
   pruneExpiredPending(state.pendingById, Date.now(), PENDING_TTL_MS);
   return state;


### PR DESCRIPTION
## Summary

- **Problem:** `loadState` in `device-pairing.ts` uses `pending ?? {}` to fall back to an empty object, but when `pending.json` or `paired.json` contains `[]` (an empty array), `??` does not trigger because arrays are truthy. UUID-keyed entries assigned to the resulting array are silently dropped by `JSON.stringify`, breaking device pairing approval.
- **Why it matters:** Docker Compose deployments where state files get initialized as `[]` cannot complete device pairing — `approveDevicePairing` always returns `null`.
- **What changed:** Replaced `pending ?? {}` with `pending && !Array.isArray(pending) ? pending : {}` (same for `paired`) so that array-shaped state files are normalized to `{}` on load. Added a regression test that seeds both files with `[]` and verifies the full request → approve → persist round-trip.
- **What did NOT change (scope boundary):** No changes to `readJsonFile`, `writeJsonAtomic`, or any other state file handling. Only the `loadState` function's fallback logic was tightened.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63035
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The nullish coalescing operator (`??`) only guards against `null`/`undefined`, not against unexpected value types like arrays. `[]` is truthy so `pending ?? {}` passes the array through.
- **Missing detection / guardrail:** No type assertion or shape validation on the parsed JSON before assigning to the typed state object.
- **Contributing context:** State files can end up as `[]` in Docker Compose deployments when the volume is initialized or reset.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/infra/device-pairing.test.ts`
- **Scenario the test should lock in:** When `pending.json` and `paired.json` both contain `[]`, `requestDevicePairing` → `approveDevicePairing` should succeed, and persisted files should contain objects (not arrays).
- **Why this is the smallest reliable guardrail:** A unit test at the `loadState` consumer level directly exercises the buggy code path with minimal setup.
- **Existing test that already covers this:** None.

## User-visible / Behavior Changes

Device pairing in Docker Compose deployments with array-typed state files will now succeed instead of silently failing.

## Diagram (if applicable)

```text
Before:
[readJsonFile returns []] -> [pending ?? {} → []] -> [UUID keys on array] -> [JSON.stringify drops keys] -> [approval fails]

After:
[readJsonFile returns []] -> [Array.isArray check → {}] -> [UUID keys on object] -> [JSON.stringify preserves keys] -> [approval succeeds]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (also affects Linux Docker)
- Runtime/container: Node.js / Docker Compose

### Steps

1. Ensure `devices/pending.json` and `devices/paired.json` contain `[]`
2. Run `requestDevicePairing` followed by `approveDevicePairing`
3. Observe result

### Expected

- `approveDevicePairing` returns `{ status: 'approved', ... }`

### Actual (before fix)

- `approveDevicePairing` returns `null`

## Evidence

- [x] Failing test/log before + passing after
- All 32 tests pass including the new regression test

## Human Verification (required)

- **Verified scenarios:** Full request → approve → persist round-trip with `[]`-typed state files
- **Edge cases checked:** Verified that normal `{}` state files still work (all 31 existing tests pass)
- **What you did not verify:** Production Docker Compose deployment end-to-end

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** If a state file somehow contains a non-array, non-object truthy value (e.g., a string), the `Array.isArray` check alone won't catch it.
  - **Mitigation:** `readJsonFile` is typed to return `Record<string, T> | null`, so non-object returns are already outside the expected contract. The `Array.isArray` guard handles the most likely failure mode.

---
<sub>🔧 Generated by [issue-to-pr](https://github.com/4yDX3906/issue-to-pr)</sub>