### PR TITLE
fix(device-pairing): coerce array-typed state files to plain objects in loadState

### DIFF
--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -911,4 +911,42 @@ describe("device pairing tokens", () => {
     await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
     await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(false);
   });
+
+  test("recovers from array-typed pending.json and paired.json (#63035)", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const { pendingPath, pairedPath } = resolvePairingPaths(baseDir, "devices");
+    const { mkdir } = await import("node:fs/promises");
+    const path = await import("node:path");
+    await mkdir(path.dirname(pendingPath), { recursive: true });
+
+    // Seed both state files with JSON arrays — the exact corruption from #63035
+    await writeFile(pendingPath, "[]\n");
+    await writeFile(pairedPath, "[]\n");
+
+    // A normal pairing request must succeed despite the corrupted files
+    const result = await requestDevicePairing(
+      { deviceId: "device-1", publicKey: "pk-1", role: "operator", scopes: ["operator.read"] },
+      baseDir,
+    );
+    expect(result.created).toBe(true);
+
+    // The pending request must survive a JSON round-trip (the core symptom of #63035)
+    const rawPending = JSON.parse(await readFile(pendingPath, "utf8"));
+    expect(Array.isArray(rawPending)).toBe(false);
+    expect(rawPending[result.request.requestId]).toBeDefined();
+
+    // Approve and verify the paired device persists correctly
+    await approveDevicePairing(
+      result.request.requestId,
+      { callerScopes: ["operator.read"] },
+      baseDir,
+    );
+    const paired = await getPairedDevice("device-1", baseDir);
+    expect(paired).not.toBeNull();
+    expect(paired?.deviceId).toBe("device-1");
+
+    const rawPaired = JSON.parse(await readFile(pairedPath, "utf8"));
+    expect(Array.isArray(rawPaired)).toBe(false);
+    expect(rawPaired["device-1"]).toBeDefined();
+  });
 });

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -6,6 +6,7 @@ import {
 } from "../shared/device-bootstrap-profile.js";
 import { resolveMissingRequestedScope, roleScopesAllow } from "../shared/operator-scope-compat.js";
 import {
+  coerceToRecord,
   createAsyncLock,
   pruneExpiredPending,
   readJsonFile,
@@ -108,8 +109,8 @@ async function loadState(baseDir?: string): Promise<DevicePairingStateFile> {
     readJsonFile<Record<string, PairedDevice>>(pairedPath),
   ]);
   const state: DevicePairingStateFile = {
-    pendingById: pending ?? {},
-    pairedByDeviceId: paired ?? {},
+    pendingById: coerceToRecord<DevicePairingPendingRequest>(pending),
+    pairedByDeviceId: coerceToRecord<PairedDevice>(paired),
   };
   pruneExpiredPending(state.pendingById, Date.now(), PENDING_TTL_MS);
   return state;

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -3,6 +3,7 @@ import { resolveMissingRequestedScope } from "../shared/operator-scope-compat.js
 import { normalizeArrayBackedTrimmedStringList } from "../shared/string-normalization.js";
 import { type NodeApprovalScope, resolveNodePairApprovalScopes } from "./node-pairing-authz.js";
 import {
+  coerceToRecord,
   createAsyncLock,
   pruneExpiredPending,
   readJsonFile,
@@ -138,8 +139,8 @@ async function loadState(baseDir?: string): Promise<NodePairingStateFile> {
     readJsonFile<Record<string, NodePairingPairedNode>>(pairedPath),
   ]);
   const state: NodePairingStateFile = {
-    pendingById: pending ?? {},
-    pairedByNodeId: paired ?? {},
+    pendingById: coerceToRecord<NodePairingPendingRequest>(pending),
+    pairedByNodeId: coerceToRecord<NodePairingPairedNode>(paired),
   };
   pruneExpiredPending(state.pendingById, Date.now(), PENDING_TTL_MS);
   return state;

--- a/src/infra/pairing-files.test.ts
+++ b/src/infra/pairing-files.test.ts
@@ -1,10 +1,53 @@
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  coerceToRecord,
   pruneExpiredPending,
   reconcilePendingPairingRequests,
   resolvePairingPaths,
 } from "./pairing-files.js";
+
+describe("coerceToRecord", () => {
+  it("returns an empty object for null", () => {
+    expect(coerceToRecord(null)).toEqual({});
+  });
+
+  it("returns an empty object for undefined", () => {
+    expect(coerceToRecord(undefined)).toEqual({});
+  });
+
+  it("returns an empty object for an array (the #63035 root cause)", () => {
+    const result = coerceToRecord<{ id: string }>([]);
+    expect(result).toEqual({});
+    expect(Array.isArray(result)).toBe(false);
+
+    // Verify the fix: UUID keys survive JSON round-trip on the coerced object
+    const uuid = "4bf6458c-631f-44b2-ba9e-d27f3aa96e09";
+    result[uuid] = { id: uuid };
+    const roundTripped = JSON.parse(JSON.stringify(result));
+    expect(roundTripped[uuid]).toEqual({ id: uuid });
+  });
+
+  it("returns an empty object for a non-empty array", () => {
+    expect(coerceToRecord([1, 2, 3])).toEqual({});
+  });
+
+  it("returns an empty object for primitive values", () => {
+    expect(coerceToRecord("string")).toEqual({});
+    expect(coerceToRecord(42)).toEqual({});
+    expect(coerceToRecord(true)).toEqual({});
+  });
+
+  it("passes through a plain object unchanged", () => {
+    const obj = { key: { name: "value" } };
+    expect(coerceToRecord(obj)).toBe(obj);
+  });
+
+  it("passes through an empty object unchanged", () => {
+    const obj = {};
+    expect(coerceToRecord(obj)).toBe(obj);
+  });
+});
 
 describe("pairing file helpers", () => {
   it("resolves pairing file paths from explicit base dirs", () => {

--- a/src/infra/pairing-files.ts
+++ b/src/infra/pairing-files.ts
@@ -3,6 +3,22 @@ import { resolveStateDir } from "../config/paths.js";
 
 export { createAsyncLock, readJsonFile, writeJsonAtomic } from "./json-files.js";
 
+/**
+ * Coerce a value read from a JSON state file into a plain object map.
+ *
+ * `readJsonFile` may return any valid JSON value – including arrays – when the
+ * persisted file was corrupted or written by an incompatible version.  Callers
+ * that expect `Record<string, T>` must guard against non-object / array inputs
+ * so that subsequent property assignments are not silently dropped by
+ * `JSON.stringify` (which only serialises numeric-index entries for arrays).
+ */
+export function coerceToRecord<T>(value: unknown): Record<string, T> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, T>;
+}
+
 export function resolvePairingPaths(baseDir: string | undefined, subdir: string) {
   const root = baseDir ?? resolveStateDir();
   const dir = path.join(root, subdir);


### PR DESCRIPTION
### Summary

- **Problem**: `loadState()` in `src/infra/device-pairing.ts:111` and `src/infra/node-pairing.ts:141` uses nullish coalescing (`pending ?? {}`, `paired ?? {}`) to default the return value of `readJsonFile()`. When `pending.json` or `paired.json` contains a JSON array (`[]`) instead of an object, the array passes through because arrays are truthy in JavaScript. UUID-keyed pairing requests assigned onto the array are then silently dropped by `JSON.stringify()` on the next `persistState()` call (line 119), permanently destroying all device/node pairing state. Every Docker CLI command fails with `gateway closed (1008): pairing required`.

- **Root Cause**: `readJsonFile<T>()` in `src/infra/json-files.ts:26` is a generic JSON deserializer that returns whatever `JSON.parse()` produces — including arrays and primitives. The TypeScript generic `T` provides zero runtime safety (it uses `as T` cast). The `?? {}` guard in `loadState()` only catches `null` and `undefined`, not type mismatches. When the persisted file contains `[]`, the array is truthy, so `??` does not trigger. JavaScript silently accepts UUID string-key assignments on arrays (`arr["some-uuid"] = value` works in memory), but `JSON.stringify()` only serializes numeric-index entries for arrays, discarding all string-keyed data. This creates a permanent self-amplifying data-loss loop: `persistState()` writes `[]` back to disk, and every subsequent `loadState()` reads `[]` again. The sibling module `src/infra/device-bootstrap.ts` (line 136) already guards against this exact scenario with an explicit `Array.isArray()` check, but the pairing loaders were missing this validation.

- **Fix**: Introduce a shared, exported `coerceToRecord<T>(value: unknown): Record<string, T>` helper in `src/infra/pairing-files.ts` that rejects `null`, `undefined`, arrays, and primitive values, returning `{}` for any non-plain-object input. Replace `?? {}` with `coerceToRecord()` in both `device-pairing.ts` and `node-pairing.ts` `loadState()` functions. This approach avoids side effects because: (1) it follows the existing project pattern in `device-bootstrap.ts`; (2) it does not modify the generic `readJsonFile()` or `writeJsonAtomic()` utilities used by 20+ callers; (3) for valid `Record<string, T>` inputs it returns the original object reference with zero overhead; (4) the fix is self-healing — the first `loadState()` coerces `[]` to `{}`, and the next `persistState()` writes a valid object back to disk, permanently repairing the corrupted file.

- **What changed**:
  - `src/infra/pairing-files.ts` — added exported `coerceToRecord<T>()` helper with JSDoc (+16 lines)
  - `src/infra/device-pairing.ts` — imported `coerceToRecord`, replaced `pending ?? {}` and `paired ?? {}` with `coerceToRecord(pending)` and `coerceToRecord(paired)` in `loadState()` (+3/-2 lines)
  - `src/infra/node-pairing.ts` — identical change to its `loadState()` (+3/-2 lines)
  - `src/infra/pairing-files.test.ts` — added 7 unit tests for `coerceToRecord` covering null, undefined, empty array, non-empty array, primitives, plain object pass-through, empty object pass-through (+43 lines)
  - `src/infra/device-pairing.test.ts` — added 1 integration test that seeds `[]` into both state files and verifies full request-approve-persist round-trip with JSON round-trip validation (+38 lines)

- **What did NOT change (scope boundary)**: `readJsonFile()` and `writeJsonAtomic()` in `json-files.ts` are untouched — they are generic utilities and type validation is the caller's responsibility. `persistState()` is unchanged. No changes to gateway handshake logic, CLI, auth flow, or any module outside `src/infra/`. No changes to `device-bootstrap.ts` (it already has its own guard). Total: 5 files changed, +103/-4 lines.

### Reproduction

1. Deploy OpenClaw v2026.4.8 via Docker Compose with gateway and CLI containers sharing a network namespace
2. Ensure `~/.openclaw/devices/pending.json` and `paired.json` contain `[]` instead of `{}` (can occur from version migration or corrupted init)
3. Run: `docker exec openclaw-openclaw-cli-1 /usr/local/bin/openclaw cron list`
4. Observe error: `gateway closed (1008): pairing required`
5. Gateway log shows: `closed before connect remote=127.0.0.1 code=1008 reason=pairing required`
6. Replace both files with `{}` and restart gateway — CLI works immediately (confirming root cause)

### Risk / Mitigation

- **Risk**: If any legitimate use case stores arrays in `pending.json` or `paired.json`, the data would be silently converted to an empty object.
- **Mitigation**: The pairing state schema (`DevicePairingStateFile`, `NodePairingStateFile`) explicitly defines `pendingById` and `pairedByDeviceId`/`pairedByNodeId` as `Record<string, T>`. Arrays are never a valid state format. The sibling `device-bootstrap.ts` already applies the same coercion pattern in production without issues.

- **Risk**: `node-pairing.ts` change is not covered by a dedicated integration test.
- **Mitigation**: The shared `coerceToRecord()` function is thoroughly unit-tested with 7 cases. The `node-pairing.ts` `loadState()` is structurally identical to `device-pairing.ts` and calls the same shared helper. The device-pairing integration test validates the full pipeline end-to-end.

- **Risk**: Test coverage — 43 tests all pass (32 device-pairing + 11 pairing-files), zero regressions confirmed via `npx vitest run --config vitest.infra.config.ts`.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens
- [x] Memory / storage

### Linked Issue/PR

Fixes #63035
