### PR TITLE
fix(image-tool): read timeoutSeconds from config instead of hardcoded 30s

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1442,3 +1442,100 @@ describe("image tool response validation", () => {
     expect(text).toBe("hello");
   });
 });
+
+describe("image tool timeout config", () => {
+  it("forwards tools.media.image.timeoutSeconds to the describe call", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const capturedTimeoutMs: number[] = [];
+      const describeSpy = vi.fn(
+        async (params: ImageDescriptionRequest): Promise<{ text: string; model: string }> => {
+          capturedTimeoutMs.push(params.timeoutMs);
+          return { text: "described", model: params.model };
+        },
+      );
+      __testing.setProviderDepsForTest({
+        buildProviderRegistry: () => new Map(),
+        getMediaUnderstandingProvider: () => undefined,
+        describeImageWithModel: describeSpy,
+        describeImagesWithModel: vi.fn(async () => ({ text: "described", model: "m" })),
+        resolveAutoMediaKeyProviders: () => [],
+        resolveDefaultMediaModel: () => undefined,
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            imageModel: { primary: "openai/gpt-5.4-mini" },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              api: "openai-completions",
+              baseUrl: "https://api.openai.invalid/v1",
+              apiKey: "test-key",
+              models: [makeModelDefinition("gpt-5.4-mini", ["text", "image"])],
+            },
+          },
+        },
+        tools: { media: { image: { timeoutSeconds: 120 } } },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      await tool.execute("t1", {
+        prompt: "Describe the image.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+
+      expect(describeSpy).toHaveBeenCalledTimes(1);
+      expect(capturedTimeoutMs[0]).toBe(120_000);
+    });
+  });
+
+  it("uses the default 60s timeout when config is not set", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const capturedTimeoutMs: number[] = [];
+      const describeSpy = vi.fn(
+        async (params: ImageDescriptionRequest): Promise<{ text: string; model: string }> => {
+          capturedTimeoutMs.push(params.timeoutMs);
+          return { text: "described", model: params.model };
+        },
+      );
+      __testing.setProviderDepsForTest({
+        buildProviderRegistry: () => new Map(),
+        getMediaUnderstandingProvider: () => undefined,
+        describeImageWithModel: describeSpy,
+        describeImagesWithModel: vi.fn(async () => ({ text: "described", model: "m" })),
+        resolveAutoMediaKeyProviders: () => [],
+        resolveDefaultMediaModel: () => undefined,
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            imageModel: { primary: "openai/gpt-5.4-mini" },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              api: "openai-completions",
+              baseUrl: "https://api.openai.invalid/v1",
+              apiKey: "test-key",
+              models: [makeModelDefinition("gpt-5.4-mini", ["text", "image"])],
+            },
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      await tool.execute("t1", {
+        prompt: "Describe the image.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+
+      expect(describeSpy).toHaveBeenCalledTimes(1);
+      expect(capturedTimeoutMs[0]).toBe(60_000);
+    });
+  });
+});

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1444,6 +1444,10 @@ describe("image tool response validation", () => {
 });
 
 describe("image tool timeout config", () => {
+  afterEach(() => {
+    __testing.setProviderDepsForTest();
+  });
+
   it("forwards tools.media.image.timeoutSeconds to the describe call", async () => {
     await withTempAgentDir(async (agentDir) => {
       const capturedTimeoutMs: number[] = [];

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -2,10 +2,12 @@ import { resolve, isAbsolute } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  DEFAULT_TIMEOUT_SECONDS,
   resolveAutoMediaKeyProviders,
   resolveDefaultMediaModel,
 } from "../../media-understanding/defaults.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
+import { resolveTimeoutMs } from "../../media-understanding/resolve.js";
 import { buildProviderRegistry } from "../../media-understanding/runner.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import {
@@ -191,6 +193,10 @@ async function runImagePrompt(params: {
   const effectiveCfg = applyImageModelConfigDefaults(params.cfg, params.imageModelConfig);
   const providerCfg: OpenClawConfig = effectiveCfg ?? {};
   const providerRegistry = imageToolProviderDeps.buildProviderRegistry(undefined, providerCfg);
+  const timeoutMs = resolveTimeoutMs(
+    params.cfg?.tools?.media?.image?.timeoutSeconds,
+    DEFAULT_TIMEOUT_SECONDS.image,
+  );
 
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
@@ -216,7 +222,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -234,7 +240,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -251,7 +257,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });


### PR DESCRIPTION
## Summary

`runImagePrompt()` passes a hardcoded `timeoutMs: 30_000` to all three `describeImage` / `describeImages` call sites. The `tools.media.image.timeoutSeconds` config field has no effect on the image tool, even though the rest of the media-understanding pipeline (`runner.entries.ts`) already reads it via `resolveTimeoutMs()`.

Users with slower self-hosted models (LMStudio, Ollama, vLLM on modest hardware) see every image request abort at exactly 30s regardless of their configured timeout.

## Before

```
tools:
  media:
    image:
      timeoutSeconds: 120   # <-- ignored

→ image tool always aborts after 30s
→ "Image model failed: Request was aborted."
```

## After

```
tools:
  media:
    image:
      timeoutSeconds: 120   # <-- respected

→ image tool waits up to 120s
→ default without config: 60s (matches DEFAULT_TIMEOUT_SECONDS.image)
```

## What changed

- `src/agents/tools/image-tool.ts` — replaced three hardcoded `timeoutMs: 30_000` with a single `resolveTimeoutMs(cfg?.tools?.media?.image?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS.image)` call, reusing the same helpers the media-understanding runner already uses.
- `src/agents/tools/image-tool.test.ts` — two new tests: one verifying a configured 120s timeout is forwarded as 120 000 ms, one verifying the unconfigured default is 60 000 ms.

The unconfigured default also changes from 30s → 60s, aligning with `DEFAULT_TIMEOUT_SECONDS.image` which audio/video tools already use.

Closes #62944