### PR TITLE
fix(gateway): restore memory dreaming startup reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/tailscale: start Tailscale exposure and the gateway update check before awaiting channel and plugin sidecar startup so remote operators are not locked out when startup sidecars stall.
 - QQBot/streaming: make block streaming configurable per QQ bot account via `streaming.mode` (`"partial"` | `"off"`, default `"partial"`) instead of hardcoding it off, so responses can be delivered incrementally. (#63746)
 - Dreaming/gateway: require `operator.admin` for persistent `/dreaming on|off` changes and treat missing gateway client scopes as unprivileged instead of silently allowing config writes. (#63872) Thanks @mbelinky.
+- Gateway/plugins: include selected memory plugins in gateway startup loading and restore active plugin internal hooks after startup reset so memory-core startup reconciliation can recover managed dreaming cron reliably again. (#63097) Thanks @Mouvibe.
 
 ## 2026.4.9
 

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
+const registerInternalHookMock = vi.fn();
 const ensureOpenClawModelsJsonMock = vi.fn<
   (config: unknown, agentDir: unknown) => Promise<{ agentDir: string; wrote: boolean }>
 >(async () => ({ agentDir: "/tmp/agent", wrote: false }));
@@ -19,6 +20,16 @@ const resolveModelMock = vi.fn<
     api: "openai-codex-responses",
   },
 }));
+
+vi.mock("../hooks/internal-hooks.js", async () => {
+  const actual = await vi.importActual<typeof import("../hooks/internal-hooks.js")>(
+    "../hooks/internal-hooks.js",
+  );
+  return {
+    ...actual,
+    registerInternalHook: (...args: unknown[]) => registerInternalHookMock(...args),
+  };
+});
 
 vi.mock("../agents/agent-paths.js", () => ({
   resolveOpenClawAgentDir: () => "/tmp/agent",
@@ -40,17 +51,52 @@ vi.mock("../agents/pi-embedded-runner/model.js", () => ({
 }));
 
 let prewarmConfiguredPrimaryModel: typeof import("./server-startup.js").__testing.prewarmConfiguredPrimaryModel;
+let reRegisterPluginInternalHooks: typeof import("./server-startup.js").__testing.reRegisterPluginInternalHooks;
+
+function createPluginRegistryWithStartupHook(params?: {
+  status?: "loaded" | "error";
+  registerWhenHooksEnabled?: boolean;
+  handler?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    plugins: [{ id: "memory-core", status: params?.status ?? "loaded" }],
+    hooks: [
+      {
+        pluginId: "memory-core",
+        entry: {
+          hook: {
+            name: "memory-core-short-term-dreaming-cron",
+            description: "",
+            source: "openclaw-plugin",
+            pluginId: "memory-core",
+            filePath: "/tmp/memory-core.js",
+            baseDir: "/tmp",
+            handlerPath: "/tmp/memory-core.js",
+          },
+          frontmatter: {},
+          metadata: { events: ["gateway:startup"] },
+          invocation: { enabled: true },
+        },
+        events: ["gateway:startup"],
+        handler: params?.handler ?? vi.fn(),
+        registerWhenHooksEnabled: params?.registerWhenHooksEnabled ?? true,
+        source: "/tmp/memory-core.js",
+      },
+    ],
+  } as never;
+}
 
 describe("gateway startup primary model warmup", () => {
   beforeAll(async () => {
     ({
-      __testing: { prewarmConfiguredPrimaryModel },
+      __testing: { prewarmConfiguredPrimaryModel, reRegisterPluginInternalHooks },
     } = await import("./server-startup.js"));
   });
 
   beforeEach(() => {
     ensureOpenClawModelsJsonMock.mockClear();
     resolveModelMock.mockClear();
+    registerInternalHookMock.mockClear();
   });
 
   it("prewarms an explicit configured primary model", async () => {
@@ -107,5 +153,49 @@ describe("gateway startup primary model warmup", () => {
 
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
     expect(resolveModelMock).not.toHaveBeenCalled();
+  });
+
+  it("re-registers plugin internal hooks after clear/load so gateway:startup hooks survive startup reset", () => {
+    const handler = vi.fn();
+    const restored = reRegisterPluginInternalHooks(
+      createPluginRegistryWithStartupHook({ handler }),
+      {} as OpenClawConfig,
+    );
+
+    expect(restored).toBe(1);
+    expect(registerInternalHookMock).toHaveBeenCalledWith("gateway:startup", handler);
+  });
+
+  it("skips plugin hooks that were not active at initial registration time", () => {
+    const restored = reRegisterPluginInternalHooks(
+      createPluginRegistryWithStartupHook({ registerWhenHooksEnabled: false }),
+      {} as OpenClawConfig,
+    );
+
+    expect(restored).toBe(0);
+    expect(registerInternalHookMock).not.toHaveBeenCalled();
+  });
+
+  it("skips plugin hook restoration when internal hooks are currently disabled", () => {
+    const restored = reRegisterPluginInternalHooks(createPluginRegistryWithStartupHook(), {
+      hooks: {
+        internal: {
+          enabled: false,
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(restored).toBe(0);
+    expect(registerInternalHookMock).not.toHaveBeenCalled();
+  });
+
+  it("skips plugin hook restoration for plugins that failed to load", () => {
+    const restored = reRegisterPluginInternalHooks(
+      createPluginRegistryWithStartupHook({ status: "error" }),
+      {} as OpenClawConfig,
+    );
+
+    expect(restored).toBe(0);
+    expect(registerInternalHookMock).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -22,6 +22,7 @@ import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import {
   clearInternalHooks,
   createInternalHookEvent,
+  registerInternalHook,
   triggerInternalHook,
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
@@ -35,6 +36,31 @@ import {
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
+
+function reRegisterPluginInternalHooks(
+  pluginRegistry: ReturnType<typeof loadOpenClawPlugins>,
+  cfg: ReturnType<typeof loadConfig>,
+): number {
+  if (cfg.hooks?.internal?.enabled === false) {
+    return 0;
+  }
+  const loadedPluginIds = new Set(
+    pluginRegistry.plugins
+      .filter((plugin) => plugin.status === "loaded")
+      .map((plugin) => plugin.id),
+  );
+  let restored = 0;
+  for (const hook of pluginRegistry.hooks) {
+    if (!hook.handler || !hook.registerWhenHooksEnabled || !loadedPluginIds.has(hook.pluginId)) {
+      continue;
+    }
+    for (const event of hook.events) {
+      registerInternalHook(event, hook.handler);
+      restored += 1;
+    }
+  }
+  return restored;
+}
 
 async function prewarmConfiguredPrimaryModel(params: {
   cfg: ReturnType<typeof loadConfig>;
@@ -142,9 +168,14 @@ export async function startGatewaySidecars(params: {
     // Clear any previously registered hooks to ensure fresh loading
     clearInternalHooks();
     const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
-    if (loadedCount > 0) {
+    const restoredPluginHookCount = reRegisterPluginInternalHooks(
+      params.pluginRegistry,
+      params.cfg,
+    );
+    const totalHookCount = loadedCount + restoredPluginHookCount;
+    if (totalHookCount > 0) {
       params.logHooks.info(
-        `loaded ${loadedCount} internal hook handler${loadedCount > 1 ? "s" : ""}`,
+        `loaded ${totalHookCount} internal hook handler${totalHookCount > 1 ? "s" : ""}`,
       );
     }
   } catch (err) {
@@ -229,4 +260,5 @@ export async function startGatewaySidecars(params: {
 
 export const __testing = {
   prewarmConfiguredPrimaryModel,
+  reRegisterPluginInternalHooks,
 };

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -58,6 +58,15 @@ function createManifestRegistryFixture() {
         cliBackends: [],
       },
       {
+        id: "memory-core",
+        kind: "memory",
+        channels: [],
+        origin: "bundled",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "demo-global-sidecar",
         channels: [],
         origin: "global",
@@ -180,26 +189,33 @@ describe("resolveGatewayStartupPluginIds", () => {
         enabledPluginIds: ["voice-call"],
         modelId: "demo-cli/demo-model",
       }),
-      ["demo-channel", "browser", "voice-call"],
+      ["demo-channel", "browser", "voice-call", "memory-core"],
     ],
     [
       "keeps bundled startup sidecars with enabledByDefault at idle startup",
       {} as OpenClawConfig,
-      ["demo-channel", "browser"],
+      ["demo-channel", "browser", "memory-core"],
     ],
     [
       "keeps provider plugins out of idle startup when only provider config references them",
       createStartupConfig({
         providerIds: ["demo-provider"],
       }),
-      ["demo-channel", "browser"],
+      ["demo-channel", "browser", "memory-core"],
     ],
     [
       "includes explicitly enabled non-channel sidecars in startup scope",
       createStartupConfig({
         enabledPluginIds: ["demo-global-sidecar", "voice-call"],
       }),
-      ["demo-channel", "browser", "voice-call", "demo-global-sidecar"],
+      ["demo-channel", "browser", "voice-call", "memory-core", "demo-global-sidecar"],
+    ],
+    [
+      "includes explicitly enabled memory plugins in startup scope",
+      createStartupConfig({
+        enabledPluginIds: ["memory-core"],
+      }),
+      ["demo-channel", "browser", "memory-core"],
     ],
     [
       "keeps default-enabled startup sidecars when a restrictive allowlist permits them",
@@ -207,14 +223,14 @@ describe("resolveGatewayStartupPluginIds", () => {
         allowPluginIds: ["browser"],
         noConfiguredChannels: true,
       }),
-      ["browser"],
+      ["browser", "memory-core"],
     ],
     [
       "includes every configured channel plugin and excludes other channels",
       createStartupConfig({
         channelIds: ["demo-channel", "demo-other-channel"],
       }),
-      ["demo-channel", "demo-other-channel", "browser"],
+      ["demo-channel", "demo-other-channel", "browser", "memory-core"],
     ],
   ] as const)("%s", (_name, config, expected) => {
     expectStartupPluginIdsCase({ config, expected });
@@ -239,7 +255,7 @@ describe("resolveGatewayStartupPluginIds", () => {
     expectStartupPluginIdsCase({
       config: effectiveConfig,
       activationSourceConfig: rawConfig,
-      expected: ["demo-channel", "browser"],
+      expected: ["demo-channel", "browser", "memory-core"],
     });
   });
 });

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -28,6 +28,10 @@ function isGatewayStartupSidecar(plugin: PluginManifestRecord): boolean {
   return plugin.channels.length === 0 && !hasRuntimeContractSurface(plugin);
 }
 
+function isGatewayStartupMemoryPlugin(plugin: PluginManifestRecord): boolean {
+  return hasKind(plugin.kind, "memory");
+}
+
 export function resolveChannelPluginIds(params: {
   config: OpenClawConfig;
   workspaceDir?: string;
@@ -105,7 +109,7 @@ export function resolveGatewayStartupPluginIds(params: {
       if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
         return true;
       }
-      if (!isGatewayStartupSidecar(plugin)) {
+      if (!isGatewayStartupSidecar(plugin) && !isGatewayStartupMemoryPlugin(plugin)) {
         return false;
       }
       const activationState = resolveEffectivePluginActivationState({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { clearInternalHooks, getRegisteredEventKeys } from "../hooks/internal-hooks.js";
 import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
@@ -1478,8 +1479,133 @@ module.exports = { id: "throws-after-import", register() {} };`,
       "loaded",
     );
     expect(scoped.hooks.map((entry) => entry.entry.hook.name)).toEqual(["snapshot-hook"]);
+    expect(scoped.hooks[0]?.handler).toBeTypeOf("function");
+    expect(scoped.hooks[0]?.registerWhenHooksEnabled).toBe(true);
     expect(getRegisteredEventKeys()).toEqual([]);
 
+    clearInternalHooks();
+  });
+
+  it("restores cached plugin hooks using the current internal hook config", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "internal-hook-cache",
+      filename: "internal-hook-cache.cjs",
+      body: `module.exports = {
+        id: "internal-hook-cache",
+        register(api) {
+          api.registerHook("gateway:startup", () => {}, { name: "cache-hook" });
+        },
+      };`,
+    });
+    const enabledConfig = {
+      hooks: {
+        internal: {
+          enabled: true,
+        },
+      },
+      plugins: {
+        load: { paths: [plugin.file] },
+        allow: ["internal-hook-cache"],
+      },
+    } as OpenClawConfig;
+    const disabledConfig = {
+      hooks: {
+        internal: {
+          enabled: false,
+        },
+      },
+      plugins: {
+        load: { paths: [plugin.file] },
+        allow: ["internal-hook-cache"],
+      },
+    } as OpenClawConfig;
+    const {
+      __testing: { reRegisterPluginInternalHooks },
+    } = await import("../gateway/server-startup.js");
+
+    clearPluginLoaderCache();
+    clearInternalHooks();
+
+    const enabledRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: enabledConfig,
+    });
+    expect(getRegisteredEventKeys()).toEqual(["gateway:startup"]);
+
+    clearInternalHooks();
+
+    const disabledRegistry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: disabledConfig,
+    });
+    expect(disabledRegistry).toBe(enabledRegistry);
+
+    const disabledRestored = reRegisterPluginInternalHooks(disabledRegistry, disabledConfig);
+    expect(disabledRestored).toBe(0);
+    expect(getRegisteredEventKeys()).toEqual([]);
+
+    const enabledRestored = reRegisterPluginInternalHooks(disabledRegistry, enabledConfig);
+    expect(enabledRestored).toBe(1);
+    expect(getRegisteredEventKeys()).toEqual(["gateway:startup"]);
+
+    clearPluginLoaderCache();
+    clearInternalHooks();
+  });
+
+  it("does not restore hooks from plugins that failed during register", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "internal-hook-register-failure",
+      filename: "internal-hook-register-failure.cjs",
+      body: `module.exports = {
+        id: "internal-hook-register-failure",
+        register(api) {
+          api.registerHook("gateway:startup", () => {}, { name: "failed-hook" });
+          throw new Error("boom");
+        },
+      };`,
+    });
+    const config = {
+      hooks: {
+        internal: {
+          enabled: true,
+        },
+      },
+      plugins: {
+        load: { paths: [plugin.file] },
+        allow: ["internal-hook-register-failure"],
+      },
+    } as OpenClawConfig;
+    const {
+      __testing: { reRegisterPluginInternalHooks },
+    } = await import("../gateway/server-startup.js");
+
+    clearPluginLoaderCache();
+    clearInternalHooks();
+
+    const registry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config,
+    });
+
+    expect(
+      registry.plugins.find((entry) => entry.id === "internal-hook-register-failure"),
+    ).toMatchObject({
+      status: "error",
+      failurePhase: "register",
+      error: expect.stringContaining("boom"),
+    });
+    expect(registry.hooks.map((entry) => entry.entry.hook.name)).toEqual(["failed-hook"]);
+    expect(getRegisteredEventKeys()).toEqual(["gateway:startup"]);
+
+    clearInternalHooks();
+
+    const restored = reRegisterPluginInternalHooks(registry, config);
+    expect(restored).toBe(0);
+    expect(getRegisteredEventKeys()).toEqual([]);
+
+    clearPluginLoaderCache();
     clearInternalHooks();
   });
 

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -135,6 +135,8 @@ export type PluginHookRegistration = {
   pluginId: string;
   entry: HookEntry;
   events: string[];
+  handler?: import("../hooks/internal-hooks.js").InternalHookHandler;
+  registerWhenHooksEnabled: boolean;
   source: string;
   rootDir?: string;
 };

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -256,20 +256,24 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           invocation: { enabled: true },
         };
 
+    const hookSystemEnabled = config?.hooks?.internal?.enabled !== false;
+    const registerWhenHooksEnabled = opts?.register !== false;
+    const shouldRegister =
+      registryParams.activateGlobalSideEffects === true &&
+      hookSystemEnabled &&
+      registerWhenHooksEnabled;
+
     record.hookNames.push(name);
     registry.hooks.push({
       pluginId: record.id,
       entry: hookEntry,
       events: normalizedEvents,
+      handler,
+      registerWhenHooksEnabled,
       source: record.source,
     });
 
-    const hookSystemEnabled = config?.hooks?.internal?.enabled !== false;
-    if (
-      !registryParams.activateGlobalSideEffects ||
-      !hookSystemEnabled ||
-      opts?.register === false
-    ) {
+    if (!shouldRegister) {
       return;
     }
 

--- a/src/plugins/status.test-helpers.ts
+++ b/src/plugins/status.test-helpers.ts
@@ -94,6 +94,7 @@ export function createCustomHook(params: {
     pluginId: params.pluginId,
     events: params.events,
     source,
+    registerWhenHooksEnabled: true,
     entry: {
       hook: {
         name: params.name ?? "legacy",


### PR DESCRIPTION
## Summary
- include the selected memory plugin in gateway startup loading so `memory-core` startup reconciliation runs on clean restart
- preserve active plugin internal hooks across gateway startup hook reload without re-enabling hooks that were never active
- keep focused dreaming regressions around wrapped heartbeat triggers, fake-success detection, artifact evidence, narrative idempotency, and startup hook restoration

## Why
This rescues the core startup path behind the recent managed-dreaming reports on macOS and similar setups:
- `#62327`
- `#62920`
- `#63465`

Those reports all describe the same user-visible failure mode: dreaming is enabled in config, but the managed `Memory Dreaming Promotion` cron is never recreated after startup because the `memory-core` startup hook path does not reliably survive gateway startup reload.

`#63449` is only partially overlapping. This PR should help if the job is missing because startup reconciliation never ran, but it does not attempt to fix cron-store corruption / backup-restore behavior.

## Validation
Passed focused regression coverage:
- `corepack pnpm exec vitest run --config vitest.config.ts src/plugins/loader.test.ts -t 'does not register internal hooks globally during non-activating loads' --reporter=verbose`
- `corepack pnpm exec vitest run --config vitest.config.ts src/plugins/channel-plugin-ids.test.ts src/gateway/server-startup.test.ts extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-narrative.test.ts src/cron/service.wake.test.ts --reporter=verbose`

Additional gate status:
- `scripts/pr-prepare gates 63097` now passes changelog validation and `pnpm build`
- full `pnpm check` is still blocked by an unrelated baseline `tsgo` failure at `src/auto-reply/reply/followup-runner.test.ts:1140`, which is unchanged on this branch versus `origin/main`

## Related
- addresses `#62327`
- addresses `#62920`
- addresses `#63465`
- related to `#30257`
- partial overlap with `#63449`
