### PR TITLE
fix(discord): dedupe inbound deliveries across handler instances

### DIFF
--- a/extensions/discord/src/monitor.tool-result.test-helpers.ts
+++ b/extensions/discord/src/monitor.tool-result.test-helpers.ts
@@ -12,8 +12,10 @@ import {
   updateLastRouteMock,
   upsertPairingRequestMock,
 } from "./monitor.tool-result.test-harness.js";
-import { __resetDiscordInboundDedupeForTest } from "./monitor/message-handler.js";
-import { createDiscordMessageHandler } from "./monitor/message-handler.js";
+import {
+  __resetDiscordInboundDedupeForTest,
+  createDiscordMessageHandler,
+} from "./monitor/message-handler.js";
 import { __resetDiscordChannelInfoCacheForTest } from "./monitor/message-utils.js";
 import { createNoopThreadBindingManager } from "./monitor/thread-bindings.js";
 

--- a/extensions/discord/src/monitor.tool-result.test-helpers.ts
+++ b/extensions/discord/src/monitor.tool-result.test-helpers.ts
@@ -12,6 +12,7 @@ import {
   updateLastRouteMock,
   upsertPairingRequestMock,
 } from "./monitor.tool-result.test-harness.js";
+import { __resetDiscordInboundDedupeForTest } from "./monitor/message-handler.js";
 import { createDiscordMessageHandler } from "./monitor/message-handler.js";
 import { __resetDiscordChannelInfoCacheForTest } from "./monitor/message-utils.js";
 import { createNoopThreadBindingManager } from "./monitor/thread-bindings.js";
@@ -47,6 +48,7 @@ export const CATEGORY_GUILD_CFG = {
 } satisfies Config;
 
 export function resetDiscordToolResultHarness() {
+  __resetDiscordInboundDedupeForTest();
   installDiscordToolResultHarnessSpies();
   __resetDiscordChannelInfoCacheForTest();
   sendMock.mockClear().mockResolvedValue(undefined);

--- a/extensions/discord/src/monitor/inbound-worker.ts
+++ b/extensions/discord/src/monitor/inbound-worker.ts
@@ -1,4 +1,5 @@
 import { createRunStateMachine } from "openclaw/plugin-sdk/channel-lifecycle";
+import type { DedupeCache } from "openclaw/plugin-sdk/infra-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { danger, formatDurationSeconds } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
@@ -15,11 +16,12 @@ type DiscordInboundWorkerParams = {
   setStatus?: DiscordMonitorStatusSink;
   abortSignal?: AbortSignal;
   runTimeoutMs?: number;
+  inboundDedupeCache?: DedupeCache;
   __testing?: DiscordInboundWorkerTestingHooks;
 };
 
 export type DiscordInboundWorker = {
-  enqueue: (job: DiscordInboundJob) => void;
+  enqueue: (job: DiscordInboundJob, options?: { dedupeKey?: string | null }) => void;
   deactivate: () => void;
 };
 
@@ -165,7 +167,7 @@ export function createDiscordInboundWorker(
   });
 
   return {
-    enqueue(job) {
+    enqueue(job, options) {
       void runQueue
         .enqueue(job.queueKey, async () => {
           if (!runState.isActive()) {
@@ -174,6 +176,9 @@ export function createDiscordInboundWorker(
           runState.onRunStart();
           try {
             if (!runState.isActive()) {
+              return;
+            }
+            if (options?.dedupeKey && params.inboundDedupeCache?.check(options.dedupeKey)) {
               return;
             }
             await processDiscordInboundJob({

--- a/extensions/discord/src/monitor/message-handler.module-test-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.module-test-helpers.ts
@@ -1,13 +1,15 @@
 import type { MockFn } from "openclaw/plugin-sdk/testing";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
 import type { DiscordInboundWorkerTestingHooks } from "./inbound-worker.js";
 
 export const preflightDiscordMessageMock: MockFn = vi.fn();
 export const processDiscordMessageMock: MockFn = vi.fn();
 export const deliverDiscordReplyMock: MockFn = vi.fn(async () => undefined);
 
-const { createDiscordMessageHandler: createRealDiscordMessageHandler } =
-  await import("./message-handler.js");
+const {
+  createDiscordMessageHandler: createRealDiscordMessageHandler,
+  __resetDiscordInboundDedupeForTest,
+} = await import("./message-handler.js");
 type DiscordMessageHandlerParams = Parameters<typeof createRealDiscordMessageHandler>[0];
 type DiscordMessageHandlerTestingHooks = NonNullable<DiscordMessageHandlerParams["__testing"]>;
 type PreflightDiscordMessageHook = NonNullable<
@@ -17,6 +19,12 @@ type ProcessDiscordMessageHook = NonNullable<
   DiscordInboundWorkerTestingHooks["processDiscordMessage"]
 >;
 type DeliverDiscordReplyHook = NonNullable<DiscordInboundWorkerTestingHooks["deliverDiscordReply"]>;
+
+afterEach(() => {
+  __resetDiscordInboundDedupeForTest();
+});
+
+export { __resetDiscordInboundDedupeForTest };
 
 export function createDiscordMessageHandler(
   ...args: Parameters<typeof createRealDiscordMessageHandler>

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -266,7 +266,25 @@ describe("createDiscordMessageHandler queue behavior", () => {
     await vi.waitFor(() => {
       expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
     });
-    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets an active handler process the duplicate when another handler is already deactivated", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const handlerA = createHandlerWithDefaultPreflight();
+    const handlerB = createHandlerWithDefaultPreflight();
+    const duplicate = createMessageData("m-deactivated");
+
+    handlerA.deactivate();
+
+    await expect(handlerA(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await expect(handlerB(duplicate as never, {} as never)).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue", async () => {

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -252,6 +252,23 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
   });
 
+  it("drops duplicate inbound deliveries across distinct handler instances", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const handlerA = createHandlerWithDefaultPreflight();
+    const handlerB = createHandlerWithDefaultPreflight();
+    const duplicate = createMessageData("m-shared");
+
+    await expect(handlerA(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await expect(handlerB(duplicate as never, {} as never)).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+  });
+
   it("applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -4,7 +4,11 @@ import {
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
-import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  createDedupeCache,
+  resolveGlobalDedupeCache,
+  type DedupeCache,
+} from "openclaw/plugin-sdk/infra-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { buildDiscordInboundJob } from "./inbound-job.js";
 import {
@@ -34,7 +38,7 @@ type DiscordMessageHandlerParams = Omit<
 
 type DiscordMessageHandlerTestingHooks = DiscordInboundWorkerTestingHooks & {
   preflightDiscordMessage?: typeof preflightDiscordMessage;
-  inboundDedupeCache?: ReturnType<typeof resolveGlobalDedupeCache>;
+  inboundDedupeCache?: DedupeCache;
 };
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
@@ -87,10 +91,13 @@ export function createDiscordMessageHandler(
     setStatus: params.setStatus,
     abortSignal: params.abortSignal,
     runTimeoutMs: params.workerRunTimeoutMs,
+    inboundDedupeCache: params.__testing?.inboundDedupeCache ?? recentDiscordInboundMessages,
     __testing: params.__testing,
   });
-  const recentInboundMessages =
-    params.__testing?.inboundDedupeCache ?? recentDiscordInboundMessages;
+  const recentInboundMessages = createDedupeCache({
+    ttlMs: RECENT_DISCORD_MESSAGE_TTL_MS,
+    maxSize: RECENT_DISCORD_MESSAGE_MAX,
+  });
 
   const { debouncer } = createChannelInboundDebouncer<{
     data: DiscordMessageEvent;
@@ -151,7 +158,12 @@ export function createDiscordMessageHandler(
           return;
         }
         applyImplicitReplyBatchGate(ctx, params.replyToMode, false);
-        inboundWorker.enqueue(buildDiscordInboundJob(ctx));
+        inboundWorker.enqueue(buildDiscordInboundJob(ctx), {
+          dedupeKey: buildDiscordInboundDedupeKey({
+            accountId: params.accountId,
+            data: last.data,
+          }),
+        });
         return;
       }
       const combinedBaseText = entries
@@ -197,7 +209,12 @@ export function createDiscordMessageHandler(
           ctxBatch.MessageSidLast = ids[ids.length - 1];
         }
       }
-      inboundWorker.enqueue(buildDiscordInboundJob(ctx));
+      inboundWorker.enqueue(buildDiscordInboundJob(ctx), {
+        dedupeKey: buildDiscordInboundDedupeKey({
+          accountId: params.accountId,
+          data: last.data,
+        }),
+      });
     },
     onError: (err) => {
       params.runtime.error?.(danger(`discord debounce flush failed: ${String(err)}`));

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -4,7 +4,7 @@ import {
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
-import { createDedupeCache } from "openclaw/plugin-sdk/infra-runtime";
+import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/infra-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { buildDiscordInboundJob } from "./inbound-job.js";
 import {
@@ -34,6 +34,7 @@ type DiscordMessageHandlerParams = Omit<
 
 type DiscordMessageHandlerTestingHooks = DiscordInboundWorkerTestingHooks & {
   preflightDiscordMessage?: typeof preflightDiscordMessage;
+  inboundDedupeCache?: ReturnType<typeof resolveGlobalDedupeCache>;
 };
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
@@ -42,6 +43,12 @@ export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
 
 const RECENT_DISCORD_MESSAGE_TTL_MS = 5 * 60_000;
 const RECENT_DISCORD_MESSAGE_MAX = 5000;
+const RECENT_DISCORD_MESSAGE_CACHE_KEY = Symbol.for("openclaw.discord.recentInboundMessages");
+
+const recentDiscordInboundMessages = resolveGlobalDedupeCache(RECENT_DISCORD_MESSAGE_CACHE_KEY, {
+  ttlMs: RECENT_DISCORD_MESSAGE_TTL_MS,
+  maxSize: RECENT_DISCORD_MESSAGE_MAX,
+});
 
 function buildDiscordInboundDedupeKey(params: {
   accountId: string;
@@ -51,14 +58,14 @@ function buildDiscordInboundDedupeKey(params: {
   if (!messageId) {
     return null;
   }
-  const channelId = resolveDiscordMessageChannelId({
-    message: params.data.message,
-    eventChannelId: params.data.channel_id,
-  });
-  if (!channelId) {
-    return null;
-  }
-  return `${params.accountId}:${channelId}:${messageId}`;
+  // Discord message ids are globally unique snowflakes, so account + message id
+  // is enough to reject duplicate deliveries even when the same inbound message
+  // is observed by multiple handler instances or under different channel aliases.
+  return `${params.accountId}:${messageId}`;
+}
+
+export function __resetDiscordInboundDedupeForTest(): void {
+  recentDiscordInboundMessages.clear();
 }
 
 export function createDiscordMessageHandler(
@@ -82,10 +89,8 @@ export function createDiscordMessageHandler(
     runTimeoutMs: params.workerRunTimeoutMs,
     __testing: params.__testing,
   });
-  const recentInboundMessages = createDedupeCache({
-    ttlMs: RECENT_DISCORD_MESSAGE_TTL_MS,
-    maxSize: RECENT_DISCORD_MESSAGE_MAX,
-  });
+  const recentInboundMessages =
+    params.__testing?.inboundDedupeCache ?? recentDiscordInboundMessages;
 
   const { debouncer } = createChannelInboundDebouncer<{
     data: DiscordMessageEvent;


### PR DESCRIPTION
Closes #63027
## Summary

- Problem: Discord could send duplicate replies for a single inbound DM when the same inbound delivery reached more than one `createDiscordMessageHandler(...)` instance.
- Why it matters: One user message could trigger two reply paths, including an extra queued follow-up reply, which matches the behavior reported in #63027 and doubles token spend.
- What changed: Moved Discord inbound dedupe from handler-instance scope to a process-global cache, keyed by `accountId + messageId`, and added a regression test for duplicate delivery across distinct handler instances.
- What did NOT change (scope boundary): This PR does not change queue semantics, provider behavior, or the upstream listener lifecycle that may cause duplicate deliveries to appear in the first place.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63027
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/discord/src/monitor/message-handler.ts` created its inbound dedupe cache inside `createDiscordMessageHandler()`, so dedupe only worked within a single handler instance.
- Missing detection / guardrail: There was no regression test covering the same Discord `message.id` being delivered to two distinct handler instances.
- Contributing context (if known): Duplicate deliveries can happen when monitor/listener lifecycle overlap or reconnect paths surface the same inbound event more than once. The exact upstream trigger from the field report is still unknown, but this layer should have rejected the duplicate anyway.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/message-handler.queue.test.ts`
- Scenario the test should lock in: Two distinct Discord handlers receive the same inbound Discord message with the same `message.id`, and only one processing path runs.
- Why this is the smallest reliable guardrail: A single-handler test cannot catch this bug because the failure only appears when dedupe must span handler instances.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord inbound messages are no longer replied to twice when the same inbound delivery is observed by more than one handler instance in the same process.
- In `queue mode: collect`, users should no longer see the extra queued follow-up reply that was caused by the duplicate second processing path.

## Diagram (if applicable)

```text
Before:
[one Discord inbound message]
  -> [handler A sees message.id = X] -> [reply path runs]
  -> [handler B sees message.id = X] -> [duplicate reply / queued follow-up]

After:
[one Discord inbound message]
  -> [handler A or B claims message.id = X in global dedupe cache]
  -> [reply path runs once]
  -> [duplicate delivery dropped]
```
## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local reproduction on macOS; original issue report says Linux
- Runtime/container: Node `v25.3.0`, pnpm `10.32.1`
- Model/provider: Not provider-specific; reproduced with mocked Discord inbound processing
- Integration/channel (if any): Discord DM
- Relevant config (redacted): Discord auto-reply enabled; queue mode `collect`

### Steps

1. Create two distinct `createDiscordMessageHandler(...)` instances.
2. Deliver the same inbound Discord event with the same `message.id` to both handlers.
3. Observe whether the message is processed once or twice.

### Expected

- One inbound Discord `message.id` should be processed once per process.

### Actual

- Before this fix, the same inbound Discord `message.id` was processed twice when it reached two handler instances, which could surface as a duplicate queued follow-up reply.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before fix:

- New regression scenario failed locally because one inbound Discord message id triggered `processDiscordMessageMock` 2 times instead of the expected 1 time.

After fix:

- `pnpm test extensions/discord/src/monitor/message-handler.queue.test.ts`
  - Test Files: `1` passed (`1`)
  - Tests: `16` passed (`16`)

- `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts`
  - Test Files: `1` passed (`1`)
  - Tests: `28` passed (`28`)

- `pnpm test extensions/discord/src/monitor/monitor.test.ts`
  - Test Files: `1` passed (`1`)
  - Tests: `22` passed (`22`)

- `pnpm test:extension discord`
  - Test Files: `112` passed (`112`)
  - Tests: `929` passed (`929`)

## Human Verification (required)

- Verified scenarios: Added and ran a regression test for duplicate delivery across distinct handler instances; reran the touched Discord handler/monitor test files; ran the recommended extension lane `pnpm test:extension discord`.
- Edge cases checked: Duplicate delivery within one handler instance; duplicate delivery across distinct handler instances; global dedupe state reset between tests so test isolation stays intact.
- What you did **not** verify: Live Discord DM behavior against a real account; Linux-specific runtime behavior; the exact upstream source of duplicate deliveries in the field; full-repo `pnpm build && pnpm check && pnpm test`.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: A process-global dedupe cache could suppress intentional reprocessing if the exact same Discord `message.id` were somehow replayed inside the TTL window.
  - Mitigation: Discord message ids are globally unique snowflakes, and the correct behavior for a single inbound message id is exactly-once processing per process. The cache is also bounded by TTL and `accountId`.

- Risk: A shared dedupe cache can leak across tests and create false positives.
  - Mitigation: Added `__resetDiscordInboundDedupeForTest()` and wired it into test helpers so each test starts from a clean dedupe state.

## AI Assistance
Made with Codex