### PR TITLE
fix(tools): add acp-only guidance to sessions_spawn streamTo parameter

### DIFF
--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -33,10 +33,11 @@ export function describeSessionsSendTool(): string {
 
 export function describeSessionsSpawnTool(): string {
   return [
-    'Spawn an isolated session with `runtime="subagent"` or `runtime="acp"`.',
+    'Spawn an isolated session with `runtime="subagent"` (default) or `runtime="acp"`.',
     '`mode="run"` is one-shot and `mode="session"` is persistent or thread-bound.',
     "Subagents inherit the parent workspace directory automatically.",
     "Use this when the work should happen in a fresh child session instead of the current one.",
+    'For subagent spawns, only pass task, agentId, and runTimeoutSeconds. Do not set streamTo or resumeSessionId — those require runtime="acp".',
   ].join(" ");
 }
 

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -37,7 +37,7 @@ export function describeSessionsSpawnTool(): string {
     '`mode="run"` is one-shot and `mode="session"` is persistent or thread-bound.',
     "Subagents inherit the parent workspace directory automatically.",
     "Use this when the work should happen in a fresh child session instead of the current one.",
-    'For subagent spawns, only pass task, agentId, and runTimeoutSeconds. Do not set streamTo or resumeSessionId — those require runtime="acp".',
+    'For subagent spawns, do not set streamTo or resumeSessionId — those require runtime="acp".',
   ].join(" ");
 }
 

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -325,4 +325,19 @@ describe("sessions_spawn tool", () => {
     expect(contentSchema?.type).toBe("string");
     expect(contentSchema?.maxLength).toBeUndefined();
   });
+
+  it("includes acp-only guidance in streamTo schema description", () => {
+    const tool = createSessionsSpawnTool();
+    const schema = tool.parameters as {
+      properties?: {
+        streamTo?: {
+          description?: string;
+        };
+      };
+    };
+
+    const description = schema.properties?.streamTo?.description ?? "";
+    expect(description).toContain("acp");
+    expect(description).toContain("subagent");
+  });
 });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -96,7 +96,10 @@ const SessionsSpawnToolSchema = Type.Object({
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
-  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
+  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS, {
+    description:
+      'Stream progress updates back to the parent session. Only supported for runtime="acp". Do not set this parameter when using runtime="subagent".',
+  }),
   lightContext: Type.Optional(
     Type.Boolean({
       description:


### PR DESCRIPTION
## Summary

- Add `description` to `streamTo` schema field in `sessions_spawn` tool, explicitly stating it requires `runtime="acp"` and must not be set for `runtime="subagent"`
- Update `describeSessionsSpawnTool()` to list which params are subagent-safe vs acp-only
- Add test verifying the schema description contains acp guidance

Closes #63120

## Context

LLMs using `sessions_spawn` consistently pass `streamTo: "parent"` even when `runtime` is `"subagent"`, because nothing in the schema tells them it's acp-only. This causes 100% spawn failures in multi-agent setups. Other acp-only params like `resumeSessionId` already have descriptions stating the requirement — `streamTo` was the only one missing this guidance.

## Test plan

- [x] Existing `sessions-spawn-tool.test.ts` tests pass (13/13)
- [x] New test verifies `streamTo` schema description mentions both "acp" and "subagent"
- [x] Manual verification: the runtime validation at L195 remains unchanged (defense in depth)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)