### PR TITLE
make port optional for TLS manual connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ Docs: https://docs.openclaw.ai
 - Agents/model resolution: keep explicit-model runtime comparisons on the configured workspace plugin registry, so workspace-installed providers do not silently fall back to stale explicit metadata during runtime model lookup.
 - Providers/Z.AI: default onboarding and endpoint detection to GLM-5.1 instead of GLM-5. (#61998) Thanks @serg0x.
 - Reply execution: prefer the active runtime snapshot over stale queued reply config during embedded reply and follow-up execution so SecretRef-backed reply turns stop crashing after secrets have already resolved. (#62693) Thanks @mbelinky.
+- Android/manual connect: allow blank port input only for TLS manual gateway endpoints so standard HTTPS Tailscale hosts default to `443` without silently changing cleartext manual connects. (#63134) Thanks @Tyler-RNG.
 
 ## 2026.4.5
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -464,14 +464,18 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
               colors = outlinedColors(),
             )
 
-            Text("Port", style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold), color = mobileTextSecondary)
+            Text(
+              if (manualTlsInput) "Port (optional, defaults to 443)" else "Port",
+              style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+              color = mobileTextSecondary,
+            )
             OutlinedTextField(
               value = manualPortInput,
               onValueChange = {
                 manualPortInput = it
                 validationText = null
               },
-              placeholder = { Text("18789", style = mobileBody, color = mobileTextTertiary) },
+              placeholder = { Text(if (manualTlsInput) "443" else "18789", style = mobileBody, color = mobileTextTertiary) },
               modifier = Modifier.fillMaxWidth(),
               singleLine = true,
               keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -235,7 +235,7 @@ internal fun gatewayEndpointValidationMessage(
       when (source) {
         GatewayEndpointInputSource.SETUP_CODE -> "Setup code has invalid gateway URL."
         GatewayEndpointInputSource.QR_SCAN -> "QR code did not contain a valid setup code."
-        GatewayEndpointInputSource.MANUAL -> "Enter a valid manual host and port to connect."
+        GatewayEndpointInputSource.MANUAL -> "Enter a valid manual endpoint to connect."
       }
   }
 }
@@ -244,8 +244,11 @@ internal fun composeGatewayManualUrl(hostInput: String, portInput: String, tls: 
   val host = hostInput.trim()
   if (host.isEmpty()) return null
   val portTrimmed = portInput.trim()
-  val defaultPort = if (tls) 443 else 18789
-  val port = if (portTrimmed.isEmpty()) defaultPort else portTrimmed.toIntOrNull() ?: return null
+  val port = if (portTrimmed.isEmpty()) {
+    if (tls) 443 else return null
+  } else {
+    portTrimmed.toIntOrNull() ?: return null
+  }
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
   return "$scheme://$host:$port"

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -242,8 +242,11 @@ internal fun gatewayEndpointValidationMessage(
 
 internal fun composeGatewayManualUrl(hostInput: String, portInput: String, tls: Boolean): String? {
   val host = hostInput.trim()
-  val port = portInput.trim().toIntOrNull() ?: return null
-  if (host.isEmpty() || port !in 1..65535) return null
+  if (host.isEmpty()) return null
+  val portTrimmed = portInput.trim()
+  val defaultPort = if (tls) 443 else 18789
+  val port = if (portTrimmed.isEmpty()) defaultPort else portTrimmed.toIntOrNull() ?: return null
+  if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
   return "$scheme://$host:$port"
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1148,11 +1148,15 @@ private fun GatewayStep(
               onboardingTextFieldColors(),
           )
 
-          Text("PORT", style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp), color = onboardingTextSecondary)
+          Text(
+            if (manualTls) "PORT (optional, defaults to 443)" else "PORT",
+            style = onboardingCaption1Style.copy(letterSpacing = 0.9.sp),
+            color = onboardingTextSecondary,
+          )
           OutlinedTextField(
             value = manualPort,
             onValueChange = onManualPortChange,
-            placeholder = { Text("18789", color = onboardingTextTertiary, style = onboardingBodyStyle) },
+            placeholder = { Text(if (manualTls) "443" else "18789", color = onboardingTextTertiary, style = onboardingBodyStyle) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -472,10 +472,10 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun composeGatewayManualUrlDefaultsPortTo18789WhenNoTlsAndPortBlank() {
+  fun composeGatewayManualUrlRejectsBlankPortWhenTlsIsOff() {
     val url = composeGatewayManualUrl("127.0.0.1", "", tls = false)
 
-    assertEquals("http://127.0.0.1:18789", url)
+    assertNull(url)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -464,6 +464,42 @@ class GatewayConfigResolverTest {
     assertEquals(false, resolved?.tls)
   }
 
+  @Test
+  fun composeGatewayManualUrlDefaultsPortTo443WhenTlsAndPortBlank() {
+    val url = composeGatewayManualUrl("mydevice.tail1234.ts.net", "", tls = true)
+
+    assertEquals("https://mydevice.tail1234.ts.net:443", url)
+  }
+
+  @Test
+  fun composeGatewayManualUrlDefaultsPortTo18789WhenNoTlsAndPortBlank() {
+    val url = composeGatewayManualUrl("127.0.0.1", "", tls = false)
+
+    assertEquals("http://127.0.0.1:18789", url)
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigManualAcceptsTailscaleHostWithoutPort() {
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = false,
+        setupCode = "",
+        savedManualHost = "",
+        savedManualPort = "",
+        savedManualTls = true,
+        manualHostInput = "mydevice.tail1234.ts.net",
+        manualPortInput = "",
+        manualTlsInput = true,
+        fallbackBootstrapToken = "",
+        fallbackToken = "",
+        fallbackPassword = "",
+      )
+
+    assertEquals("mydevice.tail1234.ts.net", resolved?.host)
+    assertEquals(443, resolved?.port)
+    assertEquals(true, resolved?.tls)
+  }
+
   private fun encodeSetupCode(payloadJson: String): String {
     return Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))
   }


### PR DESCRIPTION
 ## Summary   

  - **Problem:** Manual connect with TLS enabled required a port number even when connecting to a standard HTTPS host (e.g. Tailscale Serve on port 443)                                        - **Why it matters:** Users with Tailscale HTTPS setups (`mydevice.ts.net`) were blocked — leaving port blank silently failed with "Enter a valid host and port"
  - **What changed:** Port field now defaults to 443 (TLS) or 18789 (no TLS) when left blank; port label/placeholder updates to communicate this                                              
  - **What did NOT change:** Non-TLS connections, setup code flow, existing explicit port behavior — all unchanged

  ## Change Type

  - [x] Bug fix
  - [x] Feature

  ## Scope

  - [x] Gateway / orchestration
  - [x] UI / DX

  ## Linked Issue/PR

  - [ ] This PR fixes a bug or regression

  ## Root Cause

  - Root cause: `composeGatewayManualUrl()` called `toIntOrNull()` on the port input and returned `null` immediately if blank — no default was applied
  - Missing detection / guardrail: No test covered empty port input in the manual TLS path
  - Contributing context: Port was always required when the app only targeted LAN/emulator setups; Tailscale Serve HTTPS made the default-443 case common

  ## Regression Test Plan

  - Coverage level: [x] Unit test
  - Target test or file: `GatewayConfigResolverTest.kt`
  - Scenario: `composeGatewayManualUrl` with blank port + TLS returns a valid `https://host:443` URL; `resolveGatewayConnectConfig` resolves correctly for a Tailscale host with no port      
  entered
  - Why smallest reliable guardrail: The bug lived entirely in `composeGatewayManualUrl` — a unit test exercises the exact failure path
  - If no new test is added, why not: N/A — 3 new tests added

  ## User-visible / Behavior Changes

  - Port field is now optional when TLS is enabled; leaving it blank connects on port 443
  - Port label reads "Port (optional, defaults to 443)" and placeholder shows `443` when TLS toggle is on
  - No change when TLS is off — port still required, placeholder still `18789`

  ## Diagram

  ```text
  Before:
  [TLS on, port blank] -> composeGatewayManualUrl returns null -> "Enter a valid host and port"

  After:
  [TLS on, port blank] -> composeGatewayManualUrl defaults to 443 -> connect succeeds

  Security Impact

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Steps

  1. Open manual connect, toggle TLS on
  2. Enter a Tailscale host (e.g. mydevice.tail1234.ts.net), leave port blank
  3. Tap Connect

  Expected

  - Connects successfully on port 443

  Actual (before fix)

  - Fails with "Enter a valid manual host and port to connect"

  Evidence

  - 3 new unit tests pass: composeGatewayManualUrlDefaultsPortTo443WhenTlsAndPortBlank, composeGatewayManualUrlDefaultsPortTo18789WhenNoTlsAndPortBlank,
  resolveGatewayConnectConfigManualAcceptsTailscaleHostWithoutPort

  Human Verification

  - Verified scenarios: Tailscale HTTPS host connects with blank port; explicit port still works; LAN/emulator non-TLS flow unchanged
  - Edge cases checked: Port field with TLS off still requires a value; explicit port 443 with TLS still works
  - What I did not verify: Non-Tailscale public HTTPS hosts (expected to work identically)

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No