### PR TITLE
fix(agents,gateway): keep subagent announces in the original thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Docs: https://docs.openclaw.ai
 
 - Sandbox/security: auto-derive CDP source-range from Docker network gateway and refuse to start the socat relay without one, so peer containers cannot reach CDP unauthenticated. (#61404) Thanks @dims.
 - Daemon/launchd: keep `openclaw gateway stop` persistent without uninstalling the macOS LaunchAgent, re-enable it on explicit restart or repair, and harden launchd label handling. (#64447) Thanks @ngutman.
+- Agents/Slack: preserve threaded announce delivery when `sessions.list` rows lack stored thread metadata by falling back to the thread id encoded in the session key. (#63143) Thanks @mariosousa-finn.
 
 ## 2026.4.9
 

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -1,5 +1,6 @@
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { callGateway } from "../../gateway/call.js";
+import { parseThreadSessionSuffix } from "../../sessions/session-key-utils.js";
 import { normalizeOptionalStringifiedId } from "../../shared/string-coerce.js";
 import { SessionListRow } from "./sessions-helpers.js";
 import type { AnnounceTarget } from "./sessions-send-helpers.js";
@@ -12,6 +13,10 @@ export async function resolveAnnounceTarget(params: {
   const parsed = resolveAnnounceTargetFromKey(params.sessionKey);
   const parsedDisplay = resolveAnnounceTargetFromKey(params.displayKey);
   const fallback = parsed ?? parsedDisplay ?? null;
+  const fallbackThreadId =
+    fallback?.threadId ??
+    parseThreadSessionSuffix(params.sessionKey).threadId ??
+    parseThreadSessionSuffix(params.displayKey).threadId;
 
   if (fallback) {
     const normalized = normalizeChannelId(fallback.channel);
@@ -55,7 +60,10 @@ export async function resolveAnnounceTarget(params: {
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
       (typeof origin?.accountId === "string" ? origin.accountId : undefined);
     const threadId = normalizeOptionalStringifiedId(
-      deliveryContext?.threadId ?? match?.lastThreadId,
+      deliveryContext?.threadId ??
+        match?.lastThreadId ??
+        origin?.threadId ??
+        fallbackThreadId,
     );
     if (channel && to) {
       return { channel, to, accountId, threadId };

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -42,7 +42,6 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       roundOneReply: "Worker completed successfully",
     });
 
-    // Find the gateway send call (not the waitForAgentRun call)
     const sendCall = gatewayCalls.find((call) => call.method === "send");
     expect(sendCall).toBeDefined();
     const sendParams = sendCall?.params as Record<string, unknown>;

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -145,7 +145,7 @@ function expectWorkerTranscriptPath(
 ) {
   const session = getFirstListedSession(result);
   expect(session).toMatchObject({ key: "agent:worker:main" });
-  const transcriptPath = String(session?.transcriptPath ?? "");
+  const transcriptPath = session?.transcriptPath ?? "";
   expect(path.normalize(transcriptPath)).toContain(path.normalize(params.containsPath));
   expect(transcriptPath).toMatch(new RegExp(`${params.sessionId}\\.jsonl$`));
 }
@@ -334,6 +334,33 @@ describe("resolveAnnounceTarget", () => {
       to: "123@g.us",
       accountId: "work",
       threadId: "271",
+    });
+  });
+
+  it("keeps threadId from sessions.list delivery context for announce delivery", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            accountId: "work",
+            threadId: "thread-77",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+      accountId: "work",
+      threadId: "thread-77",
     });
   });
 });

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -80,7 +80,6 @@ const installRegistry = async () => {
           },
           capabilities: { chatTypes: ["direct", "channel", "thread"] },
           messaging: {
-            resolveSessionConversation: resolveSessionConversationStub,
             resolveSessionTarget: resolveSessionTargetStub,
           },
           config: {
@@ -103,6 +102,30 @@ const installRegistry = async () => {
             preferSessionLookupForAnnounceTarget: true,
           },
           capabilities: { chatTypes: ["direct", "group"] },
+          messaging: {
+            resolveSessionConversation: resolveSessionConversationStub,
+            resolveSessionTarget: resolveSessionTargetStub,
+          },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
+      {
+        pluginId: "slack",
+        source: "test",
+        plugin: {
+          id: "slack",
+          meta: {
+            id: "slack",
+            label: "Slack",
+            selectionLabel: "Slack",
+            docsPath: "/channels/slack",
+            blurb: "Slack test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "channel", "thread"] },
           messaging: {
             resolveSessionConversation: resolveSessionConversationStub,
             resolveSessionTarget: resolveSessionTargetStub,
@@ -361,6 +384,32 @@ describe("resolveAnnounceTarget", () => {
       to: "123@g.us",
       accountId: "work",
       threadId: "thread-77",
+    });
+  });
+
+  it("preserves threaded Slack session keys when sessions.list lacks stored thread metadata", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:slack:channel:C123:thread:1710000000.000100",
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:C123",
+            accountId: "workspace",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:slack:channel:C123:thread:1710000000.000100",
+      displayKey: "agent:main:slack:channel:C123:thread:1710000000.000100",
+    });
+    expect(target).toEqual({
+      channel: "slack",
+      to: "channel:C123",
+      accountId: "workspace",
+      threadId: "1710000000.000100",
     });
   });
 });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -34,6 +34,7 @@ import {
 } from "../../shared/string-coerce.js";
 import { createRunningTaskRun } from "../../tasks/task-executor.js";
 import {
+  mergeDeliveryContext,
   normalizeDeliveryContext,
   normalizeSessionDeliveryFields,
 } from "../../utils/delivery-context.js";
@@ -563,6 +564,26 @@ export const agentHandlers: GatewayRequestHandlers = {
       resolvedGroupChannel = resolvedGroupChannel || inheritedGroup?.groupChannel;
       resolvedGroupSpace = resolvedGroupSpace || inheritedGroup?.groupSpace;
       const deliveryFields = normalizeSessionDeliveryFields(entry);
+      // When the session has no delivery context yet (e.g. a freshly-spawned subagent
+      // with deliver: false), seed it from the request's channel/to/threadId params.
+      // Without this, subagent sessions end up with deliveryContext: {channel: "slack"}
+      // and no `to`/`threadId`, which causes announce delivery to either target the
+      // wrong channel (when the parent's lastTo drifts) or fail entirely.
+      const requestDeliveryHint = normalizeDeliveryContext({
+        channel: request.channel?.trim(),
+        to: request.to?.trim(),
+        accountId: request.accountId?.trim(),
+        // Pass threadId directly — normalizeDeliveryContext handles both
+        // string and numeric threadIds (e.g., Matrix uses integers).
+        threadId: request.threadId,
+      });
+      const effectiveDelivery = mergeDeliveryContext(
+        deliveryFields.deliveryContext,
+        requestDeliveryHint,
+      );
+      const effectiveDeliveryFields = normalizeSessionDeliveryFields({
+        deliveryContext: effectiveDelivery,
+      });
       const nextEntryPatch: SessionEntry = {
         sessionId,
         updatedAt: now,
@@ -573,11 +594,11 @@ export const agentHandlers: GatewayRequestHandlers = {
         systemSent: entry?.systemSent,
         sendPolicy: entry?.sendPolicy,
         skillsSnapshot: entry?.skillsSnapshot,
-        deliveryContext: deliveryFields.deliveryContext,
-        lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
-        lastTo: deliveryFields.lastTo ?? entry?.lastTo,
-        lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
-        lastThreadId: deliveryFields.lastThreadId ?? entry?.lastThreadId,
+        deliveryContext: effectiveDeliveryFields.deliveryContext,
+        lastChannel: effectiveDeliveryFields.lastChannel ?? entry?.lastChannel,
+        lastTo: effectiveDeliveryFields.lastTo ?? entry?.lastTo,
+        lastAccountId: effectiveDeliveryFields.lastAccountId ?? entry?.lastAccountId,
+        lastThreadId: effectiveDeliveryFields.lastThreadId ?? entry?.lastThreadId,
         modelOverride: entry?.modelOverride,
         providerOverride: entry?.providerOverride,
         label: labelValue,

--- a/src/gateway/server.agent.subagent-delivery-context.test.ts
+++ b/src/gateway/server.agent.subagent-delivery-context.test.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
+import { setRegistry } from "./server.agent.gateway-server-agent.mocks.js";
+import { createRegistry } from "./server.e2e-registry-helpers.js";
+import {
+  connectOk,
+  installGatewayTestHooks,
+  rpcReq,
+  startServerWithClient,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let server: Awaited<ReturnType<typeof startServerWithClient>>["server"];
+let ws: Awaited<ReturnType<typeof startServerWithClient>>["ws"];
+let sessionStoreDir: string;
+let sessionStorePath: string;
+
+const createStubChannelPlugin = (params: {
+  id: ChannelPlugin["id"];
+  label: string;
+}): ChannelPlugin => ({
+  ...createChannelTestPluginBase({
+    id: params.id,
+    label: params.label,
+  }),
+  outbound: {
+    deliveryMode: "direct",
+    resolveTarget: ({ to }) => {
+      const trimmed = to?.trim() ?? "";
+      if (trimmed) {
+        return { ok: true, to: trimmed };
+      }
+      return { ok: false, error: new Error(`missing target for ${params.id}`) };
+    },
+    sendText: async () => ({ channel: params.id, messageId: "msg-test" }),
+    sendMedia: async () => ({ channel: params.id, messageId: "msg-test" }),
+  },
+});
+
+const defaultRegistry = createRegistry([
+  {
+    pluginId: "slack",
+    source: "test",
+    plugin: createStubChannelPlugin({ id: "slack", label: "Slack" }),
+  },
+]);
+
+beforeAll(async () => {
+  const started = await startServerWithClient();
+  server = started.server;
+  ws = started.ws;
+  await connectOk(ws);
+  sessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-subagent-delivery-ctx-"));
+  sessionStorePath = path.join(sessionStoreDir, "sessions.json");
+});
+
+afterAll(async () => {
+  ws.close();
+  await server.close();
+  await fs.rm(sessionStoreDir, { recursive: true, force: true });
+});
+
+type StoredEntry = {
+  deliveryContext?: { channel?: string; to?: string; threadId?: string; accountId?: string };
+  lastChannel?: string;
+  lastTo?: string;
+  lastThreadId?: string | number;
+  lastAccountId?: string;
+};
+
+describe("subagent session deliveryContext from spawn request params", () => {
+  test("new subagent session inherits deliveryContext from request channel/to/threadId", async () => {
+    setRegistry(defaultRegistry);
+    testState.sessionStorePath = sessionStorePath;
+    await writeSessionStore({ entries: {} });
+
+    const res = await rpcReq(ws, "agent", {
+      message: "[Subagent Task]: analyze data",
+      sessionKey: "agent:main:subagent:test-delivery-ctx",
+      channel: "slack",
+      to: "channel:C0AF8TW48UQ",
+      accountId: "default",
+      threadId: "1774374945.091819",
+      deliver: false,
+      idempotencyKey: "idem-subagent-delivery-ctx-1",
+    });
+    expect(res.ok).toBe(true);
+
+    const stored = JSON.parse(await fs.readFile(sessionStorePath, "utf-8")) as Record<
+      string,
+      StoredEntry
+    >;
+    const entry = stored["agent:main:subagent:test-delivery-ctx"];
+    expect(entry).toBeDefined();
+    expect(entry?.deliveryContext?.channel).toBe("slack");
+    expect(entry?.deliveryContext?.to).toBe("channel:C0AF8TW48UQ");
+    expect(entry?.deliveryContext?.threadId).toBe("1774374945.091819");
+    expect(entry?.deliveryContext?.accountId).toBe("default");
+    expect(entry?.lastChannel).toBe("slack");
+    expect(entry?.lastTo).toBe("channel:C0AF8TW48UQ");
+  });
+
+  test("existing session deliveryContext is NOT overwritten by request params", async () => {
+    setRegistry(defaultRegistry);
+    testState.sessionStorePath = sessionStorePath;
+    await writeSessionStore({
+      entries: {
+        "agent:main:subagent:existing-ctx": {
+          sessionId: "sess-existing",
+          updatedAt: Date.now(),
+          deliveryContext: {
+            channel: "slack",
+            to: "user:U09U1LV7JDN",
+            accountId: "default",
+            threadId: "1771242986.529939",
+          },
+          lastChannel: "slack",
+          lastTo: "user:U09U1LV7JDN",
+          lastAccountId: "default",
+          lastThreadId: "1771242986.529939",
+        },
+      },
+    });
+
+    const res = await rpcReq(ws, "agent", {
+      message: "follow-up",
+      sessionKey: "agent:main:subagent:existing-ctx",
+      channel: "slack",
+      to: "channel:C0AF8TW48UQ",
+      threadId: "9999999999.000000",
+      deliver: false,
+      idempotencyKey: "idem-subagent-delivery-ctx-2",
+    });
+    expect(res.ok).toBe(true);
+
+    const stored = JSON.parse(await fs.readFile(sessionStorePath, "utf-8")) as Record<
+      string,
+      StoredEntry
+    >;
+    const entry = stored["agent:main:subagent:existing-ctx"];
+    expect(entry).toBeDefined();
+    // The ORIGINAL deliveryContext should be preserved (primary wins in merge).
+    expect(entry?.deliveryContext?.to).toBe("user:U09U1LV7JDN");
+    expect(entry?.deliveryContext?.threadId).toBe("1771242986.529939");
+    expect(entry?.lastTo).toBe("user:U09U1LV7JDN");
+  });
+
+  test("pre-patched subagent session (via sessions.patch) inherits deliveryContext from agent request", async () => {
+    // Simulates the real subagent spawn flow: spawnSubagentDirect calls sessions.patch
+    // first (to set spawnDepth, spawnedBy, etc.), then calls callSubagentGateway({method: "agent"}).
+    // The sessions.patch creates a partial entry without deliveryContext.
+    // The agent handler must seed deliveryContext from the request params.
+    setRegistry(defaultRegistry);
+    testState.sessionStorePath = sessionStorePath;
+    await writeSessionStore({
+      entries: {
+        "agent:main:subagent:pre-patched": {
+          sessionId: "sess-pre-patched",
+          updatedAt: Date.now(),
+          spawnDepth: 1,
+          spawnedBy: "agent:main:slack:direct:u07fdr83w6n:thread:1775577152.364109",
+        },
+      },
+    });
+
+    const res = await rpcReq(ws, "agent", {
+      message: "[Subagent Task]: investigate data",
+      sessionKey: "agent:main:subagent:pre-patched",
+      channel: "slack",
+      to: "user:U07FDR83W6N",
+      accountId: "default",
+      threadId: "1775577152.364109",
+      deliver: false,
+      idempotencyKey: "idem-subagent-delivery-ctx-prepatched",
+    });
+    expect(res.ok).toBe(true);
+
+    const stored = JSON.parse(await fs.readFile(sessionStorePath, "utf-8")) as Record<
+      string,
+      StoredEntry
+    >;
+    const entry = stored["agent:main:subagent:pre-patched"];
+    expect(entry).toBeDefined();
+    expect(entry?.deliveryContext?.channel).toBe("slack");
+    expect(entry?.deliveryContext?.to).toBe("user:U07FDR83W6N");
+    expect(entry?.deliveryContext?.threadId).toBe("1775577152.364109");
+    expect(entry?.deliveryContext?.accountId).toBe("default");
+    expect(entry?.lastThreadId).toBe("1775577152.364109");
+  });
+
+  test("request without to/threadId does not inject empty values", async () => {
+    setRegistry(defaultRegistry);
+    testState.sessionStorePath = sessionStorePath;
+    await writeSessionStore({ entries: {} });
+
+    const res = await rpcReq(ws, "agent", {
+      message: "internal task",
+      sessionKey: "agent:main:subagent:no-routing",
+      channel: "slack",
+      deliver: false,
+      idempotencyKey: "idem-subagent-delivery-ctx-3",
+    });
+    expect(res.ok).toBe(true);
+
+    const stored = JSON.parse(await fs.readFile(sessionStorePath, "utf-8")) as Record<
+      string,
+      StoredEntry
+    >;
+    const entry = stored["agent:main:subagent:no-routing"];
+    expect(entry).toBeDefined();
+    expect(entry?.deliveryContext?.channel).toBe("slack");
+    expect(entry?.deliveryContext?.to).toBeUndefined();
+    expect(entry?.deliveryContext?.threadId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: subagent sessions created without an initial delivery context could lose the caller's `to` / `threadId`, and later A2A announce delivery also dropped `threadId` when resolving the target from `sessions.list`.
- Why it matters: subagent completion/announce messages can drift to the wrong destination or escape to a top-level channel instead of staying in the original thread/topic.
- What changed: seed new subagent session delivery context from the spawn request, preserve resolved announce `threadId`, and include that `threadId` in the gateway `send` call.
- What did NOT change (scope boundary): this does not change announce content, channel-specific formatting, or unrelated session routing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #54479
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: newly spawned subagent sessions could be persisted before they had a usable `deliveryContext`, so announce delivery later depended on mutable legacy `last*` fields; separately, `resolveAnnounceTarget()` extracted thread information but returned only `{ channel, to, accountId }`, and the A2A announce `send` call also omitted `threadId`.
- Missing detection / guardrail: there was no regression test covering a thread-scoped subagent spawn followed by announce delivery through the `sessions.list` lookup path.
- Contributing context (if known): this showed up in the v2026.4.x path where thread-scoped announce delivery relies on reconstructed session routing metadata.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server.agent.subagent-delivery-context.test.ts`
  - `src/agents/tools/sessions.test.ts`
  - `src/agents/tools/sessions-send-tool.a2a.test.ts`
- Scenario the test should lock in: a subagent spawned from a threaded request keeps the original routing context, and a later announce send still includes the thread/topic id.
- Why this is the smallest reliable guardrail: it covers both the persistence boundary in the gateway and the announce-delivery lookup/send path without depending on a live channel integration.
- Existing test that already covers this (if any): the gateway delivery-context tests already covered the spawn-side behavior; this PR extends announce-path coverage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Subagent completion/announce messages stay in the same thread/topic more reliably instead of falling back to a top-level destination.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[threaded request] -> [subagent session persisted without complete delivery context]
                 -> [announce target reconstructed without threadId]
                 -> [announce sent without threadId] -> [wrong/top-level destination]

After:
[threaded request] -> [subagent session seeded with channel/to/threadId]
                 -> [announce target keeps threadId]
                 -> [announce send includes threadId] -> [original thread/topic]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): thread-scoped session routing / agent-to-agent announce flow
- Relevant config (redacted): default local test harness config

### Steps

1. Spawn a subagent from a threaded request where the subagent session does not yet have a delivery context.
2. Let announce target resolution fall back to `sessions.list`.
3. Send the A2A announce reply.

### Expected

- The subagent session keeps the request `channel`, `to`, `accountId`, and `threadId`.
- The resolved announce target includes `threadId`.
- The gateway `send` call includes `threadId`.

### Actual

- Before this change, announce resolution/send could lose `threadId`, causing delivery to miss the original thread/topic.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran targeted vitest coverage for gateway subagent delivery-context seeding, announce-target resolution, and A2A announce send propagation.
- Edge cases checked: existing session delivery context is not overwritten; request without `to`/`threadId` does not inject empty values; announce target can hydrate `threadId` from `deliveryContext` / `lastThreadId` / `origin.threadId`.
- What you did **not** verify: live channel integration behavior against a production workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: thread/topic ids now flow through announce resolution in more cases, including numeric values from legacy session rows.
  - Mitigation: the code normalizes routed thread ids to strings and adds targeted regression coverage for both resolution and send.
- Risk: new-session seeding could accidentally override an existing delivery context.
  - Mitigation: the gateway path merges request hints only as fallback values and existing delivery context remains authoritative, with regression coverage.
