### PR TITLE
fix(whatsapp): bypass legacy dep shim in sendMedia to restore attachment delivery

### DIFF
--- a/extensions/whatsapp/contract-surfaces.ts
+++ b/extensions/whatsapp/contract-surfaces.ts
@@ -3,7 +3,7 @@ type UnsupportedSecretRefConfigCandidate = {
   value: unknown;
 };
 
-export { normalizeCompatibilityConfig } from "./src/doctor-contract.js";
+export { normalizeCompatibilityConfig } from "./src/doctor.js";
 import { hasAnyWhatsAppAuth } from "./src/accounts.js";
 export { canonicalizeLegacySessionKey, isLegacyGroupSessionKey } from "./src/session-contract.js";
 

--- a/extensions/whatsapp/contract-surfaces.ts
+++ b/extensions/whatsapp/contract-surfaces.ts
@@ -3,7 +3,7 @@ type UnsupportedSecretRefConfigCandidate = {
   value: unknown;
 };
 
-export { normalizeCompatibilityConfig } from "./src/doctor.js";
+export { normalizeCompatibilityConfig } from "./src/doctor-contract.js";
 import { hasAnyWhatsAppAuth } from "./src/accounts.js";
 export { canonicalizeLegacySessionKey, isLegacyGroupSessionKey } from "./src/session-contract.js";
 

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -54,6 +54,47 @@ describe("createWhatsAppOutboundBase", () => {
     expect(result).toMatchObject({ channel: "whatsapp", messageId: "msg-1" });
   });
 
+  it("sendMedia bypasses legacy deps and always calls sendMessageWhatsApp directly (#63126)", async () => {
+    const legacyShim = vi.fn(async () => ({
+      messageId: "legacy-msg",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const sendMessageWhatsApp = vi.fn(async () => ({
+      messageId: "direct-msg",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+
+    const result = await outbound.sendMedia!({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "voice memo",
+      mediaUrl: "/tmp/workspace/test.mp3",
+      mediaLocalRoots: ["/tmp/workspace"],
+      accountId: "default",
+      deps: { sendWhatsApp: legacyShim, whatsapp: legacyShim },
+      gifPlayback: false,
+    });
+
+    // Legacy shim must NOT be called — it drops mediaUrl silently.
+    expect(legacyShim).not.toHaveBeenCalled();
+    // The direct sendMessageWhatsApp must receive the mediaUrl.
+    expect(sendMessageWhatsApp).toHaveBeenCalledWith(
+      "whatsapp:+15551234567",
+      "voice memo",
+      expect.objectContaining({
+        mediaUrl: "/tmp/workspace/test.mp3",
+      }),
+    );
+    expect(result).toMatchObject({ channel: "whatsapp", messageId: "direct-msg" });
+  });
+
   it("threads cfg into sendPollWhatsApp call", async () => {
     const sendPollWhatsApp = vi.fn(async () => ({
       messageId: "wa-poll-1",

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -97,14 +97,13 @@ export function createWhatsAppOutboundBase({
         mediaLocalRoots,
         mediaReadFile,
         accountId,
-        deps,
         gifPlayback,
       }) => {
-        const send =
-          resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-            legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-          }) ?? sendMessageWhatsApp;
-        return await send(to, normalizeText(text), {
+        // Always call sendMessageWhatsApp directly for media sends.
+        // Legacy deps resolved via resolveOutboundSendDep pre-date the
+        // media-aware signature and silently drop mediaUrl, causing
+        // attachments to never reach the recipient.  See #63126.
+        return await sendMessageWhatsApp(to, normalizeText(text), {
           verbose: false,
           cfg,
           mediaUrl,


### PR DESCRIPTION
## Summary

- **Bypass legacy `resolveOutboundSendDep` in `sendMedia`** — the legacy `deps.whatsapp`/`sendWhatsApp` shim pre-dates the media-aware signature and silently drops `mediaUrl`, causing all WhatsApp media sends (images, audio, documents) to arrive as text-only while reporting success
- The `sendText` path still uses dep resolution for backwards compatibility; only `sendMedia` is changed
- Added a regression test that verifies legacy deps are not called for media sends

## Test plan

- [x] Existing `outbound-base.test.ts` tests pass (4/4)
- [x] New test `sendMedia bypasses legacy deps and always calls sendMessageWhatsApp directly (#63126)` confirms legacy shim is never invoked and `mediaUrl` reaches `sendMessageWhatsApp`
- [ ] Manual verification: `openclaw message send --channel whatsapp --media <file>` delivers attachment to recipient

Fixes #63126

🤖 Generated with [Claude Code](https://claude.com/claude-code)