### PR TITLE
feat(sessions): archive transcript before compaction truncation

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1149,7 +1149,7 @@ export async function compactEmbeddedPiSessionDirect(
                 log.info(
                   `[compaction] post-compaction truncation removed ${truncResult.entriesRemoved} entries ` +
                     `(sessionKey=${params.sessionKey ?? params.sessionId})` +
-                    (archivePath ? ` archived=${archivePath}` : ""),
+                    (truncResult.archived ? ` archived=${archivePath}` : ""),
                 );
               }
             } catch (err) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -10,6 +10,7 @@ import {
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { formatSessionArchiveTimestamp } from "../../config/sessions/artifacts.js";
 import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
@@ -1129,19 +1130,26 @@ export async function compactEmbeddedPiSessionDirect(
           // Truncate session file to remove compacted entries (#39953)
           if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction) {
             try {
+              const archiveBeforeTruncation =
+                params.config?.agents?.defaults?.compaction?.archiveBeforeTruncation !== false;
+              const archivePath = archiveBeforeTruncation
+                ? `${params.sessionFile}.compaction.${formatSessionArchiveTimestamp()}`
+                : undefined;
               const heartbeatSummary = resolveHeartbeatSummaryForAgent(
                 params.config,
                 sessionAgentId,
               );
               const truncResult = await truncateSessionAfterCompaction({
                 sessionFile: params.sessionFile,
+                archivePath,
                 ackMaxChars: heartbeatSummary.ackMaxChars,
                 heartbeatPrompt: heartbeatSummary.prompt,
               });
               if (truncResult.truncated) {
                 log.info(
                   `[compaction] post-compaction truncation removed ${truncResult.entriesRemoved} entries ` +
-                    `(sessionKey=${params.sessionKey ?? params.sessionId})`,
+                    `(sessionKey=${params.sessionKey ?? params.sessionId})` +
+                    (archivePath ? ` archived=${archivePath}` : ""),
                 );
               }
             } catch (err) {

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -199,11 +199,13 @@ export async function truncateSessionAfterCompaction(params: {
   }
 
   // Archive original file if requested
+  let archived = false;
   if (params.archivePath) {
     try {
       const archiveDir = path.dirname(params.archivePath);
       await fs.mkdir(archiveDir, { recursive: true });
       await fs.copyFile(sessionFile, params.archivePath);
+      archived = true;
       log.info(`[session-truncation] Archived pre-truncation file to ${params.archivePath}`);
     } catch (err) {
       const reason = formatErrorMessage(err);
@@ -240,12 +242,13 @@ export async function truncateSessionAfterCompaction(params: {
       `reduction=${bytesBefore > 0 ? ((1 - bytesAfter / bytesBefore) * 100).toFixed(1) : "?"}%`,
   );
 
-  return { truncated: true, entriesRemoved, bytesBefore, bytesAfter };
+  return { truncated: true, entriesRemoved, archived, bytesBefore, bytesAfter };
 }
 
 export type TruncationResult = {
   truncated: boolean;
   entriesRemoved: number;
+  archived?: boolean;
   bytesBefore?: number;
   bytesAfter?: number;
   reason?: string;

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -1,4 +1,4 @@
-export type SessionArchiveReason = "bak" | "reset" | "deleted";
+export type SessionArchiveReason = "bak" | "reset" | "deleted" | "compaction";
 
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
@@ -20,7 +20,8 @@ export function isSessionArchiveArtifactName(fileName: string): boolean {
   return (
     hasArchiveSuffix(fileName, "deleted") ||
     hasArchiveSuffix(fileName, "reset") ||
-    hasArchiveSuffix(fileName, "bak")
+    hasArchiveSuffix(fileName, "bak") ||
+    hasArchiveSuffix(fileName, "compaction")
   );
 }
 

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -91,11 +91,12 @@ function resolveCompactionArchiveRetentionMs(
   if (raw === false) {
     return null;
   }
-  if (raw === undefined || raw === null || raw === "") {
+  const normalized = normalizeStringifiedOptionalString(raw);
+  if (!normalized) {
     return DEFAULT_COMPACTION_ARCHIVE_RETENTION_MS;
   }
   try {
-    return parseDurationMs(String(raw).trim(), { defaultUnit: "d" });
+    return parseDurationMs(normalized, { defaultUnit: "d" });
   } catch {
     return DEFAULT_COMPACTION_ARCHIVE_RETENTION_MS;
   }

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -32,6 +32,7 @@ export type ResolvedSessionMaintenanceConfig = {
   maxEntries: number;
   rotateBytes: number;
   resetArchiveRetentionMs: number | null;
+  compactionArchiveRetentionMs: number | null;
   maxDiskBytes: number | null;
   highWaterBytes: number | null;
 };
@@ -78,6 +79,25 @@ function resolveResetArchiveRetentionMs(
     return parseDurationMs(normalized, { defaultUnit: "d" });
   } catch {
     return pruneAfterMs;
+  }
+}
+
+const DEFAULT_COMPACTION_ARCHIVE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+function resolveCompactionArchiveRetentionMs(
+  maintenance: SessionMaintenanceConfig | undefined,
+): number | null {
+  const raw = maintenance?.compactionArchiveRetention;
+  if (raw === false) {
+    return null;
+  }
+  if (raw === undefined || raw === null || raw === "") {
+    return DEFAULT_COMPACTION_ARCHIVE_RETENTION_MS;
+  }
+  try {
+    return parseDurationMs(String(raw).trim(), { defaultUnit: "d" });
+  } catch {
+    return DEFAULT_COMPACTION_ARCHIVE_RETENTION_MS;
   }
 }
 
@@ -148,6 +168,7 @@ export function resolveMaintenanceConfig(): ResolvedSessionMaintenanceConfig {
     maxEntries: maintenance?.maxEntries ?? DEFAULT_SESSION_MAX_ENTRIES,
     rotateBytes: resolveRotateBytes(maintenance),
     resetArchiveRetentionMs: resolveResetArchiveRetentionMs(maintenance, pruneAfterMs),
+    compactionArchiveRetentionMs: resolveCompactionArchiveRetentionMs(maintenance),
     maxDiskBytes,
     highWaterBytes: resolveHighWaterBytes(maintenance, maxDiskBytes),
   };

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -349,7 +349,11 @@ async function saveSessionStoreUnlocked(
       for (const archivedDir of archivedForDeletedSessions) {
         archivedDirs.add(archivedDir);
       }
-      if (archivedDirs.size > 0 || maintenance.resetArchiveRetentionMs != null) {
+      if (
+        archivedDirs.size > 0 ||
+        maintenance.resetArchiveRetentionMs != null ||
+        maintenance.compactionArchiveRetentionMs != null
+      ) {
         const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
         const targetDirs =
           archivedDirs.size > 0 ? [...archivedDirs] : [path.dirname(path.resolve(storePath))];
@@ -363,6 +367,13 @@ async function saveSessionStoreUnlocked(
             directories: targetDirs,
             olderThanMs: maintenance.resetArchiveRetentionMs,
             reason: "reset",
+          });
+        }
+        if (maintenance.compactionArchiveRetentionMs != null) {
+          await cleanupArchivedSessionTranscripts({
+            directories: targetDirs,
+            olderThanMs: maintenance.compactionArchiveRetentionMs,
+            reason: "compaction",
           });
         }
       }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -379,6 +379,13 @@ async function saveSessionStoreUnlocked(
         }
       }
 
+      // Eagerly clean up compaction archives for pruned/capped sessions.
+      // Once a session is removed from the store its directory is no longer
+      // tracked, so future retention sweeps would never find its archives.
+      // Deleting them now (regardless of age) avoids the need to persist
+      // removed-session directories across saves.
+      await cleanupCompactionArchivesForRemovedSessions(removedSessionFiles, referencedSessionIds);
+
       // Rotate the on-disk file if it exceeds the size threshold.
       await rotateSessionFile(storePath, maintenance.rotateBytes);
 
@@ -523,6 +530,44 @@ function rememberRemovedSessionFile(
 ): void {
   if (!removedSessionFiles.has(entry.sessionId) || entry.sessionFile) {
     removedSessionFiles.set(entry.sessionId, entry.sessionFile);
+  }
+}
+
+/**
+ * Eagerly delete `.compaction.*` archive files for sessions that have been
+ * pruned or capped out of the store.  Once a session entry is gone, its
+ * directory is no longer visited by the periodic retention sweep, so any
+ * compaction archives younger than retention would leak indefinitely.
+ * Cleaning them up at prune time sidesteps the problem entirely.
+ */
+async function cleanupCompactionArchivesForRemovedSessions(
+  removedSessionFiles: ReadonlyMap<string, string | undefined>,
+  referencedSessionIds: ReadonlySet<string>,
+): Promise<void> {
+  for (const [sessionId, sessionFile] of removedSessionFiles) {
+    if (!sessionFile || referencedSessionIds.has(sessionId)) {
+      continue;
+    }
+    const resolvedFile = path.resolve(sessionFile);
+    const dir = path.dirname(resolvedFile);
+    const baseName = path.basename(resolvedFile);
+    const prefix = `${baseName}.compaction.`;
+    let entries: string[];
+    try {
+      entries = await fs.promises.readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.startsWith(prefix)) {
+        continue;
+      }
+      try {
+        await fs.promises.rm(path.join(dir, entry));
+      } catch {
+        // Best-effort: the file may already have been removed.
+      }
+    }
   }
 }
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -284,6 +284,18 @@ async function saveSessionStoreUnlocked(
     const shouldWarnOnly = maintenance.mode === "warn";
     const beforeCount = Object.keys(store).length;
 
+    // Collect directories from all sessions *before* prune/cap so that
+    // directories belonging to about-to-be-removed entries are still included
+    // in the archive cleanup scan (fixes leaked archives for pruned sessions
+    // with legacy external paths).
+    const allSessionDirs = new Set<string>();
+    for (const entry of Object.values(store)) {
+      const sf = entry?.sessionFile?.trim();
+      if (sf) {
+        allSessionDirs.add(path.dirname(path.resolve(sf)));
+      }
+    }
+
     if (shouldWarnOnly) {
       const activeSessionKey = opts?.activeSessionKey?.trim();
       if (activeSessionKey) {
@@ -333,7 +345,7 @@ async function saveSessionStoreUnlocked(
           rememberRemovedSessionFile(removedSessionFiles, entry);
         },
       });
-      const archivedDirs = new Set<string>();
+      const archivedDirs = new Set<string>(allSessionDirs);
       const referencedSessionIds = new Set(
         Object.values(store)
           .map((entry) => entry?.sessionId)
@@ -349,20 +361,7 @@ async function saveSessionStoreUnlocked(
       for (const archivedDir of archivedForDeletedSessions) {
         archivedDirs.add(archivedDir);
       }
-      // Also include parent directories of active session transcript files so
-      // that compaction archives for sessions with legacy absolute paths
-      // (outside the store directory) are cleaned up.
-      for (const entry of Object.values(store)) {
-        const sf = entry?.sessionFile?.trim();
-        if (sf) {
-          archivedDirs.add(path.dirname(path.resolve(sf)));
-        }
-      }
-      if (
-        archivedDirs.size > 0 ||
-        maintenance.resetArchiveRetentionMs != null ||
-        maintenance.compactionArchiveRetentionMs != null
-      ) {
+      if (archivedDirs.size > 0 || maintenance.resetArchiveRetentionMs != null) {
         const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
         const targetDirs =
           archivedDirs.size > 0 ? [...archivedDirs] : [path.dirname(path.resolve(storePath))];
@@ -376,13 +375,6 @@ async function saveSessionStoreUnlocked(
             directories: targetDirs,
             olderThanMs: maintenance.resetArchiveRetentionMs,
             reason: "reset",
-          });
-        }
-        if (maintenance.compactionArchiveRetentionMs != null) {
-          await cleanupArchivedSessionTranscripts({
-            directories: targetDirs,
-            olderThanMs: maintenance.compactionArchiveRetentionMs,
-            reason: "compaction",
           });
         }
       }
@@ -405,6 +397,22 @@ async function saveSessionStoreUnlocked(
         pruned,
         capped,
         diskBudget,
+      });
+    }
+
+    // Compaction archive cleanup runs regardless of mode — warn mode skips
+    // prune/cap but still needs to sweep expired .compaction.* files.
+    if (maintenance.compactionArchiveRetentionMs != null) {
+      const compactionDirs = new Set<string>(allSessionDirs);
+      // In enforce mode the store may have shrunk, but allSessionDirs was
+      // captured before pruning so it already covers removed entries.
+      // Also include the store directory itself as a fallback.
+      compactionDirs.add(path.dirname(path.resolve(storePath)));
+      const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
+      await cleanupArchivedSessionTranscripts({
+        directories: [...compactionDirs],
+        olderThanMs: maintenance.compactionArchiveRetentionMs,
+        reason: "compaction",
       });
     }
   }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -349,6 +349,15 @@ async function saveSessionStoreUnlocked(
       for (const archivedDir of archivedForDeletedSessions) {
         archivedDirs.add(archivedDir);
       }
+      // Also include parent directories of active session transcript files so
+      // that compaction archives for sessions with legacy absolute paths
+      // (outside the store directory) are cleaned up.
+      for (const entry of Object.values(store)) {
+        const sf = entry?.sessionFile?.trim();
+        if (sf) {
+          archivedDirs.add(path.dirname(path.resolve(sf)));
+        }
+      }
       if (
         archivedDirs.size > 0 ||
         maintenance.resetArchiveRetentionMs != null ||

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -392,6 +392,13 @@ export type AgentCompactionConfig = {
    */
   truncateAfterCompaction?: boolean;
   /**
+   * Archive the session transcript before truncating compacted entries.
+   * Creates a `.compaction.<timestamp>` backup alongside the session file
+   * so data can be recovered if needed. Only applies when
+   * `truncateAfterCompaction` is enabled. Default: true.
+   */
+  archiveBeforeTruncation?: boolean;
+  /**
    * Send a "🧹 Compacting context..." notice to the user when compaction starts.
    * Default: false (silent by default).
    */

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -201,6 +201,11 @@ export type SessionMaintenanceConfig = {
    */
   resetArchiveRetention?: string | number | false;
   /**
+   * Retention for archived compaction transcripts (`*.compaction.<timestamp>`).
+   * Set `false` to disable compaction-archive cleanup. Default: "7d".
+   */
+  compactionArchiveRetention?: string | number | false;
+  /**
    * Optional per-agent sessions-directory disk budget (e.g. "500mb").
    * When exceeded, warn (mode=warn) or enforce oldest-first cleanup (mode=enforce).
    */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -149,6 +149,8 @@ export const AgentDefaultsSchema = z
           .strict()
           .optional(),
         notifyUser: z.boolean().optional(),
+        truncateAfterCompaction: z.boolean().optional(),
+        archiveBeforeTruncation: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -79,6 +79,7 @@ export const SessionSchema = z
         maxEntries: z.number().int().positive().optional(),
         rotateBytes: z.union([z.string(), z.number()]).optional(),
         resetArchiveRetention: z.union([z.string(), z.number(), z.literal(false)]).optional(),
+        compactionArchiveRetention: z.union([z.string(), z.number(), z.literal(false)]).optional(),
         maxDiskBytes: z.union([z.string(), z.number()]).optional(),
         highWaterBytes: z.union([z.string(), z.number()]).optional(),
       })
@@ -119,6 +120,25 @@ export const SessionSchema = z
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               path: ["resetArchiveRetention"],
+              message: "invalid duration (use ms, s, m, h, d)",
+            });
+          }
+        }
+        if (
+          val.compactionArchiveRetention !== undefined &&
+          val.compactionArchiveRetention !== false
+        ) {
+          try {
+            parseDurationMs(
+              normalizeStringifiedOptionalString(val.compactionArchiveRetention) ?? "",
+              {
+                defaultUnit: "d",
+              },
+            );
+          } catch {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["compactionArchiveRetention"],
               message: "invalid duration (use ms, s, m, h, d)",
             });
           }


### PR DESCRIPTION
## Summary
- When `truncateAfterCompaction` is enabled, transcript entries are now archived to `{sessionFile}.compaction.{timestamp}` before deletion, instead of being permanently lost
- Configurable retention period via `compactionArchiveRetention` (default: 7 days)
- Archived files are automatically cleaned up during regular session store maintenance

Closes #63119

## Changes
- `src/agents/pi-embedded-runner/compact.ts` — generate archive path and pass to truncation
- `src/config/sessions/artifacts.ts` — register `compaction` as archive artifact type
- `src/config/types.agent-defaults.ts` — add `archiveBeforeTruncation` option
- `src/config/types.base.ts` — add `compactionArchiveRetention` config
- `src/config/sessions/store-maintenance.ts` — resolve retention config
- `src/config/sessions/store.ts` — cleanup expired compaction archives

## Test plan
- [x] Existing session-truncation tests pass (9/9)
- [x] Store pruning integration tests pass (10/10)
- [x] Session-utils.fs tests pass (51/51)
- [x] Pre-commit hooks (lint, typecheck) pass
- [ ] Manual: trigger compaction, verify `.compaction.*` file created
- [ ] Manual: wait past retention, verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)