### PR TITLE
fix(plugins): preserve memory capability across cached loads

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -34,9 +34,11 @@ import {
 import {
   clearMemoryPluginState,
   buildMemoryPromptSection,
+  getMemoryCapabilityRegistration,
   getMemoryRuntime,
   listActiveMemoryPublicArtifacts,
   listMemoryCorpusSupplements,
+  registerMemoryCapability,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
   registerMemoryPromptSupplement,
@@ -1759,6 +1761,133 @@ module.exports = { id: "throws-after-import", register() {} };`,
         contentType: "markdown",
       },
     ]);
+  });
+
+  it("preserves the existing memory capability during non-activating snapshot loads", () => {
+    useNoBundledPlugins();
+    registerMemoryCapability("existing-memory", {
+      publicArtifacts: {
+        listArtifacts: async () => [
+          {
+            kind: "memory-root",
+            workspaceDir: "/tmp/existing-memory",
+            relativePath: "MEMORY.md",
+            absolutePath: "/tmp/existing-memory/MEMORY.md",
+            agentIds: ["main"],
+            contentType: "markdown",
+          },
+        ],
+      },
+    });
+
+    const plugin = writePlugin({
+      id: "snapshot-memory-artifacts",
+      filename: "snapshot-memory-artifacts.cjs",
+      body: `module.exports = {
+        id: "snapshot-memory-artifacts",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            publicArtifacts: {
+              listArtifacts: async () => [{
+                kind: "memory-root",
+                workspaceDir: "/tmp/snapshot-memory-artifacts",
+                relativePath: "MEMORY.md",
+                absolutePath: "/tmp/snapshot-memory-artifacts/MEMORY.md",
+                agentIds: ["main"],
+                contentType: "markdown",
+              }],
+            },
+          });
+        },
+      };`,
+    });
+
+    loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["snapshot-memory-artifacts"],
+          slots: { memory: "snapshot-memory-artifacts" },
+        },
+      },
+      onlyPluginIds: ["snapshot-memory-artifacts"],
+      activate: false,
+      cache: false,
+    });
+
+    expect(getMemoryCapabilityRegistration()?.pluginId).toBe("existing-memory");
+  });
+
+  it("restores the previous memory capability when plugin register throws", () => {
+    useNoBundledPlugins();
+    const existingPlugin = writePlugin({
+      id: "existing-memory",
+      filename: "existing-memory.cjs",
+      body: `module.exports = {
+        id: "existing-memory",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            publicArtifacts: {
+              listArtifacts: async () => [{
+                kind: "memory-root",
+                workspaceDir: "/tmp/existing-memory",
+                relativePath: "MEMORY.md",
+                absolutePath: "/tmp/existing-memory/MEMORY.md",
+                agentIds: ["main"],
+                contentType: "markdown",
+              }],
+            },
+          });
+        },
+      };`,
+    });
+
+    const plugin = writePlugin({
+      id: "failing-memory-artifacts",
+      filename: "failing-memory-artifacts.cjs",
+      body: `module.exports = {
+        id: "failing-memory-artifacts",
+        register(api) {
+          api.registerMemoryCapability({
+            publicArtifacts: {
+              listArtifacts: async () => [{
+                kind: "memory-root",
+                workspaceDir: "/tmp/failing-memory-artifacts",
+                relativePath: "MEMORY.md",
+                absolutePath: "/tmp/failing-memory-artifacts/MEMORY.md",
+                agentIds: ["main"],
+                contentType: "markdown",
+              }],
+            },
+          });
+          throw new Error("register failed");
+        },
+      };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [existingPlugin.file, plugin.file] },
+          allow: ["existing-memory", "failing-memory-artifacts"],
+          entries: {
+            "existing-memory": { enabled: true },
+            "failing-memory-artifacts": { enabled: true },
+          },
+          slots: { memory: "existing-memory" },
+        },
+      },
+      onlyPluginIds: ["existing-memory", "failing-memory-artifacts"],
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "failing-memory-artifacts")?.status).toBe(
+      "error",
+    );
+    expect(getMemoryCapabilityRegistration()?.pluginId).toBe("existing-memory");
   });
 
   it.each([

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -32,8 +32,10 @@ import {
   registerMemoryEmbeddingProvider,
 } from "./memory-embedding-providers.js";
 import {
+  clearMemoryPluginState,
   buildMemoryPromptSection,
   getMemoryRuntime,
+  listActiveMemoryPublicArtifacts,
   listMemoryCorpusSupplements,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
@@ -1689,6 +1691,74 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(getGlobalHookRunner()).not.toBeNull();
 
     resetGlobalHookRunner();
+  });
+
+  it("restores memory public artifacts when serving a plugin registry from cache", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cache-memory-artifacts",
+      filename: "cache-memory-artifacts.cjs",
+      body: `module.exports = {
+        id: "cache-memory-artifacts",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            publicArtifacts: {
+              listArtifacts: async () => [{
+                kind: "memory-root",
+                workspaceDir: "/tmp/cache-memory-artifacts",
+                relativePath: "MEMORY.md",
+                absolutePath: "/tmp/cache-memory-artifacts/MEMORY.md",
+                agentIds: ["main"],
+                contentType: "markdown",
+              }],
+            },
+          });
+        },
+      };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["cache-memory-artifacts"],
+          slots: { memory: "cache-memory-artifacts" },
+        },
+      },
+      onlyPluginIds: ["cache-memory-artifacts"],
+    } satisfies Parameters<typeof loadOpenClawPlugins>[0];
+
+    loadOpenClawPlugins(options);
+    await expect(
+      listActiveMemoryPublicArtifacts({ cfg: options.config as never }),
+    ).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/cache-memory-artifacts",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/cache-memory-artifacts/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+
+    clearMemoryPluginState();
+
+    loadOpenClawPlugins(options);
+    await expect(
+      listActiveMemoryPublicArtifacts({ cfg: options.config as never }),
+    ).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/cache-memory-artifacts",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/cache-memory-artifacts/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
   });
 
   it.each([

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1681,6 +1681,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       });
       const previousCompactionProviders = listRegisteredCompactionProviders();
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
+      const previousMemoryCapability = getMemoryCapabilityRegistration();
       const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
       const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
@@ -1702,6 +1703,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           restoreRegisteredCompactionProviders(previousCompactionProviders);
           restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
           restoreMemoryPluginState({
+            capability: previousMemoryCapability,
             corpusSupplements: previousMemoryCorpusSupplements,
             promptBuilder: previousMemoryPromptBuilder,
             promptSupplements: previousMemoryPromptSupplements,
@@ -1715,6 +1717,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         restoreRegisteredCompactionProviders(previousCompactionProviders);
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
         restoreMemoryPluginState({
+          capability: previousMemoryCapability,
           corpusSupplements: previousMemoryCorpusSupplements,
           promptBuilder: previousMemoryPromptBuilder,
           promptSupplements: previousMemoryPromptSupplements,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -42,6 +42,7 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
@@ -148,6 +149,7 @@ export class PluginLoadReentryError extends Error {
 
 type CachedPluginState = {
   registry: PluginRegistry;
+  memoryCapability: ReturnType<typeof getMemoryCapabilityRegistration>;
   memoryCorpusSupplements: ReturnType<typeof listMemoryCorpusSupplements>;
   compactionProviders: ReturnType<typeof listRegisteredCompactionProviders>;
   memoryEmbeddingProviders: ReturnType<typeof listRegisteredMemoryEmbeddingProviders>;
@@ -1085,6 +1087,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       restoreRegisteredCompactionProviders(cached.compactionProviders);
       restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
       restoreMemoryPluginState({
+        capability: cached.memoryCapability,
         corpusSupplements: cached.memoryCorpusSupplements,
         promptBuilder: cached.memoryPromptBuilder,
         promptSupplements: cached.memoryPromptSupplements,
@@ -1766,6 +1769,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     if (cacheEnabled) {
       setCachedPluginRegistry(cacheKey, {
+        memoryCapability: getMemoryCapabilityRegistration(),
         memoryCorpusSupplements: listMemoryCorpusSupplements(),
         registry,
         compactionProviders: listRegisteredCompactionProviders(),


### PR DESCRIPTION
## Summary
- preserve the registered memory capability when restoring a cached plugin registry
- add a regression test that verifies `publicArtifacts` survive a cache hit
- fix `memory-wiki` bridge imports that would otherwise see zero exported artifacts after cached loads

## Testing
- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config vitest.plugins.config.ts src/plugins/loader.test.ts src/plugins/memory-state.test.ts`

Closes #63157.
