### PR TITLE
fix(daemon): re-bootstrap LaunchAgent after bootout in gateway restart

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -767,4 +767,28 @@ describe("stopLaunchAgent", () => {
     expect(output).toContain("Stopped LaunchAgent");
     expect(output).not.toContain("degraded");
   });
+
+  it("falls back to bootout-only when HOME is missing (sanitized shell)", async () => {
+    // Omit HOME and USERPROFILE so resolveLaunchAgentPlistPath throws
+    const env: Record<string, string | undefined> = {
+      OPENCLAW_PROFILE: "default",
+    };
+
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout: out });
+
+    // bootout should still be called
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout")).toBe(true);
+    // disable and bootstrap should be skipped — they need the plist path
+    expect(state.launchctlCalls.some((c) => c[0] === "disable")).toBe(false);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(false);
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("degraded");
+    expect(output).not.toContain("Warning");
+  });
 });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -672,7 +672,7 @@ describe("stopLaunchAgent", () => {
     expect(output).not.toContain("degraded");
   });
 
-  it("warns when disable fails but still attempts bootstrap", async () => {
+  it("skips bootstrap when disable fails to keep service fully unregistered", async () => {
     const env = createDefaultLaunchdEnv();
     state.disableError = "Operation not permitted";
     state.disableCode = 1;
@@ -686,10 +686,9 @@ describe("stopLaunchAgent", () => {
     await stopLaunchAgent({ env, stdout: out });
 
     expect(output).toContain("launchctl disable failed");
-    expect(output).toContain("KeepAlive may restart");
-    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(true);
+    expect(output).toContain("skipping bootstrap");
+    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(false);
     expect(output).toContain("Stopped LaunchAgent");
-    expect(output).not.toContain("degraded");
   });
 
   it("reports degraded stop when bootstrap fails with a genuine error", async () => {
@@ -746,7 +745,7 @@ describe("stopLaunchAgent", () => {
     expect(output).not.toContain("degraded");
   });
 
-  it("warns on both disable and bootstrap failure", async () => {
+  it("does not call bootstrap when disable fails even if bootstrap would also fail", async () => {
     const env = createDefaultLaunchdEnv();
     state.disableError = "Permission denied";
     state.disableCode = 1;
@@ -762,7 +761,10 @@ describe("stopLaunchAgent", () => {
     await stopLaunchAgent({ env, stdout: out });
 
     expect(output).toContain("launchctl disable failed");
-    expect(output).toContain("launchctl bootstrap failed");
-    expect(output).toContain("Stopped LaunchAgent (degraded)");
+    // bootstrap should never be attempted when disable failed
+    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(false);
+    expect(output).not.toContain("launchctl bootstrap failed");
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("degraded");
   });
 });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -484,7 +484,10 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    // enable is always called before kickstart to clear any persisted disabled
+    // state from a prior stop (#63128), but bootstrap should not be called when
+    // the failure is not a "not loaded" error.
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 
@@ -517,7 +520,10 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    // enable is always called before kickstart to clear any persisted disabled
+    // state from a prior stop (#63128), but bootstrap should not be called when
+    // the failure is not a "not loaded" error.
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,6 +11,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -22,6 +23,8 @@ const state = vi.hoisted(() => ({
   bootstrapCode: 1,
   kickstartError: "",
   kickstartFailuresRemaining: 0,
+  disableError: "",
+  disableCode: 0,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -79,6 +82,9 @@ vi.mock("./exec-file.js", () => ({
         return { stdout: "", stderr: "Could not find service", code: 113 };
       }
       return { stdout: state.printOutput, stderr: "", code: 0 };
+    }
+    if (call[0] === "disable" && state.disableError) {
+      return { stdout: "", stderr: state.disableError, code: state.disableCode };
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: state.bootstrapCode };
@@ -162,6 +168,8 @@ beforeEach(() => {
   state.bootstrapCode = 1;
   state.kickstartError = "";
   state.kickstartFailuresRemaining = 0;
+  state.disableError = "";
+  state.disableCode = 0;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -617,5 +625,144 @@ describe("resolveLaunchAgentPlistPath", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveLaunchAgentPlistPath(env)).toBe(expected);
+  });
+});
+
+describe("stopLaunchAgent", () => {
+  function createDefaultLaunchdEnv(): Record<string, string | undefined> {
+    return {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+  }
+
+  function resolveServiceTarget() {
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    return { domain, label: "ai.openclaw.gateway", serviceTarget: `${domain}/ai.openclaw.gateway` };
+  }
+
+  it("executes bootout, disable, and bootstrap in order on success", async () => {
+    const env = createDefaultLaunchdEnv();
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout: out });
+
+    const { domain, serviceTarget } = resolveServiceTarget();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+
+    const bootoutIdx = state.launchctlCalls.findIndex(
+      (c) => c[0] === "bootout" && c[1] === serviceTarget,
+    );
+    const disableIdx = state.launchctlCalls.findIndex(
+      (c) => c[0] === "disable" && c[1] === serviceTarget,
+    );
+    const bootstrapIdx = state.launchctlCalls.findIndex(
+      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
+    );
+
+    expect(bootoutIdx).toBeGreaterThanOrEqual(0);
+    expect(disableIdx).toBeGreaterThan(bootoutIdx);
+    expect(bootstrapIdx).toBeGreaterThan(disableIdx);
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("Warning");
+    expect(output).not.toContain("degraded");
+  });
+
+  it("warns when disable fails but still attempts bootstrap", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.disableError = "Operation not permitted";
+    state.disableCode = 1;
+
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout: out });
+
+    expect(output).toContain("launchctl disable failed");
+    expect(output).toContain("KeepAlive may restart");
+    expect(state.launchctlCalls.some((c) => c[0] === "bootstrap")).toBe(true);
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("degraded");
+  });
+
+  it("reports degraded stop when bootstrap fails with a genuine error", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.bootstrapError = "Could not find specified service";
+    state.bootstrapCode = 1;
+
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout: out });
+
+    expect(output).toContain("launchctl bootstrap failed");
+    expect(output).toContain("unregistered, not just dormant");
+    expect(output).toContain("Stopped LaunchAgent (degraded)");
+  });
+
+  it("treats bootstrap 'already exists in domain' as success", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.bootstrapError =
+      "Could not bootstrap service: 5: Input/output error: already exists in domain for gui/501";
+    state.bootstrapCode = 5;
+
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout: out });
+
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("degraded");
+    expect(output).not.toContain("Warning");
+  });
+
+  it("treats bootstrap exit code 130 as success", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.bootstrapError = "Service already loaded";
+    state.bootstrapCode = 130;
+
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout: out });
+
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("degraded");
+  });
+
+  it("warns on both disable and bootstrap failure", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.disableError = "Permission denied";
+    state.disableCode = 1;
+    state.bootstrapError = "Could not find specified service";
+    state.bootstrapCode = 1;
+
+    const out = new PassThrough();
+    let output = "";
+    out.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout: out });
+
+    expect(output).toContain("launchctl disable failed");
+    expect(output).toContain("launchctl bootstrap failed");
+    expect(output).toContain("Stopped LaunchAgent (degraded)");
   });
 });

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -465,13 +465,23 @@ function isUnsupportedGuiDomain(detail: string): boolean {
 }
 
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
+  const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
-  const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const label = resolveLaunchAgentLabel({ env: serviceEnv });
+  const serviceTarget = `${domain}/${label}`;
+  const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const res = await execLaunchctl(["bootout", serviceTarget]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
     throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  // Re-bootstrap the plist so the service stays registered with launchd after
+  // bootout.  Without this, the LaunchAgent is fully deregistered and neither
+  // `launchctl kickstart` nor KeepAlive can revive it — `openclaw gateway
+  // restart` would find a dead service.  Disable the service first so that
+  // KeepAlive / RunAtLoad do not immediately relaunch it.  (#63128)
+  await execLaunchctl(["disable", serviceTarget]);
+  await execLaunchctl(["bootstrap", domain, plistPath]);
+  stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }
 
 async function writeLaunchAgentPlist({
@@ -620,6 +630,10 @@ export async function restartLaunchAgent({
   if (cleanupPort !== null) {
     cleanStaleGatewayProcessesSync(cleanupPort);
   }
+
+  // Clear any persisted "disabled" state (e.g. from a prior `openclaw gateway
+  // stop`) so that KeepAlive and kickstart work as expected.  (#63128)
+  await execLaunchctl(["enable", serviceTarget]);
 
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -479,8 +479,28 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
   // `launchctl kickstart` nor KeepAlive can revive it — `openclaw gateway
   // restart` would find a dead service.  Disable the service first so that
   // KeepAlive / RunAtLoad do not immediately relaunch it.  (#63128)
-  await execLaunchctl(["disable", serviceTarget]);
-  await execLaunchctl(["bootstrap", domain, plistPath]);
+  const disable = await execLaunchctl(["disable", serviceTarget]);
+  if (disable.code !== 0) {
+    const detail = (disable.stderr || disable.stdout).trim();
+    stdout.write(
+      `${formatLine("Warning", `launchctl disable failed (KeepAlive may restart the service): ${detail}`)}\n`,
+    );
+  }
+  const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
+  if (boot.code !== 0) {
+    const detail = (boot.stderr || boot.stdout).trim();
+    const normalized = normalizeLowercaseStringOrEmpty(detail);
+    // exit 130 / "already exists in domain" means the service is still
+    // registered — that is fine, we just wanted it to stay loaded.
+    const alreadyLoaded = boot.code === 130 || normalized.includes("already exists in domain");
+    if (!alreadyLoaded) {
+      stdout.write(
+        `${formatLine("Warning", `launchctl bootstrap failed — service is unregistered, not just dormant: ${detail}`)}\n`,
+      );
+      stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+      return;
+    }
+  }
   stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -474,18 +474,23 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
     throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
   }
-  // Re-bootstrap the plist so the service stays registered with launchd after
-  // bootout.  Without this, the LaunchAgent is fully deregistered and neither
-  // `launchctl kickstart` nor KeepAlive can revive it — `openclaw gateway
-  // restart` would find a dead service.  Disable the service first so that
-  // KeepAlive / RunAtLoad do not immediately relaunch it.  (#63128)
+  // Disable the service so KeepAlive / RunAtLoad do not immediately relaunch
+  // it.  If disable fails, do NOT proceed to bootstrap — the service was
+  // already bootout'd, so without bootstrap it stays fully unregistered,
+  // which is the safer failure mode for a stop operation.  (#63128, #63164)
   const disable = await execLaunchctl(["disable", serviceTarget]);
   if (disable.code !== 0) {
     const detail = (disable.stderr || disable.stdout).trim();
     stdout.write(
-      `${formatLine("Warning", `launchctl disable failed (KeepAlive may restart the service): ${detail}`)}\n`,
+      `${formatLine("Warning", `launchctl disable failed — skipping bootstrap to keep service unregistered: ${detail}`)}\n`,
     );
+    stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
+    return;
   }
+  // Re-bootstrap the plist so the service stays registered (but disabled) with
+  // launchd after bootout.  Without this, the LaunchAgent is fully deregistered
+  // and neither `launchctl kickstart` nor KeepAlive can revive it — `openclaw
+  // gateway restart` would find a dead service.
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -469,10 +469,23 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const serviceTarget = `${domain}/${label}`;
-  const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  // Best-effort plist resolution: HOME/USERPROFILE may be absent in sanitized
+  // shells or service wrappers.  When unavailable we can still bootout by
+  // service-target label; we just lose the disable+bootstrap "dormant
+  // registration" benefit.
+  let plistPath: string | undefined;
+  try {
+    plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  } catch {
+    // swallow — plistPath stays undefined
+  }
   const res = await execLaunchctl(["bootout", serviceTarget]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
     throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+  }
+  if (plistPath == null) {
+    stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
+    return;
   }
   // Disable the service so KeepAlive / RunAtLoad do not immediately relaunch
   // it.  If disable fails, do NOT proceed to bootstrap — the service was


### PR DESCRIPTION
## Summary
- `openclaw gateway restart` on macOS called `launchctl bootout` which fully deregistered the LaunchAgent, leaving the gateway dead with no auto-restart
- Fix: after bootout, re-bootstrap the plist so the service stays registered but dormant; on restart, enable before kickstart to clear any persisted disabled state

Closes #63128

## Changes
- `src/daemon/launchd.ts` — `stopLaunchAgent`: add `disable` + `bootstrap` after `bootout`; `restartLaunchAgent`: add `enable` before `kickstart -k`
- `src/daemon/launchd.test.ts` — update assertions for new enable-before-kickstart behavior

## Test plan
- [x] launchd.test.ts (all pass)
- [x] launchd-recovery.test.ts (all pass)
- [x] lifecycle.test.ts + lifecycle-core.test.ts (all pass, 61 total)
- [ ] Manual: `openclaw gateway restart` on macOS, verify service stays in `launchctl list`
- [ ] Manual: `openclaw gateway stop` then `openclaw gateway start`, verify KeepAlive works

🤖 Generated with [Claude Code](https://claude.com/claude-code)