### PR TITLE
docs(memory-wiki): add QMD bridge recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/memory-wiki: add the recommended QMD + bridge-mode hybrid recipe plus zero-artifact troubleshooting guidance for `memory-wiki` bridge setups. (#63165) Thanks @sercada and @vincentkoc.
+
 ### Fixes
 
 - Memory/active-memory+dreaming: keep active-memory recall runs on the strongest resolved channel, consume managed dreaming heartbeat events exactly once, stop dreaming from re-ingesting its own narrative transcripts, and add explicit repair/dedupe recovery flows in CLI, doctor, and the Dreams UI.

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -336,7 +336,6 @@ knowledge layer:
   memory: {
     backend: "qmd",
       "memory-wiki": {
-      "memory-wiki": {
         enabled: true,
         config: {
           vaultMode: "bridge",

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -45,6 +45,28 @@ both layers in one pass with `memory_search corpus=all`.
 When you need wiki-specific ranking, provenance, or direct page access, use the
 wiki-native tools instead.
 
+## Recommended hybrid pattern
+
+A strong default for local-first setups is:
+
+- QMD as the active memory backend for recall and broad semantic search
+- `memory-wiki` in `bridge` mode for durable synthesized knowledge pages
+
+That split works well because each layer stays focused:
+
+- QMD keeps raw notes, session exports, and extra collections searchable
+- `memory-wiki` compiles stable entities, claims, dashboards, and source pages
+
+Practical rule:
+
+- use `memory_search` when you want one broad recall pass across memory
+- use `wiki_search` and `wiki_get` when you want provenance-aware wiki results
+- use `memory_search corpus=all` when you want shared search to span both layers
+
+If bridge mode reports zero exported artifacts, the active memory plugin is not
+currently exposing public bridge inputs yet. Run `openclaw wiki doctor` first,
+then confirm the active memory plugin supports public artifacts.
+
 ## Vault modes
 
 `memory-wiki` supports three vault modes:
@@ -303,6 +325,51 @@ Key toggles:
 - `context.includeCompiledDigestPrompt`: append compact digest snapshot to memory prompt sections
 - `render.createBacklinks`: generate deterministic related blocks
 - `render.createDashboards`: generate dashboard pages
+
+### Example: QMD + bridge mode
+
+Use this when you want QMD for recall and `memory-wiki` for a maintained
+knowledge layer:
+
+```json5
+{
+  memory: {
+    backend: "qmd",
+  },
+  plugins: {
+    allow: ["memory-core", "memory-wiki"],
+    entries: {
+      "memory-wiki": {
+        enabled: true,
+        config: {
+          vaultMode: "bridge",
+          bridge: {
+            enabled: true,
+            readMemoryArtifacts: true,
+            indexDreamReports: true,
+            indexDailyNotes: true,
+            indexMemoryRoot: true,
+            followMemoryEvents: true,
+          },
+          search: {
+            backend: "shared",
+            corpus: "all",
+          },
+          context: {
+            includeCompiledDigestPrompt: false,
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+This keeps:
+
+- QMD in charge of active memory recall
+- `memory-wiki` focused on compiled pages and dashboards
+- prompt shape unchanged until you intentionally enable compiled digest prompts
 
 ## CLI
 

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -337,7 +337,6 @@ knowledge layer:
     backend: "qmd",
   },
   plugins: {
-    allow: ["memory-core", "memory-wiki"],
     entries: {
       "memory-wiki": {
         enabled: true,

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -335,9 +335,7 @@ knowledge layer:
 {
   memory: {
     backend: "qmd",
-  },
-  plugins: {
-    entries: {
+      "memory-wiki": {
       "memory-wiki": {
         enabled: true,
         config: {


### PR DESCRIPTION
## Summary
- add a documented hybrid pattern for QMD recall plus `memory-wiki` bridge synthesis
- include a concrete configuration example for bridge mode with shared search
- add troubleshooting guidance for zero-artifact bridge imports

## Testing
- `pnpm dlx markdownlint-cli2 docs/plugins/memory-wiki.md`

Closes #63159.
