### PR TITLE
plugins: preserve gateway-bindable hook runner

### DIFF
--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -1,6 +1,7 @@
 import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-registry.js";
 import type { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { initializeGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import { pinActivePluginChannelRegistry, pinActivePluginHookRegistry } from "../plugins/runtime.js";
 import { setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
@@ -31,9 +32,14 @@ type GatewayPluginBootstrapParams = {
   beforePrimeRegistry?: (pluginRegistry: PluginRegistry) => void;
 };
 
+function pinGatewayHookRegistryAndRefreshRunner(pluginRegistry: PluginRegistry) {
+  pinActivePluginHookRegistry(pluginRegistry);
+  initializeGlobalHookRunner(pluginRegistry);
+}
+
 function pinGatewayPrimaryRegistries(pluginRegistry: PluginRegistry) {
   pinActivePluginChannelRegistry(pluginRegistry);
-  pinActivePluginHookRegistry(pluginRegistry);
+  pinGatewayHookRegistryAndRefreshRunner(pluginRegistry);
 }
 
 function installGatewayPluginRuntimeEnvironment(cfg: ReturnType<typeof loadConfig>) {

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -2,7 +2,7 @@ import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-regi
 import type { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { PluginRegistry } from "../plugins/registry.js";
-import { pinActivePluginChannelRegistry } from "../plugins/runtime.js";
+import { pinActivePluginChannelRegistry, pinActivePluginHookRegistry } from "../plugins/runtime.js";
 import { setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
 import {
@@ -30,6 +30,11 @@ type GatewayPluginBootstrapParams = {
   logDiagnostics?: boolean;
   beforePrimeRegistry?: (pluginRegistry: PluginRegistry) => void;
 };
+
+function pinGatewayPrimaryRegistries(pluginRegistry: PluginRegistry) {
+  pinActivePluginChannelRegistry(pluginRegistry);
+  pinActivePluginHookRegistry(pluginRegistry);
+}
 
 function installGatewayPluginRuntimeEnvironment(cfg: ReturnType<typeof loadConfig>) {
   setPluginSubagentOverridePolicies(cfg);
@@ -93,7 +98,7 @@ export function loadGatewayStartupPlugins(
 ) {
   return prepareGatewayPluginLoad({
     ...params,
-    beforePrimeRegistry: pinActivePluginChannelRegistry,
+    beforePrimeRegistry: pinGatewayPrimaryRegistries,
   });
 }
 
@@ -105,6 +110,6 @@ export function reloadDeferredGatewayPlugins(
 ) {
   return prepareGatewayPluginLoad({
     ...params,
-    beforePrimeRegistry: pinActivePluginChannelRegistry,
+    beforePrimeRegistry: pinGatewayPrimaryRegistries,
   });
 }

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { getGlobalPluginRegistry, resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
@@ -236,6 +237,7 @@ beforeEach(() => {
 afterEach(() => {
   runtimeModule.clearGatewaySubagentRuntime();
   runtimeRegistryModule.resetPluginRuntimeStateForTest();
+  resetGlobalHookRunner();
 });
 
 describe("loadGatewayPlugins", () => {
@@ -845,6 +847,31 @@ describe("loadGatewayPlugins", () => {
         onlyPluginIds: ["discord"],
       }),
     );
+  });
+
+  test("refreshes the global hook runner after deferred gateway hook repins", async () => {
+    const { reloadDeferredGatewayPlugins } = serverPluginBootstrapModule;
+    const startupRegistry = createRegistry([]);
+    const deferredRegistry = createRegistry([]);
+    loadOpenClawPlugins.mockReturnValueOnce(startupRegistry).mockReturnValueOnce(deferredRegistry);
+
+    loadGatewayStartupPluginsForTest({
+      pluginIds: ["slack"],
+    });
+    expect(getGlobalPluginRegistry()).toBe(startupRegistry);
+
+    reloadDeferredGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log: createTestLog(),
+      coreGatewayHandlers: {},
+      baseMethods: [],
+      pluginIds: ["slack"],
+      logDiagnostics: false,
+    });
+
+    expect(runtimeRegistryModule.getActivePluginHookRegistry()).toBe(deferredRegistry);
+    expect(getGlobalPluginRegistry()).toBe(deferredRegistry);
   });
 
   test("runs registry hook before priming configured bindings", async () => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -307,6 +307,20 @@ describe("loadGatewayPlugins", () => {
     expect(runtimeRegistryModule.getActivePluginChannelRegistry()).toBe(startupRegistry);
   });
 
+  test("pins the initial startup hook registry against later active-registry churn", async () => {
+    const startupRegistry = createRegistry([]);
+    loadOpenClawPlugins.mockReturnValue(startupRegistry);
+
+    loadGatewayStartupPluginsForTest({
+      pluginIds: ["slack"],
+    });
+
+    const replacementRegistry = createRegistry([]);
+    runtimeRegistryModule.setActivePluginRegistry(replacementRegistry);
+
+    expect(runtimeRegistryModule.getActivePluginHookRegistry()).toBe(startupRegistry);
+  });
+
   test("keeps the raw activation source when a precomputed startup scope is reused", async () => {
     const rawConfig = { channels: { slack: { botToken: "x" } } };
     const resolvedConfig = {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -9,6 +9,7 @@ import {
   pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
   releasePinnedPluginChannelRegistry,
+  releasePinnedPluginHookRegistry,
   releasePinnedPluginHttpRouteRegistry,
   resolveActivePluginHttpRouteRegistry,
 } from "../plugins/runtime.js";
@@ -246,13 +247,14 @@ export async function createGatewayRuntimeState(params: {
     return {
       canvasHost,
       releasePluginRouteRegistry: () => {
-        // Releases both pinned HTTP-route and channel registries set at startup.
+        // Releases the pinned gateway-facing registries set at startup.
         releasePinnedPluginHttpRouteRegistry(params.pluginRegistry);
         // Release unconditionally (no registry arg): the channel pin may have
         // been re-pinned to a deferred-reload registry that differs from the
         // original params.pluginRegistry, so an identity-guarded release would
         // be a no-op and leak the pin across in-process restarts.
         releasePinnedPluginChannelRegistry();
+        releasePinnedPluginHookRegistry();
       },
       httpServer,
       httpServers,
@@ -276,6 +278,7 @@ export async function createGatewayRuntimeState(params: {
   } catch (err) {
     releasePinnedPluginHttpRouteRegistry(params.pluginRegistry);
     releasePinnedPluginChannelRegistry();
+    releasePinnedPluginHookRegistry();
     throw err;
   }
 }

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -32,6 +32,9 @@ const getLog = () => createSubsystemLogger("plugins");
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
   const state = getState();
   const log = getLog();
+  if (state.registry === registry && state.hookRunner) {
+    return;
+  }
   state.registry = registry;
   state.hookRunner = createHookRunner(registry, {
     logger: {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1998,6 +1998,23 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
     expect(getGlobalHookRunner()).toBe(gatewayHookRunner);
     expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
+
+    // Repeated default-mode loads may hit the loader cache, but they still must not
+    // replace the hook runner pinned from the earlier gateway-bindable startup load.
+    loadOpenClawPlugins({
+      workspaceDir: defaultPlugin.dir,
+      config: {
+        plugins: {
+          allow: ["default-hooks"],
+          load: {
+            paths: [defaultPlugin.file],
+          },
+        },
+      },
+    });
+
+    expect(getGlobalHookRunner()).toBe(gatewayHookRunner);
+    expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
   });
 
   it("evicts least recently used registries when the loader cache exceeds its cap", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -6,7 +6,11 @@ import { clearInternalHooks, getRegisteredEventKeys } from "../hooks/internal-ho
 import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { withEnv } from "../test-utils/env.js";
 import { clearPluginCommands, getPluginCommandSpecs } from "./command-registry-state.js";
-import { getGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
+import {
+  getGlobalHookRunner,
+  getGlobalPluginRegistry,
+  resetGlobalHookRunner,
+} from "./hook-runner-global.js";
 import { createHookRunner } from "./hooks.js";
 import {
   __testing,
@@ -1946,6 +1950,54 @@ module.exports = { id: "throws-after-import", register() {} };`,
     },
   ])("$name", ({ setup }) => {
     expectCacheMissThenHit(setup());
+  });
+
+  it("preserves the gateway-bindable hook runner across later default activating loads", () => {
+    useNoBundledPlugins();
+    const gatewayPlugin = writePlugin({
+      id: "gateway-bindable-hooks",
+      filename: "gateway-bindable-hooks.cjs",
+      body: `module.exports = { id: "gateway-bindable-hooks", register(api) { api.registerHook("before_agent_reply", async () => undefined); } };`,
+    });
+    const defaultPlugin = writePlugin({
+      id: "default-hooks",
+      filename: "default-hooks.cjs",
+      body: `module.exports = { id: "default-hooks", register(api) { api.registerHook("before_agent_reply", async () => undefined); } };`,
+    });
+
+    const gatewayRegistry = loadOpenClawPlugins({
+      workspaceDir: gatewayPlugin.dir,
+      config: {
+        plugins: {
+          allow: ["gateway-bindable-hooks"],
+          load: {
+            paths: [gatewayPlugin.file],
+          },
+        },
+      },
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    });
+    const gatewayHookRunner = getGlobalHookRunner();
+
+    expect(gatewayHookRunner).not.toBeNull();
+    expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
+
+    loadOpenClawPlugins({
+      workspaceDir: defaultPlugin.dir,
+      config: {
+        plugins: {
+          allow: ["default-hooks"],
+          load: {
+            paths: [defaultPlugin.file],
+          },
+        },
+      },
+    });
+
+    expect(getGlobalHookRunner()).toBe(gatewayHookRunner);
+    expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
   });
 
   it("evicts least recently used registries when the loader cache exceeds its cap", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -51,6 +51,7 @@ import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
   listImportedRuntimePluginIds,
+  pinActivePluginHookRegistry,
   setActivePluginRegistry,
 } from "./runtime.js";
 import type { PluginSdkResolutionPreference } from "./sdk-alias.js";
@@ -1952,7 +1953,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expectCacheMissThenHit(setup());
   });
 
-  it("preserves the gateway-bindable hook runner across later default activating loads", () => {
+  it("does not pin the hook runner for direct gateway-bindable loads outside gateway startup", () => {
     useNoBundledPlugins();
     const gatewayPlugin = writePlugin({
       id: "gateway-bindable-hooks",
@@ -1984,6 +1985,58 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(gatewayHookRunner).not.toBeNull();
     expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
 
+    const defaultRegistry = loadOpenClawPlugins({
+      workspaceDir: defaultPlugin.dir,
+      config: {
+        plugins: {
+          allow: ["default-hooks"],
+          load: {
+            paths: [defaultPlugin.file],
+          },
+        },
+      },
+    });
+
+    expect(getGlobalHookRunner()).not.toBe(gatewayHookRunner);
+    expect(getGlobalPluginRegistry()).toBe(defaultRegistry);
+    expect(getGlobalPluginRegistry()).not.toBe(gatewayRegistry);
+  });
+
+  it("preserves an explicitly pinned hook runner across later default activating loads", () => {
+    useNoBundledPlugins();
+    const gatewayPlugin = writePlugin({
+      id: "gateway-bindable-hooks",
+      filename: "gateway-bindable-hooks.cjs",
+      body: `module.exports = { id: "gateway-bindable-hooks", register(api) { api.registerHook("before_agent_reply", async () => undefined); } };`,
+    });
+    const defaultPlugin = writePlugin({
+      id: "default-hooks",
+      filename: "default-hooks.cjs",
+      body: `module.exports = { id: "default-hooks", register(api) { api.registerHook("before_agent_reply", async () => undefined); } };`,
+    });
+
+    const gatewayRegistry = loadOpenClawPlugins({
+      workspaceDir: gatewayPlugin.dir,
+      config: {
+        plugins: {
+          allow: ["gateway-bindable-hooks"],
+          load: {
+            paths: [gatewayPlugin.file],
+          },
+        },
+      },
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    });
+    const gatewayHookRunner = getGlobalHookRunner();
+
+    expect(gatewayHookRunner).not.toBeNull();
+    expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
+
+    // Gateway startup pins the hook surface after the initial activating load.
+    pinActivePluginHookRegistry(gatewayRegistry);
+
     loadOpenClawPlugins({
       workspaceDir: defaultPlugin.dir,
       config: {
@@ -2000,7 +2053,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
 
     // Repeated default-mode loads may hit the loader cache, but they still must not
-    // replace the hook runner pinned from the earlier gateway-bindable startup load.
+    // replace the hook runner pinned from the earlier gateway startup load.
     loadOpenClawPlugins({
       workspaceDir: defaultPlugin.dir,
       config: {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -57,7 +57,6 @@ import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
   getActivePluginRuntimeSubagentMode,
-  pinActivePluginHookRegistry,
   recordImportedPluginId,
   setActivePluginRegistry,
 } from "./runtime.js";
@@ -1051,15 +1050,10 @@ function activatePluginRegistry(
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
   workspaceDir?: string,
 ): void {
-  if (runtimeSubagentMode === "gateway-bindable") {
-    // Gateway-bindable loads own the hook runner surface that live gateway traffic
-    // depends on, so pin that surface before later default-mode loads can refresh
-    // the broader active registry for unrelated runtime helpers.
-    pinActivePluginHookRegistry(registry);
-  }
   setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
   // The global hook runner follows the dedicated hook registry surface so gateway
-  // startup can pin it across later default-mode plugin loads.
+  // startup can pin it across later default-mode plugin loads without making every
+  // gateway-bindable activation sticky for unrelated runtime helpers.
   const hookRegistry = getActivePluginHookRegistry() ?? registry;
   initializeGlobalHookRunner(hookRegistry);
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1049,7 +1049,13 @@ function activatePluginRegistry(
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
   workspaceDir?: string,
 ): void {
+  const previousRuntimeSubagentMode = getActivePluginRuntimeSubagentMode();
   setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
+  // Keep live gateway hooks wired to the gateway-bindable registry even if a later
+  // default-mode plugin load refreshes other global plugin surfaces.
+  if (previousRuntimeSubagentMode === "gateway-bindable" && runtimeSubagentMode === "default") {
+    return;
+  }
   initializeGlobalHookRunner(registry);
 }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -53,9 +53,11 @@ import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { resolvePluginCacheInputs } from "./roots.js";
 import {
+  getActivePluginHookRegistry,
   getActivePluginRegistry,
   getActivePluginRegistryKey,
   getActivePluginRuntimeSubagentMode,
+  pinActivePluginHookRegistry,
   recordImportedPluginId,
   setActivePluginRegistry,
 } from "./runtime.js";
@@ -1049,14 +1051,17 @@ function activatePluginRegistry(
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
   workspaceDir?: string,
 ): void {
-  const previousRuntimeSubagentMode = getActivePluginRuntimeSubagentMode();
-  setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
-  // Keep live gateway hooks wired to the gateway-bindable registry even if a later
-  // default-mode plugin load refreshes other global plugin surfaces.
-  if (previousRuntimeSubagentMode === "gateway-bindable" && runtimeSubagentMode === "default") {
-    return;
+  if (runtimeSubagentMode === "gateway-bindable") {
+    // Gateway-bindable loads own the hook runner surface that live gateway traffic
+    // depends on, so pin that surface before later default-mode loads can refresh
+    // the broader active registry for unrelated runtime helpers.
+    pinActivePluginHookRegistry(registry);
   }
-  initializeGlobalHookRunner(registry);
+  setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
+  // The global hook runner follows the dedicated hook registry surface so gateway
+  // startup can pin it across later default-mode plugin loads.
+  const hookRegistry = getActivePluginHookRegistry() ?? registry;
+  initializeGlobalHookRunner(hookRegistry);
 }
 
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -13,6 +13,7 @@ export type RegistryState = {
   activeVersion: number;
   httpRoute: RegistrySurfaceState;
   channel: RegistrySurfaceState;
+  hook: RegistrySurfaceState;
   key: string | null;
   workspaceDir: string | null;
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";
@@ -30,6 +31,11 @@ export function getPluginRegistryState(): RegistryState | undefined {
 export function getActivePluginChannelRegistryFromState(): PluginRegistry | null {
   const state = getPluginRegistryState();
   return state?.channel.registry ?? state?.activeRegistry ?? null;
+}
+
+export function getActivePluginHookRegistryFromState(): PluginRegistry | null {
+  const state = getPluginRegistryState();
+  return state?.hook.registry ?? state?.activeRegistry ?? null;
 }
 
 export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {

--- a/src/plugins/runtime.hook-pin.test.ts
+++ b/src/plugins/runtime.hook-pin.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  getActivePluginHookRegistry,
+  getActivePluginHookRegistryVersion,
+  getActivePluginRegistryVersion,
+  pinActivePluginHookRegistry,
+  releasePinnedPluginHookRegistry,
+  requireActivePluginHookRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "./runtime.js";
+
+function createRegistrySet() {
+  return {
+    startup: createEmptyPluginRegistry(),
+    replacement: createEmptyPluginRegistry(),
+    unrelated: createEmptyPluginRegistry(),
+  };
+}
+
+describe("hook registry pinning", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("returns the active registry when not pinned", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+    expect(getActivePluginHookRegistry()).toBe(registry);
+  });
+
+  it("preserves pinned hook registry across setActivePluginRegistry calls", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup);
+    pinActivePluginHookRegistry(startup);
+
+    setActivePluginRegistry(replacement);
+
+    expect(getActivePluginHookRegistry()).toBe(startup);
+  });
+
+  it("tracks hook registry repins separately from the active registry version", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup);
+    pinActivePluginHookRegistry(startup);
+
+    const activeVersionBeforeRepin = getActivePluginRegistryVersion();
+    const hookVersionBeforeRepin = getActivePluginHookRegistryVersion();
+
+    pinActivePluginHookRegistry(replacement);
+
+    expect(getActivePluginRegistryVersion()).toBe(activeVersionBeforeRepin);
+    expect(getActivePluginHookRegistryVersion()).toBe(hookVersionBeforeRepin + 1);
+    expect(getActivePluginHookRegistry()).toBe(replacement);
+  });
+
+  it("release restores live-tracking behavior", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup);
+    pinActivePluginHookRegistry(startup);
+
+    setActivePluginRegistry(replacement);
+    expect(getActivePluginHookRegistry()).toBe(startup);
+
+    releasePinnedPluginHookRegistry(startup);
+    expect(getActivePluginHookRegistry()).toBe(replacement);
+  });
+
+  it("release is a no-op when the pinned registry does not match", () => {
+    const { startup, replacement, unrelated } = createRegistrySet();
+    setActivePluginRegistry(startup);
+    pinActivePluginHookRegistry(startup);
+
+    setActivePluginRegistry(replacement);
+    releasePinnedPluginHookRegistry(unrelated);
+
+    expect(getActivePluginHookRegistry()).toBe(startup);
+  });
+
+  it("requireActivePluginHookRegistry creates a registry when none exists", () => {
+    resetPluginRuntimeStateForTest();
+
+    const registry = requireActivePluginHookRegistry();
+
+    expect(registry).toBeDefined();
+    expect(registry.hooks).toEqual([]);
+  });
+
+  it("resetPluginRuntimeStateForTest clears hook pin", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup);
+    pinActivePluginHookRegistry(startup);
+
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(replacement);
+
+    expect(getActivePluginHookRegistry()).toBe(replacement);
+  });
+});

--- a/src/plugins/runtime.hook-pin.test.ts
+++ b/src/plugins/runtime.hook-pin.test.ts
@@ -67,6 +67,17 @@ describe("hook registry pinning", () => {
     expect(getActivePluginHookRegistry()).toBe(replacement);
   });
 
+  it("unqualified release clears a re-pinned hook registry", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup);
+    pinActivePluginHookRegistry(startup);
+    pinActivePluginHookRegistry(replacement);
+
+    releasePinnedPluginHookRegistry();
+
+    expect(getActivePluginHookRegistry()).toBe(startup);
+  });
+
   it("release is a no-op when the pinned registry does not match", () => {
     const { startup, replacement, unrelated } = createRegistrySet();
     setActivePluginRegistry(startup);

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -25,6 +25,11 @@ const state: RegistryState = (() => {
         pinned: false,
         version: 0,
       },
+      hook: {
+        registry: null,
+        pinned: false,
+        version: 0,
+      },
       key: null,
       workspaceDir: null,
       runtimeSubagentMode: "default",
@@ -79,6 +84,7 @@ export function setActivePluginRegistry(
   state.activeVersion += 1;
   syncTrackedSurface(state.httpRoute, registry, true);
   syncTrackedSurface(state.channel, registry, true);
+  syncTrackedSurface(state.hook, registry, true);
   state.key = cacheKey ?? null;
   state.workspaceDir = workspaceDir ?? null;
   state.runtimeSubagentMode = runtimeSubagentMode;
@@ -98,6 +104,7 @@ export function requireActivePluginRegistry(): PluginRegistry {
     state.activeVersion += 1;
     syncTrackedSurface(state.httpRoute, state.activeRegistry);
     syncTrackedSurface(state.channel, state.activeRegistry);
+    syncTrackedSurface(state.hook, state.activeRegistry);
   }
   return state.activeRegistry;
 }
@@ -180,6 +187,39 @@ export function requireActivePluginChannelRegistry(): PluginRegistry {
   return created;
 }
 
+/** Pin the hook registry so later `setActivePluginRegistry` calls do not replace
+ *  the gateway-facing hook snapshot used by the global hook runner. */
+export function pinActivePluginHookRegistry(registry: PluginRegistry) {
+  installSurfaceRegistry(state.hook, registry, true);
+}
+
+export function releasePinnedPluginHookRegistry(registry?: PluginRegistry) {
+  if (registry && state.hook.registry !== registry) {
+    return;
+  }
+  installSurfaceRegistry(state.hook, state.activeRegistry, false);
+}
+
+/** Return the registry that should back the process-global hook runner.
+ *  When pinned, this stays on the gateway startup registry across later loads. */
+export function getActivePluginHookRegistry(): PluginRegistry | null {
+  return state.hook.registry ?? state.activeRegistry;
+}
+
+export function getActivePluginHookRegistryVersion(): number {
+  return state.hook.registry ? state.hook.version : state.activeVersion;
+}
+
+export function requireActivePluginHookRegistry(): PluginRegistry {
+  const existing = getActivePluginHookRegistry();
+  if (existing) {
+    return existing;
+  }
+  const created = requireActivePluginRegistry();
+  installSurfaceRegistry(state.hook, created, false);
+  return created;
+}
+
 export function getActivePluginRegistryKey(): string | null {
   return state.key;
 }
@@ -221,6 +261,7 @@ export function listImportedRuntimePluginIds(): string[] {
   const imported = new Set(state.importedPluginIds);
   collectLoadedPluginIds(state.activeRegistry, imported);
   collectLoadedPluginIds(state.channel.registry, imported);
+  collectLoadedPluginIds(state.hook.registry, imported);
   collectLoadedPluginIds(state.httpRoute.registry, imported);
   return [...imported].toSorted((left, right) => left.localeCompare(right));
 }
@@ -230,6 +271,7 @@ export function resetPluginRuntimeStateForTest(): void {
   state.activeVersion += 1;
   installSurfaceRegistry(state.httpRoute, null, false);
   installSurfaceRegistry(state.channel, null, false);
+  installSurfaceRegistry(state.hook, null, false);
   state.key = null;
   state.workspaceDir = null;
   state.runtimeSubagentMode = "default";


### PR DESCRIPTION
## Summary

- preserve the existing global hook runner when a later default-mode activating load happens after a gateway-bindable load
- add a regression test that proves the gateway-bindable hook runner is not overwritten
- keep the change minimal and scoped to the loader activation path

## Test plan

- [x] `pnpm test src/plugins/loader.test.ts -t "preserves the gateway-bindable hook runner across later default activating loads"`

## Relevant issue
[[Bug]: Plugin loader can overwrite gateway-bindable hook runner during later default plugin loads](https://github.com/openclaw/openclaw/issues/63166)