### PR TITLE
fix: address Ollama timeout issue

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -387,7 +387,7 @@ export async function runEmbeddedAttempt(
   // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
   // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.
   ensureGlobalUndiciEnvProxyDispatcher();
-  ensureGlobalUndiciStreamTimeouts();
+  ensureGlobalUndiciStreamTimeouts({ timeoutMs: params.timeoutMs });
 
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,


### PR DESCRIPTION
## Summary

Fixes an issue where Ollama requests would timeout after 60 seconds regardless of configuration.

## Changes

- Updated `pi-embedded-runner` to pass `timeoutMs` to `ensureGlobalUndiciStreamTimeouts`

## Testing

- Verified timeout logic in code

Fixes openclaw/openclaw#63175