### PR TITLE
fix(slack): isolate doctor contract API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,7 @@ Docs: https://docs.openclaw.ai
 - Agents/inbound metadata: strip NUL bytes from serialized inbound context blocks before they reach backend spawn args, so malformed message metadata cannot crash agent spawn with `ERR_INVALID_ARG_VALUE`. (#65389) Thanks @adminfedres and @vincentkoc.
 - iMessage: retry transient `watch.subscribe` startup failures before tearing down the monitor, so brief local transport stalls do not immediately bounce the channel. (#65393) Thanks @vincentkoc.
 - Status/session_status: move shared session status text into a neutral internal status module and keep the tool importing a local runtime shim, so built `session_status` no longer depends on reply command internals or a bundler-opaque runtime import. (#65807) Thanks @dutifulbob.
+- Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
 
 ## 2026.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - TTS/reply media: persist OpenClaw temp voice outputs into managed outbound media and allow them through reply-media normalization, so voice-note replies stop silently dropping. (#63511) Thanks @jetd1.
 - Agents/OpenAI: recover embedded GPT-style runs when reasoning-only or empty turns need bounded continuation, with replay-safe retry gating and incomplete-turn fallback when no visible answer arrives. (#66167) thanks @jalehman
 - Outbound/relay-status: suppress internal relay-status placeholder payloads (`No channel reply.`, `Replied in-thread.`, `Replied in #...`, wiki-update status variants ending in `No channel reply.`) before channel delivery so internal housekeeping text does not leak to users.
+- Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
 
 ## 2026.4.12
 
@@ -297,13 +298,11 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/scheduling: spread interval heartbeats across stable per-agent phases derived from gateway identity, so provider traffic is distributed more uniformly across the configured interval instead of clustering around startup-relative times. (#64560) Thanks @odysseus0.
 - Config/media: accept `tools.media.asyncCompletion.directSend` in strict config validation so gateways no longer reject the generated-schema-backed async media completion setting at startup. (#63618) Thanks @qiziAI.
 - Telegram/exec: preserve delayed exec completion routing for forum topics by pinning background exec completions to the topic where the run started even if the session route later drifts. (#64580) thanks @jalehman.
-<<<<<<< HEAD
 - Agents/locks: unregister the session write-lock `exit` cleanup handler during teardown so repeated lock lifecycle resets stop stacking process listeners in long-running gateway processes. (#65391) Thanks @adminfedres and @vincentkoc.
 - CLI/Claude: rename the trusted inbound metadata schema to `openclaw.inbound_meta.v2` so Claude CLI no longer trips Anthropic's blocked `openclaw.inbound_meta.v1` filter on channel-originated turns. (#65399) Thanks @SzyMig and @vincentkoc.
 - Agents/inbound metadata: strip NUL bytes from serialized inbound context blocks before they reach backend spawn args, so malformed message metadata cannot crash agent spawn with `ERR_INVALID_ARG_VALUE`. (#65389) Thanks @adminfedres and @vincentkoc.
 - iMessage: retry transient `watch.subscribe` startup failures before tearing down the monitor, so brief local transport stalls do not immediately bounce the channel. (#65393) Thanks @vincentkoc.
 - Status/session_status: move shared session status text into a neutral internal status module and keep the tool importing a local runtime shim, so built `session_status` no longer depends on reply command internals or a bundler-opaque runtime import. (#65807) Thanks @dutifulbob.
-- Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
 
 ## 2026.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/scheduling: spread interval heartbeats across stable per-agent phases derived from gateway identity, so provider traffic is distributed more uniformly across the configured interval instead of clustering around startup-relative times. (#64560) Thanks @odysseus0.
 - Config/media: accept `tools.media.asyncCompletion.directSend` in strict config validation so gateways no longer reject the generated-schema-backed async media completion setting at startup. (#63618) Thanks @qiziAI.
 - Telegram/exec: preserve delayed exec completion routing for forum topics by pinning background exec completions to the topic where the run started even if the session route later drifts. (#64580) thanks @jalehman.
+<<<<<<< HEAD
 - Agents/locks: unregister the session write-lock `exit` cleanup handler during teardown so repeated lock lifecycle resets stop stacking process listeners in long-running gateway processes. (#65391) Thanks @adminfedres and @vincentkoc.
 - CLI/Claude: rename the trusted inbound metadata schema to `openclaw.inbound_meta.v2` so Claude CLI no longer trips Anthropic's blocked `openclaw.inbound_meta.v1` filter on channel-originated turns. (#65399) Thanks @SzyMig and @vincentkoc.
 - Agents/inbound metadata: strip NUL bytes from serialized inbound context blocks before they reach backend spawn args, so malformed message metadata cannot crash agent spawn with `ERR_INVALID_ARG_VALUE`. (#65389) Thanks @adminfedres and @vincentkoc.

--- a/extensions/slack/doctor-contract-api.ts
+++ b/extensions/slack/doctor-contract-api.ts
@@ -1,0 +1,1 @@
+export { normalizeCompatibilityConfig, legacyConfigRules } from "./src/doctor-contract.js";

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -157,6 +157,13 @@ describe("bundled plugin metadata", () => {
     );
   });
 
+  it("keeps Slack's doctor contract sidecar on the bundled public surface", () => {
+    const slack = listRepoBundledPluginMetadata().find((entry) => entry.dirName === "slack");
+    expectArtifactPresence(slack?.publicSurfaceArtifacts, {
+      contains: ["doctor-contract-api.js"],
+    });
+  });
+
   it("loads tlon channel config metadata from the lightweight schema surface", () => {
     expect(collectRepoBundledChannelConfigsForTest("tlon")?.tlon).toEqual(
       expect.objectContaining({

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -61,6 +61,30 @@ describe("doctor-contract-registry getJiti", () => {
     );
   });
 
+  it("prefers doctor-contract-api over the broader contract-api surface", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(pluginRoot, "doctor-contract-api.js"),
+      "export default {};\n",
+      "utf-8",
+    );
+    fs.writeFileSync(path.join(pluginRoot, "contract-api.js"), "export default {};\n", "utf-8");
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "test-plugin", rootDir: pluginRoot }],
+      diagnostics: [],
+    });
+
+    listPluginDoctorLegacyConfigRules({
+      workspaceDir: pluginRoot,
+      env: {},
+    });
+
+    expect(mocks.createJiti).toHaveBeenCalledTimes(1);
+    expect(mocks.createJiti.mock.calls[0]?.[0]).toBe(
+      path.join(pluginRoot, "doctor-contract-api.js"),
+    );
+  });
+
   it("narrows touched-path doctor ids for scoped dry-run validation", () => {
     expect(
       collectRelevantDoctorPluginIdsForTouchedPaths({


### PR DESCRIPTION
## Summary

- Problem: commands that warm config early, such as `openclaw cron`, could crash during config read when `channels.slack` was present.
- Why it matters: the doctor-contract registry fell back to Slack's broad `contract-api` surface, which pulled in unrelated contract code during config warmup.
- What changed: added a dedicated runtime sidecar at `extensions/slack/doctor-contract-api.ts` and added a regression test that locks the registry preference to that sidecar.
- What did NOT change (scope boundary): no Slack doctor rule logic changed, no config schema changed, and no general contract-registry behavior changed outside this missing Slack surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/plugins/doctor-contract-registry.ts` already prefers `doctor-contract-api*` over `contract-api*`, but Slack did not expose a dedicated `doctor-contract-api` sidecar. That forced runtime fallback to the broader Slack contract surface during config warmup.
- Missing detection / guardrail: there was no regression test asserting that the registry prefers `doctor-contract-api` when both public surfaces exist.
- Contributing context (if known): this showed up on CLI paths that read config before command execution, with `channels.slack` present.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/doctor-contract-registry.test.ts`
- Scenario the test should lock in: when both `doctor-contract-api.js` and `contract-api.js` exist, the registry loads the doctor sidecar.
- Why this is the smallest reliable guardrail: the bug is in doctor-contract resolution, so the registry seam is the narrowest place to prevent the bad fallback.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Commands that warm config no longer need Slack's broad `contract-api` surface just to read doctor compatibility rules. That avoids the Slack-related config read crash on the affected CLI path.

## Diagram (if applicable)

```text
Before:
[openclaw cron] -> [config warmup] -> [Slack contract-api fallback] -> [unrelated Slack contract load] -> [crash]

After:
[openclaw cron] -> [config warmup] -> [Slack doctor-contract-api] -> [doctor rules only] -> [command continues]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local CLI checkout
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): `channels.slack` present in user config

### Steps

1. Keep a config with `channels.slack` configured.
2. Run a command that warms config/context before execution, such as `openclaw cron --help`.
3. Observe which public Slack surface the doctor registry resolves during config warmup.

### Expected

- Config warmup loads only the Slack doctor-contract surface and does not fall back to unrelated Slack contract code.

### Actual

- Before this patch, Slack fell back to the broad `contract-api` surface and could crash during config read.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/plugins/doctor-contract-registry.test.ts` passes with the new preference assertion; bundled plugin build entry resolution includes `extensions/slack/doctor-contract-api.ts` and `dist/extensions/slack/doctor-contract-api.js`.
- Edge cases checked: verified the preference behavior when both sidecars exist.
- What you did **not** verify: a full `pnpm build` is still red in this checkout because of an unrelated `canvas:a2ui:bundle` failure.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another bundled channel plugin could still rely on the broad `contract-api` fallback for doctor-only loading.
  - Mitigation: this change adds Slack's missing narrow sidecar and locks the intended preference with a regression test.
