### PR TITLE
fix: build multipart body manually in transcribeOpenAiCompatibleAudio

### DIFF
--- a/extensions/openai/media-understanding-provider.test.ts
+++ b/extensions/openai/media-understanding-provider.test.ts
@@ -53,19 +53,23 @@ describe("transcribeOpenAiAudio", () => {
     expect(headers.get("authorization")).toBe("Bearer test-key");
     expect(headers.get("x-custom")).toBe("1");
 
-    const form = seenInit?.body as FormData;
-    expect(form).toBeInstanceOf(FormData);
-    expect(form.get("model")).toBe("gpt-4o-transcribe");
-    expect(form.get("language")).toBe("en");
-    expect(form.get("prompt")).toBe("hello");
-    const file = form.get("file") as Blob | { type?: string; name?: string } | null;
-    expect(file).not.toBeNull();
-    if (file) {
-      expect(file.type).toBe("audio/wav");
-      if ("name" in file && typeof file.name === "string") {
-        expect(file.name).toBe("voice.wav");
-      }
-    }
+    // Body is a raw Buffer with an explicit multipart/form-data Content-Type (not a FormData instance).
+    // This sidesteps the undici npm fetch / globalThis.FormData incompatibility where the
+    // Content-Type boundary header is never set when using a custom dispatcher.
+    expect(Buffer.isBuffer(seenInit?.body)).toBe(true);
+    const ct = headers.get("content-type") ?? "";
+    expect(ct).toMatch(/^multipart\/form-data; boundary=/);
+
+    const bodyStr = Buffer.from(seenInit?.body as Buffer).toString("utf8");
+    expect(bodyStr).toContain('name="model"');
+    expect(bodyStr).toContain("gpt-4o-transcribe");
+    expect(bodyStr).toContain('name="language"');
+    expect(bodyStr).toContain("en");
+    expect(bodyStr).toContain('name="prompt"');
+    expect(bodyStr).toContain("hello");
+    expect(bodyStr).toContain('name="file"');
+    expect(bodyStr).toContain('filename="voice.wav"');
+    expect(bodyStr).toContain("Content-Type: audio/wav");
   });
 
   it("throws when the provider response omits text", async () => {

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -118,6 +118,24 @@ describe("transcribeOpenAiCompatibleAudio", () => {
       expect(bodyStr).toContain("test prompt");
     });
 
+    it("sanitizes quotes and CRLF in the filename", async () => {
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+      await transcribeOpenAiCompatibleAudio({
+        buffer: Buffer.from("audio"),
+        fileName: 'bad"name\r\nInjected: header',
+        apiKey: "k",
+        timeoutMs: 1000,
+        fetchFn,
+        provider: "openai",
+        defaultBaseUrl: "https://api.openai.com/v1",
+        defaultModel: "gpt-4o-transcribe",
+      });
+
+      const bodyStr = decodeBody(getRequest().init?.body);
+      expect(bodyStr).toContain('filename="bad\\"nameInjected: header"');
+    });
+
     it("omits language and prompt fields when not provided", async () => {
       const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
 

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -133,7 +133,7 @@ describe("transcribeOpenAiCompatibleAudio", () => {
       });
 
       const bodyStr = decodeBody(getRequest().init?.body);
-      expect(bodyStr).toContain('filename="bad\\"nameInjected: header"');
+      expect(bodyStr).toContain('filename="bad%22nameInjected: header"');
     });
 
     it("strips CR/LF from mime type", async () => {

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -5,6 +5,16 @@ import {
 } from "./audio.test-helpers.js";
 import { transcribeOpenAiCompatibleAudio } from "./openai-compatible-audio.js";
 
+function decodeBody(body: BodyInit | null | undefined): string {
+  if (!body) {
+    return "";
+  }
+  if (body instanceof Uint8Array || Buffer.isBuffer(body)) {
+    return Buffer.from(body).toString("utf8");
+  }
+  return String(body);
+}
+
 installPinnedHostnameTestHooks();
 
 describe("transcribeOpenAiCompatibleAudio", () => {
@@ -47,5 +57,84 @@ describe("transcribeOpenAiCompatibleAudio", () => {
     expect(headers.get("originator")).toBeNull();
     expect(headers.get("version")).toBeNull();
     expect(headers.get("user-agent")).toBeNull();
+  });
+
+  describe("multipart body construction", () => {
+    it("sends a Buffer body with explicit multipart/form-data Content-Type", async () => {
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+      await transcribeOpenAiCompatibleAudio({
+        buffer: Buffer.from("audio-bytes"),
+        fileName: "clip.ogg",
+        mime: "audio/ogg",
+        apiKey: "k",
+        timeoutMs: 1000,
+        fetchFn,
+        provider: "openai",
+        defaultBaseUrl: "https://api.openai.com/v1",
+        defaultModel: "gpt-4o-transcribe",
+        model: "whisper-1",
+      });
+
+      const { init } = getRequest();
+      const headers = new Headers(init?.headers);
+      const ct = headers.get("content-type") ?? "";
+      expect(ct).toMatch(/^multipart\/form-data; boundary=/);
+      // Body must be a Buffer, not a FormData instance
+      expect(Buffer.isBuffer(init?.body)).toBe(true);
+    });
+
+    it("encodes the file, model, language, and prompt fields correctly", async () => {
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+      const audioBytes = Buffer.from("raw-audio");
+
+      await transcribeOpenAiCompatibleAudio({
+        buffer: audioBytes,
+        fileName: "voice.ogg",
+        mime: "audio/ogg; codecs=opus",
+        apiKey: "k",
+        timeoutMs: 1000,
+        fetchFn,
+        provider: "openai",
+        defaultBaseUrl: "https://api.openai.com/v1",
+        defaultModel: "gpt-4o-transcribe",
+        model: "whisper-1",
+        language: "en",
+        prompt: "test prompt",
+      });
+
+      const { init } = getRequest();
+      const bodyStr = decodeBody(init?.body);
+
+      expect(bodyStr).toContain('name="file"');
+      expect(bodyStr).toContain('filename="voice.ogg"');
+      expect(bodyStr).toContain("Content-Type: audio/ogg; codecs=opus");
+      expect(bodyStr).toContain(audioBytes.toString("binary"));
+      expect(bodyStr).toContain('name="model"');
+      expect(bodyStr).toContain("whisper-1");
+      expect(bodyStr).toContain('name="language"');
+      expect(bodyStr).toContain("en");
+      expect(bodyStr).toContain('name="prompt"');
+      expect(bodyStr).toContain("test prompt");
+    });
+
+    it("omits language and prompt fields when not provided", async () => {
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+      await transcribeOpenAiCompatibleAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "note.mp3",
+        apiKey: "k",
+        timeoutMs: 1000,
+        fetchFn,
+        provider: "openai",
+        defaultBaseUrl: "https://api.openai.com/v1",
+        defaultModel: "gpt-4o-transcribe",
+      });
+
+      const bodyStr = decodeBody(getRequest().init?.body);
+      expect(bodyStr).not.toContain('name="language"');
+      expect(bodyStr).not.toContain('name="prompt"');
+    });
   });
 });

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -12,7 +12,11 @@ function decodeBody(body: BodyInit | null | undefined): string {
   if (body instanceof Uint8Array || Buffer.isBuffer(body)) {
     return Buffer.from(body).toString("utf8");
   }
-  return String(body);
+  if (typeof body === "string") {
+    return body;
+  }
+  // FormData, Blob, URLSearchParams, ReadableStream — not expected in these tests
+  return "[non-string body]";
 }
 
 installPinnedHostnameTestHooks();

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -136,6 +136,26 @@ describe("transcribeOpenAiCompatibleAudio", () => {
       expect(bodyStr).toContain('filename="bad\\"nameInjected: header"');
     });
 
+    it("strips CR/LF from mime type", async () => {
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+      await transcribeOpenAiCompatibleAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "clip.ogg",
+        mime: "audio/ogg\r\nInjected: header",
+        apiKey: "k",
+        timeoutMs: 1000,
+        fetchFn,
+        provider: "openai",
+        defaultBaseUrl: "https://api.openai.com/v1",
+        defaultModel: "gpt-4o-transcribe",
+      });
+
+      const bodyStr = decodeBody(getRequest().init?.body);
+      expect(bodyStr).toContain("Content-Type: audio/oggInjected: header");
+      expect(bodyStr).not.toContain("\r\nInjected:");
+    });
+
     it("omits language and prompt fields when not provided", async () => {
       const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
 

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -156,6 +156,25 @@ describe("transcribeOpenAiCompatibleAudio", () => {
       expect(bodyStr).not.toContain("\r\nInjected:");
     });
 
+    it("falls back to application/octet-stream when mime is empty after sanitization", async () => {
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+      await transcribeOpenAiCompatibleAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "clip.ogg",
+        mime: "\r\n",
+        apiKey: "k",
+        timeoutMs: 1000,
+        fetchFn,
+        provider: "openai",
+        defaultBaseUrl: "https://api.openai.com/v1",
+        defaultModel: "gpt-4o-transcribe",
+      });
+
+      const bodyStr = decodeBody(getRequest().init?.body);
+      expect(bodyStr).toContain("Content-Type: application/octet-stream");
+    });
+
     it("omits language and prompt fields when not provided", async () => {
       const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
 

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -39,25 +39,58 @@ export async function transcribeOpenAiCompatibleAudio(
   const url = `${baseUrl}/audio/transcriptions`;
 
   const model = resolveModel(params.model, params.defaultModel);
-  const form = new FormData();
   const fileName = params.fileName?.trim() || path.basename(params.fileName) || "audio";
-  const bytes = new Uint8Array(params.buffer);
-  const blob = new Blob([bytes], {
-    type: params.mime ?? "application/octet-stream",
-  });
-  form.append("file", blob, fileName);
-  form.append("model", model);
+  // Build the multipart body manually rather than using `new FormData()`.
+  //
+  // When requests go through `fetchWithRuntimeDispatcher` (undici npm package fetch
+  // with a custom dispatcher), Node.js's globalThis.FormData is not recognised by
+  // undici: the Content-Type multipart boundary is never set, so the server receives
+  // a body it cannot parse (e.g. Flask: "No file part in the request").
+  // globalThis.fetch handles globalThis.FormData correctly, but audio transcription
+  // requests go through the SSRF-guarded undici path, not globalThis.fetch.
+  // Constructing the body as a Buffer with an explicit Content-Type sidesteps the
+  // incompatibility entirely and works with any fetch implementation.
+  const mime = params.mime ?? "application/octet-stream";
+  const boundary = `----FormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
+  const enc = new TextEncoder();
+  const parts: Uint8Array[] = [
+    enc.encode(
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${fileName}"\r\nContent-Type: ${mime}\r\n\r\n`,
+    ),
+    new Uint8Array(params.buffer),
+    enc.encode(
+      `\r\n--${boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\n${model}\r\n`,
+    ),
+  ];
   if (params.language?.trim()) {
-    form.append("language", params.language.trim());
+    parts.push(
+      enc.encode(
+        `--${boundary}\r\nContent-Disposition: form-data; name="language"\r\n\r\n${params.language.trim()}\r\n`,
+      ),
+    );
   }
   if (params.prompt?.trim()) {
-    form.append("prompt", params.prompt.trim());
+    parts.push(
+      enc.encode(
+        `--${boundary}\r\nContent-Disposition: form-data; name="prompt"\r\n\r\n${params.prompt.trim()}\r\n`,
+      ),
+    );
   }
+  parts.push(enc.encode(`--${boundary}--\r\n`));
+  const totalLen = parts.reduce((sum, p) => sum + p.length, 0);
+  const body = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const part of parts) {
+    body.set(part, offset);
+    offset += part.length;
+  }
+  const headersWithCT = new Headers(headers);
+  headersWithCT.set("content-type", `multipart/form-data; boundary=${boundary}`);
 
   const { response: res, release } = await postTranscriptionRequest({
     url,
-    headers,
-    body: form,
+    headers: headersWithCT,
+    body: Buffer.from(body),
     timeoutMs: params.timeoutMs,
     fetchFn,
     allowPrivateNetwork,

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -55,7 +55,7 @@ export async function transcribeOpenAiCompatibleAudio(
     "application/octet-stream";
   const boundary = `----FormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
   const enc = new TextEncoder();
-  const safeFileName = fileName.replace(/[\r\n"]/g, (c) => (c === '"' ? '\\"' : ""));
+  const safeFileName = fileName.replace(/[\r\n"]/g, (c) => (c === '"' ? "%22" : ""));
   const parts: Uint8Array[] = [
     enc.encode(
       `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${safeFileName}"\r\nContent-Type: ${mime}\r\n\r\n`,

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -50,7 +50,9 @@ export async function transcribeOpenAiCompatibleAudio(
   // requests go through the SSRF-guarded undici path, not globalThis.fetch.
   // Constructing the body as a Buffer with an explicit Content-Type sidesteps the
   // incompatibility entirely and works with any fetch implementation.
-  const mime = (params.mime ?? "application/octet-stream").replace(/[\r\n]/g, "");
+  const mime =
+    (params.mime ?? "application/octet-stream").replace(/[\r\n]/g, "") ||
+    "application/octet-stream";
   const boundary = `----FormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
   const enc = new TextEncoder();
   const safeFileName = fileName.replace(/[\r\n"]/g, (c) => (c === '"' ? '\\"' : ""));

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -50,7 +50,7 @@ export async function transcribeOpenAiCompatibleAudio(
   // requests go through the SSRF-guarded undici path, not globalThis.fetch.
   // Constructing the body as a Buffer with an explicit Content-Type sidesteps the
   // incompatibility entirely and works with any fetch implementation.
-  const mime = params.mime ?? "application/octet-stream";
+  const mime = (params.mime ?? "application/octet-stream").replace(/[\r\n]/g, "");
   const boundary = `----FormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
   const enc = new TextEncoder();
   const safeFileName = fileName.replace(/[\r\n"]/g, (c) => (c === '"' ? '\\"' : ""));

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -53,9 +53,10 @@ export async function transcribeOpenAiCompatibleAudio(
   const mime = params.mime ?? "application/octet-stream";
   const boundary = `----FormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
   const enc = new TextEncoder();
+  const safeFileName = fileName.replace(/[\r\n"]/g, (c) => (c === '"' ? '\\"' : ""));
   const parts: Uint8Array[] = [
     enc.encode(
-      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${fileName}"\r\nContent-Type: ${mime}\r\n\r\n`,
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${safeFileName}"\r\nContent-Type: ${mime}\r\n\r\n`,
     ),
     new Uint8Array(params.buffer),
     enc.encode(


### PR DESCRIPTION
## Problem

\`transcribeOpenAiCompatibleAudio\` uses \`new FormData()\` (Node.js \`globalThis.FormData\`) to build the audio upload body. Audio transcription requests are dispatched through \`fetchWithRuntimeDispatcher\`, which uses undici's npm package \`fetch\` with a custom dispatcher for DNS pinning. undici's npm \`fetch\` does not handle \`globalThis.FormData\` — the \`Content-Type: multipart/form-data; boundary=...\` header is never set, so the server receives an unparseable body:

\`\`\`
HTTP 400: {"error": "No file part in the request"}
\`\`\`

This error is caught by \`runAttachmentEntries\` and logged only at \`logVerbose\` level. From the user's perspective, the transcript silently comes back as \`undefined\` and the gateway says "I didn't catch that — please type your message."

Confirmed with undici npm v8.0.2 + Node.js v24.14.0. \`globalThis.fetch\` handles \`globalThis.FormData\` correctly; undici's npm \`fetch\` does not.

Closes #63201

## Fix

Replace \`FormData\` / \`Blob\` with a manually-constructed \`Uint8Array\` multipart body and an explicit \`Content-Type\` header containing the boundary. This works correctly with any fetch implementation — undici npm, undici with a custom dispatcher, or \`globalThis.fetch\`.

\`\`\`typescript
// Before
const form = new FormData();
form.append("file", new Blob([bytes], { type: mime }), fileName);
form.append("model", model);
// ...
await postTranscriptionRequest({ body: form, headers, ... });

// After
const boundary = `----FormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
// ... build Uint8Array parts manually ...
const headersWithCT = new Headers(headers);
headersWithCT.set("content-type", `multipart/form-data; boundary=${boundary}`);
await postTranscriptionRequest({ body: Buffer.from(body), headers: headersWithCT, ... });
\`\`\`

## Testing

Three new tests in \`openai-compatible-audio.test.ts\`:

1. Confirms the request body is a \`Buffer\` (not \`FormData\`) and the \`Content-Type\` header is \`multipart/form-data; boundary=...\`
2. Confirms all four fields (\`file\`, \`model\`, \`language\`, \`prompt\`) are correctly encoded in the body
3. Confirms optional \`language\` and \`prompt\` fields are omitted when not provided

All 5 tests pass (2 existing + 3 new).

## Affected paths

- \`src/media-understanding/openai-compatible-audio.ts\` — replace FormData with manual multipart
- \`src/media-understanding/openai-compatible-audio.test.ts\` — three new test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)