### PR TITLE
fix: discover symlinked plugin directories

### DIFF
--- a/extensions/minimax/provider-http.test-helpers.ts
+++ b/extensions/minimax/provider-http.test-helpers.ts
@@ -1,46 +1,14 @@
-import type { resolveProviderHttpRequestConfig } from "openclaw/plugin-sdk/provider-http";
-import { afterEach, vi } from "vitest";
-
-type ResolveProviderHttpRequestConfigParams = Parameters<
-  typeof resolveProviderHttpRequestConfig
->[0];
-
-const providerHttpMocks = vi.hoisted(() => ({
-  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
-  postJsonRequestMock: vi.fn(),
-  fetchWithTimeoutMock: vi.fn(),
-  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-  resolveProviderHttpRequestConfigMock: vi.fn((params: ResolveProviderHttpRequestConfigParams) => ({
-    baseUrl: params.baseUrl ?? params.defaultBaseUrl,
-    allowPrivateNetwork: false,
-    headers: new Headers(params.defaultHeaders),
-    dispatcherPolicy: undefined,
-  })),
-}));
-
-vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
-  resolveApiKeyForProvider: providerHttpMocks.resolveApiKeyForProviderMock,
-}));
-
-vi.mock("openclaw/plugin-sdk/provider-http", () => ({
-  assertOkOrThrowHttpError: providerHttpMocks.assertOkOrThrowHttpErrorMock,
-  fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
-  postJsonRequest: providerHttpMocks.postJsonRequestMock,
-  resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
-}));
+import {
+  getProviderHttpMocks,
+  installProviderHttpMockCleanup,
+} from "../../test/helpers/media-generation/provider-http-mocks.js";
 
 export function getMinimaxProviderHttpMocks() {
-  return providerHttpMocks;
+  return getProviderHttpMocks();
 }
 
 export function installMinimaxProviderHttpMockCleanup(): void {
-  afterEach(() => {
-    providerHttpMocks.resolveApiKeyForProviderMock.mockClear();
-    providerHttpMocks.postJsonRequestMock.mockReset();
-    providerHttpMocks.fetchWithTimeoutMock.mockReset();
-    providerHttpMocks.assertOkOrThrowHttpErrorMock.mockClear();
-    providerHttpMocks.resolveProviderHttpRequestConfigMock.mockClear();
-  });
+  installProviderHttpMockCleanup();
 }
 
 export function loadMinimaxMusicGenerationProviderModule() {

--- a/extensions/minimax/provider-http.test-helpers.ts
+++ b/extensions/minimax/provider-http.test-helpers.ts
@@ -1,14 +1,46 @@
-import {
-  getProviderHttpMocks,
-  installProviderHttpMockCleanup,
-} from "../../test/helpers/media-generation/provider-http-mocks.js";
+import type { resolveProviderHttpRequestConfig } from "openclaw/plugin-sdk/provider-http";
+import { afterEach, vi } from "vitest";
+
+type ResolveProviderHttpRequestConfigParams = Parameters<
+  typeof resolveProviderHttpRequestConfig
+>[0];
+
+const providerHttpMocks = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
+  postJsonRequestMock: vi.fn(),
+  fetchWithTimeoutMock: vi.fn(),
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: ResolveProviderHttpRequestConfigParams) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders),
+    dispatcherPolicy: undefined,
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: providerHttpMocks.resolveApiKeyForProviderMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+  assertOkOrThrowHttpError: providerHttpMocks.assertOkOrThrowHttpErrorMock,
+  fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
+  postJsonRequest: providerHttpMocks.postJsonRequestMock,
+  resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
+}));
 
 export function getMinimaxProviderHttpMocks() {
-  return getProviderHttpMocks();
+  return providerHttpMocks;
 }
 
 export function installMinimaxProviderHttpMockCleanup(): void {
-  installProviderHttpMockCleanup();
+  afterEach(() => {
+    providerHttpMocks.resolveApiKeyForProviderMock.mockClear();
+    providerHttpMocks.postJsonRequestMock.mockReset();
+    providerHttpMocks.fetchWithTimeoutMock.mockReset();
+    providerHttpMocks.assertOkOrThrowHttpErrorMock.mockClear();
+    providerHttpMocks.resolveProviderHttpRequestConfigMock.mockClear();
+  });
 }
 
 export function loadMinimaxMusicGenerationProviderModule() {

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -306,7 +306,6 @@ describe("discoverOpenClawPlugins", () => {
     expect(diagnostics).toEqual([]);
   });
 
-
   it("does not recurse arbitrary workspace directories for plugin auto-discovery", () => {
     const stateDir = makeTempDir();
     const workspaceDir = path.join(stateDir, "workspace");

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -279,6 +279,34 @@ describe("discoverOpenClawPlugins", () => {
     expectCandidateIds(candidates, { includes: ["alpha", "beta"] });
   });
 
+  it("discovers symlinked plugin directories in scanned roots", async () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions");
+    mkdirSafe(globalExt);
+
+    const linkedPluginDir = path.join(stateDir, "linked-plugin-src");
+    createPackagePluginWithEntry({
+      packageDir: linkedPluginDir,
+      packageName: "@openclaw/linked-plugin",
+      pluginId: "linked-plugin",
+    });
+
+    const symlinkPath = path.join(globalExt, "linked-plugin");
+    fs.symlinkSync(
+      linkedPluginDir,
+      symlinkPath,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const { candidates, diagnostics } = await discoverWithStateDir(stateDir, {});
+    expectCandidateIds(candidates, { includes: ["linked-plugin"] });
+    expect(findCandidateById(candidates, "linked-plugin")?.rootDir).toBe(
+      fs.realpathSync(linkedPluginDir),
+    );
+    expect(diagnostics).toEqual([]);
+  });
+
+
   it("does not recurse arbitrary workspace directories for plugin auto-discovery", () => {
     const stateDir = makeTempDir();
     const workspaceDir = path.join(stateDir, "workspace");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -331,6 +331,32 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   return false;
 }
 
+function resolveScannedEntryType(
+  entry: fs.Dirent,
+  fullPath: string,
+): "file" | "directory" | null {
+  if (entry.isFile()) {
+    return "file";
+  }
+  if (entry.isDirectory()) {
+    return "directory";
+  }
+  if (!entry.isSymbolicLink()) {
+    return null;
+  }
+  const stat = safeStatSync(fullPath);
+  if (!stat) {
+    return null;
+  }
+  if (stat.isFile()) {
+    return "file";
+  }
+  if (stat.isDirectory()) {
+    return "directory";
+  }
+  return null;
+}
+
 function resolvesToSameDirectory(left?: string, right?: string): boolean {
   if (!left || !right) {
     return false;
@@ -593,7 +619,8 @@ function discoverInDirectory(params: {
 
   for (const entry of entries) {
     const fullPath = path.join(params.dir, entry.name);
-    if (entry.isFile()) {
+    const entryType = resolveScannedEntryType(entry, fullPath);
+    if (entryType === "file") {
       if (!isExtensionFile(fullPath)) {
         continue;
       }
@@ -608,8 +635,9 @@ function discoverInDirectory(params: {
         ownershipUid: params.ownershipUid,
         workspaceDir: params.workspaceDir,
       });
+      continue;
     }
-    if (!entry.isDirectory()) {
+    if (entryType !== "directory") {
       continue;
     }
     if (params.skipDirectories?.has(entry.name)) {


### PR DESCRIPTION
Summary:
- follow symlinked entries when scanning plugin directories
- treat symlinked files and symlinked plugin directories like their resolved target type
- add a discovery test for a symlinked plugin directory in the global extensions root

Why:
- placing a plugin repo behind ~/.openclaw/extensions/<id> as a symlink currently gets skipped during directory scanning
- the loader only handled Dirent.isFile() and Dirent.isDirectory(), but symlinked directories report isSymbolicLink() instead