### PR TITLE
fix: treat empty status model overrides as unset

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1352,6 +1352,42 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Context: 49k/200k");
   });
 
+  it("treats empty status-card overrides as unset for context resolution", () => {
+    MODEL_CONTEXT_TOKEN_CACHE.clear();
+
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            "openai-codex": {
+              models: [{ id: "gpt-5.4", contextWindow: 1_050_000 }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "openai-codex/gpt-5.4",
+      },
+      sessionEntry: {
+        sessionId: "sess-empty-status-card-override",
+        updatedAt: 0,
+        providerOverride: "",
+        model: "gpt-5.4",
+        modelProvider: "openai-codex",
+        totalTokens: 111_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "oauth",
+      activeModelAuth: "oauth",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Context: 111k/1.1m");
+    expect(normalized).not.toContain("Context: 111k/200k");
+  });
+
   it("keeps provider-aware lookup for bare transcript model ids", async () => {
     await withTempHome(
       async (dir) => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -442,8 +442,10 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultModel: DEFAULT_MODEL,
     allowPluginNormalization: false,
   });
-  const selectedProvider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
-  const selectedModel = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  const selectedProvider =
+    normalizeOptionalString(entry?.providerOverride) ?? resolved.provider ?? DEFAULT_PROVIDER;
+  const selectedModel =
+    normalizeOptionalString(entry?.modelOverride) ?? resolved.model ?? DEFAULT_MODEL;
   const modelRefs = resolveSelectedAndActiveModel({
     selectedProvider,
     selectedModel,


### PR DESCRIPTION
## Summary
- treat empty status-card model overrides as unset when resolving the selected model
- preserve provider-aware context window lookup for session status cards
- add a regression test covering empty `providerOverride` on `openai-codex/gpt-5.4`

## Why
`session_status` could report a generic 200k context window instead of the actual 1.05M window when the status card passed an empty override string through to the renderer.

## Testing
- `./node_modules/.bin/vitest run src/auto-reply/status.test.ts src/agents/openclaw-tools.session-status.test.ts`