### PR TITLE
fix: include extensions/ in published files for bundled plugin runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "!docs/.i18n/zh-CN.tm.jsonl",
     "skills/",
     "scripts/npm-runner.mjs",
-    "scripts/postinstall-bundled-plugins.mjs"
+    "scripts/postinstall-bundled-plugins.mjs",
+    "extensions/"
   ],
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

When publishing OpenClaw, the `dist/extensions/*/package.json` files were not included because `extensions/` wasn't in the `files` array in `package.json`. This caused the postinstall script to fail to install `@buape/carbon` and other bundled plugin runtime dependencies, resulting in `MODULE_NOT_FOUND` errors at runtime.

## Changes

- Added `extensions/` to the `files` array in `package.json` so that bundled plugin metadata and their declared dependencies are available in the npm package

## Testing

The fix ensures that when users install the published npm package, the postinstall script (`scripts/postinstall-bundled-plugins.mjs`) can read the `dist/extensions/*/package.json` files to discover and install the required runtime dependencies like `@buape/carbon`.

Fixes openclaw/openclaw#63231