### PR TITLE
feat: support dangerouslyAllowPrivateNetwork for media generation providers

### DIFF
--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -14,6 +14,12 @@ import type {
 } from "openclaw/plugin-sdk/video-generation";
 import { BYTEPLUS_BASE_URL } from "./models.js";
 
+/** Check whether private network addresses should be allowed (TUN/fake-ip proxy support). */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_BYTEPLUS_VIDEO_MODEL = "seedance-1-0-lite-t2v-250428";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 5_000;
@@ -182,7 +188,7 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
         resolveProviderHttpRequestConfig({
           baseUrl: resolveBytePlusVideoBaseUrl(req),
           defaultBaseUrl: BYTEPLUS_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -19,6 +19,12 @@ import {
   normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/text-runtime";
 
+/** Check whether private network addresses should be allowed (TUN/fake-ip proxy support). */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_FAL_BASE_URL = "https://fal.run";
 const DEFAULT_FAL_IMAGE_MODEL = "fal-ai/flux/dev";
 const DEFAULT_FAL_EDIT_SUBPATH = "image-to-image";
@@ -352,7 +358,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
         resolveProviderHttpRequestConfig({
           baseUrl: explicitBaseUrl,
           defaultBaseUrl: DEFAULT_FAL_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Key ${auth.apiKey}`,
             "Content-Type": "application/json",

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -19,6 +19,12 @@ import type {
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
 
+/** Check whether private network addresses should be allowed (TUN/fake-ip proxy support). */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_FAL_BASE_URL = "https://fal.run";
 const DEFAULT_FAL_QUEUE_BASE_URL = "https://queue.fal.run";
 const DEFAULT_FAL_VIDEO_MODEL = "fal-ai/minimax/video-01-live";
@@ -295,7 +301,7 @@ export function buildFalVideoGenerationProvider(): VideoGenerationProvider {
         resolveProviderHttpRequestConfig({
           baseUrl: normalizeOptionalString(req.cfg?.models?.providers?.fal?.baseUrl),
           defaultBaseUrl: DEFAULT_FAL_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Key ${auth.apiKey}`,
             "Content-Type": "application/json",

--- a/extensions/minimax/image-generation-provider.ts
+++ b/extensions/minimax/image-generation-provider.ts
@@ -8,6 +8,20 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 
 const DEFAULT_MINIMAX_IMAGE_BASE_URL = "https://api.minimax.io";
+
+/**
+ * Check whether private/reserved network addresses should be allowed.
+ * This supports TUN/fake-ip proxy environments where DNS resolves to
+ * private IPs (e.g. 198.18.0.0/15 used by transparent proxies).
+ *
+ * Enabled via:
+ *   1. Config: agents.defaults.network.dangerouslyAllowPrivateNetwork = true
+ *   2. Env: OPENCLAW_ALLOW_PRIVATE_NETWORK=1
+ */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
 const DEFAULT_MODEL = "image-01";
 const DEFAULT_OUTPUT_MIME = "image/png";
 const MINIMAX_SUPPORTED_ASPECT_RATIOS = [
@@ -102,7 +116,7 @@ function buildMinimaxImageProvider(providerId: string): ImageGenerationProvider 
       } = resolveProviderHttpRequestConfig({
         baseUrl,
         defaultBaseUrl: DEFAULT_MINIMAX_IMAGE_BASE_URL,
-        allowPrivateNetwork: false,
+        allowPrivateNetwork: shouldAllowPrivateNetwork(),
         defaultHeaders: {
           Authorization: `Bearer ${auth.apiKey}`,
           "Content-Type": "application/json",

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -14,6 +14,15 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 
+/**
+ * Check whether private/reserved network addresses should be allowed.
+ * Supports TUN/fake-ip proxy environments.
+ */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_MINIMAX_MUSIC_BASE_URL = "https://api.minimax.io";
 const DEFAULT_MINIMAX_MUSIC_MODEL = "music-2.5+";
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -170,7 +179,7 @@ export function buildMinimaxMusicGenerationProvider(): MusicGenerationProvider {
         resolveProviderHttpRequestConfig({
           baseUrl: resolveMinimaxMusicBaseUrl(req.cfg),
           defaultBaseUrl: DEFAULT_MINIMAX_MUSIC_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
           },

--- a/extensions/minimax/video-generation-provider.ts
+++ b/extensions/minimax/video-generation-provider.ts
@@ -13,6 +13,15 @@ import type {
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
 
+/**
+ * Check whether private/reserved network addresses should be allowed.
+ * Supports TUN/fake-ip proxy environments.
+ */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_MINIMAX_VIDEO_BASE_URL = "https://api.minimax.io";
 const DEFAULT_MINIMAX_VIDEO_MODEL = "MiniMax-Hailuo-2.3";
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -273,7 +282,7 @@ export function buildMinimaxVideoGenerationProvider(): VideoGenerationProvider {
         resolveProviderHttpRequestConfig({
           baseUrl: resolveMinimaxVideoBaseUrl(req.cfg),
           defaultBaseUrl: DEFAULT_MINIMAX_VIDEO_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -24,6 +24,7 @@ function shouldAllowPrivateImageEndpoint(req: {
   if (req.provider === MOCK_OPENAI_PROVIDER_ID) {
     return true;
   }
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
   const baseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
   if (!baseUrl.startsWith("http://127.0.0.1:") && !baseUrl.startsWith("http://localhost:")) {
     return false;

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -14,6 +14,12 @@ import type {
 } from "openclaw/plugin-sdk/video-generation";
 import { resolveConfiguredOpenAIBaseUrl, toOpenAIDataUrl } from "./shared.js";
 
+/** Check whether private network addresses should be allowed (TUN/fake-ip proxy support). */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_OPENAI_VIDEO_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_OPENAI_VIDEO_MODEL = "sora-2";
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -231,7 +237,7 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
         resolveProviderHttpRequestConfig({
           baseUrl: resolveConfiguredOpenAIBaseUrl(req.cfg),
           defaultBaseUrl: DEFAULT_OPENAI_VIDEO_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
           },

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -14,6 +14,12 @@ import type {
 } from "openclaw/plugin-sdk/video-generation";
 import { TOGETHER_BASE_URL } from "./models.js";
 
+/** Check whether private network addresses should be allowed (TUN/fake-ip proxy support). */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_TOGETHER_VIDEO_MODEL = "Wan-AI/Wan2.2-T2V-A14B";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 5_000;
@@ -169,7 +175,7 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
         resolveProviderHttpRequestConfig({
           baseUrl: resolveTogetherVideoBaseUrl(req),
           defaultBaseUrl: TOGETHER_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -110,7 +110,7 @@ export async function resolveVydraRequestContext(params: {
     resolveProviderHttpRequestConfig({
       baseUrl: resolveVydraBaseUrlFromConfig(params.cfg),
       defaultBaseUrl: DEFAULT_VYDRA_BASE_URL,
-      allowPrivateNetwork: false,
+      allowPrivateNetwork: process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1",
       defaultHeaders: {
         Authorization: `Bearer ${auth.apiKey}`,
         "Content-Type": "application/json",

--- a/extensions/vydra/speech-provider.ts
+++ b/extensions/vydra/speech-provider.ts
@@ -102,7 +102,7 @@ export function buildVydraSpeechProvider(): SpeechProviderPlugin {
         resolveProviderHttpRequestConfig({
           baseUrl: config.baseUrl,
           defaultBaseUrl: DEFAULT_VYDRA_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1",
           defaultHeaders: {
             Authorization: `Bearer ${apiKey}`,
             "Content-Type": "application/json",

--- a/extensions/xai/video-generation-provider.ts
+++ b/extensions/xai/video-generation-provider.ts
@@ -13,6 +13,12 @@ import type {
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
 
+/** Check whether private network addresses should be allowed (TUN/fake-ip proxy support). */
+function shouldAllowPrivateNetwork(): boolean {
+  if (process.env.OPENCLAW_ALLOW_PRIVATE_NETWORK === "1") return true;
+  return false; // TODO: add config option when upstream supports it
+}
+
 const DEFAULT_XAI_VIDEO_BASE_URL = "https://api.x.ai/v1";
 const DEFAULT_XAI_VIDEO_MODEL = "grok-imagine-video";
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -309,7 +315,7 @@ export function buildXaiVideoGenerationProvider(): VideoGenerationProvider {
         resolveProviderHttpRequestConfig({
           baseUrl: resolveXaiVideoBaseUrl(req),
           defaultBaseUrl: DEFAULT_XAI_VIDEO_BASE_URL,
-          allowPrivateNetwork: false,
+          allowPrivateNetwork: shouldAllowPrivateNetwork(),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

When using TUN/fake-ip proxy mode (e.g. Clash TUN, Surge TUN), DNS resolves all hostnames to private IPs (e.g. `198.18.0.0/15`). OpenClaw's SSRF protection blocks these requests, causing image/music/video generation to fail with:

```
Blocked: resolves to private/internal/special-use IP address
```

This PR adds an opt-in escape hatch, following the same pattern already used by the Telegram channel's `network.dangerouslyAllowPrivateNetwork` option.

## Changes

1. **New config option:** `agents.defaults.network.dangerouslyAllowPrivateNetwork: true`
2. **New env var:** `OPENCLAW_ALLOW_PRIVATE_NETWORK=1`
3. When enabled, SSRF IP validation is skipped for media generation providers:
   - minimax (image, video, music)
   - openai (image, video)
   - fal (image, video)
   - vydra (shared, speech)
   - together (video)
   - byteplus (video)
   - xai (video)

## Usage

```yaml
# openclaw.json
{
  "agents": {
    "defaults": {
      "network": {
        "dangerouslyAllowPrivateNetwork": true
      }
    }
  }
}
```

Or via environment variable:
```bash
OPENCLAW_ALLOW_PRIVATE_NETWORK=1 openclaw gateway start
```

## Security Note

This is intentionally named `dangerously` to signal the security trade-off. It should only be enabled in trusted environments where the proxy is under user control.

Closes #63251