### PR TITLE
Google: fix double /v1beta in music and video generation base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Google media generation: strip a configured trailing `/v1beta` from Google music/video provider base URLs before calling the Google GenAI SDK, preventing doubled `/v1beta/v1beta` paths. Fixes #63240. (#63258) Thanks @Hybirdss.
 - Google Chat: preserve reply text when a typing indicator message is deleted or can no longer be updated, so media captions and first text chunks are resent instead of silently disappearing. (#71498) Thanks @colin-lgtm.
 - Heartbeat: clamp oversized scheduler delays through the shared safe timer helper, preventing `every` values over Node's timeout cap from becoming a 1 ms crash loop. Fixes #71414. (#71478) Thanks @hclsys.
 - Control UI/chat: collapse assistant token/model context details behind an explicit Context disclosure and show full dates in message footers, making historical transcript timing clear without noisy default metadata. (#71337) Thanks @BunsDev.

--- a/extensions/google/music-generation-provider.test.ts
+++ b/extensions/google/music-generation-provider.test.ts
@@ -120,7 +120,7 @@ describe("google music generation provider", () => {
       instrumental: true,
     });
 
-    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+    expect(createGoogleGenAIMock).toHaveBeenCalledWith(
       expect.objectContaining({
         httpOptions: expect.objectContaining({
           baseUrl: "https://generativelanguage.googleapis.com",
@@ -160,7 +160,7 @@ describe("google music generation provider", () => {
       instrumental: true,
     });
 
-    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+    expect(createGoogleGenAIMock).toHaveBeenCalledWith(
       expect.objectContaining({
         httpOptions: expect.objectContaining({
           baseUrl: "https://proxy.example.com/v1beta/route",
@@ -202,7 +202,7 @@ describe("google music generation provider", () => {
       instrumental: true,
     });
 
-    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+    expect(createGoogleGenAIMock).toHaveBeenCalledWith(
       expect.objectContaining({
         httpOptions: expect.objectContaining({
           baseUrl: "https://generativelanguage.googleapis.com",
@@ -238,7 +238,7 @@ describe("google music generation provider", () => {
       instrumental: true,
     });
 
-    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+    expect(createGoogleGenAIMock).toHaveBeenCalledWith(
       expect.objectContaining({
         httpOptions: expect.not.objectContaining({
           baseUrl: expect.anything(),

--- a/extensions/google/music-generation-provider.test.ts
+++ b/extensions/google/music-generation-provider.test.ts
@@ -82,6 +82,171 @@ describe("google music generation provider", () => {
     );
   });
 
+  it("strips /v1beta suffix from configured baseUrl before passing to GoogleGenAI SDK", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                inlineData: {
+                  data: Buffer.from("mp3-bytes").toString("base64"),
+                  mimeType: "audio/mpeg",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = buildGoogleMusicGenerationProvider();
+    await provider.generateMusic({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      prompt: "ambient ocean",
+      cfg: {
+        models: {
+          providers: {
+            google: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", models: [] },
+          },
+        },
+      },
+      instrumental: true,
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://generativelanguage.googleapis.com",
+        }),
+      }),
+    );
+  });
+
+  it("does NOT strip /v1beta when it appears mid-path (end-anchor proof)", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { inlineData: { data: Buffer.from("x").toString("base64"), mimeType: "audio/mpeg" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = buildGoogleMusicGenerationProvider();
+    await provider.generateMusic({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      prompt: "test",
+      cfg: {
+        models: {
+          providers: { google: { baseUrl: "https://proxy.example.com/v1beta/route", models: [] } },
+        },
+      },
+      instrumental: true,
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://proxy.example.com/v1beta/route",
+        }),
+      }),
+    );
+  });
+
+  it("passes baseUrl unchanged when no /v1beta suffix is present", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { inlineData: { data: Buffer.from("x").toString("base64"), mimeType: "audio/mpeg" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = buildGoogleMusicGenerationProvider();
+    await provider.generateMusic({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      prompt: "test",
+      cfg: {
+        models: {
+          providers: {
+            google: { baseUrl: "https://generativelanguage.googleapis.com", models: [] },
+          },
+        },
+      },
+      instrumental: true,
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://generativelanguage.googleapis.com",
+        }),
+      }),
+    );
+  });
+
+  it("does not set baseUrl when none is configured", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { inlineData: { data: Buffer.from("x").toString("base64"), mimeType: "audio/mpeg" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = buildGoogleMusicGenerationProvider();
+    await provider.generateMusic({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      prompt: "test",
+      cfg: {},
+      instrumental: true,
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.not.objectContaining({
+          baseUrl: expect.anything(),
+        }),
+      }),
+    );
+  });
+
   it("rejects unsupported wav output on clip model", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",

--- a/extensions/google/music-generation-provider.ts
+++ b/extensions/google/music-generation-provider.ts
@@ -37,7 +37,7 @@ type GoogleGenerateMusicResponse = {
 
 function resolveConfiguredGoogleMusicBaseUrl(req: MusicGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
-  return configured ? normalizeGoogleApiBaseUrl(configured) : undefined;
+  return configured ? normalizeGoogleApiBaseUrl(configured).replace(/\/v1beta$/i, "") : undefined;
 }
 
 function buildMusicPrompt(req: MusicGenerationRequest): string {

--- a/extensions/google/music-generation-provider.ts
+++ b/extensions/google/music-generation-provider.ts
@@ -6,7 +6,7 @@ import type {
 } from "openclaw/plugin-sdk/music-generation";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { normalizeGoogleApiBaseUrl } from "./api.js";
+import { resolveGoogleGenerativeAiApiOrigin } from "./api.js";
 import {
   createGoogleMusicGenerationProviderMetadata,
   DEFAULT_GOOGLE_MUSIC_MODEL,
@@ -37,7 +37,7 @@ type GoogleGenerateMusicResponse = {
 
 function resolveConfiguredGoogleMusicBaseUrl(req: MusicGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
-  return configured ? normalizeGoogleApiBaseUrl(configured).replace(/\/v1beta$/i, "") : undefined;
+  return configured ? resolveGoogleGenerativeAiApiOrigin(configured) : undefined;
 }
 
 function buildMusicPrompt(req: MusicGenerationRequest): string {

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -100,6 +100,121 @@ describe("google video generation provider", () => {
     );
   });
 
+  it("strips /v1beta suffix from configured baseUrl before passing to GoogleGenAI SDK", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          { video: { videoBytes: Buffer.from("mp4").toString("base64"), mimeType: "video/mp4" } },
+        ],
+      },
+    });
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "google",
+      model: "veo-3.1-fast-generate-preview",
+      prompt: "A tiny robot watering a windowsill garden",
+      cfg: {
+        models: {
+          providers: {
+            google: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", models: [] },
+          },
+        },
+      },
+      durationSeconds: 3,
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://generativelanguage.googleapis.com",
+        }),
+      }),
+    );
+  });
+
+  it("does NOT strip /v1beta when it appears mid-path (end-anchor proof)", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          { video: { videoBytes: Buffer.from("mp4").toString("base64"), mimeType: "video/mp4" } },
+        ],
+      },
+    });
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "google",
+      model: "veo-3.1-fast-generate-preview",
+      prompt: "test",
+      cfg: {
+        models: {
+          providers: { google: { baseUrl: "https://proxy.example.com/v1beta/route", models: [] } },
+        },
+      },
+      durationSeconds: 3,
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://proxy.example.com/v1beta/route",
+        }),
+      }),
+    );
+  });
+
+  it("passes baseUrl unchanged when no /v1beta suffix is present", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          { video: { videoBytes: Buffer.from("mp4").toString("base64"), mimeType: "video/mp4" } },
+        ],
+      },
+    });
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "google",
+      model: "veo-3.1-fast-generate-preview",
+      prompt: "test",
+      cfg: {
+        models: {
+          providers: {
+            google: { baseUrl: "https://generativelanguage.googleapis.com", models: [] },
+          },
+        },
+      },
+      durationSeconds: 3,
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://generativelanguage.googleapis.com",
+        }),
+      }),
+    );
+  });
+
   it("rejects mixed image and video inputs", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -130,7 +130,7 @@ describe("google video generation provider", () => {
       durationSeconds: 3,
     });
 
-    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+    expect(createGoogleGenAIMock).toHaveBeenCalledWith(
       expect.objectContaining({
         httpOptions: expect.objectContaining({
           baseUrl: "https://generativelanguage.googleapis.com",
@@ -167,7 +167,7 @@ describe("google video generation provider", () => {
       durationSeconds: 3,
     });
 
-    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+    expect(createGoogleGenAIMock).toHaveBeenCalledWith(
       expect.objectContaining({
         httpOptions: expect.objectContaining({
           baseUrl: "https://proxy.example.com/v1beta/route",
@@ -206,7 +206,7 @@ describe("google video generation provider", () => {
       durationSeconds: 3,
     });
 
-    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+    expect(createGoogleGenAIMock).toHaveBeenCalledWith(
       expect.objectContaining({
         httpOptions: expect.objectContaining({
           baseUrl: "https://generativelanguage.googleapis.com",

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -13,7 +13,7 @@ import type {
   VideoGenerationProvider,
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
-import { normalizeGoogleApiBaseUrl } from "./api.js";
+import { resolveGoogleGenerativeAiApiOrigin } from "./api.js";
 import {
   createGoogleVideoGenerationProviderMetadata,
   DEFAULT_GOOGLE_VIDEO_MODEL,
@@ -29,7 +29,7 @@ const MAX_POLL_ATTEMPTS = 90;
 
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
-  return configured ? normalizeGoogleApiBaseUrl(configured).replace(/\/v1beta$/i, "") : undefined;
+  return configured ? resolveGoogleGenerativeAiApiOrigin(configured) : undefined;
 }
 
 function parseVideoSize(size: string | undefined): { width: number; height: number } | undefined {

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -29,7 +29,7 @@ const MAX_POLL_ATTEMPTS = 90;
 
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
-  return configured ? normalizeGoogleApiBaseUrl(configured) : undefined;
+  return configured ? normalizeGoogleApiBaseUrl(configured).replace(/\/v1beta$/i, "") : undefined;
 }
 
 function parseVideoSize(size: string | undefined): { width: number; height: number } | undefined {


### PR DESCRIPTION
## Summary
- Strip `/v1beta` suffix from `resolveConfiguredGoogleMusicBaseUrl()` and `resolveConfiguredGoogleVideoBaseUrl()` before passing to the GoogleGenAI SDK, which appends its own `/v1beta` apiVersion
- Matches the existing pattern used by text generation in `normalizeGoogleGenerativeAiBaseUrl()`

## Problem
When `models.providers.google.baseUrl` is configured (e.g., `https://generativelanguage.googleapis.com/v1beta`), music and video generation construct a doubled path `/v1beta/v1beta`, resulting in 404 errors for all Lyria and Veo models.

The text generation path already handles this correctly via `.replace(/\/v1beta$/i, "")` in `normalizeGoogleGenerativeAiBaseUrl()`. The music and video providers were missing this strip.

## Changes
- `extensions/google/music-generation-provider.ts`: Add `.replace(/\/v1beta$/i, "")` to `resolveConfiguredGoogleMusicBaseUrl()`
- `extensions/google/video-generation-provider.ts`: Add `.replace(/\/v1beta$/i, "")` to `resolveConfiguredGoogleVideoBaseUrl()`
- `extensions/google/music-generation-provider.test.ts`: 3 new vitest cases asserting SDK ctor receives the correctly-stripped baseUrl
- `extensions/google/video-generation-provider.test.ts`: 2 new vitest cases with the same assertion

## Test plan
- [x] Regex strips `/v1beta` suffix from configured baseUrl before SDK call — asserted via `GoogleGenAIMock` ctor argument capture in `music-generation-provider.test.ts::"strips /v1beta suffix..."` and `video-generation-provider.test.ts::"strips /v1beta suffix..."`
- [x] End-anchor verified — mid-path `/v1beta/route` is NOT stripped (`"does NOT strip /v1beta when it appears mid-path (end-anchor proof)"` in both files). An unanchored regex would fail these cases.
- [x] No-op when baseUrl contains no `/v1beta` suffix — asserted in `"passes baseUrl unchanged when no /v1beta suffix is present"` in both files
- [x] Unconfigured case unchanged — `music-generation-provider.test.ts::"does not set baseUrl when none is configured"` confirms `httpOptions` omits `baseUrl` when `cfg.models.providers.google.baseUrl` is not set
- [x] Text generation path unaffected — this PR does not touch `normalizeGoogleGenerativeAiBaseUrl()` or any text provider; `extensions/google/api.ts` `normalizeGoogleApiBaseUrl()` at line 34-53 is unchanged

```
$ pnpm exec vitest run \
    extensions/google/music-generation-provider.test.ts \
    extensions/google/video-generation-provider.test.ts
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

Manual end-to-end confirmation (requires live Google API key, out of CI scope):
- `music_generate` with `google/lyria-3-clip-preview` — expected to succeed after fix; regex behavior is CI-verified above
- `video_generate` with Google Veo — same

Fixes #63240.
