### PR TITLE
fix(google): strip /v1beta from music and video provider baseUrl before GoogleGenAI SDK call

### DIFF
--- a/extensions/google/music-generation-provider.test.ts
+++ b/extensions/google/music-generation-provider.test.ts
@@ -77,6 +77,56 @@ describe("google music generation provider", () => {
     );
   });
 
+  it("strips /v1beta from configured Google baseUrl before passing to GoogleGenAI SDK", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                inlineData: {
+                  data: Buffer.from("mp3-bytes").toString("base64"),
+                  mimeType: "audio/mpeg",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = buildGoogleMusicGenerationProvider();
+    await provider.generateMusic({
+      provider: "google",
+      model: "lyria-3-clip-preview",
+      prompt: "chill lofi beats",
+      cfg: {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+            },
+          },
+        },
+      },
+    });
+
+    // The SDK appends its own /v1beta — if we pass /v1beta in baseUrl the path becomes
+    // /v1beta/v1beta/... and the request 404s. The provider must strip it before calling SDK.
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://generativelanguage.googleapis.com",
+        }),
+      }),
+    );
+  });
+
   it("rejects unsupported wav output on clip model", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",

--- a/extensions/google/music-generation-provider.ts
+++ b/extensions/google/music-generation-provider.ts
@@ -8,7 +8,7 @@ import type {
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { normalizeGoogleApiBaseUrl } from "./api.js";
+import { resolveGoogleGenerativeAiApiOrigin } from "./api.js";
 
 const DEFAULT_GOOGLE_MUSIC_MODEL = "lyria-3-clip-preview";
 const GOOGLE_PRO_MUSIC_MODEL = "lyria-3-pro-preview";
@@ -35,7 +35,10 @@ type GoogleGenerateMusicResponse = {
 
 function resolveConfiguredGoogleMusicBaseUrl(req: MusicGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
-  return configured ? normalizeGoogleApiBaseUrl(configured) : undefined;
+  // resolveGoogleGenerativeAiApiOrigin normalizes and strips /v1beta because the GoogleGenAI
+  // SDK appends its own API version segment — passing /v1beta produces a double
+  // /v1beta/v1beta path that returns 404.
+  return configured ? resolveGoogleGenerativeAiApiOrigin(configured) : undefined;
 }
 
 function buildMusicPrompt(req: MusicGenerationRequest): string {

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -154,4 +154,56 @@ describe("google video generation provider", () => {
       }),
     );
   });
+
+  it("strips /v1beta from configured Google baseUrl before passing to GoogleGenAI SDK", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: false,
+      name: "operations/456",
+    });
+    getVideosOperationMock.mockResolvedValue({
+      done: true,
+      name: "operations/456",
+      response: {
+        generatedVideos: [
+          {
+            video: {
+              videoBytes: Buffer.from("mp4-bytes").toString("base64"),
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+      },
+    });
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "google",
+      model: "veo-3.1-fast-generate-preview",
+      prompt: "A sunset timelapse over the ocean",
+      cfg: {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+            },
+          },
+        },
+      },
+    });
+
+    // The SDK appends its own /v1beta — if we pass /v1beta in baseUrl the path becomes
+    // /v1beta/v1beta/... and the request 404s. The provider must strip it before calling SDK.
+    expect(GoogleGenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpOptions: expect.objectContaining({
+          baseUrl: "https://generativelanguage.googleapis.com",
+        }),
+      }),
+    );
+  });
 });

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -10,7 +10,7 @@ import type {
   VideoGenerationProvider,
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
-import { normalizeGoogleApiBaseUrl } from "./api.js";
+import { resolveGoogleGenerativeAiApiOrigin } from "./api.js";
 
 const DEFAULT_GOOGLE_VIDEO_MODEL = "veo-3.1-fast-generate-preview";
 const DEFAULT_TIMEOUT_MS = 180_000;
@@ -23,7 +23,10 @@ const GOOGLE_VIDEO_MAX_DURATION_SECONDS =
 
 function resolveConfiguredGoogleVideoBaseUrl(req: VideoGenerationRequest): string | undefined {
   const configured = normalizeOptionalString(req.cfg?.models?.providers?.google?.baseUrl);
-  return configured ? normalizeGoogleApiBaseUrl(configured) : undefined;
+  // resolveGoogleGenerativeAiApiOrigin normalizes and strips /v1beta because the GoogleGenAI
+  // SDK appends its own API version segment — passing /v1beta produces a double
+  // /v1beta/v1beta path that returns 404.
+  return configured ? resolveGoogleGenerativeAiApiOrigin(configured) : undefined;
 }
 
 function parseVideoSize(size: string | undefined): { width: number; height: number } | undefined {


### PR DESCRIPTION
## Summary

Fixes #63240.

When `models.providers.google.baseUrl` is configured (e.g. the default `https://generativelanguage.googleapis.com/v1beta`), both the music and video generation providers were passing this URL through `normalizeGoogleApiBaseUrl`, which ensures `/v1beta` is present. The GoogleGenAI SDK then appends its own API version segment (`/v1beta`), producing a double `/v1beta/v1beta` path that returns 404.

**Root cause:** `resolveConfiguredGoogleMusicBaseUrl` and `resolveConfiguredGoogleVideoBaseUrl` used `normalizeGoogleApiBaseUrl` (which adds `/v1beta`) instead of `resolveGoogleGenerativeAiApiOrigin` (which normalizes and strips `/v1beta`).

The text generation path already handles this correctly via `resolveGoogleGenerativeAiApiOrigin`. This PR applies the same pattern to the music and video providers.

## Changes

- `extensions/google/music-generation-provider.ts`: switch to `resolveGoogleGenerativeAiApiOrigin` in `resolveConfiguredGoogleMusicBaseUrl`
- `extensions/google/video-generation-provider.ts`: switch to `resolveGoogleGenerativeAiApiOrigin` in `resolveConfiguredGoogleVideoBaseUrl`
- `extensions/google/music-generation-provider.test.ts`: add regression test asserting the SDK receives a baseUrl without `/v1beta`

## Test plan

- [ ] Run `pnpm test extensions/google/music-generation-provider.test.ts` — new test verifies the SDK receives `https://generativelanguage.googleapis.com` (no `/v1beta`) when configured baseUrl includes it
- [ ] Manually configure `models.providers.google.baseUrl: "https://generativelanguage.googleapis.com/v1beta"` and run `music_generate` with a Lyria model — should succeed rather than 404
- [ ] `video_generate` with a configured baseUrl should also work correctly now