### PR TITLE
fix: auto-configure MiniMax speech provider for OAuth credentials

### DIFF
--- a/extensions/minimax/index.ts
+++ b/extensions/minimax/index.ts
@@ -9,7 +9,7 @@ import {
 } from "./media-understanding-provider.js";
 import { buildMinimaxMusicGenerationProvider } from "./music-generation-provider.js";
 import { registerMinimaxProviders } from "./provider-registration.js";
-import { buildMinimaxSpeechProvider } from "./speech-provider.js";
+import { buildMinimaxSpeechProvider, buildMinimaxPortalSpeechProvider } from "./speech-provider.js";
 import { createMiniMaxWebSearchProvider } from "./src/minimax-web-search-provider.js";
 import { buildMinimaxVideoGenerationProvider } from "./video-generation-provider.js";
 
@@ -26,6 +26,7 @@ export default definePluginEntry({
     api.registerMusicGenerationProvider(buildMinimaxMusicGenerationProvider());
     api.registerVideoGenerationProvider(buildMinimaxVideoGenerationProvider());
     api.registerSpeechProvider(buildMinimaxSpeechProvider());
+    api.registerSpeechProvider(buildMinimaxPortalSpeechProvider());
     api.registerWebSearchProvider(createMiniMaxWebSearchProvider());
   },
 });

--- a/extensions/minimax/openclaw.plugin.json
+++ b/extensions/minimax/openclaw.plugin.json
@@ -61,7 +61,7 @@
     }
   ],
   "contracts": {
-    "speechProviders": ["minimax"],
+    "speechProviders": ["minimax", "minimax-portal"],
     "mediaUnderstandingProviders": ["minimax", "minimax-portal"],
     "imageGenerationProviders": ["minimax", "minimax-portal"],
     "musicGenerationProviders": ["minimax"],

--- a/extensions/minimax/plugin-registration.contract.test.ts
+++ b/extensions/minimax/plugin-registration.contract.test.ts
@@ -3,7 +3,7 @@ import { describePluginRegistrationContract } from "../../test/helpers/plugins/p
 describePluginRegistrationContract({
   pluginId: "minimax",
   providerIds: ["minimax", "minimax-portal"],
-  speechProviderIds: ["minimax"],
+  speechProviderIds: ["minimax", "minimax-portal"],
   mediaUnderstandingProviderIds: ["minimax", "minimax-portal"],
   imageGenerationProviderIds: ["minimax", "minimax-portal"],
   videoGenerationProviderIds: ["minimax"],

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildMinimaxSpeechProvider } from "./speech-provider.js";
+import { buildMinimaxPortalSpeechProvider, buildMinimaxSpeechProvider } from "./speech-provider.js";
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  isProviderApiKeyConfigured: vi.fn(() => false),
+}));
+
+const { isProviderApiKeyConfigured } = await import("openclaw/plugin-sdk/provider-auth");
 
 describe("buildMinimaxSpeechProvider", () => {
   const provider = buildMinimaxSpeechProvider();
@@ -316,5 +322,59 @@ describe("buildMinimaxSpeechProvider", () => {
       expect(voices.length).toBeGreaterThan(0);
       expect(voices[0].id).toBe("English_expressive_narrator");
     });
+  });
+});
+
+describe("buildMinimaxPortalSpeechProvider", () => {
+  const provider = buildMinimaxPortalSpeechProvider();
+
+  afterEach(() => {
+    vi.mocked(isProviderApiKeyConfigured).mockReset();
+  });
+
+  it("has id minimax-portal", () => {
+    expect(provider.id).toBe("minimax-portal");
+    expect(provider.label).toBe("MiniMax");
+  });
+
+  it("reports configured when OAuth auth profile exists", () => {
+    vi.mocked(isProviderApiKeyConfigured).mockImplementation(
+      ({ provider: id }) => id === "minimax-portal",
+    );
+    expect(
+      provider.isConfigured({
+        providerConfig: {},
+        timeoutMs: 30_000,
+        agentDir: "/fake/agent/dir",
+      }),
+    ).toBe(true);
+  });
+
+  it("reports not configured when no credentials exist", () => {
+    const savedKey = process.env.MINIMAX_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
+    vi.mocked(isProviderApiKeyConfigured).mockReturnValue(false);
+    try {
+      expect(
+        provider.isConfigured({
+          providerConfig: {},
+          timeoutMs: 30_000,
+        }),
+      ).toBe(false);
+    } finally {
+      if (savedKey) {
+        process.env.MINIMAX_API_KEY = savedKey;
+      }
+    }
+  });
+
+  it("reports configured when API key is in provider config", () => {
+    vi.mocked(isProviderApiKeyConfigured).mockReturnValue(false);
+    expect(
+      provider.isConfigured({
+        providerConfig: { apiKey: "sk-test" },
+        timeoutMs: 30_000,
+      }),
+    ).toBe(true);
   });
 });

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -1,3 +1,4 @@
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechDirectiveTokenParseContext,
@@ -150,9 +151,9 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
   }
 }
 
-export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
+function buildMinimaxSpeechProviderForId(providerId: string): SpeechProviderPlugin {
   return {
-    id: "minimax",
+    id: providerId,
     label: "MiniMax",
     autoSelectOrder: 40,
     models: MINIMAX_TTS_MODELS,
@@ -203,8 +204,9 @@ export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
       ...(asFiniteNumber(params.pitch) == null ? {} : { pitch: asFiniteNumber(params.pitch) }),
     }),
     listVoices: async () => MINIMAX_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
-    isConfigured: ({ providerConfig }) =>
-      Boolean(readMinimaxProviderConfig(providerConfig).apiKey || process.env.MINIMAX_API_KEY),
+    isConfigured: ({ providerConfig, agentDir }) =>
+      Boolean(readMinimaxProviderConfig(providerConfig).apiKey || process.env.MINIMAX_API_KEY) ||
+      isProviderApiKeyConfigured({ provider: providerId, agentDir }),
     synthesize: async (req) => {
       const config = readMinimaxProviderConfig(req.providerConfig);
       const overrides = readMinimaxOverrides(req.providerOverrides);
@@ -231,4 +233,12 @@ export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
       };
     },
   };
+}
+
+export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
+  return buildMinimaxSpeechProviderForId("minimax");
+}
+
+export function buildMinimaxPortalSpeechProvider(): SpeechProviderPlugin {
+  return buildMinimaxSpeechProviderForId("minimax-portal");
 }

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -472,7 +472,11 @@ export function setTtsEnabled(prefsPath: string, enabled: boolean): void {
   setTtsAutoMode(prefsPath, enabled ? "always" : "off");
 }
 
-export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): TtsProvider {
+export function getTtsProvider(
+  config: ResolvedTtsConfig,
+  prefsPath: string,
+  agentDir?: string,
+): TtsProvider {
   const prefs = readPrefs(prefsPath);
   const prefsProvider =
     canonicalizeSpeechProviderId(prefs.tts?.provider) ??
@@ -489,6 +493,7 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
       provider.isConfigured({
         providerConfig: config.providerConfigs[provider.id] ?? {},
         timeoutMs: config.timeoutMs,
+        agentDir,
       })
     ) {
       return provider.id;
@@ -615,6 +620,7 @@ export function isTtsProviderConfigured(
   config: ResolvedTtsConfig,
   provider: TtsProvider,
   cfg?: OpenClawConfig,
+  agentDir?: string,
 ): boolean {
   const resolvedProvider = getSpeechProvider(provider, cfg);
   if (!resolvedProvider) {
@@ -625,6 +631,7 @@ export function isTtsProviderConfigured(
       cfg,
       providerConfig: getResolvedSpeechProviderConfig(config, resolvedProvider.id, cfg),
       timeoutMs: config.timeoutMs,
+      agentDir,
     }) ?? false
   );
 }
@@ -677,6 +684,7 @@ function resolveReadySpeechProvider(params: {
   cfg: OpenClawConfig;
   config: ResolvedTtsConfig;
   requireTelephony?: boolean;
+  agentDir?: string;
 }): TtsProviderReadyResolution {
   const resolvedProvider = getSpeechProvider(params.provider, params.cfg);
   if (!resolvedProvider) {
@@ -696,6 +704,7 @@ function resolveReadySpeechProvider(params: {
       cfg: params.cfg,
       providerConfig,
       timeoutMs: params.config.timeoutMs,
+      agentDir: params.agentDir,
     })
   ) {
     return {
@@ -724,6 +733,7 @@ function resolveTtsRequestSetup(params: {
   prefsPath?: string;
   providerOverride?: TtsProvider;
   disableFallback?: boolean;
+  agentDir?: string;
 }):
   | {
       config: ResolvedTtsConfig;
@@ -740,7 +750,7 @@ function resolveTtsRequestSetup(params: {
     };
   }
 
-  const userProvider = getTtsProvider(config, prefsPath);
+  const userProvider = getTtsProvider(config, prefsPath, params.agentDir);
   const provider =
     canonicalizeSpeechProviderId(params.providerOverride, params.cfg) ?? userProvider;
   return {
@@ -756,6 +766,7 @@ export async function textToSpeech(params: {
   channel?: string;
   overrides?: TtsDirectiveOverrides;
   disableFallback?: boolean;
+  agentDir?: string;
 }): Promise<TtsResult> {
   const synthesis = await synthesizeSpeech(params);
   if (!synthesis.success || !synthesis.audioBuffer || !synthesis.fileExtension) {
@@ -794,6 +805,7 @@ export async function synthesizeSpeech(params: {
   channel?: string;
   overrides?: TtsDirectiveOverrides;
   disableFallback?: boolean;
+  agentDir?: string;
 }): Promise<TtsSynthesisResult> {
   const setup = resolveTtsRequestSetup({
     text: params.text,
@@ -801,6 +813,7 @@ export async function synthesizeSpeech(params: {
     prefsPath: params.prefsPath,
     providerOverride: params.overrides?.provider,
     disableFallback: params.disableFallback,
+    agentDir: params.agentDir,
   });
   if ("error" in setup) {
     return { success: false, error: setup.error };
@@ -826,6 +839,7 @@ export async function synthesizeSpeech(params: {
         provider,
         cfg: params.cfg,
         config,
+        agentDir: params.agentDir,
       });
       if (resolvedProvider.kind === "skip") {
         errors.push(resolvedProvider.message);
@@ -896,11 +910,13 @@ export async function textToSpeechTelephony(params: {
   text: string;
   cfg: OpenClawConfig;
   prefsPath?: string;
+  agentDir?: string;
 }): Promise<TtsTelephonyResult> {
   const setup = resolveTtsRequestSetup({
     text: params.text,
     cfg: params.cfg,
     prefsPath: params.prefsPath,
+    agentDir: params.agentDir,
   });
   if ("error" in setup) {
     return { success: false, error: setup.error };
@@ -924,6 +940,7 @@ export async function textToSpeechTelephony(params: {
         cfg: params.cfg,
         config,
         requireTelephony: true,
+        agentDir: params.agentDir,
       });
       if (resolvedProvider.kind === "skip") {
         errors.push(resolvedProvider.message);
@@ -1028,6 +1045,7 @@ export async function maybeApplyTtsToPayload(params: {
   kind?: "tool" | "block" | "final";
   inboundAudio?: boolean;
   ttsAuto?: string;
+  agentDir?: string;
 }): Promise<ReplyPayload> {
   if (params.payload.isCompactionNotice) {
     return params.payload;
@@ -1146,6 +1164,7 @@ export async function maybeApplyTtsToPayload(params: {
     prefsPath,
     channel: params.channel,
     overrides: directives.overrides,
+    agentDir: params.agentDir,
   });
 
   if (result.success && result.audioPath) {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -224,6 +224,7 @@ export function createOpenClawTools(
     createTtsTool({
       agentChannel: options?.agentChannel,
       config: options?.config,
+      agentDir: options?.agentDir,
     }),
     ...collectPresentOpenClawTools([imageGenerateTool, musicGenerateTool, videoGenerateTool]),
     createGatewayTool({

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -17,6 +17,7 @@ const TtsToolSchema = Type.Object({
 export function createTtsTool(opts?: {
   config?: OpenClawConfig;
   agentChannel?: GatewayMessageChannel;
+  agentDir?: string;
 }): AnyAgentTool {
   return {
     label: "TTS",
@@ -33,6 +34,7 @@ export function createTtsTool(opts?: {
         text,
         cfg,
         channel: channel ?? opts?.agentChannel,
+        agentDir: opts?.agentDir,
       });
 
       if (result.success && result.audioPath) {

--- a/src/tts/provider-types.ts
+++ b/src/tts/provider-types.ts
@@ -38,6 +38,7 @@ export type SpeechProviderConfiguredContext = {
   cfg?: OpenClawConfig;
   providerConfig: SpeechProviderConfig;
   timeoutMs: number;
+  agentDir?: string;
 };
 
 export type SpeechSynthesisRequest = {


### PR DESCRIPTION
  Summary

  - Problem: The MiniMax speech provider's isConfigured only checked providerConfig.apiKey and MINIMAX_API_KEY env var. Users who logged in via OAuth or pasted an API key during onboarding had credentials stored in auth-profiles.json, which the speech provider never consulted.
  - Why it matters: OAuth users had TTS silently unavailable — the agent's TTS tool would skip MiniMax because it appeared unconfigured, even though valid credentials existed.
  - What changed: Added optional agentDir to SpeechProviderConfiguredContext, threaded it through the speech-core runtime and TTS tool, parameterized the MiniMax speech provider for both minimax and minimax-portal provider IDs, and updated isConfigured to check auth profiles via isProviderApiKeyConfigured.
  - What did NOT change (scope boundary): No changes to the OAuth flow itself, no changes to how credentials are stored, no changes to other speech providers (OpenAI, ElevenLabs, Microsoft). The agentDir field is optional — all existing providers and callers that don't pass it continue to work identically.

  Change Type (select all)

  - Bug fix
  - Chore/infra

  Scope (select all touched areas)

  - Integrations
  - API / contracts

  Root Cause (if applicable)

  - Root cause: SpeechProviderConfiguredContext lacked agentDir, so speech providers had no way to consult the auth profile store. Other capability providers (image, video, music generation) already received agentDir in their isConfigured context — speech was the outlier.
  - Missing detection / guardrail: No test asserted that OAuth-authenticated users would have MiniMax TTS auto-configured. The speech provider contract type didn't include auth-profile-aware fields.

  User-visible / Behavior Changes

  - MiniMax TTS is now auto-configured for users who logged in via MiniMax OAuth (minimax-portal) or pasted an API key during onboarding (minimax). Previously, TTS would silently skip MiniMax unless MINIMAX_API_KEY was set as an env var or manually added to TTS config.

  Diagram (if applicable)

  Before:
  [OAuth login] -> [token in auth-profiles.json] -> [speech isConfigured checks env/config only] -> NOT CONFIGURED

  After:
  [OAuth login] -> [token in auth-profiles.json] -> [speech isConfigured checks env/config + auth profiles via agentDir] -> CONFIGURED

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No — existing isProviderApiKeyConfigured is reused; no new credential access paths.
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Environment

  - OS: macOS
  - Runtime/container: Node 22+, Bun
  - Model/provider: MiniMax (minimax, minimax-portal)
  - Integration/channel (if any): TTS tool
  - Relevant config (redacted): MiniMax OAuth credentials in auth-profiles.json

  Steps

  1. Log in via MiniMax OAuth (minimax-portal provider)
  2. Trigger TTS via the agent's tts tool or auto-TTS
  3. Observe whether MiniMax speech provider is selected

  Expected

  - MiniMax speech provider reports as configured and is available for TTS

  Actual

  - Before: MiniMax speech provider reports not configured, TTS skips it
  - After: MiniMax speech provider detects OAuth credentials, TTS works

  Compatibility / Migration

  - Backward compatible? Yes — agentDir is optional in SpeechProviderConfiguredContext. Existing providers ignore it. Existing callers that don't pass it behave identically.
  - Config/env changes? No
  - Migration needed? No