### PR TITLE
fix(bonjour): guard JSON.parse against malformed Tailscale output

### DIFF
--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -160,7 +160,7 @@ function parseDigSrv(stdout: string): { host: string; port: number } | null {
 }
 
 function parseTailscaleStatusIPv4s(stdout: string): string[] {
-  const parsed = stdout ? (JSON.parse(stdout) as Record<string, unknown>) : {};
+  const parsed = stdout ? (() => { try { return JSON.parse(stdout) as Record<string, unknown>; } catch { return {}; } })() : {};
   const out: string[] = [];
 
   const addIps = (value: unknown) => {


### PR DESCRIPTION
`parseTailscaleStatusIPv4s` calls `JSON.parse` without error handling. If Tailscale outputs unexpected content, it throws an unhandled exception. Wraps the call in try/catch and returns an empty object on failure.