### PR TITLE
fix: use Number.parseFloat instead of global parseFloat for consistency

### DIFF
--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -171,10 +171,10 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
       model.max_output_tokens ??
       8192,
     cost: {
-      input: parseFloat(model.pricing?.prompt || "0") * 1_000_000,
-      output: parseFloat(model.pricing?.completion || "0") * 1_000_000,
-      cacheRead: parseFloat(model.pricing?.input_cache_read || "0") * 1_000_000,
-      cacheWrite: parseFloat(model.pricing?.input_cache_write || "0") * 1_000_000,
+      input: Number.parseFloat(model.pricing?.prompt || "0") * 1_000_000,
+      output: Number.parseFloat(model.pricing?.completion || "0") * 1_000_000,
+      cacheRead: Number.parseFloat(model.pricing?.input_cache_read || "0") * 1_000_000,
+      cacheWrite: Number.parseFloat(model.pricing?.input_cache_write || "0") * 1_000_000,
     },
   };
 }

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -110,7 +110,7 @@ export async function fetchCodexUsage(
     const balance =
       typeof data.credits.balance === "number"
         ? data.credits.balance
-        : parseFloat(data.credits.balance) || 0;
+        : Number.parseFloat(data.credits.balance) || 0;
     plan = plan ? `${plan} ($${balance.toFixed(2)})` : `$${balance.toFixed(2)}`;
   }
 


### PR DESCRIPTION
Two files use the global `parseFloat()` instead of `Number.parseFloat()`. The rest of the codebase consistently uses `Number.parseFloat()`. This aligns them for consistency and avoids potential issues with global scope pollution.