### PR TITLE
fix(pairing): don't silently swallow unexpected stat errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/config: include rejected validation paths in foreground and service last-known-good recovery logs plus main-agent notices, so unsupported direct edits explain which key caused restore instead of looking like silent reversion. Fixes #75060. Thanks @amknight.
 - Plugins/runtime-deps: hash the OS-canonical `packageRoot` via `fs.realpathSync.native` (with `path.resolve` fallback) when computing the bundled runtime-deps stage key, so loader and channel `bundled-root` callers no longer derive divergent stage directories under `~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/` and bundled channels stop failing with `ENOENT` on shared dist chunks under Windows npm symlinks, junctions, or PM2 multi-instance worker layouts. Fixes #74963. (#75048) Thanks @openperf and @vincentkoc.
 - fix(logging): add redaction patterns for Tencent Cloud, Alibaba Cloud, HuggingFace and Replicate API keys (#58162). Thanks @gavyngong
+- Pairing: surface unexpected allowlist filesystem stat errors instead of treating the allowlist as missing, so permission and I/O failures are visible during pairing authorization checks. (#63324) Thanks @franciscomaestre.
 
 ## 2026.4.29
 

--- a/src/pairing/allow-from-store-file.test.ts
+++ b/src/pairing/allow-from-store-file.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
 import {
+  readAllowFromFileSyncWithExists,
   resolveAllowFromAccountId,
   resolveAllowFromFilePath,
   safeChannelKey,
@@ -23,6 +25,10 @@ function expectInvalidPairingKey(params: {
     return;
   }
   throw new Error("expected invalid pairing key error");
+}
+
+function fsError(message: string, code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code });
 }
 
 describe("allow-from store file keys", () => {
@@ -63,5 +69,26 @@ describe("allow-from store file keys", () => {
       message: "invalid pairing account id: sanitized filename key is empty; got string length 1",
       leaked: "/",
     });
+  });
+});
+
+describe("allow-from store file reads", () => {
+  it("rethrows unexpected sync stat errors", () => {
+    const error = fsError("permission denied", "EACCES");
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementation(() => {
+      throw error;
+    });
+
+    try {
+      expect(() =>
+        readAllowFromFileSyncWithExists({
+          cacheNamespace: "test",
+          filePath: "/tmp/openclaw-allowFrom.json",
+          normalizeStore: () => [],
+        }),
+      ).toThrow(error);
+    } finally {
+      statSpy.mockRestore();
+    }
   });
 });

--- a/src/pairing/allow-from-store-file.ts
+++ b/src/pairing/allow-from-store-file.ts
@@ -272,7 +272,7 @@ export function readAllowFromFileSyncWithExists(params: {
   } catch (err) {
     const code = (err as { code?: string }).code;
     if (code !== "ENOENT") {
-      return { entries: [], exists: false };
+      throw err;
     }
   }
 

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -472,6 +472,32 @@ describe("pairing store", () => {
     });
   });
 
+  it("rethrows unexpected stat errors after allowFrom writes", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const allowFromPath = resolveAllowFromFilePath(stateDir, "telegram", "yy");
+      const error = Object.assign(new Error("stat failed"), { code: "EACCES" });
+      const originalStat = fsSync.promises.stat.bind(fsSync.promises);
+      const statSpy = vi.spyOn(fsSync.promises, "stat").mockImplementation(async (target) => {
+        if (String(target) === allowFromPath) {
+          throw error;
+        }
+        return await originalStat(target);
+      });
+
+      try {
+        await expect(
+          addChannelAllowFromStoreEntry({
+            channel: "telegram",
+            accountId: "yy",
+            entry: "12345",
+          }),
+        ).rejects.toBe(error);
+      } finally {
+        statSpy.mockRestore();
+      }
+    });
+  });
+
   it("reads allowFrom variants with account-scoped isolation", async () => {
     await withTempStateDir(async (stateDir) => {
       for (const { setup, accountId, expected, expectedLegacy } of [

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -305,7 +305,12 @@ async function writeAllowFromState(filePath: string, allowFrom: string[]): Promi
   let stat: Awaited<ReturnType<typeof fs.promises.stat>> | null = null;
   try {
     stat = await fs.promises.stat(filePath);
-  } catch {}
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code !== "ENOENT") {
+      throw err;
+    }
+  }
   setAllowFromFileReadCache({
     cacheNamespace: PAIRING_ALLOW_FROM_CACHE_NAMESPACE,
     filePath,


### PR DESCRIPTION
The empty `catch {}` block after `fs.promises.stat()` silently ignores all errors, including unexpected ones like `EACCES` or `EIO`. Only `ENOENT` (file not yet created) is expected here. This re-throws anything else to surface real errors.