### PR TITLE
fix: use Number.parseInt instead of global parseInt for consistency

### DIFF
--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -181,7 +181,7 @@ export function formatUserTime(
     if (!map.weekday || !map.year || !map.month || !map.day || !map.hour || !map.minute) {
       return undefined;
     }
-    const dayNum = parseInt(map.day, 10);
+    const dayNum = Number.parseInt(map.day, 10);
     const suffix = ordinalSuffix(dayNum);
     const timePart = use24Hour
       ? `${map.hour}:${map.minute}`

--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -65,7 +65,7 @@ function parseLspMessages(buffer: string): { messages: unknown[]; remaining: str
       continue;
     }
 
-    const contentLength = parseInt(match[1], 10);
+    const contentLength = Number.parseInt(match[1], 10);
     const bodyStart = headerEnd + 4;
     const bodyEnd = bodyStart + contentLength;
 

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -178,7 +178,7 @@ export function isoToPerplexityDate(iso: string): string | undefined {
     return undefined;
   }
   const [, year, month, day] = match;
-  return `${parseInt(month, 10)}/${parseInt(day, 10)}/${year}`;
+  return `${Number.parseInt(month, 10)}/${Number.parseInt(day, 10)}/${year}`;
 }
 
 export function normalizeToIsoDate(value: string): string | undefined {

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -240,7 +240,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
 
       // Special handling for suspicious-network: check port
       if (rule.ruleId === "suspicious-network") {
-        const port = parseInt(match[1], 10);
+        const port = Number.parseInt(match[1], 10);
         if (STANDARD_PORTS.has(port)) {
           continue;
         }


### PR DESCRIPTION
Four files use the global `parseInt()` instead of `Number.parseInt()`. The rest of the codebase consistently uses `Number.parseInt()`. All calls already pass radix 10, so this is a pure consistency fix.