### PR TITLE
fix(bindings): log persist errors instead of silently swallowing them

### DIFF
--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -89,7 +89,10 @@ async function persistBindingsToDisk(): Promise<void> {
 
 function enqueuePersist(): Promise<void> {
   persistPromise = persistPromise
-    .catch(() => {})
+    .catch((e: unknown) => {
+      // Previous persist failed — log and continue so the queue doesn't stall
+      console.warn("[current-conversation-bindings] persist error (retrying):", e);
+    })
     .then(async () => {
       await persistBindingsToDisk();
     });


### PR DESCRIPTION
The empty `.catch(() => {})` in `enqueuePersist()` silently discards persistence errors, making it impossible to diagnose why conversation bindings are not being saved to disk.\n\nThis logs the error with `console.warn` so it surfaces in logs while still allowing the queue to continue processing.