### PR TITLE
feat(serper): add Serper.dev Google Search plugin

### DIFF
--- a/extensions/serper/index.ts
+++ b/extensions/serper/index.ts
@@ -1,2 +1,11 @@
-export { createSerperWebSearchProvider } from "./web-search-contract-api.js";
-export { createSerperWebSearchProviderPlugin } from "./src/serper-web-search-provider.js";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createSerperWebSearchProviderPlugin } from "./src/serper-web-search-provider.js";
+
+export default definePluginEntry({
+  id: "serper",
+  name: "Serper Plugin",
+  description: "Bundled Serper (Google Search) plugin",
+  register(api) {
+    api.registerWebSearchProvider(createSerperWebSearchProviderPlugin());
+  },
+});

--- a/extensions/serper/index.ts
+++ b/extensions/serper/index.ts
@@ -1,0 +1,2 @@
+export { createSerperWebSearchProvider } from "./web-search-contract-api.js";
+export { createSerperWebSearchProviderPlugin } from "./src/serper-web-search-provider.js";

--- a/extensions/serper/openclaw.plugin.json
+++ b/extensions/serper/openclaw.plugin.json
@@ -1,0 +1,47 @@
+{
+  "id": "serper",
+  "providerAuthEnvVars": {
+    "serper": ["SERPER_API_KEY"]
+  },
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Serper API Key",
+      "help": "Serper.dev API key for Google Search results (fallback: SERPER_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "your-serper-api-key"
+    }
+  },
+  "contracts": {
+    "webSearchProviders": ["serper"]
+  },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          },
+          "gl": {
+            "type": "string",
+            "description": "Country code for results (e.g. 'us', 'ec'). Default: 'us'."
+          },
+          "hl": {
+            "type": "string",
+            "description": "Language code for results (e.g. 'en', 'es'). Default: 'en'."
+          },
+          "num": {
+            "type": "number",
+            "description": "Number of results to return (1-100). Default: 10."
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/serper/package.json
+++ b/extensions/serper/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/serper-plugin",
+  "version": "2026.4.9",
+  "private": true,
+  "description": "OpenClaw Serper (Google Search) plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/serper/src/serper-web-search-provider.ts
+++ b/extensions/serper/src/serper-web-search-provider.ts
@@ -59,14 +59,29 @@ function resolveSerperConfig(searchConfig?: SearchConfigRecord): SerperConfig {
     : {};
 }
 
-function resolveApiKey(
-  searchConfig?: SearchConfigRecord,
-  pluginConfig?: Record<string, unknown>,
-): string | undefined {
-  const fromPlugin = pluginConfig?.apiKey;
-  if (typeof fromPlugin === "string" && fromPlugin.trim()) return fromPlugin.trim();
+function mergeScopedSearchConfig(
+  searchConfig: SearchConfigRecord | undefined,
+  key: string,
+  pluginConfig: Record<string, unknown> | undefined,
+  options?: { mirrorApiKeyToTopLevel?: boolean },
+): SearchConfigRecord | undefined {
+  if (!pluginConfig) return searchConfig;
+  const currentScoped = isRecord(searchConfig?.[key]) ? searchConfig?.[key] : {};
+  const next: SearchConfigRecord = {
+    ...searchConfig,
+    [key]: { ...currentScoped, ...pluginConfig },
+  };
+  if (options?.mirrorApiKeyToTopLevel && pluginConfig.apiKey !== undefined) {
+    next.apiKey = pluginConfig.apiKey;
+  }
+  return next;
+}
+
+function resolveApiKey(searchConfig?: SearchConfigRecord): string | undefined {
   const fromSearch = searchConfig?.apiKey;
   if (typeof fromSearch === "string" && fromSearch.trim()) return fromSearch.trim();
+  const fromSerper = resolveSerperConfig(searchConfig).apiKey;
+  if (typeof fromSerper === "string" && fromSerper.trim()) return fromSerper.trim();
   return process.env.SERPER_API_KEY?.trim() || undefined;
 }
 
@@ -83,7 +98,9 @@ function createSerperToolDefinition(
     isConfigured: Boolean(apiKey),
     execute: async (query: string, options?: { numResults?: number }) => {
       if (!apiKey) {
-        throw new Error("Serper API key not configured. Set SERPER_API_KEY or configure via plugin settings.");
+        throw new Error(
+          "Serper API key not configured. Set SERPER_API_KEY or configure via plugin settings.",
+        );
       }
 
       const num = options?.numResults ?? serperConfig.num ?? 10;
@@ -143,19 +160,14 @@ export function createSerperWebSearchProviderPlugin(): WebSearchProviderPlugin {
       webSearch.apiKey = value;
     },
 
-    mergeSearchConfig(
-      searchConfig: SearchConfigRecord | undefined,
-      pluginConfig: Record<string, unknown> | undefined,
-    ): SearchConfigRecord | undefined {
-      if (!pluginConfig) return searchConfig;
-      return {
-        ...searchConfig,
-        serper: { ...(isRecord(searchConfig?.serper) ? searchConfig.serper : {}), ...pluginConfig },
-        ...(pluginConfig.apiKey !== undefined ? { apiKey: pluginConfig.apiKey } : {}),
-      };
-    },
-
-    createTool: (searchConfig?: SearchConfigRecord) =>
-      createSerperToolDefinition(searchConfig),
+    createTool: (ctx) =>
+      createSerperToolDefinition(
+        mergeScopedSearchConfig(
+          ctx.searchConfig,
+          PLUGIN_ID,
+          resolvePluginConfig(ctx.config, PLUGIN_ID),
+          { mirrorApiKeyToTopLevel: true },
+        ),
+      ),
   };
 }

--- a/extensions/serper/src/serper-web-search-provider.ts
+++ b/extensions/serper/src/serper-web-search-provider.ts
@@ -52,6 +52,13 @@ function ensureObject(target: Record<string, unknown>, key: string): Record<stri
   return next;
 }
 
+function setTopLevelCredentialValue(
+  searchConfigTarget: Record<string, unknown>,
+  value: unknown,
+): void {
+  searchConfigTarget.apiKey = value;
+}
+
 function resolveSerperConfig(searchConfig?: SearchConfigRecord): SerperConfig {
   const serper = searchConfig?.serper;
   return serper && typeof serper === "object" && !Array.isArray(serper)
@@ -145,6 +152,9 @@ export function createSerperWebSearchProviderPlugin(): WebSearchProviderPlugin {
     signupUrl: "https://serper.dev",
     autoDetectOrder: 15,
     credentialPath,
+    inactiveSecretPaths: [`plugins.entries.${PLUGIN_ID}.config.webSearch.apiKey`],
+    getCredentialValue: (searchConfig) => searchConfig?.apiKey,
+    setCredentialValue: setTopLevelCredentialValue,
 
     getConfiguredCredentialValue(config: ConfigInput): unknown {
       return resolvePluginConfig(config, PLUGIN_ID)?.apiKey;

--- a/extensions/serper/src/serper-web-search-provider.ts
+++ b/extensions/serper/src/serper-web-search-provider.ts
@@ -1,0 +1,161 @@
+import type {
+  SearchConfigRecord,
+  WebSearchProviderPlugin,
+  WebSearchProviderToolDefinition,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { isRecord } from "openclaw/plugin-sdk/text-runtime";
+
+const SERPER_API_URL = "https://google.serper.dev/search";
+const PLUGIN_ID = "serper";
+
+interface SerperConfig {
+  apiKey?: string;
+  gl?: string;
+  hl?: string;
+  num?: number;
+}
+
+interface SerperResult {
+  title?: string;
+  link?: string;
+  snippet?: string;
+}
+
+interface SerperResponse {
+  organic?: SerperResult[];
+}
+
+type ConfigInput = Parameters<
+  NonNullable<WebSearchProviderPlugin["getConfiguredCredentialValue"]>
+>[0];
+type ConfigTarget = Parameters<
+  NonNullable<WebSearchProviderPlugin["setConfiguredCredentialValue"]>
+>[0];
+
+function resolvePluginConfig(
+  config: ConfigInput,
+  pluginId: string,
+): Record<string, unknown> | undefined {
+  if (!isRecord(config)) return undefined;
+  const plugins = isRecord(config.plugins) ? config.plugins : undefined;
+  const entries = isRecord(plugins?.entries) ? plugins.entries : undefined;
+  const entry = isRecord(entries?.[pluginId]) ? entries[pluginId] : undefined;
+  const pluginConfig = isRecord(entry?.config) ? entry.config : undefined;
+  return isRecord(pluginConfig?.webSearch) ? pluginConfig.webSearch : undefined;
+}
+
+function ensureObject(target: Record<string, unknown>, key: string): Record<string, unknown> {
+  const current = target[key];
+  if (isRecord(current)) return current;
+  const next: Record<string, unknown> = {};
+  target[key] = next;
+  return next;
+}
+
+function resolveSerperConfig(searchConfig?: SearchConfigRecord): SerperConfig {
+  const serper = searchConfig?.serper;
+  return serper && typeof serper === "object" && !Array.isArray(serper)
+    ? (serper as SerperConfig)
+    : {};
+}
+
+function resolveApiKey(
+  searchConfig?: SearchConfigRecord,
+  pluginConfig?: Record<string, unknown>,
+): string | undefined {
+  const fromPlugin = pluginConfig?.apiKey;
+  if (typeof fromPlugin === "string" && fromPlugin.trim()) return fromPlugin.trim();
+  const fromSearch = searchConfig?.apiKey;
+  if (typeof fromSearch === "string" && fromSearch.trim()) return fromSearch.trim();
+  return process.env.SERPER_API_KEY?.trim() || undefined;
+}
+
+function createSerperToolDefinition(
+  searchConfig?: SearchConfigRecord,
+): WebSearchProviderToolDefinition {
+  const serperConfig = resolveSerperConfig(searchConfig);
+  const apiKey = resolveApiKey(searchConfig);
+
+  return {
+    id: PLUGIN_ID,
+    label: "Serper (Google Search)",
+    description: "Search the web using Google via Serper.dev",
+    isConfigured: Boolean(apiKey),
+    execute: async (query: string, options?: { numResults?: number }) => {
+      if (!apiKey) {
+        throw new Error("Serper API key not configured. Set SERPER_API_KEY or configure via plugin settings.");
+      }
+
+      const num = options?.numResults ?? serperConfig.num ?? 10;
+      const body: Record<string, unknown> = { q: query, num };
+      if (serperConfig.gl) body.gl = serperConfig.gl;
+      if (serperConfig.hl) body.hl = serperConfig.hl;
+
+      const response = await fetch(SERPER_API_URL, {
+        method: "POST",
+        headers: {
+          "X-API-KEY": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Serper API error: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as SerperResponse;
+      return (data.organic ?? []).map((r) => ({
+        title: r.title ?? "",
+        url: r.link ?? "",
+        snippet: r.snippet ?? "",
+      }));
+    },
+  };
+}
+
+export function createSerperWebSearchProviderPlugin(): WebSearchProviderPlugin {
+  const credentialPath = `plugins.entries.${PLUGIN_ID}.config.webSearch.apiKey`;
+
+  return {
+    id: PLUGIN_ID,
+    label: "Serper (Google Search)",
+    hint: "Real Google results · country/language filters",
+    onboardingScopes: ["text-inference"],
+    credentialLabel: "Serper API key",
+    envVars: ["SERPER_API_KEY"],
+    placeholder: "your-serper-api-key",
+    signupUrl: "https://serper.dev",
+    autoDetectOrder: 15,
+    credentialPath,
+
+    getConfiguredCredentialValue(config: ConfigInput): unknown {
+      return resolvePluginConfig(config, PLUGIN_ID)?.apiKey;
+    },
+
+    setConfiguredCredentialValue(configTarget: ConfigTarget, value: unknown): void {
+      const plugins = ensureObject(configTarget as Record<string, unknown>, "plugins");
+      const entries = ensureObject(plugins, "entries");
+      const entry = ensureObject(entries, PLUGIN_ID);
+      if (entry.enabled === undefined) entry.enabled = true;
+      const config = ensureObject(entry, "config");
+      const webSearch = ensureObject(config, "webSearch");
+      webSearch.apiKey = value;
+    },
+
+    mergeSearchConfig(
+      searchConfig: SearchConfigRecord | undefined,
+      pluginConfig: Record<string, unknown> | undefined,
+    ): SearchConfigRecord | undefined {
+      if (!pluginConfig) return searchConfig;
+      return {
+        ...searchConfig,
+        serper: { ...(isRecord(searchConfig?.serper) ? searchConfig.serper : {}), ...pluginConfig },
+        ...(pluginConfig.apiKey !== undefined ? { apiKey: pluginConfig.apiKey } : {}),
+      };
+    },
+
+    createTool: (searchConfig?: SearchConfigRecord) =>
+      createSerperToolDefinition(searchConfig),
+  };
+}

--- a/extensions/serper/web-search-contract-api.ts
+++ b/extensions/serper/web-search-contract-api.ts
@@ -1,0 +1,28 @@
+import {
+  createWebSearchProviderContractFields,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search-config-contract";
+
+export function createSerperWebSearchProvider(): WebSearchProviderPlugin {
+  const credentialPath = "plugins.entries.serper.config.webSearch.apiKey";
+
+  return {
+    id: "serper",
+    label: "Serper (Google Search)",
+    hint: "Real Google results · country/language filters",
+    onboardingScopes: ["text-inference"],
+    credentialLabel: "Serper API key",
+    envVars: ["SERPER_API_KEY"],
+    placeholder: "your-serper-api-key",
+    signupUrl: "https://serper.dev",
+    docsUrl: "https://docs.openclaw.ai/serper-search",
+    autoDetectOrder: 15,
+    credentialPath,
+    ...createWebSearchProviderContractFields({
+      credentialPath,
+      searchCredential: { type: "top-level" },
+      configuredCredential: { pluginId: "serper" },
+    }),
+    createTool: () => null,
+  };
+}


### PR DESCRIPTION
Adds a new web search provider plugin for Serper.dev, which provides real Google Search results via a simple REST API. Mirrors the existing Brave plugin structure.

Features: full WebSearchProviderPlugin contract, configurable country/language/num params, API key via plugin config or SERPER_API_KEY env var, auto-detection order 15.