### PR TITLE
fix: Clarify sessions_send schema field guidance for sessionKey/label

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -65,9 +65,14 @@ disk instead of treating `sessions_history` as a raw dump.
 `sessions_send` delivers a message to another session and optionally waits for
 the response:
 
+- Target the destination with **either** `sessionKey` **or** `label`, not both.
+- Use `sessionKey` when you already have an exact key from `sessions_list`.
+- Use `label` when you want OpenClaw to resolve a visible session by label.
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return
   immediately.
 - **Wait for reply:** set a timeout and get the response inline.
+
+If both `sessionKey` and `label` are provided, the tool returns an input error.
 
 After the target responds, OpenClaw can run a **reply-back loop** where the
 agents alternate messages (up to 5 turns). The target agent can reply

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -33,9 +33,25 @@ import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./session
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
-  sessionKey: Type.Optional(Type.String()),
-  label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
-  agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+  sessionKey: Type.Optional(
+    Type.String({
+      description: "Exact target session key. Preferred when known. Do not also provide label.",
+    }),
+  ),
+  label: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: SESSION_LABEL_MAX_LENGTH,
+      description: "Visible session label to resolve when sessionKey is not available. Do not provide alongside sessionKey.",
+    }),
+  ),
+  agentId: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 64,
+      description: "Optional agent id hint for label-based resolution.",
+    }),
+  ),
   message: Type.String(),
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
 });


### PR DESCRIPTION
## Summary

- Update `sessions_send` tool schema descriptions to clarify the mutual exclusion between `sessionKey` and `label` parameters
- Prevents confusing errors when both parameters are provided simultaneously

Closes #63308

## Changes

- Added clear guidance in schema field descriptions explaining that `sessionKey` and `label` are mutually exclusive
- Updated description text to indicate which parameter takes precedence

## Testing

- Verified schema descriptions are accurate
- Confirmed tool behavior matches updated documentation

**AI Disclosure:** This fix was developed with AI assistance (Claude via islo.dev).

---
*Built autonomously by [islo.dev](https://islo.dev)*