### PR TITLE
fix(plugins): preserve memory capability across loader restores

### DIFF
--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -57,6 +57,21 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 
 const DISCORD_COMMAND_ARG_CUSTOM_ID_KEY = "cmdarg";
+const DISCORD_MODEL_PICKER_APPLY_SETTLE_MS = 250;
+
+let waitForDiscordModelPickerApplyImpl = async (delayMs: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+};
+
+export const __testing = {
+  setDiscordModelPickerApplyWaitImpl(
+    next: typeof waitForDiscordModelPickerApplyImpl,
+  ): typeof waitForDiscordModelPickerApplyImpl {
+    const previous = waitForDiscordModelPickerApplyImpl;
+    waitForDiscordModelPickerApplyImpl = next;
+    return previous;
+  },
+};
 
 export type DiscordCommandArgContext = {
   cfg: ReturnType<typeof loadConfig>;
@@ -810,7 +825,7 @@ export async function handleDiscordModelPickerInteraction(params: {
       return;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await waitForDiscordModelPickerApplyImpl(DISCORD_MODEL_PICKER_APPLY_SETTLE_MS);
 
     const effectiveModelRef = resolveDiscordModelPickerCurrentModel({
       cfg: ctx.cfg,

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -10,7 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
-import { replyWithDiscordModelPickerProviders } from "./native-command-ui.js";
+import {
+  __testing as nativeCommandUiTesting,
+  replyWithDiscordModelPickerProviders,
+} from "./native-command-ui.js";
 import {
   __testing as nativeCommandTesting,
   createDiscordModelPickerFallbackButton,
@@ -49,21 +52,6 @@ type MockInteraction = {
 
 function createModelsProviderData(entries: Record<string, string[]>): ModelsProviderData {
   return createBaseModelsProviderData(entries, { defaultProviderOrder: "sorted" });
-}
-
-async function waitForCondition(
-  predicate: () => boolean,
-  opts?: { attempts?: number; delayMs?: number },
-): Promise<void> {
-  const attempts = opts?.attempts ?? 50;
-  const delayMs = opts?.delayMs ?? 0;
-  for (let index = 0; index < attempts; index += 1) {
-    if (predicate()) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
-  throw new Error("condition not met");
 }
 
 function createModelPickerContext(): ModelPickerContext {
@@ -253,15 +241,25 @@ function createDispatchSpy() {
 }
 
 describe("Discord model picker interactions", () => {
+  let restoreModelPickerApplyWait: (() => void) | undefined;
+
   beforeEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     nativeCommandTesting.setDispatchReplyWithDispatcher(
       dispatcherModule.dispatchReplyWithDispatcher,
     );
+    const previousWaitForDiscordModelPickerApply =
+      nativeCommandUiTesting.setDiscordModelPickerApplyWaitImpl(async () => {});
+    restoreModelPickerApplyWait = () =>
+      nativeCommandUiTesting.setDiscordModelPickerApplyWaitImpl(
+        previousWaitForDiscordModelPickerApply,
+      );
   });
 
   afterEach(() => {
+    restoreModelPickerApplyWait?.();
+    restoreModelPickerApplyWait = undefined;
     vi.useRealTimers();
   });
 
@@ -354,7 +352,9 @@ describe("Discord model picker interactions", () => {
     await button.run(submitInteraction as unknown as PickerButtonInteraction, submitData);
 
     expect(withTimeoutSpy).toHaveBeenCalledTimes(1);
-    await waitForCondition(() => dispatchSpy.mock.calls.length === 1);
+    await vi.waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    });
     expect(submitInteraction.followUp).toHaveBeenCalledTimes(1);
     const followUpPayload = submitInteraction.followUp.mock.calls[0]?.[0] as {
       components?: Array<{ components?: Array<{ content?: string }> }>;

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -33,13 +33,14 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   buildMemoryPromptSection,
+  clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryRuntime,
+  listActiveMemoryPublicArtifacts,
   listMemoryCorpusSupplements,
+  registerMemoryCapability,
   registerMemoryCorpusSupplement,
-  registerMemoryFlushPlanResolver,
   registerMemoryPromptSupplement,
-  registerMemoryPromptSection,
-  registerMemoryRuntime,
   resolveMemoryFlushPlan,
 } from "./memory-state.js";
 import { createEmptyPluginRegistry } from "./registry.js";
@@ -1504,7 +1505,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(scoped.providers.map((entry) => entry.provider.id)).toEqual(["deepseek"]);
   });
 
-  it("does not replace active memory plugin registries during non-activating loads", () => {
+  it("does not replace active memory plugin registries during non-activating loads", async () => {
     useNoBundledPlugins();
     registerMemoryEmbeddingProvider({
       id: "active",
@@ -1514,16 +1515,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
       search: async () => [],
       get: async () => null,
     });
-    registerMemoryPromptSection(() => ["active memory section"]);
     registerMemoryPromptSupplement("memory-wiki", () => ["active wiki supplement"]);
-    registerMemoryFlushPlanResolver(() => ({
-      softThresholdTokens: 1,
-      forceFlushTranscriptBytes: 2,
-      reserveTokensFloor: 3,
-      prompt: "active",
-      systemPrompt: "active",
-      relativePath: "memory/active.md",
-    }));
     const activeRuntime = {
       async getMemorySearchManager() {
         return { manager: null, error: "active" };
@@ -1532,7 +1524,33 @@ module.exports = { id: "throws-after-import", register() {} };`,
         return { backend: "builtin" as const };
       },
     };
-    registerMemoryRuntime(activeRuntime);
+    const activeArtifacts = [
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/active-workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/active-workspace/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown" as const,
+      },
+    ];
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["active memory section"],
+      flushPlanResolver: () => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 2,
+        reserveTokensFloor: 3,
+        prompt: "active",
+        systemPrompt: "active",
+        relativePath: "memory/active.md",
+      }),
+      runtime: activeRuntime,
+      publicArtifacts: {
+        async listArtifacts() {
+          return activeArtifacts;
+        },
+      },
+    });
     const plugin = writePlugin({
       id: "snapshot-memory",
       filename: "snapshot-memory.cjs",
@@ -1544,21 +1562,35 @@ module.exports = { id: "throws-after-import", register() {} };`,
             id: "snapshot",
             create: async () => ({ provider: null }),
           });
-          api.registerMemoryPromptSection(() => ["snapshot memory section"]);
-          api.registerMemoryFlushPlan(() => ({
-            softThresholdTokens: 10,
-            forceFlushTranscriptBytes: 20,
-            reserveTokensFloor: 30,
-            prompt: "snapshot",
-            systemPrompt: "snapshot",
-            relativePath: "memory/snapshot.md",
-          }));
-          api.registerMemoryRuntime({
-            async getMemorySearchManager() {
-              return { manager: null, error: "snapshot" };
+          api.registerMemoryCapability({
+            promptBuilder: () => ["snapshot memory section"],
+            flushPlanResolver: () => ({
+              softThresholdTokens: 10,
+              forceFlushTranscriptBytes: 20,
+              reserveTokensFloor: 30,
+              prompt: "snapshot",
+              systemPrompt: "snapshot",
+              relativePath: "memory/snapshot.md",
+            }),
+            runtime: {
+              async getMemorySearchManager() {
+                return { manager: null, error: "snapshot" };
+              },
+              resolveMemoryBackendConfig() {
+                return { backend: "qmd", qmd: {} };
+              },
             },
-            resolveMemoryBackendConfig() {
-              return { backend: "qmd", qmd: {} };
+            publicArtifacts: {
+              async listArtifacts() {
+                return [{
+                  kind: "daily-note",
+                  workspaceDir: "/tmp/snapshot-workspace",
+                  relativePath: "memory/2026-04-08.md",
+                  absolutePath: "/tmp/snapshot-workspace/memory/2026-04-08.md",
+                  agentIds: ["snapshot"],
+                  contentType: "markdown",
+                }];
+              },
             },
           });
         },
@@ -1587,6 +1619,12 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(listMemoryCorpusSupplements()).toHaveLength(1);
     expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/active.md");
     expect(getMemoryRuntime()).toBe(activeRuntime);
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "memory-core",
+    });
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual(
+      activeArtifacts,
+    );
     expect(listMemoryEmbeddingProviders().map((adapter) => adapter.id)).toEqual(["active"]);
   });
 
@@ -1689,6 +1727,95 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(getGlobalHookRunner()).not.toBeNull();
 
     resetGlobalHookRunner();
+  });
+
+  it("restores memory capability public artifacts when serving a registry from cache", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cache-memory",
+      filename: "cache-memory.cjs",
+      body: `module.exports = {
+        id: "cache-memory",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            promptBuilder: () => ["cache memory section"],
+            flushPlanResolver: () => ({
+              softThresholdTokens: 10,
+              forceFlushTranscriptBytes: 20,
+              reserveTokensFloor: 30,
+              prompt: "cache",
+              systemPrompt: "cache",
+              relativePath: "memory/cache.md",
+            }),
+            runtime: {
+              async getMemorySearchManager() {
+                return { manager: null, error: "cache" };
+              },
+              resolveMemoryBackendConfig() {
+                return { backend: "builtin" };
+              },
+            },
+            publicArtifacts: {
+              async listArtifacts() {
+                return [{
+                  kind: "memory-root",
+                  workspaceDir: "/tmp/cache-workspace",
+                  relativePath: "MEMORY.md",
+                  absolutePath: "/tmp/cache-workspace/MEMORY.md",
+                  agentIds: ["cache"],
+                  contentType: "markdown",
+                }];
+              },
+            },
+          });
+        },
+      };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["cache-memory"],
+          slots: { memory: "cache-memory" },
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins(options);
+    expect(first.plugins.find((entry) => entry.id === "cache-memory")?.status).toBe("loaded");
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/cache-workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/cache-workspace/MEMORY.md",
+        agentIds: ["cache"],
+        contentType: "markdown",
+      },
+    ]);
+
+    clearMemoryPluginState();
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([]);
+
+    const second = loadOpenClawPlugins(options);
+    expect(second).toBe(first);
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "cache-memory",
+    });
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/cache-workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/cache-workspace/MEMORY.md",
+        agentIds: ["cache"],
+        contentType: "markdown",
+      },
+    ]);
   });
 
   it.each([

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -42,6 +42,7 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
@@ -148,13 +149,9 @@ export class PluginLoadReentryError extends Error {
 
 type CachedPluginState = {
   registry: PluginRegistry;
-  memoryCorpusSupplements: ReturnType<typeof listMemoryCorpusSupplements>;
   compactionProviders: ReturnType<typeof listRegisteredCompactionProviders>;
   memoryEmbeddingProviders: ReturnType<typeof listRegisteredMemoryEmbeddingProviders>;
-  memoryFlushPlanResolver: ReturnType<typeof getMemoryFlushPlanResolver>;
-  memoryPromptBuilder: ReturnType<typeof getMemoryPromptSectionBuilder>;
-  memoryPromptSupplements: ReturnType<typeof listMemoryPromptSupplements>;
-  memoryRuntime: ReturnType<typeof getMemoryRuntime>;
+  memoryState: Parameters<typeof restoreMemoryPluginState>[0];
 };
 
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
@@ -295,6 +292,17 @@ function setCachedPluginRegistry(cacheKey: string, state: CachedPluginState): vo
     }
     registryCache.delete(oldestKey);
   }
+}
+
+function snapshotMemoryPluginState(): Parameters<typeof restoreMemoryPluginState>[0] {
+  return {
+    capability: getMemoryCapabilityRegistration(),
+    corpusSupplements: listMemoryCorpusSupplements(),
+    promptBuilder: getMemoryPromptSectionBuilder(),
+    promptSupplements: listMemoryPromptSupplements(),
+    flushPlanResolver: getMemoryFlushPlanResolver(),
+    runtime: getMemoryRuntime(),
+  };
 }
 
 function buildCacheKey(params: {
@@ -1084,13 +1092,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (cached) {
       restoreRegisteredCompactionProviders(cached.compactionProviders);
       restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
-      restoreMemoryPluginState({
-        corpusSupplements: cached.memoryCorpusSupplements,
-        promptBuilder: cached.memoryPromptBuilder,
-        promptSupplements: cached.memoryPromptSupplements,
-        flushPlanResolver: cached.memoryFlushPlanResolver,
-        runtime: cached.memoryRuntime,
-      });
+      restoreMemoryPluginState(cached.memoryState);
       if (shouldActivate) {
         activatePluginRegistry(
           cached.registry,
@@ -1678,11 +1680,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       });
       const previousCompactionProviders = listRegisteredCompactionProviders();
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
-      const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
-      const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
-      const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
-      const previousMemoryPromptSupplements = listMemoryPromptSupplements();
-      const previousMemoryRuntime = getMemoryRuntime();
+      const previousMemoryState = snapshotMemoryPluginState();
 
       try {
         const result = register(api);
@@ -1698,26 +1696,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         if (!shouldActivate) {
           restoreRegisteredCompactionProviders(previousCompactionProviders);
           restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
-          restoreMemoryPluginState({
-            corpusSupplements: previousMemoryCorpusSupplements,
-            promptBuilder: previousMemoryPromptBuilder,
-            promptSupplements: previousMemoryPromptSupplements,
-            flushPlanResolver: previousMemoryFlushPlanResolver,
-            runtime: previousMemoryRuntime,
-          });
+          restoreMemoryPluginState(previousMemoryState);
         }
         registry.plugins.push(record);
         seenIds.set(pluginId, candidate.origin);
       } catch (err) {
         restoreRegisteredCompactionProviders(previousCompactionProviders);
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
-        restoreMemoryPluginState({
-          corpusSupplements: previousMemoryCorpusSupplements,
-          promptBuilder: previousMemoryPromptBuilder,
-          promptSupplements: previousMemoryPromptSupplements,
-          flushPlanResolver: previousMemoryFlushPlanResolver,
-          runtime: previousMemoryRuntime,
-        });
+        restoreMemoryPluginState(previousMemoryState);
         recordPluginError({
           logger,
           registry,
@@ -1766,14 +1752,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     if (cacheEnabled) {
       setCachedPluginRegistry(cacheKey, {
-        memoryCorpusSupplements: listMemoryCorpusSupplements(),
         registry,
         compactionProviders: listRegisteredCompactionProviders(),
         memoryEmbeddingProviders: listRegisteredMemoryEmbeddingProviders(),
-        memoryFlushPlanResolver: getMemoryFlushPlanResolver(),
-        memoryPromptBuilder: getMemoryPromptSectionBuilder(),
-        memoryPromptSupplements: listMemoryPromptSupplements(),
-        memoryRuntime: getMemoryRuntime(),
+        memoryState: snapshotMemoryPluginState(),
       });
     }
     if (shouldActivate) {


### PR DESCRIPTION
## Summary

Fix plugin loader memory-state restore behavior so the full active memory capability is preserved during cache replay and non-activating or scoped restore paths.

This fixes a bug where `memoryPluginState.capability` could be overwritten by partial snapshots that omitted `capability.publicArtifacts`, causing `listActiveMemoryPublicArtifacts()` to return an empty list even though `memory-core` had registered public artifacts correctly.

## User-visible effect

This restores memory-wiki bridge artifact discovery, including surfaces like:

- `openclaw wiki status`
- `openclaw wiki bridge import`
- gateway `wiki.status` and `wiki.bridge.import`
- `wiki_status` tool

## Root cause

`src/plugins/loader.ts` restored partial memory state fragments such as runtime, prompt, and flush state, but did not preserve the full memory capability registration. Since public artifact enumeration reads from `memoryPluginState.capability.publicArtifacts`, that dropped exported artifacts to zero.

## Changes

- preserve full memory capability state during:
  - cache replay
  - non-activating or scoped rollback after plugin registration
- add a follow-up Discord test stabilization for a timer-sensitive model-picker suite that timed out in CI after the PR landed
  - this keeps runtime behavior unchanged
  - this is limited to the Discord model-picker settle-delay test seam and test polling behavior

## Tests

Added regression coverage for:

- preserving `publicArtifacts` after a non-activating scoped load
- preserving `publicArtifacts` when serving a registry from cache
- stabilizing the Discord model-picker timer-dependent test path in CI

## Verification

- `pnpm test src/plugins/loader.test.ts`
- `pnpm test extensions/memory-wiki/src/bridge.test.ts`
- `pnpm build`
- `pnpm test extensions/discord/src/monitor/native-command.model-picker.test.ts`

Also verified locally after restart that:

- `openclaw wiki status` reports exported artifacts correctly
- `openclaw wiki bridge import` syncs real artifacts and workspaces instead of returning all zeros
