### PR TITLE
fix(cron): guard against undefined sessionTarget in startsWith calls

### DIFF
--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -72,7 +72,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     job.payload.kind === "agentTurn" &&
     (job.sessionTarget === "isolated" ||
       job.sessionTarget === "current" ||
-      job.sessionTarget.startsWith("session:"));
+      (job.sessionTarget?.startsWith("session:") ?? false));
   const resolvedMode = isIsolatedAgentTurn ? "announce" : "none";
 
   return {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -287,7 +287,7 @@ export function buildGatewayCronService(params: {
     runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       let sessionKey = `cron:${job.id}`;
-      if (job.sessionTarget.startsWith("session:")) {
+      if (job.sessionTarget?.startsWith("session:")) {
         sessionKey = assertSafeCronSessionTargetId(job.sessionTarget.slice(8));
       }
       try {


### PR DESCRIPTION
## Bug
Cron jobs crash with `TypeError: Cannot read properties of undefined (reading 'startsWith')` when `payload.kind='agentTurn'` but `sessionTarget` is missing.

## Root Cause
Two call sites in the cron runtime assume `job.sessionTarget` is always defined:
- `src/cron/delivery-plan.ts` — `job.sessionTarget.startsWith("session:")`
- `src/gateway/server-cron.ts` — `job.sessionTarget.startsWith("session:")`

## Fix
Add optional chaining + nullish coalescing: `job.sessionTarget?.startsWith("session:") ?? false`

Fixes #63383