### PR TITLE
fix(gateway): preserve restart continuations after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - fix(config): accept truncateAfterCompaction (#68395). Thanks @MonkeyLeeT
 - CLI/Claude: keep Claude CLI session bindings stable across OAuth access-token refreshes, so gateway restarts continue the same Claude conversation instead of minting a fresh one. (#70132) Thanks @obviyus.
 - QQBot: add `INTERACTION` intent (`1 << 26`) to the gateway constants and include it in the `FULL_INTENTS` mask so interaction events are received. (#70143) Thanks @cxyhhhhh.
+- Gateway/restart: preserve one-shot continuation instructions across gateway restarts so agents can resume and reply back to the original chat after reboot. (#63406) Thanks @VACInc.
 
 ## 2026.4.21
 

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -69,6 +69,30 @@ describe("gateway tool restart continuation", () => {
     scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true, delayMs: 250 });
   });
 
+  it("uses a flat enum for continuationKind in the tool schema", async () => {
+    const { createGatewayTool } = await import("./gateway-tool.js");
+    const tool = createGatewayTool();
+    const continuationKind = (
+      tool.parameters as {
+        properties?: {
+          continuationKind?: {
+            type?: string;
+            enum?: string[];
+            anyOf?: unknown[];
+          };
+        };
+      }
+    ).properties?.continuationKind;
+
+    expect(continuationKind).toEqual(
+      expect.objectContaining({
+        type: "string",
+        enum: ["systemEvent", "agentTurn"],
+      }),
+    );
+    expect(continuationKind).not.toHaveProperty("anyOf");
+  });
+
   it("writes an agentTurn continuation into the restart sentinel", async () => {
     const { createGatewayTool } = await import("./gateway-tool.js");
     const tool = createGatewayTool({

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -93,6 +93,15 @@ describe("gateway tool restart continuation", () => {
     expect(continuationKind).not.toHaveProperty("anyOf");
   });
 
+  it("instructs agents to use continuationMessage when a restart still needs a reply", async () => {
+    const { createGatewayTool } = await import("./gateway-tool.js");
+    const tool = createGatewayTool();
+
+    expect(tool.description).toContain("still owe the user a reply");
+    expect(tool.description).toContain("continuationMessage");
+    expect(tool.description).toContain("do not write restart sentinel files directly");
+  });
+
   it("writes an agentTurn continuation into the restart sentinel", async () => {
     const { createGatewayTool } = await import("./gateway-tool.js");
     const tool = createGatewayTool({

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
+
+const isRestartEnabledMock = vi.fn(() => true);
+const extractDeliveryInfoMock = vi.fn(() => ({
+  deliveryContext: {
+    channel: "slack",
+    to: "slack:C123",
+    accountId: "workspace-1",
+  },
+  threadId: "thread-42",
+}));
+const formatDoctorNonInteractiveHintMock = vi.fn(() => "Run: openclaw doctor --non-interactive");
+const writeRestartSentinelMock = vi.fn(async (_payload: RestartSentinelPayload) => "/tmp/restart");
+const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true, delayMs: 250 }));
+
+vi.mock("../../config/commands.js", () => ({
+  isRestartEnabled: isRestartEnabledMock,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  extractDeliveryInfo: extractDeliveryInfoMock,
+}));
+
+vi.mock("../../infra/restart-sentinel.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/restart-sentinel.js")>(
+    "../../infra/restart-sentinel.js",
+  );
+  return {
+    ...actual,
+    formatDoctorNonInteractiveHint: formatDoctorNonInteractiveHintMock,
+    writeRestartSentinel: writeRestartSentinelMock,
+  };
+});
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    info: vi.fn(),
+  })),
+}));
+
+vi.mock("./gateway.js", () => ({
+  callGatewayTool: vi.fn(),
+  readGatewayCallOptions: vi.fn(() => ({})),
+}));
+
+describe("gateway tool restart continuation", () => {
+  beforeEach(() => {
+    isRestartEnabledMock.mockReset();
+    isRestartEnabledMock.mockReturnValue(true);
+    extractDeliveryInfoMock.mockReset();
+    extractDeliveryInfoMock.mockReturnValue({
+      deliveryContext: {
+        channel: "slack",
+        to: "slack:C123",
+        accountId: "workspace-1",
+      },
+      threadId: "thread-42",
+    });
+    formatDoctorNonInteractiveHintMock.mockReset();
+    formatDoctorNonInteractiveHintMock.mockReturnValue("Run: openclaw doctor --non-interactive");
+    writeRestartSentinelMock.mockReset();
+    writeRestartSentinelMock.mockResolvedValue("/tmp/restart");
+    scheduleGatewaySigusr1RestartMock.mockReset();
+    scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true, delayMs: 250 });
+  });
+
+  it("writes an agentTurn continuation into the restart sentinel", async () => {
+    const { createGatewayTool } = await import("./gateway-tool.js");
+    const tool = createGatewayTool({
+      agentSessionKey: "agent:main:main",
+      config: {},
+    });
+
+    const result = await tool.execute?.("tool-call-1", {
+      action: "restart",
+      delayMs: 250,
+      reason: "continue after reboot",
+      note: "Gateway restarting now",
+      continuationMessage: "Reply with exactly: Yay! I did it!",
+    });
+
+    expect(writeRestartSentinelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "restart",
+        status: "ok",
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "slack",
+          to: "slack:C123",
+          accountId: "workspace-1",
+        },
+        threadId: "thread-42",
+        message: "Gateway restarting now",
+        continuation: {
+          kind: "agentTurn",
+          message: "Reply with exactly: Yay! I did it!",
+        },
+      }),
+    );
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith({
+      delayMs: 250,
+      reason: "continue after reboot",
+    });
+    expect(result?.details).toEqual({ scheduled: true, delayMs: 250 });
+  });
+});

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -14,7 +14,7 @@ import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../../security/dangerous-config-flags.js";
 import { normalizeOptionalString, readStringValue } from "../../shared/string-coerce.js";
-import { stringEnum } from "../schema/typebox.js";
+import { optionalStringEnum, stringEnum } from "../schema/typebox.js";
 import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
 import { isOpenClawOwnerOnlyCoreToolName } from "./owner-only-tools.js";
@@ -289,9 +289,7 @@ const GatewayToolSchema = Type.Object({
   // restart
   delayMs: Type.Optional(Type.Number()),
   reason: Type.Optional(Type.String()),
-  continuationKind: Type.Optional(
-    Type.Union([Type.Literal("systemEvent"), Type.Literal("agentTurn")]),
-  ),
+  continuationKind: optionalStringEnum(["systemEvent", "agentTurn"] as const),
   continuationMessage: Type.Optional(Type.String()),
   // config.get, config.schema.lookup, config.apply, update.run
   gatewayUrl: Type.Optional(Type.String()),

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -289,6 +289,10 @@ const GatewayToolSchema = Type.Object({
   // restart
   delayMs: Type.Optional(Type.Number()),
   reason: Type.Optional(Type.String()),
+  continuationKind: Type.Optional(
+    Type.Union([Type.Literal("systemEvent"), Type.Literal("agentTurn")]),
+  ),
+  continuationMessage: Type.Optional(Type.String()),
   // config.get, config.schema.lookup, config.apply, update.run
   gatewayUrl: Type.Optional(Type.String()),
   gatewayToken: Type.Optional(Type.String()),
@@ -317,7 +321,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: isOpenClawOwnerOnlyCoreToolName("gateway"),
     description:
-      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
+      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. For restart follow-up work, pass `continuationMessage` and optionally `continuationKind`.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -335,6 +339,8 @@ export function createGatewayTool(opts?: {
             : undefined;
         const reason = normalizeOptionalString(params.reason)?.slice(0, 200);
         const note = normalizeOptionalString(params.note);
+        const continuationMessage = normalizeOptionalString(params.continuationMessage);
+        const continuationKind = normalizeOptionalString(params.continuationKind);
         // Extract channel + threadId for routing after restart.
         // Uses generic :thread: parsing plus plugin-owned session grammars.
         const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
@@ -346,6 +352,17 @@ export function createGatewayTool(opts?: {
           deliveryContext,
           threadId,
           message: note ?? reason ?? null,
+          continuation: continuationMessage
+            ? continuationKind === "systemEvent"
+              ? {
+                  kind: "systemEvent",
+                  text: continuationMessage,
+                }
+              : {
+                  kind: "agentTurn",
+                  message: continuationMessage,
+                }
+            : null,
           doctorHint: formatDoctorNonInteractiveHint(),
           stats: {
             mode: "gateway.restart",

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -319,7 +319,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: isOpenClawOwnerOnlyCoreToolName("gateway"),
     description:
-      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. For restart follow-up work, pass `continuationMessage` and optionally `continuationKind`.",
+      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. If restarting during a user task and you still owe the user a reply, pass a specific one-shot `continuationMessage` for what to verify or report after boot; do not write restart sentinel files directly. Use `continuationKind` only when it should be a system event instead of a normal agent turn.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
+
+type LoadedSessionEntry = ReturnType<typeof import("./session-utils.js").loadSessionEntry>;
+type RecordInboundSessionAndDispatchReplyParams = Parameters<
+  typeof import("../plugin-sdk/inbound-reply-dispatch.js").recordInboundSessionAndDispatchReply
+>[0];
 
 const mocks = vi.hoisted(() => ({
   resolveSessionAgentId: vi.fn(() => "agent-from-key"),
@@ -22,12 +28,19 @@ const mocks = vi.hoisted(() => ({
       threadId: undefined,
     }),
   ),
-  loadSessionEntry: vi.fn(() => ({
-    cfg: {},
-    entry: {},
-    storePath: "/tmp/sessions.json",
-    canonicalKey: "agent:main:main",
-  })),
+  loadSessionEntry: vi.fn(
+    (): LoadedSessionEntry => ({
+      cfg: {},
+      entry: {
+        sessionId: "agent:main:main",
+        updatedAt: 0,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      legacyKey: undefined,
+    }),
+  ),
   deliveryContextFromSession: vi.fn(
     ():
       | { channel?: string; to?: string; accountId?: string; threadId?: string | number }
@@ -37,7 +50,7 @@ const mocks = vi.hoisted(() => ({
     ...b,
     ...a,
   })),
-  getChannelPlugin: vi.fn(() => undefined),
+  getChannelPlugin: vi.fn((): ChannelPlugin | undefined => undefined),
   normalizeChannelId: vi.fn<(channel?: string | null) => string | null>(),
   resolveOutboundTarget: vi.fn(((_params?: { to?: string }) => ({
     ok: true as const,
@@ -51,7 +64,9 @@ const mocks = vi.hoisted(() => ({
   requestHeartbeatNow: vi.fn(),
   injectTimestamp: vi.fn((message: string) => `stamped:${message}`),
   timestampOptsFromConfig: vi.fn(() => ({})),
-  recordInboundSessionAndDispatchReply: vi.fn(async () => {}),
+  recordInboundSessionAndDispatchReply: vi.fn(
+    async (_params: RecordInboundSessionAndDispatchReplyParams) => {},
+  ),
   logWarn: vi.fn(),
 }));
 
@@ -168,9 +183,14 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.loadSessionEntry.mockReset();
     mocks.loadSessionEntry.mockReturnValue({
       cfg: {},
-      entry: {},
+      entry: {
+        sessionId: "agent:main:main",
+        updatedAt: 0,
+      },
+      store: {},
       storePath: "/tmp/sessions.json",
       canonicalKey: "agent:main:main",
+      legacyKey: undefined,
     });
     mocks.deliveryContextFromSession.mockReset();
     mocks.deliveryContextFromSession.mockReturnValue(undefined);
@@ -338,6 +358,12 @@ describe("scheduleRestartSentinelWake", () => {
         },
       },
     } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.recordInboundSessionAndDispatchReply.mockImplementationOnce(async (params) => {
+      await params.deliver({
+        text: "done",
+        replyToId: "restart-sentinel:agent:main:main:agentTurn:123",
+      });
+    });
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -369,9 +395,22 @@ describe("scheduleRestartSentinelWake", () => {
 
   it("preserves derived reply transport ids in continuation context", async () => {
     mocks.getChannelPlugin.mockReturnValue({
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "WhatsApp",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
       threading: {
-        resolveReplyTransport: ({ threadId }: { threadId?: string }) => ({
-          replyToId: threadId ? `reply:${threadId}` : undefined,
+        resolveReplyTransport: ({ threadId }: { threadId?: string | number | null }) => ({
+          replyToId: threadId != null ? `reply:${String(threadId)}` : undefined,
           threadId: null,
         }),
       },
@@ -392,6 +431,12 @@ describe("scheduleRestartSentinelWake", () => {
         },
       },
     } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.recordInboundSessionAndDispatchReply.mockImplementationOnce(async (params) => {
+      await params.deliver({
+        text: "done",
+        replyToId: "restart-sentinel:agent:main:main:agentTurn:123",
+      });
+    });
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -401,6 +446,48 @@ describe("scheduleRestartSentinelWake", () => {
           ReplyToId: "reply:thread-42",
           MessageThreadId: undefined,
         }),
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payloads: [
+          {
+            text: "done",
+            replyToId: "reply:thread-42",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("strips synthetic reply transport ids when no real reply target exists", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.recordInboundSessionAndDispatchReply.mockImplementationOnce(async (params) => {
+      await params.deliver({
+        text: "done",
+        replyToId: "restart-sentinel:agent:main:main:agentTurn:123",
+      });
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payloads: [{ text: "done" }],
       }),
     );
   });
@@ -444,6 +531,35 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.requestHeartbeatNow).toHaveBeenNthCalledWith(2, {
       reason: "wake",
+      sessionKey: "agent:main:main",
+    });
+  });
+
+  it("enqueues systemEvent continuation without stale partial delivery context", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "systemEvent",
+          text: "continue after restart",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.resolveOutboundTarget.mockReturnValueOnce({
+      ok: false,
+      error: new Error("missing route"),
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenNthCalledWith(2, "continue after restart", {
       sessionKey: "agent:main:main",
     });
   });
@@ -698,12 +814,27 @@ describe("scheduleRestartSentinelWake", () => {
       .mockReturnValueOnce({
         cfg: {},
         entry: {
+          sessionId: "agent:main:matrix:channel:!lowercased:example.org:thread:$thread-event",
+          updatedAt: 0,
           origin: { provider: "matrix", accountId: "acct-thread", threadId: "$thread-event" },
         },
+        store: {},
+        storePath: "/tmp/sessions.json",
+        canonicalKey: "agent:main:matrix:channel:!lowercased:example.org:thread:$thread-event",
+        legacyKey: undefined,
       })
       .mockReturnValueOnce({
         cfg: {},
-        entry: { lastChannel: "matrix", lastTo: "room:!MixedCase:example.org" },
+        entry: {
+          sessionId: "agent:main:matrix:channel:!lowercased:example.org",
+          updatedAt: 0,
+          lastChannel: "matrix",
+          lastTo: "room:!MixedCase:example.org",
+        },
+        store: {},
+        storePath: "/tmp/sessions.json",
+        canonicalKey: "agent:main:matrix:channel:!lowercased:example.org",
+        legacyKey: undefined,
       });
     mocks.deliveryContextFromSession
       .mockReturnValueOnce({

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -22,7 +22,12 @@ const mocks = vi.hoisted(() => ({
       threadId: undefined,
     }),
   ),
-  loadSessionEntry: vi.fn(() => ({ cfg: {}, entry: {} })),
+  loadSessionEntry: vi.fn(() => ({
+    cfg: {},
+    entry: {},
+    storePath: "/tmp/sessions.json",
+    canonicalKey: "agent:main:main",
+  })),
   deliveryContextFromSession: vi.fn(
     ():
       | { channel?: string; to?: string; accountId?: string; threadId?: string | number }
@@ -34,16 +39,19 @@ const mocks = vi.hoisted(() => ({
   })),
   getChannelPlugin: vi.fn(() => undefined),
   normalizeChannelId: vi.fn<(channel?: string | null) => string | null>(),
-  resolveOutboundTarget: vi.fn((_params?: { to?: string }) => ({
+  resolveOutboundTarget: vi.fn(((_params?: { to?: string }) => ({
     ok: true as const,
     to: "+15550002",
-  })),
+  })) as (params?: { to?: string }) => { ok: true; to: string } | { ok: false; error: Error }),
   deliverOutboundPayloads: vi.fn(async () => [{ channel: "whatsapp", messageId: "msg-1" }]),
   enqueueDelivery: vi.fn(async () => "queue-1"),
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
   enqueueSystemEvent: vi.fn(),
   requestHeartbeatNow: vi.fn(),
+  injectTimestamp: vi.fn((message: string) => `stamped:${message}`),
+  timestampOptsFromConfig: vi.fn(() => ({})),
+  recordInboundSessionAndDispatchReply: vi.fn(async () => {}),
   logWarn: vi.fn(),
 }));
 
@@ -110,6 +118,10 @@ vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: mocks.enqueueSystemEvent,
 }));
 
+vi.mock("../plugin-sdk/inbound-reply-dispatch.js", () => ({
+  recordInboundSessionAndDispatchReply: mocks.recordInboundSessionAndDispatchReply,
+}));
+
 vi.mock("../infra/heartbeat-wake.js", async () => {
   return await mergeMockedModule(
     await vi.importActual<typeof import("../infra/heartbeat-wake.js")>(
@@ -125,6 +137,11 @@ vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: vi.fn(() => ({
     warn: mocks.logWarn,
   })),
+}));
+
+vi.mock("./server-methods/agent-timestamp.js", () => ({
+  injectTimestamp: mocks.injectTimestamp,
+  timestampOptsFromConfig: mocks.timestampOptsFromConfig,
 }));
 
 const { scheduleRestartSentinelWake } = await import("./server-restart-sentinel.js");
@@ -149,7 +166,12 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.parseSessionThreadInfo.mockReset();
     mocks.parseSessionThreadInfo.mockReturnValue({ baseSessionKey: null, threadId: undefined });
     mocks.loadSessionEntry.mockReset();
-    mocks.loadSessionEntry.mockReturnValue({ cfg: {}, entry: {} });
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      entry: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+    });
     mocks.deliveryContextFromSession.mockReset();
     mocks.deliveryContextFromSession.mockReturnValue(undefined);
     mocks.normalizeChannelId.mockClear();
@@ -163,6 +185,10 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.failDelivery.mockClear();
     mocks.enqueueSystemEvent.mockClear();
     mocks.requestHeartbeatNow.mockClear();
+    mocks.injectTimestamp.mockClear();
+    mocks.timestampOptsFromConfig.mockClear();
+    mocks.recordInboundSessionAndDispatchReply.mockReset();
+    mocks.recordInboundSessionAndDispatchReply.mockResolvedValue(undefined);
     mocks.logWarn.mockClear();
   });
 
@@ -201,6 +227,7 @@ describe("scheduleRestartSentinelWake", () => {
       reason: "wake",
       sessionKey: "agent:main:main",
     });
+    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
     expect(mocks.logWarn).not.toHaveBeenCalled();
   });
 
@@ -292,6 +319,189 @@ describe("scheduleRestartSentinelWake", () => {
     );
   });
 
+  it("dispatches agentTurn continuation after the restart notice in the same routed thread", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "Reply with exactly: Yay! I did it!",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [{ text: "restart message" }],
+        threadId: "thread-42",
+      }),
+    );
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledTimes(1);
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "whatsapp",
+        accountId: "acct-2",
+        routeSessionKey: "agent:main:main",
+        ctxPayload: expect.objectContaining({
+          Body: "Reply with exactly: Yay! I did it!",
+          BodyForAgent: "stamped:Reply with exactly: Yay! I did it!",
+          SessionKey: "agent:main:main",
+          OriginatingChannel: "whatsapp",
+          OriginatingTo: "+15550002",
+          ExplicitDeliverRoute: true,
+          MessageThreadId: "thread-42",
+        }),
+      }),
+    );
+  });
+
+  it("requests another wake after enqueueing a systemEvent continuation", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "systemEvent",
+          text: "continue after restart",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenNthCalledWith(
+      2,
+      "continue after restart",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        deliveryContext: expect.objectContaining({
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+          threadId: "thread-42",
+        }),
+      }),
+    );
+    expect(mocks.requestHeartbeatNow).toHaveBeenNthCalledWith(1, {
+      reason: "wake",
+      sessionKey: "agent:main:main",
+    });
+    expect(mocks.requestHeartbeatNow).toHaveBeenNthCalledWith(2, {
+      reason: "wake",
+      sessionKey: "agent:main:main",
+    });
+  });
+
+  it("logs and continues when continuation delivery fails", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.recordInboundSessionAndDispatchReply.mockRejectedValueOnce(new Error("dispatch failed"));
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "restart message",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("continuation delivery failed"),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        continuationKind: "agentTurn",
+      }),
+    );
+  });
+
+  it("warns and skips agentTurn continuation when restart routing cannot resolve a destination", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.resolveOutboundTarget.mockReturnValueOnce({
+      ok: false,
+      error: new Error("missing route"),
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("restart continuation route unavailable"),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        continuationKind: "agentTurn",
+      }),
+    );
+  });
+
+  it("consumes continuation once and does not replay it on later startup cycles", async () => {
+    mocks.consumeRestartSentinel
+      .mockResolvedValueOnce({
+        payload: {
+          sessionKey: "agent:main:main",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "+15550002",
+            accountId: "acct-2",
+          },
+          ts: 123,
+          continuation: {
+            kind: "agentTurn",
+            message: "continue",
+          },
+        },
+      } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>)
+      .mockResolvedValueOnce(
+        null as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>,
+      );
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledTimes(1);
+  });
+
   it("does not wake the main session when the sentinel has no sessionKey", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
       payload: {
@@ -306,6 +516,32 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.requestHeartbeatNow).not.toHaveBeenCalled();
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("warns when continuation cannot run because the restart sentinel has no sessionKey", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        message: "restart message",
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
+      sessionKey: "agent:main:main",
+    });
+    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("continuation skipped"),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        continuationKind: "agentTurn",
+      }),
+    );
   });
 
   it("skips outbound restart notice when no canonical delivery context survives restart", async () => {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -543,7 +543,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     );
   });
-
   it("skips outbound restart notice when no canonical delivery context survives restart", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
       payload: {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -174,6 +174,8 @@ describe("scheduleRestartSentinelWake", () => {
     });
     mocks.deliveryContextFromSession.mockReset();
     mocks.deliveryContextFromSession.mockReturnValue(undefined);
+    mocks.getChannelPlugin.mockReset();
+    mocks.getChannelPlugin.mockReturnValue(undefined);
     mocks.normalizeChannelId.mockClear();
     mocks.resolveOutboundTarget.mockReset();
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true as const, to: "+15550002" });
@@ -355,10 +357,49 @@ describe("scheduleRestartSentinelWake", () => {
           Body: "Reply with exactly: Yay! I did it!",
           BodyForAgent: "stamped:Reply with exactly: Yay! I did it!",
           SessionKey: "agent:main:main",
+          Provider: "whatsapp",
+          Surface: "whatsapp",
           OriginatingChannel: "whatsapp",
           OriginatingTo: "+15550002",
-          ExplicitDeliverRoute: true,
           MessageThreadId: "thread-42",
+        }),
+      }),
+    );
+  });
+
+  it("preserves derived reply transport ids in continuation context", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      threading: {
+        resolveReplyTransport: ({ threadId }: { threadId?: string }) => ({
+          replyToId: threadId ? `reply:${threadId}` : undefined,
+          threadId: null,
+        }),
+      },
+    });
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        threadId: "thread-42",
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctxPayload: expect.objectContaining({
+          ReplyToId: "reply:thread-42",
+          MessageThreadId: undefined,
         }),
       }),
     );
@@ -433,6 +474,39 @@ describe("scheduleRestartSentinelWake", () => {
         sessionKey: "agent:main:main",
       }),
     );
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("continuation delivery failed"),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        continuationKind: "agentTurn",
+      }),
+    );
+  });
+
+  it("logs and continues when continuation dispatch reports a delivery error", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.recordInboundSessionAndDispatchReply.mockImplementationOnce(
+      async (params: { onDispatchError: (err: unknown, info: { kind: string }) => void }) => {
+        params.onDispatchError(new Error("route failed"), { kind: "final" });
+      },
+    );
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
     expect(mocks.logWarn).toHaveBeenCalledWith(
       expect.stringContaining("continuation delivery failed"),
       expect.objectContaining({

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -313,6 +313,45 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.failDelivery).toHaveBeenCalledWith("queue-1", "transport still not ready");
   });
 
+  it("still dispatches continuation after restart notice retries are exhausted", async () => {
+    vi.useFakeTimers();
+    mocks.deliverOutboundPayloads.mockRejectedValue(new Error("transport still not ready"));
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    const wakePromise = scheduleRestartSentinelWake({ deps: {} as never });
+    await Promise.resolve();
+    await Promise.resolve();
+    for (let attempt = 1; attempt < 45; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+    await wakePromise;
+
+    expect(mocks.failDelivery).toHaveBeenCalledWith("queue-1", "transport still not ready");
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledTimes(1);
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeSessionKey: "agent:main:main",
+        ctxPayload: expect.objectContaining({
+          Body: "continue",
+        }),
+      }),
+    );
+  });
+
   it("prefers top-level sentinel threadId for wake routing context", async () => {
     // Legacy or malformed sentinel JSON can still carry a nested threadId.
     mocks.consumeRestartSentinel.mockResolvedValue({
@@ -326,7 +365,7 @@ describe("scheduleRestartSentinelWake", () => {
         } as never,
         threadId: "fresh-thread",
       },
-    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -488,6 +527,79 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.deliverOutboundPayloads).toHaveBeenLastCalledWith(
       expect.objectContaining({
         payloads: [{ text: "done" }],
+      }),
+    );
+  });
+
+  it("preserves non-synthetic reply transport ids from continuation payloads", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.recordInboundSessionAndDispatchReply.mockImplementationOnce(async (params) => {
+      await params.deliver({
+        text: "done",
+        replyToId: "provider-reply-id",
+      });
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payloads: [
+          {
+            text: "done",
+            replyToId: "provider-reply-id",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("dispatches agentTurn continuation from session delivery context when sentinel routing is empty", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue",
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    mocks.deliveryContextFromSession.mockReturnValue({
+      channel: "telegram",
+      to: "telegram:200482621",
+      accountId: "default",
+    });
+    mocks.resolveOutboundTarget.mockReturnValue({
+      ok: true as const,
+      to: "telegram:200482621",
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        accountId: "default",
+        ctxPayload: expect.objectContaining({
+          Body: "continue",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "telegram:200482621",
+        }),
       }),
     );
   });

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -1,3 +1,7 @@
+import { resolveSessionAgentId } from "../agents/agent-scope.js";
+import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
+import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
+import { recordInboundSession } from "../channels/session.js";
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
@@ -11,14 +15,18 @@ import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import {
   consumeRestartSentinel,
   formatRestartSentinelMessage,
+  type RestartSentinelContinuation,
   summarizeRestartSentinel,
 } from "../infra/restart-sentinel.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { recordInboundSessionAndDispatchReply } from "../plugin-sdk/inbound-reply-dispatch.js";
 import {
   deliveryContextFromSession,
   mergeDeliveryContext,
 } from "../utils/delivery-context.shared.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
+import { injectTimestamp, timestampOptsFromConfig } from "./server-methods/agent-timestamp.js";
 import { loadSessionEntry } from "./session-utils.js";
 
 const log = createSubsystemLogger("gateway/restart-sentinel");
@@ -126,6 +134,130 @@ async function deliverRestartSentinelNotice(params: {
   }
 }
 
+function buildRestartContinuationMessageId(params: {
+  sessionKey: string;
+  kind: RestartSentinelContinuation["kind"];
+  ts: number;
+}) {
+  return `restart-sentinel:${params.sessionKey}:${params.kind}:${params.ts}`;
+}
+
+async function dispatchRestartSentinelContinuation(params: {
+  deps: CliDeps;
+  cfg: ReturnType<typeof loadSessionEntry>["cfg"];
+  storePath: string;
+  sessionKey: string;
+  continuation: RestartSentinelContinuation;
+  ts: number;
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  replyToId?: string;
+  threadId?: string;
+}) {
+  if (params.continuation.kind === "systemEvent") {
+    enqueueSystemEvent(params.continuation.text, {
+      sessionKey: params.sessionKey,
+      ...(params.channel || params.to || params.accountId || params.threadId
+        ? {
+            deliveryContext: {
+              ...(params.channel ? { channel: params.channel } : {}),
+              ...(params.to ? { to: params.to } : {}),
+              ...(params.accountId ? { accountId: params.accountId } : {}),
+              ...(params.threadId ? { threadId: params.threadId } : {}),
+            },
+          }
+        : {}),
+    });
+    requestHeartbeatNow({ reason: "wake", sessionKey: params.sessionKey });
+    return;
+  }
+
+  if (!params.channel || !params.to) {
+    throw new Error("restart continuation route unavailable");
+  }
+
+  const messageId = buildRestartContinuationMessageId({
+    sessionKey: params.sessionKey,
+    kind: params.continuation.kind,
+    ts: params.ts,
+  });
+  const continuationChannel = params.channel;
+  const continuationTo = params.to;
+  const userMessage = params.continuation.message.trim();
+  const agentId = resolveSessionAgentId({
+    sessionKey: params.sessionKey,
+    config: params.cfg,
+  });
+  let dispatchError: unknown;
+  await recordInboundSessionAndDispatchReply({
+    cfg: params.cfg,
+    channel: continuationChannel,
+    accountId: params.accountId,
+    agentId,
+    routeSessionKey: params.sessionKey,
+    storePath: params.storePath,
+    ctxPayload: finalizeInboundContext(
+      {
+        Body: userMessage,
+        BodyForAgent: injectTimestamp(userMessage, timestampOptsFromConfig(params.cfg)),
+        BodyForCommands: userMessage,
+        RawBody: userMessage,
+        CommandBody: userMessage,
+        SessionKey: params.sessionKey,
+        AccountId: params.accountId,
+        MessageSid: messageId,
+        Timestamp: Date.now(),
+        Provider: INTERNAL_MESSAGE_CHANNEL,
+        Surface: INTERNAL_MESSAGE_CHANNEL,
+        ChatType: "direct",
+        CommandAuthorized: true,
+        OriginatingChannel: continuationChannel,
+        OriginatingTo: continuationTo,
+        ExplicitDeliverRoute: true,
+        MessageThreadId: params.threadId,
+      },
+      {
+        forceBodyForCommands: true,
+        forceChatType: true,
+      },
+    ),
+    recordInboundSession,
+    dispatchReplyWithBufferedBlockDispatcher,
+    deliver: async (payload) => {
+      const results = await deliverOutboundPayloads({
+        cfg: params.cfg,
+        channel: continuationChannel,
+        to: continuationTo,
+        accountId: params.accountId,
+        replyToId: params.replyToId,
+        threadId: params.threadId,
+        payloads: [payload],
+        session: buildOutboundSessionContext({
+          cfg: params.cfg,
+          sessionKey: params.sessionKey,
+        }),
+        deps: params.deps,
+        bestEffort: false,
+      });
+      if (results.length === 0) {
+        throw new Error("restart continuation delivery returned no results");
+      }
+    },
+    onRecordError: (err) => {
+      log.warn(`restart continuation failed to record inbound session metadata: ${String(err)}`, {
+        sessionKey: params.sessionKey,
+      });
+    },
+    onDispatchError: (err) => {
+      dispatchError ??= err;
+    },
+  });
+  if (dispatchError) {
+    throw dispatchError;
+  }
+}
+
 export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const sentinel = await consumeRestartSentinel();
   if (!sentinel) {
@@ -145,12 +277,18 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   if (!sessionKey) {
     const mainSessionKey = resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(message, { sessionKey: mainSessionKey });
+    if (payload.continuation) {
+      log.warn(`${summary}: continuation skipped: restart sentinel sessionKey unavailable`, {
+        sessionKey: mainSessionKey,
+        continuationKind: payload.continuation.kind,
+      });
+    }
     return;
   }
 
   const { baseSessionKey, threadId: sessionThreadId } = parseSessionThreadInfo(sessionKey);
 
-  const { cfg, entry } = loadSessionEntry(sessionKey);
+  const { cfg, entry, canonicalKey, storePath } = loadSessionEntry(sessionKey);
 
   // Prefer delivery context from sentinel (captured at restart) over session store
   // Handles race condition where store wasn't flushed before restart
@@ -175,57 +313,82 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const channelRaw = origin?.channel;
   const channel = channelRaw ? normalizeChannelId(channelRaw) : null;
   const to = origin?.to;
-  if (!channel || !to) {
-    return;
-  }
-
-  const resolved = resolveOutboundTarget({
-    channel,
-    to,
-    cfg,
-    accountId: origin?.accountId,
-    mode: "implicit",
-  });
-  if (!resolved.ok) {
-    return;
-  }
-
   const threadId =
     payload.threadId ??
     sessionThreadId ??
     (origin?.threadId != null ? String(origin.threadId) : undefined);
+  let resolvedTo: string | undefined;
+  let replyToId: string | undefined;
+  let resolvedThreadId = threadId;
 
-  const replyTransport =
-    getChannelPlugin(channel)?.threading?.resolveReplyTransport?.({
+  if (channel && to) {
+    const resolved = resolveOutboundTarget({
+      channel,
+      to,
       cfg,
       accountId: origin?.accountId,
-      threadId,
-    }) ?? null;
-  const replyToId = replyTransport?.replyToId ?? undefined;
-  const resolvedThreadId =
-    replyTransport && Object.hasOwn(replyTransport, "threadId")
-      ? replyTransport.threadId != null
-        ? String(replyTransport.threadId)
-        : undefined
-      : threadId;
-  const outboundSession = buildOutboundSessionContext({
-    cfg,
-    sessionKey,
-  });
+      mode: "implicit",
+    });
+    if (resolved.ok) {
+      resolvedTo = resolved.to;
+      const replyTransport =
+        getChannelPlugin(channel)?.threading?.resolveReplyTransport?.({
+          cfg,
+          accountId: origin?.accountId,
+          threadId,
+        }) ?? null;
+      replyToId = replyTransport?.replyToId ?? undefined;
+      resolvedThreadId =
+        replyTransport && Object.hasOwn(replyTransport, "threadId")
+          ? replyTransport.threadId != null
+            ? String(replyTransport.threadId)
+            : undefined
+          : threadId;
+      const outboundSession = buildOutboundSessionContext({
+        cfg,
+        sessionKey: canonicalKey,
+      });
 
-  await deliverRestartSentinelNotice({
-    deps: params.deps,
-    cfg,
-    sessionKey,
-    summary,
-    message,
-    channel,
-    to: resolved.to,
-    accountId: origin?.accountId,
-    replyToId,
-    threadId: resolvedThreadId,
-    session: outboundSession,
-  });
+      await deliverRestartSentinelNotice({
+        deps: params.deps,
+        cfg,
+        sessionKey: canonicalKey,
+        summary,
+        message,
+        channel,
+        to: resolvedTo,
+        accountId: origin?.accountId,
+        replyToId,
+        threadId: resolvedThreadId,
+        session: outboundSession,
+      });
+    }
+  }
+
+  if (!payload.continuation) {
+    return;
+  }
+
+  try {
+    await dispatchRestartSentinelContinuation({
+      deps: params.deps,
+      cfg,
+      storePath,
+      sessionKey: canonicalKey,
+      continuation: payload.continuation,
+      ts: payload.ts,
+      channel: channel ?? undefined,
+      to: resolvedTo,
+      accountId: origin?.accountId,
+      replyToId,
+      threadId: resolvedThreadId,
+    });
+  } catch (err) {
+    log.warn(`${summary}: continuation delivery failed: ${String(err)}`, {
+      sessionKey: canonicalKey,
+      continuationKind: payload.continuation.kind,
+    });
+  }
 }
 
 export function shouldWakeFromRestartSentinel() {

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -1,8 +1,8 @@
 import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
-import { recordInboundSession } from "../channels/session.js";
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
+import { recordInboundSession } from "../channels/session.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/thread-info.js";
@@ -25,7 +25,6 @@ import {
   deliveryContextFromSession,
   mergeDeliveryContext,
 } from "../utils/delivery-context.shared.js";
-import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./server-methods/agent-timestamp.js";
 import { loadSessionEntry } from "./session-utils.js";
 
@@ -208,10 +207,11 @@ async function dispatchRestartSentinelContinuation(params: {
         AccountId: params.accountId,
         MessageSid: messageId,
         Timestamp: Date.now(),
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
+        Provider: continuationChannel,
+        Surface: continuationChannel,
         ChatType: "direct",
         CommandAuthorized: true,
+        ReplyToId: params.replyToId,
         OriginatingChannel: continuationChannel,
         OriginatingTo: continuationTo,
         ExplicitDeliverRoute: true,
@@ -225,6 +225,10 @@ async function dispatchRestartSentinelContinuation(params: {
     recordInboundSession,
     dispatchReplyWithBufferedBlockDispatcher,
     deliver: async (payload) => {
+      const outboundPayload =
+        payload.replyToId === messageId && params.replyToId
+          ? { ...payload, replyToId: params.replyToId }
+          : payload;
       const results = await deliverOutboundPayloads({
         cfg: params.cfg,
         channel: continuationChannel,
@@ -232,7 +236,7 @@ async function dispatchRestartSentinelContinuation(params: {
         accountId: params.accountId,
         replyToId: params.replyToId,
         threadId: params.threadId,
-        payloads: [payload],
+        payloads: [outboundPayload],
         session: buildOutboundSessionContext({
           cfg: params.cfg,
           sessionKey: params.sessionKey,

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -21,6 +21,7 @@ import {
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { recordInboundSessionAndDispatchReply } from "../plugin-sdk/inbound-reply-dispatch.js";
+import type { OutboundReplyPayload } from "../plugin-sdk/reply-payload.js";
 import {
   deliveryContextFromSession,
   mergeDeliveryContext,
@@ -141,6 +142,46 @@ function buildRestartContinuationMessageId(params: {
   return `restart-sentinel:${params.sessionKey}:${params.kind}:${params.ts}`;
 }
 
+type RestartContinuationRoute = {
+  channel: string;
+  to: string;
+  accountId?: string;
+  replyToId?: string;
+  threadId?: string;
+};
+
+function resolveRestartContinuationRoute(params: {
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  replyToId?: string;
+  threadId?: string;
+}): RestartContinuationRoute | undefined {
+  if (!params.channel || !params.to) {
+    return undefined;
+  }
+  return {
+    channel: params.channel,
+    to: params.to,
+    ...(params.accountId ? { accountId: params.accountId } : {}),
+    ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+    ...(params.threadId ? { threadId: params.threadId } : {}),
+  };
+}
+
+function resolveRestartContinuationOutboundPayload(params: {
+  payload: OutboundReplyPayload;
+  messageId: string;
+  replyToId?: string;
+}): OutboundReplyPayload {
+  if (params.payload.replyToId !== params.messageId) {
+    return params.payload;
+  }
+  const payload: OutboundReplyPayload = { ...params.payload };
+  delete payload.replyToId;
+  return params.replyToId ? { ...payload, replyToId: params.replyToId } : payload;
+}
+
 async function dispatchRestartSentinelContinuation(params: {
   deps: CliDeps;
   cfg: ReturnType<typeof loadSessionEntry>["cfg"];
@@ -148,22 +189,18 @@ async function dispatchRestartSentinelContinuation(params: {
   sessionKey: string;
   continuation: RestartSentinelContinuation;
   ts: number;
-  channel?: string;
-  to?: string;
-  accountId?: string;
-  replyToId?: string;
-  threadId?: string;
+  route?: RestartContinuationRoute;
 }) {
   if (params.continuation.kind === "systemEvent") {
     enqueueSystemEvent(params.continuation.text, {
       sessionKey: params.sessionKey,
-      ...(params.channel || params.to || params.accountId || params.threadId
+      ...(params.route
         ? {
             deliveryContext: {
-              ...(params.channel ? { channel: params.channel } : {}),
-              ...(params.to ? { to: params.to } : {}),
-              ...(params.accountId ? { accountId: params.accountId } : {}),
-              ...(params.threadId ? { threadId: params.threadId } : {}),
+              channel: params.route.channel,
+              to: params.route.to,
+              ...(params.route.accountId ? { accountId: params.route.accountId } : {}),
+              ...(params.route.threadId ? { threadId: params.route.threadId } : {}),
             },
           }
         : {}),
@@ -172,17 +209,16 @@ async function dispatchRestartSentinelContinuation(params: {
     return;
   }
 
-  if (!params.channel || !params.to) {
+  if (!params.route) {
     throw new Error("restart continuation route unavailable");
   }
 
+  const route = params.route;
   const messageId = buildRestartContinuationMessageId({
     sessionKey: params.sessionKey,
     kind: params.continuation.kind,
     ts: params.ts,
   });
-  const continuationChannel = params.channel;
-  const continuationTo = params.to;
   const userMessage = params.continuation.message.trim();
   const agentId = resolveSessionAgentId({
     sessionKey: params.sessionKey,
@@ -191,8 +227,8 @@ async function dispatchRestartSentinelContinuation(params: {
   let dispatchError: unknown;
   await recordInboundSessionAndDispatchReply({
     cfg: params.cfg,
-    channel: continuationChannel,
-    accountId: params.accountId,
+    channel: route.channel,
+    accountId: route.accountId,
     agentId,
     routeSessionKey: params.sessionKey,
     storePath: params.storePath,
@@ -204,18 +240,18 @@ async function dispatchRestartSentinelContinuation(params: {
         RawBody: userMessage,
         CommandBody: userMessage,
         SessionKey: params.sessionKey,
-        AccountId: params.accountId,
+        AccountId: route.accountId,
         MessageSid: messageId,
         Timestamp: Date.now(),
-        Provider: continuationChannel,
-        Surface: continuationChannel,
+        Provider: route.channel,
+        Surface: route.channel,
         ChatType: "direct",
         CommandAuthorized: true,
-        ReplyToId: params.replyToId,
-        OriginatingChannel: continuationChannel,
-        OriginatingTo: continuationTo,
+        ReplyToId: route.replyToId,
+        OriginatingChannel: route.channel,
+        OriginatingTo: route.to,
         ExplicitDeliverRoute: true,
-        MessageThreadId: params.threadId,
+        MessageThreadId: route.threadId,
       },
       {
         forceBodyForCommands: true,
@@ -225,17 +261,18 @@ async function dispatchRestartSentinelContinuation(params: {
     recordInboundSession,
     dispatchReplyWithBufferedBlockDispatcher,
     deliver: async (payload) => {
-      const outboundPayload =
-        payload.replyToId === messageId && params.replyToId
-          ? { ...payload, replyToId: params.replyToId }
-          : payload;
+      const outboundPayload = resolveRestartContinuationOutboundPayload({
+        payload,
+        messageId,
+        replyToId: route.replyToId,
+      });
       const results = await deliverOutboundPayloads({
         cfg: params.cfg,
-        channel: continuationChannel,
-        to: continuationTo,
-        accountId: params.accountId,
-        replyToId: params.replyToId,
-        threadId: params.threadId,
+        channel: route.channel,
+        to: route.to,
+        accountId: route.accountId,
+        replyToId: route.replyToId,
+        threadId: route.threadId,
         payloads: [outboundPayload],
         session: buildOutboundSessionContext({
           cfg: params.cfg,
@@ -381,11 +418,13 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
       sessionKey: canonicalKey,
       continuation: payload.continuation,
       ts: payload.ts,
-      channel: channel ?? undefined,
-      to: resolvedTo,
-      accountId: origin?.accountId,
-      replyToId,
-      threadId: resolvedThreadId,
+      route: resolveRestartContinuationRoute({
+        channel: channel ?? undefined,
+        to: resolvedTo,
+        accountId: origin?.accountId,
+        replyToId,
+        threadId: resolvedThreadId,
+      }),
     });
   } catch (err) {
     log.warn(`${summary}: continuation delivery failed: ${String(err)}`, {

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -34,6 +34,10 @@ describe("restart sentinel", () => {
         status: "ok" as const,
         ts: Date.now(),
         sessionKey: "agent:main:mobilechat:dm:+15555550123",
+        continuation: {
+          kind: "agentTurn" as const,
+          message: "Reply with exactly: Yay! I did it!",
+        },
         stats: { mode: "git" },
       };
       const filePath = await writeRestartSentinel(payload);
@@ -41,9 +45,11 @@ describe("restart sentinel", () => {
 
       const read = await readRestartSentinel();
       expect(read?.payload.kind).toBe("update");
+      expect(read?.payload.continuation).toEqual(payload.continuation);
 
       const consumed = await consumeRestartSentinel();
       expect(consumed?.payload.sessionKey).toBe(payload.sessionKey);
+      expect(consumed?.payload.continuation).toEqual(payload.continuation);
 
       const empty = await readRestartSentinel();
       expect(empty).toBeNull();

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -27,6 +27,16 @@ export type RestartSentinelStats = {
   durationMs?: number | null;
 };
 
+export type RestartSentinelContinuation =
+  | {
+      kind: "systemEvent";
+      text: string;
+    }
+  | {
+      kind: "agentTurn";
+      message: string;
+    };
+
 export type RestartSentinelPayload = {
   kind: "config-apply" | "config-patch" | "update" | "restart";
   status: "ok" | "error" | "skipped";
@@ -41,6 +51,7 @@ export type RestartSentinelPayload = {
   /** Thread ID for reply threading (e.g., Slack thread_ts). */
   threadId?: string;
   message?: string | null;
+  continuation?: RestartSentinelContinuation | null;
   doctorHint?: string | null;
   stats?: RestartSentinelStats | null;
 };


### PR DESCRIPTION
## Summary

- Problem: restart-sentinel wake preserved the restart notice, but requested post-restart continuation work could be dropped, delayed, or lose context after reboot.
- Why it matters: `gateway.restart` is used specifically to resume work after reboot, so silent continuation loss breaks the main use case and is hard to diagnose.
- What changed: the sentinel now carries an optional one-shot continuation, `gateway.restart` can request it, restart wake dispatches it back into the same session/thread, and the edge cases raised in review now warn or re-wake instead of silently failing.
- What did NOT change (scope boundary): this does not add a durable continuation queue, change restart authorization, or broaden routing beyond the existing session-scoped restart sentinel flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50137
- Related #53940, #60864
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the original restart-sentinel path only needed to enqueue and wake a restart notice; once continuation support was added, the later continuation enqueue/dispatch path inherited assumptions that were only safe for the original single-event wake flow.
- Missing detection / guardrail: there was no regression coverage for post-restart continuation delivery semantics, especially around schema shape, missing routing/session state, timestamp preservation, and `systemEvent` wake timing.
- Contributing context (if known): `gateway.restart` allows continuation requests without an explicit `sessionKey`, and `systemEvent` continuation enqueue happens later than the original restart wake.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-restart-sentinel.test.ts`, `src/agents/tools/gateway-tool.test.ts`, `src/infra/restart-sentinel.test.ts`
- Scenario the test should lock in: restart continuation survives reboot in the same routed context, warns instead of silently disappearing when session/route state is missing, keeps stamped agent context, and re-wakes `systemEvent` continuations.
- Why this is the smallest reliable guardrail: the failures happen in the orchestration seam between persisted sentinel payloads, restart wake scheduling, session routing, and tool schema generation, so helper-only tests would miss them.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `gateway.restart` can resume a one-shot continuation after reboot in the same session/thread instead of only sending a restart notice.
- `agentTurn` continuations now preserve the stamped agent-facing text used for time-sensitive follow-up work.
- `systemEvent` continuations now trigger their own wake instead of depending on the earlier restart-notice wake timing.
- If restart continuation cannot run because route or session state is missing, the failure is now surfaced as a warning instead of being silently dropped.

## Diagram (if applicable)

```text
Before:
[gateway.restart + continuation] -> [restart notice wake] -> [continuation may be dropped/delayed]

After:
[gateway.restart + continuation] -> [restart notice wake] -> [continuation dispatched or warning logged] -> [result visible]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: the owner-only `gateway.restart` tool now accepts optional continuation inputs and can resume one follow-up turn after reboot. Risk is constrained by the existing restart auth boundary, one-shot sentinel consumption, same-session routing, and explicit warning/fail-fast handling when continuation delivery is unavailable.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): mocked channel routing in targeted tests
- Relevant config (redacted): default local test config

### Steps

1. Invoke `gateway.restart` with `continuationMessage` in a routed session.
2. Let restart sentinel wake run after startup.
3. Exercise `agentTurn`, `systemEvent`, missing-route, and missing-`sessionKey` continuation cases.

### Expected

- Continuation resumes in the same routed context after reboot, or logs a visible warning when it cannot be delivered.
- `systemEvent` continuation requests a wake after enqueue.
- `agentTurn` continuation keeps stamped `BodyForAgent` context.

### Actual

- Before this fix set, continuation edge cases could be silently dropped, delayed, or lose the stamped agent context.
- After this fix set, the tested restart continuation paths behave deterministically and fail visibly when delivery is unavailable.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran targeted restart-sentinel/tool tests covering agent-turn continuation dispatch, `systemEvent` continuation wake, missing-route warning, missing-`sessionKey` warning, one-shot consumption, and flat enum tool schema generation.
- Edge cases checked: timestamp preservation in `BodyForAgent`, no-route fail-fast path, no-`sessionKey` warning path, and delayed `systemEvent` wake after restart notice delivery.
- What you did **not** verify: live restart behavior against a real channel/integration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: continuation behavior now depends on the persisted restart sentinel shape and the new gateway tool inputs staying aligned.
  - Mitigation: targeted tests cover sentinel payload, tool schema shape, restart wake dispatch, and the reviewed edge cases.
- Risk: `systemEvent` continuation now schedules an extra heartbeat wake for the same session.
  - Mitigation: the wake is narrowly scoped to the continuation session and covered by regression test coverage in `src/gateway/server-restart-sentinel.test.ts`.
