### PR TITLE
fix(byteplus): normalize resolution to lowercase before Seedance API call

### DIFF
--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -208,8 +208,11 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
       if (aspectRatio) {
         body.ratio = aspectRatio;
       }
-      if (req.resolution) {
-        body.resolution = req.resolution;
+      // Seedance API requires lowercase resolution values (e.g. "480p", "720p"); uppercase
+      // variants like "480P" are rejected with InvalidParameter.
+      const resolution = normalizeOptionalString(req.resolution)?.toLowerCase();
+      if (resolution) {
+        body.resolution = resolution;
       }
       if (typeof req.durationSeconds === "number" && Number.isFinite(req.durationSeconds)) {
         body.duration = Math.max(1, Math.round(req.durationSeconds));


### PR DESCRIPTION
## Summary

The Seedance API rejects resolution values with uppercase letters — `"480P"`, `"720P"` etc return `InvalidParameter`, while `"480p"`, `"720p"` are accepted correctly. This caused the BytePlus video generation live test to fail with:

```
BytePlus video generation failed (HTTP 400): {"error":{"code":"InvalidParameter","message":"the parameter resolution specified in the request is not valid for model seedance-1-0-lite-t2v in t2v..."}}
```

`resolveLiveVideoResolution` (in `src/video-generation/live-test-helpers.ts`) returns `"480P"` (uppercase), which flows into `req.resolution` and was being set directly as `body.resolution = req.resolution` — triggering the 400.

## Fix

Normalize `req.resolution` to lowercase at the provider layer before setting `body.resolution`:

```typescript
// Before
if (req.resolution) {
  body.resolution = req.resolution;  // "480P" → HTTP 400
}

// After
const resolution = normalizeOptionalString(req.resolution)?.toLowerCase();
if (resolution) {
  body.resolution = resolution;  // "480p" → accepted
}
```

This keeps `VideoGenerationResolution` type and all callers unchanged.

## Verification

Direct API calls against `ark.ap-southeast.bytepluses.com`:

| Value | As JSON body field | Result |
|-------|-------------------|--------|
| `"480P"` | `body.resolution = "480P"` | HTTP 400 InvalidParameter |
| `"720P"` | `body.resolution = "720P"` | HTTP 400 InvalidParameter (all models) |
| `"480p"` | `body.resolution = "480p"` | Task created successfully |
| `"720p"` | `body.resolution = "720p"` | Task created (t2v, i2v, 1.5-pro) |
| `"1080p"` | `body.resolution = "1080p"` | Task created successfully |

No inline text embedding needed — JSON body field works correctly with lowercase values.
