### PR TITLE
fix(heartbeat): widen empty-detection to skip API calls for comment-only HEARTBEAT.md (#61690)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.
 - Dreaming/narrative: harden request-scoped diary fallback so scheduled dreaming only falls back on the dedicated subagent-runtime error, stop trusting spoofable raw error-code objects, and avoid leaking workspace paths when local fallback writes fail. (#64156) Thanks @mbelinky.
+- Heartbeat: ignore doc-only Markdown fence markers in the default `HEARTBEAT.md` template so comment-only heartbeat scaffolds skip API calls again. (#63434) Thanks @ravyg.
 
 ## 2026.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Bedrock: let `/btw` side questions use `auth: "aws-sdk"` without a static API key so Bedrock IAM and instance-role sessions stop failing before the side question runs. (#64218) Thanks @SnowSky1.
 - Agents/failover: detect llama.cpp slot context overflows as context-overflow errors so compaction can retry self-hosted OpenAI-compatible runs instead of surfacing the raw upstream 400. (#64196) Thanks @alexander-applyinnovations.
 - Claude CLI/skills: pass eligible OpenClaw skills into CLI runs, including native Claude Code skill resolution via a temporary plugin plus per-run skill env/API key injection. (#62686, #62723) Thanks @zomars.
+- Heartbeat: ignore doc-only Markdown fence markers in the default `HEARTBEAT.md` template so comment-only heartbeat scaffolds skip API calls again. (#63434) Thanks @ravyg.
 
 ## 2026.4.9
 
@@ -144,7 +145,6 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.
 - Dreaming/narrative: harden request-scoped diary fallback so scheduled dreaming only falls back on the dedicated subagent-runtime error, stop trusting spoofable raw error-code objects, and avoid leaking workspace paths when local fallback writes fail. (#64156) Thanks @mbelinky.
-- Heartbeat: ignore doc-only Markdown fence markers in the default `HEARTBEAT.md` template so comment-only heartbeat scaffolds skip API calls again. (#63434) Thanks @ravyg.
 
 ## 2026.4.8
 

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -6,6 +6,7 @@ import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace
 import {
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
+  DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
   DEFAULT_MEMORY_FILENAME,
@@ -171,6 +172,21 @@ describe("ensureAgentWorkspace", () => {
       "utf-8",
     );
     expect(persisted).toContain('"setupCompletedAt": "2026-03-15T02:30:00.000Z"');
+  });
+
+  it("writes the current fenced HEARTBEAT template body into new workspaces", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    const heartbeat = await fs.readFile(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME), "utf-8");
+    expect(heartbeat).toContain("```markdown");
+    expect(heartbeat).toContain(
+      "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
+    );
+    expect(heartbeat).toContain(
+      "# Add tasks below when you want the agent to check something periodically.",
+    );
   });
 });
 

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -201,96 +201,36 @@ describe("isHeartbeatContentEffectivelyEmpty", () => {
     const defaultTemplate = `# HEARTBEAT.md
 
 Keep this file empty unless you want a tiny checklist. Keep it small.
-`;
+    `;
     expect(isHeartbeatContentEffectivelyEmpty(defaultTemplate)).toBe(false);
   });
 
-  it("returns true when an HTML comment is the only content (#61690)", () => {
-    expect(isHeartbeatContentEffectivelyEmpty("<!-- nothing to do -->")).toBe(true);
-    expect(
-      isHeartbeatContentEffectivelyEmpty(`# HEARTBEAT.md
-<!-- Add tasks below when you want periodic checks. -->
-`),
-    ).toBe(true);
-  });
+  it("returns true for the current fenced heartbeat template body (#61690)", () => {
+    const content = `# HEARTBEAT.md Template
 
-  it("returns true for a multi-line HTML comment block (#61690)", () => {
-    const content = `# HEARTBEAT.md
-<!--
-This file is intentionally empty.
-Add tasks below when you want the agent to check periodically.
--->
+\`\`\`markdown
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+\`\`\`
 `;
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
   });
 
-  it("returns false when an HTML comment is followed by real content", () => {
-    const content = `<!-- old note -->
-- Check email`;
+  it("returns false when fenced heartbeat content includes a real task", () => {
+    const content = `\`\`\`markdown
+# Keep this file empty when you want to skip.
+
+- Check email
+\`\`\`
+`;
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
   });
 
-  it("returns true for an empty `tasks:` block (#61690)", () => {
-    // A bare `tasks:` declaration with nothing under it is the YAML
-    // equivalent of "no tasks". The runner additionally checks that
-    // parseHeartbeatTasks returned no entries before skipping, so this is
-    // safe even when other lines exist.
-    expect(isHeartbeatContentEffectivelyEmpty("tasks:")).toBe(true);
-    expect(
-      isHeartbeatContentEffectivelyEmpty(`# HEARTBEAT.md
-
-tasks:
-`),
-    ).toBe(true);
-  });
-
-  it("returns false when `tasks:` is followed by actionable text on the same line", () => {
-    // A `tasks:` line with content on the same line is suspicious; only
-    // the bare declaration form is treated as comment-equivalent.
-    expect(isHeartbeatContentEffectivelyEmpty("tasks: do everything")).toBe(false);
-  });
-
-  it("returns true when leading YAML frontmatter is the only content (#61690)", () => {
-    const content = `---
-title: HEARTBEAT
-heartbeat: true
----
-
-# HEARTBEAT.md
-`;
-    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
-  });
-
-  it("returns true when an HTML comment precedes YAML frontmatter (#61690)", () => {
-    // After stripping the HTML comment we are left with a leading newline
-    // before the `---` fence. The frontmatter regex must tolerate that
-    // leading whitespace, otherwise the comment-then-frontmatter layout
-    // (a common template shape) is misclassified as non-empty and the
-    // preflight gate keeps making LLM calls.
-    const content = `<!-- note -->
----
-title: HEARTBEAT
----
-
-# HEARTBEAT.md
-`;
-    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
-  });
-
-  it("returns true when blank lines precede YAML frontmatter", () => {
-    const content = `
-
----
-title: HEARTBEAT
----
-`;
-    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
-  });
-
-  it("returns false for leading --- fenced prose that is not YAML frontmatter", () => {
-    const content = `---
-Check logs
----
+  it("returns false when a code fence wraps plain instructional prose", () => {
+    const content = `\`\`\`markdown
+Keep this file empty unless you want a tiny checklist.
+\`\`\`
 `;
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
   });

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -193,13 +193,72 @@ describe("isHeartbeatContentEffectivelyEmpty", () => {
     expect(isHeartbeatContentEffectivelyEmpty("## Subheader\n### Another")).toBe(true);
   });
 
-  it("returns true for default template content (header + comment)", () => {
+  it("returns false when a template includes plain instructional prose", () => {
+    // Regression: this test used to be named "returns true for default template
+    // content" while asserting `false`, which obscured the real behavior. The
+    // heuristic does NOT skip plain-text instructional sentences because they
+    // are indistinguishable from actionable content.
     const defaultTemplate = `# HEARTBEAT.md
 
 Keep this file empty unless you want a tiny checklist. Keep it small.
 `;
-    // Note: The template has actual text content, so it's NOT effectively empty
     expect(isHeartbeatContentEffectivelyEmpty(defaultTemplate)).toBe(false);
+  });
+
+  it("returns true when an HTML comment is the only content (#61690)", () => {
+    expect(isHeartbeatContentEffectivelyEmpty("<!-- nothing to do -->")).toBe(true);
+    expect(
+      isHeartbeatContentEffectivelyEmpty(`# HEARTBEAT.md
+<!-- Add tasks below when you want periodic checks. -->
+`),
+    ).toBe(true);
+  });
+
+  it("returns true for a multi-line HTML comment block (#61690)", () => {
+    const content = `# HEARTBEAT.md
+<!--
+This file is intentionally empty.
+Add tasks below when you want the agent to check periodically.
+-->
+`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+
+  it("returns false when an HTML comment is followed by real content", () => {
+    const content = `<!-- old note -->
+- Check email`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
+  });
+
+  it("returns true for an empty `tasks:` block (#61690)", () => {
+    // A bare `tasks:` declaration with nothing under it is the YAML
+    // equivalent of "no tasks". The runner additionally checks that
+    // parseHeartbeatTasks returned no entries before skipping, so this is
+    // safe even when other lines exist.
+    expect(isHeartbeatContentEffectivelyEmpty("tasks:")).toBe(true);
+    expect(
+      isHeartbeatContentEffectivelyEmpty(`# HEARTBEAT.md
+
+tasks:
+`),
+    ).toBe(true);
+  });
+
+  it("returns false when `tasks:` is followed by actionable text on the same line", () => {
+    // A `tasks:` line with content on the same line is suspicious; only
+    // the bare declaration form is treated as comment-equivalent.
+    expect(isHeartbeatContentEffectivelyEmpty("tasks: do everything")).toBe(false);
+  });
+
+  it("returns true when leading YAML frontmatter is the only content (#61690)", () => {
+    const content = `---
+title: HEARTBEAT
+heartbeat: true
+---
+
+# HEARTBEAT.md
+`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
   });
 
   it("returns true for header with only empty lines", () => {

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -287,6 +287,14 @@ title: HEARTBEAT
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
   });
 
+  it("returns false for leading --- fenced prose that is not YAML frontmatter", () => {
+    const content = `---
+Check logs
+---
+`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
+  });
+
   it("returns true for header with only empty lines", () => {
     expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n\n\n")).toBe(true);
   });

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -261,6 +261,32 @@ heartbeat: true
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
   });
 
+  it("returns true when an HTML comment precedes YAML frontmatter (#61690)", () => {
+    // After stripping the HTML comment we are left with a leading newline
+    // before the `---` fence. The frontmatter regex must tolerate that
+    // leading whitespace, otherwise the comment-then-frontmatter layout
+    // (a common template shape) is misclassified as non-empty and the
+    // preflight gate keeps making LLM calls.
+    const content = `<!-- note -->
+---
+title: HEARTBEAT
+---
+
+# HEARTBEAT.md
+`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+
+  it("returns true when blank lines precede YAML frontmatter", () => {
+    const content = `
+
+---
+title: HEARTBEAT
+---
+`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+
   it("returns true for header with only empty lines", () => {
     expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n\n\n")).toBe(true);
   });

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -20,14 +20,11 @@ export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
  * Check if HEARTBEAT.md content is "effectively empty" - meaning it has no actionable tasks.
  * This allows skipping heartbeat API calls when no tasks are configured.
  *
- * A file is considered effectively empty if, after dropping HTML comment blocks
- * and any leading YAML frontmatter, every remaining line is one of:
- * - Whitespace / empty
- * - A markdown ATX header (`#`, `##`, ...) — including a leading `# ...` title
- * - An empty list item stub (`- `, `- [ ]`, `* `, `+ `)
- * - A bare `tasks:` declaration line (combined with the runner's
- *   `parseHeartbeatTasks(content).length === 0` gate, this still requires
- *   that no tasks were actually parsed before skipping)
+ * A file is considered effectively empty if it contains only:
+ * - Whitespace / empty lines
+ * - Markdown ATX headers (`#`, `##`, ...)
+ * - Markdown fence markers such as ``` or ```markdown
+ * - Empty list item stubs (`- `, `- [ ]`, `* `, `+ `)
  *
  * Note: A missing file returns false (not effectively empty) so the LLM can still
  * decide what to do. This function is only for when the file exists but has no content.
@@ -40,19 +37,7 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
     return false;
   }
 
-  // Strip HTML comment blocks (including multi-line) so files that document
-  // themselves with `<!-- ... -->` instead of markdown headers still count
-  // as empty. Without this, a workspace template like
-  //   <!-- Add tasks below when you want periodic checks. -->
-  // would defeat the skip path and trigger a full heartbeat API call.
-  let stripped = content.replace(/<!--[\s\S]*?-->/g, "");
-
-  // Strip a leading YAML frontmatter block. Keep this narrow: a top-of-file
-  // `--- ... ---` block can also be ordinary markdown content, and treating
-  // that as frontmatter would incorrectly skip real heartbeat instructions.
-  stripped = stripLeadingYamlFrontmatter(stripped);
-
-  const lines = stripped.split("\n");
+  const lines = content.split("\n");
   for (const line of lines) {
     const trimmed = line.trim();
     // Skip empty lines
@@ -69,11 +54,9 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
     if (/^[-*+]\s*(\[[\sXx]?\]\s*)?$/.test(trimmed)) {
       continue;
     }
-    // Skip a bare `tasks:` line. The runner additionally requires
-    // `parseHeartbeatTasks(content).length === 0` before skipping, so a
-    // declared-but-empty tasks block still routes to the skip path while
-    // any line that actually parses as a task keeps the LLM call.
-    if (/^tasks:\s*$/i.test(trimmed)) {
+    // Ignore markdown fence markers that were added for doc rendering but do
+    // not carry task semantics in the workspace template body.
+    if (/^```[A-Za-z0-9_-]*$/.test(trimmed)) {
       continue;
     }
     // Found a non-empty, non-comment line - there's actionable content
@@ -81,49 +64,6 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
   }
   // All lines were either empty or comments
   return true;
-}
-
-function stripLeadingYamlFrontmatter(content: string): string {
-  const lines = content.split(/\r?\n/);
-  let start = 0;
-  while (start < lines.length && !lines[start]?.trim()) {
-    start += 1;
-  }
-
-  if (lines[start]?.trim() !== "---") {
-    return content;
-  }
-
-  let end = start + 1;
-  while (end < lines.length && lines[end]?.trim() !== "---") {
-    end += 1;
-  }
-  if (end >= lines.length) {
-    return content;
-  }
-
-  const bodyLines = lines.slice(start + 1, end);
-  let sawYamlField = false;
-  for (const line of bodyLines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-    if (/^[A-Za-z0-9_-]+:\s*(?:.*)?$/.test(trimmed)) {
-      sawYamlField = true;
-      continue;
-    }
-    if (sawYamlField && (/^\s+.+$/.test(line) || /^-\s+.+$/.test(trimmed))) {
-      continue;
-    }
-    return content;
-  }
-
-  if (!sawYamlField && bodyLines.some((line) => line.trim())) {
-    return content;
-  }
-
-  return [...lines.slice(0, start), ...lines.slice(end + 1)].join("\n");
 }
 
 export function resolveHeartbeatPrompt(raw?: string): string {

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -47,12 +47,10 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
   // would defeat the skip path and trigger a full heartbeat API call.
   let stripped = content.replace(/<!--[\s\S]*?-->/g, "");
 
-  // Strip a leading YAML frontmatter block. Some templates wrap heartbeat
-  // metadata in `--- ... ---` even when there are no actionable tasks below.
-  // Allow leading whitespace so frontmatter is still detected when an HTML
-  // comment was stripped above (which can leave a leading blank line) or when
-  // the file starts with blank lines before the `---` fence.
-  stripped = stripped.replace(/^\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+  // Strip a leading YAML frontmatter block. Keep this narrow: a top-of-file
+  // `--- ... ---` block can also be ordinary markdown content, and treating
+  // that as frontmatter would incorrectly skip real heartbeat instructions.
+  stripped = stripLeadingYamlFrontmatter(stripped);
 
   const lines = stripped.split("\n");
   for (const line of lines) {
@@ -83,6 +81,49 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
   }
   // All lines were either empty or comments
   return true;
+}
+
+function stripLeadingYamlFrontmatter(content: string): string {
+  const lines = content.split(/\r?\n/);
+  let start = 0;
+  while (start < lines.length && !lines[start]?.trim()) {
+    start += 1;
+  }
+
+  if (lines[start]?.trim() !== "---") {
+    return content;
+  }
+
+  let end = start + 1;
+  while (end < lines.length && lines[end]?.trim() !== "---") {
+    end += 1;
+  }
+  if (end >= lines.length) {
+    return content;
+  }
+
+  const bodyLines = lines.slice(start + 1, end);
+  let sawYamlField = false;
+  for (const line of bodyLines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    if (/^[A-Za-z0-9_-]+:\s*(?:.*)?$/.test(trimmed)) {
+      sawYamlField = true;
+      continue;
+    }
+    if (sawYamlField && (/^\s+.+$/.test(line) || /^-\s+.+$/.test(trimmed))) {
+      continue;
+    }
+    return content;
+  }
+
+  if (!sawYamlField && bodyLines.some((line) => line.trim())) {
+    return content;
+  }
+
+  return [...lines.slice(0, start), ...lines.slice(end + 1)].join("\n");
 }
 
 export function resolveHeartbeatPrompt(raw?: string): string {

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -20,10 +20,14 @@ export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
  * Check if HEARTBEAT.md content is "effectively empty" - meaning it has no actionable tasks.
  * This allows skipping heartbeat API calls when no tasks are configured.
  *
- * A file is considered effectively empty if it contains only:
- * - Whitespace
- * - Comment lines (lines starting with #)
- * - Empty lines
+ * A file is considered effectively empty if, after dropping HTML comment blocks
+ * and any leading YAML frontmatter, every remaining line is one of:
+ * - Whitespace / empty
+ * - A markdown ATX header (`#`, `##`, ...) — including a leading `# ...` title
+ * - An empty list item stub (`- `, `- [ ]`, `* `, `+ `)
+ * - A bare `tasks:` declaration line (combined with the runner's
+ *   `parseHeartbeatTasks(content).length === 0` gate, this still requires
+ *   that no tasks were actually parsed before skipping)
  *
  * Note: A missing file returns false (not effectively empty) so the LLM can still
  * decide what to do. This function is only for when the file exists but has no content.
@@ -36,7 +40,18 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
     return false;
   }
 
-  const lines = content.split("\n");
+  // Strip HTML comment blocks (including multi-line) so files that document
+  // themselves with `<!-- ... -->` instead of markdown headers still count
+  // as empty. Without this, a workspace template like
+  //   <!-- Add tasks below when you want periodic checks. -->
+  // would defeat the skip path and trigger a full heartbeat API call.
+  let stripped = content.replace(/<!--[\s\S]*?-->/g, "");
+
+  // Strip a leading YAML frontmatter block. Some templates wrap heartbeat
+  // metadata in `--- ... ---` even when there are no actionable tasks below.
+  stripped = stripped.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+
+  const lines = stripped.split("\n");
   for (const line of lines) {
     const trimmed = line.trim();
     // Skip empty lines
@@ -51,6 +66,13 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
     }
     // Skip empty markdown list items like "- [ ]" or "* [ ]" or just "- "
     if (/^[-*+]\s*(\[[\sXx]?\]\s*)?$/.test(trimmed)) {
+      continue;
+    }
+    // Skip a bare `tasks:` line. The runner additionally requires
+    // `parseHeartbeatTasks(content).length === 0` before skipping, so a
+    // declared-but-empty tasks block still routes to the skip path while
+    // any line that actually parses as a task keeps the LLM call.
+    if (/^tasks:\s*$/i.test(trimmed)) {
       continue;
     }
     // Found a non-empty, non-comment line - there's actionable content

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -49,7 +49,10 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
 
   // Strip a leading YAML frontmatter block. Some templates wrap heartbeat
   // metadata in `--- ... ---` even when there are no actionable tasks below.
-  stripped = stripped.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+  // Allow leading whitespace so frontmatter is still detected when an HTML
+  // comment was stripped above (which can leave a leading blank line) or when
+  // the file starts with blank lines before the `---` fence.
+  stripped = stripped.replace(/^\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
 
   const lines = stripped.split("\n");
   for (const line of lines) {

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1198,6 +1198,7 @@ describe("runHeartbeatOnce", () => {
   type HeartbeatFileState =
     | "empty"
     | "actionable"
+    | "legacy-comment-only"
     | "fenced-empty"
     | "fenced-actionable"
     | "missing"
@@ -1218,6 +1219,17 @@ describe("runHeartbeatOnce", () => {
       await fs.writeFile(
         path.join(workspaceDir, "HEARTBEAT.md"),
         "# HEARTBEAT.md\n\n## Tasks\n\n",
+        "utf-8",
+      );
+    } else if (params.fileState === "legacy-comment-only") {
+      // Compatibility case for the pre-198de10523 template shape, before the
+      // docs template started wrapping the scaffold in a fenced ```markdown block.
+      await fs.writeFile(
+        path.join(workspaceDir, "HEARTBEAT.md"),
+        `# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+`,
         "utf-8",
       );
     } else if (params.fileState === "fenced-empty") {
@@ -1334,6 +1346,14 @@ describe("runHeartbeatOnce", () => {
       {
         name: "empty file + interval skips",
         fileState: "empty",
+        expectedStatus: "skipped",
+        expectedSkipReason: "empty-heartbeat-file",
+        expectedSendCalls: 0,
+        expectedReplyCalls: 0,
+      },
+      {
+        name: "legacy comment-only template + interval skips",
+        fileState: "legacy-comment-only",
         expectedStatus: "skipped",
         expectedSkipReason: "empty-heartbeat-file",
         expectedSendCalls: 0,

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1195,7 +1195,13 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
-  type HeartbeatFileState = "empty" | "actionable" | "missing" | "read-error";
+  type HeartbeatFileState =
+    | "empty"
+    | "actionable"
+    | "fenced-empty"
+    | "fenced-actionable"
+    | "missing"
+    | "read-error";
 
   async function runHeartbeatFileScenario(params: {
     fileState: HeartbeatFileState;
@@ -1214,10 +1220,34 @@ describe("runHeartbeatOnce", () => {
         "# HEARTBEAT.md\n\n## Tasks\n\n",
         "utf-8",
       );
+    } else if (params.fileState === "fenced-empty") {
+      await fs.writeFile(
+        path.join(workspaceDir, "HEARTBEAT.md"),
+        `# HEARTBEAT.md Template
+
+\`\`\`markdown
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+\`\`\`
+`,
+        "utf-8",
+      );
     } else if (params.fileState === "actionable") {
       await fs.writeFile(
         path.join(workspaceDir, "HEARTBEAT.md"),
         "# HEARTBEAT.md\n\n- Check server logs\n- Review pending PRs\n",
+        "utf-8",
+      );
+    } else if (params.fileState === "fenced-actionable") {
+      await fs.writeFile(
+        path.join(workspaceDir, "HEARTBEAT.md"),
+        `\`\`\`markdown
+# Keep this file empty when you want to skip.
+
+- Check server logs
+\`\`\`
+`,
         "utf-8",
       );
     } else if (params.fileState === "read-error") {
@@ -1310,6 +1340,14 @@ describe("runHeartbeatOnce", () => {
         expectedReplyCalls: 0,
       },
       {
+        name: "fenced empty template + interval skips",
+        fileState: "fenced-empty",
+        expectedStatus: "skipped",
+        expectedSkipReason: "empty-heartbeat-file",
+        expectedSendCalls: 0,
+        expectedReplyCalls: 0,
+      },
+      {
         name: "empty file + wake runs",
         fileState: "empty",
         reason: "wake",
@@ -1332,6 +1370,13 @@ describe("runHeartbeatOnce", () => {
       {
         name: "actionable file runs",
         fileState: "actionable",
+        expectedStatus: "ran",
+        expectedSendCalls: 1,
+        expectedReplyCalls: 1,
+      },
+      {
+        name: "fenced actionable template runs",
+        fileState: "fenced-actionable",
         expectedStatus: "ran",
         expectedSendCalls: 1,
         expectedReplyCalls: 1,


### PR DESCRIPTION
## Summary

- **Problem:** A default-installed `HEARTBEAT.md` could fire a full heartbeat LLM call every interval even when the file was effectively just scaffold text.
- **Root cause:** `docs/reference/templates/HEARTBEAT.md` was changed in `198de10523` to wrap the scaffold body in a fenced ```` ```markdown ```` block so Mintlify would render the `#` lines as code instead of page headings. Runtime `loadTemplate()` strips frontmatter but not fenced markers, so those ```` ``` ```` lines are written verbatim into the user workspace. `isHeartbeatContentEffectivelyEmpty()` treated those marker lines as actionable content, so the preflight skip path never fired.
- **What changed:** `isHeartbeatContentEffectivelyEmpty()` now treats Markdown fence marker lines such as ```` ``` ```` and ```` ```markdown ```` as format-only noise, while still treating real content inside the fence as actionable. The PR also adds regression coverage for the current fenced template shape, the pre-fence legacy comment-only template shape, and runner-level skip behavior.
- **What did NOT change:** This PR does **not** add HTML comment, YAML frontmatter, or bare `tasks:` handling. Those patterns are not part of the shipped heartbeat template path that caused the regression.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #61690
- Related #61347
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** the runtime heartbeat scaffold and the docs template share the same source file. After `198de10523`, the shipped `HEARTBEAT.md` scaffold started including fenced Markdown markers for docs rendering, but runtime template loading still wrote those markers into workspaces.
- **Missing detection / guardrail:** `isHeartbeatContentEffectivelyEmpty()` skipped headers and blank lines but not fence marker lines, so a comment-only scaffold created from the current template looked non-empty.
- **Why old installs also matter:** pre-`198de10523` installs may still have the old comment-only scaffold shape, so the regression tests keep both shapes covered.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration / runner test
- **Target tests or files:**
  - `src/auto-reply/heartbeat.test.ts`
  - `src/agents/workspace.test.ts`
  - `src/infra/heartbeat-runner.returns-default-unset.test.ts`
- **Scenarios the tests lock in:**
  - the current fenced default template body is treated as effectively empty
  - the legacy pre-fence comment-only template body is still treated as effectively empty
  - fenced content with a real task still runs and does not skip
  - new workspaces really do seed the fenced `HEARTBEAT.md` template body from `docs/reference/templates/HEARTBEAT.md`
- **Why this is the smallest reliable guardrail:** it covers the actual docs-template-to-workspace path plus the runner preflight gate, not just the helper in isolation.

## User-visible / Behavior Changes

For users whose `HEARTBEAT.md` still contains only the shipped scaffold text, heartbeat ticks now return `{status: "skipped", reason: "empty-heartbeat-file"}` again instead of making an unnecessary LLM call. Fenced templates with real task content still run normally.

## Diagram

```text
Before (default shipped scaffold after 198de10523):
[interval tick] -> workspace HEARTBEAT.md contains ```markdown / ``` lines
                -> isHeartbeatContentEffectivelyEmpty: false
                -> full LLM call

After:
[interval tick] -> fence marker lines ignored as formatting noise
                -> scaffold-only HEARTBEAT.md classified empty
                -> {status: "skipped"}
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: local repo test environment
- Runtime: Node `22+`, pnpm `10.x`
- Model/provider: provider-agnostic; the fix is in heartbeat preflight gating before any LLM call

### Steps

1. Inspect `docs/reference/templates/HEARTBEAT.md` and confirm the scaffold body is fenced with ```` ```markdown ````.
2. Confirm `src/agents/workspace.ts` strips frontmatter but not fence markers when seeding the workspace template.
3. Run:
   - `pnpm test src/auto-reply/heartbeat.test.ts`
   - `pnpm test src/agents/workspace.test.ts`
   - `pnpm test src/infra/heartbeat-runner.returns-default-unset.test.ts`

### Expected

- Current fenced scaffold-only `HEARTBEAT.md` skips heartbeat runs.
- Legacy comment-only scaffold still skips.
- Fenced heartbeat files with real tasks still run.

### Actual

Matches expected.

## Evidence

- [x] Failing test/log before + passing after

```text
pnpm test src/auto-reply/heartbeat.test.ts
pnpm test src/agents/workspace.test.ts
pnpm test src/infra/heartbeat-runner.returns-default-unset.test.ts
```

All passed locally on the final PR head.

## Human Verification

- **Verified scenarios:**
  - current fenced template scaffold is classified empty
  - legacy pre-fence comment-only scaffold is classified empty
  - fenced scaffold with real tasks is not classified empty
  - workspace seeding still writes the fenced heartbeat template body from the docs template source
- **What I did NOT verify:** live end-to-end billing/provider behavior against a real model API. The change is confined to local preflight gating, and runner-level tests cover the skip path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** fence marker lines are ignored even outside the shipped scaffold.
  - **Mitigation:** only the marker lines themselves are ignored; content inside the fence is still evaluated normally, and runner tests cover fenced actionable content.
- **Risk:** future template formatting changes could drift from runtime assumptions again.
  - **Mitigation:** workspace seeding and runner gating are now both covered by regression tests.
