### PR TITLE
feat(skills): add quantum-memory — AI memory with knowledge graphs + QAOA

### DIFF
--- a/skills/quantum-memory/SKILL.md
+++ b/skills/quantum-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quantum-memory
-description: Quantum-optimized memory retrieval for AI agents. Use when building agent memory systems, replacing Mem0/LangChain memory, or needing relationship-aware recall that finds connected memory clusters instead of individual matches. Triggers on memory system setup, agent memory upgrade, knowledge graph memory, QAOA optimization, recall quality improvement, short-term memory with recency boost. Installs via pip (quantum-memory-graph). #1 R@5 on LongMemEval (ICLR 2025) to our knowledge.
+description: Quantum-optimized memory retrieval for AI agents. Use when building agent memory systems, replacing Mem0/LangChain memory, or needing relationship-aware recall that finds connected memory clusters instead of individual matches. Triggers on memory system setup, agent memory upgrade, knowledge graph memory, QAOA optimization, recall quality improvement, short-term memory with recency boost. Installs via pip (quantum-memory-graph). Benchmarked on LongMemEval (ICLR 2025).
 ---
 
 # Quantum Memory Graph

--- a/skills/quantum-memory/SKILL.md
+++ b/skills/quantum-memory/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: quantum-memory
+description: Quantum-optimized memory retrieval for AI agents. Use when building agent memory systems, replacing Mem0/LangChain memory, or needing relationship-aware recall that finds connected memory clusters instead of individual matches. Triggers on memory system setup, agent memory upgrade, knowledge graph memory, QAOA optimization, recall quality improvement, short-term memory with recency boost. Installs via pip (quantum-memory-graph). #1 R@5 on LongMemEval (ICLR 2025) to our knowledge.
+---
+
+# Quantum Memory Graph
+
+Relationship-aware memory for AI agents. Knowledge graphs + quantum-optimized subgraph selection (QAOA).
+
+## When to Use
+
+- Building or upgrading an AI agent's memory system
+- Replacing flat similarity search (Mem0, LangChain memory, raw vector DB)
+- Need memories that work *together* as connected context, not isolated matches
+- Want recency-aware retrieval (recent memories rank higher)
+
+## Install
+
+```bash
+pip install quantum-memory-graph
+```
+
+For high-accuracy mode (needs ~2GB RAM, GPU recommended):
+```bash
+pip install quantum-memory-graph
+# Then use model="thenlper/gte-large" — 96.6% R@5
+```
+
+## Quick Start
+
+```python
+from quantum_memory_graph import store, recall
+
+# Store memories — automatically builds knowledge graph
+store("Project Alpha uses React frontend with TypeScript.")
+store("Project Alpha backend is FastAPI with PostgreSQL.")
+store("FastAPI connects to PostgreSQL via SQLAlchemy ORM.")
+
+# Recall — graph traversal + QAOA finds the optimal combination
+result = recall("What is Project Alpha's full tech stack?", K=4)
+for memory in result["memories"]:
+    print(f"  {memory['text']}")
+```
+
+## Model Selection
+
+Read `references/models.md` for full comparison table.
+
+- **Default** (`all-MiniLM-L6-v2`): 90MB, no GPU, 93.4% R@5. Use for laptops/CI.
+- **High accuracy** (`thenlper/gte-large`): 1.3GB, GPU recommended, 96.6% R@5.
+
+```python
+from quantum_memory_graph import MemoryGraph
+mg = MemoryGraph(model="thenlper/gte-large")
+```
+
+## Short-Term Memory (v0.4.0+)
+
+Recency boost is ON by default. Recent memories score higher automatically.
+
+```python
+from quantum_memory_graph import store, recall, get_stm
+
+store("User prefers dark mode")  # Gets recency boost
+
+# Track conversation context
+stm = get_stm()
+stm.conversation.add_turn("What are preferences?", memory_ids=["m1"])
+```
+
+Three layers:
+- **Recency**: +0.3 last hour, +0.15 last day, +0.05 last week
+- **Working memory**: Last 20 memories always available
+- **Conversation context**: Current topic gets priority
+
+## Deploy as Microservice
+
+```bash
+pip install quantum-memory-graph[api]
+python -m quantum_memory_graph.api --port 8502
+```
+
+Endpoints: `POST /store`, `POST /recall`, `POST /store-batch`, `GET /stats`
+
+Multiple agents share one API server. See `references/deployment.md` for migration guide.
+
+## Migrate from Mem0
+
+```python
+from quantum_memory_graph import store
+for memory in existing_memories:
+    store(memory["text"], metadata=memory.get("metadata"))
+# Graph connections built automatically
+```
+
+## IBM Quantum Hardware
+
+```bash
+pip install quantum-memory-graph[ibm]
+export IBM_QUANTUM_TOKEN=your_token
+```
+
+Runs QAOA on real quantum hardware (validated on ibm_fez, ibm_kingston).

--- a/skills/quantum-memory/references/deployment.md
+++ b/skills/quantum-memory/references/deployment.md
@@ -49,7 +49,7 @@ for msg in langchain_memory.chat_memory.messages:
 
 ## Production Tips
 
-- **Shared server**: One instance serves all agents. Shared knowledge graph means Agent A's memories help Agent B.
+- **Shared server**: One instance serves all agents within the same trust boundary. ⚠️ **Single-user/team only** — all agents share one knowledge graph. For multi-tenant deployments, run separate instances or namespace by user ID to prevent cross-user memory access.
 - **Model choice**: `gte-large` on GPU servers, `MiniLM` on laptops/CI.
 - **Batch import**: Use `/store-batch` for bulk migration — 10x faster.
 - **Persistence**: Graph saves to disk automatically. Restarts preserve all memories.

--- a/skills/quantum-memory/references/deployment.md
+++ b/skills/quantum-memory/references/deployment.md
@@ -1,0 +1,56 @@
+# Deployment Guide
+
+## Microservice Setup
+
+Run QMG as a shared API server for multiple agents:
+
+```bash
+pip install quantum-memory-graph[api]
+
+# Default model (lightweight)
+python -m quantum_memory_graph.api --port 8502
+
+# High accuracy (GPU recommended)
+QMG_MODEL=thenlper/gte-large python -m quantum_memory_graph.api --port 8502
+```
+
+## API Endpoints
+
+- `POST /store` — `{"text": "memory content", "source": "agent-1"}`
+- `POST /recall` — `{"query": "what to find", "K": 5}`
+- `POST /store-batch` — `{"texts": ["mem1", "mem2", ...]}` (10x faster)
+- `GET /stats` — Graph statistics
+- `GET /` — Health check
+
+## Migrate from Mem0
+
+```python
+from quantum_memory_graph import store
+
+# Export from Mem0 (PostgreSQL)
+import psycopg2
+conn = psycopg2.connect("postgresql://...")
+cur = conn.cursor()
+cur.execute("SELECT content, metadata FROM memories")
+
+for content, metadata in cur.fetchall():
+    store(content, metadata=metadata)
+```
+
+## Migrate from LangChain Memory
+
+```python
+from quantum_memory_graph import store
+
+# From ConversationBufferMemory
+for msg in langchain_memory.chat_memory.messages:
+    store(msg.content, source="langchain_import")
+```
+
+## Production Tips
+
+- **Shared server**: One instance serves all agents. Shared knowledge graph means Agent A's memories help Agent B.
+- **Model choice**: `gte-large` on GPU servers, `MiniLM` on laptops/CI.
+- **Batch import**: Use `/store-batch` for bulk migration — 10x faster.
+- **Persistence**: Graph saves to disk automatically. Restarts preserve all memories.
+- **Monitoring**: Hit `GET /stats` for node/edge counts, density, components.

--- a/skills/quantum-memory/references/models.md
+++ b/skills/quantum-memory/references/models.md
@@ -1,0 +1,32 @@
+# Model Selection Guide
+
+## Benchmark Results (LongMemEval — ICLR 2025, 500 questions)
+
+| Model | Size | GPU? | R@5 | R@10 | NDCG@10 | Best For |
+|-------|------|------|-----|------|---------|----------|
+| `all-MiniLM-L6-v2` (default) | 90MB | No | 93.4% | 97.4% | 90.8% | Laptops, CI/CD, prototyping |
+| `BAAI/bge-large-en-v1.5` | 1.3GB | Recommended | 95.9% | 98.2% | 94.0% | Production servers |
+| `intfloat/e5-large-v2` | 1.3GB | Recommended | 96.0% | 98.1% | 94.6% | Best ranking quality |
+| `thenlper/gte-large` | 1.3GB | Recommended | 96.6% | 98.7% | 94.3% | Maximum retrieval accuracy |
+
+## Usage
+
+```python
+from quantum_memory_graph import MemoryGraph
+
+# Default — works everywhere
+mg = MemoryGraph()
+
+# High accuracy
+mg = MemoryGraph(model="thenlper/gte-large")
+
+# Best ranking
+mg = MemoryGraph(model="intfloat/e5-large-v2")
+```
+
+## Notes
+
+- Default runs on CPU, any machine. No GPU needed.
+- Larger models benefit from GPU (60x speedup) but work on CPU too — just slower.
+- All models produce normalized embeddings for cosine similarity.
+- Pass any sentence-transformers model name to `model=` parameter.


### PR DESCRIPTION
## quantum-memory skill

Adds a new skill for AI agent memory systems using knowledge graphs and quantum optimization (QAOA).

### What it does
- Finds **connected groups** of memories instead of individual similarity matches
- Knowledge graph maps relationships between memories (semantic, entity, temporal, source)
- QAOA selects the optimal *combination* of memories for any query
- Short-term memory layer: recency boost, working memory buffer, conversation context

### Benchmark Results (LongMemEval — ICLR 2025)
| Model | R@5 | R@10 | NDCG@10 |
|-------|-----|------|---------|
| gte-large | 96.6% | 98.7% | 94.3% |
| e5-large | 96.0% | 98.1% | 94.6% |
| MiniLM (default) | 93.4% | 97.4% | 90.8% |

#1 to our knowledge among published results.

### Install
```bash
pip install quantum-memory-graph
```

### Links
- PyPI: https://pypi.org/project/quantum-memory-graph/
- GitHub: https://github.com/Dustin-a11y/quantum-memory-graph
- ClawHub: https://clawhub.ai/skills/quantum-memory
- MIT License, Copyright Coinkong (Chefs Attraction AI Lab)
- Built with MemPalace by @bensig