### PR TITLE
Clarify OpenAI auth setup hint for separate Codex OAuth

### DIFF
--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -206,7 +206,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
           choiceLabel: "OpenAI API key",
           groupId: "openai",
           groupLabel: "OpenAI",
-          groupHint: "Codex OAuth + API key",
+          groupHint: "API key here, or use separate OpenAI Codex (ChatGPT OAuth)",
         },
       }),
     ],

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -206,7 +206,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
           choiceLabel: "OpenAI API key",
           groupId: "openai",
           groupLabel: "OpenAI",
-          groupHint: "API key here, or use separate OpenAI Codex (ChatGPT OAuth)",
+          groupHint: "API key only (use separate OpenAI Codex for OAuth)",
         },
       }),
     ],

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -19,7 +19,7 @@
       "choiceHint": "Browser sign-in",
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "API key only (use separate OpenAI Codex for OAuth)"
+      "groupHint": "Codex OAuth + API key"
     },
     {
       "provider": "openai",

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -19,7 +19,7 @@
       "choiceHint": "Browser sign-in",
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "Codex OAuth + API key"
+      "groupHint": "API key here, or use separate OpenAI Codex (ChatGPT OAuth)"
     },
     {
       "provider": "openai",
@@ -28,7 +28,7 @@
       "choiceLabel": "OpenAI API key",
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "Codex OAuth + API key",
+      "groupHint": "API key here, or use separate OpenAI Codex (ChatGPT OAuth)",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -19,7 +19,7 @@
       "choiceHint": "Browser sign-in",
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "API key here, or use separate OpenAI Codex (ChatGPT OAuth)"
+      "groupHint": "API key only (use separate OpenAI Codex for OAuth)"
     },
     {
       "provider": "openai",
@@ -28,7 +28,7 @@
       "choiceLabel": "OpenAI API key",
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "API key here, or use separate OpenAI Codex (ChatGPT OAuth)",
+      "groupHint": "API key only (use separate OpenAI Codex for OAuth)",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The OpenAI auth/setup hint still implied a combined OpenAI/Codex auth path even though `openai` (API key) and `openai-codex` (OAuth) are now separate provider routes.
- Why it matters: This creates onboarding/configure confusion and can leave users thinking the standard OpenAI setup also covers Codex OAuth.
- What changed: Updated the OpenAI group hint text to say `API key only (use separate OpenAI Codex for OAuth)` in both the plugin manifest and provider auth choice definition. Happy to reword as needed
- What did NOT change (scope boundary): No auth logic, provider routing, token handling, or model resolution behavior changed. Its just a string change

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #30533
- Related #61666
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write N/A. If the cause is unclear, write Unknown.

- Root cause: UX copy drift. The setup hint kept older combined wording after `openai` and `openai-codex` became separate auth/provider paths.
- Missing detection / guardrail: No test or copy audit was asserting that onboarding/configure text clearly distinguishes OpenAI API-key auth from Codex OAuth.
- Contributing context (if known): There was prior issue history around this confusion, but the current hint on `main` was still stale.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write N/A.

- Coverage level that should have caught this:
 - [ ] Unit test
 - [x] Seam / integration test
 - [ ] End-to-end test
 - [ ] Existing coverage already sufficient
- Target test or file: auth-choice / onboarding output coverage for OpenAI provider hints
- Scenario the test should lock in: OpenAI API-key setup text should clearly say it is API-key only and point users to separate OpenAI Codex OAuth when relevant.
- Why this is the smallest reliable guardrail: The bug is in assembled UX copy, not auth runtime behavior.
- Existing test that already covers this (if any): Existing checks/lint passed for touched files, but I did not find a test explicitly locking this wording in.
- If no new test is added, why not: This PR is intentionally tiny and copy-only; I kept scope limited to correcting the stale hint.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write None.

- OpenAI setup/auth hint now reads: `API key only (use separate OpenAI Codex for OAuth)`

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write N/A.

Before:
[user selects OpenAI setup] -> [hint suggests combined OpenAI/Codex auth path]

After:
[user selects OpenAI setup] -> [hint says API key only] -> [user is directed to separate Codex OAuth path if needed]

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: OpenAI / OpenAI Codex auth setup copy
- Integration/channel (if any): onboarding/configure auth-choice UI text
- Relevant config (redacted): default plugin/provider

### Steps
1. Inspect current OpenAI auth choice definitions in `extensions/openai/openai-provider.ts` and `extensions/openai/openclaw.plugin.json`.
2. Verify the old hint still implied a combined OpenAI/Codex auth grouping.
3. Update the hint text and run the repo checks triggered by commit hooks.

### Expected

- OpenAI setup text should clearly indicate API-key-only setup and not imply that Codex OAuth is included.

### Actual

- The old hint still suggested a combined OpenAI/Codex auth grouping until this copy change.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the stale hint existed on current `main`; updated both source locations so the displayed hint is now explicit about API key vs separate Codex OAuth.
- Edge cases checked: Verified both the manifest and provider code path use the updated wording so they stay aligned.
- What you did not verify: I did not run the full interactive onboarding flow end-to-end in the UI after the copy change.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write None.

- Risk: The new wording could still be considered incomplete if maintainers want stronger separation than a hint-only fix.
 - Mitigation: Kept the change intentionally narrow and copy-only, so it improves clarity without changing behavior or making broader UX assumptions.