### PR TITLE
feat(openai-codex): add gpt-5.4-pro forward-compat #63404

### DIFF
--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -145,7 +145,9 @@ describe("discord native /think autocomplete", () => {
     providerThinkingMocks.resolveProviderBinaryThinking.mockReturnValue(undefined);
     providerThinkingMocks.resolveProviderDefaultThinkingLevel.mockReturnValue(undefined);
     providerThinkingMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
-      provider === "openai-codex" && context.modelId === "gpt-5.4" ? true : undefined,
+      provider === "openai-codex" && ["gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)
+        ? true
+        : undefined,
     );
     buildModelsProviderDataMock.mockResolvedValue({
       byProvider: new Map<string, Set<string>>(),
@@ -172,7 +174,9 @@ describe("discord native /think autocomplete", () => {
     providerThinkingMocks.resolveProviderDefaultThinkingLevel.mockReturnValue(undefined);
     providerThinkingMocks.resolveProviderXHighThinking.mockReset();
     providerThinkingMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
-      provider === "openai-codex" && context.modelId === "gpt-5.4" ? true : undefined,
+      provider === "openai-codex" && ["gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)
+        ? true
+        : undefined,
     );
     fs.mkdirSync(path.dirname(STORE_PATH), { recursive: true });
     fs.writeFileSync(

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -170,6 +170,26 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("resolves gpt-5.4-pro with pro pricing when no codex template exists in registry", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4-pro",
+      modelRegistry: {
+        find: () => undefined,
+      },
+    } as never);
+
+    expect(model).toMatchObject({
+      id: "gpt-5.4-pro",
+      contextWindow: 1_050_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+      cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+
   it("resolves gpt-5.4-mini from codex templates with codex-sized limits", () => {
     const provider = buildOpenAICodexProviderPlugin();
 

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -267,4 +267,31 @@ describe("openai codex provider", () => {
       }),
     );
   });
+
+  it("augments gpt-5.4-pro from catalog gpt-5.4 when legacy codex rows are absent", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const entries = provider.augmentModelCatalog?.({
+      env: process.env,
+      entries: [
+        {
+          id: "gpt-5.4",
+          name: "gpt-5.4",
+          provider: "openai-codex",
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: 272_000,
+        },
+      ],
+    } as never);
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        id: "gpt-5.4-pro",
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+      }),
+    );
+  });
 });

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -228,6 +228,7 @@ describe("openai codex provider", () => {
         id: "gpt-5.4",
         contextWindow: 1_050_000,
         contextTokens: 272_000,
+        cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
       }),
     );
     expect(entries).toContainEqual(
@@ -235,12 +236,14 @@ describe("openai codex provider", () => {
         id: "gpt-5.4-pro",
         contextWindow: 1_050_000,
         contextTokens: 272_000,
+        cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
       }),
     );
     expect(entries).toContainEqual(
       expect.objectContaining({
         id: "gpt-5.4-mini",
         contextWindow: 272_000,
+        cost: { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
       }),
     );
   });

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -134,6 +134,42 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("resolves gpt-5.4-pro with pro pricing and codex-sized limits", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4-pro",
+      modelRegistry: {
+        find: (providerId: string, modelId: string) => {
+          if (providerId === "openai-codex" && modelId === "gpt-5.3-codex") {
+            return {
+              id: "gpt-5.3-codex",
+              name: "gpt-5.3-codex",
+              provider: "openai-codex",
+              api: "openai-codex-responses",
+              baseUrl: "https://chatgpt.com/backend-api",
+              reasoning: true,
+              input: ["text", "image"] as const,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 272_000,
+              maxTokens: 128_000,
+            };
+          }
+          return undefined;
+        },
+      } as never,
+    });
+
+    expect(model).toMatchObject({
+      id: "gpt-5.4-pro",
+      contextWindow: 1_050_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+      cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+
   it("resolves gpt-5.4-mini from codex templates with codex-sized limits", () => {
     const provider = buildOpenAICodexProviderPlugin();
 
@@ -190,6 +226,13 @@ describe("openai codex provider", () => {
     expect(entries).toContainEqual(
       expect.objectContaining({
         id: "gpt-5.4",
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+      }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        id: "gpt-5.4-pro",
         contextWindow: 1_050_000,
         contextTokens: 272_000,
       }),

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -356,6 +356,7 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
           contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+          cost: OPENAI_CODEX_GPT_54_COST,
         }),
         buildOpenAISyntheticCatalogEntry(gpt54Template, {
           id: OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
@@ -363,12 +364,14 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
           contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+          cost: OPENAI_CODEX_GPT_54_PRO_COST,
         }),
         buildOpenAISyntheticCatalogEntry(gpt54MiniTemplate, {
           id: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
           reasoning: true,
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_MINI_CONTEXT_TOKENS,
+          cost: OPENAI_CODEX_GPT_54_MINI_COST,
         }),
         buildOpenAISyntheticCatalogEntry(sparkTemplate, {
           id: OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -66,6 +66,11 @@ const OPENAI_CODEX_GPT_54_MINI_COST = {
   cacheWrite: 0,
 } as const;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
+/** Legacy codex rows first; fall back to catalog `gpt-5.4` when the API omits 5.3/5.2. */
+const OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS = [
+  ...OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
+  OPENAI_CODEX_GPT_54_MODEL_ID,
+] as const;
 const OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
   "gpt-5.1-codex-mini",
@@ -337,7 +342,7 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
       const gpt54Template = findCatalogTemplate({
         entries: ctx.entries,
         providerId: PROVIDER_ID,
-        templateIds: OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
+        templateIds: OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS,
       });
       const gpt54MiniTemplate = findCatalogTemplate({
         entries: ctx.entries,

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -180,7 +180,7 @@ function resolveCodexForwardCompatModel(
       baseUrl: OPENAI_CODEX_BASE_URL,
       reasoning: true,
       input: ["text", "image"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      cost: patch?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: patch?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
       contextTokens: patch?.contextTokens,
       maxTokens: patch?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -41,6 +41,7 @@ import {
 const PROVIDER_ID = "openai-codex";
 const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS = 272_000;
@@ -50,6 +51,12 @@ const OPENAI_CODEX_GPT_54_COST = {
   input: 2.5,
   output: 15,
   cacheRead: 0.25,
+  cacheWrite: 0,
+} as const;
+const OPENAI_CODEX_GPT_54_PRO_COST = {
+  input: 30,
+  output: 180,
+  cacheRead: 0,
   cacheWrite: 0,
 } as const;
 const OPENAI_CODEX_GPT_54_MINI_COST = {
@@ -71,6 +78,7 @@ const OPENAI_CODEX_GPT_53_SPARK_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 const OPENAI_CODEX_XHIGH_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
   OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
   OPENAI_CODEX_GPT_53_MODEL_ID,
   OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
@@ -79,6 +87,7 @@ const OPENAI_CODEX_XHIGH_MODEL_IDS = [
 ] as const;
 const OPENAI_CODEX_MODERN_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
   OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
   "gpt-5.2",
   "gpt-5.2-codex",
@@ -121,6 +130,14 @@ function resolveCodexForwardCompatModel(
       contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
       maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
       cost: OPENAI_CODEX_GPT_54_COST,
+    };
+  } else if (lower === OPENAI_CODEX_GPT_54_PRO_MODEL_ID) {
+    templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
+    patch = {
+      contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
+      contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+      maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+      cost: OPENAI_CODEX_GPT_54_PRO_COST,
     };
   } else if (lower === OPENAI_CODEX_GPT_54_MINI_MODEL_ID) {
     templateIds = OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS;
@@ -284,9 +301,13 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
     supportsXHighThinking: ({ modelId }) =>
       matchesExactOrPrefix(modelId, OPENAI_CODEX_XHIGH_MODEL_IDS),
     isModernModelRef: ({ modelId }) => matchesExactOrPrefix(modelId, OPENAI_CODEX_MODERN_MODEL_IDS),
-    preferRuntimeResolvedModel: (ctx) =>
-      normalizeProviderId(ctx.provider) === PROVIDER_ID &&
-      ctx.modelId.trim().toLowerCase() === OPENAI_CODEX_GPT_54_MODEL_ID,
+    preferRuntimeResolvedModel: (ctx) => {
+      if (normalizeProviderId(ctx.provider) !== PROVIDER_ID) {
+        return false;
+      }
+      const id = ctx.modelId.trim().toLowerCase();
+      return id === OPENAI_CODEX_GPT_54_MODEL_ID || id === OPENAI_CODEX_GPT_54_PRO_MODEL_ID;
+    },
     buildReplayPolicy: buildOpenAIReplayPolicy,
     prepareExtraParams: (ctx) => {
       const transport = ctx.extraParams?.transport;
@@ -331,6 +352,13 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
       return [
         buildOpenAISyntheticCatalogEntry(gpt54Template, {
           id: OPENAI_CODEX_GPT_54_MODEL_ID,
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
+          contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+        }),
+        buildOpenAISyntheticCatalogEntry(gpt54Template, {
+          id: OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
           reasoning: true,
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -6,6 +6,13 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 
+type SyntheticOpenAIModelCatalogCost = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+};
+
 type SyntheticOpenAIModelCatalogEntry = {
   provider: string;
   id: string;
@@ -14,6 +21,7 @@ type SyntheticOpenAIModelCatalogEntry = {
   input?: ("text" | "image")[];
   contextWindow?: number;
   contextTokens?: number;
+  cost?: SyntheticOpenAIModelCatalogCost;
 };
 
 export const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
@@ -50,6 +58,7 @@ export function buildOpenAISyntheticCatalogEntry(
     input: readonly ("text" | "image")[];
     contextWindow: number;
     contextTokens?: number;
+    cost?: SyntheticOpenAIModelCatalogCost;
   },
 ): SyntheticOpenAIModelCatalogEntry | undefined {
   if (!template) {
@@ -63,6 +72,7 @@ export function buildOpenAISyntheticCatalogEntry(
     input: [...entry.input],
     contextWindow: entry.contextWindow,
     ...(entry.contextTokens === undefined ? {} : { contextTokens: entry.contextTokens }),
+    ...(entry.cost === undefined ? {} : { cost: entry.cost }),
   };
 }
 

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -399,7 +399,8 @@ describe("isModernModelRef", () => {
       provider === "openai" &&
       ["gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano"].includes(context.modelId)
         ? true
-        : provider === "openai-codex" && ["gpt-5.4", "gpt-5.4-mini"].includes(context.modelId)
+        : provider === "openai-codex" &&
+            ["gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini"].includes(context.modelId)
           ? true
           : provider === "opencode" && ["claude-opus-4-6", "gemini-3-pro"].includes(context.modelId)
             ? true
@@ -413,6 +414,7 @@ describe("isModernModelRef", () => {
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4-mini" })).toBe(true);
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4-nano" })).toBe(true);
     expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4" })).toBe(true);
+    expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4-pro" })).toBe(true);
     expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4-mini" })).toBe(true);
     expect(isModernModelRef({ provider: "opencode", id: "claude-opus-4-6" })).toBe(true);
     expect(isModernModelRef({ provider: "opencode", id: "gemini-3-pro" })).toBe(true);

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -183,7 +183,7 @@ function buildDynamicModel(
     }
     case "openai-codex": {
       const template =
-        lower === "gpt-5.4"
+        lower === "gpt-5.4" || lower === "gpt-5.4-pro"
           ? findTemplate(params, "openai-codex", ["gpt-5.4", "gpt-5.4"])
           : lower === "gpt-5.4-mini"
             ? findTemplate(params, "openai-codex", [
@@ -214,6 +214,22 @@ function buildDynamicModel(
             api: "openai-codex-responses",
             baseUrl: OPENAI_CODEX_BASE_URL,
             cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+            contextWindow: 1_050_000,
+            contextTokens: 272_000,
+            maxTokens: 128_000,
+          },
+          fallback,
+        );
+      }
+      if (lower === "gpt-5.4-pro") {
+        return cloneTemplate(
+          template,
+          modelId,
+          {
+            provider: "openai-codex",
+            api: "openai-codex-responses",
+            baseUrl: OPENAI_CODEX_BASE_URL,
+            cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 1_050_000,
             contextTokens: 272_000,
             maxTokens: 128_000,

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
@@ -31,6 +31,7 @@ export const DEFAULT_TEST_MODEL_CATALOG: Array<{
   { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", provider: "openai" },
   { id: "gpt-5.4-nano", name: "GPT-5.4 Nano", provider: "openai" },
   { id: "gpt-5.4", name: "GPT-5.4 (Codex)", provider: "openai-codex" },
+  { id: "gpt-5.4-pro", name: "GPT-5.4 Pro (Codex)", provider: "openai-codex" },
   { id: "gpt-5.4-mini", name: "GPT-5.4 Mini (Codex)", provider: "openai-codex" },
   { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
 ];
@@ -47,6 +48,7 @@ const OPENAI_XHIGH_MODEL_IDS = [
 
 const OPENAI_CODEX_XHIGH_MODEL_IDS = [
   "gpt-5.4",
+  "gpt-5.4-pro",
   "gpt-5.4-mini",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -85,7 +85,7 @@ describe("listThinkingLevels", () => {
     providerRuntimeMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
       (provider === "openai" && ["gpt-5.4", "gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)) ||
       (provider === "openai-codex" &&
-        ["gpt-5.4", "gpt-5.4", "gpt-5.3-codex-spark"].includes(context.modelId)) ||
+        ["gpt-5.4", "gpt-5.4-pro", "gpt-5.3-codex-spark"].includes(context.modelId)) ||
       (provider === "github-copilot" && ["gpt-5.4", "gpt-5.4"].includes(context.modelId))
         ? true
         : undefined,
@@ -94,6 +94,7 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai-codex", "gpt-5.3-codex-spark")).toContain("xhigh");
+    expect(listThinkingLevels("openai-codex", "gpt-5.4-pro")).toContain("xhigh");
     expect(listThinkingLevels("openai", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai", "gpt-5.4-pro")).toContain("xhigh");

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -19,6 +19,12 @@ const OPENAI_CODEX_MINI_MODEL = {
   contextWindow: 272_000,
 };
 
+const OPENAI_CODEX_PRO_MODEL = {
+  ...OPENAI_CODEX_MODEL,
+  id: "gpt-5.4-pro",
+  name: "GPT-5.4 Pro",
+};
+
 const OPENAI_CODEX_53_MODEL = {
   ...OPENAI_CODEX_MODEL,
   id: "gpt-5.4",
@@ -232,6 +238,35 @@ describe("modelsListCommand forward-compat", () => {
       expect(codexMini).toBeTruthy();
       expect(codexMini?.missing).toBe(false);
       expect(codexMini?.tags).not.toContain("missing");
+    });
+
+    it("does not mark configured codex gpt-5.4-pro as missing when forward-compat can build a fallback", async () => {
+      mocks.resolveConfiguredEntries.mockReturnValueOnce({
+        entries: [
+          {
+            key: "openai-codex/gpt-5.4-pro",
+            ref: { provider: "openai-codex", model: "gpt-5.4-pro" },
+            tags: new Set(["configured"]),
+            aliases: [],
+          },
+        ],
+      });
+      mocks.resolveModelWithRegistry.mockReturnValueOnce({ ...OPENAI_CODEX_PRO_MODEL });
+      const runtime = createRuntime();
+
+      await modelsListCommand({ json: true }, runtime as never);
+
+      expect(mocks.printModelTable).toHaveBeenCalled();
+      const rows = lastPrintedRows<{
+        key: string;
+        tags: string[];
+        missing: boolean;
+      }>();
+
+      const codexPro = rows.find((row) => row.key === "openai-codex/gpt-5.4-pro");
+      expect(codexPro).toBeTruthy();
+      expect(codexPro?.missing).toBe(false);
+      expect(codexPro?.tags).not.toContain("missing");
     });
 
     it("passes source config to model registry loading for persistence safety", async () => {

--- a/src/plugins/provider-runtime.test-support.ts
+++ b/src/plugins/provider-runtime.test-support.ts
@@ -14,6 +14,7 @@ export const expectedAugmentedOpenaiCodexCatalogEntries = [
   { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
   { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+  { provider: "openai-codex", id: "gpt-5.4-pro", name: "gpt-5.4-pro" },
   { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   {
     provider: "openai-codex",

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -131,6 +131,7 @@ function createOpenAiCatalogProviderPlugin(
       { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
       { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+      { provider: "openai-codex", id: "gpt-5.4-pro", name: "gpt-5.4-pro" },
       { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       {
         provider: "openai-codex",


### PR DESCRIPTION
## Summary

- **Problem:** ChatGPT Pro users selecting `openai-codex/gpt-5.4-pro` hit `model not allowed: openai-codex/gpt-5.4-pro` before any API call because the Codex provider did not forward-compat resolve or advertise that model (see [issue #63404](https://github.com/openclaw/openclaw/issues/63404)).
- **Why it matters:** OAuth Codex users on Pro plans expect the same model id family as the API-key `openai` path; blocking `gpt-5.4-pro` breaks a primary workflow.
- **What changed:**
  - `extensions/openai/openai-codex-provider.ts`: add `gpt-5.4-pro` to forward-compat resolution, XHigh/modern id lists, synthetic catalog entry, Pro pricing metadata, and `preferRuntimeResolvedModel` for both `gpt-5.4` and `gpt-5.4-pro`.
  - Tests/harnesses aligned so mocks and Pi test support match real plugin behavior (model compat, thinking levels, Discord `/think` autocomplete mock, `models list` forward-compat, provider-runtime catalog expectations, e2e harness).
- **What did NOT change:** Default Codex default model remains `openai-codex/gpt-5.4`. No change to Issue’s optional follow-up (minimum thinking tier for `gpt-5.4-pro`); can be tracked separately if the upstream requires non-`none` thinking.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

 Closes #63404

## User-visible / Behavior Changes

- Users can select and run `openai-codex/gpt-5.4-pro` when authenticated via ChatGPT/Codex OAuth without `model not allowed` from missing forward-compat/catalog synthesis.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- **Model/provider:** `openai-codex` / `gpt-5.4-pro` (Codex OAuth, ChatGPT Pro plan as in issue).

### Steps (from issue)

1. Authenticate with `openai-codex` OAuth (plan Pro).
2. Set or select model `openai-codex/gpt-5.4-pro`.
3. **Before:** `model not allowed: openai-codex/gpt-5.4-pro`.
4. **After:** model resolves via provider forward-compat and catalog augmentation.

### Verification (local)

- `pnpm test extensions/openai/openai-codex-provider.test.ts`
- `pnpm test src/agents/model-compat.test.ts -t "plugin-advertised"`
- `pnpm test src/auto-reply/thinking.test.ts -t listThinkingLevels`
- `pnpm test extensions/discord/src/monitor/native-command.think-autocomplete.test.ts`
- `pnpm test src/plugins/provider-runtime.test.ts -t "resolves bundled catalog hooks"`
- `pnpm test src/commands/models/list.list-command.forward-compat.test.ts -t "gpt-5.4-pro"`

## Evidence

- [x] Unit tests updated/added for Codex `gpt-5.4-pro` resolution and aligned harnesses.

## Human Verification (required)

- **Verified:** Static/code-path review; targeted Vitest runs above on the development branch.
- **Not verified:** Live ChatGPT Pro OAuth end-to-end call (no production tokens in this environment).


## Compatibility / Migration

- **Backward compatible?** Yes (additive model id support).
- **Config/env changes?** No.
- **Migration needed?** No.

## Failure Recovery (if this breaks)

- Revert the PR commit or pin default to `openai-codex/gpt-5.4` in config until fixed.

## Risks and Mitigations

- **Risk:** Upstream Codex API constraints (e.g. minimum thinking level) not enforced client-side.
  - **Mitigation:** Issue already notes optional follow-up; monitor user reports and add policy if needed.