### PR TITLE
fix(cron): honor --session-key for isolated agentTurn jobs

### DIFF
--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -260,4 +260,70 @@ describe("buildGatewayCronService", () => {
       state.cron.stop();
     }
   });
+
+  it("honors job.sessionKey for isolated agentTurn jobs (#63442)", async () => {
+    const cfg = createCronConfig("server-cron-session-key");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "isolated-with-session-key",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        sessionKey: "my-shared-context",
+        payload: { kind: "agentTurn", message: "check status" },
+      });
+
+      expect(job.sessionKey).toBe("my-shared-context");
+
+      await state.cron.run(job.id, "force");
+
+      expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          job: expect.objectContaining({ id: job.id }),
+          sessionKey: "my-shared-context",
+        }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("falls back to cron:<id> when no sessionKey is set on isolated jobs", async () => {
+    const cfg = createCronConfig("server-cron-fallback");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "isolated-no-key",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentTurn", message: "check status" },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: `cron:${job.id}`,
+        }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
 });

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -286,9 +286,13 @@ export function buildGatewayCronService(params: {
     },
     runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
-      let sessionKey = `cron:${job.id}`;
+      let sessionKey: string;
       if (job.sessionTarget.startsWith("session:")) {
         sessionKey = assertSafeCronSessionTargetId(job.sessionTarget.slice(8));
+      } else if (job.sessionKey) {
+        sessionKey = job.sessionKey;
+      } else {
+        sessionKey = `cron:${job.id}`;
       }
       try {
         return await runCronIsolatedAgentTurn({


### PR DESCRIPTION
## Summary

Fixes #63442 — `cron: --session-key silently ignored for isolated agentTurn jobs`.

## Root Cause

In `server-cron.ts`, `runIsolatedAgentJob` hardcoded the session key to `cron:<jobId>` and only checked `job.sessionTarget` for `session:` prefixes. The user-supplied `job.sessionKey` (set via `--session-key` CLI flag) was accepted, persisted, and displayed by `cron list`, but **never wired into isolated job execution**.

## Fix

Changed session key resolution in `runIsolatedAgentJob` to a 3-tier priority:

1. **`sessionTarget`** starting with `session:` — explicit session target (unchanged)
2. **`job.sessionKey`** — user-supplied key via `--session-key` (**NEW** — was silently dropped)
3. **`cron:<jobId>`** — auto-generated fallback (unchanged, backward-compatible default)

This is a 6-line change in `server-cron.ts`. The downstream `runCronIsolatedAgentTurn` already handles custom session keys correctly (line 224 of `run.ts` uses `params.sessionKey` when provided).

## Tests

Added 2 regression tests to `server-cron.test.ts`:
- **`honors job.sessionKey for isolated agentTurn jobs (#63442)`** — confirms user-supplied key flows through
- **`falls back to cron:<id> when no sessionKey is set`** — confirms backward compatibility

All 5 tests in the file pass. Existing `run.session-key.test.ts` (8 tests) unaffected.