### PR TITLE
fix(discord): resolve allowFrom from top-level config for owner and DM auth

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -221,7 +221,7 @@ function resolveDiscordStartupDelayMs(cfg: OpenClawConfig, accountId: string): n
 const resolveDiscordDmPolicy = createScopedDmSecurityResolver<ResolvedDiscordAccount>({
   channelKey: "discord",
   resolvePolicy: (account) => account.config.dm?.policy,
-  resolveAllowFrom: (account) => account.config.dm?.allowFrom,
+  resolveAllowFrom: (account) => account.config.allowFrom ?? account.config.dm?.allowFrom,
   allowFromPathSuffix: "dm.",
   normalizeEntry: (raw) =>
     raw

--- a/extensions/discord/src/shared.allowfrom.test.ts
+++ b/extensions/discord/src/shared.allowfrom.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedDiscordAccount } from "./accounts.js";
+
+/**
+ * Extracted from discordConfigAdapter.resolveAllowFrom in shared.ts.
+ * Tests the resolution logic directly without requiring the full adapter
+ * wiring and its heavy module dependencies.
+ */
+function resolveAllowFrom(account: ResolvedDiscordAccount) {
+  return account.config.allowFrom ?? account.config.dm?.allowFrom;
+}
+
+function makeAccount(config: Partial<ResolvedDiscordAccount["config"]>): ResolvedDiscordAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    token: "test-token",
+    tokenSource: "config",
+    config: config as ResolvedDiscordAccount["config"],
+  };
+}
+
+describe("discord resolveAllowFrom", () => {
+  it("reads top-level allowFrom after dm.allowFrom was promoted by normalization", () => {
+    const account = makeAccount({ allowFrom: ["123456789"] });
+    expect(resolveAllowFrom(account)).toEqual(["123456789"]);
+  });
+
+  it("prefers top-level allowFrom over dm.allowFrom when both are present", () => {
+    const account = makeAccount({
+      allowFrom: ["111111111"],
+      dm: { allowFrom: ["222222222"] },
+    });
+    expect(resolveAllowFrom(account)).toEqual(["111111111"]);
+  });
+
+  it("falls back to dm.allowFrom when top-level is absent", () => {
+    const account = makeAccount({ dm: { allowFrom: ["987654321"] } });
+    expect(resolveAllowFrom(account)).toEqual(["987654321"]);
+  });
+
+  it("returns undefined when neither is set", () => {
+    const account = makeAccount({});
+    expect(resolveAllowFrom(account)).toBeUndefined();
+  });
+
+  it("returns empty array without falling back when top-level is empty", () => {
+    const account = makeAccount({
+      allowFrom: [],
+      dm: { allowFrom: ["fallback"] },
+    });
+    // Nullish coalescing: [] is not nullish, so no fallback.
+    expect(resolveAllowFrom(account)).toEqual([]);
+  });
+});

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -60,7 +60,8 @@ export const discordConfigAdapter = createScopedChannelConfigAdapter<ResolvedDis
   inspectAccount: adaptScopedAccountAccessor(inspectDiscordAccount),
   defaultAccountId: resolveDefaultDiscordAccountId,
   clearBaseFields: ["token", "name"],
-  resolveAllowFrom: (account: ResolvedDiscordAccount) => account.config.dm?.allowFrom,
+  resolveAllowFrom: (account: ResolvedDiscordAccount) =>
+    account.config.allowFrom ?? account.config.dm?.allowFrom,
   formatAllowFrom: (allowFrom) => formatAllowFromLowercase({ allowFrom }),
   resolveDefaultTo: (account: ResolvedDiscordAccount) => account.config.defaultTo,
 });


### PR DESCRIPTION
## Problem

When `openclaw doctor --fix` or config normalization runs, it promotes `channels.discord.dm.allowFrom` to the canonical top-level `channels.discord.allowFrom` and removes the nested copy. Two Discord adapter call sites still only read from `account.config.dm?.allowFrom`, which is now empty after normalization:

1. **Owner authorization** (`shared.ts` → `discordConfigAdapter.resolveAllowFrom`): `senderIsOwner` resolves as `false` for allowlisted DM senders, hiding owner-only tools (`cron`, `gateway`).
2. **DM security policy** (`channel.ts` → `resolveDiscordDmPolicy`): the allowlist is invisible to the pairing/allowlist policy resolver.

Observed in the field — the sender is chat-authorized but not owner-authorized:
```json
{ "ownerList": [], "senderIsOwner": false, "isAuthorizedSender": true }
```

## Fix

Both call sites now read `account.config.allowFrom ?? account.config.dm?.allowFrom`, matching the pattern already used at `channel.ts:452` (`resolveDmAllowFrom`).

## Tests

Five unit tests covering:
- Top-level `allowFrom` (post-normalization) is picked up
- Top-level is preferred when both fields are present
- Fallback to `dm.allowFrom` when top-level is absent (legacy configs)
- Returns `undefined` when neither is set
- Empty `allowFrom: []` does not fall through to `dm.allowFrom`

Closes #63261