### PR TITLE
fix(whatsapp): inherit channel dmPolicy when account omits dmPolicy (#63366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: export the channel plugin base and web-search config contract through the public package so plugins can use them without private imports.
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
-- WhatsApp/config: stop applying the channel default `dmPolicy` to parsed `accounts.*` entries when those entries omit `dmPolicy`, so merged account config inherits channel `dmPolicy=allowlist` and unknown senders no longer receive pairing challenges in that setup. (#63366)
+- WhatsApp/config: stop applying the channel default `dmPolicy` / `groupPolicy` to parsed `accounts.*` entries when those keys are omitted, and ignore `undefined` account overlay fields when merging channel + account config so programmatic loaders cannot wipe channel policy. (#63366)
 
 ## 2026.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: export the channel plugin base and web-search config contract through the public package so plugins can use them without private imports.
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
+- WhatsApp/config: stop applying the channel default `dmPolicy` to parsed `accounts.*` entries when those entries omit `dmPolicy`, so merged account config inherits channel `dmPolicy=allowlist` and unknown senders no longer receive pairing challenges in that setup. (#63366)
 
 ## 2026.4.8
 

--- a/src/channels/plugins/account-helpers.test.ts
+++ b/src/channels/plugins/account-helpers.test.ts
@@ -323,6 +323,7 @@ describe("mergeAccountConfig", () => {
     enabled?: boolean;
     defaultAccount?: string;
     name?: string;
+    dmPolicy?: string;
     accounts?: Record<string, { name: string }>;
     commands?: {
       native?: boolean;
@@ -378,6 +379,48 @@ describe("mergeAccountConfig", () => {
         },
         accountConfig: {
           commands: {
+            callbackPath: "/work",
+          },
+        },
+        nestedObjectKeys: ["commands"],
+      },
+      expected: {
+        commands: {
+          native: true,
+          callbackPath: "/work",
+        },
+      },
+    },
+    {
+      name: "does not let account undefined values override channel fields",
+      input: {
+        channelConfig: {
+          enabled: true,
+          dmPolicy: "allowlist",
+        },
+        accountConfig: {
+          name: "Work",
+          dmPolicy: undefined,
+        },
+      },
+      expected: {
+        enabled: true,
+        dmPolicy: "allowlist",
+        name: "Work",
+      },
+    },
+    {
+      name: "deep-merge omits undefined keys inside nested overlay objects",
+      input: {
+        channelConfig: {
+          commands: {
+            native: true,
+            callbackPath: "/base",
+          },
+        },
+        accountConfig: {
+          commands: {
+            native: undefined,
             callbackPath: "/work",
           },
         },

--- a/src/channels/plugins/account-helpers.ts
+++ b/src/channels/plugins/account-helpers.ts
@@ -121,6 +121,17 @@ export function resolveListedDefaultAccountId(params: {
   return params.accountIds[0] ?? DEFAULT_ACCOUNT_ID;
 }
 
+/**
+ * Drop keys whose values are `undefined` so programmatic account overlays do not clobber channel
+ * defaults (`{ ...base, ...{ dmPolicy: undefined } }` would otherwise leave `dmPolicy` undefined).
+ */
+function omitUndefinedFields(record: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!record) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+}
+
 export function mergeAccountConfig<TConfig extends Record<string, unknown>>(params: {
   channelConfig: TConfig | undefined;
   accountConfig: Partial<TConfig> | undefined;
@@ -133,9 +144,12 @@ export function mergeAccountConfig<TConfig extends Record<string, unknown>>(para
       ([key]) => !omitKeys.has(key),
     ),
   ) as TConfig;
+  const accountOverlay = omitUndefinedFields(
+    params.accountConfig as Record<string, unknown> | undefined,
+  ) as Partial<TConfig>;
   const merged = {
     ...base,
-    ...params.accountConfig,
+    ...accountOverlay,
   };
   for (const key of params.nestedObjectKeys ?? []) {
     const baseValue = base[key as keyof TConfig];
@@ -150,7 +164,7 @@ export function mergeAccountConfig<TConfig extends Record<string, unknown>>(para
     ) {
       (merged as Record<string, unknown>)[key] = {
         ...(baseValue as Record<string, unknown>),
-        ...(accountValue as Record<string, unknown>),
+        ...omitUndefinedFields(accountValue as Record<string, unknown>),
       };
     }
   }

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("WhatsApp account schema dmPolicy inheritance", () => {
+  it("does not inject default dmPolicy into account blocks that omit it", () => {
+    const res = validateConfigObject({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+          accounts: {
+            work: { allowFrom: ["+15559999999"] },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    const work = res.config.channels?.whatsapp?.accounts?.work;
+    expect(work?.dmPolicy).toBeUndefined();
+  });
+
+  it("still accepts an explicit account-level dmPolicy", () => {
+    const res = validateConfigObject({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+          accounts: {
+            work: { dmPolicy: "pairing", allowFrom: ["+15559999999"] },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.config.channels?.whatsapp?.accounts?.work?.dmPolicy).toBe("pairing");
+  });
+});

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -40,4 +40,24 @@ describe("WhatsApp account schema dmPolicy inheritance", () => {
     }
     expect(res.config.channels?.whatsapp?.accounts?.work?.dmPolicy).toBe("pairing");
   });
+
+  it("does not inject default groupPolicy into account blocks that omit it", () => {
+    const res = validateConfigObject({
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+          allowFrom: ["*"],
+          groupPolicy: "open",
+          accounts: {
+            work: { allowFrom: ["+15550001111"] },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.config.channels?.whatsapp?.accounts?.work?.groupPolicy).toBeUndefined();
+  });
 });

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -114,6 +114,10 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
   authDir: z.string().optional(),
   mediaMaxMb: z.number().int().positive().optional(),
+  // Channel `WhatsAppSharedSchema` defaults `dmPolicy` to "pairing". That default must not be
+  // applied to parsed `accounts.*` objects: `resolveMergedAccountConfig` shallow-merges account
+  // fields over the channel, so an injected default would override channel `dmPolicy=allowlist`.
+  dmPolicy: DmPolicySchema.optional(),
 }).strict();
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -118,6 +118,8 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   // applied to parsed `accounts.*` objects: `resolveMergedAccountConfig` shallow-merges account
   // fields over the channel, so an injected default would override channel `dmPolicy=allowlist`.
   dmPolicy: DmPolicySchema.optional(),
+  // Same pattern as `dmPolicy`: avoid injecting channel `groupPolicy` default into account blocks.
+  groupPolicy: GroupPolicySchema.optional(),
 }).strict();
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({


### PR DESCRIPTION
## Summary

- Problem: With `channels.whatsapp.dmPolicy="allowlist"` and a multi-account setup, an `accounts.*` entry that only set `allowFrom` (and omitted `dmPolicy`) still received Zod’s channel default `dmPolicy: "pairing"` on parse. `resolveMergedAccountConfig` shallow-merges account over channel, so that injected value overrode the channel allowlist and unknown senders could get pairing challenges.
- Why it matters: Operators expect allowlist mode to block or silently ignore unknown senders, not send pairing codes (regression described in #63366).
- What changed: `WhatsAppAccountSchema` overrides `dmPolicy` with `DmPolicySchema.optional()` (no default), so omitted account-level `dmPolicy` stays unset and merge preserves the channel policy.
- What did NOT change: Channel-level defaults, explicit per-account `dmPolicy`, or WhatsApp inbound access logic (only config parse/merge behavior).

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #63366
- Related #63366
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: Zod `.default("pairing")` on the shared WhatsApp shape was applied to nested `accounts.*` objects. Parsed account objects then overwrote channel `dmPolicy` during merge.
- Missing detection / guardrail: Unit tests for access control used raw mocked config and did not exercise parsed config defaults.
- Contributing context (if known): N/A

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/config/zod-schema.providers-whatsapp.test.ts`
- Scenario the test should lock in: Validated config must not set `accounts.*.dmPolicy` to `pairing` when the account block omits `dmPolicy` and the channel sets `allowlist`.
- Why this is the smallest reliable guardrail: Asserts the exact parse output that previously corrupted merge.
- Existing test that already covers this (if any): Inbound tests mock `loadConfig` without Zod.
- If no new test is added, why not: N/A (tests added).

## User-visible / Behavior Changes

- Multi-account WhatsApp configs with channel `dmPolicy=allowlist` and account entries that omit `dmPolicy` now inherit the channel policy after merge; pairing challenges are no longer sent to unknown senders in that configuration.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: macOS (dev)
- Validation: `pnpm check`, `pnpm test src/config/zod-schema.providers-whatsapp.test.ts`, `pnpm config:docs:check`

### Steps

1. Configure `channels.whatsapp.dmPolicy: "allowlist"` with `allowFrom` and an `accounts.work` entry that only lists `allowFrom` (no `dmPolicy`).
2. Load merged account config / run gateway with that config.

### Expected

- Effective `dmPolicy` for the account remains `allowlist`; unknown senders do not get pairing replies.

### Actual (before fix)

- Parsed account carried `dmPolicy: "pairing"`, overriding channel allowlist.

## Evidence

- [x] Failing test/log before + passing after (new unit test documents expected parse shape)

## Human Verification

- Verified scenarios: `pnpm check`, targeted Vitest for new file, `pnpm config:docs:check`.
- Edge cases checked: Explicit `accounts.*.dmPolicy: "pairing"` still parses.
- What I did **not** verify: End-to-end WhatsApp gateway against a live account (config-level fix only).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

- None: Omitted account `dmPolicy` now follows channel merge semantics; explicit account `dmPolicy` is unchanged.


Made with [Cursor](https://cursor.com)