### PR TITLE
fix(media): use default STT model for auto audio transcription (#63349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: export the channel plugin base and web-search config contract through the public package so plugins can use them without private imports.
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
+- Media/audio: when auto-selecting inbound transcription from the active provider, use the provider default speech-to-text model instead of the active chat model id so voice notes transcribe reliably again. (#63349)
 
 ## 2026.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: export the channel plugin base and web-search config contract through the public package so plugins can use them without private imports.
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
-- Media/audio: when auto-selecting inbound transcription from the active provider, use the provider default speech-to-text model instead of the active chat model id so voice notes transcribe reliably again. (#63349)
+- Media/audio: when auto-selecting inbound transcription from the active provider, ignore chat model ids (e.g. `gpt-5.4`) for STT while still honoring explicit transcription models and provider defaults so voice notes and CLI `--model` overrides behave correctly. (#63349)
 
 ## 2026.4.8
 

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -65,6 +65,7 @@ function createOpenAiAudioCfg(extra?: Partial<OpenClawConfig>): OpenClawConfig {
 async function runAutoAudioCase(params: {
   transcribeAudio: (req: AudioTranscriptionRequest) => Promise<{ text: string; model: string }>;
   cfgExtra?: Partial<OpenClawConfig>;
+  activeModel?: { provider: string; model?: string };
 }) {
   let runResult: Awaited<ReturnType<typeof runCapability>> | undefined;
   await withAudioFixture("openclaw-auto-audio", async ({ ctx, media, cache }) => {
@@ -77,6 +78,7 @@ async function runAutoAudioCase(params: {
       attachments: cache,
       media,
       providerRegistry,
+      activeModel: params.activeModel,
     });
   });
   if (!runResult) {
@@ -93,6 +95,20 @@ describe("runCapability auto audio entries", () => {
         seenModel = req.model;
         return { text: "ok", model: req.model ?? "unknown" };
       },
+    });
+    expect(result.outputs[0]?.text).toBe("ok");
+    expect(seenModel).toBe("gpt-4o-transcribe");
+    expect(result.decision.outcome).toBe("success");
+  });
+
+  it("does not pass the active chat model id to auto audio transcription", async () => {
+    let seenModel: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenModel = req.model;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      activeModel: { provider: "openai", model: "gpt-5.4" },
     });
     expect(result.outputs[0]?.text).toBe("ok");
     expect(seenModel).toBe("gpt-4o-transcribe");

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -115,6 +115,20 @@ describe("runCapability auto audio entries", () => {
     expect(result.decision.outcome).toBe("success");
   });
 
+  it("preserves explicit speech-to-text model overrides on the auto audio path", async () => {
+    let seenModel: string | undefined;
+    const result = await runAutoAudioCase({
+      transcribeAudio: async (req) => {
+        seenModel = req.model;
+        return { text: "ok", model: req.model ?? "unknown" };
+      },
+      activeModel: { provider: "openai", model: "whisper-1" },
+    });
+    expect(result.outputs[0]?.text).toBe("ok");
+    expect(seenModel).toBe("whisper-1");
+    expect(result.decision.outcome).toBe("success");
+  });
+
   it("skips auto audio when disabled", async () => {
     const result = await runAutoAudioCase({
       transcribeAudio: async () => ({

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -27,6 +27,7 @@ import { runExec } from "../process/exec.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { MediaAttachmentCache, selectAttachments } from "./attachments.js";
+import { resolveBundledDefaultMediaModel } from "./bundled-defaults.js";
 import { resolveAutoMediaKeyProviders, resolveDefaultMediaModel } from "./defaults.js";
 import { isMediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
@@ -587,6 +588,64 @@ export async function resolveAutoImageModel(params: {
   return toActive(keyEntry);
 }
 
+/**
+ * When auto-selecting STT from the active provider, `activeModel` usually mirrors the
+ * conversation model. Only reuse `activeModel.model` when it is plausibly a transcription
+ * model (explicit CLI `--model`, whisper-*, names containing "transcribe", provider STT
+ * defaults, etc.); otherwise let `runProviderEntry` pick the provider default STT model.
+ */
+function looksLikeDedicatedSpeechToTextModelId(modelId: string): boolean {
+  const m = normalizeLowercaseStringOrEmpty(modelId);
+  if (!m) {
+    return false;
+  }
+  if (m.includes("whisper")) {
+    return true;
+  }
+  if (m.includes("transcribe")) {
+    return true;
+  }
+  if (m.includes("nova-")) {
+    return true;
+  }
+  if (m.includes("voxtral")) {
+    return true;
+  }
+  return false;
+}
+
+function resolveAudioModelFromActiveModel(params: {
+  cfg: OpenClawConfig;
+  providerId: string;
+  providerRegistry: ProviderRegistry;
+  activeModel?: ActiveMediaModel;
+}): string | undefined {
+  const raw = params.activeModel?.model?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const defaultStt = resolveDefaultMediaModel({
+    cfg: params.cfg,
+    providerId: params.providerId,
+    capability: "audio",
+    providerRegistry: params.providerRegistry,
+  })?.trim();
+  if (defaultStt && raw === defaultStt) {
+    return raw;
+  }
+  const bundled = resolveBundledDefaultMediaModel({
+    providerId: params.providerId,
+    capability: "audio",
+  })?.trim();
+  if (bundled && raw === bundled) {
+    return raw;
+  }
+  if (looksLikeDedicatedSpeechToTextModelId(raw)) {
+    return raw;
+  }
+  return undefined;
+}
+
 async function resolveActiveModelEntry(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
@@ -623,8 +682,6 @@ async function resolveActiveModelEntry(params: {
   if (!hasAuth) {
     return null;
   }
-  // Audio transcription must use a speech-capable model (see bundled defaults), not the
-  // active chat model id (e.g. gpt-5.4), which is invalid for /audio/transcriptions.
   const model =
     params.capability === "image"
       ? await resolveAutoImageModelId({
@@ -633,7 +690,12 @@ async function resolveActiveModelEntry(params: {
           explicitModel: params.activeModel?.model,
         })
       : params.capability === "audio"
-        ? undefined
+        ? resolveAudioModelFromActiveModel({
+            cfg: params.cfg,
+            providerId,
+            providerRegistry: params.providerRegistry,
+            activeModel: params.activeModel,
+          })
         : params.activeModel?.model;
   if (params.capability === "image" && !model) {
     return null;

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -623,6 +623,8 @@ async function resolveActiveModelEntry(params: {
   if (!hasAuth) {
     return null;
   }
+  // Audio transcription must use a speech-capable model (see bundled defaults), not the
+  // active chat model id (e.g. gpt-5.4), which is invalid for /audio/transcriptions.
   const model =
     params.capability === "image"
       ? await resolveAutoImageModelId({
@@ -630,7 +632,9 @@ async function resolveActiveModelEntry(params: {
           providerId,
           explicitModel: params.activeModel?.model,
         })
-      : params.activeModel?.model;
+      : params.capability === "audio"
+        ? undefined
+        : params.activeModel?.model;
   if (params.capability === "image" && !model) {
     return null;
   }


### PR DESCRIPTION
## Summary

- Problem: Auto-selected inbound audio transcription reused the **active chat model id** (e.g. `gpt-5.4`) as the `/audio/transcriptions` model. That endpoint expects speech-to-text models, so transcription could fail and voice notes surfaced as raw attachments with no transcript echo (`tools.media.audio.echoTranscript`).
- Why it matters: Telegram and other channels rely on successful STT before the agent turn; failed STT matches reports in #63349.
- What changed: `resolveActiveModelEntry` no longer passes the chat model for the `audio` capability; `runProviderEntry` continues to resolve the provider default (e.g. OpenAI `gpt-4o-transcribe`) when no explicit `tools.media.audio.models` entry applies.
- What did NOT change: Explicit `tools.media.audio.models`, image/video active-model behavior, and non-auto entry paths are unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #63349
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: Active provider selection for auto audio correctly picked the same provider as chat but incorrectly forwarded the **conversation** model id into the transcription API.
- Missing detection / guardrail: Unit coverage now asserts auto audio does not pass a non-STT chat model when `activeModel` is set.

## Regression Test Plan

- Coverage level: Unit test
- Target test: `src/media-understanding/runner.auto-audio.test.ts`
- Scenario: `activeModel: { provider: "openai", model: "gpt-5.4" }` → transcription request uses `gpt-4o-transcribe`.

## User-visible / Behavior Changes

- Inbound voice/audio transcription when using auto model selection with the same provider as the active chat model now uses that provider’s default STT model instead of the chat model.

## Security Impact

- New permissions/capabilities? **No**
- New network endpoints or data exfiltration risk? **No**

## Changelog

- Entry added under **Unreleased → Fixes** in `CHANGELOG.md`.


Made with [Cursor](https://cursor.com)