### PR TITLE
fix(config): redact sourceConfig and runtimeConfig in config.get response

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -79,6 +79,73 @@ describe("redactConfigSnapshot", () => {
     expect(cfg.shortSecret.token).toBe(REDACTED_SENTINEL);
   });
 
+  it("redacts sourceConfig so gateway token does not leak", () => {
+    const snapshot = makeSnapshot({
+      gateway: {
+        auth: {
+          token: "super-secret-gateway-token-do-not-leak",
+        },
+      },
+    });
+    const result = redactConfigSnapshot(snapshot);
+
+    // config, parsed, resolved are known-redacted — verify as baseline
+    const cfg = result.config as Record<string, Record<string, Record<string, string>>>;
+    expect(cfg.gateway.auth.token).toBe(REDACTED_SENTINEL);
+
+    const parsed = result.parsed as Record<string, Record<string, Record<string, string>>>;
+    expect(parsed.gateway.auth.token).toBe(REDACTED_SENTINEL);
+
+    const resolved = result.resolved as Record<string, Record<string, Record<string, string>>>;
+    expect(resolved.gateway.auth.token).toBe(REDACTED_SENTINEL);
+
+    // sourceConfig and runtimeConfig must also be redacted
+    const src = result.sourceConfig as Record<string, Record<string, Record<string, string>>>;
+    expect(src.gateway.auth.token).toBe(REDACTED_SENTINEL);
+
+    const rt = result.runtimeConfig as Record<string, Record<string, Record<string, string>>>;
+    expect(rt.gateway.auth.token).toBe(REDACTED_SENTINEL);
+  });
+
+  it("redacts sourceConfig and runtimeConfig for all sensitive field patterns", () => {
+    const snapshot = makeSnapshot({
+      channels: {
+        telegram: { botToken: "telegram-bot-token-secret-value" },
+        slack: { signingSecret: "slack-signing-secret-value" },
+      },
+      models: {
+        providers: {
+          openai: { apiKey: "sk-proj-secret-key-value", baseUrl: "https://api.openai.com" },
+        },
+      },
+    });
+    const result = redactConfigSnapshot(snapshot);
+
+    // sourceConfig must have secrets redacted
+    const src = result.sourceConfig as typeof snapshot.config;
+    expect(src.channels.telegram.botToken).toBe(REDACTED_SENTINEL);
+    expect(src.channels.slack.signingSecret).toBe(REDACTED_SENTINEL);
+    expect(src.models.providers.openai.apiKey).toBe(REDACTED_SENTINEL);
+    expect(src.models.providers.openai.baseUrl).toBe("https://api.openai.com");
+
+    // runtimeConfig must have secrets redacted
+    const rt = result.runtimeConfig as typeof snapshot.config;
+    expect(rt.channels.telegram.botToken).toBe(REDACTED_SENTINEL);
+    expect(rt.channels.slack.signingSecret).toBe(REDACTED_SENTINEL);
+    expect(rt.models.providers.openai.apiKey).toBe(REDACTED_SENTINEL);
+    expect(rt.models.providers.openai.baseUrl).toBe("https://api.openai.com");
+  });
+
+  it("does not leak raw gateway token anywhere in the serialized snapshot", () => {
+    const secretToken = "gateway-token-that-must-never-appear-in-output";
+    const snapshot = makeSnapshot({
+      gateway: { auth: { token: secretToken } },
+    });
+    const result = redactConfigSnapshot(snapshot);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(secretToken);
+  });
+
   it("redacts googlechat serviceAccount object payloads", () => {
     const snapshot = makeSnapshot({
       channels: {

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -680,6 +680,32 @@ describe("redactConfigSnapshot", () => {
     expect(result.resolved).toEqual({});
   });
 
+  it("redacts sourceConfig and runtimeConfig for invalid snapshots", () => {
+    const snapshot: ConfigFileSnapshot = {
+      path: "/test",
+      exists: true,
+      raw: '{ "gateway": { "auth": { "token": "leaky-secret" } } }',
+      parsed: { gateway: { auth: { token: "leaky-secret" } } },
+      sourceConfig: {
+        gateway: { auth: { token: "leaky-secret" } },
+      } as ConfigFileSnapshot["sourceConfig"],
+      resolved: {
+        gateway: { auth: { token: "leaky-secret" } },
+      } as ConfigFileSnapshot["resolved"],
+      valid: false,
+      runtimeConfig: {
+        gateway: { auth: { token: "leaky-secret" } },
+      } as ConfigFileSnapshot["runtimeConfig"],
+      config: {} as ConfigFileSnapshot["config"],
+      issues: [{ path: "", message: "invalid config" }],
+      warnings: [],
+      legacyIssues: [],
+    };
+    const result = redactConfigSnapshot(snapshot);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("leaky-secret");
+  });
+
   it("handles deeply nested tokens in accounts", () => {
     const snapshot = makeSnapshot({
       channels: {

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -424,6 +424,8 @@ export function redactConfigSnapshot(
       raw: null,
       parsed: null,
       resolved: {},
+      sourceConfig: redactConfigObject(snapshot.sourceConfig, uiHints),
+      runtimeConfig: redactConfigObject(snapshot.runtimeConfig, uiHints),
     };
   }
   // else: snapshot.config must be valid and populated, as that is what

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -447,6 +447,11 @@ export function redactConfigSnapshot(
   }
   // Also redact the resolved config (contains values after ${ENV} substitution)
   const redactedResolved = redactConfigObject(snapshot.resolved, uiHints);
+  // Redact sourceConfig and runtimeConfig to prevent leaking secrets through
+  // the spread of the original snapshot (these were previously passed through
+  // unredacted, exposing e.g. gateway.auth.token to operator.read clients).
+  const redactedSourceConfig = redactConfigObject(snapshot.sourceConfig, uiHints);
+  const redactedRuntimeConfig = redactConfigObject(snapshot.runtimeConfig, uiHints);
 
   return {
     ...snapshot,
@@ -454,6 +459,8 @@ export function redactConfigSnapshot(
     raw: redactedRaw,
     parsed: redactedParsed,
     resolved: redactedResolved,
+    sourceConfig: redactedSourceConfig,
+    runtimeConfig: redactedRuntimeConfig,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Problem**: `redactConfigSnapshot()` spreads the original snapshot (`...snapshot`) but only overrides `config`, `raw`, `parsed`, and `resolved` with redacted versions. The `sourceConfig` and `runtimeConfig` fields pass through **unredacted**, exposing secrets (e.g. `gateway.auth.token`) to any client with `operator.read` scope via `config.get`.
- **Impact**: Privilege escalation — a read-only operator can extract the gateway token from `sourceConfig.gateway.auth.token` or `runtimeConfig.gateway.auth.token` and re-authenticate with admin scope.
- **Fix**: Apply `redactConfigObject()` to `sourceConfig` and `runtimeConfig` before returning, matching the existing treatment of `resolved`.
- **What did NOT change**: No scope changes, no new dependencies, no behavioral changes to `config`, `raw`, `parsed`, or `resolved` redaction.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens
- [x] API / contracts

## Linked Issue/PR

- N/A — discovered via external security audit PoC

## Root Cause (if applicable)

- **Root cause**: `src/config/redact-snapshot.ts:451-457` — the spread operator `...snapshot` copies all fields including `sourceConfig` and `runtimeConfig`, then only `config`, `raw`, `parsed`, and `resolved` are overridden with redacted versions. The two remaining config representations were never added to the explicit redaction list.
- **Missing detection**: No test asserted that `sourceConfig` or `runtimeConfig` were redacted; existing tests only checked `config`, `parsed`, `resolved`, and `raw`.

## Regression Test Plan

- **Coverage level**: Unit tests
- **Target tests**: `src/config/redact-snapshot.test.ts`
- **3 new tests added**:
  1. `redacts sourceConfig so gateway token does not leak` — verifies `sourceConfig.gateway.auth.token` and `runtimeConfig.gateway.auth.token` are replaced with the redaction sentinel
  2. `redacts sourceConfig and runtimeConfig for all sensitive field patterns` — verifies botToken, signingSecret, apiKey across both fields, while preserving non-sensitive values like `baseUrl`
  3. `does not leak raw gateway token anywhere in the serialized snapshot` — serializes the entire snapshot to JSON and asserts the plaintext token does not appear anywhere

## User-visible Changes

None — redaction is transparent to UI consumers that already handle the `__OPENCLAW_REDACTED__` sentinel.

## Security Impact

- **Secrets/credentials**: Yes — this fix prevents gateway auth tokens, API keys, bot tokens, and other sensitive config values from leaking through `sourceConfig` and `runtimeConfig` in `config.get` responses.
- **Risk**: The prior behavior allowed any `operator.read` client to obtain the gateway token and escalate to admin. The fix closes this path.

## Evidence

Failing test output before fix:
```
FAIL  redacts sourceConfig and runtimeConfig for all sensitive field patterns
  expected 'telegram-bot-token-secret-value' to be '__OPENCLAW_REDACTED__'

FAIL  does not leak raw gateway token anywhere in the serialized snapshot
  serialized snapshot contains 'gateway-token-that-must-never-appear-in-output'
  leaked through sourceConfig and runtimeConfig
```

After fix: all 62 tests pass across 4 redact-snapshot test files (41 in main file).

## Human Verification

- [x] Confirmed `sourceConfig` and `runtimeConfig` leaked plaintext tokens before fix
- [x] Confirmed all 3 new tests fail before fix, pass after
- [x] Confirmed all 62 existing redact-snapshot tests still pass
- [x] `pnpm check` passes (tsgo, oxlint, format, all lint gates)

## Review Conversations

N/A — new PR

## Compatibility / Migration

- [x] Backward compatible — no config changes, no new fields, no migration needed
- Clients that previously read secrets from `sourceConfig`/`runtimeConfig` will now see `__OPENCLAW_REDACTED__` (same sentinel used in all other redacted fields)