### PR TITLE
fix(feishu): clean deprecated keys in doctor --fix

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,4 +1,5 @@
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import { feishuDoctor } from "./doctor.js";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createMessageToolCardSchema } from "openclaw/plugin-sdk/channel-actions";
 import {
@@ -541,6 +542,7 @@ function resolveFeishuMemberIdType(
 export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResult> =
   createChatChannelPlugin({
     base: {
+      doctor: feishuDoctor,
       id: "feishu",
       meta: {
         ...meta,

--- a/extensions/feishu/src/doctor.test.ts
+++ b/extensions/feishu/src/doctor.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { cleanStaleFeishuConfig } from "./doctor.js";
+
+describe("cleanStaleFeishuConfig", () => {
+  it("returns unchanged config when no feishu channel", async () => {
+    const cfg = {} as Parameters<typeof cleanStaleFeishuConfig>[0]["cfg"];
+    const result = await cleanStaleFeishuConfig({ cfg });
+    expect(result.changes).toHaveLength(0);
+    expect(result.config).toBe(cfg);
+  });
+
+  it("returns unchanged config when feishu config has no deprecated keys", async () => {
+    const cfg = {
+      channels: { feishu: { appId: "test-app", enabled: true } },
+    } as Parameters<typeof cleanStaleFeishuConfig>[0]["cfg"];
+    const result = await cleanStaleFeishuConfig({ cfg });
+    expect(result.changes).toHaveLength(0);
+  });
+
+  it("removes top-level ackReaction deprecated key", async () => {
+    const cfg = {
+      channels: { feishu: { appId: "test-app", ackReaction: "👍" } },
+    } as Parameters<typeof cleanStaleFeishuConfig>[0]["cfg"];
+    const result = await cleanStaleFeishuConfig({ cfg });
+    expect(result.changes.some((c) => c.includes('channels.feishu.ackReaction'))).toBe(true);
+    const feishu = (result.config.channels as Record<string, Record<string, unknown>>).feishu;
+    expect(feishu).not.toHaveProperty("ackReaction");
+    expect(feishu).toHaveProperty("appId");
+  });
+
+  it("removes top-level threadSession deprecated key", async () => {
+    const cfg = {
+      channels: { feishu: { appId: "test-app", threadSession: true } },
+    } as Parameters<typeof cleanStaleFeishuConfig>[0]["cfg"];
+    const result = await cleanStaleFeishuConfig({ cfg });
+    expect(result.changes.some((c) => c.includes('channels.feishu.threadSession'))).toBe(true);
+    const feishu = (result.config.channels as Record<string, Record<string, unknown>>).feishu;
+    expect(feishu).not.toHaveProperty("threadSession");
+  });
+
+  it("removes deprecated keys from account-level config", async () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          appId: "test-app",
+          accounts: {
+            default: { appId: "account-app", ackReaction: "👍" },
+          },
+        },
+      },
+    } as Parameters<typeof cleanStaleFeishuConfig>[0]["cfg"];
+    const result = await cleanStaleFeishuConfig({ cfg });
+    expect(
+      result.changes.some((c) => c.includes("channels.feishu.accounts.default.ackReaction")),
+    ).toBe(true);
+  });
+
+  it("removes both ackReaction and threadSession when both present", async () => {
+    const cfg = {
+      channels: {
+        feishu: { appId: "test-app", ackReaction: "👍", threadSession: true },
+      },
+    } as Parameters<typeof cleanStaleFeishuConfig>[0]["cfg"];
+    const result = await cleanStaleFeishuConfig({ cfg });
+    expect(result.changes).toHaveLength(2);
+    const feishu = (result.config.channels as Record<string, Record<string, unknown>>).feishu;
+    expect(feishu).not.toHaveProperty("ackReaction");
+    expect(feishu).not.toHaveProperty("threadSession");
+    expect(feishu).toHaveProperty("appId");
+  });
+});

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -1,0 +1,97 @@
+import type {
+  ChannelDoctorAdapter,
+  ChannelDoctorConfigMutation,
+} from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+const DEPRECATED_FEISHU_KEYS = ["ackReaction", "threadSession"] as const;
+
+function cleanDeprecatedKeys(
+  entry: Record<string, unknown>,
+  pathLabel: string,
+  changes: string[],
+): { entry: Record<string, unknown>; changed: boolean } {
+  let changed = false;
+  const next = { ...entry };
+  for (const key of DEPRECATED_FEISHU_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(next, key)) {
+      delete next[key];
+      changes.push(`Removed deprecated key "${pathLabel}.${key}".`);
+      changed = true;
+    }
+  }
+  return { entry: next, changed };
+}
+
+export async function cleanStaleFeishuConfig({
+  cfg,
+}: {
+  cfg: OpenClawConfig;
+}): Promise<ChannelDoctorConfigMutation> {
+  const rawFeishu = asObjectRecord(
+    (cfg.channels as Record<string, unknown> | undefined)?.feishu,
+  );
+  if (!rawFeishu) {
+    return { config: cfg, changes: [] };
+  }
+
+  const changes: string[] = [];
+  let feishuChanged = false;
+  let nextFeishu = { ...rawFeishu };
+
+  // Clean top-level deprecated keys
+  const topLevel = cleanDeprecatedKeys(nextFeishu, "channels.feishu", changes);
+  nextFeishu = topLevel.entry;
+  feishuChanged = feishuChanged || topLevel.changed;
+
+  // Clean account-level deprecated keys
+  const rawAccounts = asObjectRecord(nextFeishu.accounts);
+  if (rawAccounts) {
+    let accountsChanged = false;
+    const accounts = { ...rawAccounts };
+    for (const [accountId, rawAccount] of Object.entries(rawAccounts)) {
+      const account = asObjectRecord(rawAccount);
+      if (!account) {
+        continue;
+      }
+      const cleaned = cleanDeprecatedKeys(
+        account,
+        `channels.feishu.accounts.${accountId}`,
+        changes,
+      );
+      if (cleaned.changed) {
+        accounts[accountId] = cleaned.entry;
+        accountsChanged = true;
+      }
+    }
+    if (accountsChanged) {
+      nextFeishu = { ...nextFeishu, accounts };
+      feishuChanged = true;
+    }
+  }
+
+  if (!feishuChanged) {
+    return { config: cfg, changes: [] };
+  }
+
+  return {
+    config: {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        feishu: nextFeishu as unknown as NonNullable<OpenClawConfig["channels"]>["feishu"],
+      } as OpenClawConfig["channels"],
+    },
+    changes,
+  };
+}
+
+export const feishuDoctor: ChannelDoctorAdapter = {
+  cleanStaleConfig: cleanStaleFeishuConfig,
+};


### PR DESCRIPTION
## Summary

In v4.8, `ackReaction` and `threadSession` were removed from the Feishu channel config schema. However, `doctor --fix` did not gain a corresponding cleanup step to remove these deprecated keys from existing user configs.

This causes validation failures on upgrade:
```
channels.feishu: invalid config: must NOT have additional properties
```

## Fix

Add a `cleanStaleConfig` implementation to the Feishu channel doctor that removes `ackReaction` and `threadSession` keys from both top-level and account-level Feishu config.

## Changes

- **extensions/feishu/src/doctor.ts**: New file implementing `feishuDoctor` with `cleanStaleConfig` to remove deprecated keys
- **extensions/feishu/src/doctor.test.ts**: Tests covering top-level and account-level cleanup
- **extensions/feishu/src/channel.ts**: Wire `feishuDoctor` into the `feishuPlugin`

## Testing

```
✓ extension-feishu extensions/feishu/src/doctor.test.ts (6 tests)
```

Fixes #63101