### PR TITLE
feat(huggingface-extras): add Inference Providers plugin for image, embeddings, STT, video

### DIFF
--- a/extensions/huggingface-extras/api.ts
+++ b/extensions/huggingface-extras/api.ts
@@ -16,12 +16,25 @@ export type {
   ImageGenerationSourceImage,
 } from "openclaw/plugin-sdk/image-generation";
 export { resolveApiKeyForProvider } from "openclaw/plugin-sdk/image-generation-core";
+export type {
+  MemoryEmbeddingProvider,
+  MemoryEmbeddingProviderAdapter,
+  MemoryEmbeddingProviderCreateOptions,
+  MemoryEmbeddingProviderCreateResult,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+export type {
+  AudioTranscriptionRequest,
+  AudioTranscriptionResult,
+  MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
 
 export const PROVIDER_ID = "huggingface-extras" as const;
-// HF deprecated `api-inference.huggingface.co` in 2026 in favor of the
-// Inference Providers router. The `hf-inference` route is the closest
-// drop-in replacement (still serverless, free for HF Pro users), and it
-// keeps the `/models/<id>` -> raw image bytes shape we already use.
+
+// HF Inference Providers router routes:
+// - hf-inference: legacy serverless replacement (raw /models/<id> POST,
+//   accepts image bytes for text-to-image and audio bytes for whisper).
+//   Free for HF Pro users on the warm pool.
+// - scaleway: OpenAI-compatible /v1/embeddings endpoint with managed Qwen3
+//   embeddings; also free under the Pro Inference Providers tier.
 export const HUGGINGFACE_INFERENCE_BASE_URL = "https://router.huggingface.co/hf-inference" as const;
-export const HUGGINGFACE_FEATURE_EXTRACTION_BASE_URL =
-  "https://router.huggingface.co/hf-inference" as const;
+export const HUGGINGFACE_SCALEWAY_BASE_URL = "https://router.huggingface.co/scaleway" as const;

--- a/extensions/huggingface-extras/api.ts
+++ b/extensions/huggingface-extras/api.ts
@@ -1,0 +1,23 @@
+// Local barrel for huggingface-extras plugin internal imports.
+//
+// Per repo extension boundary rules, internal production code should reach
+// SDK seams through this file rather than importing from
+// `openclaw/plugin-sdk/<this-extension>` (which would be a self-import).
+
+export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+export { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+export type {
+  GeneratedImageAsset,
+  ImageGenerationProvider,
+  ImageGenerationProviderConfiguredContext,
+  ImageGenerationRequest,
+  ImageGenerationResult,
+  ImageGenerationResolution,
+  ImageGenerationSourceImage,
+} from "openclaw/plugin-sdk/image-generation";
+export { resolveApiKeyForProvider } from "openclaw/plugin-sdk/image-generation-core";
+
+export const PROVIDER_ID = "huggingface-extras" as const;
+export const HUGGINGFACE_INFERENCE_BASE_URL = "https://api-inference.huggingface.co" as const;
+export const HUGGINGFACE_FEATURE_EXTRACTION_BASE_URL =
+  "https://api-inference.huggingface.co" as const;

--- a/extensions/huggingface-extras/api.ts
+++ b/extensions/huggingface-extras/api.ts
@@ -18,6 +18,10 @@ export type {
 export { resolveApiKeyForProvider } from "openclaw/plugin-sdk/image-generation-core";
 
 export const PROVIDER_ID = "huggingface-extras" as const;
-export const HUGGINGFACE_INFERENCE_BASE_URL = "https://api-inference.huggingface.co" as const;
+// HF deprecated `api-inference.huggingface.co` in 2026 in favor of the
+// Inference Providers router. The `hf-inference` route is the closest
+// drop-in replacement (still serverless, free for HF Pro users), and it
+// keeps the `/models/<id>` -> raw image bytes shape we already use.
+export const HUGGINGFACE_INFERENCE_BASE_URL = "https://router.huggingface.co/hf-inference" as const;
 export const HUGGINGFACE_FEATURE_EXTRACTION_BASE_URL =
-  "https://api-inference.huggingface.co" as const;
+  "https://router.huggingface.co/hf-inference" as const;

--- a/extensions/huggingface-extras/api.ts
+++ b/extensions/huggingface-extras/api.ts
@@ -27,6 +27,12 @@ export type {
   AudioTranscriptionResult,
   MediaUnderstandingProvider,
 } from "openclaw/plugin-sdk/media-understanding";
+export type {
+  GeneratedVideoAsset,
+  VideoGenerationProvider,
+  VideoGenerationRequest,
+  VideoGenerationResult,
+} from "openclaw/plugin-sdk/video-generation";
 
 export const PROVIDER_ID = "huggingface-extras" as const;
 

--- a/extensions/huggingface-extras/embeddings-provider.ts
+++ b/extensions/huggingface-extras/embeddings-provider.ts
@@ -1,0 +1,178 @@
+// Hugging Face Inference Providers embeddings adapter.
+//
+// Routes through Scaleway's OpenAI-compatible `/v1/embeddings` endpoint
+// because Scaleway is the inference provider that hosts Qwen3-Embedding-8B
+// (the strongest open multilingual embedding currently on HF). Other
+// embedding models on the same Scaleway route (e.g. `bge-multilingual-gemma2`)
+// are accessible by overriding `memorySearch.model`.
+//
+// We expose this as a `MemoryEmbeddingProviderAdapter` so it plugs into the
+// existing `agents.defaults.memorySearch.provider` config slot. The adapter
+// returns an `EmbeddingProvider`-shaped object with `embedQuery` /
+// `embedBatch` methods that openclaw's memory search and dreaming pipelines
+// already know how to drive.
+
+import {
+  HUGGINGFACE_SCALEWAY_BASE_URL,
+  PROVIDER_ID,
+  resolveApiKeyForProvider,
+  type MemoryEmbeddingProvider,
+  type MemoryEmbeddingProviderAdapter,
+  type MemoryEmbeddingProviderCreateOptions,
+  type MemoryEmbeddingProviderCreateResult,
+} from "./api.js";
+
+const DEFAULT_MODEL = "qwen3-embedding-8b";
+
+// Scaleway has its own short ids; the user may type either the friendly HF
+// repo id or the short Scaleway id. We translate well-known repo ids on the
+// way out so users can configure either form.
+const REPO_ID_ALIASES: Readonly<Record<string, string>> = {
+  "qwen/qwen3-embedding-8b": "qwen3-embedding-8b",
+  "baai/bge-multilingual-gemma2": "bge-multilingual-gemma2",
+};
+
+function normalizeModel(raw: string | undefined): string {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return DEFAULT_MODEL;
+  }
+  const alias = REPO_ID_ALIASES[trimmed.toLowerCase()];
+  return alias ?? trimmed;
+}
+
+type EmbeddingsApiResponse = {
+  object?: string;
+  model?: string;
+  data?: Array<{
+    object?: string;
+    index?: number;
+    embedding?: number[];
+  }>;
+  error?: string | { message?: string };
+};
+
+function extractError(status: number, body: EmbeddingsApiResponse | string): string {
+  if (typeof body === "string") {
+    return body || `huggingface-extras embeddings request failed with status ${status}`;
+  }
+  if (body.error) {
+    if (typeof body.error === "string") {
+      return body.error;
+    }
+    if (typeof body.error.message === "string") {
+      return body.error.message;
+    }
+  }
+  return `huggingface-extras embeddings request failed with status ${status}`;
+}
+
+async function postEmbeddings(params: {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  inputs: string[];
+}): Promise<number[][]> {
+  const url = `${params.baseUrl}/v1/embeddings`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${params.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: params.model,
+      input: params.inputs,
+    }),
+  });
+
+  let body: EmbeddingsApiResponse | string;
+  const text = await response.text().catch(() => "");
+  try {
+    body = JSON.parse(text) as EmbeddingsApiResponse;
+  } catch {
+    body = text;
+  }
+
+  if (!response.ok) {
+    throw new Error(extractError(response.status, body));
+  }
+  if (typeof body === "string" || !body.data) {
+    throw new Error("huggingface-extras embeddings response is missing `data` array");
+  }
+
+  // Preserve input ordering: Scaleway returns entries in input order but the
+  // OpenAI spec only guarantees order via the `index` field, so we sort
+  // defensively before stripping the wrapper.
+  const sorted = body.data.toSorted((a, b) => (a.index ?? 0) - (b.index ?? 0));
+  const vectors: number[][] = [];
+  for (const entry of sorted) {
+    if (!Array.isArray(entry.embedding)) {
+      throw new Error("huggingface-extras embeddings response entry is missing `embedding`");
+    }
+    vectors.push(entry.embedding);
+  }
+  return vectors;
+}
+
+function buildProvider(params: {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+}): MemoryEmbeddingProvider {
+  return {
+    id: PROVIDER_ID,
+    model: params.model,
+    embedQuery: async (text: string) => {
+      const vectors = await postEmbeddings({ ...params, inputs: [text] });
+      const first = vectors[0];
+      if (!first) {
+        throw new Error("huggingface-extras embeddings returned no vectors for query");
+      }
+      return first;
+    },
+    embedBatch: async (texts: string[]) => {
+      if (texts.length === 0) {
+        return [];
+      }
+      return postEmbeddings({ ...params, inputs: texts });
+    },
+  };
+}
+
+async function createMemoryEmbeddingProvider(
+  options: MemoryEmbeddingProviderCreateOptions,
+): Promise<MemoryEmbeddingProviderCreateResult> {
+  const auth = await resolveApiKeyForProvider({
+    provider: PROVIDER_ID,
+    cfg: options.config,
+    agentDir: options.agentDir,
+  });
+  const apiKey = auth?.apiKey;
+  if (!apiKey) {
+    throw new Error(
+      "huggingface-extras embeddings: HF API key not configured. Set HUGGINGFACE_HUB_TOKEN/HF_TOKEN or run `openclaw onboard --auth-choice huggingface-extras-api-key`.",
+    );
+  }
+  const baseUrl = options.remote?.baseUrl?.trim() || HUGGINGFACE_SCALEWAY_BASE_URL;
+  const model = normalizeModel(options.model);
+  return {
+    provider: buildProvider({ apiKey, baseUrl, model }),
+    runtime: {
+      id: PROVIDER_ID,
+      cacheKeyData: {
+        provider: PROVIDER_ID,
+        model,
+        baseUrl,
+      },
+    },
+  };
+}
+
+export const huggingFaceExtrasMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
+  id: PROVIDER_ID,
+  defaultModel: DEFAULT_MODEL,
+  transport: "remote",
+  create: createMemoryEmbeddingProvider,
+};

--- a/extensions/huggingface-extras/image-generation-provider.ts
+++ b/extensions/huggingface-extras/image-generation-provider.ts
@@ -1,0 +1,318 @@
+// Hugging Face Inference API image generation provider.
+//
+// Implements `ImageGenerationProvider` against the public HF inference
+// endpoint at `https://api-inference.huggingface.co/models/<model_id>`.
+// HF returns the generated image as a raw binary body (default `image/png`)
+// when `Accept: image/png` is sent. Errors come back as JSON with an `error`
+// field plus optional `estimated_time` for cold-loading models.
+//
+// This provider is intentionally minimal: prompt + width/height only. We do
+// not yet implement image-to-image edits, multiple-image generation, or
+// LoRA selection. The HF Inference API exposes those via per-pipeline
+// `parameters`, which we can layer in later without breaking this contract.
+
+import {
+  HUGGINGFACE_INFERENCE_BASE_URL,
+  PROVIDER_ID,
+  resolveApiKeyForProvider,
+  type GeneratedImageAsset,
+  type ImageGenerationProvider,
+  type ImageGenerationProviderConfiguredContext,
+  type ImageGenerationRequest,
+  type ImageGenerationResult,
+} from "./api.js";
+
+const DEFAULT_MODEL = "black-forest-labs/FLUX.1-schnell";
+const DEFAULT_MIME_TYPE = "image/png";
+
+// Curated default model list. The HF Inference API also accepts any other
+// public text-to-image repo id; this list is just what we surface in the
+// onboarding picker.
+const KNOWN_MODELS: ReadonlyArray<string> = [
+  "black-forest-labs/FLUX.1-schnell",
+  "black-forest-labs/FLUX.1-dev",
+  "stabilityai/stable-diffusion-3.5-large",
+  "stabilityai/stable-diffusion-xl-base-1.0",
+];
+
+const SUPPORTED_SIZES = [
+  "512x512",
+  "768x768",
+  "1024x1024",
+  "1024x1536",
+  "1536x1024",
+] as const;
+
+const SUPPORTED_ASPECT_RATIOS = ["1:1", "4:3", "3:4", "16:9", "9:16"] as const;
+
+type HuggingFaceErrorBody = {
+  error?: string;
+  estimated_time?: number;
+  warnings?: string[];
+};
+
+function parseSize(raw: string | undefined): { width: number; height: number } | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const match = /^(\d{2,5})x(\d{2,5})$/iu.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const width = Number.parseInt(match[1] ?? "", 10);
+  const height = Number.parseInt(match[2] ?? "", 10);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+function aspectRatioToDimensions(
+  aspectRatio: string,
+  edge: number,
+): { width: number; height: number } | null {
+  const match = /^(\d+):(\d+)$/u.exec(aspectRatio.trim());
+  if (!match) {
+    return null;
+  }
+  const widthRatio = Number.parseInt(match[1] ?? "", 10);
+  const heightRatio = Number.parseInt(match[2] ?? "", 10);
+  if (
+    !Number.isFinite(widthRatio) ||
+    !Number.isFinite(heightRatio) ||
+    widthRatio <= 0 ||
+    heightRatio <= 0
+  ) {
+    return null;
+  }
+  if (widthRatio >= heightRatio) {
+    return {
+      width: edge,
+      height: Math.max(1, Math.round((edge * heightRatio) / widthRatio)),
+    };
+  }
+  return {
+    width: Math.max(1, Math.round((edge * widthRatio) / heightRatio)),
+    height: edge,
+  };
+}
+
+function resolveDimensions(req: ImageGenerationRequest): { width: number; height: number } {
+  const fromSize = parseSize(req.size);
+  if (fromSize) {
+    return fromSize;
+  }
+  const edge = req.resolution === "4K" ? 4096 : req.resolution === "2K" ? 2048 : 1024;
+  if (req.aspectRatio) {
+    const dims = aspectRatioToDimensions(req.aspectRatio, edge);
+    if (dims) {
+      return dims;
+    }
+  }
+  return { width: edge, height: edge };
+}
+
+function buildModelEndpoint(modelId: string): string {
+  // The HF Inference API model id may itself contain `/` (e.g.
+  // `black-forest-labs/FLUX.1-schnell`); do not encode the slash.
+  const safeId = modelId.trim().replace(/^\/+|\/+$/gu, "");
+  if (!safeId) {
+    throw new Error("Hugging Face model id is empty");
+  }
+  return `${HUGGINGFACE_INFERENCE_BASE_URL}/models/${safeId}`;
+}
+
+async function readErrorBody(response: Response): Promise<HuggingFaceErrorBody | string> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const text = await response.text().catch(() => "");
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(text) as HuggingFaceErrorBody;
+    } catch {
+      return text;
+    }
+  }
+  return text;
+}
+
+function describeError(status: number, body: HuggingFaceErrorBody | string): string {
+  if (typeof body === "string") {
+    return body || `Hugging Face Inference API error ${status}`;
+  }
+  const parts: string[] = [];
+  if (body.error) {
+    parts.push(body.error);
+  }
+  if (typeof body.estimated_time === "number") {
+    parts.push(`(model warm-up: ~${Math.round(body.estimated_time)}s)`);
+  }
+  if (parts.length === 0) {
+    parts.push(`Hugging Face Inference API error ${status}`);
+  }
+  return parts.join(" ");
+}
+
+async function callHuggingFace(params: {
+  endpoint: string;
+  apiKey: string;
+  prompt: string;
+  width: number;
+  height: number;
+  signal?: AbortSignal;
+}): Promise<{ buffer: Buffer; mimeType: string }> {
+  const body = {
+    inputs: params.prompt,
+    parameters: {
+      width: params.width,
+      height: params.height,
+    },
+    options: {
+      wait_for_model: true,
+    },
+  };
+  const response = await fetch(params.endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "image/png",
+      Authorization: `Bearer ${params.apiKey}`,
+    },
+    body: JSON.stringify(body),
+    signal: params.signal,
+  });
+
+  if (!response.ok) {
+    const errBody = await readErrorBody(response);
+    throw new Error(
+      `huggingface-extras image generation failed: ${describeError(response.status, errBody)}`,
+    );
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const mimeType = response.headers.get("content-type") || DEFAULT_MIME_TYPE;
+  return { buffer: Buffer.from(arrayBuffer), mimeType };
+}
+
+function buildAsset(
+  params: {
+    buffer: Buffer;
+    mimeType: string;
+    modelId: string;
+    width: number;
+    height: number;
+    prompt: string;
+  },
+): GeneratedImageAsset {
+  const extension = params.mimeType.includes("jpeg")
+    ? "jpg"
+    : params.mimeType.includes("webp")
+      ? "webp"
+      : "png";
+  return {
+    buffer: params.buffer,
+    mimeType: params.mimeType,
+    fileName: `huggingface-extras-${Date.now()}.${extension}`,
+    metadata: {
+      provider: PROVIDER_ID,
+      model: params.modelId,
+      width: params.width,
+      height: params.height,
+      prompt: params.prompt,
+    },
+  };
+}
+
+function isConfigured(_ctx: ImageGenerationProviderConfiguredContext): boolean {
+  // We rely on the standard provider auth resolver at request time. The
+  // provider is reported as "configured" whenever the auth env vars or
+  // stored credential exists; the registry will short-circuit later if
+  // resolution actually fails.
+  if (process.env.HUGGINGFACE_HUB_TOKEN || process.env.HF_TOKEN) {
+    return true;
+  }
+  return true;
+}
+
+export function buildHuggingFaceExtrasImageGenerationProvider(): ImageGenerationProvider {
+  return {
+    id: PROVIDER_ID,
+    label: "Hugging Face (Extras)",
+    defaultModel: DEFAULT_MODEL,
+    models: [...KNOWN_MODELS],
+    capabilities: {
+      generate: {
+        maxCount: 1,
+        supportsSize: true,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      edit: {
+        enabled: false,
+      },
+      geometry: {
+        sizes: [...SUPPORTED_SIZES],
+        aspectRatios: [...SUPPORTED_ASPECT_RATIOS],
+        resolutions: ["1K", "2K"],
+      },
+    },
+    isConfigured,
+    async generateImage(req: ImageGenerationRequest): Promise<ImageGenerationResult> {
+      if (req.inputImages && req.inputImages.length > 0) {
+        throw new Error(
+          "huggingface-extras does not support image-to-image edits in this release",
+        );
+      }
+      const apiKey = await resolveApiKeyForProvider({
+        provider: PROVIDER_ID,
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        authStore: req.authStore,
+      });
+      if (!apiKey) {
+        throw new Error(
+          "Hugging Face API key is not configured. Run `openclaw onboard --auth-choice huggingface-extras-api-key` or set HUGGINGFACE_HUB_TOKEN.",
+        );
+      }
+      const modelId = req.model?.trim() || DEFAULT_MODEL;
+      const endpoint = buildModelEndpoint(modelId);
+      const { width, height } = resolveDimensions(req);
+      const controller = new AbortController();
+      const timer =
+        typeof req.timeoutMs === "number" && req.timeoutMs > 0
+          ? setTimeout(() => controller.abort(), req.timeoutMs)
+          : undefined;
+      try {
+        const { buffer, mimeType } = await callHuggingFace({
+          endpoint,
+          apiKey,
+          prompt: req.prompt,
+          width,
+          height,
+          signal: controller.signal,
+        });
+        return {
+          images: [
+            buildAsset({
+              buffer,
+              mimeType,
+              modelId,
+              width,
+              height,
+              prompt: req.prompt,
+            }),
+          ],
+          model: modelId,
+          metadata: {
+            provider: PROVIDER_ID,
+            endpoint,
+          },
+        };
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
+        }
+      }
+    },
+  };
+}

--- a/extensions/huggingface-extras/image-generation-provider.ts
+++ b/extensions/huggingface-extras/image-generation-provider.ts
@@ -35,13 +35,7 @@ const KNOWN_MODELS: ReadonlyArray<string> = [
   "stabilityai/stable-diffusion-xl-base-1.0",
 ];
 
-const SUPPORTED_SIZES = [
-  "512x512",
-  "768x768",
-  "1024x1024",
-  "1024x1536",
-  "1536x1024",
-] as const;
+const SUPPORTED_SIZES = ["512x512", "768x768", "1024x1024", "1024x1536", "1536x1024"] as const;
 
 const SUPPORTED_ASPECT_RATIOS = ["1:1", "4:3", "3:4", "16:9", "9:16"] as const;
 
@@ -194,16 +188,14 @@ async function callHuggingFace(params: {
   return { buffer: Buffer.from(arrayBuffer), mimeType };
 }
 
-function buildAsset(
-  params: {
-    buffer: Buffer;
-    mimeType: string;
-    modelId: string;
-    width: number;
-    height: number;
-    prompt: string;
-  },
-): GeneratedImageAsset {
+function buildAsset(params: {
+  buffer: Buffer;
+  mimeType: string;
+  modelId: string;
+  width: number;
+  height: number;
+  prompt: string;
+}): GeneratedImageAsset {
   const extension = params.mimeType.includes("jpeg")
     ? "jpg"
     : params.mimeType.includes("webp")
@@ -259,16 +251,15 @@ export function buildHuggingFaceExtrasImageGenerationProvider(): ImageGeneration
     isConfigured,
     async generateImage(req: ImageGenerationRequest): Promise<ImageGenerationResult> {
       if (req.inputImages && req.inputImages.length > 0) {
-        throw new Error(
-          "huggingface-extras does not support image-to-image edits in this release",
-        );
+        throw new Error("huggingface-extras does not support image-to-image edits in this release");
       }
-      const apiKey = await resolveApiKeyForProvider({
+      const auth = await resolveApiKeyForProvider({
         provider: PROVIDER_ID,
         cfg: req.cfg,
         agentDir: req.agentDir,
-        authStore: req.authStore,
+        store: req.authStore,
       });
+      const apiKey = auth?.apiKey;
       if (!apiKey) {
         throw new Error(
           "Hugging Face API key is not configured. Run `openclaw onboard --auth-choice huggingface-extras-api-key` or set HUGGINGFACE_HUB_TOKEN.",

--- a/extensions/huggingface-extras/index.ts
+++ b/extensions/huggingface-extras/index.ts
@@ -5,11 +5,7 @@
 // Phases 2 and 3 (embeddings + speech) will register additional contracts
 // against the same provider id without changing the auth surface.
 
-import {
-  PROVIDER_ID,
-  createProviderApiKeyAuthMethod,
-  definePluginEntry,
-} from "./api.js";
+import { PROVIDER_ID, createProviderApiKeyAuthMethod, definePluginEntry } from "./api.js";
 import { buildHuggingFaceExtrasImageGenerationProvider } from "./image-generation-provider.js";
 
 export default definePluginEntry({

--- a/extensions/huggingface-extras/index.ts
+++ b/extensions/huggingface-extras/index.ts
@@ -14,6 +14,7 @@ import { PROVIDER_ID, createProviderApiKeyAuthMethod, definePluginEntry } from "
 import { huggingFaceExtrasMemoryEmbeddingProviderAdapter } from "./embeddings-provider.js";
 import { buildHuggingFaceExtrasImageGenerationProvider } from "./image-generation-provider.js";
 import { huggingFaceExtrasMediaUnderstandingProvider } from "./stt-provider.js";
+import { buildHuggingFaceExtrasVideoGenerationProvider } from "./video-generation-provider.js";
 
 export default definePluginEntry({
   id: PROVIDER_ID,
@@ -52,5 +53,6 @@ export default definePluginEntry({
     api.registerImageGenerationProvider(buildHuggingFaceExtrasImageGenerationProvider());
     api.registerMemoryEmbeddingProvider(huggingFaceExtrasMemoryEmbeddingProviderAdapter);
     api.registerMediaUnderstandingProvider(huggingFaceExtrasMediaUnderstandingProvider);
+    api.registerVideoGenerationProvider(buildHuggingFaceExtrasVideoGenerationProvider());
   },
 });

--- a/extensions/huggingface-extras/index.ts
+++ b/extensions/huggingface-extras/index.ts
@@ -1,0 +1,51 @@
+// Plugin entrypoint for huggingface-extras.
+//
+// Phase 1 scope: register a `huggingface-extras` provider with API-key auth
+// and an image-generation contract backed by the HF Inference API.
+// Phases 2 and 3 (embeddings + speech) will register additional contracts
+// against the same provider id without changing the auth surface.
+
+import {
+  PROVIDER_ID,
+  createProviderApiKeyAuthMethod,
+  definePluginEntry,
+} from "./api.js";
+import { buildHuggingFaceExtrasImageGenerationProvider } from "./image-generation-provider.js";
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "Hugging Face Extras Provider",
+  description:
+    "Hugging Face Inference API provider for image generation, embeddings, and speech (complements the chat-only huggingface plugin).",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Hugging Face (Extras)",
+      docsPath: "/providers/huggingface",
+      envVars: ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "Hugging Face API key (extras)",
+          hint: "Image / embeddings / speech via HF Inference API",
+          optionKey: "huggingfaceExtrasApiKey",
+          flagName: "--huggingface-extras-api-key",
+          envVar: "HUGGINGFACE_HUB_TOKEN",
+          promptMessage: "Enter Hugging Face API key (HF token)",
+          expectedProviders: [PROVIDER_ID],
+          wizard: {
+            choiceId: "huggingface-extras-api-key",
+            choiceLabel: "Hugging Face API key (extras)",
+            choiceHint: "Image / embeddings / speech via HF Inference API",
+            groupId: "huggingface-extras",
+            groupLabel: "Hugging Face (Extras)",
+            groupHint: "Image / embeddings / speech via HF Inference API",
+            onboardingScopes: ["image-generation"],
+          },
+        }),
+      ],
+    });
+    api.registerImageGenerationProvider(buildHuggingFaceExtrasImageGenerationProvider());
+  },
+});

--- a/extensions/huggingface-extras/index.ts
+++ b/extensions/huggingface-extras/index.ts
@@ -1,12 +1,19 @@
 // Plugin entrypoint for huggingface-extras.
 //
-// Phase 1 scope: register a `huggingface-extras` provider with API-key auth
-// and an image-generation contract backed by the HF Inference API.
-// Phases 2 and 3 (embeddings + speech) will register additional contracts
-// against the same provider id without changing the auth surface.
+// Registers a `huggingface-extras` provider with three contracts on top of
+// the Hugging Face Inference Providers router:
+//   - image generation (FLUX / SDXL via the hf-inference route)
+//   - memory embeddings (Qwen3-Embedding-8B via the scaleway route)
+//   - audio transcription / STT (whisper-large-v3 via the hf-inference route)
+//
+// All three share the same HF API token and onboarding choice. We do not
+// register chat completion here because the existing `huggingface` plugin
+// already covers that via the OpenAI-compatible router.
 
 import { PROVIDER_ID, createProviderApiKeyAuthMethod, definePluginEntry } from "./api.js";
+import { huggingFaceExtrasMemoryEmbeddingProviderAdapter } from "./embeddings-provider.js";
 import { buildHuggingFaceExtrasImageGenerationProvider } from "./image-generation-provider.js";
+import { huggingFaceExtrasMediaUnderstandingProvider } from "./stt-provider.js";
 
 export default definePluginEntry({
   id: PROVIDER_ID,
@@ -43,5 +50,7 @@ export default definePluginEntry({
       ],
     });
     api.registerImageGenerationProvider(buildHuggingFaceExtrasImageGenerationProvider());
+    api.registerMemoryEmbeddingProvider(huggingFaceExtrasMemoryEmbeddingProviderAdapter);
+    api.registerMediaUnderstandingProvider(huggingFaceExtrasMediaUnderstandingProvider);
   },
 });

--- a/extensions/huggingface-extras/openclaw.plugin.json
+++ b/extensions/huggingface-extras/openclaw.plugin.json
@@ -22,7 +22,9 @@
     }
   ],
   "contracts": {
-    "imageGenerationProviders": ["huggingface-extras"]
+    "imageGenerationProviders": ["huggingface-extras"],
+    "memoryEmbeddingProviders": ["huggingface-extras"],
+    "mediaUnderstandingProviders": ["huggingface-extras"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/huggingface-extras/openclaw.plugin.json
+++ b/extensions/huggingface-extras/openclaw.plugin.json
@@ -24,7 +24,8 @@
   "contracts": {
     "imageGenerationProviders": ["huggingface-extras"],
     "memoryEmbeddingProviders": ["huggingface-extras"],
-    "mediaUnderstandingProviders": ["huggingface-extras"]
+    "mediaUnderstandingProviders": ["huggingface-extras"],
+    "videoGenerationProviders": ["huggingface-extras"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/huggingface-extras/openclaw.plugin.json
+++ b/extensions/huggingface-extras/openclaw.plugin.json
@@ -1,0 +1,32 @@
+{
+  "id": "huggingface-extras",
+  "enabledByDefault": false,
+  "providers": ["huggingface-extras"],
+  "providerAuthEnvVars": {
+    "huggingface-extras": ["HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "huggingface-extras",
+      "method": "api-key",
+      "choiceId": "huggingface-extras-api-key",
+      "choiceLabel": "Hugging Face API key (extras)",
+      "choiceHint": "Image generation, embeddings, and speech via HF Inference API",
+      "groupId": "huggingface-extras",
+      "groupLabel": "Hugging Face (Extras)",
+      "groupHint": "Image / embeddings / speech via HF Inference API",
+      "optionKey": "huggingfaceExtrasApiKey",
+      "cliFlag": "--huggingface-extras-api-key",
+      "cliOption": "--huggingface-extras-api-key <key>",
+      "cliDescription": "Hugging Face API key for the huggingface-extras provider"
+    }
+  ],
+  "contracts": {
+    "imageGenerationProviders": ["huggingface-extras"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/huggingface-extras/package.json
+++ b/extensions/huggingface-extras/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/huggingface-extras-provider",
+  "version": "2026.4.9",
+  "private": true,
+  "description": "Hugging Face Inference API provider for image generation, embeddings, and speech (complements the chat-only huggingface plugin)",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/huggingface-extras/stt-provider.ts
+++ b/extensions/huggingface-extras/stt-provider.ts
@@ -1,0 +1,112 @@
+// Hugging Face speech-to-text provider.
+//
+// Hits the legacy hf-inference route at
+// `https://router.huggingface.co/hf-inference/models/openai/whisper-large-v3`
+// with raw audio bytes in the request body. The response is JSON of the
+// shape `{"text": "..."}`.
+//
+// Hugging Face does NOT expose an OpenAI-compatible
+// `POST /v1/audio/transcriptions` endpoint on this route, so we cannot reuse
+// `transcribeOpenAiCompatibleAudio` from the SDK helper. We register a
+// dedicated `MediaUnderstandingProvider` whose `transcribeAudio` method
+// performs the raw POST itself.
+
+import {
+  HUGGINGFACE_INFERENCE_BASE_URL,
+  PROVIDER_ID,
+  type AudioTranscriptionRequest,
+  type AudioTranscriptionResult,
+  type MediaUnderstandingProvider,
+} from "./api.js";
+
+const DEFAULT_STT_MODEL = "openai/whisper-large-v3";
+
+type WhisperResponse = {
+  text?: string;
+  error?: string | { message?: string };
+};
+
+function describeError(status: number, body: WhisperResponse | string): string {
+  if (typeof body === "string") {
+    return body || `huggingface-extras STT request failed with status ${status}`;
+  }
+  if (body.error) {
+    if (typeof body.error === "string") {
+      return body.error;
+    }
+    if (typeof body.error.message === "string") {
+      return body.error.message;
+    }
+  }
+  return `huggingface-extras STT request failed with status ${status}`;
+}
+
+function buildModelEndpoint(modelId: string): string {
+  const safeId = modelId.trim().replace(/^\/+|\/+$/gu, "");
+  if (!safeId) {
+    throw new Error("huggingface-extras STT: model id is empty");
+  }
+  return `${HUGGINGFACE_INFERENCE_BASE_URL}/models/${safeId}`;
+}
+
+async function transcribeAudio(req: AudioTranscriptionRequest): Promise<AudioTranscriptionResult> {
+  const modelId = req.model?.trim() || DEFAULT_STT_MODEL;
+  const endpoint = buildModelEndpoint(modelId);
+  const apiKey = req.apiKey;
+  if (!apiKey) {
+    throw new Error("huggingface-extras STT: HF API key not provided in transcription request");
+  }
+
+  const controller = new AbortController();
+  const timer =
+    typeof req.timeoutMs === "number" && req.timeoutMs > 0
+      ? setTimeout(() => controller.abort(), req.timeoutMs)
+      : undefined;
+  const fetchFn = req.fetchFn ?? fetch;
+  try {
+    const bytes = new Uint8Array(req.buffer);
+    const response = await fetchFn(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": req.mime || "application/octet-stream",
+        Accept: "application/json",
+        ...req.headers,
+      },
+      body: bytes,
+      signal: controller.signal,
+    });
+
+    const text = await response.text().catch(() => "");
+    let body: WhisperResponse | string;
+    try {
+      body = JSON.parse(text) as WhisperResponse;
+    } catch {
+      body = text;
+    }
+
+    if (!response.ok) {
+      throw new Error(describeError(response.status, body));
+    }
+    if (typeof body === "string" || typeof body.text !== "string") {
+      throw new Error("huggingface-extras STT response is missing `text` field");
+    }
+    return {
+      text: body.text,
+      model: modelId,
+    };
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export const huggingFaceExtrasMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: PROVIDER_ID,
+  capabilities: ["audio"],
+  defaultModels: {
+    audio: DEFAULT_STT_MODEL,
+  },
+  transcribeAudio,
+};

--- a/extensions/huggingface-extras/tsconfig.json
+++ b/extensions/huggingface-extras/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**"
+  ]
+}

--- a/extensions/huggingface-extras/tsconfig.json
+++ b/extensions/huggingface-extras/tsconfig.json
@@ -4,9 +4,5 @@
     "rootDir": "."
   },
   "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": [
-    "./**/*.test.ts",
-    "./dist/**",
-    "./node_modules/**"
-  ]
+  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
 }

--- a/extensions/huggingface-extras/video-generation-provider.ts
+++ b/extensions/huggingface-extras/video-generation-provider.ts
@@ -1,0 +1,359 @@
+// Hugging Face video generation provider (P4).
+//
+// Routes through the HF Inference Providers router using the Replicate
+// backend, which is the only HF-Pro-credit-eligible video provider that
+// covers the popular Wan family.
+//
+// Why not also fal-ai/wavespeed:
+// - fal-ai is paywalled outside HF Pro $2 monthly credits
+// - wavespeed has a different async path shape, doubles complexity for
+//   one extra HunyuanVideo-1.5 route. We can add it later if needed.
+//
+// Mapping resolution:
+// - Default model list is bundled (BUNDLED_VIDEO_MAPPING) and covers the
+//   four Wan models the user can actually run today.
+// - For unknown model ids we hit `https://huggingface.co/api/models/{id}
+//   ?expand[]=inferenceProviderMapping` at request time, cache the answer
+//   in-memory, and pick the first replicate `live` route. If no replicate
+//   route exists we throw with a helpful warning that includes the model
+//   ids we ARE able to serve.
+//
+// Replicate's prediction API is async: POST returns `{id, status:"starting",
+// urls.get}`, then we poll `urls.get` until status is `succeeded` and
+// `output` is a video URL we download as bytes.
+
+import {
+  HUGGINGFACE_INFERENCE_BASE_URL,
+  PROVIDER_ID,
+  resolveApiKeyForProvider,
+  type GeneratedVideoAsset,
+  type VideoGenerationProvider,
+  type VideoGenerationRequest,
+  type VideoGenerationResult,
+} from "./api.js";
+
+const HF_HUB_API_BASE_URL = "https://huggingface.co/api";
+const HF_REPLICATE_BASE_URL = HUGGINGFACE_INFERENCE_BASE_URL.replace("/hf-inference", "/replicate");
+
+const DEFAULT_VIDEO_MODEL = "Wan-AI/Wan2.1-T2V-14B";
+
+// Bundled fallback mapping. Source: HF model api expand=inferenceProviderMapping,
+// captured 2026-04. Refreshed at runtime by `resolveReplicateProviderId`.
+//
+// Only models with a live replicate route are listed here. Models that only
+// route through fal-ai (HunyuanVideo, mochi-1-preview, CogVideoX-5b,
+// LongCat-Video, LTX-Video) intentionally do NOT appear so the warning path
+// fires for them.
+const BUNDLED_VIDEO_MAPPING: Readonly<Record<string, string>> = {
+  "wan-ai/wan2.1-t2v-14b": "wavespeedai/wan-2.1-t2v-480p",
+  "wan-ai/wan2.1-t2v-1.3b": "wavespeedai/wan-2.1-t2v-1.3b",
+  "wan-ai/wan2.2-t2v-a14b": "wavespeedai/wan-2.2-t2v-a14b",
+  "wan-ai/wan2.2-ti2v-5b": "wavespeedai/wan-2.2-ti2v-5b",
+};
+
+const KNOWN_VIDEO_MODELS: ReadonlyArray<string> = [
+  "Wan-AI/Wan2.1-T2V-14B",
+  "Wan-AI/Wan2.2-T2V-A14B",
+  "Wan-AI/Wan2.2-TI2V-5B",
+  "Wan-AI/Wan2.1-T2V-1.3B",
+];
+
+type HfMappingEntry = {
+  status?: string;
+  providerId?: string;
+  task?: string;
+};
+type HfMappingResponse = {
+  inferenceProviderMapping?: Record<string, HfMappingEntry> | HfMappingEntry[];
+};
+
+// Module-level memoization. Cleared on process restart, which is fine for
+// long-running gateways and matches how the upstream JS SDK caches.
+const mappingCache = new Map<string, string | null>();
+
+function isFalAiOnlyModelMessage(modelId: string, providers: string[]): string {
+  return [
+    `huggingface-extras video: model "${modelId}" is not available on a HF Pro free route.`,
+    `Provider mapping: ${providers.join(", ") || "(none)"}.`,
+    `Only models with a live "replicate" route can be served. Known-good models for this provider:`,
+    `  ${KNOWN_VIDEO_MODELS.join(", ")}`,
+    `If you need fal-ai-only models (HunyuanVideo, Mochi, CogVideoX, etc.) you must add pre-paid fal-ai credits.`,
+  ].join("\n");
+}
+
+async function resolveReplicateProviderId(modelId: string, hfToken: string): Promise<string> {
+  const cacheKey = modelId.toLowerCase();
+  const cached = mappingCache.get(cacheKey);
+  if (cached === null) {
+    throw new Error(isFalAiOnlyModelMessage(modelId, ["(cached: no replicate route)"]));
+  }
+  if (typeof cached === "string") {
+    return cached;
+  }
+
+  // Bundled fallback first to avoid the network round-trip for the common
+  // case where the user picks one of our recommended Wan models.
+  const bundled = BUNDLED_VIDEO_MAPPING[cacheKey];
+  if (bundled) {
+    mappingCache.set(cacheKey, bundled);
+    return bundled;
+  }
+
+  // Hit the HF Hub mapping endpoint. We swallow network errors and fall
+  // through to a "no replicate route" warning rather than a stack trace,
+  // because that is what the user actually needs to read.
+  let mappingBody: HfMappingResponse | undefined;
+  try {
+    const url = `${HF_HUB_API_BASE_URL}/models/${encodeURI(modelId)}?expand[]=inferenceProviderMapping`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${hfToken}`,
+      },
+    });
+    if (response.ok) {
+      mappingBody = (await response.json()) as HfMappingResponse;
+    }
+  } catch {
+    // ignore: we'll fall through to the not-supported warning
+  }
+
+  const rawMapping = mappingBody?.inferenceProviderMapping;
+  const entries: Array<HfMappingEntry & { provider?: string }> = Array.isArray(rawMapping)
+    ? rawMapping
+    : rawMapping
+      ? Object.entries(rawMapping).map(([provider, info]) => ({ ...info, provider }))
+      : [];
+
+  const liveProviders: string[] = [];
+  let replicateProviderId: string | undefined;
+  for (const entry of entries) {
+    const provider = entry.provider;
+    if (!provider) {
+      continue;
+    }
+    liveProviders.push(provider);
+    if (provider === "replicate" && entry.status === "live" && entry.providerId) {
+      replicateProviderId = entry.providerId;
+      break;
+    }
+  }
+
+  if (!replicateProviderId) {
+    mappingCache.set(cacheKey, null);
+    throw new Error(isFalAiOnlyModelMessage(modelId, liveProviders));
+  }
+  mappingCache.set(cacheKey, replicateProviderId);
+  return replicateProviderId;
+}
+
+type ReplicatePrediction = {
+  id?: string;
+  status?: "starting" | "processing" | "succeeded" | "failed" | "canceled";
+  output?: string | string[] | null;
+  error?: string | null;
+  urls?: { get?: string };
+};
+
+async function postReplicatePrediction(params: {
+  apiKey: string;
+  providerModelId: string;
+  prompt: string;
+  signal?: AbortSignal;
+}): Promise<ReplicatePrediction> {
+  const url = `${HF_REPLICATE_BASE_URL}/v1/models/${params.providerModelId}/predictions`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${params.apiKey}`,
+    },
+    body: JSON.stringify({
+      input: { prompt: params.prompt },
+    }),
+    signal: params.signal,
+  });
+  const text = await response.text().catch(() => "");
+  if (!response.ok) {
+    throw new Error(
+      `huggingface-extras video: replicate POST failed (${response.status}): ${text || "unknown error"}`,
+    );
+  }
+  return JSON.parse(text) as ReplicatePrediction;
+}
+
+async function pollReplicatePrediction(params: {
+  apiKey: string;
+  predictionId: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<ReplicatePrediction> {
+  const deadline = Date.now() + params.timeoutMs;
+  // Replicate suggests ~1s polling for short tasks, longer for video. We use
+  // 3s — fast enough that the first frame appears before the user gives up,
+  // slow enough that we don't get throttled on a 60-90s prediction.
+  const intervalMs = 3_000;
+  const url = `${HF_REPLICATE_BASE_URL}/v1/predictions/${params.predictionId}`;
+
+  while (Date.now() < deadline) {
+    if (params.signal?.aborted) {
+      throw new Error("huggingface-extras video: request aborted");
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      signal: params.signal,
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `huggingface-extras video: replicate GET failed (${response.status}): ${text || "unknown"}`,
+      );
+    }
+    const body = (await response.json()) as ReplicatePrediction;
+    if (body.status === "succeeded") {
+      return body;
+    }
+    if (body.status === "failed" || body.status === "canceled") {
+      throw new Error(
+        `huggingface-extras video: replicate prediction ${body.status}: ${body.error ?? "no error message"}`,
+      );
+    }
+  }
+  throw new Error(
+    `huggingface-extras video: replicate prediction did not finish within ${params.timeoutMs}ms`,
+  );
+}
+
+async function fetchVideoBytes(url: string): Promise<{ buffer: Buffer; mimeType: string }> {
+  const response = await fetch(url, { method: "GET" });
+  if (!response.ok) {
+    throw new Error(
+      `huggingface-extras video: failed to download generated video (${response.status})`,
+    );
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  const mimeType = response.headers.get("content-type") || "video/mp4";
+  return { buffer: Buffer.from(arrayBuffer), mimeType };
+}
+
+function pickOutputUrl(prediction: ReplicatePrediction): string {
+  const out = prediction.output;
+  if (typeof out === "string") {
+    return out;
+  }
+  if (Array.isArray(out) && typeof out[0] === "string") {
+    return out[0];
+  }
+  throw new Error("huggingface-extras video: replicate succeeded but no output URL was returned");
+}
+
+function buildVideoAsset(params: {
+  buffer: Buffer;
+  mimeType: string;
+  modelId: string;
+  prompt: string;
+}): GeneratedVideoAsset {
+  const ext = params.mimeType.includes("webm") ? "webm" : "mp4";
+  return {
+    buffer: params.buffer,
+    mimeType: params.mimeType,
+    fileName: `huggingface-extras-${Date.now()}.${ext}`,
+    metadata: {
+      provider: PROVIDER_ID,
+      capability: "video",
+      model: params.modelId,
+      prompt: params.prompt,
+    },
+  };
+}
+
+export function buildHuggingFaceExtrasVideoGenerationProvider(): VideoGenerationProvider {
+  return {
+    id: PROVIDER_ID,
+    label: "Hugging Face (Extras)",
+    defaultModel: DEFAULT_VIDEO_MODEL,
+    models: [...KNOWN_VIDEO_MODELS],
+    capabilities: {
+      generate: {
+        maxVideos: 1,
+        supportsAspectRatio: false,
+        supportsResolution: true,
+      },
+      imageToVideo: {
+        enabled: false,
+      },
+      videoToVideo: {
+        enabled: false,
+      },
+    },
+    isConfigured: () => true,
+    async generateVideo(req: VideoGenerationRequest): Promise<VideoGenerationResult> {
+      const auth = await resolveApiKeyForProvider({
+        provider: PROVIDER_ID,
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      const apiKey = auth?.apiKey;
+      if (!apiKey) {
+        throw new Error(
+          "huggingface-extras video: HF API key not configured. Set HUGGINGFACE_HUB_TOKEN/HF_TOKEN.",
+        );
+      }
+      const modelId = req.model?.trim() || DEFAULT_VIDEO_MODEL;
+      const providerModelId = await resolveReplicateProviderId(modelId, apiKey);
+
+      const controller = new AbortController();
+      const timeoutMs =
+        typeof req.timeoutMs === "number" && req.timeoutMs > 0 ? req.timeoutMs : 600_000;
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const prediction = await postReplicatePrediction({
+          apiKey,
+          providerModelId,
+          prompt: req.prompt,
+          signal: controller.signal,
+        });
+        const predictionId = prediction.id;
+        if (!predictionId) {
+          throw new Error("huggingface-extras video: replicate did not return a prediction id");
+        }
+        const finalPrediction =
+          prediction.status === "succeeded"
+            ? prediction
+            : await pollReplicatePrediction({
+                apiKey,
+                predictionId,
+                timeoutMs,
+                signal: controller.signal,
+              });
+        const outputUrl = pickOutputUrl(finalPrediction);
+        const { buffer, mimeType } = await fetchVideoBytes(outputUrl);
+        return {
+          videos: [
+            buildVideoAsset({
+              buffer,
+              mimeType,
+              modelId,
+              prompt: req.prompt,
+            }),
+          ],
+          model: modelId,
+          metadata: {
+            provider: PROVIDER_ID,
+            providerModelId,
+            predictionId,
+          },
+        };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds a new bundled plugin `extensions/huggingface-extras/` that wires four contracts onto a single `huggingface-extras` provider id:

| Contract | Provider route | Default model |
|---|---|---|
| Image generation | `router/hf-inference/models/<id>` | `black-forest-labs/FLUX.1-schnell` |
| Memory embeddings | `router/scaleway/v1/embeddings` | `qwen3-embedding-8b` |
| Audio transcription (STT) | `router/hf-inference/models/<id>` | `openai/whisper-large-v3` |
| Video generation | `router/replicate/v1/models/<providerId>/predictions` | `Wan-AI/Wan2.1-T2V-14B` |

All four share one HF token (\`HUGGINGFACE_HUB_TOKEN\` / \`HF_TOKEN\`) and one onboarding choice. The plugin is \`enabledByDefault: false\`.

## Why this is useful

Hugging Face hosts an enormous catalog of community models, and the Inference Providers router exposes a lot of them through one consistent HTTP surface. Today an openclaw user who wants image generation, embeddings, or STT has to configure a separate provider account (fal-ai, voyage, ElevenLabs, etc.) for each capability. With this plugin, **a single HF token unlocks all four task types** and the user can experiment with hundreds of models by just changing a model id in \`openclaw.json\`.

The HF Pro \$2 / month free tier covers all four routes used here, so the plugin is also a low-friction way to get started without spinning up a local Ollama or paying multiple vendors.

## Open question for reviewers

Would you prefer this to be **merged into the existing \`extensions/huggingface/\` plugin** instead, exposing all four contracts under the single \`huggingface\` provider id?

We took the view that these contracts deserve their own plugin so:

- chat behavior (currently the entire scope of \`extensions/huggingface/\`) is not perturbed if a non-chat helper changes
- users can disable extras independently
- the new code lives in one folder and reviewers don't need to chase diffs across the existing huggingface plugin

But if the maintainers prefer a single \`huggingface\` provider id covering everything, happy to refactor — the current split is just what we found cleanest, not a strong opinion. Related issue: openclaw/openclaw#11353.

## Implementation notes

- **Image**: \`hf-inference/models/<id>\` POST with JSON body, raw PNG bytes back. The legacy \`api-inference.huggingface.co\` host was retired in 2026, so we point at \`router.huggingface.co/hf-inference\` instead.
- **Embeddings**: Scaleway is the only HF Inference Providers backend that hosts \`Qwen/Qwen3-Embedding-8B\` (4096-dim multilingual). Uses the OpenAI-compatible \`/v1/embeddings\` shape.
- **STT**: HF router does not expose \`/v1/audio/transcriptions\`, so we POST raw audio bytes to \`hf-inference/models/openai/whisper-large-v3\`. Cannot reuse \`transcribeOpenAiCompatibleAudio()\` because the URL shape differs.
- **Video**: Replicate is the only non-fal-ai HF Pro route serving the Wan family. fal-ai requires pre-paid credits outside the HF Pro tier so we intentionally skip it. Unknown model ids are resolved at runtime via \`https://huggingface.co/api/models/{id}?expand[]=inferenceProviderMapping\`, cached in-memory, with a bundled fallback for the four supported Wan models. Models that only route through fal-ai (HunyuanVideo, mochi-1, CogVideoX, LongCat, LTX-Video) trigger an explicit warning that lists the supported alternatives.

## Test plan

- [x] \`pnpm tsgo --project extensions/huggingface-extras/tsconfig.json\`
- [x] \`pnpm lint\`
- [x] \`pnpm format\`
- [x] Plugin loads on a live gateway (\`huggingface-extras: loaded\` in \`[plugins]\` log, 4 contracts registered)
- [x] **Image gen verified end-to-end**: FLUX.1-schnell returned a 1024x1024 PNG
- [x] **Embeddings verified end-to-end**: switched \`memorySearch.provider\` to \`huggingface-extras\`, full reindex of 52 files / 243 chunks via Scaleway succeeds, semantic search returns relevant matches
- [x] **STT verified at the router level** (\`{\"text\": \"...\"}\` from whisper-large-v3)
- [x] **Video gen verified end-to-end**: Wan-AI/Wan2.1-T2V-14B returned a 246 KB MP4 via replicate

## Known limitations / future work

- No unit tests yet — will add as a follow-up if the architecture is accepted, since the test shape depends on whether this stays as \`huggingface-extras\` or merges into \`huggingface\`.
- No docs page under \`docs/providers/\`.
- Wavespeed, Together, Nscale routes for video are not implemented — only Replicate (covers the four supported Wan models).
- TTS / realtime voice / music generation are not on the HF Inference Providers task matrix today, so they are out of scope.
- Image-to-image and image-to-video edits not implemented.