### PR TITLE
fix(outbound): accept message tool media alias for sends #63493

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -39,6 +39,8 @@ export const SendParamsSchema = Type.Object(
   {
     to: NonEmptyString,
     message: Type.Optional(Type.String()),
+    /** Alias of `mediaUrl` (message tool / clients that use the send attachment field name). */
+    media: Type.Optional(Type.String()),
     mediaUrl: Type.Optional(Type.String()),
     mediaUrls: Type.Optional(Type.Array(Type.String())),
     gifPlayback: Type.Optional(Type.Boolean()),

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -225,6 +225,35 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("accepts `media` as alias of mediaUrl for gateway send", async () => {
+    mockDeliverySuccess("m-media-field");
+
+    const { respond } = await runSend({
+      to: "channel:C1",
+      media: "https://example.com/from-media-field.png",
+      channel: "slack",
+      idempotencyKey: "idem-media-field",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [
+          {
+            text: "",
+            mediaUrl: "https://example.com/from-media-field.png",
+            mediaUrls: undefined,
+          },
+        ],
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ messageId: "m-media-field" }),
+      undefined,
+      expect.objectContaining({ channel: "slack" }),
+    );
+  });
+
   it("forwards gateway client scopes into outbound delivery", async () => {
     mockDeliverySuccess("m-scope");
 

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -254,6 +254,31 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("does not promote legacy `media` to mediaUrl when mediaUrls is already set", async () => {
+    mockDeliverySuccess("m-media-urls-win");
+
+    await runSend({
+      to: "channel:C1",
+      message: "",
+      mediaUrls: ["https://example.com/authoritative.png"],
+      media: "https://example.com/compat-legacy-only.png",
+      channel: "slack",
+      idempotencyKey: "idem-media-urls-authoritative",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [
+          {
+            text: "",
+            mediaUrl: undefined,
+            mediaUrls: ["https://example.com/authoritative.png"],
+          },
+        ],
+      }),
+    );
+  });
+
   it("forwards gateway client scopes into outbound delivery", async () => {
     mockDeliverySuccess("m-scope");
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -195,6 +195,7 @@ export const sendHandlers: GatewayRequestHandlers = {
     const request = p as {
       to: string;
       message?: string;
+      media?: string;
       mediaUrl?: string;
       mediaUrls?: string[];
       gifPlayback?: boolean;
@@ -224,7 +225,8 @@ export const sendHandlers: GatewayRequestHandlers = {
     }
     const to = normalizeOptionalString(request.to) ?? "";
     const message = normalizeOptionalString(request.message) ?? "";
-    const mediaUrl = normalizeOptionalString(request.mediaUrl);
+    const mediaUrl =
+      normalizeOptionalString(request.mediaUrl) ?? normalizeOptionalString(request.media);
     const mediaUrls = Array.isArray(request.mediaUrls)
       ? request.mediaUrls
           .map((entry) => normalizeOptionalString(entry))

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -225,13 +225,17 @@ export const sendHandlers: GatewayRequestHandlers = {
     }
     const to = normalizeOptionalString(request.to) ?? "";
     const message = normalizeOptionalString(request.message) ?? "";
-    const mediaUrl =
-      normalizeOptionalString(request.mediaUrl) ?? normalizeOptionalString(request.media);
     const mediaUrls = Array.isArray(request.mediaUrls)
       ? request.mediaUrls
           .map((entry) => normalizeOptionalString(entry))
           .filter((entry): entry is string => Boolean(entry))
       : undefined;
+    const hasExplicitMediaUrls = (mediaUrls?.length ?? 0) > 0;
+    // `media` is a legacy alias for `mediaUrl` only when no authoritative `mediaUrls` list is set;
+    // otherwise merging would duplicate attachments (normalizeReplyPayloadsForDelivery merges both).
+    const mediaUrl =
+      normalizeOptionalString(request.mediaUrl) ??
+      (hasExplicitMediaUrls ? undefined : normalizeOptionalString(request.media));
     if (!message && !mediaUrl && (mediaUrls?.length ?? 0) === 0) {
       respond(
         false,

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -89,6 +89,23 @@ describe("sendMessage", () => {
     );
   });
 
+  it("does not promote legacy `media` when mediaUrls is already set", async () => {
+    await sendMessage({
+      cfg: {},
+      channel: "telegram",
+      to: "123456",
+      content: "caption",
+      mediaUrls: ["https://example.com/authoritative.png"],
+      media: "https://example.com/compat-only.png",
+    });
+
+    const call = mocks.deliverOutboundPayloads.mock.calls[0]?.[0] as {
+      payloads: Array<{ mediaUrl?: string; mediaUrls?: string[] }>;
+    };
+    expect(call?.payloads?.[0]?.mediaUrl).toBeUndefined();
+    expect(call?.payloads?.[0]?.mediaUrls).toEqual(["https://example.com/authoritative.png"]);
+  });
+
   it("propagates the send idempotency key into mirrored transcript delivery", async () => {
     await sendMessage({
       cfg: {},

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -2,6 +2,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import type { OpenClawConfig } from "../../config/config.js";
 import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -224,7 +225,15 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
   const plugin = resolveRequiredPlugin(channel, cfg);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
-  const resolvedMediaUrl = params.mediaUrl ?? params.media;
+  const normalizedMediaUrls = Array.isArray(params.mediaUrls)
+    ? params.mediaUrls
+        .map((entry) => normalizeOptionalString(entry))
+        .filter((entry): entry is string => Boolean(entry))
+    : undefined;
+  const hasExplicitMediaUrls = (normalizedMediaUrls?.length ?? 0) > 0;
+  const resolvedMediaUrl =
+    normalizeOptionalString(params.mediaUrl) ??
+    (hasExplicitMediaUrls ? undefined : normalizeOptionalString(params.media));
   const normalizedPayloads = normalizeReplyPayloadsForDelivery([
     {
       text: params.content,

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -50,6 +50,8 @@ type MessageSendParams = {
   /** Active agent id for per-agent outbound media root scoping. */
   agentId?: string;
   channel?: string;
+  /** Alias of `mediaUrl` (message tool field name). */
+  media?: string;
   mediaUrl?: string;
   mediaUrls?: string[];
   gifPlayback?: boolean;
@@ -222,10 +224,11 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
   const plugin = resolveRequiredPlugin(channel, cfg);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
+  const resolvedMediaUrl = params.mediaUrl ?? params.media;
   const normalizedPayloads = normalizeReplyPayloadsForDelivery([
     {
       text: params.content,
-      mediaUrl: params.mediaUrl,
+      mediaUrl: resolvedMediaUrl,
       mediaUrls: params.mediaUrls,
     },
   ]);
@@ -236,7 +239,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   const mirrorMediaUrls = normalizedPayloads.flatMap(
     (payload) => resolveSendableOutboundReplyParts(payload).mediaUrls,
   );
-  const primaryMediaUrl = mirrorMediaUrls[0] ?? params.mediaUrl ?? null;
+  const primaryMediaUrl = mirrorMediaUrls[0] ?? resolvedMediaUrl ?? null;
 
   if (params.dryRun) {
     return {
@@ -308,7 +311,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     params: {
       to: params.to,
       message: params.content,
-      mediaUrl: params.mediaUrl,
+      mediaUrl: resolvedMediaUrl,
       mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -140,12 +140,15 @@ export async function executeSendAction(params: {
   }
 
   throwIfAborted(params.ctx.abortSignal);
+  const mediaFallback =
+    typeof params.ctx.params.media === "string" ? params.ctx.params.media : undefined;
   const result: MessageSendResult = await sendMessage({
     cfg: params.ctx.cfg,
     to: params.to,
     content: params.message,
     agentId: params.ctx.agentId,
     mediaUrl: params.mediaUrl || undefined,
+    media: mediaFallback,
     mediaUrls: params.mediaUrls,
     channel: params.ctx.channel || undefined,
     accountId: params.ctx.accountId ?? undefined,

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -61,6 +61,34 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ).toEqual([]);
   });
 
+  it("maps message-tool `media` onto mediaUrl when no explicit mediaUrl/mediaUrls", () => {
+    const out = normalizeReplyPayloadsForDelivery([
+      { text: "Test", media: "/home/user/.openclaw/media/x.jpg" } as unknown as ReplyPayload,
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      text: "Test",
+      mediaUrl: "/home/user/.openclaw/media/x.jpg",
+    });
+    expect(out[0]).not.toHaveProperty("media");
+  });
+
+  it("does not override explicit mediaUrl when `media` is also present", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        {
+          text: "hi",
+          mediaUrl: "https://a.example/p.png",
+          media: "https://b.example/ignored.png",
+        } as unknown as ReplyPayload,
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        mediaUrl: "https://a.example/p.png",
+      }),
+    ]);
+  });
+
   it("keeps JSON NO_REPLY objects that include extra fields", () => {
     expect(
       normalizeReplyPayloadsForDelivery([{ text: '{"action":"NO_REPLY","note":"example"}' }]),

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -12,6 +12,7 @@ import {
   hasReplyPayloadContent,
   type InteractiveReply,
 } from "../../interactive/payload.js";
+import { readStringValue } from "../../shared/string-coerce.js";
 
 export type NormalizedOutboundPayload = {
   text: string;
@@ -52,11 +53,29 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
   return merged;
 }
 
+/** Map message-tool `media` (and similar loose payloads) onto `mediaUrl` when no explicit media is set. */
+function applyOutboundMediaFieldAlias(payload: ReplyPayload): ReplyPayload {
+  const mediaAlias = readStringValue((payload as Record<string, unknown>).media);
+  if (!mediaAlias) {
+    return payload;
+  }
+  if (payload.mediaUrl?.trim()) {
+    return payload;
+  }
+  if (payload.mediaUrls?.some((entry) => typeof entry === "string" && entry.trim().length > 0)) {
+    return payload;
+  }
+  const promoted: ReplyPayload = { ...payload, mediaUrl: mediaAlias };
+  delete (promoted as Record<string, unknown>).media;
+  return promoted;
+}
+
 export function normalizeReplyPayloadsForDelivery(
   payloads: readonly ReplyPayload[],
 ): ReplyPayload[] {
   const normalized: ReplyPayload[] = [];
-  for (const payload of payloads) {
+  for (const entry of payloads) {
+    const payload = applyOutboundMediaFieldAlias(entry);
     if (shouldSuppressReasoningPayload(payload)) {
       continue;
     }

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -7,6 +7,7 @@ import {
   hasOutboundReplyContent,
   hasOutboundText,
   isNumericTargetId,
+  normalizeOutboundReplyPayload,
   resolveOutboundMediaUrls,
   resolveSendableOutboundReplyParts,
   resolveTextChunksWithFallback,
@@ -67,6 +68,36 @@ describe("sendPayloadWithChunkedTextAndMedia", () => {
     expect(isNumericTargetId("  987  ")).toBe(true);
     expect(isNumericTargetId("ab12")).toBe(false);
     expect(isNumericTargetId("")).toBe(false);
+  });
+});
+
+describe("normalizeOutboundReplyPayload", () => {
+  it("maps `media` to mediaUrl when mediaUrl is absent", () => {
+    expect(
+      normalizeOutboundReplyPayload({
+        text: "hi",
+        media: "/data/photo.jpg",
+      }),
+    ).toEqual({
+      text: "hi",
+      mediaUrls: undefined,
+      mediaUrl: "/data/photo.jpg",
+      replyToId: undefined,
+    });
+  });
+
+  it("prefers explicit mediaUrl over `media`", () => {
+    expect(
+      normalizeOutboundReplyPayload({
+        mediaUrl: "https://a/x.png",
+        media: "https://b/y.png",
+      }),
+    ).toEqual({
+      text: undefined,
+      mediaUrls: undefined,
+      mediaUrl: "https://a/x.png",
+      replyToId: undefined,
+    });
   });
 });
 

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -38,7 +38,9 @@ export function normalizeOutboundReplyPayload(
         (entry): entry is string => typeof entry === "string" && entry.length > 0,
       )
     : undefined;
-  const mediaUrl = readStringValue(payload.mediaUrl);
+  const explicitMediaUrl = readStringValue(payload.mediaUrl);
+  const mediaAlias = readStringValue(payload.media);
+  const mediaUrl = explicitMediaUrl ?? mediaAlias;
   const replyToId = readStringValue(payload.replyToId);
   return {
     text,


### PR DESCRIPTION
## Summary

- Problem: The `message` tool uses a `media` field for local paths and HTTPS URLs, but several outbound paths only normalized or forwarded `mediaUrl` / `mediaUrls`. That could strip attachments so WhatsApp (and similar) logged `hasMedia: false` and sent text-only.
- Why it matters: Agents cannot reliably deliver photos/files from MCP or disk when the payload only carried `media`.
- What changed: Treat `media` as an alias of `mediaUrl` in Plugin SDK normalization, reply payload delivery normalization, `sendMessage`, gateway `send` (schema + handler), and outbound send service fallback from `ctx.params.media`.
- What did NOT change (scope boundary): No WhatsApp/Baileys-specific hacks; no changes to security CODEOWNERS paths; no unrelated refactors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63493
- Related #63493

## User-visible / Behavior Changes

- Gateway `send` accepts an optional `media` field as an alias for `mediaUrl`.
- Outbound delivery and `sendMessage` honor `media` when `mediaUrl` is absent, aligning with the `message` tool schema.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux (CI / local dev)
- Runtime/container: Node 22+ / Vitest
- Model/provider: N/A
- Integration/channel (if any): Covered generically via gateway `send` + payload normalization tests (not live WhatsApp)
- Relevant config (redacted): N/A

### Steps

1. Call gateway `send` with `to`, `channel`, `idempotencyKey`, and **`media`** set to a URL (no `mediaUrl`).
2. Run unit tests for `normalizeReplyPayloadsForDelivery` with a payload carrying **`media`** only.
3. Run `normalizeOutboundReplyPayload` tests for `media` → `mediaUrl` mapping.

### Expected

- Delivery receives payloads with `mediaUrl` populated (or equivalent merged `mediaUrls`).
- No silent drop of attachments solely because the field was named `media`.

### Actual

- Added/adjusted tests; targeted `pnpm test` on touched `*.test.ts` files passed; `scripts/committer` run completed `pnpm check` green for the committed tree.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Unit tests for `src/infra/outbound/payloads.test.ts`, `src/gateway/server-methods/send.test.ts`, `src/plugin-sdk/reply-payload.test.ts`; commit hook `pnpm check` after `scripts/committer`.
- Edge cases checked: `media` + existing `mediaUrl` (explicit `mediaUrl` wins); promotion removes stray `media` key after alias in delivery normalization.
- What I did **not** verify: Live WhatsApp multi-device send against a real session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- Revert the PR / restore prior `main` for the listed files under `src/plugin-sdk/reply-payload.ts`, `src/infra/outbound/payloads.ts`, `src/infra/outbound/message.ts`, `src/infra/outbound/outbound-send-service.ts`, `src/gateway/server-methods/send.ts`, `src/gateway/protocol/schema/agent.ts`.
- Known bad symptoms: unexpected preference of `media` over `mediaUrl` if both differ (intended: explicit `mediaUrl` wins where implemented).

## Risks and Mitigations

- Risk: Callers pass both `media` and `mediaUrl` with different values.
  - Mitigation: Alias layers prefer explicit `mediaUrl` / non-empty `mediaUrls` over `media` where documented in code paths touched.