### PR TITLE
fix(test): update status-all format test for beta version semver comparison

### DIFF
--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -83,7 +83,7 @@ describe("status-all format", () => {
       },
       channelLabel: "stable (config)",
       gitLabel: "main · tag v1.2.3",
-      updateLine: "git main · ↔ origin/main · behind 2 · npm latest 2026.4.9",
+      updateLine: "git main · ↔ origin/main · behind 2 · npm update 2026.4.9",
       updateAvailable: true,
     });
   });


### PR DESCRIPTION
## Summary

- Fix failing `buildStatusUpdateSurface` test in `src/commands/status-all/format.test.ts`
- The test expected `"npm latest 2026.4.9"` but the package version is `2026.4.9-beta.1`, which semver treats as less than `2026.4.9`, so `formatUpdateOneLiner` correctly outputs `"npm update 2026.4.9"`
- Updated the expected string to match the correct production behavior

## Test plan

- [x] `pnpm test -- src/commands/status-all/format.test.ts` passes (12/12)