### PR TITLE
fix(tts): allow OpenClaw temp directory paths in reply media normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: map `minimal` thinking to OpenAI's supported `low` reasoning effort for GPT-5.4 requests, so embedded runs stop failing request validation.
 - Voice-call/media-stream: resolve the source IP from trusted forwarding headers for per-IP pending-connection limits when `webhookSecurity.trustForwardingHeaders` and `trustedProxyIPs` are configured, and reserve `maxConnections` capacity for in-flight WebSocket upgrades so concurrent handshakes can no longer momentarily exceed the operator-set cap. (#66027) Thanks @eleqtrizit.
 - Feishu/allowlist: canonicalize allowlist entries by explicit `user`/`chat` kind, strip repeated `feishu:`/`lark:` provider prefixes, and stop folding opaque Feishu IDs to lowercase, so allowlist matching no longer crosses user/chat namespaces or widens to case-insensitive ID matches the operator did not intend. (#66021) Thanks @eleqtrizit.
+- TTS/reply media: persist OpenClaw temp voice outputs into managed outbound media and allow them through reply-media normalization, so voice-note replies stop silently dropping. (#63511) Thanks @jetd1.
 
 ## 2026.4.12
 

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -176,4 +176,24 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: ["/Users/peter/.openclaw/media/outbound/persisted.png"],
     });
   });
+
+  it("keeps TTS voice output from the OpenClaw temp directory", async () => {
+    // resolvePreferredOpenClawTmpDir() returns /tmp/openclaw on POSIX when it exists.
+    // We rely on the real function (no mock) since the test environment has /tmp/openclaw.
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/tmp/openclaw/tts-abc123/voice-1234567890.opus"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: "/tmp/openclaw/tts-abc123/voice-1234567890.opus",
+      mediaUrls: ["/tmp/openclaw/tts-abc123/voice-1234567890.opus"],
+    });
+    expect(saveMediaSource).not.toHaveBeenCalled();
+  });
 });

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -2,11 +2,20 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
+const resolvePreferredOpenClawTmpDir = vi.hoisted(() => vi.fn(() => "/private/tmp/openclaw-501"));
 const saveMediaSource = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/sandbox.js", () => ({
   ensureSandboxWorkspaceForSession,
 }));
+
+vi.mock("../../infra/tmp-openclaw-dir.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/tmp-openclaw-dir.js")>();
+  return {
+    ...actual,
+    resolvePreferredOpenClawTmpDir,
+  };
+});
 
 vi.mock("../../media/store.js", () => ({
   saveMediaSource,
@@ -17,6 +26,7 @@ import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
+    resolvePreferredOpenClawTmpDir.mockReset().mockReturnValue("/private/tmp/openclaw-501");
     saveMediaSource.mockReset();
     vi.unstubAllEnvs();
   });
@@ -177,9 +187,15 @@ describe("createReplyMediaPathNormalizer", () => {
     });
   });
 
-  it("keeps TTS voice output from the OpenClaw temp directory", async () => {
-    // resolvePreferredOpenClawTmpDir() returns /tmp/openclaw on POSIX when it exists.
-    // We rely on the real function (no mock) since the test environment has /tmp/openclaw.
+  it("persists TTS voice output from the preferred OpenClaw temp directory", async () => {
+    const tmpVoicePath = path.join(
+      "/private/tmp/openclaw-501",
+      "tts-abc123",
+      "voice-1234567890.opus",
+    );
+    saveMediaSource.mockResolvedValue({
+      path: "/Users/peter/.openclaw/media/outbound/tts-voice.opus",
+    });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -187,12 +203,53 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     const result = await normalize({
-      mediaUrls: ["/tmp/openclaw/tts-abc123/voice-1234567890.opus"],
+      mediaUrls: [tmpVoicePath],
+    });
+
+    expect(saveMediaSource).toHaveBeenCalledWith(tmpVoicePath, undefined, "outbound");
+    expect(result).toMatchObject({
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/tts-voice.opus",
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/tts-voice.opus"],
+    });
+  });
+
+  it("falls back to the original preferred tmp path when persisting TTS media fails", async () => {
+    const tmpVoicePath = path.join(
+      "/private/tmp/openclaw-501",
+      "tts-fallback",
+      "voice-1234567890.opus",
+    );
+    saveMediaSource.mockRejectedValue(new Error("disk full"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [tmpVoicePath],
     });
 
     expect(result).toMatchObject({
-      mediaUrl: "/tmp/openclaw/tts-abc123/voice-1234567890.opus",
-      mediaUrls: ["/tmp/openclaw/tts-abc123/voice-1234567890.opus"],
+      mediaUrl: tmpVoicePath,
+      mediaUrls: [tmpVoicePath],
+    });
+  });
+
+  it("drops host tmp paths outside the preferred OpenClaw temp directory", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/private/tmp/not-openclaw/voice-1234567890.opus"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
     });
     expect(saveMediaSource).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -19,6 +19,7 @@ const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
 const AGENT_STATE_MEDIA_DIRNAME = path.join(".openclaw", "media");
 const MANAGED_GLOBAL_MEDIA_SUBDIRS = new Set(["outbound"]);
+let cachedPreferredTmpRoot: string | null | undefined;
 
 function isPathInside(root: string, candidate: string): boolean {
   const relative = path.relative(path.resolve(root), path.resolve(candidate));
@@ -35,6 +36,32 @@ function isManagedGlobalReplyMediaPath(candidate: string): boolean {
   return MANAGED_GLOBAL_MEDIA_SUBDIRS.has(firstSegment) || firstSegment.startsWith("tool-");
 }
 
+function resolvePreferredReplyMediaTmpRoot(): string | undefined {
+  if (cachedPreferredTmpRoot !== undefined) {
+    return cachedPreferredTmpRoot ?? undefined;
+  }
+  try {
+    cachedPreferredTmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
+  } catch {
+    cachedPreferredTmpRoot = null;
+  }
+  return cachedPreferredTmpRoot ?? undefined;
+}
+
+function buildVolatileReplyMediaRoots(params: {
+  workspaceDir: string;
+  sandboxRoot?: string;
+}): string[] {
+  const roots = [params.workspaceDir, params.sandboxRoot]
+    .filter((root): root is string => Boolean(root))
+    .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
+  const preferredTmpRoot = resolvePreferredReplyMediaTmpRoot();
+  if (preferredTmpRoot) {
+    roots.push(preferredTmpRoot);
+  }
+  return roots;
+}
+
 function isAllowedAbsoluteReplyMediaPath(params: {
   candidate: string;
   workspaceDir: string;
@@ -43,32 +70,7 @@ function isAllowedAbsoluteReplyMediaPath(params: {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
     return true;
   }
-  // Allow media from the OpenClaw temp directory (TTS output, etc.).
-  // These are trusted paths written by OpenClaw's own tooling
-  // and should be deliverable as reply media.
-  if (isOpenClawTmpPath(params.candidate)) {
-    return true;
-  }
-  const volatileRoots = [params.workspaceDir, params.sandboxRoot]
-    .filter((root): root is string => Boolean(root))
-    .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
-  return volatileRoots.some((root) => isPathInside(root, params.candidate));
-}
-
-/**
- * Check whether a path is inside the OpenClaw temp directory.
- * These are trusted paths written by OpenClaw's own tooling
- * (TTS, media processing, etc.) and should be deliverable as reply media.
- */
-let cachedTmpRoot: string | undefined;
-
-function isOpenClawTmpPath(candidate: string): boolean {
-  try {
-    cachedTmpRoot ??= resolvePreferredOpenClawTmpDir();
-    return isPathInside(cachedTmpRoot, candidate);
-  } catch {
-    return false;
-  }
+  return buildVolatileReplyMediaRoots(params).some((root) => isPathInside(root, params.candidate));
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {
@@ -115,14 +117,15 @@ export function createReplyMediaPathNormalizer(params: {
     return await sandboxRootPromise;
   };
 
-  const persistVolatileAgentMedia = async (media: string): Promise<string> => {
+  const persistVolatileReplyMedia = async (media: string): Promise<string> => {
     if (!path.isAbsolute(media)) {
       return media;
     }
     const sandboxRoot = await resolveSandboxRoot();
-    const volatileRoots = [params.workspaceDir, sandboxRoot]
-      .filter((root): root is string => Boolean(root))
-      .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
+    const volatileRoots = buildVolatileReplyMediaRoots({
+      workspaceDir: params.workspaceDir,
+      sandboxRoot,
+    });
     if (!volatileRoots.some((root) => isPathInside(root, media))) {
       return media;
     }
@@ -222,7 +225,7 @@ export function createReplyMediaPathNormalizer(params: {
     for (const media of mediaList) {
       let normalized: string;
       try {
-        normalized = await persistVolatileAgentMedia(await normalizeMediaSource(media));
+        normalized = await persistVolatileReplyMedia(await normalizeMediaSource(media));
       } catch (err) {
         logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
         continue;

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -60,10 +60,12 @@ function isAllowedAbsoluteReplyMediaPath(params: {
  * These are trusted paths written by OpenClaw's own tooling
  * (TTS, media processing, etc.) and should be deliverable as reply media.
  */
+let cachedTmpRoot: string | undefined;
+
 function isOpenClawTmpPath(candidate: string): boolean {
   try {
-    const tmpRoot = resolvePreferredOpenClawTmpDir();
-    return isPathInside(tmpRoot, candidate);
+    cachedTmpRoot ??= resolvePreferredOpenClawTmpDir();
+    return isPathInside(cachedTmpRoot, candidate);
   } catch {
     return false;
   }

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -7,6 +7,7 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { saveMediaSource } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
@@ -42,10 +43,30 @@ function isAllowedAbsoluteReplyMediaPath(params: {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
     return true;
   }
+  // Allow media from the OpenClaw temp directory (TTS output, etc.).
+  // These are trusted paths written by OpenClaw's own tooling
+  // and should be deliverable as reply media.
+  if (isOpenClawTmpPath(params.candidate)) {
+    return true;
+  }
   const volatileRoots = [params.workspaceDir, params.sandboxRoot]
     .filter((root): root is string => Boolean(root))
     .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
   return volatileRoots.some((root) => isPathInside(root, params.candidate));
+}
+
+/**
+ * Check whether a path is inside the OpenClaw temp directory.
+ * These are trusted paths written by OpenClaw's own tooling
+ * (TTS, media processing, etc.) and should be deliverable as reply media.
+ */
+function isOpenClawTmpPath(candidate: string): boolean {
+  try {
+    const tmpRoot = resolvePreferredOpenClawTmpDir();
+    return isPathInside(tmpRoot, candidate);
+  } catch {
+    return false;
+  }
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {


### PR DESCRIPTION
## Summary

TTS audio attachments are silently dropped before delivery to channels (Telegram, WhatsApp, etc.) because the reply-media-path normalizer blocks absolute paths under `/tmp/openclaw/`.

### Root Cause

TTS output files are written to `/tmp/openclaw/tts-*/voice-*.opus` by `resolvePreferredOpenClawTmpDir()`. After commit `3cd4978fc2` ("refactor(agents): unify tool media reply delivery"), TTS tool results switched from inline `MEDIA:` directives to structured `details.media.mediaUrl`, which routes through `createReplyMediaPathNormalizer()`. This normalizer only allows:

1. Managed global paths (`~/.openclaw/media/outbound/`, `~/.openclaw/media/tool-*/`)
2. Workspace volatile paths (`<workspace>/.openclaw/media/`)

Absolute paths under `/tmp/openclaw/` fall through both checks and are blocked with:

```
"Absolute host-local MEDIA paths are blocked in normal replies. Use a safe relative path or the message tool."
```

The media is then silently dropped, resulting in `mediaUrl: undefined` and no voice message delivered.

### Fix

Add `isOpenClawTmpPath()` check to `isAllowedAbsoluteReplyMediaPath()` so that files in the OpenClaw temp directory (as resolved by `resolvePreferredOpenClawTmpDir()`) are treated as trusted, just like managed global media paths.

This is the same temp directory that OpenClaw itself creates and manages (`/tmp/openclaw` on POSIX, with security checks for permissions/ownership), so it is a trusted source.

### Testing

- All 7 existing tests in `reply-media-paths.test.ts` pass
- Verified manually: TTS voice messages now deliver correctly on Telegram

### Linked Issues

Closes #63110

#### Related issues and why

- **#63110** (WhatsApp audio / voice-note delivery is broken) — **Directly closes.** Same root cause: TTS writes to `/tmp/openclaw/tts-*`, media path normalizer blocks the absolute path, audio is silently dropped. Reported on WhatsApp; I reproduced and verified the fix on Telegram. The reporter also identified the likely primary bug as TTS temp paths being dropped during reply normalization, which is exactly what this PR fixes.

- **#54131** (WhatsApp outbound media `MEDIA:` token fails silently) — **Same surface, possibly same root cause.** This issue reports that `MEDIA:` local-file sends fail silently on WhatsApp. While the `MEDIA:` directive path is different from the structured `details.media` path, both ultimately go through the same `normalizeMediaSource()` → `isAllowedAbsoluteReplyMediaPath()` gate. If the `MEDIA:` path resolves to an absolute host-local path outside the allowed roots, it would be blocked the same way.

- **#45329** (Edge TTS generates audio but sendVoice fails on Telegram) — **Different root cause, same symptom.** This issue reports `Network request for sendVoice failed` — a network/transport error, not a path-block error. However, the TTS file is confirmed present at `/tmp/openclaw/tts-*` before the send attempt. It is possible that on older versions (2026.3.11), the `MEDIA:` directive path still worked for local files, and the failure was purely network-related. On current versions (2026.4.8+), the path-block issue from this PR would additionally prevent delivery even if the network error were resolved.

#### Related PRs and why they do not fix this

- **#46535** (propagate `audioAsVoice` from tool results to delivery payload) — Addresses a different layer: the `audioAsVoice` flag was lost when using the old `[[audio_as_voice]]\nMEDIA:` inline format. After `3cd4978fc2`, the format changed to structured `details.media.audioAsVoice`, which already propagates correctly through `extractToolResultMediaArtifact()`. This PR does not fix the path-blocking issue.

- **#54892** (Fix embedded replies dropping structured tool-result media) — Addresses a different layer: the embedded reply emission path only forwarded inline `MEDIA:` media and ignored `details.media.mediaUrls`. After that fix, structured media URLs are correctly propagated to the reply payload — but they still get blocked by `isAllowedAbsoluteReplyMediaPath()` because `/tmp/openclaw/` is not an allowed root. This PR complements #54892 by fixing the path-allowlist gap.

### Reproduction

1. Configure ElevenLabs TTS with Telegram channel
2. Call the `tts` tool (or trigger via `messages.tts.auto: "inbound"`)
3. Observe: no voice message is delivered
4. Gateway file log shows: `dropping blocked reply media /tmp/openclaw/tts-xxx/voice-xxx.opus: Error: Absolute host-local MEDIA paths are blocked`

After this fix, the same TTS call delivers the voice message correctly.