### PR TITLE
fix: Fix webchat TTS tool audio delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Docs: https://docs.openclaw.ai
 - Browser/security: reject strict-policy hostname navigation unless the hostname is an explicit allowlist exception or IP literal, and route CDP HTTP discovery through the pinned SSRF fetch path. (#64367) Thanks @eleqtrizit.
 - Models/vLLM: ignore empty `tool_calls` arrays from reasoning-model OpenAI-compatible replies, reset false `toolUse` stop reasons when no actual tool calls were parsed, and stop sending `tool_choice` unless tools are present so vLLM reasoning responses no longer hang indefinitely. (#61197, #61534) Thanks @balajisiva.
 - Heartbeat/scheduling: spread interval heartbeats across stable per-agent phases derived from gateway identity, so provider traffic is distributed more uniformly across the configured interval instead of clustering around startup-relative times. (#64560) Thanks @odysseus0.
+- Control UI/webchat: persist agent-run TTS audio replies into webchat history before finalization so tool-generated audio reaches webchat clients again. (#63514) thanks @bittoby
 
 ## 2026.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - WhatsApp: honor the configured default account when the active listener helper is used without an explicit account id, so named default accounts do not get registered under `default`. (#53918) Thanks @yhyatt.
 - QA/packaging: stop packaged CLI startup and completion cache generation from reading repo-only QA scenario markdown by routing QA command registration through a narrow facade. (#64648) Thanks @obviyus.
+- Control UI/webchat: persist agent-run TTS audio replies into webchat history before finalization so tool-generated audio reaches webchat clients again. (#63514) thanks @bittoby
 
 ## 2026.4.10
 
@@ -144,7 +145,6 @@ Docs: https://docs.openclaw.ai
 - Browser/security: reject strict-policy hostname navigation unless the hostname is an explicit allowlist exception or IP literal, and route CDP HTTP discovery through the pinned SSRF fetch path. (#64367) Thanks @eleqtrizit.
 - Models/vLLM: ignore empty `tool_calls` arrays from reasoning-model OpenAI-compatible replies, reset false `toolUse` stop reasons when no actual tool calls were parsed, and stop sending `tool_choice` unless tools are present so vLLM reasoning responses no longer hang indefinitely. (#61197, #61534) Thanks @balajisiva.
 - Heartbeat/scheduling: spread interval heartbeats across stable per-agent phases derived from gateway identity, so provider traffic is distributed more uniformly across the configured interval instead of clustering around startup-relative times. (#64560) Thanks @odysseus0.
-- Control UI/webchat: persist agent-run TTS audio replies into webchat history before finalization so tool-generated audio reaches webchat clients again. (#63514) thanks @bittoby
 
 ## 2026.4.9
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -294,6 +294,26 @@ describe("handleAgentEnd", () => {
     expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
   });
 
+  it("emits orphaned tool media before the lifecycle end event", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.pendingToolMediaUrls = ["/tmp/reply.opus"];
+    ctx.state.pendingToolAudioAsVoice = true;
+
+    await handleAgentEnd(ctx);
+
+    const blockReplyOrder =
+      (vi.mocked(ctx.emitBlockReply).mock.invocationCallOrder[0] as number | undefined) ?? 0;
+    const lifecycleOrder = onAgentEvent.mock.invocationCallOrder[0] as number | undefined;
+
+    expect(blockReplyOrder).toBeGreaterThan(0);
+    expect(lifecycleOrder).toBeGreaterThan(blockReplyOrder);
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+  });
+
   it("resolves compaction wait before awaiting an async block reply flush", async () => {
     let resolveFlush: (() => void) | undefined;
     const ctx = createContext(undefined);

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -18,6 +18,10 @@ const mockState = vi.hoisted(() => ({
   sessionId: "sess-1",
   mainSessionKey: "main",
   finalText: "[[reply_to_current]]",
+  dispatchedReplies: [] as Array<{
+    kind: "tool" | "block" | "final";
+    payload: { text?: string; mediaUrl?: string; mediaUrls?: string[] };
+  }>,
   dispatchError: null as Error | null,
   triggerAgentRunStart: false,
   agentRunId: "run-agent-1",
@@ -80,6 +84,16 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       ctx: MsgContext;
       dispatcher: {
         sendFinalReply: (payload: { text: string }) => boolean;
+        sendBlockReply: (payload: {
+          text?: string;
+          mediaUrl?: string;
+          mediaUrls?: string[];
+        }) => boolean;
+        sendToolResult: (payload: {
+          text?: string;
+          mediaUrl?: string;
+          mediaUrls?: string[];
+        }) => boolean;
         markComplete: () => void;
         waitForIdle: () => Promise<void>;
       };
@@ -96,7 +110,23 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       if (mockState.triggerAgentRunStart) {
         params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
       }
-      params.dispatcher.sendFinalReply({ text: mockState.finalText });
+      if (mockState.dispatchedReplies.length > 0) {
+        for (const reply of mockState.dispatchedReplies) {
+          if (reply.kind === "tool") {
+            params.dispatcher.sendToolResult(reply.payload);
+            continue;
+          }
+          if (reply.kind === "block") {
+            params.dispatcher.sendBlockReply(reply.payload);
+            continue;
+          }
+          params.dispatcher.sendFinalReply({
+            text: reply.payload.text ?? "",
+          });
+        }
+      } else {
+        params.dispatcher.sendFinalReply({ text: mockState.finalText });
+      }
       params.dispatcher.markComplete();
       await params.dispatcher.waitForIdle();
       return { ok: true };
@@ -351,6 +381,7 @@ async function runNonStreamingChatSend(params: {
 describe("chat directive tag stripping for non-streaming final payloads", () => {
   afterEach(() => {
     mockState.finalText = "[[reply_to_current]]";
+    mockState.dispatchedReplies = [];
     mockState.dispatchError = null;
     mockState.mainSessionKey = "main";
     mockState.triggerAgentRunStart = false;
@@ -426,6 +457,60 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
     const register = context.registerToolEventRecipient as unknown as ReturnType<typeof vi.fn>;
     expect(register).not.toHaveBeenCalled();
+  });
+
+  it("persists agent-run audio replies emitted as media-bearing block payloads", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-audio-");
+    const transcriptDir = path.dirname(mockState.transcriptPath);
+    const audioPath = path.join(transcriptDir, "reply.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "block",
+        payload: {
+          mediaUrl: audioPath,
+          mediaUrls: [audioPath],
+        },
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-audio",
+      expectBroadcast: false,
+    });
+
+    const assistantUpdate = mockState.emittedTranscriptUpdates.find(
+      (update) =>
+        typeof update.message === "object" &&
+        update.message !== null &&
+        (update.message as { role?: unknown }).role === "assistant" &&
+        Array.isArray((update.message as { content?: unknown }).content) &&
+        ((update.message as { content: Array<{ type?: string }> }).content.some(
+          (block) => block?.type === "audio",
+        ) ??
+          false),
+    );
+    expect(assistantUpdate).toMatchObject({
+      message: {
+        role: "assistant",
+        idempotencyKey: "idem-agent-audio:assistant-audio",
+        content: [
+          { type: "text", text: "Audio reply" },
+          {
+            type: "audio",
+            source: {
+              type: "base64",
+              media_type: "audio/mpeg",
+            },
+          },
+        ],
+      },
+    });
   });
 
   it("chat.inject keeps message defined when directive tag is the only content", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -113,6 +113,17 @@ type ChatAbortRequester = {
   isAdmin: boolean;
 };
 
+/** True when a reply payload carries at least one media reference (mediaUrl or mediaUrls). */
+function isMediaBearingPayload(payload: ReplyPayload): boolean {
+  if (payload.mediaUrl?.trim()) {
+    return true;
+  }
+  if (payload.mediaUrls?.some((url) => url.trim())) {
+    return true;
+  }
+  return false;
+}
+
 export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
@@ -1751,10 +1762,19 @@ export const chatHandlers: GatewayRequestHandlers = {
           context.logGateway.warn(`webchat dispatch failed: ${formatForLog(err)}`);
         },
         deliver: async (payload, info) => {
-          if (info.kind !== "block" && info.kind !== "final") {
-            return;
+          switch (info.kind) {
+            case "block":
+            case "final":
+              deliveredReplies.push({ payload, kind: info.kind });
+              break;
+            case "tool":
+              // Tool results that carry audio (e.g. the TTS tool) must be promoted
+              // to "final" so the downstream audio extraction path can pick them up.
+              if (isMediaBearingPayload(payload)) {
+                deliveredReplies.push({ payload, kind: "final" });
+              }
+              break;
           }
-          deliveredReplies.push({ payload, kind: info.kind });
         },
       });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1770,8 +1770,12 @@ export const chatHandlers: GatewayRequestHandlers = {
             case "tool":
               // Tool results that carry audio (e.g. the TTS tool) must be promoted
               // to "final" so the downstream audio extraction path can pick them up.
+              // Strip text to avoid leaking tool summary into the combined reply.
               if (isMediaBearingPayload(payload)) {
-                deliveredReplies.push({ payload, kind: "final" });
+                deliveredReplies.push({
+                  payload: { ...payload, text: undefined },
+                  kind: "final",
+                });
               }
               break;
           }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -124,6 +124,19 @@ function isMediaBearingPayload(payload: ReplyPayload): boolean {
   return false;
 }
 
+function buildWebchatAudioOnlyAssistantMessage(
+  payloads: ReplyPayload[],
+): { content: Array<Record<string, unknown>>; transcriptText: string } | null {
+  const audioBlocks = buildWebchatAudioContentBlocksFromReplyPayloads(payloads);
+  if (audioBlocks.length === 0) {
+    return null;
+  }
+  return {
+    transcriptText: "Audio reply",
+    content: [{ type: "text", text: "Audio reply" }, ...audioBlocks],
+  };
+}
+
 export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
@@ -1695,6 +1708,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         channel: INTERNAL_MESSAGE_CHANNEL,
       });
       const deliveredReplies: Array<{ payload: ReplyPayload; kind: "block" | "final" }> = [];
+      let appendedWebchatAgentAudio = false;
       let userTranscriptUpdatePromise: Promise<void> | null = null;
       const emitUserTranscriptUpdate = async () => {
         if (userTranscriptUpdatePromise) {
@@ -1756,6 +1770,34 @@ export const chatHandlers: GatewayRequestHandlers = {
           savedImages: await persistedImagesPromise,
         });
       };
+      const appendWebchatAgentAudioTranscriptIfNeeded = (payload: ReplyPayload) => {
+        if (!agentRunStarted || appendedWebchatAgentAudio || !isMediaBearingPayload(payload)) {
+          return;
+        }
+        const audioMessage = buildWebchatAudioOnlyAssistantMessage([payload]);
+        if (!audioMessage) {
+          return;
+        }
+        const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(sessionKey);
+        const sessionId = latestEntry?.sessionId ?? entry?.sessionId ?? clientRunId;
+        const appended = appendAssistantTranscriptMessage({
+          message: audioMessage.transcriptText,
+          content: audioMessage.content,
+          sessionId,
+          storePath: latestStorePath,
+          sessionFile: latestEntry?.sessionFile,
+          agentId,
+          createIfMissing: true,
+          idempotencyKey: `${clientRunId}:assistant-audio`,
+        });
+        if (appended.ok) {
+          appendedWebchatAgentAudio = true;
+          return;
+        }
+        context.logGateway.warn(
+          `webchat transcript append failed for audio reply: ${appended.error ?? "unknown error"}`,
+        );
+      };
       const dispatcher = createReplyDispatcher({
         ...replyPipeline,
         onError: (err) => {
@@ -1766,6 +1808,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             case "block":
             case "final":
               deliveredReplies.push({ payload, kind: info.kind });
+              appendWebchatAgentAudioTranscriptIfNeeded(payload);
               break;
             case "tool":
               // Tool results that carry audio (e.g. the TTS tool) must be promoted


### PR DESCRIPTION
## Summary

- **Problem:** The `tts` tool generates audio successfully, but webchat never delivers it to the client. The `/tts` slash command works fine.
- **Why it matters:** Agent-driven TTS is completely broken in webchat.
- **What changed:** Added a `isMediaBearingPayload` helper and updated the webchat deliver callback to accept tool results that carry media by promoting them to `"final"` kind.
- **What did NOT change:** Non-media tool results are still dropped. Block and final payloads behave the same. Other channels are not touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63033
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** The webchat deliver callback drops all `"tool"` kind payloads. TTS tool audio arrives as `"tool"` kind, so it gets silently discarded. The downstream audio extraction only looks at `"final"` kind, which makes this a double gate.
- **Missing detection / guardrail:** No test covers media-bearing tool result delivery in webchat.
- **Contributing context:** The `/tts` slash command bypasses this because it enters the pipeline as `"final"` kind directly.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/gateway/server-methods/chat.ts`
- Scenario the test should lock in: Tool result with `mediaUrl` appears in delivered replies as `"final"`.
- If no new test is added, why not: Keeping this PR minimal. Test can follow separately.

## User-visible / Behavior Changes

TTS tool audio now reaches webchat clients. Previously it was silently dropped.

## Diagram

```text
Before:
TTS tool -> deliver(payload, kind:"tool") -> dropped

After:
TTS tool -> deliver(payload, kind:"tool") -> has media? -> promote to "final" -> audio delivered
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime: Node 24
- Channel: Webchat

### Steps

1. Configure TTS with a working provider
2. Send a webchat message that makes the agent call the `tts` tool
3. Check if audio appears in the response

### Expected

Audio delivered to webchat client.

### Actual (before fix)

No audio. MP3 exists on disk but never sent.

## Evidence

- [x] Trace/log snippets

Code trace confirmed: deliver callback received `kind: "tool"` and returned early. After fix, media-bearing tool payloads enter the `case "tool"` branch and get promoted to `"final"`.

## Human Verification

- **Verified:** Full dispatch path traced from tool execution to webchat audio extraction. Lint, format, and type checks all pass.
- **Edge cases:** Empty mediaUrl, undefined mediaUrls, non-media tool results, BTW reply filtering, text assembly for media-only payloads.
- **Not verified:** Live end-to-end with a running gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Non-audio media tool results also get promoted to `"final"`.
  - **Mitigation:** The audio extraction only picks up audio files via `isAudioFileName`. Non-audio media is ignored. No side effect.
