### PR TITLE
fix: preserve threadId in announce target sessions.list fallback

### DIFF
--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -53,8 +53,14 @@ export async function resolveAnnounceTarget(params: {
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
       (typeof origin?.accountId === "string" ? origin.accountId : undefined);
+    const threadId =
+      typeof deliveryContext?.threadId === "string"
+        ? deliveryContext.threadId
+        : typeof deliveryContext?.threadId === "number" && Number.isFinite(deliveryContext.threadId)
+          ? String(deliveryContext.threadId)
+          : undefined;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -332,6 +332,82 @@ describe("resolveAnnounceTarget", () => {
       accountId: "work",
     });
   });
+
+  it("preserves string threadId from deliveryContext in sessions.list fallback", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            accountId: "work",
+            threadId: "topic-42",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+      accountId: "work",
+      threadId: "topic-42",
+    });
+  });
+
+  it("preserves numeric threadId from deliveryContext in sessions.list fallback", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            threadId: 554,
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+      threadId: "554",
+    });
+  });
+
+  it("omits threadId when deliveryContext has no threadId in sessions.list fallback", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+    });
+    expect(target?.threadId).toBeUndefined();
+  });
 });
 
 describe("sessions_list gating", () => {


### PR DESCRIPTION
## Summary

Fixes #63469

`resolveAnnounceTarget()` extracts `channel`, `to`, and `accountId` from `deliveryContext` when falling back to `sessions.list`, but was dropping `threadId`. This caused A2A announce messages to land in the channel top-level instead of the originating Telegram forum topic / thread.

## Changes

**`src/agents/tools/sessions-announce-target.ts`**
- Extract `deliveryContext.threadId` (handling both string and numeric types, matching the `SessionListDeliveryContext` definition)
- Include `threadId` in the returned `AnnounceTarget` on the `sessions.list` fallback path

**`src/agents/tools/sessions.test.ts`**
- Added 3 regression tests covering the `sessions.list` fallback:
  - String `threadId` preserved from `deliveryContext`
  - Numeric `threadId` coerced to string and preserved
  - `threadId` correctly omitted when absent

## Verification

- All 28 tests in `sessions.test.ts` pass (including 3 new)
- All 2 tests in `sessions-send-tool.a2a.test.ts` pass (existing downstream coverage)
- All 5 tests in `sessions-send-helpers.test.ts` pass
- Pre-commit checks (tsgo, lint, boundary checks) all pass