### PR TITLE
fix browser click timeouts for existing-session routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Browser/Chrome MCP: reset cached existing-session control sessions when a `navigate_page` call times out, so one stuck navigation no longer poisons the browser profile until a gateway restart. (#69733) Thanks @ayeshakhalid192007-dev.
+- Browser/Chrome MCP: propagate click timeouts and abort signals to existing-session actions so a stuck click fails fast and reconnects instead of poisoning the browser tool until gateway restart. (#63524) Thanks @dongseok0.
 - OpenCode Go: canonicalize stale bundled `opencode-go` base URLs from `/go` or `/go/v1` to `/zen/go` or `/zen/go/v1`, so older generated model metadata stops hitting the 404 HTML endpoint. (#69898)
 - Channels/preview streaming: centralize draft-preview finalization so Slack, Discord, Mattermost, and Matrix no longer flush temporary preview messages for media/error finals, and preserve first-reply threading for normal fallback delivery.
 - Discord: keep slash command follow-up chunks ephemeral when the command is configured for ephemeral replies, so long `/status` output no longer leaks fallback model or runtime details into the public channel. (#69869) thanks @gumadeiras.

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -341,6 +341,28 @@ describe("chrome MCP page parsing", () => {
     expect(tabs).toHaveLength(1);
   });
 
+  it("does not dispatch a click when the signal is already aborted", async () => {
+    const session = createFakeSession();
+    const callTool = vi.fn(async (_call: ToolCall) => {
+      throw new Error("callTool should not run");
+    });
+    session.client.callTool = callTool as typeof session.client.callTool;
+    setChromeMcpSessionFactoryForTest(async () => session);
+    const ctrl = new AbortController();
+    ctrl.abort(new Error("aborted before click"));
+
+    await expect(
+      clickChromeMcpElement({
+        profileName: "chrome-live",
+        targetId: "1",
+        uid: "btn-1",
+        signal: ctrl.signal,
+      }),
+    ).rejects.toThrow(/aborted before click/i);
+
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
   it("creates a fresh session when userDataDir changes for the same profile", async () => {
     const createdSessions: ChromeMcpSession[] = [];
     const closeMocks: Array<ReturnType<typeof vi.fn>> = [];

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clickChromeMcpElement,
   buildChromeMcpArgs,
   evaluateChromeMcpScript,
   listChromeMcpTabs,
@@ -303,6 +304,41 @@ describe("chrome MCP page parsing", () => {
     const tabs = await listChromeMcpTabs("chrome-live");
     expect(factoryCalls).toBe(2);
     expect(tabs).toHaveLength(2);
+  });
+
+  it("times out a stuck click and recovers on the next call", async () => {
+    let factoryCalls = 0;
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const callTool = vi.fn(async ({ name }: ToolCall) => {
+        if (name === "click") {
+          return await new Promise(() => {});
+        }
+        if (name === "list_pages") {
+          return {
+            content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }],
+          };
+        }
+        throw new Error(`unexpected tool ${name}`);
+      });
+      session.client.callTool = callTool as typeof session.client.callTool;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await expect(
+      clickChromeMcpElement({
+        profileName: "chrome-live",
+        targetId: "1",
+        uid: "btn-1",
+        timeoutMs: 25,
+      }),
+    ).rejects.toThrow(/timed out/i);
+
+    const tabs = await listChromeMcpTabs("chrome-live");
+    expect(factoryCalls).toBe(2);
+    expect(tabs).toHaveLength(1);
   });
 
   it("creates a fresh session when userDataDir changes for the same profile", async () => {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -310,10 +310,15 @@ async function callTool(
   userDataDir: string | undefined,
   name: string,
   args: Record<string, unknown> = {},
-  timeoutMs?: number,
+  opts?: { timeoutMs?: number; signal?: AbortSignal },
 ): Promise<ChromeMcpToolResult> {
   const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
   const session = await getSession(profileName, userDataDir);
+  const timeoutMs = opts?.timeoutMs;
+  const signal = opts?.signal;
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("aborted");
+  }
 
   const rawCall = session.client.callTool({
     name,
@@ -321,35 +326,39 @@ async function callTool(
   }) as Promise<ChromeMcpToolResult>;
 
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-  const callPromise: Promise<ChromeMcpToolResult> =
-    timeoutMs !== undefined && timeoutMs > 0
-      ? Promise.race([
-          rawCall,
-          new Promise<never>((_, reject) => {
-            timeoutHandle = setTimeout(() => {
-              // Use transport-identity check so we never delete a freshly-created replacement session.
-              const cur = sessions.get(cacheKey);
-              if (cur?.transport === session.transport) {
-                sessions.delete(cacheKey);
-              }
-              void session.client.close().catch(() => {});
-              reject(
-                new Error(
-                  `Chrome MCP "${name}" timed out after ${timeoutMs}ms. Session reset for reconnect.`,
-                ),
-              );
-            }, timeoutMs);
-          }),
-        ])
-      : rawCall;
+  let abortListener: (() => void) | undefined;
+  const racers: Array<Promise<ChromeMcpToolResult> | Promise<never>> = [rawCall];
+
+  if (timeoutMs !== undefined && timeoutMs > 0) {
+    racers.push(
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(
+            new Error(
+              `Chrome MCP "${name}" timed out after ${timeoutMs}ms. Session reset for reconnect.`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    );
+  }
+
+  if (signal) {
+    racers.push(
+      new Promise<never>((_, reject) => {
+        abortListener = () => reject(signal.reason ?? new Error("aborted"));
+        signal.addEventListener("abort", abortListener, { once: true });
+      }),
+    );
+  }
 
   let result: ChromeMcpToolResult;
   try {
-    result = await callPromise;
+    result = racers.length === 1 ? await rawCall : await Promise.race(racers);
   } catch (err) {
-    // Transport/connection error or safety-net timeout — tear down session so it reconnects.
+    void rawCall.catch(() => {});
+    // Transport/connection error, timeout, or abort: tear down session so it reconnects.
     // Transport-identity check prevents clobbering a replacement session created concurrently.
-    // Only close the client here if the timeout callback hasn't already done so.
     const cur = sessions.get(cacheKey);
     if (cur?.transport === session.transport) {
       sessions.delete(cacheKey);
@@ -359,6 +368,9 @@ async function callTool(
   } finally {
     if (timeoutHandle !== undefined) {
       clearTimeout(timeoutHandle);
+    }
+    if (signal && abortListener) {
+      signal.removeEventListener("abort", abortListener);
     }
   }
   // Tool-level errors (element not found, script error, etc.) don't indicate a
@@ -507,7 +519,7 @@ export async function navigateChromeMcpPage(params: {
       url: params.url,
       timeout: resolvedTimeoutMs,
     },
-    resolvedTimeoutMs + 5_000,
+    { timeoutMs: resolvedTimeoutMs + 5_000 },
   );
   const page = await findPageById(
     params.profileName,
@@ -554,12 +566,23 @@ export async function clickChromeMcpElement(params: {
   targetId: string;
   uid: string;
   doubleClick?: boolean;
+  timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "click", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
-    ...(params.doubleClick ? { dblClick: true } : {}),
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "click",
+    {
+      pageId: parsePageId(params.targetId),
+      uid: params.uid,
+      ...(params.doubleClick ? { dblClick: true } : {}),
+    },
+    {
+      timeoutMs: params.timeoutMs,
+      signal: params.signal,
+    },
+  );
 }
 
 export async function fillChromeMcpElement(params: {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -505,6 +505,7 @@ export async function clickViaPlaywright(opts: {
   delayMs?: number;
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
@@ -514,6 +515,36 @@ export async function clickViaPlaywright(opts: {
     : page.locator(resolved.selector!);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   const previousUrl = page.url();
+  const signal = opts.signal;
+  let abortListener: (() => void) | undefined;
+  let abortReject: ((reason: unknown) => void) | undefined;
+  let abortPromise: Promise<never> | undefined;
+  if (signal) {
+    abortPromise = new Promise((_, reject) => {
+      abortReject = reject;
+    });
+    void abortPromise.catch(() => {});
+    const disconnect = () => {
+      void forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        reason: "click aborted",
+      }).catch(() => {});
+    };
+    if (signal.aborted) {
+      disconnect();
+      throw signal.reason ?? new Error("aborted");
+    }
+    abortListener = () => {
+      disconnect();
+      abortReject?.(signal.reason ?? new Error("aborted"));
+    };
+    signal.addEventListener("abort", abortListener, { once: true });
+    if (signal.aborted) {
+      abortListener();
+      throw signal.reason ?? new Error("aborted");
+    }
+  }
   try {
     await assertInteractionNavigationCompletedSafely({
       action: async () => {
@@ -523,22 +554,28 @@ export async function clickViaPlaywright(opts: {
           ACT_MAX_CLICK_DELAY_MS,
         );
         if (delayMs > 0) {
-          await locator.hover({ timeout });
+          await awaitEvalWithAbort(locator.hover({ timeout }), abortPromise);
           await new Promise((resolve) => setTimeout(resolve, delayMs));
         }
         if (opts.doubleClick) {
-          await locator.dblclick({
+          await awaitEvalWithAbort(
+            locator.dblclick({
+              timeout,
+              button: opts.button,
+              modifiers: opts.modifiers,
+            }),
+            abortPromise,
+          );
+          return;
+        }
+        await awaitEvalWithAbort(
+          locator.click({
             timeout,
             button: opts.button,
             modifiers: opts.modifiers,
-          });
-          return;
-        }
-        await locator.click({
-          timeout,
-          button: opts.button,
-          modifiers: opts.modifiers,
-        });
+          }),
+          abortPromise,
+        );
       },
       cdpUrl: opts.cdpUrl,
       page,
@@ -548,6 +585,10 @@ export async function clickViaPlaywright(opts: {
     });
   } catch (err) {
     throw toAIFriendlyError(err, label);
+  } finally {
+    if (signal && abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
   }
 }
 

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -554,11 +554,11 @@ export async function clickViaPlaywright(opts: {
           ACT_MAX_CLICK_DELAY_MS,
         );
         if (delayMs > 0) {
-          await awaitEvalWithAbort(locator.hover({ timeout }), abortPromise);
+          await awaitActionWithAbort(locator.hover({ timeout }), abortPromise);
           await new Promise((resolve) => setTimeout(resolve, delayMs));
         }
         if (opts.doubleClick) {
-          await awaitEvalWithAbort(
+          await awaitActionWithAbort(
             locator.dblclick({
               timeout,
               button: opts.button,
@@ -568,7 +568,7 @@ export async function clickViaPlaywright(opts: {
           );
           return;
         }
-        await awaitEvalWithAbort(
+        await awaitActionWithAbort(
           locator.click({
             timeout,
             button: opts.button,

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -419,6 +419,8 @@ export function registerBrowserAgentActRoutes(
                       targetId: tab.targetId,
                       uid: action.ref!,
                       doubleClick: action.doubleClick ?? false,
+                      timeoutMs: action.timeoutMs,
+                      signal: req.signal,
                     }),
                   guard: existingSessionNavigationGuard,
                 });

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -8,6 +8,7 @@ import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helper
 const routeState = existingSessionRouteState;
 
 const chromeMcpMocks = vi.hoisted(() => ({
+  clickChromeMcpElement: vi.fn(async () => {}),
   evaluateChromeMcpScript: vi.fn(
     async (_params: { profileName: string; targetId: string; fn: string }) => true,
   ),
@@ -28,7 +29,7 @@ const navigationGuardMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../chrome-mcp.js", () => ({
-  clickChromeMcpElement: vi.fn(async () => {}),
+  clickChromeMcpElement: chromeMcpMocks.clickChromeMcpElement,
   closeChromeMcpTab: vi.fn(async () => {}),
   dragChromeMcpElement: vi.fn(async () => {}),
   evaluateChromeMcpScript: chromeMcpMocks.evaluateChromeMcpScript,
@@ -106,6 +107,7 @@ describe("existing-session browser routes", () => {
   beforeEach(() => {
     routeState.profileCtx.ensureTabAvailable.mockClear();
     routeState.profileCtx.listTabs.mockClear();
+    chromeMcpMocks.clickChromeMcpElement.mockClear();
     chromeMcpMocks.evaluateChromeMcpScript.mockReset();
     chromeMcpMocks.navigateChromeMcpPage.mockClear();
     chromeMcpMocks.takeChromeMcpScreenshot.mockClear();
@@ -260,6 +262,33 @@ describe("existing-session browser routes", () => {
       profileName: "chrome-live",
       targetId: "7",
       fn: "() => window.location.href",
+    });
+  });
+
+  it("forwards click timeoutMs to the existing-session click executor", async () => {
+    const handler = getActPostHandler();
+    const response = createBrowserRouteResponse();
+    const ctrl = new AbortController();
+
+    await handler?.(
+      {
+        params: {},
+        query: {},
+        body: { kind: "click", ref: "btn-1", timeoutMs: 1234 },
+        signal: ctrl.signal,
+      },
+      response.res,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(chromeMcpMocks.clickChromeMcpElement).toHaveBeenCalledWith({
+      profileName: "chrome-live",
+      userDataDir: undefined,
+      targetId: "7",
+      uid: "btn-1",
+      doubleClick: false,
+      timeoutMs: 1234,
+      signal: ctrl.signal,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add Chrome MCP click timeout handling so stuck existing-session clicks fail fast and reconnect cleanly on the next request
- propagate browser act click timeout and abort signals through the route and Playwright interaction path while preserving the Playwright SSRF navigation guard from main
- cover the regression with browser route and Chrome MCP tests, including a pre-aborted signal case, and verify the fix with a real OpenClaw browser flow

Fixes #57158

## Test Plan
- [x] pnpm test extensions/browser/src/browser/chrome-mcp.test.ts extensions/browser/src/browser/routes/agent.existing-session.test.ts extensions/browser/src/browser/client-fetch.loopback-auth.test.ts extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts
- [x] pnpm build
- [x] ./scripts/restart-mac.sh --no-sign --no-attach-only
- [x] openclaw browser open https://example.com
- [x] openclaw browser snapshot
- [x] openclaw browser click e2