### PR TITLE
fix(chat): don't reload history for /new and /reset commands

### DIFF
--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -5,7 +5,12 @@ export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): bo
   if (!payload || payload.state !== "final") {
     return false;
   }
-  if (!payload.message || typeof payload.message !== "object") {
+  // Don't reload when message is undefined — this is normal for /new and /reset
+  // slash commands which create a new session without an assistant response.
+  if (!payload.message) {
+    return false;
+  }
+  if (typeof payload.message !== "object") {
     return true;
   }
   const message = payload.message as Record<string, unknown>;


### PR DESCRIPTION
## Summary
Fixed a race condition where `/new` and `/reset` slash commands triggered an unintended chat history reload, causing the UI to briefly flash empty before restoring old messages.

## Problem
`shouldReloadHistoryForFinalEvent` returned `true` when `payload.message` was `undefined`. For `/new` and `/reset`, the backend doesn\'t send an assistant response (`payload.message = undefined`), so the condition incorrectly triggered a history reload. By the time `loadChatHistory` ran, the new empty transcript hadn\'t been flushed yet, so the UI loaded an empty file.

## Solution
Separated the undefined check from the type check:
- `!payload.message` → `return false` (slash commands are normal)
- `typeof payload.message !== "object"` → `return true` (error case)

## Changes
- `ui/src/ui/chat-event-reload.ts` — +6/-1 lines

## Test Plan
- [x] `/new` → `message = undefined` → no reload ✅
- [x] `/reset` → `message = undefined` → no reload ✅
- [x] Normal assistant response → reload (existing behavior) ✅
- [x] Malformed `message = "string"` → reload (error case) ✅

## Backward Compatibility
✅ Fully backward compatible — return type unchanged

See detailed proposal: references/github-contribute/PR-3-CHAT-RELOAD-FIX.md