### PR TITLE
feat: allow prompt cache key forwarding for custom/local providers

### DIFF
--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -7,6 +7,7 @@ type OpenAIResponsesPayloadModel = {
   provider?: unknown;
   contextWindow?: unknown;
   compat?: { supportsStore?: boolean };
+  promptCacheSupported?: boolean;
 };
 
 type OpenAIResponsesPayloadPolicyOptions = {
@@ -98,6 +99,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
     api: readStringValue(model.api),
     baseUrl: readStringValue(model.baseUrl),
     compat: model.compat,
+    promptCacheSupported: model.promptCacheSupported,
     capability: "llm",
     transport: "stream",
   }).capabilities;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -750,9 +750,11 @@ export function buildOpenAIResponsesParams(
     { supportsDeveloperRole },
   );
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
-  const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
-    storeMode: "disable",
-  });
+  const promptCacheSupported = (model as Record<string, unknown>).promptCacheSupported === true;
+  const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(
+    { ...model, promptCacheSupported },
+    { storeMode: "disable" },
+  );
   const params: OpenAIResponsesRequestParams = {
     model: model.id,
     input: messages,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -336,6 +336,7 @@ function applyConfiguredProviderOverrides(params: {
       maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
       headers: requestConfig.headers,
       compat: configuredModel?.compat ?? discoveredModel.compat,
+      ...(providerConfig.promptCache ? { promptCacheSupported: true } : {}),
     },
     providerRequest,
   );

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -185,12 +185,16 @@ export function createOpenAIResponsesContextManagementWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    const policy = resolveOpenAIResponsesPayloadPolicy(model, {
-      extraParams,
-      enablePromptCacheStripping: true,
-      enableServerCompaction: true,
-      storeMode: "provider-policy",
-    });
+    const promptCacheSupported = (model as Record<string, unknown>).promptCacheSupported === true;
+    const policy = resolveOpenAIResponsesPayloadPolicy(
+      { ...model, promptCacheSupported },
+      {
+        extraParams,
+        enablePromptCacheStripping: true,
+        enableServerCompaction: true,
+        storeMode: "provider-policy",
+      },
+    );
     if (
       policy.explicitStore === undefined &&
       !policy.useServerCompaction &&

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -548,6 +548,52 @@ describe("provider attribution", () => {
     });
   });
 
+  it("respects promptCacheSupported for local OpenAI-compatible providers", () => {
+    // Without promptCacheSupported: prompt cache is stripped (default)
+    expect(
+      resolveProviderRequestCapabilities({
+        provider: "local-mlx",
+        api: "openai-responses",
+        baseUrl: "http://localhost:8080/v1",
+        capability: "llm",
+        transport: "stream",
+      }),
+    ).toMatchObject({
+      endpointClass: "local",
+      shouldStripResponsesPromptCache: true,
+    });
+
+    // With promptCacheSupported: true: prompt cache is forwarded
+    expect(
+      resolveProviderRequestCapabilities({
+        provider: "local-mlx",
+        api: "openai-responses",
+        baseUrl: "http://localhost:8080/v1",
+        capability: "llm",
+        transport: "stream",
+        promptCacheSupported: true,
+      }),
+    ).toMatchObject({
+      endpointClass: "local",
+      shouldStripResponsesPromptCache: false,
+    });
+
+    // With promptCacheSupported: false: prompt cache is stripped (explicit)
+    expect(
+      resolveProviderRequestCapabilities({
+        provider: "local-mlx",
+        api: "openai-responses",
+        baseUrl: "http://localhost:8080/v1",
+        capability: "llm",
+        transport: "stream",
+        promptCacheSupported: false,
+      }),
+    ).toMatchObject({
+      endpointClass: "local",
+      shouldStripResponsesPromptCache: true,
+    });
+  });
+
   it("resolves shared compat families and native streaming-usage gates", () => {
     expect(
       resolveProviderRequestCapabilities({

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -93,6 +93,8 @@ export type ProviderRequestCapabilitiesInput = ProviderRequestPolicyInput & {
   compat?: {
     supportsStore?: boolean;
   } | null;
+  /** When true, prompt cache fields are forwarded even for proxy-like endpoints. */
+  promptCacheSupported?: boolean;
 };
 
 export type ProviderRequestCompatibilityFamily = "moonshot";
@@ -608,7 +610,10 @@ export function resolveProviderRequestCapabilities(
       OPENAI_RESPONSES_PROVIDERS.has(provider) &&
       policy.usesKnownNativeOpenAIEndpoint,
     shouldStripResponsesPromptCache:
-      api !== undefined && OPENAI_RESPONSES_APIS.has(api) && policy.usesExplicitProxyLikeEndpoint,
+      api !== undefined &&
+      OPENAI_RESPONSES_APIS.has(api) &&
+      policy.usesExplicitProxyLikeEndpoint &&
+      input.promptCacheSupported !== true,
     // Native endpoint class is the real signal here. Users can point a generic
     // provider key at Moonshot or DashScope and still need streaming usage.
     supportsNativeStreamingUsageCompat:

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -157,6 +157,7 @@ type ResolveProviderRequestPolicyConfigParams = {
     supportsStore?: boolean;
   } | null;
   modelId?: string | null;
+  promptCacheSupported?: boolean;
   allowPrivateNetwork?: boolean;
   request?: ProviderRequestTransportOverrides;
 };
@@ -587,6 +588,7 @@ export function resolveProviderRequestPolicyConfig(
     ...policyInput,
     compat: params.compat,
     modelId: params.modelId,
+    promptCacheSupported: params.promptCacheSupported,
   });
   const auth = resolveAuthOverride({
     authHeader: params.authHeader,

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -81,6 +81,12 @@ export type ModelProviderConfig = {
   headers?: Record<string, SecretInput>;
   authHeader?: boolean;
   request?: ConfiguredModelProviderRequest;
+  /**
+   * When true, `prompt_cache_key` and `prompt_cache_retention` are forwarded
+   * to this provider instead of being stripped.  Useful for local/custom
+   * OpenAI-compatible servers that implement their own prefix caching.
+   */
+  promptCache?: boolean;
   models: ModelDefinitionConfig[];
 };
 


### PR DESCRIPTION
## Summary

Adds a `promptCache` option to `ModelProviderConfig` that, when `true`, forwards `prompt_cache_key` and `prompt_cache_retention` to local/custom OpenAI-compatible servers instead of stripping them.

Fixes #61671

### Problem

The `shouldStripResponsesPromptCache` logic strips prompt cache fields from all non-native-OpenAI endpoints, including local servers that implement their own prefix caching. This prevents cross-request KV cache reuse on servers like mlx-vlm, vLLM, and others that support it.

### Impact

With prompt cache forwarding enabled on a local mlx-vlm server (Apple Silicon):
- **Cold turn**: ~12s (14K token system prompt prefill)
- **Warm turn**: ~3s (KV cache reused — **3-4x faster**)

### Changes

| File | Change |
|---|---|
| `src/config/types.models.ts` | Add `promptCache?: boolean` to `ModelProviderConfig` |
| `src/agents/provider-attribution.ts` | Add `promptCacheSupported?: boolean` to capabilities input; skip stripping when `true` |
| `src/agents/provider-request-config.ts` | Thread `promptCacheSupported` through to capabilities resolution |
| `src/agents/provider-attribution.test.ts` | 3 test cases: default strips, `true` forwards, `false` strips |

### Usage

```json
{
  "models": {
    "providers": {
      "local-mlx": {
        "api": "openai-responses",
        "baseUrl": "http://localhost:8080/v1",
        "promptCache": true,
        "models": [...]
      }
    }
  }
}
```

### Tests

```
npx vitest run src/agents/provider-attribution.test.ts
# 26 passed
```

Backward compatible — defaults to current stripping behavior when `promptCache` is not set.