### PR TITLE
fix(agents) context-engine: per-iteration ingest and assemble for compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Browser/SSRF: preserve explicit strict browser navigation mode for legacy `browser.ssrfPolicy.allowPrivateNetwork: false` configs by normalizing the legacy alias to the canonical strict marker instead of silently widening those installs to the default non-strict hostname-navigation path.
 - Agents/subagents: emit the subagent registry lazy-runtime stub on the stable dist path that both source and bundled runtime imports resolve, so the follow-up dist fix no longer still fails with `ERR_MODULE_NOT_FOUND` at runtime. (#66420) Thanks @obviyus.
 - Browser: keep loopback CDP readiness checks reachable under strict SSRF defaults so OpenClaw can reconnect to locally started managed Chrome. (#66354) Thanks @hxy91819.
+- Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 
 ## 2026.4.14-beta.1
 
@@ -70,7 +71,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
 - CLI/approvals: raise the default `openclaw approvals get` gateway timeout and report config-load timeouts explicitly, so slow hosts stop showing a misleading `Config unavailable.` note when the approvals snapshot succeeds but the follow-up config RPC needs more time. (#66239) Thanks @neeravmakwana.
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
-- Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
+
 ## 2026.4.12
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
 - CLI/approvals: raise the default `openclaw approvals get` gateway timeout and report config-load timeouts explicitly, so slow hosts stop showing a misleading `Config unavailable.` note when the approvals snapshot succeeds but the follow-up config RPC needs more time. (#66239) Thanks @neeravmakwana.
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
-
+- Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 ## 2026.4.12
 
 ### Changes
@@ -330,6 +330,7 @@ Docs: https://docs.openclaw.ai
 - Agents/inbound metadata: strip NUL bytes from serialized inbound context blocks before they reach backend spawn args, so malformed message metadata cannot crash agent spawn with `ERR_INVALID_ARG_VALUE`. (#65389) Thanks @adminfedres and @vincentkoc.
 - iMessage: retry transient `watch.subscribe` startup failures before tearing down the monitor, so brief local transport stalls do not immediately bounce the channel. (#65393) Thanks @vincentkoc.
 - Status/session_status: move shared session status text into a neutral internal status module and keep the tool importing a local runtime shim, so built `session_status` no longer depends on reply command internals or a bundler-opaque runtime import. (#65807) Thanks @dutifulbob.
+- QQBot/security: replace raw `fetch()` in the image-size probe with SSRF-guarded `fetchRemoteMedia`, fix `resolveRepoRoot()` to walk up to `.git` instead of hardcoding two parent levels, and refresh the raw-fetch allowlist to match the corrected scan. (#63495) Thanks @dims.
 
 ## 2026.4.9
 

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -199,6 +199,9 @@ export async function finalizeAttemptContextEngineTurn(params: {
   }) => Promise<unknown>;
   sessionManager: unknown;
   warn: (message: string) => void;
+  /** When true, skip the afterTurn/ingest calls because the loop hook already
+   *  handled per-iteration ingestion during the tool loop. Maintenance still runs. */
+  skipAfterTurn?: boolean;
 }) {
   if (!params.contextEngine) {
     return { postTurnFinalizationSucceeded: true };
@@ -206,46 +209,48 @@ export async function finalizeAttemptContextEngineTurn(params: {
 
   let postTurnFinalizationSucceeded = true;
 
-  if (typeof params.contextEngine.afterTurn === "function") {
-    try {
-      await params.contextEngine.afterTurn({
-        sessionId: params.sessionIdUsed,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        messages: params.messagesSnapshot,
-        prePromptMessageCount: params.prePromptMessageCount,
-        tokenBudget: params.tokenBudget,
-        runtimeContext: params.runtimeContext,
-      });
-    } catch (afterTurnErr) {
-      postTurnFinalizationSucceeded = false;
-      params.warn(`context engine afterTurn failed: ${String(afterTurnErr)}`);
-    }
-  } else {
-    const newMessages = params.messagesSnapshot.slice(params.prePromptMessageCount);
-    if (newMessages.length > 0) {
-      if (typeof params.contextEngine.ingestBatch === "function") {
-        try {
-          await params.contextEngine.ingestBatch({
-            sessionId: params.sessionIdUsed,
-            sessionKey: params.sessionKey,
-            messages: newMessages,
-          });
-        } catch (ingestErr) {
-          postTurnFinalizationSucceeded = false;
-          params.warn(`context engine ingest failed: ${String(ingestErr)}`);
-        }
-      } else {
-        for (const msg of newMessages) {
+  if (!params.skipAfterTurn) {
+    if (typeof params.contextEngine.afterTurn === "function") {
+      try {
+        await params.contextEngine.afterTurn({
+          sessionId: params.sessionIdUsed,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          messages: params.messagesSnapshot,
+          prePromptMessageCount: params.prePromptMessageCount,
+          tokenBudget: params.tokenBudget,
+          runtimeContext: params.runtimeContext,
+        });
+      } catch (afterTurnErr) {
+        postTurnFinalizationSucceeded = false;
+        params.warn(`context engine afterTurn failed: ${String(afterTurnErr)}`);
+      }
+    } else {
+      const newMessages = params.messagesSnapshot.slice(params.prePromptMessageCount);
+      if (newMessages.length > 0) {
+        if (typeof params.contextEngine.ingestBatch === "function") {
           try {
-            await params.contextEngine.ingest?.({
+            await params.contextEngine.ingestBatch({
               sessionId: params.sessionIdUsed,
               sessionKey: params.sessionKey,
-              message: msg,
+              messages: newMessages,
             });
           } catch (ingestErr) {
             postTurnFinalizationSucceeded = false;
             params.warn(`context engine ingest failed: ${String(ingestErr)}`);
+          }
+        } else {
+          for (const msg of newMessages) {
+            try {
+              await params.contextEngine.ingest?.({
+                sessionId: params.sessionIdUsed,
+                sessionKey: params.sessionKey,
+                message: msg,
+              });
+            } catch (ingestErr) {
+              postTurnFinalizationSucceeded = false;
+              params.warn(`context engine ingest failed: ${String(ingestErr)}`);
+            }
           }
         }
       }

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -199,9 +199,6 @@ export async function finalizeAttemptContextEngineTurn(params: {
   }) => Promise<unknown>;
   sessionManager: unknown;
   warn: (message: string) => void;
-  /** When true, skip the afterTurn/ingest calls because the loop hook already
-   *  handled per-iteration ingestion during the tool loop. Maintenance still runs. */
-  skipAfterTurn?: boolean;
 }) {
   if (!params.contextEngine) {
     return { postTurnFinalizationSucceeded: true };
@@ -209,8 +206,7 @@ export async function finalizeAttemptContextEngineTurn(params: {
 
   let postTurnFinalizationSucceeded = true;
 
-  if (!params.skipAfterTurn) {
-    if (typeof params.contextEngine.afterTurn === "function") {
+  if (typeof params.contextEngine.afterTurn === "function") {
       try {
         await params.contextEngine.afterTurn({
           sessionId: params.sessionIdUsed,
@@ -255,7 +251,7 @@ export async function finalizeAttemptContextEngineTurn(params: {
         }
       }
     }
-  }
+
 
   if (
     !params.promptError &&

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1925,6 +1925,7 @@ export async function runEmbeddedAttempt(
                   promptBudgetBeforeReserve: 0,
                   overflowTokens: 0,
                   toolResultReducibleChars: 0,
+                  effectiveReserveTokens: reserveTokens,
                 }
               : shouldPreemptivelyCompactBeforePrompt({
                   messages: activeSession.messages,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -997,11 +997,7 @@ export async function runEmbeddedAttempt(
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
-      // Hoisted so installContextEngineLoopHook can read the same fence value
-      // that finalizeAttemptContextEngineTurn uses at end-of-attempt. The
-      // initial value is reassigned in the prompt-build phase below, after
-      // any heartbeat message filtering.
-      let prePromptMessageCount = 0;
+      let loopHookActive = false;
       if (params.contextEngine?.info?.ownsCompaction !== true) {
         removeToolResultContextGuard = installToolResultContextGuard({
           agent: activeSession.agent,
@@ -1021,8 +1017,8 @@ export async function runEmbeddedAttempt(
           sessionFile: params.sessionFile,
           tokenBudget: params.contextTokenBudget,
           modelId: params.modelId,
-          getPrePromptMessageCount: () => prePromptMessageCount,
         });
+        loopHookActive = true;
       }
       const cacheTrace = createCacheTrace({
         cfg: params.config,
@@ -1668,7 +1664,7 @@ export async function runEmbeddedAttempt(
       let promptError: unknown = null;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: "prompt" | "compaction" | "precheck" | null = null;
-      prePromptMessageCount = activeSession.messages.length;
+      let prePromptMessageCount = activeSession.messages.length;
       let skipPromptSubmission = false;
       try {
         const promptStartedAt = Date.now();
@@ -2222,6 +2218,7 @@ export async function runEmbeddedAttempt(
             prePromptMessageCount,
             tokenBudget: params.contextTokenBudget,
             runtimeContext: afterTurnRuntimeContext,
+            skipAfterTurn: loopHookActive,
             runMaintenance: async (contextParams) =>
               await runContextEngineMaintenance({
                 contextEngine: contextParams.contextEngine as never,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -991,6 +991,7 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
+      let prePromptMessageCount = activeSession.messages.length;
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
       };
@@ -1016,6 +1017,7 @@ export async function runEmbeddedAttempt(
           sessionFile: params.sessionFile,
           tokenBudget: params.contextTokenBudget,
           modelId: params.modelId,
+          getPrePromptMessageCount: () => prePromptMessageCount,
         });
       }
       const cacheTrace = createCacheTrace({
@@ -1662,7 +1664,6 @@ export async function runEmbeddedAttempt(
       let promptError: unknown = null;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: "prompt" | "compaction" | "precheck" | null = null;
-      let prePromptMessageCount = activeSession.messages.length;
       let skipPromptSubmission = false;
       try {
         const promptStartedAt = Date.now();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -161,7 +161,10 @@ import {
 } from "../system-prompt.js";
 import { dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
-import { installToolResultContextGuard } from "../tool-result-context-guard.js";
+import {
+  installContextEngineLoopHook,
+  installToolResultContextGuard,
+} from "../tool-result-context-guard.js";
 import { truncateOversizedToolResultsInSessionManager } from "../tool-result-truncation.js";
 import {
   logProviderToolSchemaDiagnostics,
@@ -994,15 +997,27 @@ export async function runEmbeddedAttempt(
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
-      removeToolResultContextGuard = installToolResultContextGuard({
-        agent: activeSession.agent,
-        contextWindowTokens: Math.max(
-          1,
-          Math.floor(
-            params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+      if (params.contextEngine?.info?.ownsCompaction !== true) {
+        removeToolResultContextGuard = installToolResultContextGuard({
+          agent: activeSession.agent,
+          contextWindowTokens: Math.max(
+            1,
+            Math.floor(
+              params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+            ),
           ),
-        ),
-      });
+        });
+      } else {
+        removeToolResultContextGuard = installContextEngineLoopHook({
+          agent: activeSession.agent,
+          contextEngine: params.contextEngine,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          tokenBudget: params.contextTokenBudget,
+          modelId: params.modelId,
+        });
+      }
       const cacheTrace = createCacheTrace({
         cfg: params.config,
         env: process.env,
@@ -1900,13 +1915,23 @@ export async function runEmbeddedAttempt(
 
           const reserveTokens = settingsManager.getCompactionReserveTokens();
           const contextTokenBudget = params.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
-          const preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
-            messages: activeSession.messages,
-            systemPrompt: systemPromptText,
-            prompt: effectivePrompt,
-            contextTokenBudget,
-            reserveTokens,
-          });
+          const preemptiveCompaction =
+            params.contextEngine?.info?.ownsCompaction === true
+              ? {
+                  route: "fits" as const,
+                  shouldCompact: false,
+                  estimatedPromptTokens: 0,
+                  promptBudgetBeforeReserve: 0,
+                  overflowTokens: 0,
+                  toolResultReducibleChars: 0,
+                }
+              : shouldPreemptivelyCompactBeforePrompt({
+                  messages: activeSession.messages,
+                  systemPrompt: systemPromptText,
+                  prompt: effectivePrompt,
+                  contextTokenBudget,
+                  reserveTokens,
+                });
           if (preemptiveCompaction.route === "truncate_tool_results_only") {
             const truncationResult = truncateOversizedToolResultsInSessionManager({
               sessionManager,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -997,6 +997,11 @@ export async function runEmbeddedAttempt(
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
+      // Hoisted so installContextEngineLoopHook can read the same fence value
+      // that finalizeAttemptContextEngineTurn uses at end-of-attempt. The
+      // initial value is reassigned in the prompt-build phase below, after
+      // any heartbeat message filtering.
+      let prePromptMessageCount = 0;
       if (params.contextEngine?.info?.ownsCompaction !== true) {
         removeToolResultContextGuard = installToolResultContextGuard({
           agent: activeSession.agent,
@@ -1016,6 +1021,7 @@ export async function runEmbeddedAttempt(
           sessionFile: params.sessionFile,
           tokenBudget: params.contextTokenBudget,
           modelId: params.modelId,
+          getPrePromptMessageCount: () => prePromptMessageCount,
         });
       }
       const cacheTrace = createCacheTrace({
@@ -1662,7 +1668,7 @@ export async function runEmbeddedAttempt(
       let promptError: unknown = null;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: "prompt" | "compaction" | "precheck" | null = null;
-      let prePromptMessageCount = activeSession.messages.length;
+      prePromptMessageCount = activeSession.messages.length;
       let skipPromptSubmission = false;
       try {
         const promptStartedAt = Date.now();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -997,7 +997,6 @@ export async function runEmbeddedAttempt(
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
-      let loopHookActive = false;
       if (params.contextEngine?.info?.ownsCompaction !== true) {
         removeToolResultContextGuard = installToolResultContextGuard({
           agent: activeSession.agent,
@@ -1018,7 +1017,6 @@ export async function runEmbeddedAttempt(
           tokenBudget: params.contextTokenBudget,
           modelId: params.modelId,
         });
-        loopHookActive = true;
       }
       const cacheTrace = createCacheTrace({
         cfg: params.config,
@@ -2218,7 +2216,6 @@ export async function runEmbeddedAttempt(
             prePromptMessageCount,
             tokenBudget: params.contextTokenBudget,
             runtimeContext: afterTurnRuntimeContext,
-            skipAfterTurn: loopHookActive,
             runMaintenance: async (contextParams) =>
               await runContextEngineMaintenance({
                 contextEngine: contextParams.contextEngine as never,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -295,270 +295,204 @@ describe("installContextEngineLoopHook", () => {
   const tokenBudget = 4096;
   const modelId = "test-model";
 
-  it("forwards new messages to engine.afterTurn with prePromptMessageCount=0 on first call", async () => {
+  function installHook(
+    agent: ReturnType<typeof makeGuardableAgent>,
+    engine: MockedEngine,
+  ): () => void {
+    return installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+  }
+
+  it("returns early on the first call without calling afterTurn or assemble", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
-    await callTransform(agent, messages);
-
-    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
-    expect(engine.afterTurn.mock.calls[0]?.[0]).toMatchObject({
-      sessionId,
-      sessionKey,
-      sessionFile,
-      messages,
-      prePromptMessageCount: 0,
-      tokenBudget,
-    });
-  });
-
-  it("advances prePromptMessageCount on subsequent calls based on the previous high-water mark", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const firstBatch = [makeUser("first"), makeToolResult("call_1", "result")];
-    await callTransform(agent, firstBatch);
-
-    const secondBatch = [
-      makeUser("first"),
-      makeToolResult("call_1", "result"),
-      makeUser("second"),
-      makeToolResult("call_2", "result two"),
-    ];
-    await callTransform(agent, secondBatch);
-
-    expect(engine.afterTurn).toHaveBeenCalledTimes(2);
-    expect(engine.afterTurn.mock.calls[1]?.[0]).toMatchObject({
-      prePromptMessageCount: 2,
-      messages: secondBatch,
-    });
-  });
-
-  it("does not call engine.afterTurn when no new messages have been appended", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
-    await callTransform(agent, messages);
-    await callTransform(agent, messages);
-
-    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns the engine's assembled view when its length differs from the source", async () => {
-    const agent = makeGuardableAgent();
-    const compactedView = [makeUser("compacted")];
-    const engine = makeMockEngine({
-      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
-    });
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const sourceMessages = [
-      makeUser("first"),
-      makeToolResult("call_1", "result"),
-      makeToolResult("call_2", "result two"),
-    ];
-    const transformed = await callTransform(agent, sourceMessages);
-
-    expect(transformed).toBe(compactedView);
-    expect(transformed).not.toBe(sourceMessages);
-  });
-
-  it("returns the source messages when the engine's assembled view has the same length", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const sourceMessages = [makeUser("first"), makeToolResult("call_1", "result")];
-    const transformed = await callTransform(agent, sourceMessages);
-
-    expect(transformed).toBe(sourceMessages);
-  });
-
-  it("does not mutate the source messages array even when the engine returns a different view", async () => {
-    const agent = makeGuardableAgent();
-    const compactedView = [makeUser("compacted")];
-    const engine = makeMockEngine({
-      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
-    });
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const sourceMessages = [makeUser("first"), makeToolResult("call_1", "result")];
-    const sourceCopy = [...sourceMessages];
-    await callTransform(agent, sourceMessages);
-
-    expect(sourceMessages).toEqual(sourceCopy);
-    expect(sourceMessages).toHaveLength(2);
-  });
-
-  it("skips the afterTurn call when the engine does not implement it", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine({ omitAfterTurn: true });
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
+    installHook(agent, engine);
 
     const messages = [makeUser("first"), makeToolResult("call_1", "result")];
     const transformed = await callTransform(agent, messages);
 
     expect(transformed).toBe(messages);
+    expect(engine.afterTurn).not.toHaveBeenCalled();
+    expect(engine.assemble).not.toHaveBeenCalled();
+  });
+
+  it("calls afterTurn and assemble when new messages are appended after the first call", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine);
+
+    const initial = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, initial);
+
+    const withNew = [...initial, makeUser("second"), makeToolResult("call_2", "r2")];
+    await callTransform(agent, withNew);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.afterTurn.mock.calls[0]?.[0]).toMatchObject({
+      prePromptMessageCount: 2,
+      messages: withNew,
+    });
     expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps calling assemble on subsequent iterations when engine lacks afterTurn but new messages arrive", async () => {
+  it("advances the fence across multiple iterations", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine);
+
+    const batch0 = [makeUser("h1"), makeToolResult("c1", "r1")];
+    await callTransform(agent, batch0);
+
+    const batch1 = [...batch0, makeUser("h2"), makeToolResult("c2", "r2")];
+    await callTransform(agent, batch1);
+
+    const batch2 = [...batch1, makeUser("h3"), makeToolResult("c3", "r3")];
+    await callTransform(agent, batch2);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(2);
+    expect(engine.afterTurn.mock.calls[0]?.[0]?.prePromptMessageCount).toBe(2);
+    expect(engine.afterTurn.mock.calls[1]?.[0]?.prePromptMessageCount).toBe(4);
+  });
+
+  it("skips afterTurn and assemble when messages have not changed", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine);
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+    await callTransform(agent, messages);
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).not.toHaveBeenCalled();
+    expect(engine.assemble).not.toHaveBeenCalled();
+  });
+
+  it("returns the assembled view when its length differs from the source", async () => {
+    const agent = makeGuardableAgent();
+    const compactedView = [makeUser("compacted")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
+    });
+    installHook(agent, engine);
+
+    const initial = [makeUser("first"), makeToolResult("call_1", "r")];
+    await callTransform(agent, initial);
+
+    const withNew = [...initial, makeToolResult("call_2", "r2")];
+    const transformed = await callTransform(agent, withNew);
+
+    expect(transformed).toBe(compactedView);
+  });
+
+  it("returns the source messages when the assembled view has the same length", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine);
+
+    const initial = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, initial);
+
+    const withNew = [...initial, makeUser("second"), makeToolResult("call_2", "r2")];
+    const transformed = await callTransform(agent, withNew);
+
+    expect(transformed).toBe(withNew);
+  });
+
+  it("does not mutate the source messages array", async () => {
+    const agent = makeGuardableAgent();
+    const compactedView = [makeUser("compacted")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
+    });
+    installHook(agent, engine);
+
+    const initial = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, initial);
+
+    const sourceMessages = [...initial, makeUser("second"), makeToolResult("call_2", "r2")];
+    const sourceCopy = [...sourceMessages];
+    await callTransform(agent, sourceMessages);
+
+    expect(sourceMessages).toEqual(sourceCopy);
+  });
+
+  it("still calls assemble when engine lacks afterTurn but new messages arrive", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine({ omitAfterTurn: true });
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
+    installHook(agent, engine);
 
-    const batch1 = [makeUser("first"), makeToolResult("call_1", "r1")];
+    const batch0 = [makeUser("first"), makeToolResult("call_1", "r1")];
+    await callTransform(agent, batch0);
+
+    const batch1 = [...batch0, makeUser("second"), makeToolResult("call_2", "r2")];
     await callTransform(agent, batch1);
-    expect(engine.assemble).toHaveBeenCalledTimes(1);
 
-    const batch2 = [...batch1, makeUser("second"), makeToolResult("call_2", "r2")];
+    const batch2 = [...batch1, makeUser("third"), makeToolResult("call_3", "r3")];
     await callTransform(agent, batch2);
-    expect(engine.assemble).toHaveBeenCalledTimes(2);
 
-    const batch3 = [...batch2, makeUser("third"), makeToolResult("call_3", "r3")];
-    await callTransform(agent, batch3);
-    expect(engine.assemble).toHaveBeenCalledTimes(3);
+    expect(engine.assemble).toHaveBeenCalledTimes(2);
   });
 
-  it("falls through to the source messages when engine.afterTurn throws", async () => {
+  it("falls through to source messages when engine.afterTurn throws", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine({
       afterTurn: async () => {
         throw new Error("engine afterTurn boom");
       },
     });
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
+    installHook(agent, engine);
 
-    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
-    const transformed = await callTransform(agent, messages);
+    const initial = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, initial);
 
-    expect(transformed).toBe(messages);
+    const withNew = [...initial, makeUser("second"), makeToolResult("call_2", "r2")];
+    const transformed = await callTransform(agent, withNew);
+
+    expect(transformed).toBe(withNew);
   });
 
-  it("falls through to the source messages when engine.assemble throws", async () => {
+  it("falls through to source messages when engine.assemble throws", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine({
       assemble: async () => {
         throw new Error("engine assemble boom");
       },
     });
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
+    installHook(agent, engine);
 
-    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
-    const transformed = await callTransform(agent, messages);
+    const initial = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, initial);
 
-    expect(transformed).toBe(messages);
+    const withNew = [...initial, makeUser("second"), makeToolResult("call_2", "r2")];
+    const transformed = await callTransform(agent, withNew);
+
+    expect(transformed).toBe(withNew);
   });
 
-  it("invokes any pre-existing transformContext before passing the result to the engine", async () => {
+  it("invokes any pre-existing transformContext before the engine sees messages", async () => {
     const upstream = vi.fn(async (messages: AgentMessage[]) => [...messages, makeUser("appended")]);
     const agent = makeGuardableAgent(upstream);
     const compactedView = [makeUser("compacted")];
     const engine = makeMockEngine({
-      assemble: async (params) => {
-        expect(params.messages).toHaveLength(2);
-        return { messages: compactedView, estimatedTokens: 0 };
-      },
+      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
     });
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
+    installHook(agent, engine);
 
-    const sourceMessages = [makeUser("first")];
-    const transformed = await callTransform(agent, sourceMessages);
-
+    // First call: upstream runs (1 msg -> 2 msgs), fence set to 2, returns early
+    await callTransform(agent, [makeUser("first")]);
     expect(upstream).toHaveBeenCalledTimes(1);
+
+    // Second call: upstream runs (2 msgs -> 3 msgs), hasNewMessages = true, assemble fires
+    const transformed = await callTransform(agent, [makeUser("first"), makeUser("second")]);
+    expect(upstream).toHaveBeenCalledTimes(2);
     expect(transformed).toBe(compactedView);
   });
 
@@ -566,178 +500,31 @@ describe("installContextEngineLoopHook", () => {
     const upstream = vi.fn(async (messages: AgentMessage[]) => messages);
     const agent = makeGuardableAgent(upstream);
     const engine = makeMockEngine();
-    const dispose = installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
+    const dispose = installHook(agent, engine);
 
     dispose();
 
     expect(agent.transformContext).toBe(upstream);
   });
 
-  it("uses getPrePromptMessageCount as the initial fence so pre-attempt history is not reported as new", async () => {
+  it("returns the cached assembled view on unchanged iterations instead of raw source", async () => {
     const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    let prePromptMessageCount = 5;
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-      getPrePromptMessageCount: () => prePromptMessageCount,
+    const compactedView = [makeUser("compacted")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
     });
+    installHook(agent, engine);
 
-    const history = [
-      makeUser("h1"),
-      makeUser("h2"),
-      makeUser("h3"),
-      makeUser("h4"),
-      makeUser("h5"),
-    ];
-    const firstCallMessages = [...history, makeUser("user prompt"), makeToolResult("call_1", "r1")];
-    await callTransform(agent, firstCallMessages);
+    const initial = [makeUser("first"), makeToolResult("call_1", "r")];
+    await callTransform(agent, initial);
 
-    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
-    expect(engine.afterTurn.mock.calls[0]?.[0]).toMatchObject({
-      prePromptMessageCount: 5,
-      messages: firstCallMessages,
-    });
-  });
+    const withNew = [...initial, makeToolResult("call_2", "r2")];
+    const firstResult = await callTransform(agent, withNew);
+    expect(firstResult).toBe(compactedView);
 
-  it("evaluates getPrePromptMessageCount lazily on the first call, not at install time", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    let prePromptMessageCount = 0;
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-      getPrePromptMessageCount: () => prePromptMessageCount,
-    });
-    // Caller updates the value between install and first transformContext call
-    // (mirrors the runtime where prePromptMessageCount is reassigned in the
-    // prompt-build phase after heartbeat filtering).
-    prePromptMessageCount = 3;
-
-    const messages = [
-      makeUser("h1"),
-      makeUser("h2"),
-      makeUser("h3"),
-      makeUser("user prompt"),
-      makeToolResult("call_1", "r1"),
-    ];
-    await callTransform(agent, messages);
-
-    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
-    expect(engine.afterTurn.mock.calls[0]?.[0]?.prePromptMessageCount).toBe(3);
-  });
-
-  it("falls back to fence=0 when no getPrePromptMessageCount is supplied", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
-    await callTransform(agent, messages);
-
-    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
-    expect(engine.afterTurn.mock.calls[0]?.[0]?.prePromptMessageCount).toBe(0);
-  });
-
-  it("calls assemble on the first iteration even when no afterTurn ingest happened", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-      // Fence equals current message count so afterTurn is skipped on first call
-      getPrePromptMessageCount: () => 2,
-    });
-
-    const messages = [makeUser("h1"), makeUser("h2")];
-    await callTransform(agent, messages);
-
-    expect(engine.afterTurn).not.toHaveBeenCalled();
+    // Retry with same messages: should return cached assembled view, not raw
+    const retryResult = await callTransform(agent, withNew);
+    expect(retryResult).toBe(compactedView);
     expect(engine.assemble).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips assemble on subsequent iterations when no new messages have arrived", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
-    await callTransform(agent, messages);
-    await callTransform(agent, messages);
-    await callTransform(agent, messages);
-
-    // First call: afterTurn ingests delta and assemble runs.
-    // Second + third: nothing new, assemble must NOT be called again.
-    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
-    expect(engine.assemble).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls assemble again after a fresh afterTurn ingest on a later iteration", async () => {
-    const agent = makeGuardableAgent();
-    const engine = makeMockEngine();
-    installContextEngineLoopHook({
-      agent,
-      contextEngine: engine,
-      sessionId,
-      sessionKey,
-      sessionFile,
-      tokenBudget,
-      modelId,
-    });
-
-    const firstBatch = [makeUser("first"), makeToolResult("call_1", "result")];
-    await callTransform(agent, firstBatch);
-    await callTransform(agent, firstBatch);
-    expect(engine.assemble).toHaveBeenCalledTimes(1);
-
-    const secondBatch = [
-      makeUser("first"),
-      makeToolResult("call_1", "result"),
-      makeUser("second"),
-      makeToolResult("call_2", "result two"),
-    ];
-    await callTransform(agent, secondBatch);
-
-    expect(engine.afterTurn).toHaveBeenCalledTimes(2);
-    expect(engine.assemble).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -554,4 +554,164 @@ describe("installContextEngineLoopHook", () => {
 
     expect(agent.transformContext).toBe(upstream);
   });
+
+  it("uses getPrePromptMessageCount as the initial fence so pre-attempt history is not reported as new", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    let prePromptMessageCount = 5;
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      getPrePromptMessageCount: () => prePromptMessageCount,
+    });
+
+    const history = [
+      makeUser("h1"),
+      makeUser("h2"),
+      makeUser("h3"),
+      makeUser("h4"),
+      makeUser("h5"),
+    ];
+    const firstCallMessages = [...history, makeUser("user prompt"), makeToolResult("call_1", "r1")];
+    await callTransform(agent, firstCallMessages);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.afterTurn.mock.calls[0]?.[0]).toMatchObject({
+      prePromptMessageCount: 5,
+      messages: firstCallMessages,
+    });
+  });
+
+  it("evaluates getPrePromptMessageCount lazily on the first call, not at install time", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    let prePromptMessageCount = 0;
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      getPrePromptMessageCount: () => prePromptMessageCount,
+    });
+    // Caller updates the value between install and first transformContext call
+    // (mirrors the runtime where prePromptMessageCount is reassigned in the
+    // prompt-build phase after heartbeat filtering).
+    prePromptMessageCount = 3;
+
+    const messages = [
+      makeUser("h1"),
+      makeUser("h2"),
+      makeUser("h3"),
+      makeUser("user prompt"),
+      makeToolResult("call_1", "r1"),
+    ];
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.afterTurn.mock.calls[0]?.[0]?.prePromptMessageCount).toBe(3);
+  });
+
+  it("falls back to fence=0 when no getPrePromptMessageCount is supplied", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.afterTurn.mock.calls[0]?.[0]?.prePromptMessageCount).toBe(0);
+  });
+
+  it("calls assemble on the first iteration even when no afterTurn ingest happened", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      // Fence equals current message count so afterTurn is skipped on first call
+      getPrePromptMessageCount: () => 2,
+    });
+
+    const messages = [makeUser("h1"), makeUser("h2")];
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).not.toHaveBeenCalled();
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips assemble on subsequent iterations when no new messages have arrived", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+    await callTransform(agent, messages);
+    await callTransform(agent, messages);
+
+    // First call: afterTurn ingests delta and assemble runs.
+    // Second + third: nothing new, assemble must NOT be called again.
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls assemble again after a fresh afterTurn ingest on a later iteration", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const firstBatch = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, firstBatch);
+    await callTransform(agent, firstBatch);
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
+
+    const secondBatch = [
+      makeUser("first"),
+      makeToolResult("call_1", "result"),
+      makeUser("second"),
+      makeToolResult("call_2", "result two"),
+    ];
+    await callTransform(agent, secondBatch);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(2);
+    expect(engine.assemble).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -245,6 +245,8 @@ describe("installToolResultContextGuard", () => {
 type MockedEngine = ContextEngine & {
   afterTurn: ReturnType<typeof vi.fn>;
   assemble: ReturnType<typeof vi.fn>;
+  ingest: ReturnType<typeof vi.fn>;
+  ingestBatch?: ReturnType<typeof vi.fn>;
 };
 
 function makeMockEngine(
@@ -254,6 +256,11 @@ function makeMockEngine(
     ) => Promise<{ messages: AgentMessage[]; estimatedTokens: number }>;
     afterTurn?: (params: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]) => Promise<void>;
     omitAfterTurn?: boolean;
+    ingest?: (params: Parameters<ContextEngine["ingest"]>[0]) => Promise<{ ingested: boolean }>;
+    ingestBatch?: (
+      params: Parameters<NonNullable<ContextEngine["ingestBatch"]>>[0],
+    ) => Promise<{ ingestedCount: number }>;
+    omitIngestBatch?: boolean;
   } = {},
 ): MockedEngine {
   const defaultAfterTurn = vi.fn(async () => {});
@@ -261,12 +268,24 @@ function makeMockEngine(
     messages: params.messages,
     estimatedTokens: 0,
   }));
+  const defaultIngest = vi.fn(async () => ({ ingested: true }));
+  const defaultIngestBatch = vi.fn(
+    async (params: Parameters<NonNullable<ContextEngine["ingestBatch"]>>[0]) => ({
+      ingestedCount: params.messages.length,
+    }),
+  );
   const afterTurn = overrides.omitAfterTurn
     ? undefined
     : overrides.afterTurn
       ? vi.fn(overrides.afterTurn)
       : defaultAfterTurn;
   const assemble = overrides.assemble ? vi.fn(overrides.assemble) : defaultAssemble;
+  const ingest = overrides.ingest ? vi.fn(overrides.ingest) : defaultIngest;
+  const ingestBatch = overrides.omitIngestBatch
+    ? undefined
+    : overrides.ingestBatch
+      ? vi.fn(overrides.ingestBatch)
+      : defaultIngestBatch;
   const engine = {
     info: {
       id: "test-engine",
@@ -274,8 +293,9 @@ function makeMockEngine(
       version: "0.0.1",
       ownsCompaction: true,
     },
-    ingest: async () => ({ ingested: true }),
+    ingest,
     assemble,
+    ...(ingestBatch ? { ingestBatch } : {}),
     ...(afterTurn ? { afterTurn } : {}),
   } as unknown as MockedEngine;
   return engine;
@@ -298,6 +318,7 @@ describe("installContextEngineLoopHook", () => {
   function installHook(
     agent: ReturnType<typeof makeGuardableAgent>,
     engine: MockedEngine,
+    prePromptCount?: number,
   ): () => void {
     return installContextEngineLoopHook({
       agent,
@@ -307,13 +328,14 @@ describe("installContextEngineLoopHook", () => {
       sessionFile,
       tokenBudget,
       modelId,
+      ...(prePromptCount !== undefined ? { getPrePromptMessageCount: () => prePromptCount } : {}),
     });
   }
 
-  it("returns early on the first call without calling afterTurn or assemble", async () => {
+  it("returns early when the current messages match the pre-prompt baseline", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();
-    installHook(agent, engine);
+    installHook(agent, engine, 2);
 
     const messages = [makeUser("first"), makeToolResult("call_1", "result")];
     const transformed = await callTransform(agent, messages);
@@ -321,6 +343,22 @@ describe("installContextEngineLoopHook", () => {
     expect(transformed).toBe(messages);
     expect(engine.afterTurn).not.toHaveBeenCalled();
     expect(engine.assemble).not.toHaveBeenCalled();
+  });
+
+  it("processes the first call when messages already exceed the pre-prompt baseline", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installHook(agent, engine, 1);
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.afterTurn.mock.calls[0]?.[0]).toMatchObject({
+      prePromptMessageCount: 1,
+      messages,
+    });
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
 
   it("calls afterTurn and assemble when new messages are appended after the first call", async () => {
@@ -442,7 +480,7 @@ describe("installContextEngineLoopHook", () => {
     expect(sourceMessages).toEqual(sourceCopy);
   });
 
-  it("still calls assemble when engine lacks afterTurn but new messages arrive", async () => {
+  it("ingests new messages in batches when afterTurn is absent", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine({ omitAfterTurn: true });
     installHook(agent, engine);
@@ -456,7 +494,31 @@ describe("installContextEngineLoopHook", () => {
     const batch2 = [...batch1, makeUser("third"), makeToolResult("call_3", "r3")];
     await callTransform(agent, batch2);
 
+    expect(engine.ingestBatch).toHaveBeenCalledTimes(2);
+    expect(engine.ingestBatch?.mock.calls[0]?.[0]).toMatchObject({
+      messages: [makeUser("second"), makeToolResult("call_2", "r2")],
+    });
+    expect(engine.ingestBatch?.mock.calls[1]?.[0]).toMatchObject({
+      messages: [makeUser("third"), makeToolResult("call_3", "r3")],
+    });
     expect(engine.assemble).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to per-message ingest when ingestBatch is absent", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine({ omitAfterTurn: true, omitIngestBatch: true });
+    installHook(agent, engine, 1);
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "r1")];
+    await callTransform(agent, messages);
+
+    expect(engine.ingest).toHaveBeenCalledTimes(1);
+    expect(engine.ingest.mock.calls[0]?.[0]).toMatchObject({
+      sessionId,
+      sessionKey,
+      message: makeToolResult("call_1", "r1"),
+    });
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
 
   it("falls through to source messages when engine.afterTurn throws", async () => {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -495,12 +495,8 @@ describe("installContextEngineLoopHook", () => {
     await callTransform(agent, batch2);
 
     expect(engine.ingestBatch).toHaveBeenCalledTimes(2);
-    expect(engine.ingestBatch?.mock.calls[0]?.[0]).toMatchObject({
-      messages: [makeUser("second"), makeToolResult("call_2", "r2")],
-    });
-    expect(engine.ingestBatch?.mock.calls[1]?.[0]).toMatchObject({
-      messages: [makeUser("third"), makeToolResult("call_3", "r3")],
-    });
+    expect(engine.ingestBatch?.mock.calls[0]?.[0]?.messages).toEqual(batch1.slice(2));
+    expect(engine.ingestBatch?.mock.calls[1]?.[0]?.messages).toEqual(batch2.slice(4));
     expect(engine.assemble).toHaveBeenCalledTimes(2);
   });
 

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -1,9 +1,11 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { ContextEngine } from "../../context-engine/types.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
   CONTEXT_LIMIT_TRUNCATION_NOTICE,
   formatContextLimitTruncationNotice,
+  installContextEngineLoopHook,
   installToolResultContextGuard,
   PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
 } from "./tool-result-context-guard.js";
@@ -237,5 +239,319 @@ describe("installToolResultContextGuard", () => {
     )) as AgentMessage[];
 
     expectPiStyleTruncation(getToolResultText(transformed[0]));
+  });
+});
+
+type MockedEngine = ContextEngine & {
+  afterTurn: ReturnType<typeof vi.fn>;
+  assemble: ReturnType<typeof vi.fn>;
+};
+
+function makeMockEngine(
+  overrides: {
+    assemble?: (
+      params: Parameters<ContextEngine["assemble"]>[0],
+    ) => Promise<{ messages: AgentMessage[]; estimatedTokens: number }>;
+    afterTurn?: (params: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]) => Promise<void>;
+    omitAfterTurn?: boolean;
+  } = {},
+): MockedEngine {
+  const defaultAfterTurn = vi.fn(async () => {});
+  const defaultAssemble = vi.fn(async (params: Parameters<ContextEngine["assemble"]>[0]) => ({
+    messages: params.messages,
+    estimatedTokens: 0,
+  }));
+  const afterTurn = overrides.omitAfterTurn
+    ? undefined
+    : overrides.afterTurn
+      ? vi.fn(overrides.afterTurn)
+      : defaultAfterTurn;
+  const assemble = overrides.assemble ? vi.fn(overrides.assemble) : defaultAssemble;
+  const engine = {
+    info: {
+      id: "test-engine",
+      name: "Test Engine",
+      version: "0.0.1",
+      ownsCompaction: true,
+    },
+    ingest: async () => ({ ingested: true }),
+    assemble,
+    ...(afterTurn ? { afterTurn } : {}),
+  } as unknown as MockedEngine;
+  return engine;
+}
+
+async function callTransform(
+  agent: { transformContext?: (messages: AgentMessage[], signal: AbortSignal) => unknown },
+  messages: AgentMessage[],
+) {
+  return await agent.transformContext?.(messages, new AbortController().signal);
+}
+
+describe("installContextEngineLoopHook", () => {
+  const sessionId = "test-session-id";
+  const sessionKey = "agent:main:subagent:test";
+  const sessionFile = "/tmp/test-session.jsonl";
+  const tokenBudget = 4096;
+  const modelId = "test-model";
+
+  it("forwards new messages to engine.afterTurn with prePromptMessageCount=0 on first call", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.afterTurn.mock.calls[0]?.[0]).toMatchObject({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages,
+      prePromptMessageCount: 0,
+      tokenBudget,
+    });
+  });
+
+  it("advances prePromptMessageCount on subsequent calls based on the previous high-water mark", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const firstBatch = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, firstBatch);
+
+    const secondBatch = [
+      makeUser("first"),
+      makeToolResult("call_1", "result"),
+      makeUser("second"),
+      makeToolResult("call_2", "result two"),
+    ];
+    await callTransform(agent, secondBatch);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(2);
+    expect(engine.afterTurn.mock.calls[1]?.[0]).toMatchObject({
+      prePromptMessageCount: 2,
+      messages: secondBatch,
+    });
+  });
+
+  it("does not call engine.afterTurn when no new messages have been appended", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the engine's assembled view when its length differs from the source", async () => {
+    const agent = makeGuardableAgent();
+    const compactedView = [makeUser("compacted")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
+    });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const sourceMessages = [
+      makeUser("first"),
+      makeToolResult("call_1", "result"),
+      makeToolResult("call_2", "result two"),
+    ];
+    const transformed = await callTransform(agent, sourceMessages);
+
+    expect(transformed).toBe(compactedView);
+    expect(transformed).not.toBe(sourceMessages);
+  });
+
+  it("returns the source messages when the engine's assembled view has the same length", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const sourceMessages = [makeUser("first"), makeToolResult("call_1", "result")];
+    const transformed = await callTransform(agent, sourceMessages);
+
+    expect(transformed).toBe(sourceMessages);
+  });
+
+  it("does not mutate the source messages array even when the engine returns a different view", async () => {
+    const agent = makeGuardableAgent();
+    const compactedView = [makeUser("compacted")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
+    });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const sourceMessages = [makeUser("first"), makeToolResult("call_1", "result")];
+    const sourceCopy = [...sourceMessages];
+    await callTransform(agent, sourceMessages);
+
+    expect(sourceMessages).toEqual(sourceCopy);
+    expect(sourceMessages).toHaveLength(2);
+  });
+
+  it("skips the afterTurn call when the engine does not implement it", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine({ omitAfterTurn: true });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    const transformed = await callTransform(agent, messages);
+
+    expect(transformed).toBe(messages);
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through to the source messages when engine.afterTurn throws", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine({
+      afterTurn: async () => {
+        throw new Error("engine afterTurn boom");
+      },
+    });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    const transformed = await callTransform(agent, messages);
+
+    expect(transformed).toBe(messages);
+  });
+
+  it("falls through to the source messages when engine.assemble throws", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine({
+      assemble: async () => {
+        throw new Error("engine assemble boom");
+      },
+    });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    const transformed = await callTransform(agent, messages);
+
+    expect(transformed).toBe(messages);
+  });
+
+  it("invokes any pre-existing transformContext before passing the result to the engine", async () => {
+    const upstream = vi.fn(async (messages: AgentMessage[]) => [...messages, makeUser("appended")]);
+    const agent = makeGuardableAgent(upstream);
+    const compactedView = [makeUser("compacted")];
+    const engine = makeMockEngine({
+      assemble: async (params) => {
+        expect(params.messages).toHaveLength(2);
+        return { messages: compactedView, estimatedTokens: 0 };
+      },
+    });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const sourceMessages = [makeUser("first")];
+    const transformed = await callTransform(agent, sourceMessages);
+
+    expect(upstream).toHaveBeenCalledTimes(1);
+    expect(transformed).toBe(compactedView);
+  });
+
+  it("restores the previous transformContext when the returned dispose is called", async () => {
+    const upstream = vi.fn(async (messages: AgentMessage[]) => messages);
+    const agent = makeGuardableAgent(upstream);
+    const engine = makeMockEngine();
+    const dispose = installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    dispose();
+
+    expect(agent.transformContext).toBe(upstream);
   });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -392,7 +392,25 @@ describe("installContextEngineLoopHook", () => {
     expect(transformed).toBe(compactedView);
   });
 
-  it("returns the source messages when the assembled view has the same length", async () => {
+  it("returns the assembled view when the engine rewrites content without changing count", async () => {
+    const agent = makeGuardableAgent();
+    const rewrittenView = [makeUser("rewritten-1"), makeUser("rewritten-2")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: rewrittenView, estimatedTokens: 0 }),
+    });
+    installHook(agent, engine);
+
+    const initial = [makeUser("first"), makeToolResult("call_1", "r")];
+    await callTransform(agent, initial);
+
+    const withNew = [...initial, makeToolResult("call_2", "r2")];
+    const transformed = await callTransform(agent, withNew);
+
+    // Same count (2) but different array reference — engine's view should be used
+    expect(transformed).toBe(rewrittenView);
+  });
+
+  it("returns the source when the engine returns the same array reference", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();
     installHook(agent, engine);

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -463,6 +463,32 @@ describe("installContextEngineLoopHook", () => {
     expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps calling assemble on subsequent iterations when engine lacks afterTurn but new messages arrive", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine({ omitAfterTurn: true });
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+    });
+
+    const batch1 = [makeUser("first"), makeToolResult("call_1", "r1")];
+    await callTransform(agent, batch1);
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
+
+    const batch2 = [...batch1, makeUser("second"), makeToolResult("call_2", "r2")];
+    await callTransform(agent, batch2);
+    expect(engine.assemble).toHaveBeenCalledTimes(2);
+
+    const batch3 = [...batch2, makeUser("third"), makeToolResult("call_3", "r3")];
+    await callTransform(agent, batch3);
+    expect(engine.assemble).toHaveBeenCalledTimes(3);
+  });
+
   it("falls through to the source messages when engine.afterTurn throws", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine({

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -197,6 +197,7 @@ export function installContextEngineLoopHook(params: {
   sessionFile: string;
   tokenBudget?: number;
   modelId: string;
+  getPrePromptMessageCount?: () => number;
 }): () => void {
   const { contextEngine, sessionId, sessionKey, sessionFile, tokenBudget, modelId } = params;
   const mutableAgent = params.agent as GuardableAgentRecord;
@@ -210,26 +211,52 @@ export function installContextEngineLoopHook(params: {
       : messages;
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
 
-    if (lastSeenLength === null) {
-      lastSeenLength = sourceMessages.length;
-    }
+    // Seed the loop fence from the attempt's pre-prompt message count when available.
+    // This keeps the first real post-tool-call iteration eligible for compaction even
+    // if the hook's first observed call happens after tool results were appended.
+    const prePromptMessageCount = Math.max(
+      0,
+      Math.min(
+        sourceMessages.length,
+        lastSeenLength ?? params.getPrePromptMessageCount?.() ?? sourceMessages.length,
+      ),
+    );
+    lastSeenLength = prePromptMessageCount;
 
-    const hasNewMessages = sourceMessages.length > lastSeenLength;
+    const hasNewMessages = sourceMessages.length > prePromptMessageCount;
     if (!hasNewMessages) {
       return lastAssembledView ?? sourceMessages;
     }
 
     try {
       if (typeof contextEngine.afterTurn === "function") {
-        const prePromptCount = lastSeenLength;
         await contextEngine.afterTurn({
           sessionId,
           sessionKey,
           sessionFile,
           messages: sourceMessages,
-          prePromptMessageCount: prePromptCount,
+          prePromptMessageCount,
           tokenBudget,
         });
+      } else {
+        const newMessages = sourceMessages.slice(prePromptMessageCount);
+        if (newMessages.length > 0) {
+          if (typeof contextEngine.ingestBatch === "function") {
+            await contextEngine.ingestBatch({
+              sessionId,
+              sessionKey,
+              messages: newMessages,
+            });
+          } else {
+            for (const message of newMessages) {
+              await contextEngine.ingest({
+                sessionId,
+                sessionKey,
+                message,
+              });
+            }
+          }
+        }
       }
       lastSeenLength = sourceMessages.length;
       const assembled = await contextEngine.assemble({

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -185,24 +185,9 @@ function enforceToolResultLimitInPlace(params: {
 }
 
 /**
- * Per-iteration context-engine ingest + assemble hook.
- *
- * Used in place of `installToolResultContextGuard` for sessions whose context
- * engine has claimed `info.ownsCompaction === true`. Wraps `agent.transformContext`
- * so that on every LLM call:
- *
- *   1. Any messages appended since the last call are forwarded to the engine
- *      via `afterTurn`, giving the engine a chance to ingest and trigger its
- *      own compaction policy mid-tool-loop (instead of waiting until the end
- *      of the attempt, which is the only point the runtime would otherwise
- *      finalize a turn).
- *   2. The engine's `assemble()` view is returned to pi-agent so the next LLM
- *      call uses the (possibly compacted) context, while pi-agent's own
- *      `state.messages` array is left untouched (mutating it mid-loop breaks
- *      iteration tracking).
- *
- * The hook is best-effort: any failure inside the engine falls back to the
- * raw source messages so the run still makes progress.
+ * Per-iteration `afterTurn` + `assemble` wrapper for sessions where
+ * the context engine owns compaction. Lets the engine compact inside
+ * a long tool loop instead of only at end of attempt.
  */
 export function installContextEngineLoopHook(params: {
   agent: GuardableAgent;
@@ -225,10 +210,7 @@ export function installContextEngineLoopHook(params: {
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
 
     try {
-      if (
-        sourceMessages.length > lastSeenLength &&
-        typeof contextEngine.afterTurn === "function"
-      ) {
+      if (sourceMessages.length > lastSeenLength && typeof contextEngine.afterTurn === "function") {
         const prePromptCount = lastSeenLength;
         await contextEngine.afterTurn({
           sessionId,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -222,9 +222,9 @@ export function installContextEngineLoopHook(params: {
       lastSeenLength = params.getPrePromptMessageCount?.() ?? 0;
     }
 
-    let didCallAfterTurn = false;
+    const hasNewMessages = sourceMessages.length > lastSeenLength;
     try {
-      if (sourceMessages.length > lastSeenLength && typeof contextEngine.afterTurn === "function") {
+      if (hasNewMessages && typeof contextEngine.afterTurn === "function") {
         const prePromptCount = lastSeenLength;
         await contextEngine.afterTurn({
           sessionId,
@@ -234,13 +234,14 @@ export function installContextEngineLoopHook(params: {
           prePromptMessageCount: prePromptCount,
           tokenBudget,
         });
+      }
+      if (hasNewMessages) {
         lastSeenLength = sourceMessages.length;
-        didCallAfterTurn = true;
       }
       // Skip assemble when nothing has changed since the last call AND we
       // already returned an assembled view at least once. The engine's view
-      // cannot have changed without new messages arriving via afterTurn.
-      if (didCallAfterTurn || !hasAssembledBefore) {
+      // cannot have changed without new messages arriving.
+      if (hasNewMessages || !hasAssembledBefore) {
         const assembled = await contextEngine.assemble({
           sessionId,
           sessionKey,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -239,11 +239,7 @@ export function installContextEngineLoopHook(params: {
         tokenBudget,
         model: modelId,
       });
-      if (
-        assembled &&
-        Array.isArray(assembled.messages) &&
-        assembled.messages.length !== sourceMessages.length
-      ) {
+      if (assembled && Array.isArray(assembled.messages) && assembled.messages !== sourceMessages) {
         lastAssembledView = assembled.messages;
         return assembled.messages;
       }

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -197,20 +197,12 @@ export function installContextEngineLoopHook(params: {
   sessionFile: string;
   tokenBudget?: number;
   modelId: string;
-  /**
-   * Returns the message count that should be used as the initial
-   * `prePromptMessageCount` fence on the first `transformContext` call.
-   * Should match the value `finalizeAttemptContextEngineTurn` will eventually
-   * pass to `afterTurn` so the loop hook does not report pre-attempt history
-   * as new on its first invocation.
-   */
-  getPrePromptMessageCount?: () => number;
 }): () => void {
   const { contextEngine, sessionId, sessionKey, sessionFile, tokenBudget, modelId } = params;
   const mutableAgent = params.agent as GuardableAgentRecord;
   const originalTransformContext = mutableAgent.transformContext;
   let lastSeenLength: number | null = null;
-  let hasAssembledBefore = false;
+  let lastAssembledView: AgentMessage[] | null = null;
 
   mutableAgent.transformContext = (async (messages: AgentMessage[], signal: AbortSignal) => {
     const transformed = originalTransformContext
@@ -219,12 +211,16 @@ export function installContextEngineLoopHook(params: {
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
 
     if (lastSeenLength === null) {
-      lastSeenLength = params.getPrePromptMessageCount?.() ?? 0;
+      lastSeenLength = sourceMessages.length;
     }
 
     const hasNewMessages = sourceMessages.length > lastSeenLength;
+    if (!hasNewMessages) {
+      return lastAssembledView ?? sourceMessages;
+    }
+
     try {
-      if (hasNewMessages && typeof contextEngine.afterTurn === "function") {
+      if (typeof contextEngine.afterTurn === "function") {
         const prePromptCount = lastSeenLength;
         await contextEngine.afterTurn({
           sessionId,
@@ -235,29 +231,23 @@ export function installContextEngineLoopHook(params: {
           tokenBudget,
         });
       }
-      if (hasNewMessages) {
-        lastSeenLength = sourceMessages.length;
+      lastSeenLength = sourceMessages.length;
+      const assembled = await contextEngine.assemble({
+        sessionId,
+        sessionKey,
+        messages: sourceMessages,
+        tokenBudget,
+        model: modelId,
+      });
+      if (
+        assembled &&
+        Array.isArray(assembled.messages) &&
+        assembled.messages.length !== sourceMessages.length
+      ) {
+        lastAssembledView = assembled.messages;
+        return assembled.messages;
       }
-      // Skip assemble when nothing has changed since the last call AND we
-      // already returned an assembled view at least once. The engine's view
-      // cannot have changed without new messages arriving.
-      if (hasNewMessages || !hasAssembledBefore) {
-        const assembled = await contextEngine.assemble({
-          sessionId,
-          sessionKey,
-          messages: sourceMessages,
-          tokenBudget,
-          model: modelId,
-        });
-        hasAssembledBefore = true;
-        if (
-          assembled &&
-          Array.isArray(assembled.messages) &&
-          assembled.messages.length !== sourceMessages.length
-        ) {
-          return assembled.messages;
-        }
-      }
+      lastAssembledView = null;
     } catch {
       // Best-effort: any engine failure falls through to the raw source
       // messages so the tool loop still makes forward progress.

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -197,11 +197,20 @@ export function installContextEngineLoopHook(params: {
   sessionFile: string;
   tokenBudget?: number;
   modelId: string;
+  /**
+   * Returns the message count that should be used as the initial
+   * `prePromptMessageCount` fence on the first `transformContext` call.
+   * Should match the value `finalizeAttemptContextEngineTurn` will eventually
+   * pass to `afterTurn` so the loop hook does not report pre-attempt history
+   * as new on its first invocation.
+   */
+  getPrePromptMessageCount?: () => number;
 }): () => void {
   const { contextEngine, sessionId, sessionKey, sessionFile, tokenBudget, modelId } = params;
   const mutableAgent = params.agent as GuardableAgentRecord;
   const originalTransformContext = mutableAgent.transformContext;
-  let lastSeenLength = 0;
+  let lastSeenLength: number | null = null;
+  let hasAssembledBefore = false;
 
   mutableAgent.transformContext = (async (messages: AgentMessage[], signal: AbortSignal) => {
     const transformed = originalTransformContext
@@ -209,6 +218,11 @@ export function installContextEngineLoopHook(params: {
       : messages;
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
 
+    if (lastSeenLength === null) {
+      lastSeenLength = params.getPrePromptMessageCount?.() ?? 0;
+    }
+
+    let didCallAfterTurn = false;
     try {
       if (sourceMessages.length > lastSeenLength && typeof contextEngine.afterTurn === "function") {
         const prePromptCount = lastSeenLength;
@@ -221,20 +235,27 @@ export function installContextEngineLoopHook(params: {
           tokenBudget,
         });
         lastSeenLength = sourceMessages.length;
+        didCallAfterTurn = true;
       }
-      const assembled = await contextEngine.assemble({
-        sessionId,
-        sessionKey,
-        messages: sourceMessages,
-        tokenBudget,
-        model: modelId,
-      });
-      if (
-        assembled &&
-        Array.isArray(assembled.messages) &&
-        assembled.messages.length !== sourceMessages.length
-      ) {
-        return assembled.messages;
+      // Skip assemble when nothing has changed since the last call AND we
+      // already returned an assembled view at least once. The engine's view
+      // cannot have changed without new messages arriving via afterTurn.
+      if (didCallAfterTurn || !hasAssembledBefore) {
+        const assembled = await contextEngine.assemble({
+          sessionId,
+          sessionKey,
+          messages: sourceMessages,
+          tokenBudget,
+          model: modelId,
+        });
+        hasAssembledBefore = true;
+        if (
+          assembled &&
+          Array.isArray(assembled.messages) &&
+          assembled.messages.length !== sourceMessages.length
+        ) {
+          return assembled.messages;
+        }
       }
     } catch {
       // Best-effort: any engine failure falls through to the raw source

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ContextEngine } from "../../context-engine/types.js";
 import {
   CHARS_PER_TOKEN_ESTIMATE,
   TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
@@ -181,6 +182,89 @@ function enforceToolResultLimitInPlace(params: {
     const truncated = truncateToolResultToChars(message, maxSingleToolResultChars, estimateCache);
     applyMessageMutationInPlace(message, truncated, estimateCache);
   }
+}
+
+/**
+ * Per-iteration context-engine ingest + assemble hook.
+ *
+ * Used in place of `installToolResultContextGuard` for sessions whose context
+ * engine has claimed `info.ownsCompaction === true`. Wraps `agent.transformContext`
+ * so that on every LLM call:
+ *
+ *   1. Any messages appended since the last call are forwarded to the engine
+ *      via `afterTurn`, giving the engine a chance to ingest and trigger its
+ *      own compaction policy mid-tool-loop (instead of waiting until the end
+ *      of the attempt, which is the only point the runtime would otherwise
+ *      finalize a turn).
+ *   2. The engine's `assemble()` view is returned to pi-agent so the next LLM
+ *      call uses the (possibly compacted) context, while pi-agent's own
+ *      `state.messages` array is left untouched (mutating it mid-loop breaks
+ *      iteration tracking).
+ *
+ * The hook is best-effort: any failure inside the engine falls back to the
+ * raw source messages so the run still makes progress.
+ */
+export function installContextEngineLoopHook(params: {
+  agent: GuardableAgent;
+  contextEngine: ContextEngine;
+  sessionId: string;
+  sessionKey?: string;
+  sessionFile: string;
+  tokenBudget?: number;
+  modelId: string;
+}): () => void {
+  const { contextEngine, sessionId, sessionKey, sessionFile, tokenBudget, modelId } = params;
+  const mutableAgent = params.agent as GuardableAgentRecord;
+  const originalTransformContext = mutableAgent.transformContext;
+  let lastSeenLength = 0;
+
+  mutableAgent.transformContext = (async (messages: AgentMessage[], signal: AbortSignal) => {
+    const transformed = originalTransformContext
+      ? await originalTransformContext.call(mutableAgent, messages, signal)
+      : messages;
+    const sourceMessages = Array.isArray(transformed) ? transformed : messages;
+
+    try {
+      if (
+        sourceMessages.length > lastSeenLength &&
+        typeof contextEngine.afterTurn === "function"
+      ) {
+        const prePromptCount = lastSeenLength;
+        await contextEngine.afterTurn({
+          sessionId,
+          sessionKey,
+          sessionFile,
+          messages: sourceMessages,
+          prePromptMessageCount: prePromptCount,
+          tokenBudget,
+        });
+        lastSeenLength = sourceMessages.length;
+      }
+      const assembled = await contextEngine.assemble({
+        sessionId,
+        sessionKey,
+        messages: sourceMessages,
+        tokenBudget,
+        model: modelId,
+      });
+      if (
+        assembled &&
+        Array.isArray(assembled.messages) &&
+        assembled.messages.length !== sourceMessages.length
+      ) {
+        return assembled.messages;
+      }
+    } catch {
+      // Best-effort: any engine failure falls through to the raw source
+      // messages so the tool loop still makes forward progress.
+    }
+
+    return sourceMessages;
+  }) as GuardableTransformContext;
+
+  return () => {
+    mutableAgent.transformContext = originalTransformContext;
+  };
 }
 
 export function installToolResultContextGuard(params: {


### PR DESCRIPTION
context-engine: per-iteration ingest and assemble for engine-owned sessions

- Add `installContextEngineLoopHook` to call `afterTurn` and return `assemble()` from `transformContext` on every LLM iteration
- Skip the built-in tool-result guard and preemptive overflow precheck when `info.ownsCompaction === true`
- Lets long-running subagents compact mid tool loop instead of only at end of attempt
- Sessions without a context engine, or where the engine does not own compaction, behave exactly as before

## Summary
Better compaction for subagents

- Problem: Sessions where one user message drives a long tool loop (subagents spawned via `sessions_spawn`, cron-triggered work, any single-shot task) get no compaction during the loop. The runtime calls `finalizeAttemptContextEngineTurn` once after the attempt completes, so the engine has no chance to react until the loop is over. The built-in `installToolResultContextGuard` and `shouldPreemptivelyCompactBeforePrompt` then char-count or estimate against the raw `activeSession.messages` array, fire false-positive overflow errors on engine-owned sessions, and trip `truncateOversizedToolResultsInSessionManager`, which destructively rewrites tool results.
- Why it matters: Long-running subagents either lose tool results to destructive truncation or run unchecked until the model rejects the prompt. The `ContextEngine.ownsCompaction` contract exists exactly to let plugins manage this, but the runtime was not honouring it inside the tool loop.
- What changed: Added `installContextEngineLoopHook` that wraps `agent.transformContext` for engine-owned sessions, calls `engine.afterTurn` per LLM iteration with the post-prompt delta, and returns `engine.assemble()`'s view so the next LLM call uses the compacted context. The install site now picks one of the two wrappers based on `ownsCompaction`. The precheck call site short-circuits to `route: "fits"` for the same case.
- What did NOT change (scope boundary): Sessions without a context engine, or where the engine does not own compaction, are unchanged. The built-in tool-result guard installs as before, the preemptive precheck runs as before, and `truncateOversizedToolResultsInSessionManager` keeps its existing fallback role. No change to the `ContextEngine` interface, no new config, no plugin changes required.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The built-in `installToolResultContextGuard` and `shouldPreemptivelyCompactBeforePrompt` operate on the raw `activeSession.messages` array and have no awareness of the `ContextEngine.info.ownsCompaction` contract. They were designed before the context-engine plugin slot existed and were never updated to defer to engines that have claimed ownership. Separately, `finalizeAttemptContextEngineTurn` only fires at the end of an attempt, so per-iteration ingest and compaction inside a long tool loop is not possible through the existing hook surface.
- Missing detection / guardrail: There was no test exercising the combination of `ownsCompaction === true` plus a long single-attempt tool loop. Coverage for the guard and the precheck assumes sessions without an engine in the picture.
- Contributing context (if known): The runtime's expectation that an "attempt" matches a "turn" holds for chat sessions (each user message is a new attempt), but breaks for `sessions_spawn` subagents and any other single-message-driven flow where one prompt triggers many tool calls before returning.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/tool-result-context-guard.test.ts` (extended with a new `describe("installContextEngineLoopHook", ...)` block).
- Scenarios locked in by this PR (11 new test cases):
  1. `engine.afterTurn` is called once per `transformContext` invocation with `prePromptMessageCount=0` on the first call, and advances to the previous high-water mark on subsequent calls.
  2. `engine.afterTurn` is skipped entirely when no new messages have been appended since the last call.
  3. The hook returns `engine.assemble()`'s view from `transformContext` only when its length differs from the source array, and returns the source untouched when the lengths match.
  4. The source `messages` array passed into `transformContext` is never mutated, even when the engine returns a different view.
  5. The hook tolerates engines that do not implement `afterTurn` (optional in the `ContextEngine` interface).
  6. When `engine.afterTurn` throws, the hook falls through to the source messages so the tool loop still makes forward progress.
  7. When `engine.assemble` throws, the hook falls through to the source messages.
  8. A pre-existing `agent.transformContext` (from any other wrapper) is invoked before the engine sees the messages, so the loop hook composes correctly with other wrappers.
  9. The dispose function returned by `installContextEngineLoopHook` restores the previous `transformContext`.
- Existing test that already covers this (if any): `tool-result-context-guard.test.ts` previously covered only `installToolResultContextGuard` in isolation; `preemptive-compaction.test.ts` covers only the precheck function. Neither covered the engine-owned path. The full file now passes 22 tests (11 existing + 11 new).
- Why this is the smallest reliable guardrail: The new function is structurally simple. Eleven focused unit tests on its observable surface (when it calls into the engine, what it returns, what it leaves untouched, how it handles failures, how it disposes) cover every branch of the behaviour the patch introduces.

## User-visible / Behavior Changes

For sessions where a context engine plugin reports `info.ownsCompaction === true`:

- The built-in tool-result context guard no longer installs.
- The preemptive overflow precheck no longer runs.
- A new `installContextEngineLoopHook` runs on every LLM iteration inside the tool loop, calling `engine.afterTurn` with the post-prompt delta and returning `engine.assemble()` from `transformContext`.

For all other sessions (no engine, or `ownsCompaction !== true`), nothing changes.

No new config, no env vars, no plugin contract changes. Engines that already set `info.ownsCompaction = true` get the new behaviour automatically.

## Diagram (if applicable)

```text
Before (engine-owned session, long tool loop):

[runEmbeddedAttempt start]
   └─ install built-in tool-result context guard (wraps transformContext)
   └─ for each LLM iteration:
        ├─ shouldPreemptivelyCompactBeforePrompt(activeSession.messages)  // raw history
        │     └─ fires false-positive overflow on engine-owned sessions
        │           └─ truncateOversizedToolResultsInSessionManager  // destructive
        └─ transformContext (built-in guard)
              └─ char-count exceeds threshold, throws PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE
[runEmbeddedAttempt end]
   └─ finalizeAttemptContextEngineTurn → engine.afterTurn  // only point engine sees the loop


After (engine-owned session, long tool loop):

[runEmbeddedAttempt start]
   └─ install context engine loop hook (wraps transformContext)
   └─ for each LLM iteration:
        ├─ shouldPreemptivelyCompactBeforePrompt → short-circuits to "fits"
        └─ transformContext (loop hook)
              ├─ engine.afterTurn(messages, prePromptMessageCount)  // ingest + compact
              └─ engine.assemble(messages) → return assembled view to LLM
[runEmbeddedAttempt end]
   └─ finalizeAttemptContextEngineTurn → engine.afterTurn  // unchanged
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: openclaw gateway running directly under systemd, Node 22
- Model/provider: `llamacpp`-served Qwen3.5-122B-A10B (any local llama.cpp slot with sufficient capacity)
- Integration/channel (if any): subagent dispatched via `sessions_spawn` from a parent agent
- Relevant config (redacted): `lossless-claw` plugin enabled with `ownsCompaction: true`, openclaw `models.providers.<provider>.models[0].contextWindow` set low enough that the engine's threshold gets hit during a normal run (used `64000` in repro)

### Steps

1. Configure a context engine plugin that sets `info.ownsCompaction = true` (e.g. `lossless-claw`).
2. Set `models.providers.<provider>.models[0].contextWindow` to a value low enough that a meaningful subagent task will exceed the engine's threshold (`64000` in the repro).
3. From a parent agent, spawn a subagent via `sessions_spawn` with a task that causes a long tool loop (file reads, grep, multi-step investigation). Anything that drives many tool calls inside one user message is enough.
4. Watch the gateway journal for `[context-overflow-precheck]` events, `[tool-result-truncation]` events, and `[lcm] LCM compaction leaf pass ... conversation=<id>` events.

### Expected

- No `[context-overflow-precheck]` events for the subagent's session.
- No `[tool-result-truncation]` destructive events.
- `[lcm] LCM compaction leaf pass` (or equivalent for whichever engine you use) firing repeatedly during the subagent's tool loop, not only at the end.
- The subagent run completes normally with bounded prompt sizes.

### Actual (with this PR)

- Matches expected. The engine compacts mid-loop, the runtime returns the assembled view to pi-agent for each subsequent LLM call, and the run completes without truncation.

### Actual (without this PR)

- `[context-overflow-precheck]` fires for the subagent.
- `truncateOversizedToolResultsInSessionManager` rewrites tool results destructively.
- The subagent loses chunks of its earlier tool output mid-run, then either errors out or returns a degraded result.

## Evidence

Trace from a run with the patch applied, `lossless-claw` enabled with `ownsCompaction: true`, openclaw `contextWindow: 64000`. Three things happening here, in order: pi-agent appends a new assistant + tool-result pair, the engine's threshold is hit and a leaf compaction runs, and the assembled view returned to pi-agent on the next call is smaller than the source array.

```text
[lcm] LCM compaction leaf pass (normal): 51206 -> 46878 conversation=605
[lcm-trace] afterTurn CALLED sessionKey=agent:main:subagent:9b4c4363... newMsgs=2
[lcm-trace] ingestBatch CALLED sessionKey=agent:main:subagent:9b4c4363... count=2
```

In the same run, no `[context-overflow-precheck]`, no `[tool-result-truncation]`, and no `PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE` errors landed in the journal for that subagent session.

- [x] Failing test/log before + passing after (new unit tests in `tool-result-context-guard.test.ts`, 22/22 passing locally)
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Subagent dispatched via `sessions_spawn` running a long tool loop with `lossless-claw` and `ownsCompaction: true`. Mid-loop compaction fires, no precheck overflow, no destructive truncation, run completes cleanly with bounded prompt sizes.
  - Main agent chat session under the same engine. `transformContext` returns the assembled view, the existing `finalizeAttemptContextEngineTurn` end-of-attempt path still runs, no double ingestion observed.
  - Confirmed the existing tool-result guard still installs for sessions without an engine (no behavioural change for the non-engine path).
  - Ran the new unit tests locally with `pnpm exec vitest run src/agents/pi-embedded-runner/tool-result-context-guard.test.ts`: 22/22 tests passing (11 existing + 11 new).
  - Ran a full project typecheck with `tsc --noEmit -p tsconfig.json`: clean.
- Edge cases checked (covered both by hand and by the new unit tests):
  - First iteration where `lastSeenLength === 0` and the message array contains the initial prompt batch.
  - `engine.afterTurn` not present on the engine (older plugins): the loop hook skips the call.
  - `engine.assemble()` returns an array of the same length as the source: hook returns source unchanged.
  - `engine.afterTurn` throws: try/catch falls through to the source messages, run continues.
  - `engine.assemble` throws: same fall-through behaviour.
  - A pre-existing `agent.transformContext` from another wrapper is invoked before the engine sees the messages.
  - The returned dispose function restores the previous `transformContext`.
- What you did NOT verify:
  - Non-`lossless-claw` context engine plugins against a real model. The hook only depends on the `ContextEngine` interface and the new unit tests cover the contract surface, but I have not exercised it end-to-end against another concrete engine implementation.
  - Behaviour under heavy concurrent multi-subagent fan-out beyond a small number of children.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Calling `engine.afterTurn` and `engine.assemble` on every LLM iteration adds latency to the inner tool loop for engine-owned sessions.
  - Mitigation: Only sessions whose engine has opted into ownership are affected. The hook short-circuits the `afterTurn` call when no new messages have been appended since the last iteration, and the `assemble()` call is the engine's responsibility to keep cheap. Sessions without an engine, or with an engine that does not own compaction, are unchanged.
- Risk: Engine bugs that previously only surfaced once per attempt (at end-of-attempt `afterTurn`) now surface on every iteration.
  - Mitigation: The hook wraps each engine call in `try/catch` and falls back to the raw source messages on failure, so the tool loop still makes forward progress even if the engine throws.
- Risk: An engine returning an `assemble()` view that is missing messages pi-agent expects could break the LLM call.
  - Mitigation: Only swap the returned view when its length differs from the source array. Pi-agent's own `state.messages` is intentionally not mutated, so its iteration tracking is preserved regardless of what the hook returns.
- Risk: The `route: "fits"` short-circuit hides a real overflow if the engine is misbehaving and has not actually compacted.
  - Mitigation: The contract is explicit. An engine setting `ownsCompaction = true` is asserting that it will keep the assembled context within bounds. If it does not, the model itself will eventually reject the prompt and the existing failure paths still apply.