### PR TITLE
fix(acp): strip discord channel prefix for thread-bound spawns

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -65,9 +65,14 @@ disk instead of treating `sessions_history` as a raw dump.
 `sessions_send` delivers a message to another session and optionally waits for
 the response:
 
+- Target the destination with **either** `sessionKey` **or** `label`, not both.
+- Use `sessionKey` when you already have an exact key from `sessions_list`.
+- Use `label` when you want OpenClaw to resolve a visible session by label.
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return
   immediately.
 - **Wait for reply:** set a timeout and get the response inline.
+
+If both `sessionKey` and `label` are provided, the tool returns an input error.
 
 After the target responds, OpenClaw can run a **reply-back loop** where the
 agents alternate messages (up to 5 turns). The target agent can reply

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -12,6 +12,7 @@ import {
 import * as sessionPaths from "../config/sessions/paths.js";
 import * as sessionStore from "../config/sessions/store.js";
 import * as sessionTranscript from "../config/sessions/transcript.js";
+import * as channelPlugins from "../channels/plugins/index.js";
 import * as gatewayCall from "../gateway/call.js";
 import * as heartbeatWake from "../infra/heartbeat-wake.js";
 import {
@@ -82,6 +83,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 const callGatewaySpy = vi.spyOn(gatewayCall, "callGateway");
+const getChannelPluginSpy = vi.spyOn(channelPlugins, "getChannelPlugin");
 const getAcpSessionManagerSpy = vi.spyOn(acpSessionManager, "getAcpSessionManager");
 const loadSessionStoreSpy = vi.spyOn(sessionStore, "loadSessionStore");
 const resolveStorePathSpy = vi.spyOn(sessionPaths, "resolveStorePath");
@@ -484,6 +486,7 @@ describe("spawnAcpDirect", () => {
     resolveSessionTranscriptFileSpy
       .mockReset()
       .mockImplementation(async (params) => await hoisted.resolveSessionTranscriptFileMock(params));
+    getChannelPluginSpy.mockReset().mockReturnValue(null);
     areHeartbeatsEnabledSpy
       .mockReset()
       .mockImplementation(() => hoisted.areHeartbeatsEnabledMock());
@@ -496,6 +499,18 @@ describe("spawnAcpDirect", () => {
   });
 
   it("spawns ACP session, binds a new thread, and dispatches initial task", async () => {
+    getChannelPluginSpy.mockImplementation((channel) =>
+      channel === "discord"
+        ? {
+            messaging: {
+              resolveInboundConversation: () => ({
+                conversationId: "channel:parent-channel",
+              }),
+            },
+          }
+        : null,
+    );
+
     const result = await spawnAcpDirect(
       {
         task: "Investigate flaky tests",
@@ -527,6 +542,11 @@ describe("spawnAcpDirect", () => {
       expect.objectContaining({
         targetKind: "session",
         placement: "child",
+        conversation: expect.objectContaining({
+          channel: "discord",
+          accountId: "default",
+          conversationId: "parent-channel",
+        }),
       }),
     );
     expectResolvedIntroTextInBindMetadata();

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -506,7 +506,11 @@ function resolveConversationIdForThreadBinding(params: {
       })?.conversationId
     : null;
   if (normalizeOptionalString(pluginResolvedConversationId)) {
-    return normalizeOptionalString(pluginResolvedConversationId);
+    const normalizedPluginConversationId = normalizeOptionalString(pluginResolvedConversationId);
+    if (channelKey === "discord" && normalizedPluginConversationId?.startsWith("channel:")) {
+      return normalizeOptionalString(normalizedPluginConversationId.slice("channel:".length));
+    }
+    return normalizedPluginConversationId;
   }
   if (channelKey === "line") {
     const lineConversationId = normalizeLineConversationIdFallback(params.groupId ?? params.to);


### PR DESCRIPTION
## Summary

Fix Discord thread-bound ACP spawns when the resolved conversation id is returned in OpenClaw's internal `channel:<id>` format.

This normalizes Discord plugin-resolved conversation ids before handing them to the thread binding flow.

## Why

Issue #63329 reports a regression where Discord ACP thread spawns fail with `thread_binding_invalid` because `channel:<id>` is passed into the binding layer instead of the raw Discord channel id.

The binding path expects the bare Discord id, but `resolveConversationIdForThreadBinding()` could return the prefixed internal form unchanged.

## Changes

- Updated `src/agents/acp-spawn.ts`
- When `channel === "discord"` and the plugin-resolved conversation id starts with `channel:`, strip the prefix before binding
- Added a regression assertion in `src/agents/acp-spawn.test.ts` to verify the binding layer receives the raw channel id

## Scope

This change is intentionally narrow:
- only affects Discord
- only applies when the plugin-resolved conversation id is prefixed with `channel:`
- leaves all non-Discord channels unchanged
- does not alter the broader thread-binding flow

## Validation

- Added a focused regression assertion covering the Discord thread-binding path
- Change is limited to a single normalization step before binding
