### PR TITLE
fix(sessions): preserve threadId on announce target fallback

### DIFF
--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -53,8 +53,22 @@ export async function resolveAnnounceTarget(params: {
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
       (typeof origin?.accountId === "string" ? origin.accountId : undefined);
+    const threadIdRaw =
+      (typeof deliveryContext?.threadId === "string" ||
+      (typeof deliveryContext?.threadId === "number" && Number.isFinite(deliveryContext.threadId))
+        ? deliveryContext.threadId
+        : undefined) ??
+      (typeof match?.lastThreadId === "string" ||
+      (typeof match?.lastThreadId === "number" && Number.isFinite(match.lastThreadId))
+        ? match.lastThreadId
+        : undefined) ??
+      (typeof origin?.threadId === "string" ||
+      (typeof origin?.threadId === "number" && Number.isFinite(origin.threadId))
+        ? origin.threadId
+        : undefined);
+    const threadId = threadIdRaw != null && threadIdRaw !== "" ? String(threadIdRaw) : undefined;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -54,6 +54,7 @@ export type SessionListRow = {
   origin?: {
     provider?: string;
     accountId?: string;
+    threadId?: string | number;
   };
   spawnedBy?: string;
   label?: string;
@@ -83,6 +84,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string | number;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -332,6 +332,33 @@ describe("resolveAnnounceTarget", () => {
       accountId: "work",
     });
   });
+
+  it("preserves threadId when sessions.list fallback resolves the announce target", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            accountId: "ops",
+            threadId: 77,
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+      accountId: "ops",
+      threadId: "77",
+    });
+  });
 });
 
 describe("sessions_list gating", () => {


### PR DESCRIPTION
## Summary
Preserve `threadId` when `resolveAnnounceTarget()` has to fall back to `sessions.list` instead of parsing the session key directly.

## Changes
- carry `deliveryContext.threadId`, `lastThreadId`, or `origin.threadId` through the fallback lookup path
- extend the local session row typing to include the fallback thread id fields used by the resolver
- add a regression test covering the `sessions.list` fallback path

## Test Plan
- `pnpm --dir /Users/wentao/Desktop/openclaw exec vitest run src/agents/tools/sessions.test.ts -t "preserves threadId when sessions.list fallback resolves the announce target"`