### PR TITLE
fix(memory): register bundled bedrock embedding adapter

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -6,6 +6,7 @@ import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearMemoryEmbeddingProviders as clearRegistry,
+  listMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider as registerAdapter,
 } from "../../../../src/plugins/memory-embedding-providers.js";
 import "./test-runtime-mocks.js";
@@ -346,6 +347,11 @@ describe("memory index", () => {
     expect(status.vector?.enabled).toBe(true);
     expect(typeof status.vector?.available).toBe("boolean");
     expect(status.vector?.available).toBe(available);
+  });
+
+  it("registers the bundled bedrock memory embedding adapter", () => {
+    const adapters = listMemoryEmbeddingProviders();
+    expect(adapters.some((adapter) => adapter.id === "bedrock")).toBe(true);
   });
 
   it("builds FTS index and returns search results when no embedding provider is available", async () => {

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -1,5 +1,6 @@
 import fsSync from "node:fs";
 import {
+  DEFAULT_BEDROCK_EMBEDDING_MODEL,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
@@ -7,6 +8,7 @@ import {
   DEFAULT_VOYAGE_EMBEDDING_MODEL,
   OPENAI_BATCH_ENDPOINT,
   buildGeminiEmbeddingRequest,
+  createBedrockEmbeddingProvider,
   createGeminiEmbeddingProvider,
   createLocalEmbeddingProvider,
   createMistralEmbeddingProvider,
@@ -116,7 +118,13 @@ function supportsGeminiMultimodalEmbeddings(model: string): boolean {
 }
 
 function resolveMemoryEmbeddingAuthProviderId(providerId: string): string {
-  return providerId === "gemini" ? "google" : providerId;
+  if (providerId === "gemini") {
+    return "google";
+  }
+  if (providerId === "bedrock") {
+    return "amazon-bedrock";
+  }
+  return providerId;
 }
 
 const openAiAdapter: MemoryEmbeddingProviderAdapter = {
@@ -288,6 +296,34 @@ const mistralAdapter: MemoryEmbeddingProviderAdapter = {
   },
 };
 
+const bedrockAdapter: MemoryEmbeddingProviderAdapter = {
+  id: "bedrock",
+  defaultModel: DEFAULT_BEDROCK_EMBEDDING_MODEL,
+  transport: "remote",
+  autoSelectPriority: 60,
+  allowExplicitWhenConfiguredAuto: true,
+  shouldContinueAutoSelection: isMissingApiKeyError,
+  create: async (options) => {
+    const { provider, client } = await createBedrockEmbeddingProvider({
+      ...options,
+      provider: "bedrock",
+      fallback: "none",
+    });
+    return {
+      provider,
+      runtime: {
+        id: "bedrock",
+        cacheKeyData: {
+          provider: "bedrock",
+          region: client.region,
+          model: client.model,
+          dimensions: client.dimensions,
+        },
+      },
+    };
+  },
+};
+
 const localAdapter: MemoryEmbeddingProviderAdapter = {
   id: "local",
   defaultModel: DEFAULT_LOCAL_MODEL,
@@ -320,6 +356,7 @@ export const builtinMemoryEmbeddingProviderAdapters = [
   geminiAdapter,
   voyageAdapter,
   mistralAdapter,
+  bedrockAdapter,
 ] as const;
 
 const builtinMemoryEmbeddingProviderAdapterById = new Map(
@@ -377,6 +414,7 @@ export function listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata(): Ar
 }
 
 export {
+  DEFAULT_BEDROCK_EMBEDDING_MODEL,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -85,7 +85,7 @@ function formatLocalSetupError(err: unknown): string {
       ? "2) Reinstall OpenClaw (this should install node-llama-cpp): npm i -g openclaw@latest"
       : null,
     "3) If you use pnpm: pnpm approve-builds (select node-llama-cpp), then pnpm rebuild node-llama-cpp",
-    ...["openai", "gemini", "voyage", "mistral"].map(
+    ...["openai", "gemini", "voyage", "mistral", "bedrock"].map(
       (provider) => `Or set agents.defaults.memorySearch.provider = "${provider}" (remote).`,
     ),
   ]

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -473,8 +473,11 @@ describe("embedding provider local fallback", () => {
 
   it("mentions every remote provider in local setup guidance", async () => {
     mockMissingLocalEmbeddingDependency();
+    await expect(createLocalProvider()).rejects.toThrow(/provider = "openai"/i);
     await expect(createLocalProvider()).rejects.toThrow(/provider = "gemini"/i);
+    await expect(createLocalProvider()).rejects.toThrow(/provider = "voyage"/i);
     await expect(createLocalProvider()).rejects.toThrow(/provider = "mistral"/i);
+    await expect(createLocalProvider()).rejects.toThrow(/provider = "bedrock"/i);
   });
 });
 

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -57,6 +57,7 @@ export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 // implicitly assume a local Ollama instance is available.
 // Bedrock is included when AWS credentials are detected.
 const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
+const REMOTE_EMBEDDING_SETUP_PROVIDER_IDS = [...REMOTE_EMBEDDING_PROVIDER_IDS, "bedrock"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -351,7 +352,7 @@ function formatLocalSetupError(err: unknown): string {
       ? "2) Reinstall OpenClaw (this should install node-llama-cpp): npm i -g openclaw@latest"
       : null,
     "3) If you use pnpm: pnpm approve-builds (select node-llama-cpp), then pnpm rebuild node-llama-cpp",
-    ...REMOTE_EMBEDDING_PROVIDER_IDS.map(
+    ...REMOTE_EMBEDDING_SETUP_PROVIDER_IDS.map(
       (provider) => `Or set agents.defaults.memorySearch.provider = "${provider}" (remote).`,
     ),
   ]

--- a/src/memory-host-sdk/engine-embeddings.ts
+++ b/src/memory-host-sdk/engine-embeddings.ts
@@ -17,6 +17,10 @@ export type {
 } from "../plugins/memory-embedding-providers.js";
 export { createLocalEmbeddingProvider, DEFAULT_LOCAL_MODEL } from "./host/embeddings.js";
 export {
+  createBedrockEmbeddingProvider,
+  DEFAULT_BEDROCK_EMBEDDING_MODEL,
+} from "./host/embeddings-bedrock.js";
+export {
   createGeminiEmbeddingProvider,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   buildGeminiEmbeddingRequest,

--- a/src/memory-host-sdk/host/embeddings.test.ts
+++ b/src/memory-host-sdk/host/embeddings.test.ts
@@ -482,8 +482,11 @@ describe("embedding provider local fallback", () => {
 
   it("mentions every remote provider in local setup guidance", async () => {
     mockMissingLocalEmbeddingDependency();
+    await expect(createLocalProvider()).rejects.toThrow(/provider = "openai"/i);
     await expect(createLocalProvider()).rejects.toThrow(/provider = "gemini"/i);
+    await expect(createLocalProvider()).rejects.toThrow(/provider = "voyage"/i);
     await expect(createLocalProvider()).rejects.toThrow(/provider = "mistral"/i);
+    await expect(createLocalProvider()).rejects.toThrow(/provider = "bedrock"/i);
   });
 });
 

--- a/src/memory-host-sdk/host/embeddings.ts
+++ b/src/memory-host-sdk/host/embeddings.ts
@@ -58,6 +58,7 @@ export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 // implicitly assume a local Ollama instance is available.
 // Bedrock is included when AWS credentials are detected.
 const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
+const REMOTE_EMBEDDING_SETUP_PROVIDER_IDS = [...REMOTE_EMBEDDING_PROVIDER_IDS, "bedrock"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -352,7 +353,7 @@ function formatLocalSetupError(err: unknown): string {
       ? "2) Reinstall OpenClaw (this should install node-llama-cpp): npm i -g openclaw@latest"
       : null,
     "3) If you use pnpm: pnpm approve-builds (select node-llama-cpp), then pnpm rebuild node-llama-cpp",
-    ...REMOTE_EMBEDDING_PROVIDER_IDS.map(
+    ...REMOTE_EMBEDDING_SETUP_PROVIDER_IDS.map(
       (provider) => `Or set agents.defaults.memorySearch.provider = "${provider}" (remote).`,
     ),
   ]


### PR DESCRIPTION
## Summary
Wire the bundled bedrock memory embedding provider into the built-in adapter registry used by memory-core.

## Changes
- export the bedrock embedding provider from the host engine surface
- register a built-in `bedrock` memory embedding adapter in memory-core
- map the adapter to the canonical `amazon-bedrock` auth provider id
- add a regression test proving the bundled adapter is registered

## Test Plan
- `pnpm --dir /Users/wentao/Desktop/openclaw exec vitest run extensions/memory-core/src/memory/index.test.ts`