### PR TITLE
fix(comfy): read bundled plugin config shape

### DIFF
--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -26,6 +26,18 @@ function buildComfyConfig(config: Record<string, unknown>): OpenClawConfig {
   } as unknown as OpenClawConfig;
 }
 
+function buildPluginComfyConfig(config: Record<string, unknown>): OpenClawConfig {
+  return {
+    plugins: {
+      entries: {
+        comfy: {
+          config,
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
 describe("comfy image-generation provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,6 +53,20 @@ describe("comfy image-generation provider", () => {
     expect(
       provider.isConfigured?.({
         cfg: buildComfyConfig({
+          workflow: {
+            "6": { inputs: { text: "" } },
+          },
+          promptNodeId: "6",
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the bundled plugin config shape for local comfy workflows", () => {
+    const provider = buildComfyImageGenerationProvider();
+    expect(
+      provider.isConfigured?.({
+        cfg: buildPluginComfyConfig({
           workflow: {
             "6": { inputs: { text: "" } },
           },

--- a/extensions/comfy/music-generation-provider.test.ts
+++ b/extensions/comfy/music-generation-provider.test.ts
@@ -90,4 +90,71 @@ describe("comfy music-generation provider", () => {
     });
     expect(result.tracks[0]?.buffer).toEqual(Buffer.from("music-bytes"));
   });
+
+  it("accepts the bundled plugin config shape for music workflows", async () => {
+    _setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ prompt_id: "music-job-plugin" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            "music-job-plugin": {
+              outputs: {
+                "9": {
+                  audio: [{ filename: "song.mp3", subfolder: "", type: "output" }],
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("music-bytes"), {
+          status: 200,
+          headers: { "content-type": "audio/mpeg" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildComfyMusicGenerationProvider();
+    const result = await provider.generateMusic({
+      provider: "comfy",
+      model: "workflow",
+      prompt: "gentle ambient synth loop",
+      cfg: {
+        plugins: {
+          entries: {
+            comfy: {
+              config: {
+                music: {
+                  workflow: {
+                    "6": { inputs: { text: "" } },
+                    "9": { inputs: {} },
+                  },
+                  promptNodeId: "6",
+                  outputNodeId: "9",
+                },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.metadata).toMatchObject({
+      promptId: "music-job-plugin",
+      outputNodeIds: ["9"],
+    });
+  });
 });

--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -26,6 +26,18 @@ function buildComfyConfig(config: Record<string, unknown>): OpenClawConfig {
   } as unknown as OpenClawConfig;
 }
 
+function buildPluginComfyConfig(config: Record<string, unknown>): OpenClawConfig {
+  return {
+    plugins: {
+      entries: {
+        comfy: {
+          config,
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
 describe("comfy video-generation provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,6 +53,22 @@ describe("comfy video-generation provider", () => {
     expect(
       provider.isConfigured?.({
         cfg: buildComfyConfig({
+          video: {
+            workflow: {
+              "6": { inputs: { text: "" } },
+            },
+            promptNodeId: "6",
+          },
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the bundled plugin config shape for local comfy video workflows", () => {
+    const provider = buildComfyVideoGenerationProvider();
+    expect(
+      provider.isConfigured?.({
+        cfg: buildPluginComfyConfig({
           video: {
             workflow: {
               "6": { inputs: { text: "" } },

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -132,8 +132,11 @@ function mergeSsrFPolicies(...policies: Array<SsrFPolicy | undefined>): SsrFPoli
 }
 
 export function getComfyConfig(cfg?: OpenClawConfig): ComfyProviderConfig {
-  const raw = cfg?.models?.providers?.comfy;
-  return isRecord(raw) ? raw : {};
+  const legacyRaw = cfg?.models?.providers?.comfy;
+  const pluginRaw = cfg?.plugins?.entries?.comfy?.config;
+  const legacyConfig = isRecord(legacyRaw) ? legacyRaw : {};
+  const pluginConfig = isRecord(pluginRaw) ? pluginRaw : {};
+  return { ...pluginConfig, ...legacyConfig };
 }
 
 function stripNestedCapabilityConfig(config: ComfyProviderConfig): ComfyProviderConfig {


### PR DESCRIPTION
## Summary
Teach comfy runtime config resolution to read the bundled plugin config shape in addition to the legacy `models.providers.comfy` path.

## Changes
- merge `plugins.entries.comfy.config` with the legacy `models.providers.comfy` config
- keep legacy config taking precedence when both shapes are present
- add regression coverage for image, video, and music providers using the plugin config shape

## Test Plan
- `pnpm --dir /Users/wentao/Desktop/openclaw exec vitest run extensions/comfy/image-generation-provider.test.ts extensions/comfy/video-generation-provider.test.ts extensions/comfy/music-generation-provider.test.ts`