### PR TITLE
minimax: gate voiceCompatible on req.target for TTS speech provider

### DIFF
--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -240,7 +240,7 @@ describe("buildMinimaxSpeechProvider", () => {
 
       expect(result.outputFormat).toBe("mp3");
       expect(result.fileExtension).toBe(".mp3");
-      expect(result.voiceCompatible).toBe(true);
+      expect(result.voiceCompatible).toBe(false);
       expect(result.audioBuffer.toString()).toBe("fake-audio-data");
 
       expect(mockFetch).toHaveBeenCalledOnce();
@@ -250,6 +250,27 @@ describe("buildMinimaxSpeechProvider", () => {
       expect(body.model).toBe("speech-2.8-hd");
       expect(body.text).toBe("Hello world");
       expect(body.voice_setting.voice_id).toBe("English_expressive_narrator");
+    });
+
+    it("sets voiceCompatible true for voice-note target", async () => {
+      const hexAudio = Buffer.from("fake-audio-data").toString("hex");
+      const mockFetch = vi.mocked(globalThis.fetch);
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { audio: hexAudio } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await provider.synthesize({
+        text: "Hello world",
+        cfg: {} as never,
+        providerConfig: { apiKey: "sk-test", baseUrl: "https://api.minimaxi.com" },
+        target: "voice-note",
+        timeoutMs: 30000,
+      });
+
+      expect(result.voiceCompatible).toBe(true);
     });
 
     it("applies overrides", async () => {

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -240,7 +240,7 @@ describe("buildMinimaxSpeechProvider", () => {
 
       expect(result.outputFormat).toBe("mp3");
       expect(result.fileExtension).toBe(".mp3");
-      expect(result.voiceCompatible).toBe(false);
+      expect(result.voiceCompatible).toBe(true);
       expect(result.audioBuffer.toString()).toBe("fake-audio-data");
 
       expect(mockFetch).toHaveBeenCalledOnce();

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -227,7 +227,7 @@ export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
         audioBuffer,
         outputFormat: "mp3",
         fileExtension: ".mp3",
-        voiceCompatible: false,
+        voiceCompatible: true,
       };
     },
   };

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -227,7 +227,7 @@ export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
         audioBuffer,
         outputFormat: "mp3",
         fileExtension: ".mp3",
-        voiceCompatible: true,
+        voiceCompatible: req.target === "voice-note",
       };
     },
   };


### PR DESCRIPTION
## Summary

buildMinimaxSpeechProvider() hardcoded voiceCompatible: false, preventing Telegram from treating MiniMax TTS output as a voice message.

Fixed by gating voiceCompatible on req.target === "voice-note", matching the pattern used by ElevenLabs and OpenAI. This ensures MiniMax TTS only signals voice compatibility when the TTS pipeline has already determined the channel supports voice messages (Telegram, WhatsApp, Matrix, Feishu), and returns false for audio-file targets such as Discord where MP3 is not accepted for voice delivery.

Updated speech-provider.test.ts to assert false for the audio-file target and add a voice-note case asserting true.

## Testing

- pnpm test extensions/minimax/speech-provider.test.ts -- 28 tests pass

Closes #63540

---
Made with Copilot | fully reviewed by human