### PR TITLE
 fix(bluebubbles): resolve sql injection vulnerability in contact lookup

### DIFF
--- a/extensions/bluebubbles/src/participant-contact-names.test.ts
+++ b/extensions/bluebubbles/src/participant-contact-names.test.ts
@@ -149,8 +149,13 @@ describe("enrichBlueBubblesParticipantsWithContactNames", () => {
       { phoneKey: "5557654321", name: "Bob Example" },
     ]);
     expect(execFileAsync).toHaveBeenCalledTimes(1);
-    const sql = execFileAsync.mock.calls[0]?.[1]?.[3];
-    expect(sql).toContain("WHERE digits IN ('5551234567', '5557654321')");
+
+    const args = execFileAsync.mock.calls[0]?.[1] ?? [];
+    const sql = args[args.length - 1];
+    expect(sql).toContain("WHERE digits IN (?1, ?2)");
+    expect(args).toContain("-cmd");
+    expect(args).toContain(".parameter set ?1 '5551234567'");
+    expect(args).toContain(".parameter set ?2 '5557654321'");
   });
 
   it("resolves names through the macOS contacts path across multiple databases", async () => {

--- a/extensions/bluebubbles/src/participant-contact-names.ts
+++ b/extensions/bluebubbles/src/participant-contact-names.ts
@@ -156,21 +156,16 @@ async function listContactsDatabases(deps: ResolvedParticipantContactNameDeps): 
   return databases;
 }
 
-function buildSqlitePhoneKeyList(phoneKeys: string[]): string {
-  return uniqueNormalizedPhoneLookupKeys(phoneKeys)
-    .map((phoneKey) => `'${phoneKey}'`)
-    .join(", ");
-}
-
 async function queryContactsDatabase(
   dbPath: string,
   phoneKeys: string[],
   deps: ResolvedParticipantContactNameDeps,
 ): Promise<Array<{ phoneKey: string; name: string }>> {
-  const sqlitePhoneKeyList = buildSqlitePhoneKeyList(phoneKeys);
-  if (!sqlitePhoneKeyList) {
+  const uniqueKeys = uniqueNormalizedPhoneLookupKeys(phoneKeys);
+  if (uniqueKeys.length === 0) {
     return [];
   }
+  const placeholders = uniqueKeys.map((_, i) => `?${i + 1}`).join(", ");
   const sql = `
 SELECT digits, name
 FROM (
@@ -187,18 +182,21 @@ FROM (
   JOIN ZABCDPHONENUMBER p ON p.ZOWNER = r.Z_PK
   WHERE p.ZFULLNUMBER IS NOT NULL
 )
-WHERE digits IN (${sqlitePhoneKeyList})
+WHERE digits IN (${placeholders})
   AND name != '';
 `;
   const options: ExecFileOptionsWithStringEncoding = {
     encoding: "utf8",
     maxBuffer: SQLITE_MAX_BUFFER,
   };
-  const { stdout } = await deps.execFileAsync(
-    "sqlite3",
-    ["-separator", "\t", dbPath, sql],
-    options,
-  );
+  const args = ["-separator", "\t"];
+  uniqueKeys.forEach((key, index) => {
+    const escapedKey = key.replace(/'/g, "''");
+    args.push("-cmd", `.parameter set ?${index + 1} '${escapedKey}'`);
+  });
+  args.push(dbPath, sql);
+
+  const { stdout } = await deps.execFileAsync("sqlite3", args, options);
   const rows: Array<{ phoneKey: string; name: string }> = [];
   for (const line of stdout.split(/\r?\n/)) {
     const trimmed = line.trim();

--- a/package.json
+++ b/package.json
@@ -1406,7 +1406,7 @@
     "tsdown": "0.21.7",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.3"
   },
   "peerDependencies": {
     "@napi-rs/canvas": "^0.1.89",


### PR DESCRIPTION
 fix(bluebubbles): resolve sql injection vulnerability in contact lookup


Replaced dynamic string interpolation with parameterized queries for the IN
clause within `queryContactsDatabase`. Parameters are securely bound using
the `sqlite3` CLI `.parameter set` commands via `-cmd` arguments, and
single quotes are escaped to prevent injection. Updated related tests to
verify the new command arguments.