### PR TITLE
fix(plugins): ignore non-allowlisted load errors #63575

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2219,6 +2219,39 @@ module.exports = { id: "throws-after-import", register() {} };`,
     ).toThrow("plugin load failed: telegram: invalid config: <root>: must be object");
   });
 
+  it("fails fast for open allowlists even when other plugins are explicitly enabled", () => {
+    setupBundledTelegramPlugin();
+    const broken = writePlugin({
+      id: "broken",
+      filename: "broken.cjs",
+      body: `module.exports = { id: "broken", register() {} };`,
+    });
+
+    expect(() =>
+      loadOpenClawPlugins({
+        cache: false,
+        workspaceDir: cachedBundledTelegramDir,
+        throwOnLoadError: true,
+        config: {
+          channels: {
+            telegram: {
+              enabled: true,
+            },
+          },
+          plugins: {
+            load: { paths: [broken.file] },
+            entries: {
+              broken: {
+                enabled: true,
+                config: "nope" as unknown as Record<string, unknown>,
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow("plugin load failed: broken: invalid config: <root>: must be object");
+  });
+
   it("filters strict plugin load failures by plugins.allow", () => {
     const registry = {
       plugins: [

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2164,6 +2164,32 @@ module.exports = { id: "throws-after-import", register() {} };`,
     ).toThrow("plugin load failed: configurable: invalid config: <root>: must be object");
   });
 
+  it("does not suppress strict failures for explicitly enabled plugins omitted from plugins.allow", () => {
+    setupBundledTelegramPlugin();
+    expect(() =>
+      loadOpenClawPlugins({
+        cache: false,
+        workspaceDir: cachedBundledTelegramDir,
+        throwOnLoadError: true,
+        config: {
+          channels: {
+            telegram: {
+              enabled: true,
+            },
+          },
+          plugins: {
+            allow: ["browser"],
+            entries: {
+              telegram: {
+                config: "nope" as unknown as Record<string, unknown>,
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow("plugin load failed: telegram: invalid config: <root>: must be object");
+  });
+
   it("filters strict plugin load failures by plugins.allow", () => {
     const registry = {
       plugins: [

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -12,6 +12,7 @@ import {
   __testing,
   clearPluginLoaderCache,
   loadOpenClawPlugins,
+  PluginLoadFailureError,
   PluginLoadReentryError,
   resolveRuntimePluginRegistry,
 } from "./loader.js";
@@ -2161,6 +2162,19 @@ module.exports = { id: "throws-after-import", register() {} };`,
         },
       }),
     ).toThrow("plugin load failed: configurable: invalid config: <root>: must be object");
+  });
+
+  it("filters strict plugin load failures by plugins.allow", () => {
+    const registry = {
+      plugins: [
+        { id: "allowed", status: "error", error: "boom" },
+        { id: "blocked", status: "error", error: "nope" },
+      ],
+    } as unknown as PluginRegistry;
+
+    const error = new PluginLoadFailureError(registry, { onlyPluginIds: ["allowed"] });
+    expect(error.pluginIds).toEqual(["allowed"]);
+    expect(error.message).toBe("plugin load failed: allowed: boom");
   });
 
   it("fails when plugin export id mismatches manifest id", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2164,6 +2164,35 @@ module.exports = { id: "throws-after-import", register() {} };`,
     ).toThrow("plugin load failed: configurable: invalid config: <root>: must be object");
   });
 
+  it("does not throw when only non-allowlisted plugins fail under strict loading", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "third-party",
+      filename: "third-party.cjs",
+      body: `module.exports = { id: "third-party", register() {} };`,
+    });
+
+    expect(() =>
+      loadOpenClawPlugins({
+        cache: false,
+        throwOnLoadError: true,
+        config: {
+          plugins: {
+            enabled: true,
+            load: { paths: [plugin.file] },
+            allow: ["trusted-only"],
+            entries: {
+              "third-party": {
+                enabled: true,
+                config: "invalid" as unknown as Record<string, unknown>,
+              },
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("does not suppress strict failures for explicitly enabled plugins omitted from plugins.allow", () => {
     setupBundledTelegramPlugin();
     expect(() =>

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -822,14 +822,20 @@ function maybeThrowOnPluginLoadError(
   if (errored.length === 0) {
     return;
   }
-  if (allowlist.length > 0) {
-    const allowSet = new Set(allowlist);
-    if (!errored.some((entry) => allowSet.has(entry.id))) {
-      return;
+  const strictIds = new Set<string>();
+  for (const pluginId of allowlist) {
+    strictIds.add(pluginId);
+  }
+  for (const plugin of registry.plugins) {
+    if (plugin.explicitlyEnabled) {
+      strictIds.add(plugin.id);
     }
   }
+  if (strictIds.size > 0 && !errored.some((entry) => strictIds.has(entry.id))) {
+    return;
+  }
   throw new PluginLoadFailureError(registry, {
-    onlyPluginIds: allowlist.length > 0 ? allowlist : undefined,
+    onlyPluginIds: strictIds.size > 0 ? [...strictIds].toSorted() : undefined,
   });
 }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -124,8 +124,19 @@ export class PluginLoadFailureError extends Error {
   readonly pluginIds: string[];
   readonly registry: PluginRegistry;
 
-  constructor(registry: PluginRegistry) {
-    const failedPlugins = registry.plugins.filter((entry) => entry.status === "error");
+  constructor(
+    registry: PluginRegistry,
+    options?: {
+      onlyPluginIds?: readonly string[];
+    },
+  ) {
+    const filterSet =
+      options?.onlyPluginIds && options.onlyPluginIds.length > 0
+        ? new Set(options.onlyPluginIds)
+        : null;
+    const failedPlugins = registry.plugins.filter(
+      (entry) => entry.status === "error" && (!filterSet || filterSet.has(entry.id)),
+    );
     const summary = failedPlugins
       .map((entry) => `${entry.id}: ${entry.error ?? "unknown plugin load error"}`)
       .join("; ");
@@ -802,14 +813,24 @@ function pushDiagnostics(diagnostics: PluginDiagnostic[], append: PluginDiagnost
 function maybeThrowOnPluginLoadError(
   registry: PluginRegistry,
   throwOnLoadError: boolean | undefined,
+  allowlist: readonly string[],
 ): void {
   if (!throwOnLoadError) {
     return;
   }
-  if (!registry.plugins.some((entry) => entry.status === "error")) {
+  const errored = registry.plugins.filter((entry) => entry.status === "error");
+  if (errored.length === 0) {
     return;
   }
-  throw new PluginLoadFailureError(registry);
+  if (allowlist.length > 0) {
+    const allowSet = new Set(allowlist);
+    if (!errored.some((entry) => allowSet.has(entry.id))) {
+      return;
+    }
+  }
+  throw new PluginLoadFailureError(registry, {
+    onlyPluginIds: allowlist.length > 0 ? allowlist : undefined,
+  });
 }
 
 type PathMatcher = {
@@ -1785,7 +1806,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       env,
     });
 
-    maybeThrowOnPluginLoadError(registry, options.throwOnLoadError);
+    maybeThrowOnPluginLoadError(registry, options.throwOnLoadError, normalized.allow);
 
     if (shouldActivate && options.mode !== "validate") {
       const failedPlugins = registry.plugins.filter((plugin) => plugin.failedAt != null);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -822,20 +822,22 @@ function maybeThrowOnPluginLoadError(
   if (errored.length === 0) {
     return;
   }
-  const strictIds = new Set<string>();
-  for (const pluginId of allowlist) {
-    strictIds.add(pluginId);
-  }
-  for (const plugin of registry.plugins) {
-    if (plugin.explicitlyEnabled) {
-      strictIds.add(plugin.id);
+  const hasAllowlist = allowlist.length > 0;
+  const strictIds = hasAllowlist ? new Set<string>(allowlist) : null;
+  if (strictIds) {
+    for (const plugin of registry.plugins) {
+      if (plugin.explicitlyEnabled) {
+        strictIds.add(plugin.id);
+      }
     }
   }
-  if (strictIds.size > 0 && !errored.some((entry) => strictIds.has(entry.id))) {
+  // Restrict strict-error filtering to non-empty allowlists so the open-allowlist
+  // (plugins.allow is empty) semantics stay fail-fast for any plugin load error.
+  if (strictIds && !errored.some((entry) => strictIds.has(entry.id))) {
     return;
   }
   throw new PluginLoadFailureError(registry, {
-    onlyPluginIds: strictIds.size > 0 ? [...strictIds].toSorted() : undefined,
+    onlyPluginIds: strictIds && strictIds.size > 0 ? [...strictIds].toSorted() : undefined,
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: Gateway/CLI bootstrap can crash on strict plugin loading when *non-allowlisted* plugins end up in `status === "error"`.
- Why it matters: Users rely on `plugins.allow` to scope trusted/loaded plugins; failures outside the allowlist should not hard-fail boot.
- What changed: Strict load failure throwing is now filtered by `plugins.allow` (when non-empty), and the thrown error summary only includes allowlisted failures.
- What did NOT change (scope boundary): When `plugins.allow` is empty (open allowlist), strict behavior remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63575

## User-visible / Behavior Changes

- When `plugins.allow` is set (non-empty), strict plugin load errors will only throw if an allowlisted plugin failed to load/register. Errors from plugins outside the allowlist are tolerated (with diagnostics).

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node (repo default tooling)
- Relevant config (redacted): `plugins.allow` non-empty

### Tests

- `pnpm test src/plugins/loader.test.ts -t "filters strict plugin load failures by plugins.allow|throws when strict plugin loading sees plugin errors"`

## Evidence

- [x] Passing targeted test(s) (see above)

## Human Verification (required)

- Verified scenarios:
  - Allowlisted plugin failure still throws under strict loading.
  - Non-allowlisted failures are filtered out of strict throw decision and error summary when `plugins.allow` is non-empty.
- Edge cases checked:
  - `plugins.allow` empty preserves existing strict behavior.
- What I did **not** verify:
  - Full gateway boot with real third-party plugins (requires external credentials/config).
  
## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

- Risk: Filtering could mask non-allowlisted failures in strict mode.
  - Mitigation: Only applies when `plugins.allow` is explicitly set (non-empty), matching user intent to scope trusted/loaded plugins.