### PR TITLE
Cron: add deliveryPayloads config (full/last/none)

### DIFF
--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -25677,6 +25677,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "Error types to retry: rate_limit, overloaded, network, timeout, server_error. Use to restrict which errors trigger retries; omit to retry all transient types.",
       tags: ["reliability", "automation"],
     },
+    "cron.deliveryPayloads": {
+      label: "Cron Delivery Payloads Mode",
+      help: "Controls which model reply payloads are sent to the cron job delivery channel. `full` (default) sends every deliverable segment (or synthesized text when needed). `last` sends only the final segment. `none` skips channel delivery while still recording summary/output in run logs and UIs.",
+      tags: ["automation"],
+    },
     "cron.webhook": {
       label: "Cron Legacy Webhook (Deprecated)",
       help: 'Deprecated legacy fallback webhook URL used only for old jobs with `notify=true`. Migrate to per-job delivery using `delivery.mode="webhook"` plus `delivery.to`, and avoid relying on this global field.',

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -126,6 +126,7 @@ const TARGET_KEYS = [
   "cron.retry.maxAttempts",
   "cron.retry.backoffMs",
   "cron.retry.retryOn",
+  "cron.deliveryPayloads",
   "cron.webhook",
   "cron.webhookToken",
   "cron.sessionRetention",
@@ -694,6 +695,13 @@ describe("config help copy quality", () => {
 
     const keepLines = FIELD_HELP["cron.runLog.keepLines"];
     expect(keepLines.includes("2000")).toBe(true);
+  });
+
+  it("documents cron delivery payload modes", () => {
+    const help = FIELD_HELP["cron.deliveryPayloads"];
+    expect(help.includes("full")).toBe(true);
+    expect(help.includes("last")).toBe(true);
+    expect(help.includes("none")).toBe(true);
   });
 
   it("documents approvals filters and target semantics", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1302,6 +1302,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Backoff delays in ms for each retry attempt (default: [30000, 60000, 300000]). Use shorter values for faster retries.",
   "cron.retry.retryOn":
     "Error types to retry: rate_limit, overloaded, network, timeout, server_error. Use to restrict which errors trigger retries; omit to retry all transient types.",
+  "cron.deliveryPayloads":
+    "Controls which model reply payloads are sent to the cron job delivery channel. `full` (default) sends every deliverable segment (or synthesized text when needed). `last` sends only the final segment. `none` skips channel delivery while still recording summary/output in run logs and UIs.",
   "cron.webhook":
     'Deprecated legacy fallback webhook URL used only for old jobs with `notify=true`. Migrate to per-job delivery using `delivery.mode="webhook"` plus `delivery.to`, and avoid relying on this global field.',
   "cron.webhookToken":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -633,6 +633,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "cron.retry.maxAttempts": "Cron Retry Max Attempts",
   "cron.retry.backoffMs": "Cron Retry Backoff (ms)",
   "cron.retry.retryOn": "Cron Retry Error Types",
+  "cron.deliveryPayloads": "Cron Delivery Payloads Mode",
   "cron.webhook": "Cron Legacy Webhook (Deprecated)",
   "cron.webhookToken": "Cron Webhook Bearer Token",
   "cron.sessionRetention": "Cron Session Retention",

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -27,6 +27,9 @@ export type CronFailureDestinationConfig = {
   mode?: "announce" | "webhook";
 };
 
+/** How cron maps model reply payloads into outbound channel delivery lists. */
+export type CronDeliveryPayloadsMode = "full" | "last" | "none";
+
 export type CronConfig = {
   enabled?: boolean;
   store?: string;
@@ -57,4 +60,11 @@ export type CronConfig = {
   failureAlert?: CronFailureAlertConfig;
   /** Default destination for failure notifications across all cron jobs. */
   failureDestination?: CronFailureDestinationConfig;
+  /**
+   * Which assistant payloads to send to the configured delivery channel.
+   * `full` (default): all deliverable segments (or synthesized text when empty).
+   * `last`: only the last deliverable segment.
+   * `none`: do not send to channels; run logs and UI may still record summary/output text.
+   */
+  deliveryPayloads?: CronDeliveryPayloadsMode;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -566,6 +566,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        deliveryPayloads: z.enum(["full", "last", "none"]).optional(),
       })
       .strict()
       .superRefine((val, ctx) => {

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -96,4 +96,26 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayloads).toEqual([{ text: "last error", isError: true }]);
     expect(result.deliveryPayload).toEqual({ text: "last error", isError: true });
   });
+
+  it("deliveryPayloadsMode last keeps only the last deliverable segment for outbound list", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "a" }, { text: "b" }, { text: "c" }],
+      deliveryPayloadsMode: "last",
+    });
+
+    expect(result.deliveryPayloads).toEqual([{ text: "c" }]);
+    expect(result.deliveryPayload).toEqual({ text: "c" });
+    expect(result.suppressCronOutboundDelivery).toBeUndefined();
+  });
+
+  it("deliveryPayloadsMode none clears outbound list and sets suppressCronOutboundDelivery", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "hello" }],
+      deliveryPayloadsMode: "none",
+    });
+
+    expect(result.deliveryPayloads).toEqual([]);
+    expect(result.suppressCronOutboundDelivery).toBe(true);
+    expect(result.summary).toBe("hello");
+  });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -912,4 +912,17 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       timeoutMs: 10_000,
     });
   });
+
+  it("does not call deliverOutboundPayloads when suppressCronOutboundDelivery is true", async () => {
+    const params = {
+      ...makeBaseParams({
+        synthesizedText: "would normally synthesize outbound",
+        deliveryRequested: true,
+      }),
+      deliveryPayloads: [] as { text?: string }[],
+      suppressCronOutboundDelivery: true,
+    };
+    await dispatchCronDelivery(params);
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -71,6 +71,7 @@ type DispatchCronDeliveryParams = {
   deliveryRequested: boolean;
   skipHeartbeatDelivery: boolean;
   skipMessagingToolDelivery?: boolean;
+  suppressCronOutboundDelivery?: boolean;
   deliveryBestEffort: boolean;
   deliveryPayloadHasStructuredContent: boolean;
   deliveryPayloads: ReplyPayload[];
@@ -669,7 +670,12 @@ export async function dispatchCronDelivery(
     }
   };
 
-  if (params.deliveryRequested && !params.skipHeartbeatDelivery && !skipMessagingToolDelivery) {
+  if (
+    params.deliveryRequested &&
+    !params.skipHeartbeatDelivery &&
+    !skipMessagingToolDelivery &&
+    params.suppressCronOutboundDelivery !== true
+  ) {
     if (!params.resolvedDelivery.ok) {
       if (!params.deliveryBestEffort) {
         return {

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -1,6 +1,7 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "../../auto-reply/heartbeat.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { CronDeliveryPayloadsMode } from "../../config/types.cron.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
@@ -19,6 +20,7 @@ export type CronPayloadOutcome = {
   deliveryPayloadHasStructuredContent: boolean;
   hasFatalErrorPayload: boolean;
   embeddedRunError?: string;
+  suppressCronOutboundDelivery?: boolean;
 };
 
 export function pickSummaryFromOutput(text: string | undefined) {
@@ -125,6 +127,7 @@ export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxCha
 export function resolveCronPayloadOutcome(params: {
   payloads: DeliveryPayload[];
   runLevelError?: unknown;
+  deliveryPayloadsMode?: CronDeliveryPayloadsMode;
 }): CronPayloadOutcome {
   const firstText = params.payloads[0]?.text ?? "";
   const summary = pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
@@ -132,12 +135,21 @@ export function resolveCronPayloadOutcome(params: {
   const synthesizedText = normalizeOptionalString(outputText) ?? normalizeOptionalString(summary);
   const deliveryPayload = pickLastDeliverablePayload(params.payloads);
   const selectedDeliveryPayloads = pickDeliverablePayloads(params.payloads);
-  const resolvedDeliveryPayloads =
+  let resolvedDeliveryPayloads =
     selectedDeliveryPayloads.length > 0
       ? selectedDeliveryPayloads
       : synthesizedText
         ? [{ text: synthesizedText }]
         : [];
+  const mode = params.deliveryPayloadsMode ?? "full";
+  let suppressCronOutboundDelivery = false;
+  if (mode === "last" && resolvedDeliveryPayloads.length > 1) {
+    const lastPayload = resolvedDeliveryPayloads[resolvedDeliveryPayloads.length - 1];
+    resolvedDeliveryPayloads = lastPayload ? [lastPayload] : [];
+  } else if (mode === "none") {
+    resolvedDeliveryPayloads = [];
+    suppressCronOutboundDelivery = true;
+  }
   const deliveryPayloadHasStructuredContent =
     deliveryPayload?.mediaUrl !== undefined ||
     (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
@@ -169,5 +181,6 @@ export function resolveCronPayloadOutcome(params: {
     embeddedRunError: hasFatalErrorPayload
       ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
       : undefined,
+    ...(suppressCronOutboundDelivery ? { suppressCronOutboundDelivery: true } : {}),
   };
 }

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -301,12 +301,14 @@ export async function executeCronRun(params: {
 
   if (!params.isAborted()) {
     const interimPayloads = runResult.payloads ?? [];
+    const deliveryPayloadsMode = params.cfgWithAgentDefaults.cron?.deliveryPayloads ?? "full";
     const {
       deliveryPayloadHasStructuredContent: interimPayloadHasStructuredContent,
       outputText: interimOutputText,
     } = resolveCronPayloadOutcome({
       payloads: interimPayloads,
       runLevelError: runResult.meta?.error,
+      deliveryPayloadsMode,
     });
     const interimText = interimOutputText?.trim() ?? "";
     const shouldRetryInterimAck =

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -552,6 +552,8 @@ async function finalizeCronRun(params: {
   if (params.isAborted()) {
     return prepared.withRunSession({ status: "error", error: params.abortReason(), ...telemetry });
   }
+  const deliveryPayloadsMode =
+    prepared.cfgWithAgentDefaults.cron?.deliveryPayloads ?? "full";
   let {
     summary,
     outputText,
@@ -560,9 +562,11 @@ async function finalizeCronRun(params: {
     deliveryPayloadHasStructuredContent,
     hasFatalErrorPayload,
     embeddedRunError,
+    suppressCronOutboundDelivery,
   } = resolveCronPayloadOutcome({
     payloads,
     runLevelError: finalRunResult.meta?.error,
+    deliveryPayloadsMode,
   });
   const resolveRunOutcome = (result?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
     prepared.withRunSession({
@@ -606,6 +610,7 @@ async function finalizeCronRun(params: {
     deliveryRequested: prepared.deliveryRequested,
     skipHeartbeatDelivery,
     skipMessagingToolDelivery,
+    suppressCronOutboundDelivery: suppressCronOutboundDelivery === true,
     deliveryBestEffort: resolveCronDeliveryBestEffort(prepared.input.job),
     deliveryPayloadHasStructuredContent,
     deliveryPayloads,


### PR DESCRIPTION
## Title

**Cron: add `cron.deliveryPayloads` mode (`full` / `last` / `none`)**

---

## Summary

Adds a global `cron.deliveryPayloads` setting so operators can control how isolated cron runs map model reply payloads onto outbound channel delivery, without changing underlying `pickDeliverablePayloads` / `pickLastDeliverablePayload` semantics.

| Mode | Behavior |
|------|----------|
| **`full`** (default) | Same as today: use `pickDeliverablePayloads`, or fall back to a single synthesized text payload when needed. |
| **`last`** | After that resolution, if there is more than one outbound payload, keep only the **last** one (“send only the final segment”). |
| **`none`** | Outbound delivery list is always empty; **no** message is sent to the configured channel. Summary / output text / synthesized text remain available for run records and UI. Dispatch explicitly suppresses the direct/text delivery path so `synthesizedText` is not used as a fallback send. |

---

## Implementation notes

- **`resolveCronPayloadOutcome`** accepts `deliveryPayloadsMode` and returns `suppressCronOutboundDelivery: true` only for `none`.
- **`dispatchCronDelivery`** takes `suppressCronOutboundDelivery` and gates the main delivery block so empty `deliveryPayloads` cannot trigger a synthetic send via `deliverViaDirect`.
- **`finalizeCronRun`** reads `prepared.cfgWithAgentDefaults.cron?.deliveryPayloads ?? "full"` and passes the flag through to dispatch.
- **`run-executor`** uses the same mode for interim `resolveCronPayloadOutcome` so structured/interim detection stays aligned with final delivery policy.

---

## Config / schema

- `CronConfig.deliveryPayloads` in `src/config/types.cron.ts`
- Zod: `z.enum(["full", "last", "none"]).optional()` under `cron`
- Help, labels, and generated schema metadata updated (`schema.base.generated.ts`)

---

## Tests

- `resolveCronPayloadOutcome`: `last` (multi-segment → last only), `none` (empty list + suppress flag), existing `full` behavior preserved.
- `dispatchCronDelivery`: `suppressCronOutboundDelivery: true` → `deliverOutboundPayloads` not called when delivery would otherwise use synthesized fallback.

---

## Checklist (for reviewers)

- [ ] `pnpm config:docs:gen` / `pnpm config:docs:check` if you regenerate baselines locally (hash under `docs/.generated/` may need updating in environments that run full config gates).
- [ ] `pnpm test` on touched paths if not already run in CI.

---

**Suggested base branch:** `main` (or your fork’s default).  
**Branch:** `feat/cron-delivery-payloads`