### PR TITLE
feat(media): allow host-local CSV uploads #63604

### DIFF
--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -410,6 +410,34 @@ describe("runMessageAction media behavior", () => {
       }
     });
 
+    it("rejects host-local plaintext renamed as .pdf when fs root expansion is enabled", async () => {
+      await restoreRealMediaLoader();
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-attachment-fake-pdf-"));
+      try {
+        const outsidePath = path.join(tempDir, "secret.pdf");
+        await fs.writeFile(outsidePath, "not really a pdf", "utf8");
+
+        await expect(
+          runMessageAction({
+            cfg: {
+              ...cfg,
+              tools: { fs: { workspaceOnly: false } },
+            },
+            action: "sendAttachment",
+            params: {
+              channel: "bluebubbles",
+              target: "+15551234567",
+              media: outsidePath,
+              message: "caption",
+            },
+          }),
+        ).rejects.toThrow(/Host-local media sends only allow/i);
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it("rejects host-local text attachments even when fs root expansion is enabled", async () => {
       await restoreRealMediaLoader();
 

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -377,6 +377,39 @@ describe("runMessageAction media behavior", () => {
       }
     });
 
+    it("allows host-local CSV attachments when fs root expansion is enabled", async () => {
+      await restoreRealMediaLoader();
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-attachment-csv-"));
+      try {
+        const outsidePath = path.join(tempDir, "data.csv");
+        await fs.writeFile(outsidePath, "a,b\n1,2\n", "utf8");
+
+        const result = await runMessageAction({
+          cfg: {
+            ...cfg,
+            tools: { fs: { workspaceOnly: false } },
+          },
+          action: "sendAttachment",
+          params: {
+            channel: "bluebubbles",
+            target: "+15551234567",
+            media: outsidePath,
+            message: "caption",
+          },
+        });
+
+        expect(result.kind).toBe("action");
+        expect(result.payload).toMatchObject({
+          ok: true,
+          filename: "data.csv",
+          contentType: "text/csv",
+        });
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it("rejects host-local text attachments even when fs root expansion is enabled", async () => {
       await restoreRealMediaLoader();
 

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -114,27 +114,61 @@ function isHeicSource(opts: { contentType?: string; fileName?: string }): boolea
   return false;
 }
 
+function isPlausibleCsvText(buffer: Buffer): boolean {
+  // Avoid treating binary as CSV.
+  if (buffer.includes(0x00)) {
+    return false;
+  }
+  // Heuristic: require at least one comma and one newline in the first chunk.
+  const head = buffer.subarray(0, Math.min(buffer.length, 16 * 1024));
+  const hasComma = head.includes(0x2c); // ,
+  const hasNewline = head.includes(0x0a) || head.includes(0x0d); // \n or \r
+  if (!hasComma || !hasNewline) {
+    return false;
+  }
+  // Ensure it decodes as UTF-8 without replacement characters.
+  const decoded = head.toString("utf8");
+  if (decoded.includes("\uFFFD")) {
+    return false;
+  }
+  return true;
+}
+
 function assertHostReadMediaAllowed(params: {
-  contentType?: string;
+  detectedMime?: string;
+  verifiedMime?: string;
   kind: MediaKind | undefined;
+  buffer?: Buffer;
 }): void {
   if (params.kind === "image" || params.kind === "audio" || params.kind === "video") {
     return;
   }
   if (params.kind !== "document") {
-    const contentType = normalizeMimeType(params.contentType);
+    const contentType = normalizeMimeType(params.verifiedMime ?? params.detectedMime);
     throw new LocalMediaAccessError(
       "path-not-allowed",
       `Host-local media sends only allow images, audio, video, PDF, and Office documents (got ${contentType ?? "unknown"}).`,
     );
   }
-  const normalizedMime = normalizeMimeType(params.contentType);
-  if (normalizedMime && HOST_READ_ALLOWED_DOCUMENT_MIMES.has(normalizedMime)) {
+  // Host-local path: do not trust extension-derived MIME for allowlisting.
+  // Only allow verified (content-sniffed) MIME types, with a narrow CSV exception
+  // gated by a lightweight text-shape check.
+  const verified = normalizeMimeType(params.verifiedMime);
+  if (verified && HOST_READ_ALLOWED_DOCUMENT_MIMES.has(verified)) {
+    return;
+  }
+  const detected = normalizeMimeType(params.detectedMime);
+  if (
+    detected === "text/csv" &&
+    params.buffer &&
+    HOST_READ_ALLOWED_DOCUMENT_MIMES.has("text/csv") &&
+    isPlausibleCsvText(params.buffer)
+  ) {
     return;
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow images, audio, video, PDF, and Office documents (got ${normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow images, audio, video, PDF, and Office documents (got ${verified ?? "unknown"}).`,
   );
 }
 
@@ -390,8 +424,10 @@ async function loadWebMediaInternal(
   }
   if (hostReadCapability) {
     assertHostReadMediaAllowed({
-      contentType: verifiedMime ?? detectedMime,
+      detectedMime,
+      verifiedMime,
       kind: kindFromMime(detectedMime ?? verifiedMime),
+      buffer: data,
     });
   }
   return await clampAndFinalize({

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -81,6 +81,7 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/csv",
 ]);
 const MB = 1024 * 1024;
 
@@ -389,7 +390,7 @@ async function loadWebMediaInternal(
   }
   if (hostReadCapability) {
     assertHostReadMediaAllowed({
-      contentType: verifiedMime,
+      contentType: verifiedMime ?? detectedMime,
       kind: kindFromMime(detectedMime ?? verifiedMime),
     });
   }


### PR DESCRIPTION
## Summary

- Problem: Host-local media uploads reject CSV files because `text/csv` is classified as `document` but blocked by a narrower host-read document MIME allowlist, and the error often shows `unknown` due to MIME not being propagated in the host-read check path.
- Why it matters: `message(action: "upload-file")` cannot upload common data files like `.csv` even though MIME detection recognizes them.
- What changed:
  - Allow `text/csv` in the host-read document MIME allowlist.
  - Propagate `contentType` as `verifiedMime ?? detectedMime` for the host-read policy check so plaintext-like formats don’t degrade to `unknown` when sniffing fails.
  - Add a regression test to ensure host-local CSV is allowed while host-local plaintext remains rejected.
- What did NOT change (scope boundary): We did not broaden host-local allowances to `text/plain` / `text/markdown` or `text/*` generally.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63604

## User-visible / Behavior Changes

Host-local file uploads can now send `.csv` files (`text/csv`) when host-local media reads are permitted by policy.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node (repo test runner)
- Integration/channel (if any): message tool + host-local media policy path

### Steps

1. Create a local file `data.csv`.
2. Upload it via `message(action: "upload-file", filePath: "/path/to/data.csv", filename: "data.csv")` in a host-local media policy path.
3. Confirm the upload is accepted (previously rejected with `Host-local media sends only allow ... (got unknown)`).

### Expected

- `.csv` uploads are allowed and treated as a document with `contentType: text/csv`.

### Actual (before)

- Rejected by host-read allowlist; error often reported `unknown` MIME.

## Evidence

- [x] Passing test: `pnpm test src/infra/outbound/message-action-runner.media.test.ts`

## Human Verification (required)

- Verified scenarios:
  - Host-local `.csv` attachment allowed with `contentType: text/csv`.
  - Host-local `.txt` attachment still rejected.
- Edge cases checked:
  - MIME propagation no longer reports `unknown` when extension-based detection is available.
- What I did **not** verify:
  - End-to-end upload to a real external channel (relies on existing channel upload handling).

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

- Risk: Allowing CSV could enable accidental upload of sensitive structured data from host-local files.
  - Mitigation: Scope is limited to `text/csv` only; plaintext-like `text/plain` / `text/markdown` remain blocked by default.