### PR TITLE
fix(acp): route /acp lifecycle commands to local handlers

### DIFF
--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1527,6 +1527,14 @@ describe("/acp command", () => {
     expect(result?.reply?.text).toContain("Removed 1 binding");
   });
 
+  it("treats /acp stop as an alias for /acp close", async () => {
+    mockBoundThreadSession();
+    const result = await runThreadAcpCommand("/acp stop", baseCfg);
+
+    expect(hoisted.closeMock).toHaveBeenCalledTimes(1);
+    expect(result?.reply?.text).toContain(`Closed ACP session ${defaultAcpSessionKey}`);
+  });
+
   it("lists ACP sessions from the session store", async () => {
     hoisted.sessionBindingListBySessionMock.mockImplementation((key: string) =>
       key === defaultAcpSessionKey ? [createBoundThreadSession(key) as SessionBindingRecord] : [],

--- a/src/auto-reply/reply/commands-acp/shared.test.ts
+++ b/src/auto-reply/reply/commands-acp/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSpawnInput, parseSteerInput } from "./shared.js";
+import { parseSpawnInput, parseSteerInput, resolveAcpAction } from "./shared.js";
 
 describe("parseSteerInput", () => {
   it("preserves non-option instruction tokens while normalizing unicode-dash flags", () => {
@@ -37,5 +37,15 @@ describe("parseSpawnInput", () => {
       error:
         "Use either --thread or --bind for /acp spawn, not both. Usage: /acp spawn [harness-id] [--mode persistent|oneshot] [--thread auto|here|off] [--bind here|off] [--cwd <path>] [--label <label>].",
     });
+  });
+});
+
+describe("resolveAcpAction", () => {
+  it("maps stop to close and consumes the action token", () => {
+    const tokens = ["stop", "agent:codex:acp:s1"];
+    const action = resolveAcpAction(tokens);
+
+    expect(action).toBe("close");
+    expect(tokens).toEqual(["agent:codex:acp:s1"]);
   });
 });

--- a/src/auto-reply/reply/commands-acp/shared.ts
+++ b/src/auto-reply/reply/commands-acp/shared.ts
@@ -94,6 +94,10 @@ export function stopWithText(text: string): CommandHandlerResult {
 
 export function resolveAcpAction(tokens: string[]): AcpAction {
   const action = normalizeOptionalLowercaseString(tokens[0]);
+  if (action === "stop") {
+    tokens.shift();
+    return "close";
+  }
   if (
     action === "spawn" ||
     action === "cancel" ||
@@ -441,6 +445,7 @@ export function resolveAcpHelpText(): string {
     "/acp cancel [session-key|session-id|session-label]",
     "/acp steer [--session <session-key|session-id|session-label>] <instruction>",
     "/acp close [session-key|session-id|session-label]",
+    "/acp stop [session-key|session-id|session-label] (alias of /acp close)",
     "/acp status [session-key|session-id|session-label]",
     "/acp set-mode <mode> [session-key|session-id|session-label]",
     "/acp set <key> <value> [session-key|session-id|session-label]",

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -1,9 +1,42 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { shouldBypassAcpDispatchForCommand } from "./dispatch-acp-command-bypass.js";
 import { buildTestCtx } from "./test-ctx.js";
 
+function setDispatchBypassTestRegistry(params?: { discordNativeCommands?: boolean }): void {
+  if (!params?.discordNativeCommands) {
+    setActivePluginRegistry(createTestRegistry([]));
+    return;
+  }
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "discord",
+        source: "test",
+        plugin: createChannelTestPluginBase({
+          id: "discord",
+          label: "Discord",
+          capabilities: { nativeCommands: true, chatTypes: ["direct"] },
+        }),
+      },
+    ]),
+  );
+}
+
 describe("shouldBypassAcpDispatchForCommand", () => {
+  beforeEach(() => {
+    setDispatchBypassTestRegistry();
+  });
+
+  afterEach(() => {
+    setDispatchBypassTestRegistry();
+  });
+
   it("returns false for plain-text ACP turns", () => {
     const ctx = buildTestCtx({
       Provider: "discord",
@@ -52,7 +85,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
-  it("returns true for /acp slash commands when text commands are allowed on the surface", () => {
+  it("returns true for /acp slash commands when allowTextCommands resolves to true", () => {
     const ctx = buildTestCtx({
       Provider: "discord",
       Surface: "discord",
@@ -68,6 +101,26 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     } as OpenClawConfig;
 
     expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(true);
+  });
+
+  it("returns false for /acp slash commands when allowTextCommands resolves to false", () => {
+    setDispatchBypassTestRegistry({ discordNativeCommands: true });
+
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      CommandBody: "/acp cancel",
+      BodyForCommands: "/acp cancel",
+      BodyForAgent: "/acp cancel",
+      CommandSource: "text",
+    });
+    const cfg = {
+      commands: {
+        text: false,
+      },
+    } as OpenClawConfig;
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(false);
   });
 
   it("returns false for unauthorized bang-prefixed commands", () => {

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -15,7 +15,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(false);
   });
 
-  it("returns false for ACP slash commands", () => {
+  it("returns true for ACP slash commands", () => {
     const ctx = buildTestCtx({
       Provider: "discord",
       Surface: "discord",
@@ -24,7 +24,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
       BodyForAgent: "/acp cancel",
     });
 
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(false);
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
   it("returns true for ACP reset-tail slash commands", () => {
@@ -52,7 +52,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
-  it("returns false for slash commands when text commands are disabled", () => {
+  it("returns true for /acp slash commands when text commands are allowed on the surface", () => {
     const ctx = buildTestCtx({
       Provider: "discord",
       Surface: "discord",
@@ -67,7 +67,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
       },
     } as OpenClawConfig;
 
-    expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(false);
+    expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(true);
   });
 
   it("returns false for unauthorized bang-prefixed commands", () => {

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.ts
@@ -27,6 +27,10 @@ function isResetCommandCandidate(text: string): boolean {
   return /^\/(?:new|reset)(?:\s|$)/i.test(text);
 }
 
+function isAcpCommandCandidate(text: string): boolean {
+  return /^\/acp(?:\s|$)/i.test(text);
+}
+
 export function shouldBypassAcpDispatchForCommand(
   ctx: FinalizedMsgContext,
   cfg: OpenClawConfig,
@@ -47,6 +51,10 @@ export function shouldBypassAcpDispatchForCommand(
 
   if (isResetCommandCandidate(normalized)) {
     return true;
+  }
+
+  if (isAcpCommandCandidate(normalized)) {
+    return allowTextCommands;
   }
 
   if (!normalized.startsWith("!")) {


### PR DESCRIPTION
## Summary

AI-assisted: Yes. This PR was prepared with OpenClaw + Codex assistance, then reviewed and validated by me before update/push.

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: In ACP-bound conversations, `/acp cancel` and `/acp close` could be routed into ACP turn dispatch instead of local ACP lifecycle handlers.
- Why it matters: During `ACP_TURN_FAILED` loops, users lose the main recovery controls (`/acp cancel`, `/acp close`), creating a hard operational blocker.
- What changed: Treat `/acp ...` as ACP-dispatch bypass commands so they are handled locally; add `/acp stop` as an alias for `/acp close`; add focused tests.
- What did NOT change (scope boundary): No ACP runtime protocol changes, no task-store schema changes, no auth/permission model changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `shouldBypassAcpDispatchForCommand` bypassed `/new`/`/reset` and `!` commands, but not `/acp ...`, so ACP lifecycle commands could be absorbed by ACP turn dispatch.
- Missing detection / guardrail: Existing tests explicitly asserted that ACP slash commands should not bypass ACP dispatch (`dispatch-acp-command-bypass.test.ts`), locking in the wrong behavior.
- Contributing context (if known): Error copy for `ACP_TURN_FAILED` recommends `/acp cancel`, increasing impact when routing is wrong.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/dispatch-acp-command-bypass.test.ts`
  - `src/auto-reply/reply/commands-acp/shared.test.ts`
  - `src/auto-reply/reply/commands-acp.test.ts`
  - `src/plugin-sdk/acp-runtime.test.ts`
- Scenario the test should lock in: `/acp cancel` and `/acp close` bypass ACP turn dispatch and reach local lifecycle handlers, and `/acp stop` resolves to close action.
- Why this is the smallest reliable guardrail: The bug is in routing/gating and action resolution, so command-bypass unit coverage plus ACP command seam coverage is sufficient without full end-to-end harness startup.
- Existing test that already covers this (if any): ACP command handler coverage already exists in `commands-acp.test.ts`; this PR extends it for `/acp stop` alias and corrected bypass behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- `/acp cancel` now reliably executes local cancel handling in ACP-bound threads instead of falling into ACP turn execution.
- `/acp close` now reliably executes local close handling in ACP-bound threads.
- `/acp stop` is now accepted as an alias of `/acp close`.
- `/acp help` now lists `/acp stop` as an alias.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user sends /acp cancel in ACP-bound thread]
  -> [ACP dispatch path consumes command]
  -> [ACP_TURN_FAILED repeats]
  -> [session not cancelled]

After:
[user sends /acp cancel in ACP-bound thread]
  -> [command bypass for /acp]
  -> [local ACP lifecycle handler]
  -> ["✅ Cancel requested ..."]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - Added `/acp stop` alias and changed `/acp ...` routing to local handlers.
  - Mitigation: Existing command authorization and text-command gating still apply (`allowTextCommands`, sender authorization); tests cover routing semantics.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu host)
- Runtime/container: Node.js `v24.13.1`, OpenClaw runtime
- Model/provider: ACP Codex via `acpx` backend (`@zed-industries/codex-acp`)
- Integration/channel (if any): Telegram topics and webchat
- Relevant config (redacted): ACP enabled with Codex ACP command override (`env -u ... npx @zed-industries/codex-acp@^0.11.1`)

### Steps

1. Spawn ACP and bind conversation (`/acp spawn codex --bind here`).
2. Trigger ACP turn failures (`ACP_TURN_FAILED: Internal error`).
3. Send `/acp cancel` or `/acp close` in the same ACP-bound conversation.

### Expected

- Lifecycle command is handled locally and returns a success ack (cancel/close), allowing recovery.

### Actual

- Before this fix, the command could route into ACP turn dispatch and continue failing with `ACP_TURN_FAILED`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Log trail (before):
- Spawn success: `raw/telegram/chats/-1003587450790/2026/04/08.jsonl:116`
- Repeated ACP failures: same file `117,118,121,124`
- Commands received: `raw/telegram/chats/telegram:-1003587450790:topic:20/2026/04/08.jsonl:3,4,5,6`
- Errors still sent after cancel/close attempts: `raw/telegram/chats/-1003587450790/2026/04/08.jsonl:119,120,122,123`
- Stale cleanup symptom: `/tmp/openclaw-1001/openclaw-2026-04-08.log:6615,6616`

Validation (local):
- `node scripts/run-vitest.mjs run --config vitest.config.ts src/auto-reply/reply/dispatch-acp-command-bypass.test.ts src/auto-reply/reply/commands-acp/shared.test.ts src/auto-reply/reply/commands-acp.test.ts src/plugin-sdk/acp-runtime.test.ts`
- Result: `4` files passed, `58` tests passed.
- `codex review --base origin/main`
- Result: no introduced defects found.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed the root-cause routing path in code and tests.
  - Confirmed `/acp ...` bypass logic now routes to local handling.
  - Confirmed `/acp stop` resolves to the close action.
- Edge cases checked:
  - Text-command gating remains enforced by `allowTextCommands`.
  - Existing bang-command authorization behavior is unaffected.
- What you did **not** verify:
  - Live Telegram runtime replay after patch deployment (verified here via unit/seam tests and historical logs in this branch environment).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: In channels/surfaces with different command handling modes, bypass semantics could drift from intended policy.
  - Mitigation: Reuse existing `shouldHandleTextCommands` gating and keep explicit tests for the ACP slash cases.
- Risk: Alias introduces ambiguity for users expecting `/acp stop` to behave differently from close.
  - Mitigation: `/acp help` documents the alias explicitly.
