### PR TITLE
Feat/add mrscraper plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -333,6 +333,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/tavily/**"
+"extensions: mrscraper":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/mrscraper/**"
 "extensions: talk-voice":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Docs: https://docs.openclaw.ai
 - Hooks/wake: queue direct and mapped wake-hook payloads as untrusted system events so external wake content no longer enters the main session as trusted input. (#62003)
 - Slack/thread mentions: add `channels.slack.thread.requireExplicitMention` so Slack channels that already require mentions can also require explicit `@bot` mentions inside bot-participated threads. (#58276) Thanks @praktika-engineer.
 
+### Changes
+
+- Web tools/MrScraper: add a bundled `mrscraper` plugin with `web_fetch` provider fallback via the unblocker plus explicit `mrscraper_fetch_html` and `mrscraper_scrape` tools, using plugin-owned config under `plugins.entries.mrscraper.config.*`.
+
 ## 2026.4.5
 
 ### Breaking

--- a/extensions/mrscraper/index.ts
+++ b/extensions/mrscraper/index.ts
@@ -1,0 +1,15 @@
+import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { createMrScraperWebFetchProvider } from "./src/mrscraper-fetch-provider.js";
+import { createMrScraperFetchHtmlTool } from "./src/mrscraper-fetch-tool.js";
+import { createMrScraperScrapeTool } from "./src/mrscraper-scrape-tool.js";
+
+export default definePluginEntry({
+  id: "mrscraper",
+  name: "MrScraper Plugin",
+  description: "Bundled MrScraper unblocker and AI scraping plugin",
+  register(api) {
+    api.registerWebFetchProvider(createMrScraperWebFetchProvider());
+    api.registerTool(createMrScraperFetchHtmlTool(api) as AnyAgentTool);
+    api.registerTool(createMrScraperScrapeTool(api) as AnyAgentTool);
+  },
+});

--- a/extensions/mrscraper/index.ts
+++ b/extensions/mrscraper/index.ts
@@ -1,6 +1,12 @@
 import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { createMrScraperBulkRerunAiScraperTool } from "./src/mrscraper-bulk-rerun-ai-scraper-tool.js";
+import { createMrScraperBulkRerunManualScraperTool } from "./src/mrscraper-bulk-rerun-manual-scraper-tool.js";
 import { createMrScraperWebFetchProvider } from "./src/mrscraper-fetch-provider.js";
 import { createMrScraperFetchHtmlTool } from "./src/mrscraper-fetch-tool.js";
+import { createMrScraperGetAllResultsTool } from "./src/mrscraper-get-all-results-tool.js";
+import { createMrScraperGetResultByIdTool } from "./src/mrscraper-get-result-by-id-tool.js";
+import { createMrScraperRerunAiScraperTool } from "./src/mrscraper-rerun-ai-scraper-tool.js";
+import { createMrScraperRerunManualScraperTool } from "./src/mrscraper-rerun-manual-scraper-tool.js";
 import { createMrScraperScrapeTool } from "./src/mrscraper-scrape-tool.js";
 
 export default definePluginEntry({
@@ -9,7 +15,13 @@ export default definePluginEntry({
   description: "Bundled MrScraper unblocker and AI scraping plugin",
   register(api) {
     api.registerWebFetchProvider(createMrScraperWebFetchProvider());
+    api.registerTool(createMrScraperBulkRerunAiScraperTool(api) as AnyAgentTool);
+    api.registerTool(createMrScraperBulkRerunManualScraperTool(api) as AnyAgentTool);
     api.registerTool(createMrScraperFetchHtmlTool(api) as AnyAgentTool);
+    api.registerTool(createMrScraperGetAllResultsTool(api) as AnyAgentTool);
+    api.registerTool(createMrScraperGetResultByIdTool(api) as AnyAgentTool);
+    api.registerTool(createMrScraperRerunAiScraperTool(api) as AnyAgentTool);
+    api.registerTool(createMrScraperRerunManualScraperTool(api) as AnyAgentTool);
     api.registerTool(createMrScraperScrapeTool(api) as AnyAgentTool);
   },
 });

--- a/extensions/mrscraper/openclaw.plugin.json
+++ b/extensions/mrscraper/openclaw.plugin.json
@@ -1,0 +1,69 @@
+{
+  "id": "mrscraper",
+  "skills": ["./skills"],
+  "providerAuthEnvVars": {
+    "mrscraper": ["MRSCRAPER_API_TOKEN"]
+  },
+  "uiHints": {
+    "apiToken": {
+      "label": "MrScraper API Token",
+      "help": "MrScraper API token for unblocker and scraper APIs (fallback: MRSCRAPER_API_TOKEN env var).",
+      "sensitive": true,
+      "placeholder": "mrs_..."
+    },
+    "webFetch.baseUrl": {
+      "label": "MrScraper Unblocker Base URL",
+      "help": "MrScraper unblocker base URL override."
+    },
+    "platform.baseUrl": {
+      "label": "MrScraper Platform Base URL",
+      "help": "MrScraper platform API base URL override."
+    }
+  },
+  "contracts": {
+    "webFetchProviders": ["mrscraper"],
+    "tools": ["mrscraper_fetch_html", "mrscraper_scrape"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiToken": {
+        "type": ["string", "object"]
+      },
+      "webFetch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "baseUrl": {
+            "type": "string"
+          },
+          "timeoutSeconds": {
+            "type": "number"
+          },
+          "geoCode": {
+            "type": "string"
+          },
+          "blockResources": {
+            "type": "boolean"
+          }
+        }
+      },
+      "platform": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "baseUrl": {
+            "type": "string"
+          },
+          "timeoutSeconds": {
+            "type": "number"
+          },
+          "proxyCountry": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/mrscraper/openclaw.plugin.json
+++ b/extensions/mrscraper/openclaw.plugin.json
@@ -13,16 +13,27 @@
     },
     "webFetch.baseUrl": {
       "label": "MrScraper Unblocker Base URL",
-      "help": "MrScraper unblocker base URL override."
+      "help": "MrScraper unblocker base URL override.",
+      "advanced": true
     },
     "platform.baseUrl": {
       "label": "MrScraper Platform Base URL",
-      "help": "MrScraper platform API base URL override."
+      "help": "MrScraper platform API base URL override.",
+      "advanced": true
     }
   },
   "contracts": {
     "webFetchProviders": ["mrscraper"],
-    "tools": ["mrscraper_fetch_html", "mrscraper_scrape"]
+    "tools": [
+      "mrscraper_bulk_rerun_ai_scraper",
+      "mrscraper_bulk_rerun_manual_scraper",
+      "mrscraper_fetch_html",
+      "mrscraper_get_all_results",
+      "mrscraper_get_result_by_id",
+      "mrscraper_rerun_ai_scraper",
+      "mrscraper_rerun_manual_scraper",
+      "mrscraper_scrape"
+    ]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/mrscraper/package.json
+++ b/extensions/mrscraper/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/mrscraper-plugin",
+  "version": "2026.4.5",
+  "private": true,
+  "description": "OpenClaw MrScraper plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/mrscraper/skills/mrscraper/SKILL.md
+++ b/extensions/mrscraper/skills/mrscraper/SKILL.md
@@ -26,11 +26,10 @@ metadata:
 When `mrscraper` is the selected `web_fetch` provider, OpenClaw routes normal
 `web_fetch` calls through MrScraper's unblocker.
 
-| Parameter     | Description                 |
-| ------------- | --------------------------- |
-| `url`         | HTTP or HTTPS URL to fetch  |
-| `extractMode` | `markdown` or `text`        |
-| `maxChars`    | Maximum returned characters |
+| Parameter  | Description                 |
+| ---------- | --------------------------- |
+| `url`      | HTTP or HTTPS URL to fetch  |
+| `maxChars` | Maximum returned characters |
 
 ## mrscraper_fetch_html
 
@@ -40,7 +39,6 @@ and extracted text back in one tool result.
 | Parameter        | Description                                     |
 | ---------------- | ----------------------------------------------- |
 | `url`            | HTTP or HTTPS URL to fetch                      |
-| `extractMode`    | `markdown` or `text`                            |
 | `maxChars`       | Maximum returned characters                     |
 | `timeoutSeconds` | Request timeout                                 |
 | `geoCode`        | Optional country routing code like `US` or `SG` |

--- a/extensions/mrscraper/skills/mrscraper/SKILL.md
+++ b/extensions/mrscraper/skills/mrscraper/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: mrscraper
+description: MrScraper unblocker and AI scraping tools for blocked pages and structured extraction.
+metadata:
+  { "openclaw": { "emoji": "🕸️", "requires": { "config": ["plugins.entries.mrscraper.enabled"] } } }
+---
+
+# MrScraper Tools
+
+## When to use which tool
+
+| Need                              | Tool                   | When                                                                |
+| --------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| Blocked or JS-heavy page fetch    | `web_fetch`            | MrScraper can power `web_fetch` when selected as the fetch provider |
+| Rendered HTML plus extracted text | `mrscraper_fetch_html` | Need unblocker controls like `geoCode` or `blockResources`          |
+| AI-powered structured extraction  | `mrscraper_scrape`     | Need schema-free extraction from plain-language instructions        |
+
+## web_fetch
+
+When `mrscraper` is the selected `web_fetch` provider, OpenClaw routes normal
+`web_fetch` calls through MrScraper's unblocker.
+
+| Parameter     | Description                 |
+| ------------- | --------------------------- |
+| `url`         | HTTP or HTTPS URL to fetch  |
+| `extractMode` | `markdown` or `text`        |
+| `maxChars`    | Maximum returned characters |
+
+## mrscraper_fetch_html
+
+Use this when you need unblocker-specific controls or want both rendered HTML
+and extracted text back in one tool result.
+
+| Parameter        | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `url`            | HTTP or HTTPS URL to fetch                      |
+| `extractMode`    | `markdown` or `text`                            |
+| `maxChars`       | Maximum returned characters                     |
+| `timeoutSeconds` | Request timeout                                 |
+| `geoCode`        | Optional country routing code like `US` or `SG` |
+| `blockResources` | Block images/fonts/resources for faster loads   |
+
+## mrscraper_scrape
+
+Use this when you want MrScraper to create an AI scraper run from natural-language
+instructions.
+
+| Parameter         | Description                                    |
+| ----------------- | ---------------------------------------------- | --- | --- |
+| `url`             | Target page or site                            |
+| `message`         | What to extract                                |
+| `agent`           | `general`, `listing`, or `map`                 |
+| `proxyCountry`    | Optional ISO country code                      |
+| `maxDepth`        | `map` agent only                               |
+| `maxPages`        | `map` agent only                               |
+| `limit`           | `map` agent only                               |
+| `includePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
+| `excludePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
+
+## Tips
+
+- Start with `web_fetch` or `mrscraper_fetch_html` when you mainly need page contents.
+- Use `mrscraper_scrape` when you need structured extracted data instead of raw page text.
+- Prefer the `map` agent only when the task really needs multi-page crawling.

--- a/extensions/mrscraper/skills/mrscraper/SKILL.md
+++ b/extensions/mrscraper/skills/mrscraper/SKILL.md
@@ -9,11 +9,17 @@ metadata:
 
 ## When to use which tool
 
-| Need                              | Tool                   | When                                                                |
-| --------------------------------- | ---------------------- | ------------------------------------------------------------------- |
-| Blocked or JS-heavy page fetch    | `web_fetch`            | MrScraper can power `web_fetch` when selected as the fetch provider |
-| Rendered HTML plus extracted text | `mrscraper_fetch_html` | Need unblocker controls like `geoCode` or `blockResources`          |
-| AI-powered structured extraction  | `mrscraper_scrape`     | Need schema-free extraction from plain-language instructions        |
+| Need                              | Tool                                  | When                                                                |
+| --------------------------------- | ------------------------------------- | ------------------------------------------------------------------- |
+| Blocked or JS-heavy page fetch    | `web_fetch`                           | MrScraper can power `web_fetch` when selected as the fetch provider |
+| Rendered HTML plus extracted text | `mrscraper_fetch_html`                | Need unblocker controls like `geoCode` or `blockResources`          |
+| AI-powered structured extraction  | `mrscraper_scrape`                    | Need schema-free extraction from plain-language instructions        |
+| Reuse an AI scraper               | `mrscraper_rerun_ai_scraper`          | Apply an existing AI scraper to a new page or crawl target          |
+| Batch AI reruns                   | `mrscraper_bulk_rerun_ai_scraper`     | Reuse one AI scraper across many URLs                               |
+| Reuse a manual scraper            | `mrscraper_rerun_manual_scraper`      | Apply a dashboard manual scraper to a new URL                       |
+| Batch manual reruns               | `mrscraper_bulk_rerun_manual_scraper` | Reuse one manual scraper across many URLs                           |
+| Browse prior runs                 | `mrscraper_get_all_results`           | List stored results with sorting, paging, and filters               |
+| Inspect one prior run             | `mrscraper_get_result_by_id`          | Fetch one detailed result by result ID                              |
 
 ## web_fetch
 
@@ -57,8 +63,74 @@ instructions.
 | `includePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
 | `excludePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
 
+## mrscraper_rerun_ai_scraper
+
+Reuse an existing AI scraper on a new URL.
+
+| Parameter         | Description                                    |
+| ----------------- | ---------------------------------------------- | --- | --- |
+| `scraperId`       | Existing AI scraper ID                         |
+| `url`             | Target page or site                            |
+| `maxDepth`        | `map` agent only                               |
+| `maxPages`        | `map` agent only                               |
+| `limit`           | `map` agent only                               |
+| `includePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
+| `excludePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
+
+## mrscraper_bulk_rerun_ai_scraper
+
+Reuse an existing AI scraper across multiple URLs.
+
+| Parameter   | Description             |
+| ----------- | ----------------------- |
+| `scraperId` | Existing AI scraper ID  |
+| `urls`      | One or more target URLs |
+
+## mrscraper_rerun_manual_scraper
+
+Reuse an existing manual scraper on a new URL.
+
+| Parameter   | Description                |
+| ----------- | -------------------------- |
+| `scraperId` | Existing manual scraper ID |
+| `url`       | Target page or site        |
+
+## mrscraper_bulk_rerun_manual_scraper
+
+Reuse an existing manual scraper across multiple URLs.
+
+| Parameter   | Description                |
+| ----------- | -------------------------- |
+| `scraperId` | Existing manual scraper ID |
+| `urls`      | One or more target URLs    |
+
+## mrscraper_get_all_results
+
+Browse previous MrScraper runs with optional paging and filtering.
+
+| Parameter         | Description                      |
+| ----------------- | -------------------------------- |
+| `sortField`       | Sort column such as `updatedAt`  |
+| `sortOrder`       | `ASC` or `DESC`                  |
+| `pageSize`        | Number of results per page       |
+| `page`            | Page number starting at 1        |
+| `search`          | Optional text search             |
+| `dateRangeColumn` | Optional date field to filter by |
+| `startAt`         | Optional ISO start timestamp     |
+| `endAt`           | Optional ISO end timestamp       |
+
+## mrscraper_get_result_by_id
+
+Fetch one detailed result object by result ID.
+
+| Parameter  | Description        |
+| ---------- | ------------------ |
+| `resultId` | Result ID to fetch |
+
 ## Tips
 
 - Start with `web_fetch` or `mrscraper_fetch_html` when you mainly need page contents.
 - Use `mrscraper_scrape` when you need structured extracted data instead of raw page text.
+- Use the rerun tools once you already have a saved scraper ID and want to reuse it.
+- Use the result tools when you need to inspect prior jobs rather than launch a new scrape.
 - Prefer the `map` agent only when the task really needs multi-page crawling.

--- a/extensions/mrscraper/src/config.ts
+++ b/extensions/mrscraper/src/config.ts
@@ -1,0 +1,162 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  normalizeResolvedSecretInputString,
+  normalizeSecretInput,
+} from "openclaw/plugin-sdk/secret-input";
+
+export const DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL = "https://api.mrscraper.com";
+export const DEFAULT_MRSCRAPER_PLATFORM_BASE_URL = "https://api.app.mrscraper.com";
+export const DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS = 60;
+export const DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS = 120;
+
+type PluginEntryConfig =
+  | {
+      apiToken?: unknown;
+      webFetch?: {
+        baseUrl?: string;
+        timeoutSeconds?: number;
+        geoCode?: string;
+        blockResources?: boolean;
+      };
+      platform?: {
+        baseUrl?: string;
+        timeoutSeconds?: number;
+        proxyCountry?: string;
+      };
+    }
+  | undefined;
+
+type LegacyFetchConfig =
+  | {
+      mrscraper?: {
+        apiToken?: unknown;
+      };
+    }
+  | undefined;
+
+function resolvePluginConfig(cfg?: OpenClawConfig): PluginEntryConfig {
+  const pluginConfig = cfg?.plugins?.entries?.mrscraper?.config;
+  if (pluginConfig && typeof pluginConfig === "object" && !Array.isArray(pluginConfig)) {
+    return pluginConfig as PluginEntryConfig;
+  }
+  return undefined;
+}
+
+function resolveLegacyFetchConfig(cfg?: OpenClawConfig): LegacyFetchConfig {
+  const fetch = cfg?.tools?.web?.fetch;
+  if (fetch && typeof fetch === "object" && !Array.isArray(fetch)) {
+    return fetch as LegacyFetchConfig;
+  }
+  return undefined;
+}
+
+function normalizeConfiguredSecret(value: unknown, path: string): string | undefined {
+  return normalizeSecretInput(
+    normalizeResolvedSecretInputString({
+      value,
+      path,
+    }),
+  );
+}
+
+export function resolveMrScraperApiToken(cfg?: OpenClawConfig): string | undefined {
+  const pluginConfig = resolvePluginConfig(cfg);
+  const legacyFetch = resolveLegacyFetchConfig(cfg);
+  return (
+    normalizeConfiguredSecret(
+      pluginConfig?.apiToken,
+      "plugins.entries.mrscraper.config.apiToken",
+    ) ||
+    normalizeConfiguredSecret(
+      legacyFetch?.mrscraper?.apiToken,
+      "tools.web.fetch.mrscraper.apiToken",
+    ) ||
+    normalizeSecretInput(process.env.MRSCRAPER_API_TOKEN) ||
+    undefined
+  );
+}
+
+export function resolveMrScraperWebFetchConfig(cfg?: OpenClawConfig) {
+  return resolvePluginConfig(cfg)?.webFetch;
+}
+
+export function resolveMrScraperPlatformConfig(cfg?: OpenClawConfig) {
+  return resolvePluginConfig(cfg)?.platform;
+}
+
+export function resolveMrScraperUnblockerBaseUrl(cfg?: OpenClawConfig): string {
+  const configured =
+    (typeof resolveMrScraperWebFetchConfig(cfg)?.baseUrl === "string"
+      ? resolveMrScraperWebFetchConfig(cfg)?.baseUrl?.trim()
+      : "") || "";
+  return configured || DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL;
+}
+
+export function resolveMrScraperPlatformBaseUrl(cfg?: OpenClawConfig): string {
+  const configured =
+    (typeof resolveMrScraperPlatformConfig(cfg)?.baseUrl === "string"
+      ? resolveMrScraperPlatformConfig(cfg)?.baseUrl?.trim()
+      : "") || "";
+  return configured || DEFAULT_MRSCRAPER_PLATFORM_BASE_URL;
+}
+
+export function resolveMrScraperFetchTimeoutSeconds(
+  cfg?: OpenClawConfig,
+  override?: number,
+): number {
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  const configured = resolveMrScraperWebFetchConfig(cfg)?.timeoutSeconds;
+  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS;
+}
+
+export function resolveMrScraperScrapeTimeoutSeconds(
+  cfg?: OpenClawConfig,
+  override?: number,
+): number {
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  const configured = resolveMrScraperPlatformConfig(cfg)?.timeoutSeconds;
+  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS;
+}
+
+export function resolveMrScraperGeoCode(
+  cfg?: OpenClawConfig,
+  override?: string,
+): string | undefined {
+  const candidate =
+    (typeof override === "string" ? override.trim() : "") ||
+    (typeof resolveMrScraperWebFetchConfig(cfg)?.geoCode === "string"
+      ? resolveMrScraperWebFetchConfig(cfg)?.geoCode?.trim()
+      : "") ||
+    "";
+  return candidate || undefined;
+}
+
+export function resolveMrScraperBlockResources(cfg?: OpenClawConfig, override?: boolean): boolean {
+  if (typeof override === "boolean") {
+    return override;
+  }
+  return resolveMrScraperWebFetchConfig(cfg)?.blockResources === true;
+}
+
+export function resolveMrScraperProxyCountry(
+  cfg?: OpenClawConfig,
+  override?: string,
+): string | undefined {
+  const candidate =
+    (typeof override === "string" ? override.trim() : "") ||
+    (typeof resolveMrScraperPlatformConfig(cfg)?.proxyCountry === "string"
+      ? resolveMrScraperPlatformConfig(cfg)?.proxyCountry?.trim()
+      : "") ||
+    "";
+  return candidate || undefined;
+}

--- a/extensions/mrscraper/src/mrscraper-bulk-rerun-ai-scraper-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-bulk-rerun-ai-scraper-tool.ts
@@ -1,0 +1,51 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperBulkRerunAiScraper } from "./mrscraper-client.js";
+
+const MrScraperBulkRerunAiScraperSchema = Type.Object(
+  {
+    scraperId: Type.String({ description: "Existing AI scraper ID to rerun." }),
+    urls: Type.Array(Type.String({ description: "Target URL to rerun against." }), {
+      description: "One or more target URLs to rerun against.",
+      minItems: 1,
+    }),
+    timeoutSeconds: Type.Optional(
+      Type.Number({ description: "HTTP timeout in seconds for the API request.", minimum: 1 }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperBulkRerunAiScraperTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_bulk_rerun_ai_scraper",
+    label: "MrScraper Bulk Rerun AI Scraper",
+    description:
+      "Rerun an existing MrScraper AI scraper against multiple URLs and return the bulk job response.",
+    parameters: MrScraperBulkRerunAiScraperSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const urls = Array.isArray(rawParams.urls)
+        ? rawParams.urls.filter(
+            (value): value is string => typeof value === "string" && value.trim().length > 0,
+          )
+        : [];
+      if (urls.length === 0) {
+        throw new Error("mrscraper_bulk_rerun_ai_scraper requires at least one url.");
+      }
+
+      return jsonResult(
+        await runMrScraperBulkRerunAiScraper({
+          cfg: api.config,
+          scraperId: readStringParam(rawParams, "scraperId", { required: true }),
+          urls,
+          timeoutSeconds: readNumberParam(rawParams, "timeoutSeconds", { integer: true }),
+        }),
+      );
+    },
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-bulk-rerun-manual-scraper-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-bulk-rerun-manual-scraper-tool.ts
@@ -1,0 +1,51 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperBulkRerunManualScraper } from "./mrscraper-client.js";
+
+const MrScraperBulkRerunManualScraperSchema = Type.Object(
+  {
+    scraperId: Type.String({ description: "Existing manual scraper ID to rerun." }),
+    urls: Type.Array(Type.String({ description: "Target URL to rerun against." }), {
+      description: "One or more target URLs to rerun against.",
+      minItems: 1,
+    }),
+    timeoutSeconds: Type.Optional(
+      Type.Number({ description: "HTTP timeout in seconds for the API request.", minimum: 1 }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperBulkRerunManualScraperTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_bulk_rerun_manual_scraper",
+    label: "MrScraper Bulk Rerun Manual Scraper",
+    description:
+      "Rerun an existing MrScraper manual scraper against multiple URLs and return the bulk job response.",
+    parameters: MrScraperBulkRerunManualScraperSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const urls = Array.isArray(rawParams.urls)
+        ? rawParams.urls.filter(
+            (value): value is string => typeof value === "string" && value.trim().length > 0,
+          )
+        : [];
+      if (urls.length === 0) {
+        throw new Error("mrscraper_bulk_rerun_manual_scraper requires at least one url.");
+      }
+
+      return jsonResult(
+        await runMrScraperBulkRerunManualScraper({
+          cfg: api.config,
+          scraperId: readStringParam(rawParams, "scraperId", { required: true }),
+          urls,
+          timeoutSeconds: readNumberParam(rawParams, "timeoutSeconds", { integer: true }),
+        }),
+      );
+    },
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-client.ts
+++ b/extensions/mrscraper/src/mrscraper-client.ts
@@ -367,11 +367,21 @@ export async function runMrScraperCreateAiScraper(
     body.proxyCountry = proxyCountry;
   }
   if (params.agent === "map") {
-    if (typeof params.maxDepth === "number") body.maxDepth = Math.floor(params.maxDepth);
-    if (typeof params.maxPages === "number") body.maxPages = Math.floor(params.maxPages);
-    if (typeof params.limit === "number") body.limit = Math.floor(params.limit);
-    if (params.includePatterns) body.includePatterns = params.includePatterns;
-    if (params.excludePatterns) body.excludePatterns = params.excludePatterns;
+    if (typeof params.maxDepth === "number") {
+      body.maxDepth = Math.floor(params.maxDepth);
+    }
+    if (typeof params.maxPages === "number") {
+      body.maxPages = Math.floor(params.maxPages);
+    }
+    if (typeof params.limit === "number") {
+      body.limit = Math.floor(params.limit);
+    }
+    if (params.includePatterns) {
+      body.includePatterns = params.includePatterns;
+    }
+    if (params.excludePatterns) {
+      body.excludePatterns = params.excludePatterns;
+    }
   }
 
   const start = Date.now();
@@ -405,11 +415,21 @@ export async function runMrScraperRerunAiScraper(
     scraperId: params.scraperId,
     url: params.url,
   };
-  if (typeof params.maxDepth === "number") body.maxDepth = Math.floor(params.maxDepth);
-  if (typeof params.maxPages === "number") body.maxPages = Math.floor(params.maxPages);
-  if (typeof params.limit === "number") body.limit = Math.floor(params.limit);
-  if (params.includePatterns) body.includePatterns = params.includePatterns;
-  if (params.excludePatterns) body.excludePatterns = params.excludePatterns;
+  if (typeof params.maxDepth === "number") {
+    body.maxDepth = Math.floor(params.maxDepth);
+  }
+  if (typeof params.maxPages === "number") {
+    body.maxPages = Math.floor(params.maxPages);
+  }
+  if (typeof params.limit === "number") {
+    body.limit = Math.floor(params.limit);
+  }
+  if (params.includePatterns) {
+    body.includePatterns = params.includePatterns;
+  }
+  if (params.excludePatterns) {
+    body.excludePatterns = params.excludePatterns;
+  }
 
   const start = Date.now();
   const payload = await runPlatformJsonRequest({
@@ -532,10 +552,18 @@ export async function runMrScraperGetAllResults(
   endpoint.searchParams.set("sortOrder", params.sortOrder ?? "DESC");
   endpoint.searchParams.set("pageSize", String(params.pageSize ?? 10));
   endpoint.searchParams.set("page", String(params.page ?? 1));
-  if (params.search) endpoint.searchParams.set("search", params.search);
-  if (params.dateRangeColumn) endpoint.searchParams.set("dateRangeColumn", params.dateRangeColumn);
-  if (params.startAt) endpoint.searchParams.set("startAt", params.startAt);
-  if (params.endAt) endpoint.searchParams.set("endAt", params.endAt);
+  if (params.search) {
+    endpoint.searchParams.set("search", params.search);
+  }
+  if (params.dateRangeColumn) {
+    endpoint.searchParams.set("dateRangeColumn", params.dateRangeColumn);
+  }
+  if (params.startAt) {
+    endpoint.searchParams.set("startAt", params.startAt);
+  }
+  if (params.endAt) {
+    endpoint.searchParams.set("endAt", params.endAt);
+  }
 
   const start = Date.now();
   const payload = await runPlatformJsonRequest({

--- a/extensions/mrscraper/src/mrscraper-client.ts
+++ b/extensions/mrscraper/src/mrscraper-client.ts
@@ -25,7 +25,6 @@ const DEFAULT_FETCH_MAX_CHARS = 50_000;
 export type MrScraperFetchHtmlParams = {
   cfg?: OpenClawConfig;
   url: string;
-  extractMode: "markdown" | "text";
   maxChars?: number;
   timeoutSeconds?: number;
   geoCode?: string;
@@ -322,9 +321,6 @@ export async function runMrScraperFetchHtml(
   const maxChars = normalizeMaxChars(params.maxChars);
   const htmlResult = truncate(html, maxChars);
   const textResult = truncate(plainText, maxChars);
-  const requestedText = params.extractMode === "text" ? textResult.text : htmlResult.text;
-  const requestedTruncated =
-    params.extractMode === "text" ? textResult.truncated : htmlResult.truncated;
 
   return {
     url: params.url,
@@ -333,15 +329,11 @@ export async function runMrScraperFetchHtml(
     contentType: "text/html",
     extractor: "mrscraper",
     tookMs: Date.now() - start,
-    truncated: requestedTruncated,
-    warning:
-      params.extractMode === "markdown"
-        ? "MrScraper returns rendered HTML for unblocker requests; markdown mode returns the rendered HTML payload."
-        : undefined,
-    text:
-      params.extractMode === "text"
-        ? requestedText
-        : wrapExternalContent(requestedText, { source: "web_fetch", includeWarning: false }),
+    truncated: htmlResult.truncated,
+    text: wrapExternalContent(htmlResult.text, {
+      source: "web_fetch",
+      includeWarning: false,
+    }),
     html: wrapExternalContent(htmlResult.text, { source: "web_fetch", includeWarning: false }),
     renderedText: wrapExternalContent(textResult.text, {
       source: "web_fetch",

--- a/extensions/mrscraper/src/mrscraper-client.ts
+++ b/extensions/mrscraper/src/mrscraper-client.ts
@@ -1,0 +1,316 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  readResponseText,
+  resolveTimeoutSeconds,
+  withStrictWebToolsEndpoint,
+  wrapExternalContent,
+  wrapWebContent,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
+import {
+  resolveMrScraperApiToken,
+  resolveMrScraperBlockResources,
+  resolveMrScraperFetchTimeoutSeconds,
+  resolveMrScraperGeoCode,
+  resolveMrScraperPlatformBaseUrl,
+  resolveMrScraperProxyCountry,
+  resolveMrScraperScrapeTimeoutSeconds,
+  resolveMrScraperUnblockerBaseUrl,
+} from "./config.js";
+
+const ALLOWED_UNBLOCKER_HOSTS = new Set(["api.mrscraper.com"]);
+const ALLOWED_PLATFORM_HOSTS = new Set(["api.app.mrscraper.com", "sync.scraper.mrscraper.com"]);
+const DEFAULT_FETCH_MAX_CHARS = 50_000;
+
+export type MrScraperFetchHtmlParams = {
+  cfg?: OpenClawConfig;
+  url: string;
+  extractMode: "markdown" | "text";
+  maxChars?: number;
+  timeoutSeconds?: number;
+  geoCode?: string;
+  blockResources?: boolean;
+};
+
+export type MrScraperCreateAiScraperParams = {
+  cfg?: OpenClawConfig;
+  url: string;
+  message: string;
+  agent?: "general" | "listing" | "map";
+  proxyCountry?: string;
+  maxDepth?: number;
+  maxPages?: number;
+  limit?: number;
+  includePatterns?: string;
+  excludePatterns?: string;
+  timeoutSeconds?: number;
+};
+
+function resolveEndpoint(params: {
+  baseUrl: string;
+  defaultBaseUrl: string;
+  pathname?: string;
+  allowedHosts: Set<string>;
+  product: string;
+}): string {
+  const candidate = params.baseUrl.trim() || params.defaultBaseUrl;
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    url = new URL(params.defaultBaseUrl);
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`${params.product} baseUrl must use https.`);
+  }
+  if (!params.allowedHosts.has(url.hostname)) {
+    throw new Error(`${params.product} baseUrl host is not allowed: ${url.hostname}`);
+  }
+  url.username = "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+  if (params.pathname) {
+    url.pathname = params.pathname;
+  }
+  return url.toString();
+}
+
+async function throwHttpError(response: Response, label: string): Promise<never> {
+  let detail =
+    typeof response.statusText === "string" && response.statusText.trim()
+      ? response.statusText.trim()
+      : "request failed";
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const payload = (await response.json()) as Record<string, unknown>;
+      detail =
+        typeof payload.message === "string"
+          ? payload.message
+          : typeof payload.error === "string"
+            ? payload.error
+            : detail;
+    } catch {
+      // Ignore and fall back to text body parsing below.
+    }
+  } else {
+    const errorBody = await readResponseText(response, { maxBytes: 64_000 });
+    if (errorBody.text) {
+      detail = errorBody.text;
+    }
+  }
+
+  throw new Error(
+    `${label} API error (${response.status}): ${wrapWebContent(detail, "web_fetch")}`,
+  );
+}
+
+function extractTitle(html: string): string | undefined {
+  const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  return decodeHtmlEntities(match[1]).trim() || undefined;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+}
+
+function htmlToPlainText(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<noscript[\s\S]*?<\/noscript>/gi, " ")
+      .replace(/<\/(p|div|section|article|main|header|footer|aside|li|tr|h[1-6])>/gi, "\n")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\r/g, "")
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .replace(/[ \t]{2,}/g, " ")
+      .trim(),
+  );
+}
+
+function normalizeMaxChars(maxChars?: number): number {
+  if (typeof maxChars === "number" && Number.isFinite(maxChars) && maxChars > 0) {
+    return Math.floor(maxChars);
+  }
+  return DEFAULT_FETCH_MAX_CHARS;
+}
+
+function truncate(value: string, maxChars: number): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) {
+    return { text: value, truncated: false };
+  }
+  return {
+    text: value.slice(0, Math.max(0, maxChars - 1)).trimEnd(),
+    truncated: true,
+  };
+}
+
+export async function runMrScraperFetchHtml(
+  params: MrScraperFetchHtmlParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = resolveMrScraperApiToken(params.cfg);
+  if (!apiToken) {
+    throw new Error(
+      "web_fetch (mrscraper) needs a MrScraper API token. Set MRSCRAPER_API_TOKEN in the Gateway environment, or configure plugins.entries.mrscraper.config.apiToken.",
+    );
+  }
+
+  const baseUrl = resolveEndpoint({
+    baseUrl: resolveMrScraperUnblockerBaseUrl(params.cfg),
+    defaultBaseUrl: "https://api.mrscraper.com",
+    allowedHosts: ALLOWED_UNBLOCKER_HOSTS,
+    product: "MrScraper unblocker",
+  });
+  const timeoutSeconds = resolveTimeoutSeconds(
+    params.timeoutSeconds,
+    resolveMrScraperFetchTimeoutSeconds(params.cfg),
+  );
+  const url = new URL(baseUrl);
+  url.searchParams.set("token", normalizeSecretInput(apiToken));
+  url.searchParams.set("url", params.url);
+  url.searchParams.set("timeout", String(timeoutSeconds));
+  const geoCode = resolveMrScraperGeoCode(params.cfg, params.geoCode);
+  if (geoCode) {
+    url.searchParams.set("geoCode", geoCode);
+  }
+  if (resolveMrScraperBlockResources(params.cfg, params.blockResources)) {
+    url.searchParams.set("blockResources", "true");
+  }
+
+  const start = Date.now();
+  const html = await withStrictWebToolsEndpoint(
+    {
+      url: url.toString(),
+      timeoutSeconds,
+    },
+    async ({ response }) => {
+      if (!response.ok) {
+        await throwHttpError(response, "MrScraper unblocker");
+      }
+      return await response.text();
+    },
+  );
+
+  const title = extractTitle(html);
+  const plainText = htmlToPlainText(html);
+  const maxChars = normalizeMaxChars(params.maxChars);
+  const htmlResult = truncate(html, maxChars);
+  const textResult = truncate(plainText, maxChars);
+  const requestedText = params.extractMode === "text" ? textResult.text : htmlResult.text;
+  const requestedTruncated =
+    params.extractMode === "text" ? textResult.truncated : htmlResult.truncated;
+
+  return {
+    url: params.url,
+    title,
+    status: 200,
+    contentType: "text/html",
+    extractor: "mrscraper",
+    tookMs: Date.now() - start,
+    truncated: requestedTruncated,
+    warning:
+      params.extractMode === "markdown"
+        ? "MrScraper returns rendered HTML for unblocker requests; markdown mode returns the rendered HTML payload."
+        : undefined,
+    text:
+      params.extractMode === "text"
+        ? requestedText
+        : wrapExternalContent(requestedText, { source: "web_fetch", includeWarning: false }),
+    html: wrapExternalContent(htmlResult.text, { source: "web_fetch", includeWarning: false }),
+    renderedText: wrapExternalContent(textResult.text, {
+      source: "web_fetch",
+      includeWarning: false,
+    }),
+  };
+}
+
+export async function runMrScraperCreateAiScraper(
+  params: MrScraperCreateAiScraperParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = resolveMrScraperApiToken(params.cfg);
+  if (!apiToken) {
+    throw new Error(
+      "mrscraper_scrape needs a MrScraper API token. Set MRSCRAPER_API_TOKEN in the Gateway environment, or configure plugins.entries.mrscraper.config.apiToken.",
+    );
+  }
+
+  const endpoint = resolveEndpoint({
+    baseUrl: resolveMrScraperPlatformBaseUrl(params.cfg),
+    defaultBaseUrl: "https://api.app.mrscraper.com",
+    pathname: "/api/v1/scrapers-ai",
+    allowedHosts: ALLOWED_PLATFORM_HOSTS,
+    product: "MrScraper platform",
+  });
+  const timeoutSeconds = resolveTimeoutSeconds(
+    params.timeoutSeconds,
+    resolveMrScraperScrapeTimeoutSeconds(params.cfg),
+  );
+
+  const body: Record<string, unknown> = {
+    url: params.url,
+    message: params.message,
+    agent: params.agent ?? "general",
+  };
+  const proxyCountry = resolveMrScraperProxyCountry(params.cfg, params.proxyCountry);
+  if (proxyCountry) {
+    body.proxyCountry = proxyCountry;
+  }
+  if (params.agent === "map") {
+    if (typeof params.maxDepth === "number") body.maxDepth = Math.floor(params.maxDepth);
+    if (typeof params.maxPages === "number") body.maxPages = Math.floor(params.maxPages);
+    if (typeof params.limit === "number") body.limit = Math.floor(params.limit);
+    if (params.includePatterns) body.includePatterns = params.includePatterns;
+    if (params.excludePatterns) body.excludePatterns = params.excludePatterns;
+  }
+
+  const start = Date.now();
+  const payload = await withStrictWebToolsEndpoint(
+    {
+      url: endpoint,
+      timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "x-api-token": normalizeSecretInput(apiToken),
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async ({ response }) => {
+      if (!response.ok) {
+        await throwHttpError(response, "MrScraper AI scraper");
+      }
+      return (await response.json()) as Record<string, unknown>;
+    },
+  );
+
+  return {
+    provider: "mrscraper",
+    operation: "create_ai_scraper",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export const __testing = {
+  decodeHtmlEntities,
+  extractTitle,
+  htmlToPlainText,
+  resolveEndpoint,
+};

--- a/extensions/mrscraper/src/mrscraper-client.ts
+++ b/extensions/mrscraper/src/mrscraper-client.ts
@@ -46,6 +46,67 @@ export type MrScraperCreateAiScraperParams = {
   timeoutSeconds?: number;
 };
 
+export type MrScraperRerunAiScraperParams = {
+  cfg?: OpenClawConfig;
+  scraperId: string;
+  url: string;
+  maxDepth?: number;
+  maxPages?: number;
+  limit?: number;
+  includePatterns?: string;
+  excludePatterns?: string;
+  timeoutSeconds?: number;
+};
+
+export type MrScraperBulkRerunAiScraperParams = {
+  cfg?: OpenClawConfig;
+  scraperId: string;
+  urls: string[];
+  timeoutSeconds?: number;
+};
+
+export type MrScraperRerunManualScraperParams = {
+  cfg?: OpenClawConfig;
+  scraperId: string;
+  url: string;
+  timeoutSeconds?: number;
+};
+
+export type MrScraperBulkRerunManualScraperParams = {
+  cfg?: OpenClawConfig;
+  scraperId: string;
+  urls: string[];
+  timeoutSeconds?: number;
+};
+
+export type MrScraperGetAllResultsParams = {
+  cfg?: OpenClawConfig;
+  sortField?:
+    | "createdAt"
+    | "updatedAt"
+    | "id"
+    | "type"
+    | "url"
+    | "status"
+    | "error"
+    | "tokenUsage"
+    | "runtime";
+  sortOrder?: "ASC" | "DESC";
+  pageSize?: number;
+  page?: number;
+  search?: string;
+  dateRangeColumn?: string;
+  startAt?: string;
+  endAt?: string;
+  timeoutSeconds?: number;
+};
+
+export type MrScraperGetResultByIdParams = {
+  cfg?: OpenClawConfig;
+  resultId: string;
+  timeoutSeconds?: number;
+};
+
 function resolveEndpoint(params: {
   baseUrl: string;
   defaultBaseUrl: string;
@@ -107,6 +168,62 @@ async function throwHttpError(response: Response, label: string): Promise<never>
   );
 }
 
+function buildPlatformHeaders(apiToken: string): Record<string, string> {
+  return {
+    accept: "application/json",
+    "content-type": "application/json",
+    "x-api-token": normalizeSecretInput(apiToken),
+  };
+}
+
+function resolvePlatformEndpoint(pathname: string, cfg?: OpenClawConfig): string {
+  return resolveEndpoint({
+    baseUrl: resolveMrScraperPlatformBaseUrl(cfg),
+    defaultBaseUrl: "https://api.app.mrscraper.com",
+    pathname,
+    allowedHosts: ALLOWED_PLATFORM_HOSTS,
+    product: "MrScraper platform",
+  });
+}
+
+function resolvePlatformTimeoutSeconds(cfg?: OpenClawConfig, override?: number): number {
+  return resolveTimeoutSeconds(override, resolveMrScraperScrapeTimeoutSeconds(cfg));
+}
+
+async function runPlatformJsonRequest(params: {
+  cfg?: OpenClawConfig;
+  apiToken: string;
+  endpoint: string;
+  timeoutSeconds?: number;
+  init?: RequestInit;
+  label: string;
+}): Promise<Record<string, unknown>> {
+  const timeoutSeconds = resolvePlatformTimeoutSeconds(params.cfg, params.timeoutSeconds);
+  return await withStrictWebToolsEndpoint(
+    {
+      url: params.endpoint,
+      timeoutSeconds,
+      init: params.init,
+    },
+    async ({ response }) => {
+      if (!response.ok) {
+        await throwHttpError(response, params.label);
+      }
+      return (await response.json()) as Record<string, unknown>;
+    },
+  );
+}
+
+function requireMrScraperApiToken(cfg: OpenClawConfig | undefined, consumer: string): string {
+  const apiToken = resolveMrScraperApiToken(cfg);
+  if (!apiToken) {
+    throw new Error(
+      `${consumer} needs a MrScraper API token. Set MRSCRAPER_API_TOKEN in the Gateway environment, or configure plugins.entries.mrscraper.config.apiToken.`,
+    );
+  }
+  return apiToken;
+}
+
 function extractTitle(html: string): string | undefined {
   const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
   if (!match?.[1]) {
@@ -162,12 +279,7 @@ function truncate(value: string, maxChars: number): { text: string; truncated: b
 export async function runMrScraperFetchHtml(
   params: MrScraperFetchHtmlParams,
 ): Promise<Record<string, unknown>> {
-  const apiToken = resolveMrScraperApiToken(params.cfg);
-  if (!apiToken) {
-    throw new Error(
-      "web_fetch (mrscraper) needs a MrScraper API token. Set MRSCRAPER_API_TOKEN in the Gateway environment, or configure plugins.entries.mrscraper.config.apiToken.",
-    );
-  }
+  const apiToken = requireMrScraperApiToken(params.cfg, "web_fetch (mrscraper)");
 
   const baseUrl = resolveEndpoint({
     baseUrl: resolveMrScraperUnblockerBaseUrl(params.cfg),
@@ -241,24 +353,9 @@ export async function runMrScraperFetchHtml(
 export async function runMrScraperCreateAiScraper(
   params: MrScraperCreateAiScraperParams,
 ): Promise<Record<string, unknown>> {
-  const apiToken = resolveMrScraperApiToken(params.cfg);
-  if (!apiToken) {
-    throw new Error(
-      "mrscraper_scrape needs a MrScraper API token. Set MRSCRAPER_API_TOKEN in the Gateway environment, or configure plugins.entries.mrscraper.config.apiToken.",
-    );
-  }
-
-  const endpoint = resolveEndpoint({
-    baseUrl: resolveMrScraperPlatformBaseUrl(params.cfg),
-    defaultBaseUrl: "https://api.app.mrscraper.com",
-    pathname: "/api/v1/scrapers-ai",
-    allowedHosts: ALLOWED_PLATFORM_HOSTS,
-    product: "MrScraper platform",
-  });
-  const timeoutSeconds = resolveTimeoutSeconds(
-    params.timeoutSeconds,
-    resolveMrScraperScrapeTimeoutSeconds(params.cfg),
-  );
+  const apiToken = requireMrScraperApiToken(params.cfg, "mrscraper_scrape");
+  const endpoint = resolvePlatformEndpoint("/api/v1/scrapers-ai", params.cfg);
+  const timeoutSeconds = resolvePlatformTimeoutSeconds(params.cfg, params.timeoutSeconds);
 
   const body: Record<string, unknown> = {
     url: params.url,
@@ -278,31 +375,213 @@ export async function runMrScraperCreateAiScraper(
   }
 
   const start = Date.now();
-  const payload = await withStrictWebToolsEndpoint(
-    {
-      url: endpoint,
-      timeoutSeconds,
-      init: {
-        method: "POST",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-          "x-api-token": normalizeSecretInput(apiToken),
-        },
-        body: JSON.stringify(body),
-      },
+  const payload = await runPlatformJsonRequest({
+    cfg: params.cfg,
+    apiToken,
+    endpoint,
+    timeoutSeconds,
+    label: "MrScraper AI scraper",
+    init: {
+      method: "POST",
+      headers: buildPlatformHeaders(apiToken),
+      body: JSON.stringify(body),
     },
-    async ({ response }) => {
-      if (!response.ok) {
-        await throwHttpError(response, "MrScraper AI scraper");
-      }
-      return (await response.json()) as Record<string, unknown>;
-    },
-  );
+  });
 
   return {
     provider: "mrscraper",
     operation: "create_ai_scraper",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export async function runMrScraperRerunAiScraper(
+  params: MrScraperRerunAiScraperParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = requireMrScraperApiToken(params.cfg, "mrscraper_rerun_ai_scraper");
+  const endpoint = resolvePlatformEndpoint("/api/v1/scrapers-ai-rerun", params.cfg);
+  const body: Record<string, unknown> = {
+    scraperId: params.scraperId,
+    url: params.url,
+  };
+  if (typeof params.maxDepth === "number") body.maxDepth = Math.floor(params.maxDepth);
+  if (typeof params.maxPages === "number") body.maxPages = Math.floor(params.maxPages);
+  if (typeof params.limit === "number") body.limit = Math.floor(params.limit);
+  if (params.includePatterns) body.includePatterns = params.includePatterns;
+  if (params.excludePatterns) body.excludePatterns = params.excludePatterns;
+
+  const start = Date.now();
+  const payload = await runPlatformJsonRequest({
+    cfg: params.cfg,
+    apiToken,
+    endpoint,
+    timeoutSeconds: params.timeoutSeconds,
+    label: "MrScraper AI rerun",
+    init: {
+      method: "POST",
+      headers: buildPlatformHeaders(apiToken),
+      body: JSON.stringify(body),
+    },
+  });
+
+  return {
+    provider: "mrscraper",
+    operation: "rerun_ai_scraper",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export async function runMrScraperBulkRerunAiScraper(
+  params: MrScraperBulkRerunAiScraperParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = requireMrScraperApiToken(params.cfg, "mrscraper_bulk_rerun_ai_scraper");
+  const endpoint = resolvePlatformEndpoint("/api/v1/scrapers-ai-rerun/bulk", params.cfg);
+  const start = Date.now();
+  const payload = await runPlatformJsonRequest({
+    cfg: params.cfg,
+    apiToken,
+    endpoint,
+    timeoutSeconds: params.timeoutSeconds,
+    label: "MrScraper AI bulk rerun",
+    init: {
+      method: "POST",
+      headers: buildPlatformHeaders(apiToken),
+      body: JSON.stringify({
+        scraperId: params.scraperId,
+        urls: params.urls,
+      }),
+    },
+  });
+
+  return {
+    provider: "mrscraper",
+    operation: "bulk_rerun_ai_scraper",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export async function runMrScraperRerunManualScraper(
+  params: MrScraperRerunManualScraperParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = requireMrScraperApiToken(params.cfg, "mrscraper_rerun_manual_scraper");
+  const endpoint = resolvePlatformEndpoint("/api/v1/scrapers-manual-rerun", params.cfg);
+  const start = Date.now();
+  const payload = await runPlatformJsonRequest({
+    cfg: params.cfg,
+    apiToken,
+    endpoint,
+    timeoutSeconds: params.timeoutSeconds,
+    label: "MrScraper manual rerun",
+    init: {
+      method: "POST",
+      headers: buildPlatformHeaders(apiToken),
+      body: JSON.stringify({
+        scraperId: params.scraperId,
+        url: params.url,
+      }),
+    },
+  });
+
+  return {
+    provider: "mrscraper",
+    operation: "rerun_manual_scraper",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export async function runMrScraperBulkRerunManualScraper(
+  params: MrScraperBulkRerunManualScraperParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = requireMrScraperApiToken(params.cfg, "mrscraper_bulk_rerun_manual_scraper");
+  const endpoint = resolvePlatformEndpoint("/api/v1/scrapers-manual-rerun/bulk", params.cfg);
+  const start = Date.now();
+  const payload = await runPlatformJsonRequest({
+    cfg: params.cfg,
+    apiToken,
+    endpoint,
+    timeoutSeconds: params.timeoutSeconds,
+    label: "MrScraper manual bulk rerun",
+    init: {
+      method: "POST",
+      headers: buildPlatformHeaders(apiToken),
+      body: JSON.stringify({
+        scraperId: params.scraperId,
+        urls: params.urls,
+      }),
+    },
+  });
+
+  return {
+    provider: "mrscraper",
+    operation: "bulk_rerun_manual_scraper",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export async function runMrScraperGetAllResults(
+  params: MrScraperGetAllResultsParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = requireMrScraperApiToken(params.cfg, "mrscraper_get_all_results");
+  const endpoint = new URL(resolvePlatformEndpoint("/api/v1/results", params.cfg));
+  endpoint.searchParams.set("sortField", params.sortField ?? "updatedAt");
+  endpoint.searchParams.set("sortOrder", params.sortOrder ?? "DESC");
+  endpoint.searchParams.set("pageSize", String(params.pageSize ?? 10));
+  endpoint.searchParams.set("page", String(params.page ?? 1));
+  if (params.search) endpoint.searchParams.set("search", params.search);
+  if (params.dateRangeColumn) endpoint.searchParams.set("dateRangeColumn", params.dateRangeColumn);
+  if (params.startAt) endpoint.searchParams.set("startAt", params.startAt);
+  if (params.endAt) endpoint.searchParams.set("endAt", params.endAt);
+
+  const start = Date.now();
+  const payload = await runPlatformJsonRequest({
+    cfg: params.cfg,
+    apiToken,
+    endpoint: endpoint.toString(),
+    timeoutSeconds: params.timeoutSeconds,
+    label: "MrScraper results list",
+    init: {
+      method: "GET",
+      headers: buildPlatformHeaders(apiToken),
+    },
+  });
+
+  return {
+    provider: "mrscraper",
+    operation: "get_all_results",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export async function runMrScraperGetResultById(
+  params: MrScraperGetResultByIdParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = requireMrScraperApiToken(params.cfg, "mrscraper_get_result_by_id");
+  const endpoint = resolvePlatformEndpoint(
+    `/api/v1/results/${encodeURIComponent(params.resultId)}`,
+    params.cfg,
+  );
+  const start = Date.now();
+  const payload = await runPlatformJsonRequest({
+    cfg: params.cfg,
+    apiToken,
+    endpoint,
+    timeoutSeconds: params.timeoutSeconds,
+    label: "MrScraper result lookup",
+    init: {
+      method: "GET",
+      headers: buildPlatformHeaders(apiToken),
+    },
+  });
+
+  return {
+    provider: "mrscraper",
+    operation: "get_result_by_id",
     tookMs: Date.now() - start,
     ...payload,
   };

--- a/extensions/mrscraper/src/mrscraper-fetch-provider.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-provider.ts
@@ -7,14 +7,6 @@ import { runMrScraperFetchHtml } from "./mrscraper-client.js";
 const MrScraperWebFetchSchema = Type.Object(
   {
     url: Type.String({ description: "HTTP or HTTPS URL to fetch through MrScraper." }),
-    extractMode: Type.Optional(
-      Type.Unsafe<"markdown" | "text">({
-        type: "string",
-        enum: ["markdown", "text"],
-        description:
-          '"markdown" returns the rendered HTML payload; "text" returns stripped plain text. Default: markdown.',
-      }),
-    ),
     maxChars: Type.Optional(
       Type.Number({
         description: "Maximum characters to return.",
@@ -52,7 +44,7 @@ export function createMrScraperWebFetchProvider(): WebFetchProviderPlugin {
     label: "MrScraper",
     hint: "Fetch blocked pages with a stealth browser and IP rotation.",
     envVars: ["MRSCRAPER_API_TOKEN"],
-    placeholder: "mrs_...",
+    placeholder: "atk_...",
     signupUrl: "https://mrscraper.com/",
     docsUrl: "https://mrscraper.com/",
     autoDetectOrder: 60,
@@ -95,7 +87,6 @@ export function createMrScraperWebFetchProvider(): WebFetchProviderPlugin {
         await runMrScraperFetchHtml({
           cfg: config,
           url: typeof args.url === "string" ? args.url : "",
-          extractMode: args.extractMode === "text" ? "text" : "markdown",
           maxChars:
             typeof args.maxChars === "number" && Number.isFinite(args.maxChars)
               ? Math.floor(args.maxChars)

--- a/extensions/mrscraper/src/mrscraper-fetch-provider.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-provider.ts
@@ -11,7 +11,8 @@ const MrScraperWebFetchSchema = Type.Object(
       Type.Unsafe<"markdown" | "text">({
         type: "string",
         enum: ["markdown", "text"],
-        description: 'Output format: "markdown" or "text". Default: markdown.',
+        description:
+          '"markdown" returns the rendered HTML payload; "text" returns stripped plain text. Default: markdown.',
       }),
     ),
     maxChars: Type.Optional(
@@ -81,8 +82,8 @@ export function createMrScraperWebFetchProvider(): WebFetchProviderPlugin {
       const entry = (entries.mrscraper ??= {});
       const pluginConfig =
         entry.config && typeof entry.config === "object" && !Array.isArray(entry.config)
-          ? (entry.config as Record<string, unknown>)
-          : ((entry.config = {}), entry.config as Record<string, unknown>);
+          ? entry.config
+          : ((entry.config = {}), entry.config);
       pluginConfig.apiToken = value;
     },
     applySelectionConfig: (config) => enablePluginInConfig(config, "mrscraper").config,

--- a/extensions/mrscraper/src/mrscraper-fetch-provider.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-provider.ts
@@ -1,0 +1,112 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { WebFetchProviderPlugin } from "openclaw/plugin-sdk/provider-web-fetch";
+import { enablePluginInConfig } from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperFetchHtml } from "./mrscraper-client.js";
+
+const MrScraperWebFetchSchema = Type.Object(
+  {
+    url: Type.String({ description: "HTTP or HTTPS URL to fetch through MrScraper." }),
+    extractMode: Type.Optional(
+      Type.Unsafe<"markdown" | "text">({
+        type: "string",
+        enum: ["markdown", "text"],
+        description: 'Output format: "markdown" or "text". Default: markdown.',
+      }),
+    ),
+    maxChars: Type.Optional(
+      Type.Number({
+        description: "Maximum characters to return.",
+        minimum: 100,
+      }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({
+        description: "Timeout in seconds for the unblocker request.",
+        minimum: 1,
+      }),
+    ),
+    geoCode: Type.Optional(
+      Type.String({
+        description: "Optional country code for routed unblocker traffic, for example SG or US.",
+      }),
+    ),
+    blockResources: Type.Optional(
+      Type.Boolean({
+        description: "Block images, fonts, and similar resources to speed up fetches.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+function readConfiguredCredential(config?: OpenClawConfig): unknown {
+  return (config?.plugins?.entries?.mrscraper?.config as { apiToken?: unknown } | undefined)
+    ?.apiToken;
+}
+
+export function createMrScraperWebFetchProvider(): WebFetchProviderPlugin {
+  return {
+    id: "mrscraper",
+    label: "MrScraper",
+    hint: "Fetch blocked pages with a stealth browser and IP rotation.",
+    envVars: ["MRSCRAPER_API_TOKEN"],
+    placeholder: "mrs_...",
+    signupUrl: "https://mrscraper.com/",
+    docsUrl: "https://mrscraper.com/",
+    autoDetectOrder: 60,
+    credentialPath: "plugins.entries.mrscraper.config.apiToken",
+    inactiveSecretPaths: ["plugins.entries.mrscraper.config.apiToken"],
+    getCredentialValue: (fetchConfig) => {
+      if (!fetchConfig || typeof fetchConfig !== "object") {
+        return undefined;
+      }
+      const scoped = (fetchConfig as { mrscraper?: { apiToken?: unknown } }).mrscraper;
+      return scoped?.apiToken;
+    },
+    setCredentialValue: (fetchConfigTarget, value) => {
+      const current =
+        fetchConfigTarget.mrscraper &&
+        typeof fetchConfigTarget.mrscraper === "object" &&
+        !Array.isArray(fetchConfigTarget.mrscraper)
+          ? (fetchConfigTarget.mrscraper as Record<string, unknown>)
+          : {};
+      current.apiToken = value;
+      fetchConfigTarget.mrscraper = current;
+    },
+    getConfiguredCredentialValue: (config) => readConfiguredCredential(config),
+    setConfiguredCredentialValue: (configTarget, value) => {
+      const plugins = (configTarget.plugins ??= {});
+      const entries = (plugins.entries ??= {});
+      const entry = (entries.mrscraper ??= {});
+      const pluginConfig =
+        entry.config && typeof entry.config === "object" && !Array.isArray(entry.config)
+          ? (entry.config as Record<string, unknown>)
+          : ((entry.config = {}), entry.config as Record<string, unknown>);
+      pluginConfig.apiToken = value;
+    },
+    applySelectionConfig: (config) => enablePluginInConfig(config, "mrscraper").config,
+    createTool: ({ config }) => ({
+      description:
+        "Fetch a page through MrScraper's unblocker. Helpful for JS-heavy or bot-protected pages.",
+      parameters: MrScraperWebFetchSchema,
+      execute: async (args) =>
+        await runMrScraperFetchHtml({
+          cfg: config,
+          url: typeof args.url === "string" ? args.url : "",
+          extractMode: args.extractMode === "text" ? "text" : "markdown",
+          maxChars:
+            typeof args.maxChars === "number" && Number.isFinite(args.maxChars)
+              ? Math.floor(args.maxChars)
+              : undefined,
+          timeoutSeconds:
+            typeof args.timeoutSeconds === "number" && Number.isFinite(args.timeoutSeconds)
+              ? Math.floor(args.timeoutSeconds)
+              : undefined,
+          geoCode: typeof args.geoCode === "string" ? args.geoCode : undefined,
+          blockResources:
+            typeof args.blockResources === "boolean" ? args.blockResources : undefined,
+        }),
+    }),
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-fetch-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-tool.ts
@@ -10,14 +10,6 @@ import { runMrScraperFetchHtml } from "./mrscraper-client.js";
 const MrScraperFetchHtmlSchema = Type.Object(
   {
     url: Type.String({ description: "HTTP or HTTPS URL to fetch through MrScraper." }),
-    extractMode: Type.Optional(
-      Type.Unsafe<"markdown" | "text">({
-        type: "string",
-        enum: ["markdown", "text"],
-        description:
-          '"markdown" returns the rendered HTML payload; "text" returns stripped plain text. Default: markdown.',
-      }),
-    ),
     maxChars: Type.Optional(
       Type.Number({
         description: "Maximum characters to return.",
@@ -53,8 +45,6 @@ export function createMrScraperFetchHtmlTool(api: OpenClawPluginApi) {
     parameters: MrScraperFetchHtmlSchema,
     execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
       const url = readStringParam(rawParams, "url", { required: true });
-      const extractMode =
-        readStringParam(rawParams, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readNumberParam(rawParams, "maxChars", { integer: true });
       const timeoutSeconds = readNumberParam(rawParams, "timeoutSeconds", { integer: true });
       const geoCode = readStringParam(rawParams, "geoCode");
@@ -65,7 +55,6 @@ export function createMrScraperFetchHtmlTool(api: OpenClawPluginApi) {
         await runMrScraperFetchHtml({
           cfg: api.config,
           url,
-          extractMode,
           maxChars,
           timeoutSeconds,
           geoCode,

--- a/extensions/mrscraper/src/mrscraper-fetch-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-tool.ts
@@ -14,7 +14,8 @@ const MrScraperFetchHtmlSchema = Type.Object(
       Type.Unsafe<"markdown" | "text">({
         type: "string",
         enum: ["markdown", "text"],
-        description: 'Output format: "markdown" or "text". Default: markdown.',
+        description:
+          '"markdown" returns the rendered HTML payload; "text" returns stripped plain text. Default: markdown.',
       }),
     ),
     maxChars: Type.Optional(

--- a/extensions/mrscraper/src/mrscraper-fetch-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-tool.ts
@@ -1,0 +1,76 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperFetchHtml } from "./mrscraper-client.js";
+
+const MrScraperFetchHtmlSchema = Type.Object(
+  {
+    url: Type.String({ description: "HTTP or HTTPS URL to fetch through MrScraper." }),
+    extractMode: Type.Optional(
+      Type.Unsafe<"markdown" | "text">({
+        type: "string",
+        enum: ["markdown", "text"],
+        description: 'Output format: "markdown" or "text". Default: markdown.',
+      }),
+    ),
+    maxChars: Type.Optional(
+      Type.Number({
+        description: "Maximum characters to return.",
+        minimum: 100,
+      }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({
+        description: "Timeout in seconds for the unblocker request.",
+        minimum: 1,
+      }),
+    ),
+    geoCode: Type.Optional(
+      Type.String({
+        description: "Optional country code for routed unblocker traffic, for example SG or US.",
+      }),
+    ),
+    blockResources: Type.Optional(
+      Type.Boolean({
+        description: "Block images, fonts, and similar resources to speed up fetches.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperFetchHtmlTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_fetch_html",
+    label: "MrScraper Fetch HTML",
+    description:
+      "Open a page through MrScraper's unblocker and return the rendered HTML plus extracted text.",
+    parameters: MrScraperFetchHtmlSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const url = readStringParam(rawParams, "url", { required: true });
+      const extractMode =
+        readStringParam(rawParams, "extractMode") === "text" ? "text" : "markdown";
+      const maxChars = readNumberParam(rawParams, "maxChars", { integer: true });
+      const timeoutSeconds = readNumberParam(rawParams, "timeoutSeconds", { integer: true });
+      const geoCode = readStringParam(rawParams, "geoCode");
+      const blockResources =
+        typeof rawParams.blockResources === "boolean" ? rawParams.blockResources : undefined;
+
+      return jsonResult(
+        await runMrScraperFetchHtml({
+          cfg: api.config,
+          url,
+          extractMode,
+          maxChars,
+          timeoutSeconds,
+          geoCode,
+          blockResources,
+        }),
+      );
+    },
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-get-all-results-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-get-all-results-tool.ts
@@ -1,0 +1,100 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperGetAllResults } from "./mrscraper-client.js";
+
+const MrScraperGetAllResultsSchema = Type.Object(
+  {
+    sortField: Type.Optional(
+      Type.Unsafe<
+        | "createdAt"
+        | "updatedAt"
+        | "id"
+        | "type"
+        | "url"
+        | "status"
+        | "error"
+        | "tokenUsage"
+        | "runtime"
+      >({
+        type: "string",
+        enum: [
+          "createdAt",
+          "updatedAt",
+          "id",
+          "type",
+          "url",
+          "status",
+          "error",
+          "tokenUsage",
+          "runtime",
+        ],
+        description: "Column to sort by.",
+      }),
+    ),
+    sortOrder: Type.Optional(
+      Type.Unsafe<"ASC" | "DESC">({
+        type: "string",
+        enum: ["ASC", "DESC"],
+        description: 'Sort order: "ASC" or "DESC".',
+      }),
+    ),
+    pageSize: Type.Optional(Type.Number({ description: "Page size.", minimum: 1 })),
+    page: Type.Optional(Type.Number({ description: "Page number, starting from 1.", minimum: 1 })),
+    search: Type.Optional(Type.String({ description: "Optional text search filter." })),
+    dateRangeColumn: Type.Optional(
+      Type.String({ description: "Optional date field to filter by." }),
+    ),
+    startAt: Type.Optional(Type.String({ description: "Optional ISO start timestamp." })),
+    endAt: Type.Optional(Type.String({ description: "Optional ISO end timestamp." })),
+    timeoutSeconds: Type.Optional(
+      Type.Number({ description: "HTTP timeout in seconds for the API request.", minimum: 1 }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperGetAllResultsTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_get_all_results",
+    label: "MrScraper Get All Results",
+    description:
+      "List MrScraper results with pagination, sorting, and optional search/date filtering.",
+    parameters: MrScraperGetAllResultsSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) =>
+      jsonResult(
+        await runMrScraperGetAllResults({
+          cfg: api.config,
+          sortField: (() => {
+            const value = readStringParam(rawParams, "sortField");
+            return value === "createdAt" ||
+              value === "updatedAt" ||
+              value === "id" ||
+              value === "type" ||
+              value === "url" ||
+              value === "status" ||
+              value === "error" ||
+              value === "tokenUsage" ||
+              value === "runtime"
+              ? value
+              : undefined;
+          })(),
+          sortOrder: (() => {
+            const value = readStringParam(rawParams, "sortOrder");
+            return value === "ASC" || value === "DESC" ? value : undefined;
+          })(),
+          pageSize: readNumberParam(rawParams, "pageSize", { integer: true }),
+          page: readNumberParam(rawParams, "page", { integer: true }),
+          search: readStringParam(rawParams, "search"),
+          dateRangeColumn: readStringParam(rawParams, "dateRangeColumn"),
+          startAt: readStringParam(rawParams, "startAt"),
+          endAt: readStringParam(rawParams, "endAt"),
+          timeoutSeconds: readNumberParam(rawParams, "timeoutSeconds", { integer: true }),
+        }),
+      ),
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-get-result-by-id-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-get-result-by-id-tool.ts
@@ -1,0 +1,35 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperGetResultById } from "./mrscraper-client.js";
+
+const MrScraperGetResultByIdSchema = Type.Object(
+  {
+    resultId: Type.String({ description: "Result ID to fetch." }),
+    timeoutSeconds: Type.Optional(
+      Type.Number({ description: "HTTP timeout in seconds for the API request.", minimum: 1 }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperGetResultByIdTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_get_result_by_id",
+    label: "MrScraper Get Result By ID",
+    description: "Fetch one detailed MrScraper result by result ID.",
+    parameters: MrScraperGetResultByIdSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) =>
+      jsonResult(
+        await runMrScraperGetResultById({
+          cfg: api.config,
+          resultId: readStringParam(rawParams, "resultId", { required: true }),
+          timeoutSeconds: readNumberParam(rawParams, "timeoutSeconds", { integer: true }),
+        }),
+      ),
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-rerun-ai-scraper-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-rerun-ai-scraper-tool.ts
@@ -1,0 +1,58 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperRerunAiScraper } from "./mrscraper-client.js";
+
+const MrScraperRerunAiScraperSchema = Type.Object(
+  {
+    scraperId: Type.String({ description: "Existing AI scraper ID to rerun." }),
+    url: Type.String({ description: "Target URL to rerun against." }),
+    maxDepth: Type.Optional(
+      Type.Number({ description: "Map-agent only: maximum crawl depth.", minimum: 0 }),
+    ),
+    maxPages: Type.Optional(
+      Type.Number({ description: "Map-agent only: maximum pages to crawl.", minimum: 1 }),
+    ),
+    limit: Type.Optional(
+      Type.Number({ description: "Map-agent only: maximum extracted records.", minimum: 1 }),
+    ),
+    includePatterns: Type.Optional(
+      Type.String({ description: "Map-agent only: regex URL include patterns joined with ||." }),
+    ),
+    excludePatterns: Type.Optional(
+      Type.String({ description: "Map-agent only: regex URL exclude patterns joined with ||." }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({ description: "HTTP timeout in seconds for the API request.", minimum: 1 }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperRerunAiScraperTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_rerun_ai_scraper",
+    label: "MrScraper Rerun AI Scraper",
+    description:
+      "Rerun an existing MrScraper AI scraper against a new URL and return the platform response.",
+    parameters: MrScraperRerunAiScraperSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) =>
+      jsonResult(
+        await runMrScraperRerunAiScraper({
+          cfg: api.config,
+          scraperId: readStringParam(rawParams, "scraperId", { required: true }),
+          url: readStringParam(rawParams, "url", { required: true }),
+          maxDepth: readNumberParam(rawParams, "maxDepth", { integer: true }),
+          maxPages: readNumberParam(rawParams, "maxPages", { integer: true }),
+          limit: readNumberParam(rawParams, "limit", { integer: true }),
+          includePatterns: readStringParam(rawParams, "includePatterns"),
+          excludePatterns: readStringParam(rawParams, "excludePatterns"),
+          timeoutSeconds: readNumberParam(rawParams, "timeoutSeconds", { integer: true }),
+        }),
+      ),
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-rerun-manual-scraper-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-rerun-manual-scraper-tool.ts
@@ -1,0 +1,38 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperRerunManualScraper } from "./mrscraper-client.js";
+
+const MrScraperRerunManualScraperSchema = Type.Object(
+  {
+    scraperId: Type.String({ description: "Existing manual scraper ID to rerun." }),
+    url: Type.String({ description: "Target URL to rerun against." }),
+    timeoutSeconds: Type.Optional(
+      Type.Number({ description: "HTTP timeout in seconds for the API request.", minimum: 1 }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperRerunManualScraperTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_rerun_manual_scraper",
+    label: "MrScraper Rerun Manual Scraper",
+    description:
+      "Rerun an existing MrScraper manual scraper against a new URL and return the platform response.",
+    parameters: MrScraperRerunManualScraperSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) =>
+      jsonResult(
+        await runMrScraperRerunManualScraper({
+          cfg: api.config,
+          scraperId: readStringParam(rawParams, "scraperId", { required: true }),
+          url: readStringParam(rawParams, "url", { required: true }),
+          timeoutSeconds: readNumberParam(rawParams, "timeoutSeconds", { integer: true }),
+        }),
+      ),
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-scrape-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-scrape-tool.ts
@@ -1,0 +1,102 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperCreateAiScraper } from "./mrscraper-client.js";
+
+const MrScraperScrapeSchema = Type.Object(
+  {
+    url: Type.String({ description: "Target URL to scrape." }),
+    message: Type.String({ description: "Plain-language extraction instructions." }),
+    agent: Type.Optional(
+      Type.Unsafe<"general" | "listing" | "map">({
+        type: "string",
+        enum: ["general", "listing", "map"],
+        description: 'MrScraper agent type: "general", "listing", or "map".',
+      }),
+    ),
+    proxyCountry: Type.Optional(
+      Type.String({ description: "Optional ISO country code for proxy routing." }),
+    ),
+    maxDepth: Type.Optional(
+      Type.Number({
+        description: "Map-agent only: maximum crawl depth.",
+        minimum: 0,
+      }),
+    ),
+    maxPages: Type.Optional(
+      Type.Number({
+        description: "Map-agent only: maximum pages to crawl.",
+        minimum: 1,
+      }),
+    ),
+    limit: Type.Optional(
+      Type.Number({
+        description: "Map-agent only: maximum extracted records.",
+        minimum: 1,
+      }),
+    ),
+    includePatterns: Type.Optional(
+      Type.String({
+        description: "Map-agent only: regex URL include patterns separated with ||.",
+      }),
+    ),
+    excludePatterns: Type.Optional(
+      Type.String({
+        description: "Map-agent only: regex URL exclude patterns separated with ||.",
+      }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({
+        description: "HTTP timeout in seconds for the API request.",
+        minimum: 1,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperScrapeTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_scrape",
+    label: "MrScraper Scrape",
+    description:
+      "Create a MrScraper AI scraper run from plain-language instructions and return the platform response.",
+    parameters: MrScraperScrapeSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const url = readStringParam(rawParams, "url", { required: true });
+      const message = readStringParam(rawParams, "message", { required: true });
+      const agentRaw = readStringParam(rawParams, "agent");
+      const agent =
+        agentRaw === "listing" || agentRaw === "map" || agentRaw === "general"
+          ? agentRaw
+          : undefined;
+      const proxyCountry = readStringParam(rawParams, "proxyCountry");
+      const includePatterns = readStringParam(rawParams, "includePatterns");
+      const excludePatterns = readStringParam(rawParams, "excludePatterns");
+      const maxDepth = readNumberParam(rawParams, "maxDepth", { integer: true });
+      const maxPages = readNumberParam(rawParams, "maxPages", { integer: true });
+      const limit = readNumberParam(rawParams, "limit", { integer: true });
+      const timeoutSeconds = readNumberParam(rawParams, "timeoutSeconds", { integer: true });
+
+      return jsonResult(
+        await runMrScraperCreateAiScraper({
+          cfg: api.config,
+          url,
+          message,
+          agent,
+          proxyCountry,
+          maxDepth,
+          maxPages,
+          limit,
+          includePatterns,
+          excludePatterns,
+          timeoutSeconds,
+        }),
+      );
+    },
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-tools.test.ts
+++ b/extensions/mrscraper/src/mrscraper-tools.test.ts
@@ -132,7 +132,6 @@ describe("mrscraper tools", () => {
 
     await tool.execute({
       url: "https://example.com",
-      extractMode: "text",
       maxChars: 1234,
       timeoutSeconds: 30,
       geoCode: "SG",
@@ -142,7 +141,6 @@ describe("mrscraper tools", () => {
     expect(runMrScraperFetchHtml).toHaveBeenCalledWith({
       cfg: { test: true },
       url: "https://example.com",
-      extractMode: "text",
       maxChars: 1234,
       timeoutSeconds: 30,
       geoCode: "SG",
@@ -157,7 +155,6 @@ describe("mrscraper tools", () => {
 
     const result = await tool.execute("call-1", {
       url: "https://example.com",
-      extractMode: "markdown",
       maxChars: 1500,
       timeoutSeconds: 45,
       geoCode: "US",
@@ -167,7 +164,6 @@ describe("mrscraper tools", () => {
     expect(runMrScraperFetchHtml).toHaveBeenCalledWith({
       cfg: { env: "test" },
       url: "https://example.com",
-      extractMode: "markdown",
       maxChars: 1500,
       timeoutSeconds: 45,
       geoCode: "US",

--- a/extensions/mrscraper/src/mrscraper-tools.test.ts
+++ b/extensions/mrscraper/src/mrscraper-tools.test.ts
@@ -1,0 +1,241 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS,
+  DEFAULT_MRSCRAPER_PLATFORM_BASE_URL,
+  DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS,
+  DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL,
+  resolveMrScraperApiToken,
+  resolveMrScraperBlockResources,
+  resolveMrScraperFetchTimeoutSeconds,
+  resolveMrScraperPlatformBaseUrl,
+  resolveMrScraperProxyCountry,
+  resolveMrScraperScrapeTimeoutSeconds,
+  resolveMrScraperUnblockerBaseUrl,
+} from "./config.js";
+
+const { runMrScraperFetchHtml, runMrScraperCreateAiScraper } = vi.hoisted(() => ({
+  runMrScraperFetchHtml: vi.fn(async (params: Record<string, unknown>) => params),
+  runMrScraperCreateAiScraper: vi.fn(async (params: Record<string, unknown>) => params),
+}));
+
+vi.mock("./mrscraper-client.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./mrscraper-client.js")>("./mrscraper-client.js");
+  return {
+    ...actual,
+    runMrScraperFetchHtml,
+    runMrScraperCreateAiScraper,
+  };
+});
+
+describe("mrscraper tools", () => {
+  let createMrScraperWebFetchProvider: typeof import("./mrscraper-fetch-provider.js").createMrScraperWebFetchProvider;
+  let createMrScraperFetchHtmlTool: typeof import("./mrscraper-fetch-tool.js").createMrScraperFetchHtmlTool;
+  let createMrScraperScrapeTool: typeof import("./mrscraper-scrape-tool.js").createMrScraperScrapeTool;
+  let mrscraperClientTesting: typeof import("./mrscraper-client.js").__testing;
+
+  beforeAll(async () => {
+    ({ createMrScraperWebFetchProvider } = await import("./mrscraper-fetch-provider.js"));
+    ({ createMrScraperFetchHtmlTool } = await import("./mrscraper-fetch-tool.js"));
+    ({ createMrScraperScrapeTool } = await import("./mrscraper-scrape-tool.js"));
+    ({ __testing: mrscraperClientTesting } =
+      await vi.importActual<typeof import("./mrscraper-client.js")>("./mrscraper-client.js"));
+  });
+
+  beforeEach(() => {
+    runMrScraperFetchHtml.mockReset();
+    runMrScraperFetchHtml.mockImplementation(async (params: Record<string, unknown>) => params);
+    runMrScraperCreateAiScraper.mockReset();
+    runMrScraperCreateAiScraper.mockImplementation(
+      async (params: Record<string, unknown>) => params,
+    );
+    vi.unstubAllEnvs();
+  });
+
+  it("exposes fetch-provider metadata and enables the plugin", () => {
+    const provider = createMrScraperWebFetchProvider();
+    if (!provider.applySelectionConfig) {
+      throw new Error("Expected applySelectionConfig to be defined");
+    }
+    const applied = provider.applySelectionConfig({});
+
+    expect(provider.id).toBe("mrscraper");
+    expect(provider.credentialPath).toBe("plugins.entries.mrscraper.config.apiToken");
+    expect(applied.plugins?.entries?.mrscraper?.enabled).toBe(true);
+  });
+
+  it("maps web_fetch provider args into MrScraper unblocker params", async () => {
+    const provider = createMrScraperWebFetchProvider();
+    const tool = provider.createTool({
+      config: { test: true },
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({
+      url: "https://example.com",
+      extractMode: "text",
+      maxChars: 1234,
+      timeoutSeconds: 30,
+      geoCode: "SG",
+      blockResources: true,
+    });
+
+    expect(runMrScraperFetchHtml).toHaveBeenCalledWith({
+      cfg: { test: true },
+      url: "https://example.com",
+      extractMode: "text",
+      maxChars: 1234,
+      timeoutSeconds: 30,
+      geoCode: "SG",
+      blockResources: true,
+    });
+  });
+
+  it("normalizes explicit fetch-tool parameters", async () => {
+    const tool = createMrScraperFetchHtmlTool({
+      config: { env: "test" },
+    } as never);
+
+    const result = await tool.execute("call-1", {
+      url: "https://example.com",
+      extractMode: "markdown",
+      maxChars: 1500,
+      timeoutSeconds: 45,
+      geoCode: "US",
+      blockResources: false,
+    });
+
+    expect(runMrScraperFetchHtml).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      url: "https://example.com",
+      extractMode: "markdown",
+      maxChars: 1500,
+      timeoutSeconds: 45,
+      geoCode: "US",
+      blockResources: false,
+    });
+    expect(result.details).toMatchObject({
+      cfg: { env: "test" },
+      url: "https://example.com",
+    });
+  });
+
+  it("normalizes explicit AI scrape parameters", async () => {
+    const tool = createMrScraperScrapeTool({
+      config: { env: "test" },
+    } as never);
+
+    const result = await tool.execute("call-2", {
+      url: "https://example.com/catalog",
+      message: "Extract names and prices",
+      agent: "map",
+      proxyCountry: "US",
+      maxDepth: 2,
+      maxPages: 10,
+      limit: 50,
+      includePatterns: ".*/products/.*",
+      excludePatterns: ".*/cart/.*",
+      timeoutSeconds: 90,
+    });
+
+    expect(runMrScraperCreateAiScraper).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      url: "https://example.com/catalog",
+      message: "Extract names and prices",
+      agent: "map",
+      proxyCountry: "US",
+      maxDepth: 2,
+      maxPages: 10,
+      limit: 50,
+      includePatterns: ".*/products/.*",
+      excludePatterns: ".*/cart/.*",
+      timeoutSeconds: 90,
+    });
+    expect(result.details).toMatchObject({
+      cfg: { env: "test" },
+      agent: "map",
+    });
+  });
+
+  it("prefers plugin config over env defaults and falls back cleanly", () => {
+    vi.stubEnv("MRSCRAPER_API_TOKEN", "env-token");
+
+    const cfg = {
+      plugins: {
+        entries: {
+          mrscraper: {
+            config: {
+              apiToken: "plugin-token",
+              webFetch: {
+                baseUrl: "https://api.mrscraper.com",
+                timeoutSeconds: 75,
+                geoCode: "GB",
+                blockResources: true,
+              },
+              platform: {
+                baseUrl: "https://api.app.mrscraper.com",
+                timeoutSeconds: 150,
+                proxyCountry: "SG",
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveMrScraperApiToken(cfg)).toBe("plugin-token");
+    expect(resolveMrScraperUnblockerBaseUrl(cfg)).toBe("https://api.mrscraper.com");
+    expect(resolveMrScraperPlatformBaseUrl(cfg)).toBe("https://api.app.mrscraper.com");
+    expect(resolveMrScraperFetchTimeoutSeconds(cfg)).toBe(75);
+    expect(resolveMrScraperScrapeTimeoutSeconds(cfg)).toBe(150);
+    expect(resolveMrScraperProxyCountry(cfg)).toBe("SG");
+    expect(resolveMrScraperBlockResources(cfg)).toBe(true);
+  });
+
+  it("uses default config values when plugin config is missing", () => {
+    vi.stubEnv("MRSCRAPER_API_TOKEN", "env-token");
+
+    expect(resolveMrScraperApiToken()).toBe("env-token");
+    expect(resolveMrScraperUnblockerBaseUrl()).toBe(DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL);
+    expect(resolveMrScraperPlatformBaseUrl()).toBe(DEFAULT_MRSCRAPER_PLATFORM_BASE_URL);
+    expect(resolveMrScraperFetchTimeoutSeconds()).toBe(DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS);
+    expect(resolveMrScraperScrapeTimeoutSeconds()).toBe(DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS);
+    expect(resolveMrScraperBlockResources()).toBe(false);
+  });
+
+  it("extracts useful text from rendered html", () => {
+    expect(
+      mrscraperClientTesting.htmlToPlainText(
+        "<html><head><title>Example</title></head><body><main><h1>Hello</h1><p>World</p></main></body></html>",
+      ),
+    ).toContain("Hello");
+    expect(
+      mrscraperClientTesting.extractTitle(
+        "<html><head><title>Example &amp; Test</title></head><body></body></html>",
+      ),
+    ).toBe("Example & Test");
+  });
+
+  it("keeps endpoint host allowlists strict", () => {
+    expect(
+      mrscraperClientTesting.resolveEndpoint({
+        baseUrl: "https://api.mrscraper.com",
+        defaultBaseUrl: "https://api.mrscraper.com",
+        allowedHosts: new Set(["api.mrscraper.com"]),
+        product: "MrScraper unblocker",
+      }),
+    ).toBe("https://api.mrscraper.com/");
+
+    expect(() =>
+      mrscraperClientTesting.resolveEndpoint({
+        baseUrl: "https://evil.example.com",
+        defaultBaseUrl: "https://api.mrscraper.com",
+        allowedHosts: new Set(["api.mrscraper.com"]),
+        product: "MrScraper unblocker",
+      }),
+    ).toThrow("MrScraper unblocker baseUrl host is not allowed");
+  });
+});

--- a/extensions/mrscraper/src/mrscraper-tools.test.ts
+++ b/extensions/mrscraper/src/mrscraper-tools.test.ts
@@ -14,9 +14,24 @@ import {
   resolveMrScraperUnblockerBaseUrl,
 } from "./config.js";
 
-const { runMrScraperFetchHtml, runMrScraperCreateAiScraper } = vi.hoisted(() => ({
+const {
+  runMrScraperBulkRerunAiScraper,
+  runMrScraperBulkRerunManualScraper,
+  runMrScraperCreateAiScraper,
+  runMrScraperFetchHtml,
+  runMrScraperGetAllResults,
+  runMrScraperGetResultById,
+  runMrScraperRerunAiScraper,
+  runMrScraperRerunManualScraper,
+} = vi.hoisted(() => ({
+  runMrScraperBulkRerunAiScraper: vi.fn(async (params: Record<string, unknown>) => params),
+  runMrScraperBulkRerunManualScraper: vi.fn(async (params: Record<string, unknown>) => params),
   runMrScraperFetchHtml: vi.fn(async (params: Record<string, unknown>) => params),
   runMrScraperCreateAiScraper: vi.fn(async (params: Record<string, unknown>) => params),
+  runMrScraperGetAllResults: vi.fn(async (params: Record<string, unknown>) => params),
+  runMrScraperGetResultById: vi.fn(async (params: Record<string, unknown>) => params),
+  runMrScraperRerunAiScraper: vi.fn(async (params: Record<string, unknown>) => params),
+  runMrScraperRerunManualScraper: vi.fn(async (params: Record<string, unknown>) => params),
 }));
 
 vi.mock("./mrscraper-client.js", async () => {
@@ -24,30 +39,71 @@ vi.mock("./mrscraper-client.js", async () => {
     await vi.importActual<typeof import("./mrscraper-client.js")>("./mrscraper-client.js");
   return {
     ...actual,
+    runMrScraperBulkRerunAiScraper,
+    runMrScraperBulkRerunManualScraper,
     runMrScraperFetchHtml,
     runMrScraperCreateAiScraper,
+    runMrScraperGetAllResults,
+    runMrScraperGetResultById,
+    runMrScraperRerunAiScraper,
+    runMrScraperRerunManualScraper,
   };
 });
 
 describe("mrscraper tools", () => {
   let createMrScraperWebFetchProvider: typeof import("./mrscraper-fetch-provider.js").createMrScraperWebFetchProvider;
+  let createMrScraperBulkRerunAiScraperTool: typeof import("./mrscraper-bulk-rerun-ai-scraper-tool.js").createMrScraperBulkRerunAiScraperTool;
+  let createMrScraperBulkRerunManualScraperTool: typeof import("./mrscraper-bulk-rerun-manual-scraper-tool.js").createMrScraperBulkRerunManualScraperTool;
   let createMrScraperFetchHtmlTool: typeof import("./mrscraper-fetch-tool.js").createMrScraperFetchHtmlTool;
+  let createMrScraperGetAllResultsTool: typeof import("./mrscraper-get-all-results-tool.js").createMrScraperGetAllResultsTool;
+  let createMrScraperGetResultByIdTool: typeof import("./mrscraper-get-result-by-id-tool.js").createMrScraperGetResultByIdTool;
+  let createMrScraperRerunAiScraperTool: typeof import("./mrscraper-rerun-ai-scraper-tool.js").createMrScraperRerunAiScraperTool;
+  let createMrScraperRerunManualScraperTool: typeof import("./mrscraper-rerun-manual-scraper-tool.js").createMrScraperRerunManualScraperTool;
   let createMrScraperScrapeTool: typeof import("./mrscraper-scrape-tool.js").createMrScraperScrapeTool;
   let mrscraperClientTesting: typeof import("./mrscraper-client.js").__testing;
 
   beforeAll(async () => {
+    ({ createMrScraperBulkRerunAiScraperTool } =
+      await import("./mrscraper-bulk-rerun-ai-scraper-tool.js"));
+    ({ createMrScraperBulkRerunManualScraperTool } =
+      await import("./mrscraper-bulk-rerun-manual-scraper-tool.js"));
     ({ createMrScraperWebFetchProvider } = await import("./mrscraper-fetch-provider.js"));
     ({ createMrScraperFetchHtmlTool } = await import("./mrscraper-fetch-tool.js"));
+    ({ createMrScraperGetAllResultsTool } = await import("./mrscraper-get-all-results-tool.js"));
+    ({ createMrScraperGetResultByIdTool } = await import("./mrscraper-get-result-by-id-tool.js"));
+    ({ createMrScraperRerunAiScraperTool } = await import("./mrscraper-rerun-ai-scraper-tool.js"));
+    ({ createMrScraperRerunManualScraperTool } =
+      await import("./mrscraper-rerun-manual-scraper-tool.js"));
     ({ createMrScraperScrapeTool } = await import("./mrscraper-scrape-tool.js"));
     ({ __testing: mrscraperClientTesting } =
       await vi.importActual<typeof import("./mrscraper-client.js")>("./mrscraper-client.js"));
   });
 
   beforeEach(() => {
+    runMrScraperBulkRerunAiScraper.mockReset();
+    runMrScraperBulkRerunAiScraper.mockImplementation(
+      async (params: Record<string, unknown>) => params,
+    );
+    runMrScraperBulkRerunManualScraper.mockReset();
+    runMrScraperBulkRerunManualScraper.mockImplementation(
+      async (params: Record<string, unknown>) => params,
+    );
     runMrScraperFetchHtml.mockReset();
     runMrScraperFetchHtml.mockImplementation(async (params: Record<string, unknown>) => params);
     runMrScraperCreateAiScraper.mockReset();
     runMrScraperCreateAiScraper.mockImplementation(
+      async (params: Record<string, unknown>) => params,
+    );
+    runMrScraperGetAllResults.mockReset();
+    runMrScraperGetAllResults.mockImplementation(async (params: Record<string, unknown>) => params);
+    runMrScraperGetResultById.mockReset();
+    runMrScraperGetResultById.mockImplementation(async (params: Record<string, unknown>) => params);
+    runMrScraperRerunAiScraper.mockReset();
+    runMrScraperRerunAiScraper.mockImplementation(
+      async (params: Record<string, unknown>) => params,
+    );
+    runMrScraperRerunManualScraper.mockReset();
+    runMrScraperRerunManualScraper.mockImplementation(
       async (params: Record<string, unknown>) => params,
     );
     vi.unstubAllEnvs();
@@ -157,6 +213,140 @@ describe("mrscraper tools", () => {
     expect(result.details).toMatchObject({
       cfg: { env: "test" },
       agent: "map",
+    });
+  });
+
+  it("normalizes explicit AI rerun parameters", async () => {
+    const tool = createMrScraperRerunAiScraperTool({
+      config: { env: "test" },
+    } as never);
+
+    await tool.execute("call-3", {
+      scraperId: "scraper-123",
+      url: "https://example.com/catalog/next",
+      maxDepth: 3,
+      maxPages: 20,
+      limit: 100,
+      includePatterns: ".*/products/.*",
+      excludePatterns: ".*/cart/.*",
+      timeoutSeconds: 95,
+    });
+
+    expect(runMrScraperRerunAiScraper).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      scraperId: "scraper-123",
+      url: "https://example.com/catalog/next",
+      maxDepth: 3,
+      maxPages: 20,
+      limit: 100,
+      includePatterns: ".*/products/.*",
+      excludePatterns: ".*/cart/.*",
+      timeoutSeconds: 95,
+    });
+  });
+
+  it("normalizes explicit AI bulk rerun parameters", async () => {
+    const tool = createMrScraperBulkRerunAiScraperTool({
+      config: { env: "test" },
+    } as never);
+
+    await tool.execute("call-4", {
+      scraperId: "scraper-123",
+      urls: ["https://example.com/a", "https://example.com/b"],
+      timeoutSeconds: 90,
+    });
+
+    expect(runMrScraperBulkRerunAiScraper).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      scraperId: "scraper-123",
+      urls: ["https://example.com/a", "https://example.com/b"],
+      timeoutSeconds: 90,
+    });
+  });
+
+  it("normalizes explicit manual rerun parameters", async () => {
+    const tool = createMrScraperRerunManualScraperTool({
+      config: { env: "test" },
+    } as never);
+
+    await tool.execute("call-5", {
+      scraperId: "manual-123",
+      url: "https://example.com/manual",
+      timeoutSeconds: 80,
+    });
+
+    expect(runMrScraperRerunManualScraper).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      scraperId: "manual-123",
+      url: "https://example.com/manual",
+      timeoutSeconds: 80,
+    });
+  });
+
+  it("normalizes explicit manual bulk rerun parameters", async () => {
+    const tool = createMrScraperBulkRerunManualScraperTool({
+      config: { env: "test" },
+    } as never);
+
+    await tool.execute("call-6", {
+      scraperId: "manual-123",
+      urls: ["https://example.com/a", "https://example.com/b"],
+      timeoutSeconds: 70,
+    });
+
+    expect(runMrScraperBulkRerunManualScraper).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      scraperId: "manual-123",
+      urls: ["https://example.com/a", "https://example.com/b"],
+      timeoutSeconds: 70,
+    });
+  });
+
+  it("normalizes results list parameters", async () => {
+    const tool = createMrScraperGetAllResultsTool({
+      config: { env: "test" },
+    } as never);
+
+    await tool.execute("call-7", {
+      sortField: "createdAt",
+      sortOrder: "ASC",
+      pageSize: 25,
+      page: 2,
+      search: "laptop",
+      dateRangeColumn: "updatedAt",
+      startAt: "2026-01-01",
+      endAt: "2026-01-31",
+      timeoutSeconds: 60,
+    });
+
+    expect(runMrScraperGetAllResults).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      sortField: "createdAt",
+      sortOrder: "ASC",
+      pageSize: 25,
+      page: 2,
+      search: "laptop",
+      dateRangeColumn: "updatedAt",
+      startAt: "2026-01-01",
+      endAt: "2026-01-31",
+      timeoutSeconds: 60,
+    });
+  });
+
+  it("normalizes result-by-id parameters", async () => {
+    const tool = createMrScraperGetResultByIdTool({
+      config: { env: "test" },
+    } as never);
+
+    await tool.execute("call-8", {
+      resultId: "result-123",
+      timeoutSeconds: 45,
+    });
+
+    expect(runMrScraperGetResultById).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      resultId: "result-123",
+      timeoutSeconds: 45,
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,8 @@ importers:
 
   extensions/moonshot: {}
 
+  extensions/mrscraper: {}
+
   extensions/msteams:
     dependencies:
       '@microsoft/teams.api':

--- a/src/plugins/contracts/plugin-registration.mrscraper.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.mrscraper.contract.test.ts
@@ -1,0 +1,4 @@
+import { pluginRegistrationContractCases } from "../../../test/helpers/plugins/plugin-registration-contract-cases.js";
+import { describePluginRegistrationContract } from "../../../test/helpers/plugins/plugin-registration-contract.js";
+
+describePluginRegistrationContract(pluginRegistrationContractCases.mrscraper);

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -87,6 +87,19 @@ describe("discoverConfigurablePlugins", () => {
     const result = discoverConfigurablePlugins({ manifestPlugins: plugins });
     expect(result.map((p) => p.id)).toEqual(["alpha", "zeta"]);
   });
+
+  it("keeps default onboarding focused on non-advanced token fields", () => {
+    const plugins = [
+      makeManifestPlugin("mrscraper", {
+        apiToken: { label: "MrScraper API Token", sensitive: true },
+        "webFetch.baseUrl": { label: "MrScraper Unblocker Base URL", advanced: true },
+        "platform.baseUrl": { label: "MrScraper Platform Base URL", advanced: true },
+      }),
+    ];
+    const result = discoverConfigurablePlugins({ manifestPlugins: plugins });
+    expect(result).toHaveLength(1);
+    expect(Object.keys(result[0].uiHints)).toEqual(["apiToken"]);
+  });
 });
 
 describe("discoverUnconfiguredPlugins", () => {
@@ -274,5 +287,147 @@ describe("setupPluginConfig", () => {
       },
     });
     expect(result.plugins?.entries?.brave?.config?.["webSearch.mode"]).toBeUndefined();
+  });
+
+  it("surfaces disabled configurable plugins during setup and enables them when selected", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("mrscraper", {
+            "webFetch.baseUrl": { label: "MrScraper Unblocker Base URL" },
+          }),
+          enabledByDefault: undefined,
+        },
+      ],
+    });
+
+    const multiselect = vi.fn(async () => [
+      "mrscraper",
+    ]) as unknown as WizardPrompter["multiselect"];
+    const text = vi.fn(
+      async () => "https://api.mrscraper.com",
+    ) as unknown as WizardPrompter["text"];
+
+    const result = await setupPluginConfig({
+      config: {},
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "__skip__") as unknown as WizardPrompter["select"],
+        multiselect,
+        text,
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          expect.objectContaining({
+            value: "mrscraper",
+            hint: expect.stringContaining("enables plugin"),
+          }),
+        ],
+      }),
+    );
+    expect(result.plugins?.entries?.mrscraper?.enabled).toBe(true);
+    expect(result.plugins?.entries?.mrscraper?.config).toEqual({
+      webFetch: {
+        baseUrl: "https://api.mrscraper.com",
+      },
+    });
+  });
+
+  it("prompts for sensitive plugin fields during setup and stores the value", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("mrscraper", {
+            apiToken: {
+              label: "MrScraper API Token",
+              help: "Token for the unblocker and scraper APIs",
+              sensitive: true,
+            },
+          }),
+          enabledByDefault: undefined,
+        },
+      ],
+    });
+
+    const note = vi.fn(async () => {});
+    const text = vi.fn(async () => "mrs_live_token") as unknown as WizardPrompter["text"];
+
+    const result = await setupPluginConfig({
+      config: {},
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note,
+        select: vi.fn(async () => "__skip__") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => ["mrscraper"]) as unknown as WizardPrompter["multiselect"],
+        text,
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("will be stored in your local OpenClaw config"),
+      "Sensitive field",
+    );
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("MrScraper API Token"),
+      }),
+    );
+    expect(result.plugins?.entries?.mrscraper?.enabled).toBe(true);
+    expect(result.plugins?.entries?.mrscraper?.config).toEqual({
+      apiToken: "mrs_live_token",
+    });
+  });
+});
+
+describe("configurePluginConfig", () => {
+  it("lists configurable plugins even when they are not enabled yet", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("mrscraper", {
+            apiToken: { label: "MrScraper API Token", sensitive: true },
+          }),
+          enabledByDefault: undefined,
+        },
+      ],
+    });
+
+    const { configurePluginConfig } = await import("./setup.plugin-config.js");
+    const select = vi.fn(async () => "__skip__") as unknown as WizardPrompter["select"];
+
+    await configurePluginConfig({
+      config: {},
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select,
+        multiselect: vi.fn(async () => []) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => ""),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            value: "mrscraper",
+            hint: expect.stringContaining("disabled"),
+          }),
+        ]),
+      }),
+    );
   });
 });

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -286,7 +286,6 @@ async function promptPluginFields(params: {
         ...config.plugins?.entries,
         [plugin.id]: {
           ...config.plugins?.entries?.[plugin.id],
-          enabled: true,
           config: updatedConfig,
         },
       },

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -49,6 +49,10 @@ function getExistingPluginConfig(
   return (config.plugins?.entries?.[pluginId]?.config as Record<string, unknown>) ?? {};
 }
 
+function isPluginEnabled(config: OpenClawConfig, pluginId: string): boolean {
+  return config.plugins?.entries?.[pluginId]?.enabled === true;
+}
+
 function toPathSegments(fieldKey: string): string[] {
   return fieldKey.split(".").filter(Boolean);
 }
@@ -161,13 +165,22 @@ async function promptPluginFields(params: {
     const label = hint.label ?? key;
     const helpSuffix = hint.help ? ` — ${hint.help}` : "";
 
-    // Skip sensitive fields — WizardPrompter has no masked input;
-    // direct users to openclaw config set or the Web UI instead.
     if (hint.sensitive) {
+      const currentStr = formatCurrentValue(currentValue);
       await prompter.note(
-        `"${label}" is sensitive. Set it via:\n  openclaw config set plugins.entries.${plugin.id}.config.${key} <value>\nor use the Web UI Settings page.`,
+        `"${label}" will be stored in your local OpenClaw config. Keep this machine private and prefer env vars when sharing config files.`,
         "Sensitive field",
       );
+      const input = await prompter.text({
+        message: `${label}${helpSuffix}`,
+        initialValue: currentStr,
+        placeholder: hint.placeholder,
+      });
+      const trimmed = input.trim();
+      if (trimmed !== currentStr) {
+        setPathCreateStrict(updatedConfig, pathSegments, trimmed || undefined);
+        changed = true;
+      }
       continue;
     }
 
@@ -273,6 +286,7 @@ async function promptPluginFields(params: {
         ...config.plugins?.entries,
         [plugin.id]: {
           ...config.plugins?.entries?.[plugin.id],
+          enabled: true,
           config: updatedConfig,
         },
       },
@@ -296,12 +310,7 @@ export async function setupPluginConfig(params: {
   });
 
   const unconfigured = discoverUnconfiguredPlugins({
-    manifestPlugins: registry.plugins.filter((p) => {
-      // Only show enabled plugins
-      const entry = params.config.plugins?.entries?.[p.id];
-      // Plugin is discoverable if it's enabled or enabledByDefault and not denied
-      return p.enabledByDefault || entry?.enabled === true;
-    }),
+    manifestPlugins: registry.plugins,
     config: params.config,
   });
 
@@ -314,7 +323,7 @@ export async function setupPluginConfig(params: {
     options: unconfigured.map((p) => ({
       value: p.id,
       label: p.name,
-      hint: `${Object.keys(p.uiHints).length} field${Object.keys(p.uiHints).length === 1 ? "" : "s"}`,
+      hint: `${Object.keys(p.uiHints).length} field${Object.keys(p.uiHints).length === 1 ? "" : "s"}${isPluginEnabled(params.config, p.id) ? "" : " · enables plugin"}`,
     })),
   });
 
@@ -351,10 +360,7 @@ export async function configurePluginConfig(params: {
   });
 
   const configurable = discoverConfigurablePlugins({
-    manifestPlugins: registry.plugins.filter((p) => {
-      const entry = params.config.plugins?.entries?.[p.id];
-      return p.enabledByDefault || entry?.enabled === true;
-    }),
+    manifestPlugins: registry.plugins,
   });
 
   if (configurable.length === 0) {
@@ -375,7 +381,7 @@ export async function configurePluginConfig(params: {
         return {
           value: p.id,
           label: p.name,
-          hint: `${configuredCount}/${totalCount} configured`,
+          hint: `${configuredCount}/${totalCount} configured${isPluginEnabled(params.config, p.id) ? "" : " · disabled"}`,
         };
       }),
       { value: "__skip__", label: "Back", hint: "Return to section menu" },

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -72,7 +72,16 @@ export const pluginRegistrationContractCases = {
   mrscraper: {
     pluginId: "mrscraper",
     webFetchProviderIds: ["mrscraper"],
-    toolNames: ["mrscraper_fetch_html", "mrscraper_scrape"],
+    toolNames: [
+      "mrscraper_bulk_rerun_ai_scraper",
+      "mrscraper_bulk_rerun_manual_scraper",
+      "mrscraper_fetch_html",
+      "mrscraper_get_all_results",
+      "mrscraper_get_result_by_id",
+      "mrscraper_rerun_ai_scraper",
+      "mrscraper_rerun_manual_scraper",
+      "mrscraper_scrape",
+    ],
   },
   minimax: {
     pluginId: "minimax",

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -69,6 +69,11 @@ export const pluginRegistrationContractCases = {
     speechProviderIds: ["microsoft"],
     requireSpeechVoices: true,
   },
+  mrscraper: {
+    pluginId: "mrscraper",
+    webFetchProviderIds: ["mrscraper"],
+    toolNames: ["mrscraper_fetch_html", "mrscraper_scrape"],
+  },
   minimax: {
     pluginId: "minimax",
     providerIds: ["minimax", "minimax-portal"],


### PR DESCRIPTION
## Summary

- **Problem:** [MrScraper](https://mrscraper.com/) want to provide OpenClaw's capability to quickly retrieve up to date structured data from the internet. Any data from any websites, even the unreachable bot-protected data.
- **Why it matters:** MrScraper can provide any data from any websites, structured, LLM-optimized result. Enables user's to easily reach any data ready to be further analyzed and processed.
- **What changed:** Added MrScraper as a bundled plugin (`extensions/mrscraper/`): `web_fetch` provider registration (`id: mrscraper`, `autoDetectOrder: 60`) so OpenClaw can route normal `web_fetch` through the MrScraper unblocker when selected; seven dedicated agent tools (`mrscraper_fetch_html`, `mrscraper_scrape`, `mrscraper_rerun_*` / `mrscraper_bulk_rerun_*`, `mrscraper_get_all_results`, `mrscraper_get_result_by_id`); a bundled skill (`skills/mrscraper/`); plugin manifest (`openclaw.plugin.json`: contracts, `configSchema`, `uiHints`, `providerAuthEnvVars`); API token resolution via `plugins.entries.mrscraper.config.apiToken`, legacy `tools.web.fetch.mrscraper.apiToken`, and `MRSCRAPER_API_TOKEN`; Vitest coverage in `mrscraper-tools.test.ts`; labeler entry for `extensions/mrscraper/**`; and a CHANGELOG note.
- **What did NOT change (scope boundary):** No changes to other `web_fetch` providers or their behavior—this only adds a new selectable provider. No changes to `web_search` providers or search tooling. No changes to core gateway protocol, channel plugins, or unrelated product surfaces beyond normal plugin discovery/registry picking up the new extension. No dedicated `docs/ page` in this PR (and no onboarding wizard entry comparable to some other plugins); configuration follows existing plugin + config flows.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## User-visible / Behavior Changes

- New **`web_fetch` provider option:** `"mrscraper"` (label **MrScraper**). When selected, OpenClaw routes normal `web_fetch` through MrScraper’s unblocker (stealth / bot-protected pages).
- New **plugin config** under `plugins.entries.mrscraper.config`:
  - `apiToken` (SecretRef-compatible; can be string or secret object per OpenClaw config patterns)
  - Optional `webFetch`: `baseUrl`, `timeoutSeconds`, `geoCode`, `blockResources`
  - Optional `platform`: `baseUrl`, `timeoutSeconds`, `proxyCountry`
- **Legacy compatibility:** token may still be read from `tools.web.fetch.mrscraper.apiToken` when migrating older configs.
- New **env var support:** **`MRSCRAPER_API_TOKEN`** (declared in `openclaw.plugin.json` `providerAuthEnvVars`).
- **Auto-detection:** MrScraper registers as a `web_fetch` provider with `autoDetectOrder: 60` (ordering relative to other providers is defined by the existing web-fetch auto-detect logic).
- **New dedicated agent tools** (in addition to `web_fetch` when MrScraper is the provider):
  - `mrscraper_fetch_html` — explicit unblocker fetch with controls (`geoCode`, `blockResources`, etc.)
  - `mrscraper_scrape` — create an AI scraper run from natural-language instructions
  - `mrscraper_rerun_ai_scraper`, `mrscraper_bulk_rerun_ai_scraper`
  - `mrscraper_rerun_manual_scraper`, `mrscraper_bulk_rerun_manual_scraper`
  - `mrscraper_get_all_results`, `mrscraper_get_result_by_id`
- **Bundled skill** (`extensions/mrscraper/skills/mrscraper/`) explains when to use `web_fetch` vs `mrscraper_fetch_html` vs scrape / rerun / result tools.
- **Onboarding wizard:** no new onboarding step in this PR (users enable the plugin and set the token via existing config / Control UI flows).
- **User-facing docs:** no new dedicated `docs/` page in this PR (optional follow-up).

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **Yes** — new optional `plugins.entries.mrscraper.config.apiToken`, legacy `tools.web.fetch.mrscraper.apiToken`, and **`MRSCRAPER_API_TOKEN`** env var, using the same **SecretInput / normalization** patterns as other bundled plugins (`normalizeSecretInput`, plugin manifest `providerAuthEnvVars`).
- New/changed network calls? **Yes** — new **outbound HTTPS** requests to MrScraper’s **allowlisted** hosts only:
  - Unblocker default: `https://api.mrscraper.com` (configurable `webFetch.baseUrl` but **hostname must stay in the plugin allowlist**)
  - Platform default: `https://api.app.mrscraper.com` (and allowlisted `sync.scraper.mrscraper.com` where used), configurable `platform.baseUrl` with the same host allowlist
  - Calls go through **`withStrictWebToolsEndpoint`** (strict web-tools dispatcher: timeout-enforced, consistent with other web-tool egress).
- Command/tool execution surface changed? **Yes** — `web_fetch` gains **MrScraper** as a selectable provider; **seven** new tools are registered when the plugin is loaded.
- Data access scope changed? **No** — agents can only reach MrScraper APIs and user-supplied target URLs through the defined tools/provider; no broadened filesystem or host access beyond that product surface.

**Risk + mitigation:** API token is treated as a secret (config + env + legacy path). Base URLs are restricted to **HTTPS** and **explicit host allowlists** in `mrscraper-client.ts`. External / error text is passed through existing **`wrapWebContent` / `wrapExternalContent`** patterns where applicable so content is marked as untrusted for the agent.

## Repro + Verification

### Environment

- OS: <!-- e.g. macOS -->
- Runtime/container: Node 22+ / Bun (per repo baseline)
- Model/provider: N/A (tool / web_fetch provider change)
- Integration/channel (if any): N/A
- Relevant config (redacted):

```json
{
  "plugins": {
    "entries": {
      "mrscraper": {
        "enabled": true,
        "config": {
          "apiToken": "atk_..."
        }
      }
    }
  },
  "tools": {
    "web": {
      "fetch": {
        "provider": "mrscraper"
      }
    }
  }
}
```

(Alternatively set `MRSCRAPER_API_TOKEN=atk_...` in the Gateway environment.)

### Steps

1. Enable the `mrscraper` plugin and configure `plugins.entries.mrscraper.config.apiToken` (or set `MRSCRAPER_API_TOKEN`).
2. Set `tools.web.fetch.provider` to `"mrscraper"` (or rely on auto-detection if your environment matches the repo’s rules).
3. Run **`web_fetch`** against a URL that needs rendering / unblocking, **or** invoke **`mrscraper_scrape`** with a `url` and `message`, **or** invoke **`mrscraper_fetch_html`** with the same URL for explicit unblocker parameters.
4. (Optional) Call **`mrscraper_get_all_results`** with paging params to confirm platform API auth.

### Expected

- Without a token: clear error hint pointing at `MRSCRAPER_API_TOKEN` or `plugins.entries.mrscraper.config.apiToken`.
- With a valid token: `web_fetch` / `mrscraper_fetch_html` return wrapped page content (markdown/text per options); platform tools return JSON-shaped results from MrScraper APIs (per tool).

### Actual

- Confirmed via automated tests (see **Evidence**). <!-- Add your manual smoke result if you ran live API calls. -->

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Tests added/updated:**

- `extensions/mrscraper/src/mrscraper-tools.test.ts` — config resolution, web_fetch provider wiring (`enablePluginInConfig`), tool `execute` paths (client mocked), client helpers (`resolveEndpoint`, HTML helpers) where covered.
- `src/plugins/contracts/plugin-registration.mrscraper.contract.test.ts` — contract: MrScraper owns `webFetchProviders: ["mrscraper"]` and the seven `mrscraper_*` tool names (via `test/helpers/plugins/plugin-registration-contract-cases.ts`).

**Suggested gates (run before merge / paste results into PR):**

- `pnpm test extensions/mrscraper/src/mrscraper-tools.test.ts`
- `pnpm test src/plugins/contracts/plugin-registration.mrscraper.contract.test.ts`
- `pnpm check`
- `pnpm build` (if your change can affect build / lazy-loading)

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:** <!-- e.g. Plugin loads; tools appear in registry; contract test passes; token error message is actionable. -->
- **Edge cases checked:** <!-- e.g. Missing token; invalid/disallowed custom baseUrl host rejected; legacy `tools.web.fetch.mrscraper.apiToken` still resolves. -->
- **What you did not verify:** <!-- e.g. Live calls against production MrScraper API (tests mock HTTP layer); full Control UI walkthrough of every advanced field; every tool against real scraper IDs. -->

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? **Yes** — additive bundled plugin; existing `web_fetch` providers and behavior unchanged unless the user selects MrScraper.
- Config/env changes? **Yes** — new optional `plugins.entries.mrscraper` entry and `MRSCRAPER_API_TOKEN`; optional legacy read of `tools.web.fetch.mrscraper.apiToken`.
- Migration needed? **No** for existing installs that do not enable MrScraper.
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **Disable quickly:** Set `plugins.entries.mrscraper.enabled: false`, or set `tools.web.fetch.provider` to another provider, or remove `MRSCRAPER_API_TOKEN` / clear `apiToken` from config.
- **Files/config to restore:** N/A (revert PR or disable plugin).
- **Symptoms to watch:** Errors mentioning missing MrScraper API token when provider or tools are used without credentials; misconfigured custom `baseUrl` host rejected by allowlist.

## Risks and Mitigations

- **Risk:** MrScraper API availability, rate limits, or account quotas affect users who select this provider or use the tools heavily.
  - **Mitigation:** Provider selection is explicit via config (and auto-detect only when the repo’s rules select it); users can switch `web_fetch` provider or disable the plugin.

- **Risk:** User-supplied target URLs are passed to MrScraper (by design); abuse could consume quota or trigger provider-side protections.
  - **Mitigation:** Same trust model as other web tools: OpenClaw does not grant new local privileges; egress goes through strict web-tools plumbing; MrScraper token remains user-controlled.
