### PR TITLE
fix(qa-lab): wrap scenario pack read in try/catch for npm dist

### DIFF
--- a/extensions/qa-lab/src/discovery-eval.ts
+++ b/extensions/qa-lab/src/discovery-eval.ts
@@ -2,16 +2,22 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtim
 import { readQaScenarioExecutionConfig } from "./scenario-catalog.js";
 
 function readRequiredDiscoveryRefs() {
-  const config = readQaScenarioExecutionConfig("source-docs-discovery-report") as
-    | { requiredFiles?: string[] }
-    | undefined;
-  return (
-    config?.requiredFiles ?? [
-      "repo/qa/scenarios/index.md",
-      "repo/extensions/qa-lab/src/suite.ts",
-      "repo/docs/help/testing.md",
-    ]
-  );
+  try {
+    const config = readQaScenarioExecutionConfig("source-docs-discovery-report") as
+      | { requiredFiles?: string[] }
+      | undefined;
+    if (config?.requiredFiles) {
+      return config.requiredFiles;
+    }
+  } catch {
+    // qa/scenarios/index.md is not shipped in the npm distribution;
+    // fall through to the built-in default refs.
+  }
+  return [
+    "repo/qa/scenarios/index.md",
+    "repo/extensions/qa-lab/src/suite.ts",
+    "repo/docs/help/testing.md",
+  ];
 }
 
 const REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();


### PR DESCRIPTION
## Problem

Updating to v2026.4.9 causes completion cache generation to crash with `Error: qa scenario pack not found: qa/scenarios/index.md`.

## Root Cause

The `qa/scenarios/` directory is not included in the npm distribution. `readQaScenarioPack()` throws during module init before the `??` fallback can run.

## Fix

Wrap the scenario pack lookup in try/catch so the built-in default refs are used when the pack is unavailable.

Closes #63510