### PR TITLE
feat(models): allow private network via models.providers.*.request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Docs i18n: chunk raw doc translation, reject truncated tagged outputs, avoid ambiguous body-only wrapper unwrapping, and recover from terminated Pi translation sessions without changing the default `openai/gpt-5.4` path. (#62969, #63808) Thanks @hxy91819.
 - QA/testing: add a `--runner multipass` lane for `openclaw qa suite` so repo-backed QA scenarios can run inside a disposable Linux VM and write back the usual report, summary, and VM logs. (#63426) Thanks @shakkernerd.
 - Gateway: split startup and runtime seams so gateway lifecycle sequencing, reload state, and shutdown behavior stay easier to maintain without changing observed behavior. (#63975) Thanks @gumadeiras.
+- Models/providers: add per-provider `models.providers.*.request.allowPrivateNetwork` for trusted self-hosted OpenAI-compatible endpoints, keep the opt-in scoped to model request surfaces, and refresh cached WebSocket managers when request transport overrides change. (#63671) Thanks @qas.
 
 ### Fixes
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2402,7 +2402,7 @@ OpenClaw uses the built-in model catalog. Add custom providers via `models.provi
   - `request.auth`: auth strategy override. Modes: `"provider-default"` (use provider's built-in auth), `"authorization-bearer"` (with `token`), `"header"` (with `headerName`, `value`, optional `prefix`).
   - `request.proxy`: HTTP proxy override. Modes: `"env-proxy"` (use `HTTP_PROXY`/`HTTPS_PROXY` env vars), `"explicit-proxy"` (with `url`). Both modes accept an optional `tls` sub-object.
   - `request.tls`: TLS override for direct connections. Fields: `ca`, `cert`, `key`, `passphrase` (all accept SecretRef), `serverName`, `insecureSkipVerify`.
-  - `request.allowPrivateNetwork`: when `true`, allow HTTPS/WebSocket to `baseUrl` when DNS resolves to private, CGNAT, or similar ranges (operator opt-in for trusted self-hosted OpenAI-compatible endpoints). Default `false`.
+  - `request.allowPrivateNetwork`: when `true`, allow HTTPS to `baseUrl` when DNS resolves to private, CGNAT, or similar ranges, via the provider HTTP fetch guard (operator opt-in for trusted self-hosted OpenAI-compatible endpoints). WebSocket uses the same `request` for headers/TLS but not that fetch SSRF gate. Default `false`.
 - `models.providers.*.models`: explicit provider model catalog entries.
 - `models.providers.*.models.*.contextWindow`: native model context window metadata.
 - `models.providers.*.models.*.contextTokens`: optional runtime context cap. Use this when you want a smaller effective context budget than the model's native `contextWindow`.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2402,6 +2402,7 @@ OpenClaw uses the built-in model catalog. Add custom providers via `models.provi
   - `request.auth`: auth strategy override. Modes: `"provider-default"` (use provider's built-in auth), `"authorization-bearer"` (with `token`), `"header"` (with `headerName`, `value`, optional `prefix`).
   - `request.proxy`: HTTP proxy override. Modes: `"env-proxy"` (use `HTTP_PROXY`/`HTTPS_PROXY` env vars), `"explicit-proxy"` (with `url`). Both modes accept an optional `tls` sub-object.
   - `request.tls`: TLS override for direct connections. Fields: `ca`, `cert`, `key`, `passphrase` (all accept SecretRef), `serverName`, `insecureSkipVerify`.
+  - `request.allowPrivateNetwork`: when `true`, allow HTTPS/WebSocket to `baseUrl` when DNS resolves to private, CGNAT, or similar ranges (operator opt-in for trusted self-hosted OpenAI-compatible endpoints). Default `false`.
 - `models.providers.*.models`: explicit provider model catalog entries.
 - `models.providers.*.models.*.contextWindow`: native model context window metadata.
 - `models.providers.*.models.*.contextTokens`: optional runtime context cap. Use this when you want a smaller effective context budget than the model's native `contextWindow`.

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -467,6 +467,7 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
         },
         precedence: "defaults-win",
         request: this.request,
+        allowPrivateNetwork: this.request?.allowPrivateNetwork === true,
       });
       const socket = this.socketFactory(this.wsUrl, {
         headers: requestConfig.headers,

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -19,7 +19,7 @@ import { buildOpenAIWebSocketWarmUpPayload } from "./openai-ws-request.js";
 import {
   buildProviderRequestTlsClientOptions,
   resolveProviderRequestPolicyConfig,
-  type ProviderRequestTransportOverrides,
+  type ModelProviderRequestTransportOverrides,
 } from "./provider-request-config.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -289,7 +289,7 @@ export interface OpenAIWebSocketManagerOptions {
   /** Extra headers merged into the initial WebSocket handshake request. */
   headers?: Record<string, string>;
   /** Optional transport overrides for provider-owned auth or TLS wiring. */
-  request?: ProviderRequestTransportOverrides;
+  request?: ModelProviderRequestTransportOverrides;
 }
 
 export type OpenAIWebSocketConnectionState =
@@ -346,7 +346,7 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
   private readonly backoffDelaysMs: readonly number[];
   private readonly socketFactory: (url: string, options: ClientOptions) => WebSocket;
   private readonly headers?: Record<string, string>;
-  private readonly request?: ProviderRequestTransportOverrides;
+  private readonly request?: ModelProviderRequestTransportOverrides;
 
   constructor(options: OpenAIWebSocketManagerOptions = {}) {
     super();

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -3428,6 +3428,87 @@ describe("releaseWsSession / hasWsSession", () => {
   it("releaseWsSession is a no-op for unknown sessions", () => {
     expect(() => releaseWsSession("nonexistent-session")).not.toThrow();
   });
+
+  it("recreates the cached manager when request overrides change for the same session", async () => {
+    const sessionId = "registry-test";
+    const firstStreamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId, {
+      managerOptions: {
+        request: {
+          headers: { "x-test": "one" },
+        },
+      },
+    });
+    const firstStream = firstStreamFn(
+      {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+        contextWindow: 128000,
+        maxTokens: 4096,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        name: "GPT-5.4",
+      } as Parameters<typeof firstStreamFn>[0],
+      {
+        systemPrompt: "test",
+        messages: [userMsg("Hi") as Parameters<typeof convertMessagesToInputItems>[0][number]],
+        tools: [],
+      } as Parameters<typeof firstStreamFn>[1],
+    );
+
+    await new Promise((r) => setImmediate(r));
+    const firstManager = MockManager.lastInstance!;
+    firstManager.simulateEvent({
+      type: "response.completed",
+      response: makeResponseObject("resp-first", "done"),
+    });
+    for await (const _ of await resolveStream(firstStream)) {
+      // consume
+    }
+
+    const secondStreamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId, {
+      managerOptions: {
+        request: {
+          headers: { "x-test": "two" },
+          allowPrivateNetwork: true,
+        },
+      },
+    });
+    const secondStream = secondStreamFn(
+      {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+        contextWindow: 128000,
+        maxTokens: 4096,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        name: "GPT-5.4",
+      } as Parameters<typeof secondStreamFn>[0],
+      {
+        systemPrompt: "test",
+        messages: [userMsg("Again") as Parameters<typeof convertMessagesToInputItems>[0][number]],
+        tools: [],
+      } as Parameters<typeof secondStreamFn>[1],
+    );
+
+    await new Promise((r) => setImmediate(r));
+    expect(MockManager.instances).toHaveLength(2);
+    expect(firstManager.closeCallCount).toBe(1);
+    const secondManager = MockManager.lastInstance!;
+    expect(secondManager).not.toBe(firstManager);
+    expect(secondManager.connectCallCount).toBe(1);
+
+    secondManager.simulateEvent({
+      type: "response.completed",
+      response: makeResponseObject("resp-second", "done"),
+    });
+    for await (const _ of await resolveStream(secondStream)) {
+      // consume
+    }
+  });
 });
 
 describe("convertMessagesToInputItems — phase inheritance", () => {

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -71,6 +71,7 @@ import { mergeTransportMetadata } from "./transport-stream-shared.js";
 
 interface WsSession {
   manager: OpenAIWebSocketManager;
+  managerConfigSignature: string;
   /** Number of messages that were in context.messages at the END of the last streamFn call. */
   lastContextLength: number;
   /** True if the connection has been established at least once. */
@@ -333,6 +334,30 @@ function createWsManager(
           },
         }
       : {}),
+  });
+}
+
+function stringifyStable(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stringifyStable(entry)).join(",")}]`;
+  }
+  const entries = Object.entries(value).toSorted(([left], [right]) => left.localeCompare(right));
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stringifyStable(entry)}`)
+    .join(",")}}`;
+}
+
+function resolveWsManagerConfigSignature(
+  managerOptions: OpenAIWebSocketManagerOptions | undefined,
+  sessionHeaders?: Record<string, string>,
+): string {
+  return stringifyStable({
+    headers: sessionHeaders,
+    request: managerOptions?.request,
+    url: managerOptions?.url,
   });
 }
 
@@ -661,10 +686,15 @@ export function createOpenAIWebSocketStreamFn(
 
       while (true) {
         let session = wsRegistry.get(sessionId);
+        const managerConfigSignature = resolveWsManagerConfigSignature(
+          opts.managerOptions,
+          sessionHeaders,
+        );
         if (!session) {
           const manager = createWsManager(opts.managerOptions, sessionHeaders);
           session = {
             manager,
+            managerConfigSignature,
             lastContextLength: 0,
             everConnected: false,
             warmUpAttempted: false,
@@ -673,6 +703,13 @@ export function createOpenAIWebSocketStreamFn(
             degradeCooldownMs: wsSessionPolicy.degradeCooldownMs,
           };
           wsRegistry.set(sessionId, session);
+        } else if (session.managerConfigSignature !== managerConfigSignature) {
+          resetWsSession({
+            session,
+            createManager: () => createWsManager(opts.managerOptions, sessionHeaders),
+          });
+          session.managerConfigSignature = managerConfigSignature;
+          session.degradeCooldownMs = wsSessionPolicy.degradeCooldownMs;
         }
 
         if (transport !== "websocket" && isWsSessionDegraded(session)) {

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -2,6 +2,7 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
 import { createOpenAIWebSocketStreamFn } from "../openai-ws-stream.js";
+import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { createBoundaryAwareStreamFnForModel } from "../provider-transport-stream.js";
 import { stripSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import type { EmbeddedRunAttemptParams } from "./run/types.js";
@@ -105,6 +106,9 @@ export function resolveEmbeddedAgentStreamFn(params: {
     return params.wsApiKey
       ? createOpenAIWebSocketStreamFn(params.wsApiKey, params.sessionId, {
           signal: params.signal,
+          managerOptions: {
+            request: getModelProviderRequestTransport(params.model),
+          },
         })
       : currentStreamFn;
   }

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -332,6 +332,24 @@ describe("provider request config", () => {
     });
   });
 
+  it("preserves request.allowPrivateNetwork for operator-trusted LAN/overlay model bases", () => {
+    expect(sanitizeConfiguredModelProviderRequest({ allowPrivateNetwork: true })).toEqual({
+      allowPrivateNetwork: true,
+    });
+    expect(sanitizeConfiguredModelProviderRequest({ allowPrivateNetwork: false })).toEqual({
+      allowPrivateNetwork: false,
+    });
+  });
+
+  it("merges allowPrivateNetwork with later override winning", () => {
+    expect(
+      mergeProviderRequestOverrides({ allowPrivateNetwork: true }, { allowPrivateNetwork: false }),
+    ).toEqual({ allowPrivateNetwork: false });
+    expect(
+      mergeProviderRequestOverrides({ allowPrivateNetwork: false }, { allowPrivateNetwork: true }),
+    ).toEqual({ allowPrivateNetwork: true });
+  });
+
   it("merges configured request overrides with later entries winning", () => {
     expect(
       mergeProviderRequestOverrides(

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildProviderRequestDispatcherPolicy,
+  mergeModelProviderRequestOverrides,
   mergeProviderRequestOverrides,
   resolveProviderRequestPolicyConfig,
   resolveProviderRequestConfig,
@@ -9,6 +10,7 @@ import {
   sanitizeConfiguredProviderRequest,
   sanitizeRuntimeProviderRequestOverrides,
 } from "./provider-request-config.js";
+import type { ProviderRequestTransportOverrides } from "./provider-request-config.js";
 
 describe("provider request config", () => {
   it("merges discovered, provider, and model headers in precedence order", () => {
@@ -339,14 +341,25 @@ describe("provider request config", () => {
     expect(sanitizeConfiguredModelProviderRequest({ allowPrivateNetwork: false })).toEqual({
       allowPrivateNetwork: false,
     });
+    expect(
+      sanitizeConfiguredProviderRequest({
+        allowPrivateNetwork: true,
+      } as ProviderRequestTransportOverrides),
+    ).toBeUndefined();
   });
 
   it("merges allowPrivateNetwork with later override winning", () => {
     expect(
-      mergeProviderRequestOverrides({ allowPrivateNetwork: true }, { allowPrivateNetwork: false }),
+      mergeModelProviderRequestOverrides(
+        { allowPrivateNetwork: true },
+        { allowPrivateNetwork: false },
+      ),
     ).toEqual({ allowPrivateNetwork: false });
     expect(
-      mergeProviderRequestOverrides({ allowPrivateNetwork: false }, { allowPrivateNetwork: true }),
+      mergeModelProviderRequestOverrides(
+        { allowPrivateNetwork: false },
+        { allowPrivateNetwork: true },
+      ),
     ).toEqual({ allowPrivateNetwork: true });
   });
 

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -57,6 +57,9 @@ export type ProviderRequestTransportOverrides = {
   auth?: ProviderRequestAuthOverride;
   proxy?: ProviderRequestProxyOverride;
   tls?: ProviderRequestTlsOverride;
+};
+
+export type ModelProviderRequestTransportOverrides = ProviderRequestTransportOverrides & {
   allowPrivateNetwork?: boolean;
 };
 
@@ -159,7 +162,7 @@ type ResolveProviderRequestPolicyConfigParams = {
   } | null;
   modelId?: string | null;
   allowPrivateNetwork?: boolean;
-  request?: ProviderRequestTransportOverrides;
+  request?: ModelProviderRequestTransportOverrides;
 };
 
 function sanitizeConfiguredRequestString(value: unknown, path: string): string | undefined {
@@ -174,7 +177,7 @@ function sanitizeConfiguredRequestString(value: unknown, path: string): string |
 }
 
 export function sanitizeConfiguredProviderRequest(
-  request: ConfiguredModelProviderRequest | ProviderRequestTransportOverrides | undefined,
+  request: ProviderRequestTransportOverrides | undefined,
 ): ProviderRequestTransportOverrides | undefined {
   if (!request || typeof request !== "object" || Array.isArray(request)) {
     return undefined;
@@ -287,10 +290,8 @@ export function sanitizeConfiguredProviderRequest(
   }
 
   const tls = sanitizeTls(request.tls, "request.tls");
-  const rawAllow = (request as { allowPrivateNetwork?: unknown }).allowPrivateNetwork;
-  const allowPrivateNetwork = rawAllow === true ? true : rawAllow === false ? false : undefined;
 
-  if (!headers && !auth && !proxy && !tls && allowPrivateNetwork === undefined) {
+  if (!headers && !auth && !proxy && !tls) {
     return undefined;
   }
   return {
@@ -298,14 +299,22 @@ export function sanitizeConfiguredProviderRequest(
     ...(auth ? { auth } : {}),
     ...(proxy ? { proxy } : {}),
     ...(tls ? { tls } : {}),
-    ...(allowPrivateNetwork !== undefined ? { allowPrivateNetwork } : {}),
   };
 }
 
 export function sanitizeConfiguredModelProviderRequest(
   request: ConfiguredModelProviderRequest | undefined,
-): ProviderRequestTransportOverrides | undefined {
-  return sanitizeConfiguredProviderRequest(request);
+): ModelProviderRequestTransportOverrides | undefined {
+  const sanitized = sanitizeConfiguredProviderRequest(request);
+  const rawAllow = request?.allowPrivateNetwork;
+  const allowPrivateNetwork = rawAllow === true ? true : rawAllow === false ? false : undefined;
+  if (!sanitized && allowPrivateNetwork === undefined) {
+    return undefined;
+  }
+  return {
+    ...sanitized,
+    ...(allowPrivateNetwork !== undefined ? { allowPrivateNetwork } : {}),
+  };
 }
 
 export function mergeProviderRequestOverrides(
@@ -333,6 +342,21 @@ export function mergeProviderRequestOverrides(
         ? { allowPrivateNetwork: current.allowPrivateNetwork }
         : {}),
     };
+  }
+  return merged;
+}
+
+export function mergeModelProviderRequestOverrides(
+  ...overrides: Array<ModelProviderRequestTransportOverrides | undefined>
+): ModelProviderRequestTransportOverrides | undefined {
+  let merged = mergeProviderRequestOverrides(...overrides);
+  for (const current of overrides) {
+    if (current?.allowPrivateNetwork !== undefined) {
+      merged = {
+        ...merged,
+        allowPrivateNetwork: current.allowPrivateNetwork,
+      };
+    }
   }
   return merged;
 }
@@ -698,12 +722,12 @@ const MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL = Symbol.for(
 );
 
 type ModelWithProviderRequestTransport = {
-  [MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL]?: ProviderRequestTransportOverrides;
+  [MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL]?: ModelProviderRequestTransportOverrides;
 };
 
 export function attachModelProviderRequestTransport<TModel extends object>(
   model: TModel,
-  request: ProviderRequestTransportOverrides | undefined,
+  request: ModelProviderRequestTransportOverrides | undefined,
 ): TModel {
   if (!request) {
     return model;
@@ -715,6 +739,6 @@ export function attachModelProviderRequestTransport<TModel extends object>(
 
 export function getModelProviderRequestTransport(
   model: object,
-): ProviderRequestTransportOverrides | undefined {
+): ModelProviderRequestTransportOverrides | undefined {
   return (model as ModelWithProviderRequestTransport)[MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL];
 }

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -57,6 +57,7 @@ export type ProviderRequestTransportOverrides = {
   auth?: ProviderRequestAuthOverride;
   proxy?: ProviderRequestProxyOverride;
   tls?: ProviderRequestTlsOverride;
+  allowPrivateNetwork?: boolean;
 };
 
 export type ResolvedProviderRequestAuthConfig =
@@ -286,8 +287,10 @@ export function sanitizeConfiguredProviderRequest(
   }
 
   const tls = sanitizeTls(request.tls, "request.tls");
+  const rawAllow = (request as { allowPrivateNetwork?: unknown }).allowPrivateNetwork;
+  const allowPrivateNetwork = rawAllow === true ? true : rawAllow === false ? false : undefined;
 
-  if (!headers && !auth && !proxy && !tls) {
+  if (!headers && !auth && !proxy && !tls && allowPrivateNetwork === undefined) {
     return undefined;
   }
   return {
@@ -295,6 +298,7 @@ export function sanitizeConfiguredProviderRequest(
     ...(auth ? { auth } : {}),
     ...(proxy ? { proxy } : {}),
     ...(tls ? { tls } : {}),
+    ...(allowPrivateNetwork !== undefined ? { allowPrivateNetwork } : {}),
   };
 }
 
@@ -325,6 +329,9 @@ export function mergeProviderRequestOverrides(
       ...(current.auth ? { auth: current.auth } : {}),
       ...(current.proxy ? { proxy: current.proxy } : {}),
       ...(current.tls ? { tls: current.tls } : {}),
+      ...(current.allowPrivateNetwork !== undefined
+        ? { allowPrivateNetwork: current.allowPrivateNetwork }
+        : {}),
     };
   }
   return merged;

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -55,13 +55,15 @@ function buildManagedResponse(response: Response, release: () => Promise<void>):
 }
 
 function resolveModelRequestPolicy(model: Model<Api>) {
+  const request = getModelProviderRequestTransport(model);
   return resolveProviderRequestPolicyConfig({
     provider: model.provider,
     api: model.api,
     baseUrl: model.baseUrl,
     capability: "llm",
     transport: "stream",
-    request: getModelProviderRequestTransport(model),
+    request,
+    allowPrivateNetwork: request?.allowPrivateNetwork === true,
   });
 }
 

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -8739,9 +8739,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           },
                           additionalProperties: false,
                         },
-                        allowPrivateNetwork: {
-                          type: "boolean",
-                        },
                       },
                       additionalProperties: false,
                     },
@@ -10047,9 +10044,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                         additionalProperties: false,
                       },
-                      allowPrivateNetwork: {
-                        type: "boolean",
-                      },
                     },
                     additionalProperties: false,
                   },
@@ -11331,9 +11325,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                                 },
                               },
                               additionalProperties: false,
-                            },
-                            allowPrivateNetwork: {
-                              type: "boolean",
                             },
                           },
                           additionalProperties: false,
@@ -12692,9 +12683,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         description:
                           "Direct TLS client settings for audio provider requests, including custom CA trust, client certs, or SNI overrides for managed gateways and internal endpoints.",
                       },
-                      allowPrivateNetwork: {
-                        type: "boolean",
-                      },
                     },
                     additionalProperties: false,
                     title: "Audio Request Overrides",
@@ -13979,9 +13967,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                                 },
                               },
                               additionalProperties: false,
-                            },
-                            allowPrivateNetwork: {
-                              type: "boolean",
                             },
                           },
                           additionalProperties: false,
@@ -15295,9 +15280,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                         additionalProperties: false,
                       },
-                      allowPrivateNetwork: {
-                        type: "boolean",
-                      },
                     },
                     additionalProperties: false,
                   },
@@ -16579,9 +16561,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                                 },
                               },
                               additionalProperties: false,
-                            },
-                            allowPrivateNetwork: {
-                              type: "boolean",
                             },
                           },
                           additionalProperties: false,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2695,11 +2695,17 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                       description:
                         "Optional TLS settings used when connecting directly to the upstream model endpoint.",
                     },
+                    allowPrivateNetwork: {
+                      type: "boolean",
+                      title: "Model Provider Request Allow Private Network",
+                      description:
+                        "When true, allow HTTPS/WebSocket to the model base URL when DNS resolves to private, CGNAT, or similar ranges. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
+                    },
                   },
                   additionalProperties: false,
                   title: "Model Provider Request Overrides",
                   description:
-                    "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, and TLS client settings. Use these only when your upstream or enterprise network path requires transport customization.",
+                    "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, TLS client settings, and optional allowPrivateNetwork for trusted self-hosted endpoints. Use these only when your upstream or enterprise network path requires transport customization.",
                 },
                 models: {
                   type: "array",
@@ -8733,6 +8739,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           },
                           additionalProperties: false,
                         },
+                        allowPrivateNetwork: {
+                          type: "boolean",
+                        },
                       },
                       additionalProperties: false,
                     },
@@ -10038,6 +10047,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                         additionalProperties: false,
                       },
+                      allowPrivateNetwork: {
+                        type: "boolean",
+                      },
                     },
                     additionalProperties: false,
                   },
@@ -11319,6 +11331,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                                 },
                               },
                               additionalProperties: false,
+                            },
+                            allowPrivateNetwork: {
+                              type: "boolean",
                             },
                           },
                           additionalProperties: false,
@@ -12677,6 +12692,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         description:
                           "Direct TLS client settings for audio provider requests, including custom CA trust, client certs, or SNI overrides for managed gateways and internal endpoints.",
                       },
+                      allowPrivateNetwork: {
+                        type: "boolean",
+                      },
                     },
                     additionalProperties: false,
                     title: "Audio Request Overrides",
@@ -13961,6 +13979,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                                 },
                               },
                               additionalProperties: false,
+                            },
+                            allowPrivateNetwork: {
+                              type: "boolean",
                             },
                           },
                           additionalProperties: false,
@@ -15274,6 +15295,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                         additionalProperties: false,
                       },
+                      allowPrivateNetwork: {
+                        type: "boolean",
+                      },
                     },
                     additionalProperties: false,
                   },
@@ -16555,6 +16579,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                                 },
                               },
                               additionalProperties: false,
+                            },
+                            allowPrivateNetwork: {
+                              type: "boolean",
                             },
                           },
                           additionalProperties: false,
@@ -24833,7 +24860,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     },
     "models.providers.*.request": {
       label: "Model Provider Request Overrides",
-      help: "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, and TLS client settings. Use these only when your upstream or enterprise network path requires transport customization.",
+      help: "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, TLS client settings, and optional allowPrivateNetwork for trusted self-hosted endpoints. Use these only when your upstream or enterprise network path requires transport customization.",
       tags: ["models"],
     },
     "models.providers.*.request.headers": {
@@ -24965,6 +24992,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Model Provider Request TLS Skip Verify",
       help: "Skips upstream TLS certificate verification. Use only for controlled development environments.",
       tags: ["security", "models", "advanced"],
+    },
+    "models.providers.*.request.allowPrivateNetwork": {
+      label: "Model Provider Request Allow Private Network",
+      help: "When true, allow HTTPS/WebSocket to the model base URL when DNS resolves to private, CGNAT, or similar ranges. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
+      tags: ["access", "models"],
     },
     "models.providers.*.models": {
       label: "Model Provider Model List",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2699,7 +2699,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                       type: "boolean",
                       title: "Model Provider Request Allow Private Network",
                       description:
-                        "When true, allow HTTPS/WebSocket to the model base URL when DNS resolves to private, CGNAT, or similar ranges. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
+                        "When true, allow HTTPS to the model base URL when DNS resolves to private, CGNAT, or similar ranges, via the provider HTTP fetch guard (fetchWithSsrFGuard). OpenAI Responses WebSocket reuses request for headers/TLS but does not use that fetch SSRF path. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
                     },
                   },
                   additionalProperties: false,
@@ -24995,7 +24995,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     },
     "models.providers.*.request.allowPrivateNetwork": {
       label: "Model Provider Request Allow Private Network",
-      help: "When true, allow HTTPS/WebSocket to the model base URL when DNS resolves to private, CGNAT, or similar ranges. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
+      help: "When true, allow HTTPS to the model base URL when DNS resolves to private, CGNAT, or similar ranges, via the provider HTTP fetch guard (fetchWithSsrFGuard). OpenAI Responses WebSocket reuses request for headers/TLS but does not use that fetch SSRF path. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
       tags: ["access", "models"],
     },
     "models.providers.*.models": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -795,7 +795,7 @@ export const FIELD_HELP: Record<string, string> = {
   "models.providers.*.request.tls.insecureSkipVerify":
     "Skips upstream TLS certificate verification. Use only for controlled development environments.",
   "models.providers.*.request.allowPrivateNetwork":
-    "When true, allow HTTPS/WebSocket to the model base URL when DNS resolves to private, CGNAT, or similar ranges. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
+    "When true, allow HTTPS to the model base URL when DNS resolves to private, CGNAT, or similar ranges, via the provider HTTP fetch guard (fetchWithSsrFGuard). OpenAI Responses WebSocket reuses request for headers/TLS but does not use that fetch SSRF path. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
   "models.providers.*.models":
     "Declared model list for a provider including identifiers, metadata, and optional compatibility/cost hints. Keep IDs exact to provider catalog values so selection and fallback resolve correctly.",
   auth: "Authentication profile root used for multi-profile provider credentials and cooldown-based failover ordering. Keep profiles minimal and explicit so automatic failover behavior stays auditable.",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -745,7 +745,7 @@ export const FIELD_HELP: Record<string, string> = {
   "models.providers.*.authHeader":
     "When true, credentials are sent via the HTTP Authorization header even if alternate auth is possible. Use this only when your provider or proxy explicitly requires Authorization forwarding.",
   "models.providers.*.request":
-    "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, and TLS client settings. Use these only when your upstream or enterprise network path requires transport customization.",
+    "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, TLS client settings, and optional allowPrivateNetwork for trusted self-hosted endpoints. Use these only when your upstream or enterprise network path requires transport customization.",
   "models.providers.*.request.headers":
     "Extra headers merged into provider requests after default attribution and auth resolution.",
   "models.providers.*.request.auth":
@@ -794,6 +794,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional SNI/server-name override used when establishing upstream TLS.",
   "models.providers.*.request.tls.insecureSkipVerify":
     "Skips upstream TLS certificate verification. Use only for controlled development environments.",
+  "models.providers.*.request.allowPrivateNetwork":
+    "When true, allow HTTPS/WebSocket to the model base URL when DNS resolves to private, CGNAT, or similar ranges. Use only for operator-controlled self-hosted OpenAI-compatible endpoints (LAN, overlay, split DNS). Default is false.",
   "models.providers.*.models":
     "Declared model list for a provider including identifiers, metadata, and optional compatibility/cost hints. Keep IDs exact to provider catalog values so selection and fallback resolve correctly.",
   auth: "Authentication profile root used for multi-profile provider credentials and cooldown-based failover ordering. Keep profiles minimal and explicit so automatic failover behavior stays auditable.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -482,6 +482,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "models.providers.*.request.tls.passphrase": "Model Provider Request TLS Passphrase",
   "models.providers.*.request.tls.serverName": "Model Provider Request TLS Server Name",
   "models.providers.*.request.tls.insecureSkipVerify": "Model Provider Request TLS Skip Verify",
+  "models.providers.*.request.allowPrivateNetwork": "Model Provider Request Allow Private Network",
   "models.providers.*.models": "Model Provider Model List",
   "auth.cooldowns.billingBackoffHours": "Billing Backoff (hours)",
   "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -305,6 +305,26 @@ describe("config schema", () => {
     });
   });
 
+  it("rejects allowPrivateNetwork on media-understanding request config", () => {
+    expect(() =>
+      ToolsSchema.parse({
+        media: {
+          image: {
+            models: [
+              {
+                provider: "openai",
+                model: "gpt-4.1-mini",
+                request: {
+                  allowPrivateNetwork: true,
+                },
+              },
+            ],
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
   it("rejects unknown keys inside web fetch firecrawl config", () => {
     expect(() =>
       ToolsSchema.parse({

--- a/src/config/types.provider-request.ts
+++ b/src/config/types.provider-request.ts
@@ -40,6 +40,7 @@ export type ConfiguredProviderRequest = {
   auth?: ConfiguredProviderRequestAuth;
   proxy?: ConfiguredProviderRequestProxy;
   tls?: ConfiguredProviderRequestTls;
+  allowPrivateNetwork?: boolean;
 };
 
 export type ConfiguredModelProviderRequest = ConfiguredProviderRequest;

--- a/src/config/types.provider-request.ts
+++ b/src/config/types.provider-request.ts
@@ -40,7 +40,8 @@ export type ConfiguredProviderRequest = {
   auth?: ConfiguredProviderRequestAuth;
   proxy?: ConfiguredProviderRequestProxy;
   tls?: ConfiguredProviderRequestTls;
-  allowPrivateNetwork?: boolean;
 };
 
-export type ConfiguredModelProviderRequest = ConfiguredProviderRequest;
+export type ConfiguredModelProviderRequest = ConfiguredProviderRequest & {
+  allowPrivateNetwork?: boolean;
+};

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -286,6 +286,7 @@ const ConfiguredProviderRequestSchema = z
     auth: ConfiguredProviderRequestAuthSchema,
     proxy: ConfiguredProviderRequestProxySchema,
     tls: ConfiguredProviderRequestTlsSchema,
+    allowPrivateNetwork: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -280,18 +280,25 @@ const ConfiguredProviderRequestProxySchema = z
   ])
   .optional();
 
+const ConfiguredProviderRequestFields = {
+  headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
+  auth: ConfiguredProviderRequestAuthSchema,
+  proxy: ConfiguredProviderRequestProxySchema,
+  tls: ConfiguredProviderRequestTlsSchema,
+};
+
 const ConfiguredProviderRequestSchema = z
+  .object(ConfiguredProviderRequestFields)
+  .strict()
+  .optional();
+
+const ConfiguredModelProviderRequestSchema = z
   .object({
-    headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
-    auth: ConfiguredProviderRequestAuthSchema,
-    proxy: ConfiguredProviderRequestProxySchema,
-    tls: ConfiguredProviderRequestTlsSchema,
+    ...ConfiguredProviderRequestFields,
     allowPrivateNetwork: z.boolean().optional(),
   })
   .strict()
   .optional();
-
-const ConfiguredModelProviderRequestSchema = ConfiguredProviderRequestSchema;
 
 export const ModelDefinitionSchema = z
   .object({

--- a/src/plugins/runtime/model-auth-types.ts
+++ b/src/plugins/runtime/model-auth-types.ts
@@ -1,5 +1,5 @@
 import type { ResolvedProviderAuth } from "../../agents/model-auth-runtime-shared.js";
-import type { ProviderRequestTransportOverrides } from "../../agents/provider-request-config.js";
+import type { ModelProviderRequestTransportOverrides } from "../../agents/provider-request-config.js";
 
 /**
  * Runtime-ready auth result exposed to native plugins and context engines.
@@ -11,6 +11,6 @@ import type { ProviderRequestTransportOverrides } from "../../agents/provider-re
 export type ResolvedProviderRuntimeAuth = Omit<ResolvedProviderAuth, "apiKey"> & {
   apiKey?: string;
   baseUrl?: string;
-  request?: ProviderRequestTransportOverrides;
+  request?: ModelProviderRequestTransportOverrides;
   expiresAt?: number;
 };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -12,7 +12,7 @@ import type {
 } from "../agents/auth-profiles/types.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import type { FailoverReason } from "../agents/pi-embedded-helpers/types.js";
-import type { ProviderRequestTransportOverrides } from "../agents/provider-request-config.js";
+import type { ModelProviderRequestTransportOverrides } from "../agents/provider-request-config.js";
 import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
 import type { PromptMode } from "../agents/system-prompt.js";
 import type { ToolFsPolicy } from "../agents/tool-fs-policy.js";
@@ -479,7 +479,7 @@ export type ProviderPrepareRuntimeAuthContext = {
 export type ProviderPreparedRuntimeAuth = {
   apiKey: string;
   baseUrl?: string;
-  request?: ProviderRequestTransportOverrides;
+  request?: ModelProviderRequestTransportOverrides;
   expiresAt?: number;
 };
 


### PR DESCRIPTION
Add optional `request.allowPrivateNetwork` for operator-controlled self-hosted OpenAI-compatible bases (LAN/overlay/split DNS). Plumbs the flag into `resolveProviderRequestPolicyConfig` for streaming provider HTTP so `fetchWithSsrFGuard` can allow private-resolved model URLs when explicitly enabled. Embedded OpenAI Responses WebSocket uses the same `request` object (headers/TLS); it does not use the HTTP fetch SSRF stack.

Updates zod schema, config help/labels, unit tests for sanitize/merge, and threads provider `request` into the embedded WebSocket stream path (`stream-resolution.ts`).

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- **Problem:** Operators using self-hosted OpenAI-compatible APIs whose `baseUrl` resolves to private/CGNAT addresses were blocked by default SSRF-style protections, with no config-level way to opt in per provider.
- **Why it matters:** Legitimate LAN, split DNS, and overlay setups need an explicit, auditable switch; disabling SSRF globally is unsafe.
- **What changed:** New optional `models.providers.<id>.request.allowPrivateNetwork` (sanitized/merged like other request fields), wired through `resolveProviderRequestPolicyConfig` into provider HTTP fetch so `fetchWithSsrFGuard` respects the flag when `true`. Embedded OpenAI Responses WebSocket receives the model’s `request` via `managerOptions` for headers/TLS continuity (not the same SSRF gate as HTTP). Shared `ConfiguredProviderRequest` still exposes this field on some non-model surfaces that do not forward `request.allowPrivateNetwork` yet — acknowledged in review; follow-up to narrow schema or wire those paths separately.
- **What did NOT change (scope boundary):** Default behavior remains deny-private unless explicitly enabled; no broad SSRF relaxation beyond the provider request path described; unrelated providers/channels unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62147
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- **Root cause:** N/A (feature addition, not a regression fix).
- **Missing detection / guardrail:** N/A
- **Contributing context (if known):** N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/provider-request-config.test.ts` (sanitize + merge behavior for `allowPrivateNetwork`).
- **Scenario the test should lock in:** Config values normalize to boolean; merge precedence matches other `request` fields; invalid values do not silently enable private network access.
- **Why this is the smallest reliable guardrail:** Logic is centralized in provider request resolution; unit tests catch mis-merge/sanitize without needing live private endpoints.
- **Existing test that already covers this (if any):** New/updated tests in `provider-request-config.test.ts` as listed above.
- **If no new test is added, why not:** N/A — tests added/updated for sanitize/merge.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- New optional config: `models.providers.<providerId>.request.allowPrivateNetwork` (`boolean`). When omitted or `false`, behavior matches prior defaults (private-resolved model URLs remain blocked by the HTTP fetch SSRF policy). When `true`, provider **HTTP** streaming can reach private-resolved model `baseUrl`s via `fetchWithSsrFGuard` (operator opt-in). OpenAI Responses **WebSocket** uses the same `request` for handshake headers/TLS; it does not use that HTTP fetch SSRF path.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
N/A
```

## Security Impact (required)

- **New permissions/capabilities?** Yes — per-provider opt-in to relax SSRF policy for model `baseUrl` resolution to private addresses when explicitly set (HTTP fetch path).
- **Secrets/tokens handling changed?** No
- **New/changed network calls?** No new endpoints; same calls may be allowed to targets that were previously blocked when the flag is true.
- **Command/tool execution surface changed?** No
- **Data access scope changed?** No
- **If any `Yes`, explain risk + mitigation:** Risk: misconfiguration could expose traffic to unintended private hosts. Mitigation: default remains off; flag is per-provider and must be set deliberately; operators should only enable for trusted self-hosted bases.

## Repro + Verification

### Environment

- **OS:** (your OS)
- **Runtime/container:** (e.g. devcontainer / local Node version matching `engines`)
- **Model/provider:** Self-hosted OpenAI-compatible with `baseUrl` resolving to RFC1918/CGNAT (or your test harness).
- **Integration/channel (if any):** N/A
- **Relevant config (redacted):** `models.providers.<id>.baseUrl` + `models.providers.<id>.request.allowPrivateNetwork: true`

### Steps

1. Configure a provider with a private-resolved `baseUrl` and `request.allowPrivateNetwork: true`.
2. Exercise model usage over **provider HTTP streaming** (the path that uses `buildGuardedModelFetch` / `fetchWithSsrFGuard`). Optionally exercise OpenAI Responses WebSocket; headers/TLS come from `request`, not the HTTP SSRF gate.
3. Confirm HTTP traffic succeeds where it previously failed under default SSRF policy; with flag absent/false, behavior should match pre-change.

### Expected

- With flag `true`: model **HTTP** calls to a trusted private `baseUrl` succeed when DNS resolves privately (subject to the fetch guard).
- With flag `false`/omitted: behavior unchanged from before this PR (private resolution still blocked by policy on HTTP fetch).

### Actual

- (Fill after you verify locally or rely on CI.)

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

*(Adjust checkboxes to what you attach.)*

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:** Config parses; sanitize/merge unit tests; (add manual run if you did one).
- **Edge cases checked:** Omitted flag, `false`, `true`; invalid inputs rejected or normalized per tests.
- **What you did **not** verify:** Full E2E against a real private `baseUrl` in production-like network (if applicable).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- **Backward compatible?** Yes — default unchanged when the new field is omitted.
- **Config/env changes?** Yes — optional new field under `models.providers.*.request`.
- **Migration needed?** No
- **If yes, exact upgrade steps:** N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- **Risk:** Operator sets `allowPrivateNetwork` on a provider whose `baseUrl` is not fully trusted, widening SSRF exposure to internal networks.
  - **Mitigation:** Document as operator-only; default off; pair with network controls and trusted `baseUrl` where possible.