### PR TITLE
fix(agents): suppress duplicate user persistence on fallback retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ Docs: https://docs.openclaw.ai
 
 - Plugins/providers: preserve scoped cold-load fallback for enabled external manifest-contract capability providers missing from the startup registry, so providers such as Fish Audio can resolve on request without requiring `activation.onStartup` for correctness. (#76536) Thanks @Conan-Scott.
 - Gateway/update: carry `continuationMessage` from `update.run` into successful restart sentinels so session-scoped self-updates can resume one follow-up turn after the Gateway restarts. Refs #71178. (#74362) Thanks @100menotu001, @HeilbronAILabs, and @artnking.
+- Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
 
 ## 2026.5.2
 

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -765,6 +765,36 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.trajectoryFlushMock).toHaveBeenCalled();
   });
 
+  it("suppresses duplicate user persistence only after the current turn has flushed", async () => {
+    const attemptCalls: Array<Record<string, unknown>> = [];
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const first = await params.run(params.provider, params.model);
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [first],
+      };
+    });
+    state.runAgentAttemptMock.mockImplementation(async (params: unknown) => {
+      const attemptParams = params as Record<string, unknown>;
+      attemptCalls.push(attemptParams);
+      const persisted = attemptParams.onUserMessagePersisted;
+      if (typeof persisted === "function") {
+        persisted();
+      }
+      return makeSuccessResult("openai", "gpt-5.4");
+    });
+
+    await runBasicAgentCommand();
+
+    expect(attemptCalls).toHaveLength(2);
+    expect(attemptCalls[0]?.suppressPromptPersistenceOnRetry).not.toBe(true);
+    expect(typeof attemptCalls[0]?.onUserMessagePersisted).toBe("function");
+    expect(attemptCalls[1]?.suppressPromptPersistenceOnRetry).toBe(true);
+  });
+
   it("propagates non-switch errors without retrying and emits lifecycle error", async () => {
     state.runWithModelFallbackMock.mockRejectedValueOnce(new Error("provider down"));
 

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -766,7 +766,11 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
   });
 
   it("suppresses duplicate user persistence only after the current turn has flushed", async () => {
-    const attemptCalls: Array<Record<string, unknown>> = [];
+    type AttemptCall = {
+      onUserMessagePersisted?: () => void;
+      suppressPromptPersistenceOnRetry?: boolean;
+    };
+    const attemptCalls: AttemptCall[] = [];
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
       const first = await params.run(params.provider, params.model);
       const result = await params.run(params.provider, params.model);
@@ -777,13 +781,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         attempts: [first],
       };
     });
-    state.runAgentAttemptMock.mockImplementation(async (params: unknown) => {
-      const attemptParams = params as Record<string, unknown>;
+    state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
       attemptCalls.push(attemptParams);
-      const persisted = attemptParams.onUserMessagePersisted;
-      if (typeof persisted === "function") {
-        persisted();
-      }
+      attemptParams.onUserMessagePersisted?.();
       return makeSuccessResult("openai", "gpt-5.4");
     });
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -966,6 +966,7 @@ async function agentCommandInternal(
         });
 
         let fallbackAttemptIndex = 0;
+        let currentTurnUserMessagePersisted = false;
         const fallbackResult = await runWithModelFallback<AgentAttemptResult>({
           cfg,
           provider,
@@ -1022,6 +1023,11 @@ async function agentCommandInternal(
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
               sessionHasHistory:
                 !isNewSession || (await attemptExecutionRuntime.sessionFileHasContent(sessionFile)),
+              suppressPromptPersistenceOnRetry:
+                isFallbackRetry && currentTurnUserMessagePersisted,
+              onUserMessagePersisted: () => {
+                currentTurnUserMessagePersisted = true;
+              },
               onAgentEvent: (evt) => {
                 if (evt.stream.startsWith("codex_app_server.")) {
                   emitAgentEvent({

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -357,6 +357,8 @@ export function runAgentAttempt(params: {
   allowTransientCooldownProbe?: boolean;
   modelFallbacksOverride?: string[];
   sessionHasHistory?: boolean;
+  suppressPromptPersistenceOnRetry?: boolean;
+  onUserMessagePersisted?: () => void;
 }) {
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
   const claudeCliFallbackPrelude =
@@ -611,6 +613,8 @@ export function runAgentAttempt(params: {
     promptMode: params.opts.promptMode,
     disableTools: params.opts.modelRun === true,
     onAgentEvent: params.onAgentEvent,
+    suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
+    onUserMessagePersisted: params.onUserMessagePersisted,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
   });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { normalizeReplyPayload } from "../../auto-reply/reply/normalize-reply.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
@@ -358,7 +359,7 @@ export function runAgentAttempt(params: {
   modelFallbacksOverride?: string[];
   sessionHasHistory?: boolean;
   suppressPromptPersistenceOnRetry?: boolean;
-  onUserMessagePersisted?: () => void;
+  onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
 }) {
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
   const claudeCliFallbackPrelude =

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1143,6 +1143,8 @@ export async function runEmbeddedPiAgent(
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
+            suppressNextUserMessagePersistence: params.suppressNextUserMessagePersistence,
+            onUserMessagePersisted: params.onUserMessagePersisted,
           });
           const attempt = normalizeEmbeddedRunAttemptResult(rawAttempt);
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1433,8 +1433,8 @@ export async function runEmbeddedAttempt(
             : undefined,
         allowedToolNames,
         suppressNextUserMessagePersistence: params.suppressNextUserMessagePersistence,
-        onUserMessagePersisted: () => {
-          params.onUserMessagePersisted?.();
+        onUserMessagePersisted: (message) => {
+          params.onUserMessagePersisted?.(message);
         },
       });
       trackSessionManagerAccess(params.sessionFile);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1432,6 +1432,10 @@ export async function runEmbeddedAttempt(
             ? "aborted"
             : undefined,
         allowedToolNames,
+        suppressNextUserMessagePersistence: params.suppressNextUserMessagePersistence,
+        onUserMessagePersisted: () => {
+          params.onUserMessagePersisted?.();
+        },
       });
       trackSessionManagerAccess(params.sessionFile);
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-options.types.js";
 import type { ReplyPayload } from "../../../auto-reply/reply-payload.js";
@@ -179,7 +180,7 @@ export type RunEmbeddedPiAgentParams = {
    */
   allowTransientCooldownProbe?: boolean;
   suppressNextUserMessagePersistence?: boolean;
-  onUserMessagePersisted?: () => void;
+  onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
   /**
    * Dispose bundled MCP runtimes when the overall run ends instead of preserving
    * the session-scoped cache. Intended for one-shot local CLI runs that must

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -178,6 +178,8 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  suppressNextUserMessagePersistence?: boolean;
+  onUserMessagePersisted?: () => void;
   /**
    * Dispose bundled MCP runtimes when the overall run ends instead of preserving
    * the session-scoped cache. Intended for one-shot local CLI runs that must

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -97,6 +97,8 @@ export function guardSessionManager(
     allowSyntheticToolResults?: boolean;
     missingToolResultText?: string;
     allowedToolNames?: Iterable<string>;
+    suppressNextUserMessagePersistence?: boolean;
+    onUserMessagePersisted?: () => void | Promise<void>;
   },
 ): GuardedSessionManager {
   if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {
@@ -170,6 +172,8 @@ export function guardSessionManager(
             agentId: opts.agentId,
           })
         : undefined,
+    suppressNextUserMessagePersistence: opts?.suppressNextUserMessagePersistence,
+    onUserMessagePersisted: opts?.onUserMessagePersisted,
   });
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
   (sessionManager as GuardedSessionManager).clearPendingToolResults = guard.clearPendingToolResults;

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -98,7 +98,9 @@ export function guardSessionManager(
     missingToolResultText?: string;
     allowedToolNames?: Iterable<string>;
     suppressNextUserMessagePersistence?: boolean;
-    onUserMessagePersisted?: () => void | Promise<void>;
+    onUserMessagePersisted?: (
+      message: Extract<AgentMessage, { role: "user" }>,
+    ) => void | Promise<void>;
   },
 ): GuardedSessionManager {
   if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -498,6 +498,35 @@ describe("installSessionToolResultGuard", () => {
     });
   });
 
+  it("suppresses only the next persisted user message when requested", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(
+      sm,
+      {
+        suppressNextUserMessagePersistence: true,
+      } as never,
+    );
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "first",
+        timestamp: Date.now(),
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "second",
+        timestamp: Date.now() + 1,
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm);
+    expect(persisted.map((message) => message.role)).toEqual(["user"]);
+    expect(persisted[0]).toMatchObject({ content: "second" });
+  });
+
   // When an assistant message with toolCalls is aborted, no synthetic toolResult
   // should be created. Creating synthetic results for aborted/incomplete tool calls
   // causes API 400 errors: "unexpected tool_use_id found in tool_result blocks".

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -500,12 +500,9 @@ describe("installSessionToolResultGuard", () => {
 
   it("suppresses only the next persisted user message when requested", () => {
     const sm = SessionManager.inMemory();
-    installSessionToolResultGuard(
-      sm,
-      {
-        suppressNextUserMessagePersistence: true,
-      } as never,
-    );
+    installSessionToolResultGuard(sm, {
+      suppressNextUserMessagePersistence: true,
+    });
 
     sm.appendMessage(
       asAppendMessage({

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -302,6 +302,8 @@ export function installSessionToolResultGuard(
       event: PluginHookBeforeMessageWriteEvent,
     ) => PluginHookBeforeMessageWriteResult | undefined;
     maxToolResultChars?: number;
+    suppressNextUserMessagePersistence?: boolean;
+    onUserMessagePersisted?: () => void | Promise<void>;
   },
 ): {
   flushPendingToolResults: () => void;
@@ -328,6 +330,7 @@ export function installSessionToolResultGuard(
   const missingToolResultText = opts?.missingToolResultText;
   const beforeWrite = opts?.beforeMessageWriteHook;
   const maxToolResultChars = resolveMaxToolResultChars(opts);
+  let suppressNextUserMessagePersistence = opts?.suppressNextUserMessagePersistence === true;
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -450,6 +453,13 @@ export function installSessionToolResultGuard(
     if (!finalMessage) {
       return undefined;
     }
+    if (
+      (finalMessage as { role?: unknown }).role === "user" &&
+      suppressNextUserMessagePersistence
+    ) {
+      suppressNextUserMessagePersistence = false;
+      return undefined;
+    }
     const result = originalAppend(finalMessage as never);
 
     const sessionFile = (
@@ -466,6 +476,9 @@ export function installSessionToolResultGuard(
 
     if (toolCalls.length > 0) {
       pendingState.trackToolCalls(toolCalls);
+    }
+    if ((finalMessage as { role?: unknown }).role === "user") {
+      void opts?.onUserMessagePersisted?.();
     }
 
     return result;

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -303,7 +303,9 @@ export function installSessionToolResultGuard(
     ) => PluginHookBeforeMessageWriteResult | undefined;
     maxToolResultChars?: number;
     suppressNextUserMessagePersistence?: boolean;
-    onUserMessagePersisted?: () => void | Promise<void>;
+    onUserMessagePersisted?: (
+      message: Extract<AgentMessage, { role: "user" }>,
+    ) => void | Promise<void>;
   },
 ): {
   flushPendingToolResults: () => void;
@@ -478,7 +480,7 @@ export function installSessionToolResultGuard(
       pendingState.trackToolCalls(toolCalls);
     }
     if ((finalMessage as { role?: unknown }).role === "user") {
-      void opts?.onUserMessagePersisted?.();
+      void opts?.onUserMessagePersisted?.(finalMessage as Extract<AgentMessage, { role: "user" }>);
     }
 
     return result;

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -44,6 +44,12 @@ function resolveMaxToolResultChars(opts?: { maxToolResultChars?: number }): numb
   return Math.max(1, opts?.maxToolResultChars ?? DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS);
 }
 
+type UserAgentMessage = Extract<AgentMessage, { role: "user" }>;
+
+function isUserAgentMessage(message: AgentMessage): message is UserAgentMessage {
+  return message.role === "user";
+}
+
 // `details` is runtime/UI metadata, not model-visible tool output. Keep the
 // session JSONL useful for debugging without letting metadata blobs dominate
 // disk, replay repair, transcript broadcasts, or future tooling that reads raw
@@ -455,10 +461,7 @@ export function installSessionToolResultGuard(
     if (!finalMessage) {
       return undefined;
     }
-    if (
-      (finalMessage as { role?: unknown }).role === "user" &&
-      suppressNextUserMessagePersistence
-    ) {
+    if (isUserAgentMessage(finalMessage) && suppressNextUserMessagePersistence) {
       suppressNextUserMessagePersistence = false;
       return undefined;
     }
@@ -479,8 +482,8 @@ export function installSessionToolResultGuard(
     if (toolCalls.length > 0) {
       pendingState.trackToolCalls(toolCalls);
     }
-    if ((finalMessage as { role?: unknown }).role === "user") {
-      void opts?.onUserMessagePersisted?.(finalMessage as Extract<AgentMessage, { role: "user" }>);
+    if (isUserAgentMessage(finalMessage)) {
+      void opts?.onUserMessagePersisted?.(finalMessage);
     }
 
     return result;


### PR DESCRIPTION
## Summary

- suppress duplicate user-message persistence on embedded fallback retries once the current turn has already been written to the session transcript
- track current-turn persistence from the actual transcript append path instead of inferring it from whether the session already existed
- add focused regression coverage for the guard path and fallback-loop wiring

## Why

#58301 preserves the original message body on fallback retries, which is the right fix for prompt continuity. But once the original body is preserved, fallback retries can still append that same user turn again if the current turn already flushed before the retry.

This patch narrows the suppression decision to the current turn only:

- when the embedded runner actually persists the current user message, it fires a callback
- the surrounding fallback loop records that state for this run only
- later retries suppress just the duplicate persistence, while still allowing the retry prompt to be sent to the model

That keeps retry context intact without duplicating the transcript.

## What changed

- `src/agents/session-tool-result-guard.ts`
  - add one-shot suppression for the next persisted user message
  - add an `onUserMessagePersisted` callback that fires only after a user message is successfully written
- `src/agents/session-tool-result-guard-wrapper.ts`
  - thread the suppression flag and callback through `guardSessionManager(...)`
- `src/agents/pi-embedded-runner/run/params.ts`
- `src/agents/pi-embedded-runner/run.ts`
- `src/agents/pi-embedded-runner/run/attempt.ts`
  - forward the suppression/callback plumbing into each embedded attempt
- `src/agents/command/attempt-execution.ts`
  - forward `onUserMessagePersisted` and `suppressPromptPersistenceOnRetry` into `runEmbeddedPiAgent(...)`
- `src/agents/agent-command.ts`
  - keep a run-local `currentTurnUserMessagePersisted` flag and suppress duplicate persistence only on fallback retries after that flag flips true
- tests:
  - `src/agents/session-tool-result-guard.test.ts`
  - `src/agents/agent-command.live-model-switch.test.ts`

## Scope

- embedded-agent fallback persistence only
- no Telegram delivery changes
- no change to the fallback prompt-selection policy itself

## Related

- Related #26764
- Companion to #58301

## Validation

Ran locally on a fresh `main` clone:

- `corepack pnpm exec vitest run --config vitest.config.ts src/agents/session-tool-result-guard.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/pi-embedded-runner.guard.test.ts src/agents/command/attempt-execution.test.ts`
  - result: `4 files passed, 52 tests passed`
- `corepack pnpm exec vitest run --config vitest.e2e.config.ts src/agents/model-fallback.run-embedded.e2e.test.ts`
  - result: `1 file passed, 13 tests passed`

Also checked:

- `git diff --check`

## Notes

`corepack pnpm build` currently fails on fresh `main` before this diff is applied due an unrelated baseline resolver error:

- `Could not resolve 'acpx/runtime' in extensions/acpx/src/runtime.ts`

I did not change any `acpx` files in this PR.