### PR TITLE
fix: enable open-prose /prose slash command by default

### DIFF
--- a/extensions/open-prose/openclaw.plugin.json
+++ b/extensions/open-prose/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "open-prose",
+  "enabledByDefault": true,
   "name": "OpenProse",
   "description": "OpenProse VM skill pack with a /prose slash command.",
   "skills": ["./skills"],

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -64,7 +64,10 @@ describe("loadWorkspaceSkillEntries", () => {
       bundledSkillsDir: path.join(workspaceDir, ".bundled"),
     });
 
-    expect(entries).toEqual([]);
+    // Bundled plugin skills with enabledByDefault may appear from the
+    // repo-level extensions/ directory. The assertion verifies no error
+    // is thrown when the managed skills directory is empty.
+    expect(Array.isArray(entries)).toBe(true);
   });
 
   it("includes plugin-shipped skills when the plugin is enabled", async () => {

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -65,9 +65,10 @@ describe("loadWorkspaceSkillEntries", () => {
     });
 
     // Bundled plugin skills with enabledByDefault may appear from the
-    // repo-level extensions/ directory. The assertion verifies no error
-    // is thrown when the managed skills directory is empty.
-    expect(Array.isArray(entries)).toBe(true);
+    // repo-level extensions/ directory.  Filter them out so the assertion
+    // still catches regressions where workspace/managed skills leak in.
+    const nonPluginEntries = entries.filter((e) => e.skill.source !== "openclaw-extra");
+    expect(nonPluginEntries).toEqual([]);
   });
 
   it("includes plugin-shipped skills when the plugin is enabled", async () => {

--- a/src/agents/skills/plugin-skills.test.ts
+++ b/src/agents/skills/plugin-skills.test.ts
@@ -261,4 +261,69 @@ describe("resolvePluginSkillDirs", () => {
 
     expect(dirs).toEqual([path.resolve(pluginRoot, "skills")]);
   });
+
+  it("includes bundled plugin skills when enabledByDefault is true without explicit config", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-");
+    const pluginRoot = await tempDirs.make("openclaw-bundled-default-");
+    await fs.mkdir(path.join(pluginRoot, "skills"), { recursive: true });
+
+    hoisted.loadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [
+        {
+          id: "open-prose",
+          name: "OpenProse",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: ["./skills"],
+          hooks: [],
+          origin: "bundled",
+          enabledByDefault: true,
+          rootDir: pluginRoot,
+          source: pluginRoot,
+          manifestPath: path.join(pluginRoot, "openclaw.plugin.json"),
+        },
+      ],
+    });
+
+    const dirs = resolvePluginSkillDirs({
+      workspaceDir,
+      config: {} as OpenClawConfig,
+    });
+
+    expect(dirs).toEqual([path.resolve(pluginRoot, "skills")]);
+  });
+
+  it("excludes bundled plugin skills when enabledByDefault is not set", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-");
+    const pluginRoot = await tempDirs.make("openclaw-bundled-nodefault-");
+    await fs.mkdir(path.join(pluginRoot, "skills"), { recursive: true });
+
+    hoisted.loadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [
+        {
+          id: "some-plugin",
+          name: "Some Plugin",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: ["./skills"],
+          hooks: [],
+          origin: "bundled",
+          rootDir: pluginRoot,
+          source: pluginRoot,
+          manifestPath: path.join(pluginRoot, "openclaw.plugin.json"),
+        },
+      ],
+    });
+
+    const dirs = resolvePluginSkillDirs({
+      workspaceDir,
+      config: {} as OpenClawConfig,
+    });
+
+    expect(dirs).toEqual([]);
+  });
 });

--- a/src/agents/skills/plugin-skills.ts
+++ b/src/agents/skills/plugin-skills.ts
@@ -77,6 +77,7 @@ export function resolvePluginSkillDirs(params: {
       origin: record.origin,
       config: normalizedPlugins,
       rootConfig: params.config,
+      enabledByDefault: record.enabledByDefault,
     });
     if (!activationState.activated) {
       continue;


### PR DESCRIPTION
Fixes #63641

## Problem
The `/prose` slash command from the open-prose bundled plugin was not discoverable because:

1. `resolvePluginSkillDirs` did not forward `enabledByDefault` from the manifest record to `resolveEffectivePluginActivationState`, so bundled plugins without explicit user config were silently disabled.
2. The open-prose manifest lacked `enabledByDefault: true`, causing the bundled catch-all in `resolvePluginActivationState` to return `activated: false`.

## Fix
- Add `enabledByDefault: true` to `extensions/open-prose/openclaw.plugin.json`
- Forward `record.enabledByDefault` in `resolvePluginSkillDirs` to fix the general pipeline bug
- Add test coverage for both the positive and negative `enabledByDefault` cases
- Update workspace skill loading test for new activation behavior