### PR TITLE
docs(inferrs): remove stale compat workarounds from recommended config

### DIFF
--- a/docs/providers/inferrs.md
+++ b/docs/providers/inferrs.md
@@ -70,9 +70,6 @@ This example uses Gemma 4 on a local `inferrs` server.
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 131072,
             maxTokens: 4096,
-            compat: {
-              requiresStringContent: true,
-            },
           },
         ],
       },
@@ -80,50 +77,6 @@ This example uses Gemma 4 on a local `inferrs` server.
   },
 }
 ```
-
-## Why `requiresStringContent` matters
-
-Some `inferrs` Chat Completions routes accept only string
-`messages[].content`, not structured content-part arrays.
-
-If OpenClaw runs fail with an error like:
-
-```text
-messages[1].content: invalid type: sequence, expected a string
-```
-
-set:
-
-```json5
-compat: {
-  requiresStringContent: true
-}
-```
-
-OpenClaw will flatten pure text content parts into plain strings before sending
-the request.
-
-## Gemma and tool-schema caveat
-
-Some current `inferrs` + Gemma combinations accept small direct
-`/v1/chat/completions` requests but still fail on full OpenClaw agent-runtime
-turns.
-
-If that happens, try this first:
-
-```json5
-compat: {
-  requiresStringContent: true,
-  supportsTools: false
-}
-```
-
-That disables OpenClaw's tool schema surface for the model and can reduce prompt
-pressure on stricter local backends.
-
-If tiny direct requests still work but normal OpenClaw agent turns continue to
-crash inside `inferrs`, the remaining issue is usually upstream model/server
-behavior rather than OpenClaw's transport layer.
 
 ## Manual smoke test
 
@@ -147,13 +100,14 @@ below.
 
 - `curl /v1/models` fails: `inferrs` is not running, not reachable, or not
   bound to the expected host/port.
-- `messages[].content ... expected a string`: set
-  `compat.requiresStringContent: true`.
 - Direct tiny `/v1/chat/completions` calls pass, but `openclaw infer model run`
-  fails: try `compat.supportsTools: false`.
-- OpenClaw no longer gets schema errors, but `inferrs` still crashes on larger
-  agent turns: treat it as an upstream `inferrs` or model limitation and reduce
-  prompt pressure or switch local backend/model.
+  fails: check `openclaw logs --follow` for the specific error and continue in
+  the deep runbook below.
+- `inferrs` crashes only on larger agent turns: reduce prompt pressure (shorter
+  session history, lighter model) or upgrade `inferrs` to the latest release.
+- On older `inferrs` releases (before structured content-part support was added),
+  you may see `messages[].content: invalid type: sequence, expected a string`.
+  Add `compat.requiresStringContent: true` as a workaround until you upgrade.
 
 ## Proxy-style behavior
 


### PR DESCRIPTION
## Summary

- **Problem:** The inferrs provider doc recommended `compat.requiresStringContent: true` in the default config and contained a "Gemma and tool-schema caveat" section telling users to also set `compat.supportsTools: false`. These workarounds were accurate when the doc was written but have since been fixed upstream in inferrs.
- **Why it matters:** New users following the doc will copy a config with unnecessary flags, which adds confusion and makes it harder to understand when those flags _are_ needed (older releases).
- **What changed:** Removed `compat.requiresStringContent: true` from the full config example, dropped the "Why `requiresStringContent` matters" and "Gemma and tool-schema caveat" sections, and tightened the Troubleshooting items to point users toward logs and upgrading rather than workaround flags. Kept a legacy note for users still on older inferrs releases.
- **What did NOT change:** The generic `requiresStringContent` / `supportsTools` guidance in `docs/gateway/troubleshooting.md`, `docs/gateway/local-models.md`, and `docs/help/troubleshooting.md` — those describe the flags as general-purpose options for any stricter OpenAI-compatible backend and remain accurate.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: the `fix: support inferrs string-only completions` commit (9d4b0d5) added `requiresStringContent` alongside the openclaw-side workaround; the inferrs-side fix has since been merged, making the flag unnecessary for current inferrs releases.
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The doc was written when inferrs did not yet accept structured content-part arrays or handle tool schemas in agent turns. Three fixes landed in inferrs after the doc was added: native content-part array deserialization, tool-schema-to-system-context injection, and agent-turn normalization (empty assistant turns, tool-role folding, sliding-window TurboQuant crash fix).
- Missing detection / guardrail: No process to re-visit doc accuracy after upstream fixes land.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A — docs-only change, no code paths altered.

- If no new test is added, why not: docs-only

## User-visible / Behavior Changes

Users following the inferrs quickstart will no longer copy `compat.requiresStringContent: true` into their config. The flag still works if present; removing it from the example just avoids unnecessary confusion.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local
- Model/provider: inferrs + google/gemma-4-E2B-it
- Relevant config (redacted): see PR diff

### Steps

1. Follow the updated quickstart config (no `compat` block).
2. Start inferrs with `inferrs serve google/gemma-4-E2B-it`.
3. Run `openclaw infer model run --model inferrs/google/gemma-4-E2B-it --prompt "What is 2+2?"`.

### Expected

- Response returned without `messages[].content` deserialization errors or tool-schema crashes.

### Actual

- Works correctly on current inferrs releases without any `compat` flags.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verified manually against a running inferrs server; the inferrs test suite (76 unit tests) passes including new agent-turn coverage added alongside these fixes.

## Human Verification (required)

- Verified scenarios: config without `compat` block works end-to-end with current inferrs.
- Edge cases checked: older inferrs releases are still covered by the legacy note in Troubleshooting.
- What you did **not** verify: non-Gemma models (should be unaffected — the removed sections were Gemma-specific).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (removing a recommended flag from docs; flag still works if users have it)
- Migration needed? No

## Risks and Mitigations

- Risk: a user on an older inferrs release follows the updated doc and hits the content-part error.
  - Mitigation: the legacy note in Troubleshooting explicitly calls this out and tells them to add `compat.requiresStringContent: true` or upgrade.

---

> [AI-assisted] Built with OpenCode/Claude. The doc change was drafted and verified by the author.