### PR TITLE
Preserve authored and runtime prompt metadata in chat transcripts

### DIFF
--- a/src/auto-reply/inline-buttons.test.ts
+++ b/src/auto-reply/inline-buttons.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStructuredInlineButtonsChannelData,
+  supportsStructuredInlineButtonsSurface,
+} from "./inline-buttons.js";
+
+describe("inline button surfaces", () => {
+  it("supports telegram and poros as structured button surfaces", () => {
+    expect(supportsStructuredInlineButtonsSurface("telegram")).toBe(true);
+    expect(supportsStructuredInlineButtonsSurface("poros")).toBe(true);
+    expect(supportsStructuredInlineButtonsSurface("discord")).toBe(false);
+  });
+
+  it("builds channelData for the active structured surface", () => {
+    const buttons = [[{ text: "OpenAI", callback_data: "mdl_list_openai_1" }]];
+
+    expect(buildStructuredInlineButtonsChannelData(buttons, "poros")).toEqual({
+      poros: { buttons },
+    });
+    expect(buildStructuredInlineButtonsChannelData(buttons, "telegram")).toEqual({
+      telegram: { buttons },
+    });
+    expect(buildStructuredInlineButtonsChannelData(buttons, "discord")).toBeUndefined();
+  });
+});

--- a/src/auto-reply/inline-buttons.ts
+++ b/src/auto-reply/inline-buttons.ts
@@ -1,0 +1,30 @@
+type InlineKeyboardButton = { text: string; callback_data: string };
+
+type InlineKeyboardRows = InlineKeyboardButton[][];
+
+const STRUCTURED_INLINE_BUTTON_SURFACES = new Set(["telegram", "poros"]);
+
+export function supportsStructuredInlineButtonsSurface(surface?: string): boolean {
+  return normalizeStructuredInlineButtonsSurface(surface) !== null;
+}
+
+export function buildStructuredInlineButtonsChannelData(
+  buttons: InlineKeyboardRows,
+  surface?: string,
+): Record<string, { buttons: InlineKeyboardRows }> | undefined {
+  const normalizedSurface = normalizeStructuredInlineButtonsSurface(surface);
+  if (!normalizedSurface || buttons.length === 0) {
+    return undefined;
+  }
+  return {
+    [normalizedSurface]: { buttons },
+  };
+}
+
+function normalizeStructuredInlineButtonsSurface(surface?: string): string | null {
+  const normalized = surface?.trim().toLowerCase();
+  if (!normalized || !STRUCTURED_INLINE_BUTTON_SURFACES.has(normalized)) {
+    return null;
+  }
+  return normalized;
+}

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -1,4 +1,8 @@
 import { logVerbose } from "../../globals.js";
+import {
+  buildStructuredInlineButtonsChannelData,
+  supportsStructuredInlineButtonsSurface,
+} from "../inline-buttons.js";
 import { listSkillCommandsForAgents } from "../skill-commands.js";
 import {
   buildCommandsMessage,
@@ -50,7 +54,7 @@ export const handleCommandsListCommand: CommandHandler = async (params, allowTex
     });
   const surface = params.ctx.Surface;
 
-  if (surface === "telegram") {
+  if (supportsStructuredInlineButtonsSurface(surface)) {
     const result = buildCommandsMessagePaginated(params.cfg, skillCommands, {
       page: 1,
       surface,
@@ -61,15 +65,10 @@ export const handleCommandsListCommand: CommandHandler = async (params, allowTex
         shouldContinue: false,
         reply: {
           text: result.text,
-          channelData: {
-            telegram: {
-              buttons: buildCommandsPaginationKeyboard(
-                result.currentPage,
-                result.totalPages,
-                params.agentId,
-              ),
-            },
-          },
+          channelData: buildStructuredInlineButtonsChannelData(
+            buildCommandsPaginationKeyboard(result.currentPage, result.totalPages, params.agentId),
+            surface,
+          ),
         },
       };
     }

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -17,6 +17,10 @@ import {
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import {
+  buildStructuredInlineButtonsChannelData,
+  supportsStructuredInlineButtonsSurface,
+} from "../inline-buttons.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -235,12 +239,11 @@ export async function resolveModelsCommandReply(params: {
   const { provider, page, pageSize, all } = parseModelsArgs(argText);
 
   const { byProvider, providers } = await buildModelsProviderData(params.cfg, params.agentId);
-  const isTelegram = params.surface === "telegram";
+  const supportsStructuredButtons = supportsStructuredInlineButtonsSurface(params.surface);
 
   // Provider list (no provider specified)
   if (!provider) {
-    // For Telegram: show buttons if there are providers
-    if (isTelegram && providers.length > 0) {
+    if (supportsStructuredButtons && providers.length > 0) {
       const providerInfos: ProviderInfo[] = providers.map((p) => ({
         id: p,
         count: byProvider.get(p)?.size ?? 0,
@@ -249,11 +252,10 @@ export async function resolveModelsCommandReply(params: {
       const text = "Select a provider:";
       return {
         text,
-        channelData: { telegram: { buttons } },
+        channelData: buildStructuredInlineButtonsChannelData(buttons, params.surface),
       };
     }
 
-    // Text fallback for non-Telegram surfaces
     const lines: string[] = [
       "Providers:",
       ...providers.map((p) =>
@@ -297,8 +299,7 @@ export async function resolveModelsCommandReply(params: {
     return { text: lines.join("\n") };
   }
 
-  // For Telegram: use button-based model list with inline keyboard pagination
-  if (isTelegram) {
+  if (supportsStructuredButtons) {
     const telegramPageSize = getModelsPageSize();
     const totalPages = calculateTotalPages(total, telegramPageSize);
     const safePage = Math.max(1, Math.min(page, totalPages));
@@ -321,11 +322,10 @@ export async function resolveModelsCommandReply(params: {
     });
     return {
       text,
-      channelData: { telegram: { buttons } },
+      channelData: buildStructuredInlineButtonsChannelData(buttons, params.surface),
     };
   }
 
-  // Text fallback for non-Telegram surfaces
   const effectivePageSize = all ? total : pageSize;
   const pageCount = effectivePageSize > 0 ? Math.ceil(total / effectivePageSize) : 1;
   const safePage = all ? 1 : Math.max(1, Math.min(page, pageCount));

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1362,6 +1362,31 @@ describe("/models command", () => {
     expect(buttons?.length).toBeGreaterThan(0);
   });
 
+  it("lists providers on poros (buttons)", async () => {
+    const params = buildPolicyParams("/models", cfg, { Provider: "poros", Surface: "poros" });
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toBe("Select a provider:");
+    const buttons = (result.reply?.channelData as { poros?: { buttons?: unknown[][] } })?.poros
+      ?.buttons;
+    expect(buttons).toBeDefined();
+    expect(buttons?.length).toBeGreaterThan(0);
+  });
+
+  it("lists provider models on poros with structured buttons", async () => {
+    const params = buildPolicyParams("/models anthropic", cfg, {
+      Provider: "poros",
+      Surface: "poros",
+    });
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Models (anthropic");
+    const buttons = (result.reply?.channelData as { poros?: { buttons?: unknown[][] } })?.poros
+      ?.buttons;
+    expect(buttons).toBeDefined();
+    expect(buttons?.length).toBeGreaterThan(0);
+  });
+
   it("handles provider model pagination, all mode, and unknown providers", async () => {
     const cases = [
       {
@@ -1464,6 +1489,26 @@ describe("/models command", () => {
     });
 
     expect(result.reply?.text).toContain("localai");
+  });
+});
+
+describe("/commands command", () => {
+  it("renders poros pagination buttons when multiple pages are available", async () => {
+    const cfg = {
+      commands: { text: true, config: false, debug: false },
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+    } as unknown as OpenClawConfig;
+
+    const result = await handleCommands(
+      buildPolicyParams("/commands", cfg, { Provider: "poros", Surface: "poros" }),
+    );
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("ℹ️ Commands (1/");
+    const buttons = (result.reply?.channelData as { poros?: { buttons?: unknown[][] } })?.poros
+      ?.buttons;
+    expect(buttons).toBeDefined();
+    expect(buttons?.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -117,6 +117,16 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("Switch: /model <provider/model>");
   });
 
+  it("shows structured buttons for poros /model summary", async () => {
+    const reply = await resolveModelInfoReply({ surface: "poros" });
+
+    expect(reply?.text).toContain("Current:");
+    expect(reply?.text).toContain("Tap below to browse models");
+    const buttons = (reply?.channelData as { poros?: { buttons?: unknown[][] } })?.poros?.buttons;
+    expect(buttons).toBeDefined();
+    expect(buttons?.length).toBeGreaterThan(0);
+  });
+
   it("shows active runtime model when different from selected model", async () => {
     const reply = await resolveModelInfoReply({
       provider: "fireworks",

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -14,6 +14,10 @@ import {
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { shortenHomePath } from "../../utils.js";
+import {
+  buildStructuredInlineButtonsChannelData,
+  supportsStructuredInlineButtonsSurface,
+} from "../inline-buttons.js";
 import { resolveSelectedAndActiveModel } from "../model-runtime.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveModelsCommandReply } from "./commands-models.js";
@@ -246,12 +250,12 @@ export async function maybeHandleModelDirectiveInfo(params: {
       sessionEntry: params.sessionEntry,
     });
     const current = modelRefs.selected.label;
-    const isTelegram = params.surface === "telegram";
+    const supportsStructuredButtons = supportsStructuredInlineButtonsSurface(params.surface);
     const activeRuntimeLine = modelRefs.activeDiffers
       ? `Active: ${modelRefs.active.label} (runtime)`
       : null;
 
-    if (isTelegram) {
+    if (supportsStructuredButtons) {
       const buttons = buildBrowseProvidersButton();
       return {
         text: [
@@ -264,7 +268,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
         ]
           .filter(Boolean)
           .join("\n"),
-        channelData: { telegram: { buttons } },
+        channelData: buildStructuredInlineButtonsChannelData(buttons, params.surface),
       };
     }
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -576,6 +576,13 @@ export async function runPreparedReply(
     },
   };
 
+  const preparedModelInput = prefixedCommandBody.trim();
+  if (preparedModelInput) {
+    opts?.onUserPromptPrepared?.({
+      modelInput: preparedModelInput,
+    });
+  }
+
   const { runReplyAgent } = await loadAgentRunnerRuntime();
   return runReplyAgent({
     commandBody: prefixedCommandBody,

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1303,18 +1303,54 @@ describe("buildCommandsMessagePaginated", () => {
     expect(result.text).toContain("/stop - Stop the current run.");
   });
 
-  it("includes plugin commands in the paginated list", () => {
-    listPluginCommands.mockReturnValue([
-      { name: "plugin_cmd", description: "Plugin command", pluginId: "demo-plugin" },
-    ]);
+  it("formats poros output with pages", () => {
     const result = buildCommandsMessagePaginated(
       {
         commands: { config: false, debug: false },
       } as unknown as OpenClawConfig,
       undefined,
-      { surface: "telegram", page: 99 },
+      { surface: "poros", page: 1 },
     );
-    expect(result.text).toContain("Plugins");
-    expect(result.text).toContain("/plugin_cmd (demo-plugin) - Plugin command");
+    expect(result.text).toContain("ℹ️ Commands (1/");
+    expect(result.text).toContain("Session");
+    expect(result.text).toContain("/stop - Stop the current run.");
+  });
+
+  it("includes plugin commands in the paginated list", () => {
+    vi.resetModules();
+    vi.doMock("../plugins/commands.js", () => ({
+      listPluginCommands: () => [
+        { name: "plugin_cmd", description: "Plugin command", pluginId: "demo-plugin" },
+      ],
+    }));
+
+    return import("./status.js").then(({ buildCommandsMessagePaginated: buildPaginated }) => {
+      const firstPage = buildPaginated(
+        {
+          commands: { config: false, debug: false },
+        } as unknown as OpenClawConfig,
+        undefined,
+        { surface: "telegram", page: 1 },
+      );
+
+      let foundPage = firstPage;
+      for (let page = 1; page <= firstPage.totalPages; page += 1) {
+        const result = buildPaginated(
+          {
+            commands: { config: false, debug: false },
+          } as unknown as OpenClawConfig,
+          undefined,
+          { surface: "telegram", page },
+        );
+        if (result.text.includes("/plugin_cmd (demo-plugin) - Plugin command")) {
+          foundPage = result;
+          break;
+        }
+      }
+
+      expect(foundPage.text).toContain("Plugins");
+      expect(foundPage.text).toContain("/plugin_cmd (demo-plugin) - Plugin command");
+      vi.doUnmock("../plugins/commands.js");
+    });
   });
 });

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -47,6 +47,7 @@ import {
 } from "./commands-registry.js";
 import type { CommandCategory } from "./commands-registry.types.js";
 import { resolveActiveFallbackState } from "./fallback-state.js";
+import { supportsStructuredInlineButtonsSurface } from "./inline-buttons.js";
 import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 
@@ -973,8 +974,8 @@ export function buildCommandsMessagePaginated(
   options?: CommandsMessageOptions,
 ): CommandsMessageResult {
   const page = Math.max(1, options?.page ?? 1);
-  const surface = options?.surface?.toLowerCase();
-  const isTelegram = surface === "telegram";
+  const surface = options?.surface;
+  const supportsStructuredButtons = supportsStructuredInlineButtonsSurface(surface);
 
   const commands = cfg
     ? listChatCommandsForConfig(cfg, { skillCommands })
@@ -982,7 +983,7 @@ export function buildCommandsMessagePaginated(
   const pluginCommands = listPluginCommands();
   const items = buildCommandItems(commands, pluginCommands);
 
-  if (!isTelegram) {
+  if (!supportsStructuredButtons) {
     const lines = ["ℹ️ Slash commands", ""];
     lines.push(formatCommandList(items));
     return {

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -14,6 +14,11 @@ export type ModelSelectedContext = {
   thinkLevel: string | undefined;
 };
 
+/** Context passed when the final user turn has been prepared for the model. */
+export type PreparedUserPromptContext = {
+  modelInput: string;
+};
+
 export type TypingPolicy =
   | "auto"
   | "user_message"
@@ -30,6 +35,8 @@ export type GetReplyOptions = {
   images?: ImageContent[];
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;
+  /** Called once the final model-bound user turn has been prepared. */
+  onUserPromptPrepared?: (ctx: PreparedUserPromptContext) => void;
   onReplyStart?: () => Promise<void> | void;
   /** Called when the typing controller cleans up (e.g., run ended with NO_REPLY). */
   onTypingCleanup?: () => void;

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -61,6 +61,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "tts.providers",
     "models.list",
     "tools.catalog",
+    "commands.list",
     "agents.list",
     "agent.identity.get",
     "skills.status",

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -35,6 +35,7 @@ export const ChatSendParamsSchema = Type.Object(
   {
     sessionKey: ChatSendSessionKeyString,
     message: Type.String(),
+    authoredContent: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -38,6 +38,7 @@ const BASE_METHODS = [
   "talk.mode",
   "models.list",
   "tools.catalog",
+  "commands.list",
   "agents.list",
   "agents.create",
   "agents.update",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -9,6 +9,7 @@ import { agentsHandlers } from "./server-methods/agents.js";
 import { browserHandlers } from "./server-methods/browser.js";
 import { channelsHandlers } from "./server-methods/channels.js";
 import { chatHandlers } from "./server-methods/chat.js";
+import { commandsHandlers } from "./server-methods/commands.js";
 import { configHandlers } from "./server-methods/config.js";
 import { connectHandlers } from "./server-methods/connect.js";
 import { cronHandlers } from "./server-methods/cron.js";
@@ -72,6 +73,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...healthHandlers,
   ...channelsHandlers,
   ...chatHandlers,
+  ...commandsHandlers,
   ...cronHandlers,
   ...deviceHandlers,
   ...doctorHandlers,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -20,6 +20,7 @@ const mockState = vi.hoisted(() => ({
   finalText: "[[reply_to_current]]",
   triggerAgentRunStart: false,
   agentRunId: "run-agent-1",
+  preparedModelInput: undefined as string | undefined,
   sessionEntry: {} as Record<string, unknown>,
   lastDispatchCtx: undefined as MsgContext | undefined,
   lastDispatchImages: undefined as Array<{ mimeType: string; data: string }> | undefined,
@@ -77,11 +78,17 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
       };
       replyOptions?: {
         onAgentRunStart?: (runId: string) => void;
+        onUserPromptPrepared?: (ctx: { modelInput: string }) => void;
         images?: Array<{ mimeType: string; data: string }>;
       };
     }) => {
       mockState.lastDispatchCtx = params.ctx;
       mockState.lastDispatchImages = params.replyOptions?.images;
+      if (mockState.preparedModelInput) {
+        params.replyOptions?.onUserPromptPrepared?.({
+          modelInput: mockState.preparedModelInput,
+        });
+      }
       if (mockState.triggerAgentRunStart) {
         params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
       }
@@ -323,6 +330,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.mainSessionKey = "main";
     mockState.triggerAgentRunStart = false;
     mockState.agentRunId = "run-agent-1";
+    mockState.preparedModelInput = undefined;
     mockState.sessionEntry = {};
     mockState.lastDispatchCtx = undefined;
     mockState.lastDispatchImages = undefined;
@@ -1126,6 +1134,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     createTranscriptFixture("openclaw-chat-send-user-transcript-agent-run-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
+    mockState.preparedModelInput = "System: [2026-04-09 10:00 UTC]\n\nhello from dashboard";
     const respond = vi.fn();
     const context = createChatContext();
 
@@ -1134,6 +1143,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-user-transcript-agent-run",
       message: "hello from dashboard",
+      requestParams: {
+        authoredContent: "hello from dashboard",
+      },
       expectBroadcast: false,
     });
 
@@ -1150,6 +1162,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         role: "user",
         content: "hello from dashboard",
         timestamp: expect.any(Number),
+        __openclaw: {
+          modelInput: "System: [2026-04-09 10:00 UTC]\n\nhello from dashboard",
+        },
       },
     });
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -279,6 +279,23 @@ function normalizeOptionalChatSystemReceipt(
   return { ok: true, receipt: receipt || undefined };
 }
 
+function normalizeOptionalChatAuthoredContent(
+  value: unknown,
+): { ok: true; authoredContent?: string } | { ok: false; error: string } {
+  if (value == null) {
+    return { ok: true };
+  }
+  if (typeof value !== "string") {
+    return { ok: false, error: "authoredContent must be a string" };
+  }
+  const sanitized = sanitizeChatSendMessageInput(value);
+  if (!sanitized.ok) {
+    return { ok: false, error: sanitized.error };
+  }
+  const authoredContent = sanitized.message.trim();
+  return { ok: true, authoredContent: authoredContent || undefined };
+}
+
 function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   const info = client?.connect?.client;
   return (
@@ -314,14 +331,38 @@ function buildChatSendTranscriptMessage(params: {
   message: string;
   savedImages: SavedMedia[];
   timestamp: number;
+  authoredContent?: string;
+  modelInput?: string;
 }) {
   const mediaFields = resolveChatSendTranscriptMediaFields(params.savedImages);
+  const openClawMeta = buildChatSendPromptMeta(params);
   return {
     role: "user" as const,
     content: params.message,
     timestamp: params.timestamp,
     ...mediaFields,
+    ...(openClawMeta ? { __openclaw: openClawMeta } : {}),
   };
+}
+
+function buildChatSendPromptMeta(params: {
+  message: string;
+  authoredContent?: string;
+  modelInput?: string;
+}): Record<string, string> | undefined {
+  const meta: Record<string, string> = {};
+  const messageContent = params.message.trim();
+  const authoredContent = params.authoredContent?.trim();
+  const modelInput = params.modelInput?.trim();
+
+  if (authoredContent && authoredContent !== messageContent) {
+    meta.authoredContent = authoredContent;
+  }
+  if (modelInput && modelInput !== messageContent) {
+    meta.modelInput = modelInput;
+  }
+
+  return Object.keys(meta).length > 0 ? meta : undefined;
 }
 
 function resolveChatSendTranscriptMediaFields(savedImages: SavedMedia[]) {
@@ -581,6 +622,30 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
     const res = truncateChatHistoryText(stripped.text);
     entry.text = res.text;
     changed ||= stripped.changed || res.truncated;
+  }
+
+  const openClawMeta =
+    entry.__openclaw && typeof entry.__openclaw === "object" && !Array.isArray(entry.__openclaw)
+      ? { ...(entry.__openclaw as Record<string, unknown>) }
+      : null;
+  if (openClawMeta) {
+    let metaChanged = false;
+
+    if (typeof openClawMeta.authoredContent === "string") {
+      const res = truncateChatHistoryText(openClawMeta.authoredContent);
+      openClawMeta.authoredContent = res.text;
+      metaChanged ||= res.truncated;
+    }
+    if (typeof openClawMeta.modelInput === "string") {
+      const res = truncateChatHistoryText(openClawMeta.modelInput);
+      openClawMeta.modelInput = res.text;
+      metaChanged ||= res.truncated;
+    }
+
+    if (metaChanged) {
+      entry.__openclaw = openClawMeta;
+      changed = true;
+    }
   }
 
   return { message: changed ? entry : message, changed };
@@ -1237,6 +1302,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const p = params as {
       sessionKey: string;
       message: string;
+      authoredContent?: string;
       thinking?: string;
       deliver?: boolean;
       attachments?: Array<{
@@ -1275,9 +1341,19 @@ export const chatHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, systemReceiptResult.error));
       return;
     }
+    const authoredContentResult = normalizeOptionalChatAuthoredContent(p.authoredContent);
+    if (!authoredContentResult.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, authoredContentResult.error),
+      );
+      return;
+    }
     const inboundMessage = sanitizedMessageResult.message;
     const systemInputProvenance = normalizeInputProvenance(p.systemInputProvenance);
     const systemProvenanceReceipt = systemReceiptResult.receipt;
+    const authoredContent = authoredContentResult.authoredContent;
     const stopCommand = isChatStopCommandText(inboundMessage);
     const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(p.attachments);
     const rawMessage = inboundMessage.trim();
@@ -1447,6 +1523,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         channel: INTERNAL_MESSAGE_CHANNEL,
       });
       const deliveredReplies: Array<{ payload: ReplyPayload; kind: "block" | "final" }> = [];
+      let preparedModelInput: string | undefined;
       let userTranscriptUpdateEmitted = false;
       const emitUserTranscriptUpdate = async () => {
         if (userTranscriptUpdateEmitted) {
@@ -1475,6 +1552,8 @@ export const chatHandlers: GatewayRequestHandlers = {
             message: parsedMessage,
             savedImages: persistedImages,
             timestamp: now,
+            authoredContent,
+            modelInput: preparedModelInput,
           }),
         });
       };
@@ -1527,6 +1606,10 @@ export const chatHandlers: GatewayRequestHandlers = {
           runId: clientRunId,
           abortSignal: abortController.signal,
           images: parsedImages.length > 0 ? parsedImages : undefined,
+          onUserPromptPrepared: (prepared) => {
+            const trimmed = prepared.modelInput.trim();
+            preparedModelInput = trimmed || undefined;
+          },
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
             void emitUserTranscriptUpdate();

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCodes } from "../protocol/index.js";
+import { commandsHandlers } from "./commands.js";
+
+type RespondCall = [boolean, unknown?, { code: number; message: string }?];
+
+function createInvokeParams(params: Record<string, unknown>) {
+  const calls: RespondCall[] = [];
+  const respond = ((...args: RespondCall) => {
+    calls.push(args);
+  }) as never;
+
+  return {
+    calls,
+    invoke: async () =>
+      await commandsHandlers["commands.list"]({
+        params,
+        respond,
+        context: {} as never,
+        client: null,
+        req: { type: "req", id: "req-1", method: "commands.list" },
+        isWebchatConnect: () => false,
+      }),
+  };
+}
+
+describe("commands.list handler", () => {
+  it("rejects invalid params", async () => {
+    const { calls, invoke } = createInvokeParams({ extra: true });
+    await invoke();
+    const call = calls[0];
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.INVALID_REQUEST);
+    expect(call?.[2]?.message).toContain("invalid commands.list params");
+  });
+
+  it("returns canonical slash commands with ACP and subagents entries", async () => {
+    const { calls, invoke } = createInvokeParams({});
+    await invoke();
+    const call = calls[0];
+    expect(call?.[0]).toBe(true);
+
+    const payload = call?.[1] as
+      | {
+          commands: Array<{
+            key: string;
+            textAliases: string[];
+            category?: string;
+            args?: Array<{ choices?: Array<string | { value: string; label: string }> }>;
+          }>;
+        }
+      | undefined;
+
+    const acp = payload?.commands.find((command) => command.key === "acp");
+    const subagents = payload?.commands.find((command) => command.key === "subagents");
+
+    expect(acp?.textAliases).toContain("/acp");
+    expect(acp?.category).toBe("management");
+    expect(
+      acp?.args?.[0]?.choices?.some((choice) =>
+        typeof choice === "string" ? choice === "spawn" : choice.value === "spawn",
+      ),
+    ).toBe(true);
+
+    expect(subagents?.textAliases).toContain("/subagents");
+    expect(subagents?.category).toBe("management");
+  });
+});

--- a/src/gateway/server-methods/commands.ts
+++ b/src/gateway/server-methods/commands.ts
@@ -1,0 +1,115 @@
+import { listChatCommands } from "../../auto-reply/commands-registry.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+type CommandArgChoice = string | { value: string; label: string };
+type CommandArgDefinition = {
+  name: string;
+  description: string;
+  type: "string" | "number" | "boolean";
+  required?: boolean;
+  choices?: CommandArgChoice[];
+  preferAutocomplete?: boolean;
+  captureRemaining?: boolean;
+};
+type ChatCommandCatalogEntry = {
+  key: string;
+  nativeName?: string;
+  description: string;
+  textAliases: string[];
+  acceptsArgs: boolean;
+  args?: CommandArgDefinition[];
+  argsParsing?: string;
+  argsMenu?: "auto" | { arg: string; title?: string };
+  scope?: string;
+  category?: string;
+};
+
+function isSerializableChoice(choice: unknown): choice is CommandArgChoice {
+  return (
+    typeof choice === "string" ||
+    (typeof choice === "object" &&
+      choice !== null &&
+      typeof (choice as { value?: unknown }).value === "string" &&
+      typeof (choice as { label?: unknown }).label === "string")
+  );
+}
+
+function serializeCommandArgs(command: {
+  args?: Array<{
+    name: string;
+    description: string;
+    type: "string" | "number" | "boolean";
+    required?: boolean;
+    choices?: unknown;
+    preferAutocomplete?: boolean;
+    captureRemaining?: boolean;
+  }>;
+}): CommandArgDefinition[] | undefined {
+  if (!Array.isArray(command.args) || command.args.length === 0) {
+    return undefined;
+  }
+
+  const args = command.args.map((arg) => ({
+    name: arg.name,
+    description: arg.description,
+    type: arg.type,
+    required: arg.required,
+    choices: Array.isArray(arg.choices)
+      ? arg.choices.filter((choice): choice is CommandArgChoice => isSerializableChoice(choice))
+      : undefined,
+    preferAutocomplete: arg.preferAutocomplete,
+    captureRemaining: arg.captureRemaining,
+  }));
+
+  return args.length > 0 ? args : undefined;
+}
+
+function serializeCommand(
+  command: ReturnType<typeof listChatCommands>[number],
+): ChatCommandCatalogEntry {
+  return {
+    key: command.key,
+    nativeName: command.nativeName,
+    description: command.description,
+    textAliases: [...command.textAliases],
+    acceptsArgs: command.acceptsArgs === true,
+    args: serializeCommandArgs(command),
+    argsParsing: command.argsParsing,
+    argsMenu:
+      command.argsMenu === "auto"
+        ? "auto"
+        : command.argsMenu
+          ? {
+              arg: command.argsMenu.arg,
+              title: command.argsMenu.title,
+            }
+          : undefined,
+    scope: command.scope,
+    category: command.category,
+  };
+}
+
+export const commandsHandlers: GatewayRequestHandlers = {
+  "commands.list": ({ params, respond }) => {
+    if (params != null && (typeof params !== "object" || Array.isArray(params))) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid commands.list params: expected object"),
+      );
+      return;
+    }
+    if (params && Object.keys(params).length > 0) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid commands.list params: unexpected property"),
+      );
+      return;
+    }
+
+    const commands = listChatCommands().map(serializeCommand);
+    respond(true, { commands }, undefined);
+  },
+};

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -318,6 +318,40 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history preserves prepared user prompt metadata from transcript entries", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+
+      const sessionDir = await createSessionDir();
+      await writeMainSessionStore();
+
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "user",
+            timestamp: Date.now(),
+            content: '<context>\n<task id="t1">Fix scroll</task>\n</context>\n\nShip the fix',
+            __openclaw: {
+              authoredContent: "Ship the fix",
+              modelInput: "System: [2026-04-09 10:00 UTC]\n\nShip the fix",
+            },
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: '<context>\n<task id="t1">Fix scroll</task>\n</context>\n\nShip the fix',
+        __openclaw: {
+          authoredContent: "Ship the fix",
+          modelInput: "System: [2026-04-09 10:00 UTC]\n\nShip the fix",
+        },
+      });
+    });
+  });
+
   test("chat.history strips inline directives from displayed message text", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);


### PR DESCRIPTION
## Summary
- add explicit authored-content support to `chat.send` and transcript projection
- capture the prepared runtime model input before the reply agent runs and persist it under `__openclaw` metadata
- cover transcript update/history behavior with gateway regression tests

## Verification
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts`
- `pnpm build:strict-smoke`