### PR TITLE
feat(ingress): lift Slack/Telegram work requests into deterministic stage orchestration

### DIFF
--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { maybeHandleChatIngressOrchestration } from "../orchestration/task-os-chat-ingress.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
@@ -40,6 +41,14 @@ export async function dispatchInboundMessage(params: {
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
+  const ingressOrchestrated = await maybeHandleChatIngressOrchestration({
+    ctx: finalized,
+    cfg: params.cfg,
+    dispatcher: params.dispatcher,
+  });
+  if (ingressOrchestrated.handled) {
+    return { queuedFinal: true, counts: params.dispatcher.getQueuedCounts() };
+  }
   return await withReplyDispatcher({
     dispatcher: params.dispatcher,
     run: () =>
@@ -60,8 +69,9 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
-    createReplyDispatcherWithTyping(params.dispatcherOptions);
+  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping(
+    params.dispatcherOptions,
+  );
   try {
     return await dispatchInboundMessage({
       ctx: params.ctx,
@@ -74,7 +84,6 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       },
     });
   } finally {
-    markRunComplete();
     markDispatchIdle();
   }
 }

--- a/src/gateway/protocol/schema/task-os.ts
+++ b/src/gateway/protocol/schema/task-os.ts
@@ -1,0 +1,504 @@
+import { Type } from "@sinclair/typebox";
+import { NonEmptyString } from "./primitives.js";
+
+const IsoDateTimeString = Type.String({ minLength: 1 });
+const TaskDueAtSchema = Type.String({ minLength: 1 });
+
+export const PlanStatusSchema = Type.Union([
+  Type.Literal("draft"),
+  Type.Literal("active"),
+  Type.Literal("completed"),
+  Type.Literal("archived"),
+]);
+
+export const TaskStatusSchema = Type.Union([
+  Type.Literal("pending"),
+  Type.Literal("in_progress"),
+  Type.Literal("blocked"),
+  Type.Literal("completed"),
+  Type.Literal("verified"),
+]);
+
+export const TaskVerdictSchema = Type.Union([
+  Type.Literal("PASS"),
+  Type.Literal("FAIL"),
+  Type.Literal("PARTIAL"),
+]);
+
+export const TaskEvidenceSchema = Type.Object(
+  {
+    summary: NonEmptyString,
+    kind: Type.Optional(Type.String()),
+    source: Type.Optional(Type.String()),
+    provenanceTier: Type.Optional(
+      Type.Union([
+        Type.Literal("runtime_evidence"),
+        Type.Literal("research_workbench"),
+        Type.Literal("durable_memory"),
+      ]),
+    ),
+    promotionStatus: Type.Optional(
+      Type.Union([Type.Literal("research_only"), Type.Literal("promoted")]),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskEvidenceRecordSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    summary: NonEmptyString,
+    kind: Type.Optional(Type.String()),
+    source: Type.Optional(Type.String()),
+    provenanceTier: Type.Optional(
+      Type.Union([
+        Type.Literal("runtime_evidence"),
+        Type.Literal("research_workbench"),
+        Type.Literal("durable_memory"),
+      ]),
+    ),
+    promotionStatus: Type.Optional(
+      Type.Union([Type.Literal("research_only"), Type.Literal("promoted")]),
+    ),
+    createdAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskSourceKindSchema = Type.Union([
+  Type.Literal("slack"),
+  Type.Literal("telegram"),
+  Type.Literal("gmail"),
+  Type.Literal("jira"),
+  Type.Literal("notion"),
+  Type.Literal("github"),
+  Type.Literal("research"),
+]);
+
+export const TaskFingerprintKindSchema = Type.Union([
+  Type.Literal("canonical"),
+  Type.Literal("source"),
+  Type.Literal("idempotency"),
+  Type.Literal("external_link"),
+]);
+
+export const TaskResolutionStateSchema = Type.Union([
+  Type.Literal("open"),
+  Type.Literal("resolved"),
+  Type.Literal("reopened"),
+  Type.Literal("dismissed"),
+]);
+
+export const TaskReconciliationStateSchema = Type.Union([
+  Type.Literal("canonical"),
+  Type.Literal("reconciled"),
+  Type.Literal("stale"),
+  Type.Literal("conflict"),
+]);
+
+export const TaskConfidenceLabelSchema = Type.Union([
+  Type.Literal("low"),
+  Type.Literal("medium"),
+  Type.Literal("high"),
+]);
+
+export const TaskArbitrationActionSchema = Type.Union([
+  Type.Literal("created"),
+  Type.Literal("source_attached"),
+  Type.Literal("delivery_deduped"),
+  Type.Literal("notification_suppressed"),
+  Type.Literal("resolved"),
+  Type.Literal("reopened"),
+  Type.Literal("reconciled"),
+  Type.Literal("stale_marked"),
+  Type.Literal("conflict_recorded"),
+]);
+
+export const TaskCanonicalUpsertActionSchema = Type.Union([
+  Type.Literal("created"),
+  Type.Literal("merged"),
+  Type.Literal("idempotent"),
+]);
+
+export const TaskConfidenceInputSchema = Type.Object(
+  {
+    score: Type.Optional(Type.Number()),
+    reason: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskConfidenceRecordSchema = Type.Object(
+  {
+    score: Type.Number(),
+    label: TaskConfidenceLabelSchema,
+    reason: Type.Optional(Type.String()),
+    sourceKind: Type.Optional(TaskSourceKindSchema),
+    updatedAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskFingerprintRecordSchema = Type.Object(
+  {
+    kind: TaskFingerprintKindSchema,
+    value: NonEmptyString,
+    sourceKind: Type.Optional(TaskSourceKindSchema),
+    createdAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskExternalLinkInputSchema = Type.Object(
+  {
+    system: TaskSourceKindSchema,
+    externalId: Type.Optional(Type.String()),
+    url: Type.Optional(Type.String()),
+    title: Type.Optional(Type.String()),
+    status: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskExternalLinkRecordSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    system: TaskSourceKindSchema,
+    externalId: Type.Optional(Type.String()),
+    url: Type.Optional(Type.String()),
+    title: Type.Optional(Type.String()),
+    status: Type.Optional(Type.String()),
+    firstSeenAt: IsoDateTimeString,
+    lastSeenAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskSourceProvenanceRecordSchema = Type.Object(
+  {
+    sourceSurface: Type.Optional(Type.String()),
+    sourceId: Type.Optional(Type.String()),
+    requestId: Type.Optional(Type.String()),
+    idempotencyKey: NonEmptyString,
+    truthLayer: NonEmptyString,
+    truthRank: Type.Optional(Type.Number()),
+    reconciliationMode: Type.Optional(Type.String()),
+    allowCandidateTaskCreation: Type.Optional(Type.Boolean()),
+    promoteToTaskTruth: Type.Boolean(),
+    observedAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskSourceRecordSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    sourceKind: TaskSourceKindSchema,
+    signalKind: Type.Optional(Type.String()),
+    title: Type.Optional(Type.String()),
+    summary: Type.Optional(Type.String()),
+    sourceFingerprint: NonEmptyString,
+    idempotencyKey: NonEmptyString,
+    provenance: TaskSourceProvenanceRecordSchema,
+    confidence: Type.Optional(TaskConfidenceRecordSchema),
+    externalLinkIds: Type.Array(NonEmptyString),
+    firstObservedAt: IsoDateTimeString,
+    lastObservedAt: IsoDateTimeString,
+    lastResolutionState: Type.Optional(TaskResolutionStateSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskResolutionRecordSchema = Type.Object(
+  {
+    state: TaskResolutionStateSchema,
+    summary: Type.Optional(Type.String()),
+    sourceKind: Type.Optional(TaskSourceKindSchema),
+    updatedAt: IsoDateTimeString,
+    resolvedAt: Type.Optional(IsoDateTimeString),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskReconciliationRecordSchema = Type.Object(
+  {
+    state: TaskReconciliationStateSchema,
+    summary: Type.Optional(Type.String()),
+    updatedAt: IsoDateTimeString,
+    winnerSourceKind: Type.Optional(TaskSourceKindSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskArbitrationHistoryRecordSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    action: TaskArbitrationActionSchema,
+    sourceKind: Type.Optional(TaskSourceKindSchema),
+    fingerprint: NonEmptyString,
+    summary: NonEmptyString,
+    createdAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskCanonicalSourceInputSchema = Type.Object(
+  {
+    sourceKind: TaskSourceKindSchema,
+    signalKind: Type.Optional(Type.String()),
+    sourceId: Type.Optional(Type.String()),
+    sourceFingerprint: Type.Optional(Type.String()),
+    sameWorkKey: Type.Optional(Type.String()),
+    idempotencyKey: Type.Optional(Type.String()),
+    requestId: Type.Optional(Type.String()),
+    sourceSurface: Type.Optional(Type.String()),
+    observedAt: Type.Optional(IsoDateTimeString),
+    title: Type.Optional(Type.String()),
+    summary: Type.Optional(Type.String()),
+    confidence: Type.Optional(TaskConfidenceInputSchema),
+    externalLinks: Type.Optional(Type.Array(TaskExternalLinkInputSchema)),
+    resolutionState: Type.Optional(TaskResolutionStateSchema),
+    resolutionSummary: Type.Optional(Type.String()),
+    reconciliationState: Type.Optional(TaskReconciliationStateSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskCanonicalWorkInputSchema = Type.Object(
+  {
+    source: TaskCanonicalSourceInputSchema,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskCanonicalWorkRecordSchema = Type.Object(
+  {
+    canonicalFingerprint: NonEmptyString,
+    fingerprints: Type.Array(TaskFingerprintRecordSchema),
+    externalLinks: Type.Array(TaskExternalLinkRecordSchema),
+    sources: Type.Array(TaskSourceRecordSchema),
+    confidence: Type.Optional(TaskConfidenceRecordSchema),
+    resolution: TaskResolutionRecordSchema,
+    reconciliation: TaskReconciliationRecordSchema,
+    history: Type.Array(TaskArbitrationHistoryRecordSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskVerificationSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    verdict: TaskVerdictSchema,
+    summary: Type.Optional(Type.String()),
+    evidence: Type.Array(Type.String()),
+    actor: Type.Optional(Type.String()),
+    verifiedAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskBlockerSchema = Type.Object(
+  {
+    reason: NonEmptyString,
+    blockedBy: Type.Optional(Type.String()),
+    blockedAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const PlanRecordSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    title: Type.Optional(Type.String()),
+    objective: NonEmptyString,
+    approach: Type.Optional(Type.String()),
+    acceptanceCriteria: Type.Array(Type.String()),
+    status: PlanStatusSchema,
+    createdAt: IsoDateTimeString,
+    updatedAt: IsoDateTimeString,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskRecordSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    planId: Type.Optional(NonEmptyString),
+    title: NonEmptyString,
+    description: Type.Optional(Type.String()),
+    owner: Type.Optional(Type.String()),
+    ownerRole: Type.Optional(Type.String()),
+    dueAt: Type.Optional(TaskDueAtSchema),
+    status: TaskStatusSchema,
+    dependencies: Type.Array(NonEmptyString),
+    acceptanceCriteria: Type.Array(Type.String()),
+    evidence: Type.Array(TaskEvidenceRecordSchema),
+    verificationHistory: Type.Array(TaskVerificationSchema),
+    blocker: Type.Optional(TaskBlockerSchema),
+    canonicalWork: Type.Optional(TaskCanonicalWorkRecordSchema),
+    summary: Type.Optional(Type.String()),
+    createdAt: IsoDateTimeString,
+    updatedAt: IsoDateTimeString,
+    completedAt: Type.Optional(IsoDateTimeString),
+    reopenedAt: Type.Optional(IsoDateTimeString),
+    verifiedAt: Type.Optional(IsoDateTimeString),
+  },
+  { additionalProperties: false },
+);
+
+export const PlansCreateParamsSchema = Type.Object(
+  {
+    id: Type.Optional(NonEmptyString),
+    title: NonEmptyString,
+    objective: NonEmptyString,
+    status: Type.Optional(PlanStatusSchema),
+    approach: Type.Optional(Type.String()),
+    acceptanceCriteria: Type.Optional(Type.Array(Type.String())),
+  },
+  { additionalProperties: false },
+);
+
+export const PlansGetParamsSchema = Type.Object(
+  { id: NonEmptyString },
+  { additionalProperties: false },
+);
+
+export const PlansUpdateParamsSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    patch: Type.Object(
+      {
+        title: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        objective: Type.Optional(Type.String()),
+        status: Type.Optional(PlanStatusSchema),
+        approach: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        acceptanceCriteria: Type.Optional(Type.Array(Type.String())),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const TasksCreateParamsSchema = Type.Object(
+  {
+    id: Type.Optional(NonEmptyString),
+    planId: Type.Optional(NonEmptyString),
+    title: NonEmptyString,
+    description: Type.Optional(Type.String()),
+    owner: Type.Optional(Type.String()),
+    ownerRole: Type.Optional(Type.String()),
+    dueAt: Type.Optional(TaskDueAtSchema),
+    status: Type.Optional(TaskStatusSchema),
+    dependencies: Type.Optional(Type.Array(NonEmptyString)),
+    acceptanceCriteria: Type.Optional(Type.Array(Type.String())),
+    evidence: Type.Optional(Type.Array(TaskEvidenceSchema)),
+    canonicalWork: Type.Optional(TaskCanonicalWorkInputSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const TasksUpsertCanonicalParamsSchema = Type.Object(
+  {
+    id: Type.Optional(NonEmptyString),
+    planId: Type.Optional(NonEmptyString),
+    title: NonEmptyString,
+    description: Type.Optional(Type.String()),
+    owner: Type.Optional(Type.String()),
+    ownerRole: Type.Optional(Type.String()),
+    dueAt: Type.Optional(TaskDueAtSchema),
+    status: Type.Optional(TaskStatusSchema),
+    dependencies: Type.Optional(Type.Array(NonEmptyString)),
+    acceptanceCriteria: Type.Optional(Type.Array(Type.String())),
+    evidence: Type.Optional(Type.Array(TaskEvidenceSchema)),
+    canonicalWork: TaskCanonicalWorkInputSchema,
+  },
+  { additionalProperties: false },
+);
+
+export const TasksUpdateParamsSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    patch: Type.Object(
+      {
+        planId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+        title: Type.Optional(Type.String()),
+        description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        owner: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        ownerRole: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        dueAt: Type.Optional(Type.Union([TaskDueAtSchema, Type.Null()])),
+        status: Type.Optional(TaskStatusSchema),
+        dependencies: Type.Optional(Type.Array(NonEmptyString)),
+        acceptanceCriteria: Type.Optional(Type.Array(Type.String())),
+        summary: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        evidence: Type.Optional(Type.Array(TaskEvidenceSchema)),
+        canonicalWork: Type.Optional(TaskCanonicalWorkInputSchema),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const TasksListParamsSchema = Type.Object(
+  {
+    planId: Type.Optional(NonEmptyString),
+    status: Type.Optional(TaskStatusSchema),
+    owner: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const TasksBlockParamsSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    blocker: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
+export const TasksCompleteParamsSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    summary: Type.Optional(Type.String()),
+    evidence: Type.Optional(Type.Array(TaskEvidenceSchema)),
+  },
+  { additionalProperties: false },
+);
+
+export const TasksVerifyParamsSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    verdict: TaskVerdictSchema,
+    summary: Type.Optional(Type.String()),
+    evidence: Type.Optional(Type.Array(Type.String())),
+    actor: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const TaskResolutionTransitionSchema = Type.Object(
+  {
+    from: TaskResolutionStateSchema,
+    to: TaskResolutionStateSchema,
+  },
+  { additionalProperties: false },
+);
+
+export const TaskReconciliationTransitionSchema = Type.Object(
+  {
+    from: TaskReconciliationStateSchema,
+    to: TaskReconciliationStateSchema,
+  },
+  { additionalProperties: false },
+);
+
+export const TasksUpsertCanonicalResultSchema = Type.Object(
+  {
+    action: TaskCanonicalUpsertActionSchema,
+    task: TaskRecordSchema,
+    resolutionTransition: Type.Optional(TaskResolutionTransitionSchema),
+    reconciliationTransition: Type.Optional(TaskReconciliationTransitionSchema),
+  },
+  { additionalProperties: false },
+);

--- a/src/infra/heartbeat-events.ts
+++ b/src/infra/heartbeat-events.ts
@@ -18,6 +18,25 @@ export type HeartbeatEventPayload = {
   silent?: boolean;
   /** Indicator type for UI status display. */
   indicatorType?: HeartbeatIndicatorType;
+  triggerSignalId?: string;
+  triggerScore?: number;
+  triggerPersona?: string;
+  triggerChannel?: string;
+  triggerActionClassCap?: string;
+  triggerSourceKind?: "slack" | "telegram" | "gmail" | "jira" | "notion" | "github" | "research";
+  triggerSignalKind?: string;
+  triggerCanonicalFingerprint?: string;
+  triggerRequestId?: string;
+  triggerIdempotencyKey?: string;
+  triggerExternalLinks?: string[];
+  triggerTruthLayer?: string;
+  triggerUrgency?: "critical" | "high" | "medium" | "low";
+  triggerWhyNow?: string;
+  triggerConfidenceScore?: number;
+  triggerConfidenceLabel?: "low" | "medium" | "high";
+  triggerFollowUp?: string;
+  triggerNotificationStatus?: "ready" | "suppressed";
+  triggerTaskId?: string;
 };
 
 export function resolveIndicatorType(

--- a/src/orchestration/task-os-arbitration.ts
+++ b/src/orchestration/task-os-arbitration.ts
@@ -1,0 +1,908 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  loadOpenClawControlPlanePolicy,
+  resolveControlPlaneSourceTruthSystemPolicy,
+} from "../infra/control-plane-policy.js";
+
+export const TASK_SOURCE_KINDS = [
+  "slack",
+  "telegram",
+  "gmail",
+  "jira",
+  "notion",
+  "github",
+  "research",
+] as const;
+export const TASK_FINGERPRINT_KINDS = [
+  "canonical",
+  "source",
+  "idempotency",
+  "external_link",
+] as const;
+export const TASK_RESOLUTION_STATES = ["open", "resolved", "reopened", "dismissed"] as const;
+export const TASK_RECONCILIATION_STATES = ["canonical", "reconciled", "stale", "conflict"] as const;
+export const TASK_CONFIDENCE_LABELS = ["low", "medium", "high"] as const;
+export const TASK_ARBITRATION_ACTIONS = [
+  "created",
+  "source_attached",
+  "delivery_deduped",
+  "notification_suppressed",
+  "resolved",
+  "reopened",
+  "reconciled",
+  "stale_marked",
+  "conflict_recorded",
+] as const;
+
+export type TaskSourceKind = (typeof TASK_SOURCE_KINDS)[number];
+export type TaskFingerprintKind = (typeof TASK_FINGERPRINT_KINDS)[number];
+export type TaskResolutionState = (typeof TASK_RESOLUTION_STATES)[number];
+export type TaskReconciliationState = (typeof TASK_RECONCILIATION_STATES)[number];
+export type TaskConfidenceLabel = (typeof TASK_CONFIDENCE_LABELS)[number];
+export type TaskArbitrationAction = (typeof TASK_ARBITRATION_ACTIONS)[number];
+
+export type TaskConfidenceInput = {
+  score?: number;
+  reason?: string;
+};
+
+export type TaskExternalLinkInput = {
+  system: TaskSourceKind;
+  externalId?: string;
+  url?: string;
+  title?: string;
+  status?: string;
+};
+
+export type TaskCanonicalSourceInput = {
+  sourceKind: TaskSourceKind;
+  signalKind?: string;
+  sourceId?: string;
+  sourceFingerprint?: string;
+  sameWorkKey?: string;
+  idempotencyKey?: string;
+  requestId?: string;
+  sourceSurface?: string;
+  observedAt?: string;
+  title?: string;
+  summary?: string;
+  confidence?: TaskConfidenceInput;
+  externalLinks?: TaskExternalLinkInput[];
+  resolutionState?: TaskResolutionState;
+  resolutionSummary?: string;
+  reconciliationState?: TaskReconciliationState;
+};
+
+export type TaskCanonicalWorkInput = {
+  source: TaskCanonicalSourceInput;
+};
+
+export type TaskFingerprintRecord = {
+  kind: TaskFingerprintKind;
+  value: string;
+  sourceKind?: TaskSourceKind;
+  createdAt: string;
+};
+
+export type TaskConfidenceRecord = {
+  score: number;
+  label: TaskConfidenceLabel;
+  reason?: string;
+  sourceKind?: TaskSourceKind;
+  updatedAt: string;
+};
+
+export type TaskSourceProvenanceRecord = {
+  sourceSurface?: string;
+  sourceId?: string;
+  requestId?: string;
+  idempotencyKey: string;
+  truthLayer: string;
+  truthRank?: number;
+  reconciliationMode?: string;
+  allowCandidateTaskCreation: boolean;
+  promoteToTaskTruth: boolean;
+  observedAt: string;
+};
+
+export type TaskExternalLinkRecord = {
+  id: string;
+  system: TaskSourceKind;
+  externalId?: string;
+  url?: string;
+  title?: string;
+  status?: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+};
+
+export type TaskSourceRecord = {
+  id: string;
+  sourceKind: TaskSourceKind;
+  signalKind?: string;
+  title?: string;
+  summary?: string;
+  sourceFingerprint: string;
+  idempotencyKey: string;
+  provenance: TaskSourceProvenanceRecord;
+  confidence?: TaskConfidenceRecord;
+  externalLinkIds: string[];
+  firstObservedAt: string;
+  lastObservedAt: string;
+  lastResolutionState?: TaskResolutionState;
+};
+
+export type TaskResolutionRecord = {
+  state: TaskResolutionState;
+  summary?: string;
+  sourceKind?: TaskSourceKind;
+  updatedAt: string;
+  resolvedAt?: string;
+};
+
+export type TaskReconciliationRecord = {
+  state: TaskReconciliationState;
+  summary?: string;
+  updatedAt: string;
+  winnerSourceKind?: TaskSourceKind;
+};
+
+export type TaskArbitrationHistoryRecord = {
+  id: string;
+  action: TaskArbitrationAction;
+  sourceKind?: TaskSourceKind;
+  fingerprint: string;
+  summary: string;
+  createdAt: string;
+};
+
+export type TaskCanonicalWorkRecord = {
+  canonicalFingerprint: string;
+  fingerprints: TaskFingerprintRecord[];
+  externalLinks: TaskExternalLinkRecord[];
+  sources: TaskSourceRecord[];
+  confidence?: TaskConfidenceRecord;
+  resolution: TaskResolutionRecord;
+  reconciliation: TaskReconciliationRecord;
+  history: TaskArbitrationHistoryRecord[];
+};
+
+export type TaskCanonicalUpsertAction = "created" | "merged" | "idempotent";
+
+export type TaskCanonicalMergeResult = {
+  action: TaskCanonicalUpsertAction;
+  canonicalWork: TaskCanonicalWorkRecord;
+  resolutionTransition?: {
+    from: TaskResolutionState;
+    to: TaskResolutionState;
+  };
+  reconciliationTransition?: {
+    from: TaskReconciliationState;
+    to: TaskReconciliationState;
+  };
+  truthGate?: {
+    blockedResolutionUpdate: boolean;
+    blockedReconciliationUpdate: boolean;
+  };
+};
+
+function trimToUndefined(value: string | undefined | null): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeText(value: string | undefined | null): string {
+  return (trimToUndefined(value) ?? "")
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function buildFingerprint(prefix: string, values: Array<string | undefined>): string {
+  const normalized = values.map((value) => normalizeText(value)).filter(Boolean);
+  const payload = normalized.length ? normalized.join("|") : prefix;
+  return `${prefix}:sha256:${createHash("sha256").update(payload).digest("hex")}`;
+}
+
+function ensureTaskSourceKind(kind: string): TaskSourceKind {
+  const normalized = trimToUndefined(kind)?.toLowerCase();
+  const matched = TASK_SOURCE_KINDS.find((entry) => entry === normalized);
+  if (!matched) {
+    throw new Error(`unsupported task source kind: ${kind}`);
+  }
+  return matched;
+}
+
+function laterTimestamp(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) {
+    return b;
+  }
+  if (!b) {
+    return a;
+  }
+  return a >= b ? a : b;
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return Array.from(
+    new Set(values.filter((value): value is string => Boolean(trimToUndefined(value)))),
+  );
+}
+
+function normalizeConfidence(
+  input: TaskConfidenceInput | undefined,
+  sourceKind: TaskSourceKind,
+  updatedAt: string,
+) {
+  const score =
+    typeof input?.score === "number" && Number.isFinite(input.score)
+      ? Math.min(1, Math.max(0, input.score))
+      : undefined;
+  if (score === undefined) {
+    return undefined;
+  }
+  const label: TaskConfidenceLabel = score >= 0.8 ? "high" : score >= 0.45 ? "medium" : "low";
+  return {
+    score,
+    label,
+    reason: trimToUndefined(input?.reason),
+    sourceKind,
+    updatedAt,
+  } satisfies TaskConfidenceRecord;
+}
+
+function preferConfidence(
+  current: TaskConfidenceRecord | undefined,
+  next: TaskConfidenceRecord | undefined,
+): TaskConfidenceRecord | undefined {
+  if (!current) {
+    return next;
+  }
+  if (!next) {
+    return current;
+  }
+  if (next.score > current.score) {
+    return next;
+  }
+  if (next.score === current.score && next.updatedAt >= current.updatedAt) {
+    return next;
+  }
+  return current;
+}
+
+function buildExternalLinkRecord(
+  input: TaskExternalLinkInput,
+  observedAt: string,
+): TaskExternalLinkRecord {
+  const system = ensureTaskSourceKind(input.system);
+  const externalId = trimToUndefined(input.externalId);
+  const url = trimToUndefined(input.url);
+  const title = trimToUndefined(input.title);
+  if (!externalId && !url && !title) {
+    throw new Error(`external link for ${system} requires externalId, url, or title`);
+  }
+  const id = buildFingerprint("external", [system, externalId, url, title]);
+  return {
+    id,
+    system,
+    externalId,
+    url,
+    title,
+    status: trimToUndefined(input.status),
+    firstSeenAt: observedAt,
+    lastSeenAt: observedAt,
+  };
+}
+
+function resolveTruthRank(layer: string | undefined): number | undefined {
+  if (!layer) {
+    return undefined;
+  }
+  return loadOpenClawControlPlanePolicy().sourceTruthLayers.find((entry) => entry.id === layer)
+    ?.rank;
+}
+
+function buildSourceProvenanceRecord(
+  input: TaskCanonicalSourceInput,
+  observedAt: string,
+  idempotencyKey: string,
+) {
+  const policy = resolveControlPlaneSourceTruthSystemPolicy(input.sourceKind);
+  const truthLayer = policy?.layer ?? "raw_source_events";
+  return {
+    sourceSurface: trimToUndefined(input.sourceSurface),
+    sourceId: trimToUndefined(input.sourceId),
+    requestId: trimToUndefined(input.requestId),
+    idempotencyKey,
+    truthLayer,
+    truthRank: resolveTruthRank(truthLayer),
+    reconciliationMode: trimToUndefined(policy?.reconciliation_mode),
+    allowCandidateTaskCreation: policy?.allow_candidate_task_creation === true,
+    promoteToTaskTruth: policy?.promote_to_task_truth === true,
+    observedAt,
+  } satisfies TaskSourceProvenanceRecord;
+}
+
+function resolveCurrentTruthRank(
+  current: TaskCanonicalWorkRecord,
+  sourceKind: TaskSourceKind | undefined,
+): number {
+  if (!sourceKind) {
+    return 99;
+  }
+  const currentSource = current.sources.find((entry) => entry.sourceKind === sourceKind);
+  return currentSource?.provenance.truthRank ?? 99;
+}
+
+function resolveResolutionStateFromStatus(
+  status: string | undefined,
+): TaskResolutionState | undefined {
+  const normalized = normalizeText(status);
+  if (!normalized) {
+    return undefined;
+  }
+  if (
+    ["done", "closed", "resolved", "complete", "completed", "merged", "shipped"].includes(
+      normalized,
+    )
+  ) {
+    return "resolved";
+  }
+  if (
+    ["dismissed", "cancelled", "canceled", "won t do", "wont do", "duplicate"].includes(normalized)
+  ) {
+    return "dismissed";
+  }
+  if (
+    ["todo", "open", "pending", "backlog", "blocked", "in progress", "inprogress"].includes(
+      normalized,
+    )
+  ) {
+    return "open";
+  }
+  return undefined;
+}
+
+function resolveReconciliationStateFromStatus(
+  status: string | undefined,
+): TaskReconciliationState | undefined {
+  const normalized = normalizeText(status);
+  if (!normalized) {
+    return undefined;
+  }
+  if (["stale", "archived", "obsolete", "superseded"].includes(normalized)) {
+    return "stale";
+  }
+  if (["conflict", "diverged"].includes(normalized)) {
+    return "conflict";
+  }
+  return undefined;
+}
+
+export function resolveCanonicalResolutionState(
+  input: TaskCanonicalSourceInput,
+): TaskResolutionState | undefined {
+  if (input.resolutionState) {
+    return input.resolutionState;
+  }
+  for (const link of input.externalLinks ?? []) {
+    const resolved = resolveResolutionStateFromStatus(link.status);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return undefined;
+}
+
+export function resolveCanonicalReconciliationState(
+  input: TaskCanonicalSourceInput,
+): TaskReconciliationState | undefined {
+  if (input.reconciliationState) {
+    return input.reconciliationState;
+  }
+  for (const link of input.externalLinks ?? []) {
+    const reconciled = resolveReconciliationStateFromStatus(link.status);
+    if (reconciled) {
+      return reconciled;
+    }
+  }
+  return undefined;
+}
+
+export function buildCanonicalTaskFingerprint(input: TaskCanonicalWorkInput): string {
+  const sameWorkKey = trimToUndefined(input.source.sameWorkKey);
+  if (sameWorkKey) {
+    return buildFingerprint("work", [sameWorkKey]);
+  }
+  const normalizedContent =
+    normalizeText(input.source.title) || normalizeText(input.source.summary);
+  if (normalizedContent) {
+    return buildFingerprint("work", [input.source.title, input.source.summary]);
+  }
+  const linkFingerprints = (input.source.externalLinks ?? [])
+    .map(
+      (link) =>
+        buildExternalLinkRecord(link, input.source.observedAt ?? new Date().toISOString()).id,
+    )
+    .toSorted();
+  if (linkFingerprints.length) {
+    return buildFingerprint("work", linkFingerprints);
+  }
+  return buildFingerprint("work", [
+    input.source.sourceFingerprint,
+    input.source.sourceId,
+    input.source.sourceKind,
+  ]);
+}
+
+function buildSourceFingerprint(input: TaskCanonicalSourceInput): string {
+  const explicit = trimToUndefined(input.sourceFingerprint);
+  if (explicit) {
+    return buildFingerprint("source", [input.sourceKind, explicit]);
+  }
+  return buildFingerprint("source", [
+    input.sourceKind,
+    input.sourceId,
+    input.signalKind,
+    input.title,
+    input.summary,
+  ]);
+}
+
+function buildIdempotencyKey(input: TaskCanonicalSourceInput, sourceFingerprint: string): string {
+  const explicit = trimToUndefined(input.idempotencyKey);
+  if (explicit) {
+    return buildFingerprint("idempotency", [input.sourceKind, explicit]);
+  }
+  return buildFingerprint("idempotency", [input.sourceKind, input.sourceId, sourceFingerprint]);
+}
+
+function buildHistoryEntry(params: {
+  action: TaskArbitrationAction;
+  sourceKind?: TaskSourceKind;
+  fingerprint: string;
+  summary: string;
+  createdAt: string;
+}): TaskArbitrationHistoryRecord {
+  return {
+    id: randomUUID(),
+    action: params.action,
+    sourceKind: params.sourceKind,
+    fingerprint: params.fingerprint,
+    summary: params.summary,
+    createdAt: params.createdAt,
+  };
+}
+
+function buildFingerprintRecords(params: {
+  canonicalFingerprint: string;
+  sourceKind: TaskSourceKind;
+  sourceFingerprint: string;
+  idempotencyKey: string;
+  externalLinks: TaskExternalLinkRecord[];
+  observedAt: string;
+}): TaskFingerprintRecord[] {
+  const records: TaskFingerprintRecord[] = [
+    {
+      kind: "canonical",
+      value: params.canonicalFingerprint,
+      createdAt: params.observedAt,
+    },
+    {
+      kind: "source",
+      value: params.sourceFingerprint,
+      sourceKind: params.sourceKind,
+      createdAt: params.observedAt,
+    },
+    {
+      kind: "idempotency",
+      value: params.idempotencyKey,
+      sourceKind: params.sourceKind,
+      createdAt: params.observedAt,
+    },
+  ];
+  for (const link of params.externalLinks) {
+    records.push({
+      kind: "external_link",
+      value: link.id,
+      sourceKind: link.system,
+      createdAt: params.observedAt,
+    });
+  }
+  return records;
+}
+
+function sortFingerprints(records: TaskFingerprintRecord[]): TaskFingerprintRecord[] {
+  return records.toSorted((a, b) => a.value.localeCompare(b.value) || a.kind.localeCompare(b.kind));
+}
+
+function mergeFingerprints(
+  current: TaskFingerprintRecord[],
+  incoming: TaskFingerprintRecord[],
+): TaskFingerprintRecord[] {
+  const map = new Map<string, TaskFingerprintRecord>();
+  for (const record of [...current, ...incoming]) {
+    const key = `${record.kind}:${record.value}`;
+    if (!map.has(key)) {
+      map.set(key, record);
+    }
+  }
+  return sortFingerprints(Array.from(map.values()));
+}
+
+function mergeExternalLinks(
+  current: TaskExternalLinkRecord[],
+  incoming: TaskExternalLinkRecord[],
+): TaskExternalLinkRecord[] {
+  const merged = new Map<string, TaskExternalLinkRecord>();
+  for (const record of current) {
+    merged.set(record.id, { ...record });
+  }
+  for (const record of incoming) {
+    const existing = merged.get(record.id);
+    if (!existing) {
+      merged.set(record.id, record);
+      continue;
+    }
+    merged.set(record.id, {
+      ...existing,
+      externalId: existing.externalId ?? record.externalId,
+      url: existing.url ?? record.url,
+      title: existing.title ?? record.title,
+      status: record.status ?? existing.status,
+      lastSeenAt: laterTimestamp(existing.lastSeenAt, record.lastSeenAt) ?? existing.lastSeenAt,
+    });
+  }
+  return Array.from(merged.values()).toSorted((a, b) => a.id.localeCompare(b.id));
+}
+
+function summarizeState(
+  sourceKind: TaskSourceKind,
+  state: TaskResolutionState | TaskReconciliationState,
+): string {
+  return `${sourceKind} reported ${state}`;
+}
+
+function isBackfillSource(input: TaskCanonicalSourceInput): boolean {
+  const sourceSurface = normalizeText(input.sourceSurface);
+  if (sourceSurface.includes("backfill") || sourceSurface.includes("reconcile")) {
+    return true;
+  }
+  const signalKind = normalizeText(input.signalKind);
+  return signalKind.includes("backfill") || signalKind.includes("reconcile");
+}
+
+export function isTaskResolutionDone(state: TaskResolutionState | undefined): boolean {
+  return state === "resolved" || state === "dismissed";
+}
+
+export function createCanonicalTaskWork(
+  input: TaskCanonicalWorkInput,
+  fallbackObservedAt = new Date().toISOString(),
+): TaskCanonicalWorkRecord {
+  const sourceKind = ensureTaskSourceKind(input.source.sourceKind);
+  const backfill = isBackfillSource(input.source);
+  const observedAt = trimToUndefined(input.source.observedAt) ?? fallbackObservedAt;
+  const externalLinks = (input.source.externalLinks ?? []).map((entry) =>
+    buildExternalLinkRecord(entry, observedAt),
+  );
+  const canonicalFingerprint = buildCanonicalTaskFingerprint({
+    source: {
+      ...input.source,
+      sourceKind,
+    },
+  });
+  const sourceFingerprint = buildSourceFingerprint({
+    ...input.source,
+    sourceKind,
+  });
+  const idempotencyKey = buildIdempotencyKey(
+    {
+      ...input.source,
+      sourceKind,
+    },
+    sourceFingerprint,
+  );
+  const confidence = normalizeConfidence(input.source.confidence, sourceKind, observedAt);
+  const resolutionState = resolveCanonicalResolutionState(input.source) ?? "open";
+  const reconciliationState = resolveCanonicalReconciliationState(input.source) ?? "canonical";
+  const sourceRecord: TaskSourceRecord = {
+    id: buildFingerprint("source-record", [sourceKind, sourceFingerprint]),
+    sourceKind,
+    signalKind: trimToUndefined(input.source.signalKind),
+    title: trimToUndefined(input.source.title),
+    summary: trimToUndefined(input.source.summary),
+    sourceFingerprint,
+    idempotencyKey,
+    provenance: buildSourceProvenanceRecord(
+      {
+        ...input.source,
+        sourceKind,
+      },
+      observedAt,
+      idempotencyKey,
+    ),
+    confidence,
+    externalLinkIds: externalLinks.map((entry) => entry.id),
+    firstObservedAt: observedAt,
+    lastObservedAt: observedAt,
+    lastResolutionState: resolutionState,
+  };
+  return {
+    canonicalFingerprint,
+    fingerprints: buildFingerprintRecords({
+      canonicalFingerprint,
+      sourceKind,
+      sourceFingerprint,
+      idempotencyKey,
+      externalLinks,
+      observedAt,
+    }),
+    externalLinks,
+    sources: [sourceRecord],
+    confidence,
+    resolution: {
+      state: resolutionState,
+      summary: trimToUndefined(input.source.resolutionSummary),
+      sourceKind,
+      updatedAt: observedAt,
+      ...(isTaskResolutionDone(resolutionState) ? { resolvedAt: observedAt } : {}),
+    },
+    reconciliation: {
+      state: reconciliationState,
+      summary:
+        reconciliationState === "canonical"
+          ? "canonical task created"
+          : summarizeState(sourceKind, reconciliationState),
+      updatedAt: observedAt,
+      winnerSourceKind: sourceKind,
+    },
+    history: [
+      buildHistoryEntry({
+        action: "created",
+        sourceKind,
+        fingerprint: canonicalFingerprint,
+        summary: backfill
+          ? `created canonical task from ${sourceKind} backfill`
+          : `created canonical task from ${sourceKind}`,
+        createdAt: observedAt,
+      }),
+    ],
+  };
+}
+
+function matchSourceRecord(
+  sources: TaskSourceRecord[],
+  incoming: TaskSourceRecord,
+): TaskSourceRecord | undefined {
+  return sources.find((source) => {
+    if (source.idempotencyKey === incoming.idempotencyKey) {
+      return true;
+    }
+    if (source.sourceFingerprint === incoming.sourceFingerprint) {
+      return true;
+    }
+    return (
+      source.sourceKind === incoming.sourceKind &&
+      source.provenance.sourceId &&
+      source.provenance.sourceId === incoming.provenance.sourceId
+    );
+  });
+}
+
+function mergeSourceRecord(
+  current: TaskSourceRecord,
+  incoming: TaskSourceRecord,
+): TaskSourceRecord {
+  return {
+    ...current,
+    signalKind: current.signalKind ?? incoming.signalKind,
+    title: current.title ?? incoming.title,
+    summary: current.summary ?? incoming.summary,
+    confidence: preferConfidence(current.confidence, incoming.confidence),
+    externalLinkIds: uniqueStrings([...current.externalLinkIds, ...incoming.externalLinkIds]),
+    lastObservedAt:
+      laterTimestamp(current.lastObservedAt, incoming.lastObservedAt) ?? current.lastObservedAt,
+    lastResolutionState: incoming.lastResolutionState ?? current.lastResolutionState,
+    provenance: {
+      ...current.provenance,
+      sourceSurface: current.provenance.sourceSurface ?? incoming.provenance.sourceSurface,
+      sourceId: current.provenance.sourceId ?? incoming.provenance.sourceId,
+      requestId: incoming.provenance.requestId ?? current.provenance.requestId,
+      observedAt:
+        laterTimestamp(current.provenance.observedAt, incoming.provenance.observedAt) ??
+        current.provenance.observedAt,
+      truthLayer: current.provenance.truthLayer || incoming.provenance.truthLayer,
+      truthRank: current.provenance.truthRank ?? incoming.provenance.truthRank,
+      reconciliationMode:
+        current.provenance.reconciliationMode ?? incoming.provenance.reconciliationMode,
+      promoteToTaskTruth:
+        current.provenance.promoteToTaskTruth || incoming.provenance.promoteToTaskTruth,
+    },
+  };
+}
+
+function mergeConfidenceFromSources(
+  current: TaskConfidenceRecord | undefined,
+  sources: TaskSourceRecord[],
+): TaskConfidenceRecord | undefined {
+  return sources.reduce<TaskConfidenceRecord | undefined>(
+    (best, source) => preferConfidence(best, source.confidence),
+    current,
+  );
+}
+
+export function mergeCanonicalTaskWork(
+  current: TaskCanonicalWorkRecord,
+  input: TaskCanonicalWorkInput,
+  fallbackObservedAt = new Date().toISOString(),
+): TaskCanonicalMergeResult {
+  const incoming = createCanonicalTaskWork(input, fallbackObservedAt);
+  const source = incoming.sources[0];
+  const backfill = isBackfillSource(input.source);
+  if (!source) {
+    throw new Error("incoming canonical task work is missing a source");
+  }
+  const matchingSource = matchSourceRecord(current.sources, source);
+  const action: TaskCanonicalUpsertAction = matchingSource ? "idempotent" : "merged";
+
+  const sources = matchingSource
+    ? current.sources.map((entry) =>
+        entry.id === matchingSource.id ? mergeSourceRecord(entry, source) : entry,
+      )
+    : [...current.sources, source];
+  const externalLinks = mergeExternalLinks(current.externalLinks, incoming.externalLinks);
+  const fingerprints = mergeFingerprints(current.fingerprints, incoming.fingerprints);
+  const confidence = mergeConfidenceFromSources(current.confidence, sources);
+  const observedAt = source.lastObservedAt;
+  const incomingTruthRank = source.provenance.truthRank ?? 99;
+  const currentResolutionTruthRank = resolveCurrentTruthRank(
+    current,
+    current.resolution.sourceKind,
+  );
+  const currentReconciliationTruthRank = resolveCurrentTruthRank(
+    current,
+    current.reconciliation.winnerSourceKind,
+  );
+  let blockedResolutionUpdate = false;
+  let blockedReconciliationUpdate = false;
+
+  let resolution = { ...current.resolution };
+  let resolutionTransition:
+    | {
+        from: TaskResolutionState;
+        to: TaskResolutionState;
+      }
+    | undefined;
+  const incomingResolution = resolveCanonicalResolutionState(input.source);
+  if (incomingResolution && incomingResolution !== current.resolution.state) {
+    if (incomingTruthRank > currentResolutionTruthRank) {
+      blockedResolutionUpdate = true;
+    } else {
+      const nextState =
+        incomingResolution === "open" && isTaskResolutionDone(current.resolution.state)
+          ? "reopened"
+          : incomingResolution;
+      resolution = {
+        state: nextState,
+        summary: trimToUndefined(input.source.resolutionSummary) ?? current.resolution.summary,
+        sourceKind: source.sourceKind,
+        updatedAt: observedAt,
+        resolvedAt: isTaskResolutionDone(nextState)
+          ? (current.resolution.resolvedAt ?? observedAt)
+          : current.resolution.resolvedAt,
+      };
+      if (nextState !== current.resolution.state) {
+        resolutionTransition = {
+          from: current.resolution.state,
+          to: nextState,
+        };
+      }
+    }
+  }
+
+  let reconciliation = { ...current.reconciliation };
+  let reconciliationTransition:
+    | {
+        from: TaskReconciliationState;
+        to: TaskReconciliationState;
+      }
+    | undefined;
+  const explicitReconciliation = resolveCanonicalReconciliationState(input.source);
+  const nextReconciliationState =
+    explicitReconciliation ?? (sources.length > 1 ? "reconciled" : current.reconciliation.state);
+  if (nextReconciliationState !== current.reconciliation.state) {
+    if (incomingTruthRank > currentReconciliationTruthRank) {
+      blockedReconciliationUpdate = true;
+    } else {
+      reconciliation = {
+        state: nextReconciliationState,
+        summary:
+          nextReconciliationState === "reconciled"
+            ? `reconciled ${sources.length} sources`
+            : summarizeState(source.sourceKind, nextReconciliationState),
+        updatedAt: observedAt,
+        winnerSourceKind: source.sourceKind,
+      };
+      reconciliationTransition = {
+        from: current.reconciliation.state,
+        to: nextReconciliationState,
+      };
+    }
+  }
+
+  const history = [...current.history];
+  if (matchingSource) {
+    history.push(
+      buildHistoryEntry({
+        action: "delivery_deduped",
+        sourceKind: source.sourceKind,
+        fingerprint: source.idempotencyKey,
+        summary: backfill
+          ? `deduped backfill delivery from ${source.sourceKind}`
+          : `deduped repeat delivery from ${source.sourceKind}`,
+        createdAt: observedAt,
+      }),
+    );
+  } else {
+    history.push(
+      buildHistoryEntry({
+        action: "source_attached",
+        sourceKind: source.sourceKind,
+        fingerprint: source.sourceFingerprint,
+        summary: backfill
+          ? `attached ${source.sourceKind} backfill source to canonical task`
+          : `attached ${source.sourceKind} source to canonical task`,
+        createdAt: observedAt,
+      }),
+    );
+  }
+  if (resolutionTransition) {
+    history.push(
+      buildHistoryEntry({
+        action: resolutionTransition.to === "reopened" ? "reopened" : "resolved",
+        sourceKind: source.sourceKind,
+        fingerprint: incoming.canonicalFingerprint,
+        summary: summarizeState(source.sourceKind, resolutionTransition.to),
+        createdAt: observedAt,
+      }),
+    );
+  }
+  if (reconciliationTransition) {
+    history.push(
+      buildHistoryEntry({
+        action:
+          reconciliationTransition.to === "stale"
+            ? "stale_marked"
+            : reconciliationTransition.to === "conflict"
+              ? "conflict_recorded"
+              : "reconciled",
+        sourceKind: source.sourceKind,
+        fingerprint: incoming.canonicalFingerprint,
+        summary: summarizeState(source.sourceKind, reconciliationTransition.to),
+        createdAt: observedAt,
+      }),
+    );
+  }
+
+  return {
+    action,
+    canonicalWork: {
+      ...current,
+      fingerprints,
+      externalLinks,
+      sources,
+      confidence,
+      resolution,
+      reconciliation,
+      history,
+    },
+    resolutionTransition,
+    reconciliationTransition,
+    truthGate: {
+      blockedResolutionUpdate,
+      blockedReconciliationUpdate,
+    },
+  };
+}

--- a/src/orchestration/task-os-artifacts.test.ts
+++ b/src/orchestration/task-os-artifacts.test.ts
@@ -1,0 +1,385 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import { createCanonicalTaskWork } from "./task-os-arbitration.js";
+import { applyStructuredArtifact, buildDefaultArtifactDrafts } from "./task-os-artifacts.js";
+
+async function writeControlPlaneFixture(
+  home: string,
+  options?: { allowStructuredCreate?: boolean },
+) {
+  const policyDir = path.join(home, "control-plane");
+  const approvalMatrixPath = path.join(home, "approval-matrix.json");
+  const rolloutFlagsPath = path.join(home, "rollout-flags.json");
+  await fs.mkdir(policyDir, { recursive: true });
+  await fs.writeFile(
+    path.join(policyDir, "channel-policy.json"),
+    JSON.stringify(
+      {
+        schema_version: 1,
+        stage: "topology",
+        policy_version: "test-cluster",
+        channels: [
+          { id: "slack", allowed_action_classes: ["observe", "recommend", "draft", "notify"] },
+          {
+            id: "telegram",
+            approval_surface: true,
+            allowed_action_classes: ["send", "mutate", "execute"],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    path.join(policyDir, "trigger-ranking.json"),
+    JSON.stringify(
+      {
+        schema_version: 1,
+        stage: "topology",
+        policy_version: "test-cluster",
+        signals: [],
+      },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    path.join(policyDir, "persona-routing.json"),
+    JSON.stringify(
+      {
+        schema_version: 1,
+        stage: "topology",
+        policy_version: "test-cluster",
+        personas: [],
+      },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    approvalMatrixPath,
+    JSON.stringify(
+      {
+        schema_version: 1,
+        stage: "topology",
+        policy_version: "test-policy",
+        default_decision: "approve",
+        required_systems: ["slack", "gmail", "jira", "notion"],
+        required_system_actions: ["read", "draft", "create", "send", "system_change"],
+        entries: [
+          {
+            action_class: "draft",
+            decision: "allow",
+            approval_route: "none",
+            allowed_channels: ["slack", "telegram"],
+          },
+          {
+            action_class: "send",
+            decision: "approve",
+            approval_route: "telegram_approval",
+            allowed_channels: ["telegram"],
+          },
+          {
+            action_class: "mutate",
+            decision: options?.allowStructuredCreate ? "allow" : "approve",
+            approval_route: options?.allowStructuredCreate ? "none" : "telegram_approval",
+            allowed_channels: ["telegram"],
+          },
+        ],
+        system_authority_matrix: [
+          {
+            id: "slack",
+            actions: [
+              { id: "draft", action_class: "draft", decision: "allow", approval_route: "none" },
+              {
+                id: "send",
+                action_class: "send",
+                decision: "approve",
+                approval_route: "telegram_approval",
+              },
+            ],
+          },
+          {
+            id: "gmail",
+            actions: [
+              { id: "draft", action_class: "draft", decision: "allow", approval_route: "none" },
+              {
+                id: "send",
+                action_class: "send",
+                decision: "approve",
+                approval_route: "telegram_approval",
+              },
+            ],
+          },
+          {
+            id: "jira",
+            actions: [
+              {
+                id: "create",
+                action_class: "mutate",
+                decision: options?.allowStructuredCreate ? "allow" : "approve",
+                approval_route: options?.allowStructuredCreate ? "none" : "telegram_approval",
+              },
+            ],
+          },
+          {
+            id: "notion",
+            actions: [
+              {
+                id: "create",
+                action_class: "mutate",
+                decision: options?.allowStructuredCreate ? "allow" : "approve",
+                approval_route: options?.allowStructuredCreate ? "none" : "telegram_approval",
+              },
+            ],
+          },
+        ],
+        source_of_truth: {
+          precedence: ["ledger", "execution_state", "external_artifact_links", "raw_source_events"],
+          layers: [
+            { id: "ledger", rank: 1 },
+            { id: "execution_state", rank: 2 },
+            { id: "external_artifact_links", rank: 3 },
+            { id: "raw_source_events", rank: 4 },
+          ],
+          systems: [
+            {
+              id: "slack",
+              layer: "raw_source_events",
+              reconciliation_mode: "candidate_task_only",
+              promote_to_task_truth: false,
+            },
+            {
+              id: "gmail",
+              layer: "raw_source_events",
+              reconciliation_mode: "candidate_task_only",
+              promote_to_task_truth: false,
+            },
+            {
+              id: "jira",
+              layer: "external_artifact_links",
+              reconciliation_mode: "linked_issue",
+              promote_to_task_truth: false,
+            },
+            {
+              id: "notion",
+              layer: "external_artifact_links",
+              reconciliation_mode: "linked_document",
+              promote_to_task_truth: false,
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    rolloutFlagsPath,
+    JSON.stringify(
+      {
+        policy_version: "test",
+        lanes: [
+          { id: "artifact_adapters", enabled: true },
+          { id: "approval_inbox", enabled: true },
+          { id: "self_healing", enabled: false },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return {
+    OPENCLAW_CONTROL_PLANE_DIR: policyDir,
+    OPENCLAW_APPROVAL_MATRIX_PATH: approvalMatrixPath,
+    OPENCLAW_ROLLOUT_FLAGS_PATH: rolloutFlagsPath,
+  };
+}
+
+function buildTask(params: {
+  id: string;
+  sourceKind: "slack" | "gmail" | "jira" | "notion" | "github";
+  title: string;
+}) {
+  const now = "2026-04-09T12:00:00.000Z";
+  return {
+    id: params.id,
+    title: params.title,
+    status: "pending" as const,
+    dependencies: [],
+    acceptanceCriteria: [],
+    evidence: [],
+    verificationHistory: [],
+    canonicalWork: createCanonicalTaskWork(
+      {
+        source: {
+          sourceKind: params.sourceKind,
+          signalKind: "mention",
+          sourceId: `${params.sourceKind}-1`,
+          idempotencyKey: `${params.sourceKind}-delivery-1`,
+          title: params.title,
+          summary: `${params.title} summary`,
+          confidence: { score: 0.9, reason: "test fixture" },
+          observedAt: now,
+        },
+      },
+      now,
+    ),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("task-os artifacts", () => {
+  it("keeps Slack and Gmail outputs draft-only", async () => {
+    await withTempHome(async (home) => {
+      const env = await writeControlPlaneFixture(home);
+      Object.assign(process.env, env);
+      const priority = {
+        taskId: "task-1",
+        title: "Reply to launch blocker",
+        persona: "chief_of_staff",
+        urgency: "high",
+        cadence: "daily",
+        score: 82,
+        signalId: "mention",
+        actionClassCap: "draft",
+        sourceKind: "slack",
+        confidence: { score: 0.9, label: "high" },
+        whyNow: "Fresh mention needs a response",
+        followUp: "Draft the reply",
+        notification: {
+          status: "ready",
+          lowValue: false,
+          key: "k",
+          fingerprint: "f",
+          dedupeSeconds: 1,
+          reason: "ok",
+        },
+      } as const;
+
+      const drafts = buildDefaultArtifactDrafts({
+        task: buildTask({ id: "task-1", sourceKind: "slack", title: "Reply to launch blocker" }),
+        priority,
+      });
+      expect(drafts).toHaveLength(1);
+      expect(drafts[0]).toMatchObject({ kind: "slack_reply", mode: "draft_only" });
+    });
+  });
+
+  it("auto-creates Jira and Notion artifacts only when policy and target config allow it", async () => {
+    await withTempHome(async (home) => {
+      const env = await writeControlPlaneFixture(home, { allowStructuredCreate: true });
+      Object.assign(process.env, env);
+      vi.resetModules();
+      const storeModule = await import("./task-os-store.js");
+      const storePath = storeModule.resolveTaskOsStorePath();
+      const task = await storeModule.createTask({
+        id: "task-2",
+        title: "Track rollout work",
+        canonicalWork: {
+          source: {
+            sourceKind: "github",
+            signalKind: "review_requested",
+            sourceId: "openclaw/openclaw#42",
+            idempotencyKey: "github-42",
+            title: "Track rollout work",
+            summary: "Track rollout work summary",
+            confidence: { score: 0.92, reason: "review request" },
+            observedAt: "2026-04-09T12:00:00.000Z",
+          },
+        },
+      });
+      const priority = {
+        taskId: task.id,
+        title: task.title,
+        persona: "cto",
+        urgency: "high",
+        cadence: "daily",
+        score: 88,
+        signalId: "goal_deadline",
+        actionClassCap: "draft",
+        sourceKind: "github",
+        confidence: { score: 0.92, label: "high" },
+        whyNow: "Due within 24 hours",
+        followUp: "Draft the implementation plan",
+        notification: {
+          status: "ready",
+          lowValue: false,
+          key: "k",
+          fingerprint: "f",
+          dedupeSeconds: 1,
+          reason: "ok",
+        },
+      } as const;
+
+      const [jiraDraft, notionDraft] = buildDefaultArtifactDrafts({
+        task,
+        priority,
+        jiraConfig: { projectKey: "OPS", issueType: "Task" },
+        notionConfig: { databaseId: "299c0f4d-d8c8-8080-9426-e0561bf18454" },
+      });
+
+      expect(jiraDraft.mode).toBe("auto_create");
+      expect(notionDraft.mode).toBe("auto_create");
+
+      const fetchMock = vi
+        .fn(
+          async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+            new Response(),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ key: "OPS-500" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ id: "page-500", url: "https://www.notion.so/page-500" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      const jiraResult = await applyStructuredArtifact({
+        task,
+        artifact: jiraDraft,
+        storePath,
+        jiraConfig: {
+          baseUrl: "https://makestar-product.atlassian.net",
+          email: "ziho@example.com",
+          apiToken: "token",
+          projectKey: "OPS",
+          issueType: "Task",
+        },
+        fetchImpl: fetchMock,
+      });
+      const notionResult = await applyStructuredArtifact({
+        task,
+        artifact: notionDraft,
+        storePath,
+        notionConfig: {
+          apiToken: "ntn_token",
+          databaseId: "299c0f4d-d8c8-8080-9426-e0561bf18454",
+        },
+        fetchImpl: fetchMock,
+      });
+
+      expect(jiraResult).toMatchObject({ status: "created", externalId: "OPS-500" });
+      expect(notionResult).toMatchObject({ status: "created", externalId: "page-500" });
+
+      const reloaded = await storeModule.loadTaskOsStore();
+      const updatedTask = reloaded.tasks.find((entry) => entry.id === task.id);
+      expect(updatedTask?.evidence.some((entry) => entry.kind === "artifact_mutation")).toBe(true);
+      expect(
+        updatedTask?.canonicalWork?.externalLinks.some((entry) => entry.system === "jira"),
+      ).toBe(true);
+      expect(
+        updatedTask?.canonicalWork?.externalLinks.some((entry) => entry.system === "notion"),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/orchestration/task-os-chat-ingress.test.ts
+++ b/src/orchestration/task-os-chat-ingress.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+
+const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+describe("task-os chat ingress", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OPENCLAW_CONTROL_PLANE_DIR;
+    delete process.env.OPENCLAW_APPROVAL_MATRIX_PATH;
+    delete process.env.OPENCLAW_ROLLOUT_FLAGS_PATH;
+  });
+
+  it("ignores control-command messages", async () => {
+    await withTempHome(async () => {
+      vi.resetModules();
+      const { maybeHandleChatIngressOrchestration } = await import("./task-os-chat-ingress.js");
+      const dispatcher = {
+        sendFinalReply: vi.fn(),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      };
+      const result = await maybeHandleChatIngressOrchestration({
+        ctx: {
+          Body: "/status",
+          BodyForCommands: "/status",
+          SessionKey: "agent:quick:telegram:direct:8557864324",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "8557864324",
+          CommandAuthorized: true,
+        },
+        cfg: {
+          session: {},
+          agents: { defaults: {}, list: [{ id: "quick" }] },
+        } as never,
+        dispatcher: dispatcher as never,
+      });
+      expect(result.handled).toBe(false);
+      expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+      expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("promotes chat work into task-os and spawns deterministic stages", async () => {
+    await withTempHome(async (home) => {
+      const controlPlaneDir = `${home}/control-plane`;
+      const approvalMatrixPath = `${home}/approval-matrix.json`;
+      const rolloutFlagsPath = `${home}/rollout-flags.json`;
+      await import("node:fs/promises").then(async ({ mkdir, writeFile }) => {
+        await mkdir(controlPlaneDir, { recursive: true });
+        await Promise.all([
+          writeFile(
+            `${controlPlaneDir}/channel-policy.json`,
+            JSON.stringify(
+              { schema_version: 1, stage: "topology", policy_version: "test", channels: [] },
+              null,
+              2,
+            ),
+          ),
+          writeFile(
+            `${controlPlaneDir}/trigger-ranking.json`,
+            JSON.stringify(
+              { schema_version: 1, stage: "topology", policy_version: "test", signals: [] },
+              null,
+              2,
+            ),
+          ),
+          writeFile(
+            `${controlPlaneDir}/persona-routing.json`,
+            JSON.stringify(
+              { schema_version: 1, stage: "topology", policy_version: "test", personas: [] },
+              null,
+              2,
+            ),
+          ),
+          writeFile(
+            approvalMatrixPath,
+            JSON.stringify(
+              {
+                schema_version: 1,
+                stage: "topology",
+                policy_version: "test",
+                entries: [{ action_class: "draft", decision: "allow", approval_route: "none" }],
+                system_authority_matrix: [
+                  {
+                    id: "slack",
+                    actions: [
+                      {
+                        id: "draft",
+                        action_class: "draft",
+                        decision: "allow",
+                        approval_route: "none",
+                      },
+                    ],
+                  },
+                  {
+                    id: "telegram",
+                    actions: [
+                      {
+                        id: "draft",
+                        action_class: "draft",
+                        decision: "allow",
+                        approval_route: "none",
+                      },
+                    ],
+                  },
+                ],
+                source_of_truth: {
+                  precedence: [
+                    "ledger",
+                    "execution_state",
+                    "external_artifact_links",
+                    "raw_source_events",
+                  ],
+                  layers: [
+                    { id: "ledger", rank: 1 },
+                    { id: "execution_state", rank: 2 },
+                    { id: "external_artifact_links", rank: 3 },
+                    { id: "raw_source_events", rank: 4 },
+                  ],
+                  systems: [
+                    {
+                      id: "slack",
+                      layer: "raw_source_events",
+                      reconciliation_mode: "candidate_task_only",
+                      allow_candidate_task_creation: true,
+                      promote_to_task_truth: false,
+                    },
+                    {
+                      id: "telegram",
+                      layer: "raw_source_events",
+                      reconciliation_mode: "candidate_task_only",
+                      allow_candidate_task_creation: true,
+                      promote_to_task_truth: false,
+                    },
+                  ],
+                },
+              },
+              null,
+              2,
+            ),
+          ),
+          writeFile(
+            rolloutFlagsPath,
+            JSON.stringify(
+              { policy_version: "test", lanes: [{ id: "approval_inbox", enabled: true }] },
+              null,
+              2,
+            ),
+          ),
+        ]);
+      });
+      process.env.OPENCLAW_CONTROL_PLANE_DIR = controlPlaneDir;
+      process.env.OPENCLAW_APPROVAL_MATRIX_PATH = approvalMatrixPath;
+      process.env.OPENCLAW_ROLLOUT_FLAGS_PATH = rolloutFlagsPath;
+
+      spawnSubagentDirectMock.mockResolvedValue({
+        status: "accepted",
+        childSessionKey: "agent:research:subagent:1",
+      });
+      vi.resetModules();
+      const { maybeHandleChatIngressOrchestration } = await import("./task-os-chat-ingress.js");
+      const { loadTaskOsStore } = await import("./task-os-store.js");
+      const dispatcher = {
+        sendFinalReply: vi.fn(),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 1 })),
+      };
+
+      const result = await maybeHandleChatIngressOrchestration({
+        ctx: {
+          Body: "이거 조사하고 구현 계획 세워서 개발해줘",
+          BodyForCommands: "이거 조사하고 구현 계획 세워서 개발해줘",
+          SessionKey: "agent:quick:slack:channel:u08f692tp37",
+          OriginatingChannel: "slack",
+          OriginatingTo: "user:U08F692TP37",
+          MessageSid: "171717.1",
+          CommandAuthorized: false,
+        },
+        cfg: {
+          session: {},
+          agents: {
+            defaults: {},
+            list: [{ id: "quick" }, { id: "research" }, { id: "spec" }, { id: "builder" }],
+          },
+        } as never,
+        dispatcher: dispatcher as never,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.stageIds).toEqual(["research", "spec-plan", "builder", "verifier"]);
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+      expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(4);
+      const store = await loadTaskOsStore();
+      expect(store.tasks).toHaveLength(1);
+      expect(store.tasks[0]?.evidence.some((entry) => entry.kind === "ingress_stage_spawn")).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/src/orchestration/task-os-chat-ingress.ts
+++ b/src/orchestration/task-os-chat-ingress.ts
@@ -1,0 +1,260 @@
+import crypto from "node:crypto";
+import { resolveSessionAgentId } from "../agents/agent-scope.js";
+import { spawnSubagentDirect } from "../agents/subagent-spawn.js";
+import { isControlCommandMessage } from "../auto-reply/command-detection.js";
+import type { ReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
+import { isTaskOsRolloutLaneEnabled } from "./task-os-rollout.js";
+import { updateTask, upsertCanonicalTask } from "./task-os-store.js";
+
+type IngressStageAgent = "research" | "spec" | "builder";
+
+type IngressStage = {
+  id: string;
+  agentId: IngressStageAgent;
+  label: string;
+  prompt: string;
+};
+
+export type ChatIngressOrchestratorResult = {
+  handled: boolean;
+  taskId?: string;
+  stageIds?: string[];
+  ackText?: string;
+};
+
+function trimToUndefined(value: string | undefined | null): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed ? trimmed : undefined;
+}
+
+function extractChatBody(ctx: FinalizedMsgContext): string {
+  return trimToUndefined(ctx.BodyForCommands ?? ctx.CommandBody ?? ctx.RawBody ?? ctx.Body) ?? "";
+}
+
+function normalizeSourceKind(ctx: FinalizedMsgContext): "slack" | "telegram" | undefined {
+  const channel = normalizeMessageChannel(ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider);
+  if (channel === "slack" || channel === "telegram") {
+    return channel;
+  }
+  return undefined;
+}
+
+function shouldPromote(ctx: FinalizedMsgContext, cfg: OpenClawConfig): boolean {
+  if (!isTaskOsRolloutLaneEnabled("approval_inbox")) {
+    return false;
+  }
+  const sourceKind = normalizeSourceKind(ctx);
+  if (!sourceKind) {
+    return false;
+  }
+  const body = extractChatBody(ctx);
+  if (!body || body.length < 12) {
+    return false;
+  }
+  if (isControlCommandMessage(body, cfg)) {
+    return false;
+  }
+  const lowered = body.toLowerCase();
+  return [
+    "implement",
+    "fix",
+    "build",
+    "research",
+    "analyze",
+    "plan",
+    "spec",
+    "조사",
+    "분석",
+    "계획",
+    "설계",
+    "구현",
+    "개발",
+    "보완",
+    "수정",
+    "테스트",
+  ].some((token) => lowered.includes(token));
+}
+
+function classifyStages(body: string): IngressStage[] {
+  const lowered = body.toLowerCase();
+  const includeResearch = ["research", "analyze", "조사", "분석", "리서치", "문서", "논문"].some(
+    (token) => lowered.includes(token),
+  );
+  const includeBuild = [
+    "implement",
+    "fix",
+    "build",
+    "code",
+    "구현",
+    "개발",
+    "수정",
+    "보완",
+    "테스트",
+  ].some((token) => lowered.includes(token));
+  const includeSpec =
+    includeBuild ||
+    ["plan", "spec", "설계", "기획", "계획"].some((token) => lowered.includes(token));
+  const stages: IngressStage[] = [];
+  if (includeResearch) {
+    stages.push({
+      id: "research",
+      agentId: "research",
+      label: "Research",
+      prompt: `Analyze the user's request and gather the minimum facts needed before implementation.\n\nUser request:\n${body}`,
+    });
+  }
+  if (includeSpec) {
+    stages.push({
+      id: includeBuild ? "spec-plan" : "spec-only",
+      agentId: "spec",
+      label: includeBuild ? "Spec/Plan" : "Spec",
+      prompt: `Turn the user's request into an executable implementation plan.\n\nUser request:\n${body}`,
+    });
+  }
+  if (includeBuild) {
+    stages.push({
+      id: "builder",
+      agentId: "builder",
+      label: "Builder",
+      prompt: `Implement the user's request once the required context is available. Keep verification in scope and report concrete outputs only.\n\nUser request:\n${body}`,
+    });
+    stages.push({
+      id: "verifier",
+      agentId: "spec",
+      label: "Verifier",
+      prompt: `Review whether the implemented result actually satisfies the user's request and identify concrete gaps before approval/execution.\n\nUser request:\n${body}`,
+    });
+  }
+  return stages;
+}
+
+async function spawnStageSessions(params: {
+  ctx: FinalizedMsgContext;
+  requesterAgentId: string;
+  stages: IngressStage[];
+}): Promise<Array<{ id: string; status: string; childSessionKey?: string }>> {
+  const results = [] as Array<{ id: string; status: string; childSessionKey?: string }>;
+  for (const stage of params.stages) {
+    const result = await spawnSubagentDirect(
+      {
+        task: stage.prompt,
+        label: stage.label,
+        agentId: stage.agentId,
+        thread: true,
+        mode: "run",
+      },
+      {
+        agentSessionKey: params.ctx.SessionKey,
+        agentChannel: String(
+          params.ctx.OriginatingChannel ?? params.ctx.Surface ?? params.ctx.Provider ?? "",
+        ),
+        agentAccountId: params.ctx.AccountId,
+        agentTo: params.ctx.OriginatingTo ?? params.ctx.To,
+        agentThreadId: params.ctx.MessageThreadId,
+        requesterAgentIdOverride: params.requesterAgentId,
+      },
+    );
+    results.push({
+      id: stage.id,
+      status: result.status,
+      childSessionKey: result.childSessionKey,
+    });
+  }
+  return results;
+}
+
+export async function maybeHandleChatIngressOrchestration(params: {
+  ctx: FinalizedMsgContext;
+  cfg: OpenClawConfig;
+  dispatcher: ReplyDispatcher;
+}): Promise<ChatIngressOrchestratorResult> {
+  const { ctx, cfg, dispatcher } = params;
+  const requesterAgentId = resolveSessionAgentId({ sessionKey: ctx.SessionKey, config: cfg });
+  if (requesterAgentId !== "quick") {
+    return { handled: false };
+  }
+  if (!shouldPromote(ctx, cfg)) {
+    return { handled: false };
+  }
+  const sourceKind = normalizeSourceKind(ctx);
+  if (!sourceKind) {
+    return { handled: false };
+  }
+  const body = extractChatBody(ctx);
+  const stages = classifyStages(body);
+  if (stages.length === 0) {
+    return { handled: false };
+  }
+  const observedAt = new Date().toISOString();
+  const messageId =
+    trimToUndefined(
+      ctx.MessageSidFull ??
+        ctx.MessageSid ??
+        (ctx.MessageThreadId != null ? String(ctx.MessageThreadId) : undefined),
+    ) ?? crypto.randomUUID();
+  const sourceSurface = `${sourceKind}:chat_ingress`;
+  const upserted = await upsertCanonicalTask({
+    title: body.length > 90 ? `${body.slice(0, 89)}…` : body,
+    canonicalWork: {
+      source: {
+        sourceKind,
+        signalKind: "chat_request",
+        sourceId: messageId,
+        requestId: messageId,
+        idempotencyKey: `${sourceKind}:${messageId}`,
+        sourceSurface,
+        title: body.length > 90 ? `${body.slice(0, 89)}…` : body,
+        summary: body,
+        observedAt,
+        confidence: { score: 0.86, reason: "live chat ingress escalation" },
+        externalLinks: ctx.OriginatingTo
+          ? [
+              {
+                system: sourceKind,
+                externalId: String(ctx.OriginatingTo),
+                title: "chat ingress",
+              },
+            ]
+          : undefined,
+      },
+    },
+    evidence: [
+      {
+        summary: `ingress orchestrator staged ${stages.map((stage) => stage.id).join(" -> ")}`,
+        kind: "ingress_orchestrator",
+        source: sourceSurface,
+        provenanceTier: "runtime_evidence",
+      },
+    ],
+  });
+
+  const spawnResults = await spawnStageSessions({
+    ctx,
+    requesterAgentId,
+    stages,
+  });
+  await updateTask(upserted.task.id, {
+    evidence: spawnResults.map((stage) => ({
+      summary: `${stage.id}: ${stage.status}${stage.childSessionKey ? ` (${stage.childSessionKey})` : ""}`,
+      kind: "ingress_stage_spawn",
+      source: sourceSurface,
+      provenanceTier: "runtime_evidence",
+    })),
+  });
+
+  const ackText = [
+    `작업을 OpenClaw work queue에 등록했어요.`,
+    `task=${upserted.task.id}`,
+    `stages=${stages.map((stage) => stage.id).join(" -> ")}`,
+  ].join("\n");
+  dispatcher.sendFinalReply({ text: ackText });
+  return {
+    handled: true,
+    taskId: upserted.task.id,
+    stageIds: stages.map((stage) => stage.id),
+    ackText,
+  };
+}

--- a/src/orchestration/task-os-inbox.test.ts
+++ b/src/orchestration/task-os-inbox.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createCanonicalTaskWork } from "./task-os-arbitration.js";
+import { buildDefaultArtifactDrafts } from "./task-os-artifacts.js";
+import {
+  buildTaskOsInboxSnapshot,
+  renderSlackHomeQueueSummary,
+  renderTelegramApprovalPacket,
+} from "./task-os-inbox.js";
+import { buildChiefOfStaffSynthesis } from "./task-os-synthesis.js";
+
+function buildTask() {
+  const now = "2026-04-09T12:00:00.000Z";
+  return {
+    id: "task-inbox",
+    title: "Reply to launch blocker",
+    status: "pending" as const,
+    dependencies: [],
+    acceptanceCriteria: [],
+    evidence: [
+      {
+        id: "e1",
+        summary: "NotebookLM evidence packet",
+        provenanceTier: "research_workbench" as const,
+        promotionStatus: "research_only" as const,
+        createdAt: now,
+      },
+    ],
+    verificationHistory: [],
+    canonicalWork: createCanonicalTaskWork(
+      {
+        source: {
+          sourceKind: "slack",
+          signalKind: "mention",
+          sourceId: "slack-thread-1",
+          idempotencyKey: "slack-1",
+          title: "Reply to launch blocker",
+          summary: "Stakeholder is waiting on a reply",
+          confidence: { score: 0.9, reason: "direct mention" },
+          observedAt: now,
+        },
+      },
+      now,
+    ),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function writeRolloutFlags() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inbox-rollout-"));
+  const file = path.join(dir, "rollout-flags.json");
+  await fs.writeFile(
+    file,
+    JSON.stringify(
+      {
+        policy_version: "test",
+        lanes: [
+          { id: "approval_inbox", enabled: true },
+          { id: "artifact_adapters", enabled: true },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  process.env.OPENCLAW_ROLLOUT_FLAGS_PATH = file;
+}
+
+describe("task-os inbox", () => {
+  it("builds an inbox snapshot with pending approvals and research-only attachments", async () => {
+    await writeRolloutFlags();
+    const task = buildTask();
+    const synthesis = await buildChiefOfStaffSynthesis({ tasks: [task], now: task.createdAt });
+    const snapshot = buildTaskOsInboxSnapshot({ tasks: [task], synthesis });
+    const priority = synthesis.priorities[0];
+    if (!priority) {
+      throw new Error("priority missing");
+    }
+    const expectedDrafts = buildDefaultArtifactDrafts({ task, priority });
+
+    expect(snapshot.topQueue).toHaveLength(1);
+    expect(snapshot.topQueue[0]?.pendingApprovals).toHaveLength(
+      expectedDrafts.filter((draft) => draft.approval.decision !== "allow").length,
+    );
+    expect(snapshot.topQueue[0]?.artifactDrafts.map((draft) => draft.kind)).toEqual(
+      expectedDrafts.map((draft) => draft.kind),
+    );
+    expect(snapshot.topQueue[0]?.researchAttachments[0]?.promotionStatus).toBe("research_only");
+  });
+
+  it("renders Slack summary lines and Telegram approval packets with artifact versions", async () => {
+    await writeRolloutFlags();
+    const task = buildTask();
+    const synthesis = await buildChiefOfStaffSynthesis({ tasks: [task], now: task.createdAt });
+    const snapshot = buildTaskOsInboxSnapshot({ tasks: [task], synthesis });
+    const firstItem = snapshot.topQueue[0];
+    if (!firstItem) {
+      throw new Error("inbox item missing");
+    }
+
+    const lines = renderSlackHomeQueueSummary(snapshot);
+    expect(lines[0]).toContain("Reply to launch blocker");
+    expect(lines[0]).toContain("chief_of_staff");
+
+    const packet = renderTelegramApprovalPacket(firstItem);
+    expect(packet).toContain("Approval packet for Reply to launch blocker");
+    expect(packet).toContain("research_only attachment: NotebookLM evidence packet");
+    for (const draft of firstItem.pendingApprovals) {
+      expect(packet).toContain(`version=${draft.version}`);
+    }
+  });
+});

--- a/src/orchestration/task-os-self-healing.test.ts
+++ b/src/orchestration/task-os-self-healing.test.ts
@@ -1,0 +1,303 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTempHome } from "../../test/helpers/temp-home.js";
+import { createCanonicalTaskWork } from "./task-os-arbitration.js";
+import {
+  buildSelfHealingPacket,
+  decideSelfHealing,
+  executeSelfHealingPacket,
+  recordSelfHealingDecision,
+} from "./task-os-self-healing.js";
+
+async function writeControlPlaneFixture(home: string, options?: { allowCode?: boolean }) {
+  const policyDir = path.join(home, "control-plane");
+  const approvalMatrixPath = path.join(home, "approval-matrix.json");
+  const rolloutFlagsPath = path.join(home, "rollout-flags.json");
+  await fs.mkdir(policyDir, { recursive: true });
+  await fs.writeFile(
+    path.join(policyDir, "channel-policy.json"),
+    JSON.stringify(
+      { schema_version: 1, stage: "topology", policy_version: "test", channels: [] },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    path.join(policyDir, "trigger-ranking.json"),
+    JSON.stringify(
+      { schema_version: 1, stage: "topology", policy_version: "test", signals: [] },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    path.join(policyDir, "persona-routing.json"),
+    JSON.stringify(
+      { schema_version: 1, stage: "topology", policy_version: "test", personas: [] },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    approvalMatrixPath,
+    JSON.stringify(
+      {
+        schema_version: 1,
+        stage: "topology",
+        policy_version: "test",
+        entries: [
+          {
+            action_class: "execute",
+            decision: options?.allowCode ? "allow" : "approve",
+            approval_route: options?.allowCode ? "none" : "telegram_approval",
+          },
+        ],
+        system_authority_matrix: [
+          {
+            id: "github",
+            actions: [
+              {
+                id: "code",
+                action_class: "execute",
+                decision: options?.allowCode ? "allow" : "approve",
+                approval_route: options?.allowCode ? "none" : "telegram_approval",
+              },
+            ],
+          },
+        ],
+        source_of_truth: {
+          precedence: ["ledger", "execution_state", "external_artifact_links", "raw_source_events"],
+          layers: [],
+          systems: [
+            {
+              id: "github",
+              layer: "external_artifact_links",
+              reconciliation_mode: "linked_issue",
+              promote_to_task_truth: false,
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await fs.writeFile(
+    rolloutFlagsPath,
+    JSON.stringify(
+      {
+        policy_version: "test",
+        lanes: [
+          { id: "self_healing", enabled: true },
+          { id: "artifact_adapters", enabled: false },
+          { id: "approval_inbox", enabled: true },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return {
+    OPENCLAW_CONTROL_PLANE_DIR: policyDir,
+    OPENCLAW_APPROVAL_MATRIX_PATH: approvalMatrixPath,
+    OPENCLAW_PROJECTS_ROOT: home,
+    OPENCLAW_ROLLOUT_FLAGS_PATH: rolloutFlagsPath,
+  };
+}
+
+function buildTask() {
+  const now = "2026-04-09T12:00:00.000Z";
+  return {
+    id: "task-self-heal",
+    title: "Fix task os collector drift",
+    status: "pending" as const,
+    dependencies: [],
+    acceptanceCriteria: [],
+    evidence: [],
+    verificationHistory: [],
+    canonicalWork: createCanonicalTaskWork(
+      {
+        source: {
+          sourceKind: "github",
+          signalKind: "review_requested",
+          sourceId: "openclaw/openclaw#500",
+          idempotencyKey: "github-500",
+          title: "Fix task os collector drift",
+          summary: "task os collector failure needs triage",
+          confidence: { score: 0.9, reason: "ci issue" },
+          observedAt: now,
+        },
+      },
+      now,
+    ),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("task-os self healing", () => {
+  afterEach(() => {
+    delete process.env.OPENCLAW_CONTROL_PLANE_DIR;
+    delete process.env.OPENCLAW_APPROVAL_MATRIX_PATH;
+    delete process.env.OPENCLAW_PROJECTS_ROOT;
+    delete process.env.OPENCLAW_ROLLOUT_FLAGS_PATH;
+    delete process.env.OPENCLAW_SELF_HEAL_TIMEOUT_MS;
+  });
+
+  it("builds a bounded diagnostic packet for eligible failures", async () => {
+    await withTempHome(async (home) => {
+      Object.assign(process.env, await writeControlPlaneFixture(home));
+      const packet = buildSelfHealingPacket(buildTask(), {
+        taskId: "task-self-heal",
+        title: "Fix task os collector drift",
+        persona: "cto",
+        urgency: "high",
+        cadence: "daily",
+        score: 88,
+        signalId: "goal_deadline",
+        sourceKind: "github",
+        confidence: { score: 0.9, label: "high" },
+        whyNow: "Deadline-oriented work is still open",
+        followUp: "Draft the implementation plan",
+        notification: {
+          status: "ready",
+          lowValue: false,
+          key: "k",
+          fingerprint: "f",
+          dedupeSeconds: 1,
+          reason: "ok",
+        },
+      } as const);
+
+      expect(packet.fixClass).toBe("rerun_task_os_tests");
+      expect(packet.command).toEqual([
+        "pnpm",
+        "test",
+        "--",
+        "src/orchestration/task-os-store.test.ts",
+        "src/orchestration/task-os-live-collector.test.ts",
+      ]);
+      expect(packet.approval.decision).toBe("approve");
+    });
+  });
+
+  it("escalates when the repo is already red for unrelated failures", async () => {
+    await withTempHome(async (home) => {
+      Object.assign(process.env, await writeControlPlaneFixture(home));
+      const decision = decideSelfHealing({
+        task: buildTask(),
+        priority: {
+          taskId: "task-self-heal",
+          title: "Fix task os collector drift",
+          persona: "cto",
+          urgency: "high",
+          cadence: "daily",
+          score: 88,
+          signalId: "goal_deadline",
+          sourceKind: "github",
+          confidence: { score: 0.9, label: "high" },
+          whyNow: "Deadline-oriented work is still open",
+          followUp: "Draft the implementation plan",
+          notification: {
+            status: "ready",
+            lowValue: false,
+            key: "k",
+            fingerprint: "f",
+            dedupeSeconds: 1,
+            reason: "ok",
+          },
+        } as const,
+        unrelatedRepoRed: true,
+        repeatedFailures: 0,
+      });
+
+      expect(decision.outcome).toBe("escalate");
+      expect(decision.reason).toContain("unrelated failures");
+    });
+  });
+
+  it("auto-executes only when policy explicitly allows the bounded fix class", async () => {
+    await withTempHome(async (home) => {
+      const env = await writeControlPlaneFixture(home, { allowCode: true });
+      Object.assign(process.env, env);
+      vi.resetModules();
+      const storeModule = await import("./task-os-store.js");
+      const storePath = storeModule.resolveTaskOsStorePath();
+      const fixtureTask = buildTask();
+      const fixtureSource = fixtureTask.canonicalWork.sources[0];
+      if (!fixtureSource) {
+        throw new Error("fixture source missing");
+      }
+      const task = await storeModule.createTask({
+        id: fixtureTask.id,
+        title: fixtureTask.title,
+        canonicalWork: { source: fixtureSource },
+      });
+      const decision = decideSelfHealing({
+        task,
+        priority: {
+          taskId: task.id,
+          title: task.title,
+          persona: "cto",
+          urgency: "high",
+          cadence: "daily",
+          score: 88,
+          signalId: "goal_deadline",
+          sourceKind: "github",
+          confidence: { score: 0.9, label: "high" },
+          whyNow: "Deadline-oriented work is still open",
+          followUp: "Draft the implementation plan",
+          notification: {
+            status: "ready",
+            lowValue: false,
+            key: "k",
+            fingerprint: "f",
+            dedupeSeconds: 1,
+            reason: "ok",
+          },
+        } as const,
+        unrelatedRepoRed: false,
+        repeatedFailures: 0,
+        env,
+      });
+
+      expect(decision.outcome).toBe("auto_execute");
+      await recordSelfHealingDecision({ task, decision, storePath });
+
+      const reloaded = await storeModule.loadTaskOsStore(storePath);
+      expect(
+        reloaded.tasks[0]?.evidence.some((entry) => entry.kind === "self_healing_packet"),
+      ).toBe(true);
+    });
+  });
+
+  it("times out bounded commands instead of hanging forever", async () => {
+    const previous = process.env.OPENCLAW_SELF_HEAL_TIMEOUT_MS;
+    process.env.OPENCLAW_SELF_HEAL_TIMEOUT_MS = "50";
+    try {
+      const result = await executeSelfHealingPacket({
+        taskId: "task-timeout",
+        signalId: "service_anomaly",
+        fixClass: "rerun_openclaw_build",
+        summary: "timeout test",
+        whyNow: "timeout test",
+        followUp: "none",
+        command: ["node", "-e", "setTimeout(()=>{}, 1000)"],
+        cwd: process.cwd(),
+        auditKey: "self-healing:timeout",
+        rollbackKey: "rollback:self-healing:timeout",
+        approval: { decision: "allow" },
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.stderr).toContain("timed out after");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_SELF_HEAL_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_SELF_HEAL_TIMEOUT_MS = previous;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a live chat ingress orchestrator that moves Slack and Telegram natural-language work requests out of the single-turn quick-agent path into a deterministic task-os escalation pipeline.

### What changed

- **`src/orchestration/task-os-chat-ingress.ts`** — New `maybeHandleChatIngressOrchestration` helper. Detects Korean/English work-intent keywords in Slack/Telegram messages coming through the `quick` agent, promotes each qualifying request into a canonical task-os ledger item, immediately spawns the right stage chain (research → spec → builder → verifier), and replies with a thread-bound ack instead of a normal single-turn reply.

- **`src/auto-reply/dispatch.ts`** — Calls the ingress orchestrator before the normal reply path; returns early with `queuedFinal=true` when the orchestrator handled the message.

- **`src/orchestration/task-os-arbitration.ts`** — Adds `telegram` to the `TASK_SOURCE_KINDS` tuple so Telegram messages can be promoted to canonical tasks.

- **`src/gateway/protocol/schema/task-os.ts`** — Extends `TaskSourceKindSchema` with the `telegram` literal.

- **`src/infra/heartbeat-events.ts`** — Extends `triggerSourceKind` to include `telegram`.

- **Test type fixes** — `as const` annotations on literal fields in task-os artifact/inbox/self-healing test fixtures to satisfy strict TS narrowing.

### Design decisions

| Decision | Rationale |
|---|---|
| Keyword-based promotion | Lowest blast radius; avoids model call on every message |
| Spawn stages then ack | Non-blocking for the ingress thread |
| `quick`-only gate | Prevents double-escalation from other agents |
| rollout-flagged | Controlled via `approval_inbox` lane flag |

### Testing

- Ingress helper unit tests: 2 passed
- Focused proactive suite: 10 passed
- `pnpm build` passes

### Known gaps

- Stage completion sequencing across spawned child sessions is not yet implemented
- Pre-existing tsgo failures in unrelated test files (`bluebubbles`, `discord`, `gateway-status`, `delivery-queue`, `heartbeat-wake`) remain on `main` and are not caused by this change