### PR TITLE
feat(feishu): support lark-cli integration with UA tracking, security warning, and probe switch

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.60.0",
-    "@sinclair/typebox": "0.34.49"
+    "@sinclair/typebox": "0.34.49",
+    "https-proxy-agent": "^8.0.0",
+    "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/feishu/runtime-api.ts
+++ b/extensions/feishu/runtime-api.ts
@@ -49,4 +49,5 @@ export {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "openclaw/plugin-sdk/webhook-ingress";
+export { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 export { setFeishuRuntime } from "./src/runtime.js";

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -124,7 +124,8 @@ export async function beginAppRegistration(domain: FeishuDomain = "feishu"): Pro
   });
 
   const qrUrl = new URL(res.verification_uri_complete);
-  qrUrl.searchParams.set("from", "onboard");
+  qrUrl.searchParams.set("from", "oc_onboard");
+  qrUrl.searchParams.set("tp", "ob_cli_app");
 
   return {
     deviceCode: res.device_code,

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -231,7 +231,8 @@ export async function pollAppRegistration(params: {
  * otherwise the pattern is corrupted and cannot be scanned.
  */
 export async function printQrCode(url: string): Promise<void> {
-  const qrcode = await import("qrcode-terminal");
+  const mod = await import("qrcode-terminal");
+  const qrcode = mod.default ?? mod;
   qrcode.generate(url, { small: true });
 }
 

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -1,0 +1,307 @@
+/**
+ * Feishu app registration via OAuth device-code flow.
+ *
+ * Migrated from feishu-plugin-cli's `feishu-auth.ts` and `install-prompts.ts`.
+ * Replaces axios with native fetch, removes inquirer/ora/chalk in favor of
+ * the openclaw WizardPrompter surface.
+ */
+
+import type { FeishuDomain } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FEISHU_ACCOUNTS_URL = "https://accounts.feishu.cn";
+const LARK_ACCOUNTS_URL = "https://accounts.larksuite.com";
+
+const REGISTRATION_PATH = "/oauth/v1/app/registration";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AppRegistrationResult {
+  appId: string;
+  appSecret: string;
+  domain: FeishuDomain;
+  openId?: string;
+}
+
+interface InitResponse {
+  nonce: string;
+  supported_auth_methods: string[];
+}
+
+export interface BeginResult {
+  deviceCode: string;
+  qrUrl: string;
+  userCode: string;
+  interval: number;
+  expireIn: number;
+}
+
+interface RawBeginResponse {
+  device_code: string;
+  verification_uri: string;
+  user_code: string;
+  verification_uri_complete: string;
+  interval: number;
+  expire_in: number;
+}
+
+interface PollResponse {
+  client_id?: string;
+  client_secret?: string;
+  user_info?: {
+    open_id?: string;
+    tenant_brand?: "feishu" | "lark";
+  };
+  error?: string;
+  error_description?: string;
+}
+
+export type PollOutcome =
+  | { status: "success"; result: AppRegistrationResult }
+  | { status: "access_denied" }
+  | { status: "expired" }
+  | { status: "timeout" }
+  | { status: "error"; message: string };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function accountsBaseUrl(domain: FeishuDomain): string {
+  return domain === "lark" ? LARK_ACCOUNTS_URL : FEISHU_ACCOUNTS_URL;
+}
+
+async function postRegistration<T>(baseUrl: string, body: Record<string, string>): Promise<T> {
+  const response = await fetch(`${baseUrl}${REGISTRATION_PATH}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  // The poll endpoint returns 4xx for pending/error states with a JSON body.
+  const data = (await response.json()) as T;
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Step 1: Initialize registration and verify the environment supports
+ * `client_secret` auth.
+ *
+ * @throws If the environment does not support `client_secret`.
+ */
+export async function initAppRegistration(domain: FeishuDomain = "feishu"): Promise<void> {
+  const baseUrl = accountsBaseUrl(domain);
+  const res = await postRegistration<InitResponse>(baseUrl, { action: "init" });
+
+  if (!res.supported_auth_methods?.includes("client_secret")) {
+    throw new Error("Current environment does not support client_secret auth method");
+  }
+}
+
+/**
+ * Step 2: Begin the device-code flow. Returns a device code and a QR URL
+ * that the user should scan with Feishu/Lark mobile app.
+ */
+export async function beginAppRegistration(domain: FeishuDomain = "feishu"): Promise<BeginResult> {
+  const baseUrl = accountsBaseUrl(domain);
+  const res = await postRegistration<RawBeginResponse>(baseUrl, {
+    action: "begin",
+    archetype: "PersonalAgent",
+    auth_method: "client_secret",
+    request_user_info: "open_id",
+  });
+
+  const qrUrl = new URL(res.verification_uri_complete);
+  qrUrl.searchParams.set("from", "onboard");
+
+  return {
+    deviceCode: res.device_code,
+    qrUrl: qrUrl.toString(),
+    userCode: res.user_code,
+    interval: res.interval || 5,
+    expireIn: res.expire_in || 600,
+  };
+}
+
+/**
+ * Step 3: Poll for authorization result until success, denial, expiry, or
+ * timeout. Automatically handles domain switching when `tenant_brand` is
+ * detected as "lark".
+ */
+export async function pollAppRegistration(params: {
+  deviceCode: string;
+  interval: number;
+  expireIn: number;
+  initialDomain?: FeishuDomain;
+  abortSignal?: AbortSignal;
+  /** Registration type parameter: "ob_user" for user mode, "ob_app" for bot mode. */
+  tp?: string;
+}): Promise<PollOutcome> {
+  const { deviceCode, expireIn, initialDomain = "feishu", abortSignal, tp } = params;
+  let currentInterval = params.interval;
+  let domain: FeishuDomain = initialDomain;
+  let domainSwitched = false;
+
+  const deadline = Date.now() + expireIn * 1000;
+
+  while (Date.now() < deadline) {
+    if (abortSignal?.aborted) {
+      return { status: "timeout" };
+    }
+
+    const baseUrl = accountsBaseUrl(domain);
+
+    let pollRes: PollResponse;
+    try {
+      pollRes = await postRegistration<PollResponse>(baseUrl, {
+        action: "poll",
+        device_code: deviceCode,
+        ...(tp ? { tp } : {}),
+      });
+    } catch {
+      // Transient network error — keep polling.
+      await sleep(currentInterval * 1000);
+      continue;
+    }
+
+    // Domain auto-detection: switch to lark if tenant_brand says so.
+    if (pollRes.user_info?.tenant_brand) {
+      const isLark = pollRes.user_info.tenant_brand === "lark";
+      if (!domainSwitched && isLark) {
+        domain = "lark";
+        domainSwitched = true;
+        // Retry poll immediately with the correct domain.
+        continue;
+      }
+    }
+
+    // Success.
+    if (pollRes.client_id && pollRes.client_secret) {
+      return {
+        status: "success",
+        result: {
+          appId: pollRes.client_id,
+          appSecret: pollRes.client_secret,
+          domain,
+          openId: pollRes.user_info?.open_id,
+        },
+      };
+    }
+
+    // Error handling.
+    if (pollRes.error) {
+      if (pollRes.error === "authorization_pending") {
+        // Continue waiting.
+      } else if (pollRes.error === "slow_down") {
+        currentInterval += 5;
+      } else if (pollRes.error === "access_denied") {
+        return { status: "access_denied" };
+      } else if (pollRes.error === "expired_token") {
+        return { status: "expired" };
+      } else {
+        return {
+          status: "error",
+          message: `${pollRes.error}: ${pollRes.error_description ?? "unknown"}`,
+        };
+      }
+    }
+
+    await sleep(currentInterval * 1000);
+  }
+
+  return { status: "timeout" };
+}
+
+/**
+ * Print QR code directly to stdout.
+ *
+ * QR codes must be printed without any surrounding box/border decoration,
+ * otherwise the pattern is corrupted and cannot be scanned.
+ */
+export async function printQrCode(url: string): Promise<void> {
+  const qrcode = await import("qrcode-terminal");
+  qrcode.generate(url, { small: true });
+}
+
+/**
+ * Fetch the app owner's open_id using the application.v6.application.get API.
+ *
+ * Used during setup to auto-populate security policy allowlists.
+ * Returns undefined on any failure (fail-open).
+ */
+export async function getAppOwnerOpenId(params: {
+  appId: string;
+  appSecret: string;
+  domain?: FeishuDomain;
+}): Promise<string | undefined> {
+  const baseUrl =
+    params.domain === "lark" ? "https://open.larksuite.com" : "https://open.feishu.cn";
+
+  try {
+    // First, get a tenant_access_token.
+    const tokenRes = await fetch(`${baseUrl}/open-apis/auth/v3/tenant_access_token/internal`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ app_id: params.appId, app_secret: params.appSecret }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const tokenData = (await tokenRes.json()) as {
+      code?: number;
+      tenant_access_token?: string;
+    };
+    if (!tokenData.tenant_access_token) {
+      return undefined;
+    }
+
+    // Query app info for the owner's open_id.
+    const appRes = await fetch(
+      `${baseUrl}/open-apis/application/v6/applications/${params.appId}?user_id_type=open_id`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${tokenData.tenant_access_token}`,
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    );
+    const appData = (await appRes.json()) as {
+      code?: number;
+      data?: {
+        app?: {
+          owner?: { owner_id?: string; owner_type?: number; type?: number };
+          creator_id?: string;
+        };
+      };
+    };
+    if (appData.code !== 0) {
+      return undefined;
+    }
+
+    const app = appData.data?.app;
+    const owner = app?.owner;
+    const ownerType = owner?.owner_type ?? owner?.type;
+    // owner_type=2 means enterprise member; use owner_id. Otherwise fallback to creator_id.
+    return ownerType === 2 && owner?.owner_id
+      ? owner.owner_id
+      : (app?.creator_id ?? owner?.owner_id);
+  } catch {
+    return undefined;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -29,6 +29,7 @@ vi.mock("./reply-dispatcher.js", () => ({
 }));
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: mockCreateFeishuClient,
 }));
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -286,6 +286,7 @@ vi.mock("./media.js", () => ({
 }));
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: mockCreateFeishuClient,
 }));
 

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -28,6 +28,7 @@ vi.mock("./probe.js", () => ({
 }));
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: createFeishuClientMock,
 }));
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -67,7 +67,7 @@ import { collectFeishuSecurityAuditFindings } from "./security-audit.js";
 import { resolveFeishuSessionConversation } from "./session-conversation.js";
 import { resolveFeishuOutboundSessionRoute } from "./session-route.js";
 import { feishuSetupAdapter } from "./setup-core.js";
-import { feishuSetupWizard } from "./setup-surface.js";
+import { feishuSetupWizard, runFeishuLogin } from "./setup-surface.js";
 import { looksLikeFeishuId, normalizeFeishuTarget } from "./targets.js";
 import type { FeishuConfig, FeishuProbeResult, ResolvedFeishuAccount } from "./types.js";
 
@@ -1090,6 +1090,19 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             commandTo,
             fallbackTo,
           }),
+      },
+      auth: {
+        login: async ({ cfg: _cfg }) => {
+          const { createClackPrompter } = await import("openclaw/plugin-sdk/feishu");
+          const { loadConfig, writeConfigFile } =
+            await import("openclaw/plugin-sdk/config-runtime");
+          const prompter = createClackPrompter();
+          const currentCfg = loadConfig();
+          const nextCfg = await runFeishuLogin({ cfg: currentCfg, prompter });
+          if (nextCfg !== currentCfg) {
+            await writeConfigFile(nextCfg);
+          }
+        },
       },
       setup: feishuSetupAdapter,
       setupWizard: feishuSetupWizard,

--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -8,6 +8,7 @@ const chatMembersGetMock = vi.hoisted(() => vi.fn());
 const contactUserGetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: createFeishuClientMock,
 }));
 

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -244,7 +244,13 @@ describe("createFeishuClient HTTP timeout", () => {
     expect(mockBaseHttpInstance.post).toHaveBeenCalledWith(
       "https://example.com/api",
       { data: 1 },
-      expect.objectContaining({ timeout: FEISHU_HTTP_TIMEOUT_MS, headers: { "X-Custom": "yes" } }),
+      expect.objectContaining({
+        timeout: FEISHU_HTTP_TIMEOUT_MS,
+        headers: expect.objectContaining({
+          "X-Custom": "yes",
+          "User-Agent": expect.stringMatching(/^openclaw-feishu-builtin\//),
+        }),
+      }),
     );
   });
 

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -31,6 +31,10 @@ const mockBaseHttpInstance = vi.hoisted(() => ({
   delete: vi.fn().mockResolvedValue({}),
   head: vi.fn().mockResolvedValue({}),
   options: vi.fn().mockResolvedValue({}),
+  interceptors: {
+    request: { handlers: [] as unknown[], use: vi.fn() },
+    response: { handlers: [] as unknown[], use: vi.fn() },
+  },
 }));
 const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
 type ProxyEnvKey = (typeof proxyEnvKeys)[number];

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -1,7 +1,28 @@
 import type { Agent } from "node:https";
+import { createRequire } from "node:module";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import { resolveAmbientNodeProxyAgent } from "openclaw/plugin-sdk/extension-shared";
 import type { FeishuConfig, FeishuDomain, ResolvedFeishuAccount } from "./types.js";
+
+const require = createRequire(import.meta.url);
+const { version: pluginVersion } = require("../package.json") as { version: string };
+
+export { pluginVersion };
+const FEISHU_UA_BASE = `openclaw-feishu-builtin/${pluginVersion}/${process.platform}`;
+let feishuAppModeSuffix: string | undefined;
+
+/** Set the appMode suffix for User-Agent (e.g. "bot" or "user"). Call once at startup. */
+export function setFeishuUserAgentMode(appMode: string | undefined): void {
+  feishuAppModeSuffix = appMode?.trim() || undefined;
+}
+
+/** User-Agent header value, includes appMode suffix if configured. */
+export function getFeishuUserAgent(): string {
+  return feishuAppModeSuffix ? `${FEISHU_UA_BASE}/${feishuAppModeSuffix}` : FEISHU_UA_BASE;
+}
+
+/** @deprecated Use getFeishuUserAgent() for dynamic value. Kept for static import compatibility. */
+export const FEISHU_USER_AGENT = FEISHU_UA_BASE;
 
 type FeishuClientSdk = Pick<
   typeof Lark,
@@ -25,6 +46,25 @@ const defaultFeishuClientSdk: FeishuClientSdk = {
 };
 
 let feishuClientSdk: FeishuClientSdk = defaultFeishuClientSdk;
+
+// Override the SDK's default User-Agent interceptor.
+// The Lark SDK registers an axios request interceptor that sets
+// 'oapi-node-sdk/1.0.0'. Clear it and register our own with the tracking UA.
+// Reference: larksuite/openclaw-lark uses the same approach.
+(
+  Lark.defaultHttpInstance as { interceptors: { request: { handlers: unknown[] } } }
+).interceptors.request.handlers = [];
+(
+  Lark.defaultHttpInstance as {
+    interceptors: { request: { use: (fn: (req: unknown) => unknown) => void } };
+  }
+).interceptors.request.use((req: unknown) => {
+  const r = req as { headers?: Record<string, string> };
+  if (r.headers) {
+    r.headers["User-Agent"] = getFeishuUserAgent();
+  }
+  return req;
+});
 
 /** Default HTTP timeout for Feishu API requests (30 seconds). */
 export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
@@ -61,14 +101,18 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
 
 /**
  * Create an HTTP instance that delegates to the Lark SDK's default instance
- * but injects a default request timeout to prevent indefinite hangs
- * (e.g. when the Feishu API is slow, causing per-chat queue deadlocks).
+ * but injects a default request timeout and User-Agent header to prevent
+ * indefinite hangs and enable OAPI request tracking.
  */
 function createTimeoutHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
   const base: FeishuHttpInstanceLike = feishuClientSdk.defaultHttpInstance;
 
   function injectTimeout<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
-    return { timeout: defaultTimeoutMs, ...opts } as Lark.HttpRequestOptions<D>;
+    return {
+      timeout: defaultTimeoutMs,
+      ...opts,
+      headers: { "User-Agent": getFeishuUserAgent(), ...opts?.headers },
+    } as Lark.HttpRequestOptions<D>;
   }
 
   return {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -11,7 +11,9 @@ export { pluginVersion };
 const FEISHU_UA_BASE = `openclaw-feishu-builtin/${pluginVersion}/${process.platform}`;
 let feishuAppModeSuffix: string | undefined;
 
-/** Set the appMode suffix for User-Agent (e.g. "bot" or "user"). Call once at startup. */
+/** Set the appMode suffix for User-Agent (e.g. "bot" or "user"). Call once at startup.
+ * Note: module-global — in multi-account scenarios the last caller wins.
+ * This is acceptable because user mode only supports single-account. */
 export function setFeishuUserAgentMode(appMode: string | undefined): void {
   feishuAppModeSuffix = appMode?.trim() || undefined;
 }

--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -22,6 +22,7 @@ vi.mock("./dynamic-agent.js", () => ({
 }));
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: createFeishuClientMock,
 }));
 

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -211,6 +211,7 @@ export const FeishuConfigSchema = z
     enabled: z.boolean().optional(),
     defaultAccount: z.string().optional(),
     appMode: FeishuAppModeSchema.optional(),
+    disableSecurityWarning: z.boolean().optional(),
     // Top-level credentials (backward compatible for single-account mode)
     appId: z.string().optional(),
     appSecret: buildSecretInputSchema().optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -10,6 +10,7 @@ const ChannelActionsSchema = z
   .strict()
   .optional();
 
+const FeishuAppModeSchema = z.enum(["user", "bot"]);
 const DmPolicySchema = z.enum(["open", "pairing", "allowlist"]);
 const GroupPolicySchema = z.union([
   z.enum(["open", "allowlist", "disabled"]),
@@ -209,6 +210,7 @@ export const FeishuConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
     defaultAccount: z.string().optional(),
+    appMode: FeishuAppModeSchema.optional(),
     // Top-level credentials (backward compatible for single-account mode)
     appId: z.string().optional(),
     appSecret: buildSecretInputSchema().optional(),

--- a/extensions/feishu/src/directory.test.ts
+++ b/extensions/feishu/src/directory.test.ts
@@ -4,6 +4,7 @@ import type { ClawdbotConfig } from "../runtime-api.js";
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: createFeishuClientMock,
 }));
 

--- a/extensions/feishu/src/docx.account-selection.test.ts
+++ b/extensions/feishu/src/docx.account-selection.test.ts
@@ -9,6 +9,7 @@ const createFeishuClientMock = vi.fn((creds: { appId?: string } | undefined) => 
 vi.mock("./client.js", () => {
   return {
     createFeishuClient: (creds: { appId?: string } | undefined) => createFeishuClientMock(creds),
+    setFeishuUserAgentMode: vi.fn(),
   };
 });
 

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -21,6 +21,7 @@ const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 const emptyConfig: ClawdbotConfig = {};
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: createFeishuClientMock,
 }));
 

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,4 +1,7 @@
 import * as crypto from "crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
@@ -11,7 +14,7 @@ import {
 } from "./bot.js";
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
-import { createEventDispatcher } from "./client.js";
+import { createEventDispatcher, createFeishuClient, setFeishuUserAgentMode } from "./client.js";
 import { handleFeishuCommentEvent } from "./comment-handler.js";
 import { isRecord, readString } from "./comment-shared.js";
 import {
@@ -28,7 +31,7 @@ import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { getMessageFeishu } from "./send.js";
+import { getMessageFeishu, sendCardFeishu } from "./send.js";
 import { createFeishuThreadBindingManager } from "./thread-bindings.js";
 import type { FeishuChatType, ResolvedFeishuAccount } from "./types.js";
 
@@ -827,10 +830,219 @@ export type MonitorSingleAccountParams = {
   botOpenIdSource?: BotOpenIdSource;
 };
 
+// --- open policy security warning (one-time) ---
+
+function resolveFeishuStateDir(): string {
+  const stateOverride = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (stateOverride) {
+    return path.join(stateOverride, "feishu");
+  }
+  return path.join(os.homedir(), ".openclaw", "feishu");
+}
+
+function resolveWarningRecordPath(): string {
+  return path.join(resolveFeishuStateDir(), "open-policy-warning.json");
+}
+
+type WarningRecord = {
+  userOpenId: string;
+  warnedAt: string;
+  dmPolicy: string;
+  groupPolicy: string;
+};
+
+function readWarningRecord(): WarningRecord | null {
+  try {
+    const raw = require("node:fs").readFileSync(resolveWarningRecordPath(), "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function writeWarningRecord(record: WarningRecord): Promise<void> {
+  const filePath = resolveWarningRecordPath();
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(record, null, 2), "utf-8");
+}
+
+function buildOpenPolicyWarningCard(params: {
+  dmOpen: boolean;
+  groupOpen: boolean;
+}): Record<string, unknown> {
+  const risks: string[] = [];
+  const risksEn: string[] = [];
+  if (params.dmOpen) {
+    risks.push("单聊策略为 open，任何人都可以与机器人私聊");
+    risksEn.push("DM policy is open — anyone can chat with the bot");
+  }
+  if (params.groupOpen) {
+    risks.push("群聊策略为 open，任何群成员都可以触发机器人");
+    risksEn.push("Group policy is open — any group member can trigger the bot");
+  }
+
+  const zhContent =
+    "当前使用**用户身份模式**，机器人以你的身份执行飞书操作。但检测到以下安全风险：\n\n" +
+    risks.map((r) => `⚠️ ${r}`).join("\n") +
+    "\n\n" +
+    "这意味着其他用户的对话可能触发以你的身份执行操作，存在**身份越权风险**。\n\n" +
+    "**建议操作：**\n" +
+    "- 将单聊策略（dmPolicy）改为 `allowlist` 或 `pairing`\n" +
+    "- 将群聊策略（groupPolicy）改为 `disabled` 或设置 `groupSenderAllowFrom`\n\n" +
+    "可在 `~/.openclaw/openclaw.json` 的 `channels.feishu` 中修改。";
+
+  const enContent =
+    "You are using **user-identity mode** — the bot operates Feishu as you. However, the following security risks were detected:\n\n" +
+    risksEn.map((r) => `⚠️ ${r}`).join("\n") +
+    "\n\n" +
+    "This means other users' messages may trigger operations under your identity, posing an **identity escalation risk**.\n\n" +
+    "**Recommended actions:**\n" +
+    "- Set dmPolicy to `allowlist` or `pairing`\n" +
+    "- Set groupPolicy to `disabled` or configure `groupSenderAllowFrom`\n\n" +
+    "Edit `channels.feishu` in `~/.openclaw/openclaw.json`.";
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: {
+        tag: "plain_text",
+        i18n: {
+          zh_cn: "⚠️ 安全策略提醒",
+          en_us: "⚠️ Security Policy Warning",
+        },
+      },
+      template: "orange",
+    },
+    i18n_elements: {
+      zh_cn: [{ tag: "markdown", content: zhContent }],
+      en_us: [{ tag: "markdown", content: enContent }],
+    },
+  };
+}
+
+export async function checkAndWarnOpenPolicyRisk(params: {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  log: (...args: unknown[]) => void;
+}): Promise<void> {
+  const { cfg, accountId, log } = params;
+  try {
+    const feishuCfg = (cfg as Record<string, unknown>).channels as
+      | Record<string, unknown>
+      | undefined;
+    const accountCfg = (feishuCfg?.feishu ?? feishuCfg?.[accountId]) as
+      | Record<string, unknown>
+      | undefined;
+
+    // 1. Check if security warning is disabled
+    if (accountCfg?.disableSecurityWarning === true) {
+      log(`feishu[${accountId}]: open policy warning skipped: disabled by config`);
+      return;
+    }
+
+    // 2. Only warn in user-identity mode
+    if (accountCfg?.appMode !== "user") {
+      return;
+    }
+
+    // 3. Check if any policy is open
+    const dmPolicy = accountCfg?.dmPolicy as string | undefined;
+    const groupPolicy = accountCfg?.groupPolicy as string | undefined;
+    const dmOpen = dmPolicy === "open";
+    const groupOpen = groupPolicy === "open";
+    if (!dmOpen && !groupOpen) {
+      return;
+    }
+
+    // 4. Check if already warned
+    const existingRecord = readWarningRecord();
+    if (existingRecord) {
+      log(`feishu[${accountId}]: open policy warning skipped: already warned`);
+      return;
+    }
+
+    // 5. Resolve app owner via OAPI
+    let ownerOpenId: string | undefined;
+    try {
+      const account = resolveFeishuAccount({ cfg, accountId });
+      if (!account.configured || !account.appId) {
+        log(`feishu[${accountId}]: open policy warning skipped: account not configured`);
+        return;
+      }
+      const client = createFeishuClient(account) as {
+        request: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+      };
+      const appResp = (await client.request({
+        method: "GET",
+        url: `/open-apis/application/v6/applications/${account.appId}`,
+        data: {},
+        params: { lang: "zh_cn", user_id_type: "open_id" },
+        timeout: 10_000,
+      })) as { data?: { app?: { owner?: { owner_id?: string } } } };
+      ownerOpenId = appResp.data?.app?.owner?.owner_id;
+    } catch (err) {
+      log(
+        `feishu[${accountId}]: open policy warning skipped: failed to resolve owner (${String(err)})`,
+      );
+      return;
+    }
+
+    if (!ownerOpenId) {
+      log(`feishu[${accountId}]: open policy warning skipped: owner not found`);
+      return;
+    }
+
+    // 6. Send warning card
+    const card = buildOpenPolicyWarningCard({ dmOpen, groupOpen });
+    let sent = false;
+    try {
+      await sendCardFeishu({ cfg, to: `user:${ownerOpenId}`, card, accountId });
+      sent = true;
+      log(`feishu[${accountId}]: open policy warning sent to owner ${ownerOpenId}`);
+    } catch (err) {
+      log(
+        `feishu[${accountId}]: open policy warning failed for owner ${ownerOpenId}: ${String(err)}`,
+      );
+    }
+
+    // 7. Write record only on success
+    if (sent) {
+      const warnedAt = new Intl.DateTimeFormat("sv-SE", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+        timeZoneName: "longOffset",
+      })
+        .format(new Date())
+        .replace(" ", "T")
+        .replace(/\s*GMT/, "");
+      await writeWarningRecord({
+        userOpenId: ownerOpenId,
+        warnedAt,
+        dmPolicy: dmPolicy ?? "",
+        groupPolicy: groupPolicy ?? "",
+      });
+    }
+    log(`feishu[${accountId}]: open policy warning complete (sent=${sent})`);
+  } catch (err) {
+    log(`feishu[${accountId}]: open policy warning check failed (non-fatal): ${String(err)}`);
+  }
+}
+
+// --- end open policy security warning ---
+
 export async function monitorSingleAccount(params: MonitorSingleAccountParams): Promise<void> {
   const { cfg, account, runtime, abortSignal } = params;
   const { accountId } = account;
   const log = runtime?.log ?? console.log;
+
+  // Set User-Agent appMode suffix from config (e.g. "bot" or "user")
+  const appMode = (account.config as Record<string, unknown>).appMode as string | undefined;
+  setFeishuUserAgentMode(appMode);
 
   const botOpenIdSource = params.botOpenIdSource ?? { kind: "fetch" };
   const botIdentity =
@@ -856,6 +1068,9 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   if (warmupCount > 0) {
     log(`feishu[${accountId}]: dedup warmup loaded ${warmupCount} entries from disk`);
   }
+
+  // One-time open policy security warning (non-blocking)
+  void checkAndWarnOpenPolicyRisk({ cfg, accountId, log });
 
   let threadBindingManager: ReturnType<typeof createFeishuThreadBindingManager> | null = null;
   try {

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -840,8 +840,9 @@ function resolveFeishuStateDir(): string {
   return path.join(os.homedir(), ".openclaw", "feishu");
 }
 
-function resolveWarningRecordPath(): string {
-  return path.join(resolveFeishuStateDir(), "open-policy-warning.json");
+function resolveWarningRecordPath(accountId: string): string {
+  const sanitized = accountId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  return path.join(resolveFeishuStateDir(), `open-policy-warning-${sanitized}.json`);
 }
 
 type WarningRecord = {
@@ -851,17 +852,17 @@ type WarningRecord = {
   groupPolicy: string;
 };
 
-function readWarningRecord(): WarningRecord | null {
+async function readWarningRecord(accountId: string): Promise<WarningRecord | null> {
   try {
-    const raw = require("node:fs").readFileSync(resolveWarningRecordPath(), "utf-8");
+    const raw = await fs.readFile(resolveWarningRecordPath(accountId), "utf-8");
     return JSON.parse(raw);
   } catch {
     return null;
   }
 }
 
-async function writeWarningRecord(record: WarningRecord): Promise<void> {
-  const filePath = resolveWarningRecordPath();
+async function writeWarningRecord(accountId: string, record: WarningRecord): Promise<void> {
+  const filePath = resolveWarningRecordPath(accountId);
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, JSON.stringify(record, null, 2), "utf-8");
 }
@@ -927,12 +928,9 @@ export async function checkAndWarnOpenPolicyRisk(params: {
 }): Promise<void> {
   const { cfg, accountId, log } = params;
   try {
-    const feishuCfg = (cfg as Record<string, unknown>).channels as
-      | Record<string, unknown>
-      | undefined;
-    const accountCfg = (feishuCfg?.feishu ?? feishuCfg?.[accountId]) as
-      | Record<string, unknown>
-      | undefined;
+    // Resolve the merged account config (top-level defaults + per-account overrides)
+    const account = resolveFeishuAccount({ cfg, accountId });
+    const accountCfg = account.config as unknown as Record<string, unknown>;
 
     // 1. Check if security warning is disabled
     if (accountCfg?.disableSecurityWarning === true) {
@@ -955,7 +953,7 @@ export async function checkAndWarnOpenPolicyRisk(params: {
     }
 
     // 4. Check if already warned
-    const existingRecord = readWarningRecord();
+    const existingRecord = await readWarningRecord(accountId);
     if (existingRecord) {
       log(`feishu[${accountId}]: open policy warning skipped: already warned`);
       return;
@@ -964,7 +962,6 @@ export async function checkAndWarnOpenPolicyRisk(params: {
     // 5. Resolve app owner via OAPI
     let ownerOpenId: string | undefined;
     try {
-      const account = resolveFeishuAccount({ cfg, accountId });
       if (!account.configured || !account.appId) {
         log(`feishu[${accountId}]: open policy warning skipped: account not configured`);
         return;
@@ -1020,7 +1017,7 @@ export async function checkAndWarnOpenPolicyRisk(params: {
         .format(new Date())
         .replace(" ", "T")
         .replace(/\s*GMT/, "");
-      await writeWarningRecord({
+      await writeWarningRecord(accountId, {
         userOpenId: ownerOpenId,
         warnedAt,
         dmPolicy: dmPolicy ?? "",

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -35,6 +35,7 @@ const createMonitorRuntime = () =>
   }) as never;
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createEventDispatcher: createEventDispatcherMock,
 }));
 

--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -5,6 +5,7 @@ import type { ResolvedFeishuAccount } from "./types.js";
 const createFeishuWSClientMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuWSClient: createFeishuWSClientMock,
 }));
 

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -28,6 +28,7 @@ const TEST_DOC_TOKEN = "doxxxxxxx";
 vi.mock("./client.js", () => ({
   createEventDispatcher: createEventDispatcherMock,
   createFeishuClient: createFeishuClientMock,
+  setFeishuUserAgentMode: vi.fn(),
 }));
 
 vi.mock("./comment-handler.js", () => ({

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -23,6 +23,8 @@ let handlers: Record<string, (data: unknown) => Promise<void>> = {};
 
 vi.mock("./client.js", () => ({
   createEventDispatcher: createEventDispatcherMock,
+  createFeishuClient: vi.fn(),
+  setFeishuUserAgentMode: vi.fn(),
 }));
 
 vi.mock("./bot.js", async () => {

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -7,6 +7,8 @@ export function createFeishuClientMockModule(): {
   return {
     createFeishuWSClient: vi.fn(() => ({ start: vi.fn(), close: vi.fn() })),
     createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
+    createFeishuClient: vi.fn(),
+    setFeishuUserAgentMode: vi.fn(),
   };
 }
 

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -31,6 +31,7 @@ vi.mock("./runtime.js", () => ({
 }));
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: vi.fn(() => ({ request: vi.fn() })),
 }));
 

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -4,13 +4,14 @@ import { clearProbeCache, FEISHU_PROBE_REQUEST_TIMEOUT_MS, probeFeishu } from ".
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: createFeishuClientMock,
 }));
 
 const DEFAULT_CREDS = { appId: "cli_123", appSecret: "secret" } as const; // pragma: allowlist secret
 const DEFAULT_SUCCESS_RESPONSE = {
   code: 0,
-  bot: { bot_name: "TestBot", open_id: "ou_abc123" },
+  data: { pingBotInfo: { botName: "TestBot", botID: "ou_abc123" } },
 } as const;
 const DEFAULT_SUCCESS_RESULT = {
   ok: true,
@@ -20,7 +21,7 @@ const DEFAULT_SUCCESS_RESULT = {
 } as const;
 const BOT1_RESPONSE = {
   code: 0,
-  bot: { bot_name: "Bot1", open_id: "ou_1" },
+  data: { pingBotInfo: { botName: "Bot1", botID: "ou_1" } },
 } as const;
 
 function makeRequestFn(response: Record<string, unknown>) {
@@ -135,8 +136,9 @@ describe("probeFeishu", () => {
 
     expect(requestFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "GET",
-        url: "/open-apis/bot/v3/info",
+        method: "POST",
+        url: "/open-apis/bot/v1/openclaw_bot/ping",
+        data: { needBotInfo: true },
         timeout: FEISHU_PROBE_REQUEST_TIMEOUT_MS,
       }),
     );
@@ -259,16 +261,15 @@ describe("probeFeishu", () => {
     });
   });
 
-  it("handles response.data.bot fallback path", async () => {
-    setupClient({
-      code: 0,
-      data: { bot: { bot_name: "DataBot", open_id: "ou_data" } },
-    });
+  it("returns empty bot info when pingBotInfo is missing", async () => {
+    setupClient({ code: 0, data: {} });
 
-    await expectDefaultSuccessResult(DEFAULT_CREDS, {
-      ...DEFAULT_SUCCESS_RESULT,
-      botName: "DataBot",
-      botOpenId: "ou_data",
+    const result = await probeFeishu(DEFAULT_CREDS);
+    expect(result).toEqual({
+      ok: true,
+      appId: "cli_123",
+      botName: undefined,
+      botOpenId: undefined,
     });
   });
 });

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -18,20 +18,19 @@ export type ProbeFeishuOptions = {
   abortSignal?: AbortSignal;
 };
 
-type FeishuBotInfoResponse = {
+type FeishuPingResponse = {
   code: number;
   msg?: string;
-  bot?: { bot_name?: string; open_id?: string };
-  data?: { bot?: { bot_name?: string; open_id?: string } };
+  data?: { pingBotInfo?: { botID?: string; botName?: string } };
 };
 
 type FeishuRequestClient = ReturnType<typeof createFeishuClient> & {
   request(params: {
-    method: "GET";
+    method: "POST";
     url: string;
-    data: Record<string, never>;
+    data: Record<string, unknown>;
     timeout: number;
-  }): Promise<FeishuBotInfoResponse>;
+  }): Promise<FeishuPingResponse>;
 };
 
 function setCachedProbeResult(
@@ -81,12 +80,11 @@ export async function probeFeishu(
 
   try {
     const client = createFeishuClient(creds) as FeishuRequestClient;
-    // Use bot/v3/info API to get bot information
-    const responseResult = await raceWithTimeoutAndAbort<FeishuBotInfoResponse>(
+    const responseResult = await raceWithTimeoutAndAbort<FeishuPingResponse>(
       client.request({
-        method: "GET",
-        url: "/open-apis/bot/v3/info",
-        data: {},
+        method: "POST",
+        url: "/open-apis/bot/v1/openclaw_bot/ping",
+        data: { needBotInfo: true },
         timeout: timeoutMs,
       }),
       {
@@ -135,14 +133,14 @@ export async function probeFeishu(
       );
     }
 
-    const bot = response.bot || response.data?.bot;
+    const botInfo = response.data?.pingBotInfo;
     return setCachedProbeResult(
       cacheKey,
       {
         ok: true,
         appId: creds.appId,
-        botName: bot?.bot_name,
-        botOpenId: bot?.open_id,
+        botName: botInfo?.botName,
+        botOpenId: botInfo?.botID,
       },
       PROBE_SUCCESS_TTL_MS,
     );

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -59,7 +59,10 @@ vi.mock("./send.js", () => ({
   sendStructuredCardFeishu: sendStructuredCardFeishuMock,
 }));
 vi.mock("./media.js", () => ({ sendMediaFeishu: sendMediaFeishuMock }));
-vi.mock("./client.js", () => ({ createFeishuClient: createFeishuClientMock }));
+vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
+  createFeishuClient: createFeishuClientMock,
+}));
 vi.mock("./targets.js", () => ({ resolveReceiveIdType: resolveReceiveIdTypeMock }));
 vi.mock("./typing.js", () => ({
   addTypingIndicator: addTypingIndicatorMock,

--- a/extensions/feishu/src/send-target.test.ts
+++ b/extensions/feishu/src/send-target.test.ts
@@ -10,6 +10,7 @@ vi.mock("./accounts.js", () => ({
 }));
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: createFeishuClientMock,
 }));
 

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -37,6 +37,7 @@ vi.mock("openclaw/plugin-sdk/text-runtime", async (importOriginal) => {
 });
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: mockCreateFeishuClient,
 }));
 

--- a/extensions/feishu/src/setup-surface.test.ts
+++ b/extensions/feishu/src/setup-surface.test.ts
@@ -1,4 +1,3 @@
-import { adaptScopedAccountAccessor } from "openclaw/plugin-sdk/channel-config-helpers";
 import { describe, expect, it, vi } from "vitest";
 import { createNonExitingTypedRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
 import {
@@ -6,44 +5,27 @@ import {
   createPluginSetupWizardStatus,
   createTestWizardPrompter,
   runSetupWizardConfigure,
-  type WizardPrompter,
 } from "../../../test/helpers/plugins/setup-wizard.js";
-import {
-  listFeishuAccountIds,
-  resolveDefaultFeishuAccountId,
-  resolveFeishuAccount,
-} from "./accounts.js";
-import { feishuSetupAdapter } from "./setup-core.js";
-import { feishuSetupWizard } from "./setup-surface.js";
 
 vi.mock("./probe.js", () => ({
   probeFeishu: vi.fn(async () => ({ ok: false, error: "mocked" })),
 }));
 
+vi.mock("./app-registration.js", () => ({
+  initAppRegistration: vi.fn(async () => {
+    throw new Error("mocked: scan-to-create not available");
+  }),
+  beginAppRegistration: vi.fn(),
+  pollAppRegistration: vi.fn(),
+  printQrCode: vi.fn(async () => {}),
+  getAppOwnerOpenId: vi.fn(async () => undefined),
+}));
+
+import { feishuPlugin } from "./channel.js";
+
 const baseStatusContext = {
   accountOverrides: {},
 };
-
-const feishuSetupPlugin = {
-  id: "feishu",
-  meta: {
-    id: "feishu",
-    label: "Feishu",
-    selectionLabel: "Feishu/Lark (飞书)",
-    docsPath: "/channels/feishu",
-    blurb: "飞书/Lark enterprise messaging.",
-  },
-  capabilities: {
-    chatTypes: ["direct", "group"] as Array<"direct" | "group">,
-  },
-  config: {
-    listAccountIds: (cfg: unknown) => listFeishuAccountIds(cfg as never),
-    defaultAccountId: (cfg: unknown) => resolveDefaultFeishuAccountId(cfg as never),
-    resolveAccount: adaptScopedAccountAccessor(resolveFeishuAccount),
-  },
-  setup: feishuSetupAdapter,
-  setupWizard: feishuSetupWizard,
-} as const;
 
 async function withEnvVars(values: Record<string, string | undefined>, run: () => Promise<void>) {
   const previous = new Map<string, string | undefined>();
@@ -83,54 +65,21 @@ async function getStatusWithEnvRefs(params: { appIdKey: string; appSecretKey: st
   });
 }
 
-const feishuConfigure = createPluginSetupWizardConfigure(feishuSetupPlugin);
-const feishuGetStatus = createPluginSetupWizardStatus(feishuSetupPlugin);
+const feishuConfigure = createPluginSetupWizardConfigure(feishuPlugin);
+const feishuGetStatus = createPluginSetupWizardStatus(feishuPlugin);
 type FeishuConfigureRuntime = Parameters<typeof feishuConfigure>[0]["runtime"];
 
 describe("feishu setup wizard", () => {
-  it("setup adapter preserves a selected named account id", () => {
-    expect(
-      feishuSetupPlugin.setup?.resolveAccountId?.({
-        cfg: {} as never,
-        accountId: "work",
-        input: {},
-      } as never),
-    ).toBe("work");
-  });
-
-  it("setup adapter uses configured defaultAccount when accountId is omitted", () => {
-    expect(
-      feishuSetupPlugin.setup?.resolveAccountId?.({
-        cfg: {
-          channels: {
-            feishu: {
-              defaultAccount: "work",
-              accounts: {
-                work: {
-                  appId: "work-app",
-                  appSecret: "work-secret", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        } as never,
-        accountId: undefined,
-        input: {},
-      } as never),
-    ).toBe("work");
-  });
-
   it("does not throw when config appId/appSecret are SecretRef objects", async () => {
     const text = vi
       .fn()
       .mockResolvedValueOnce("cli_from_prompt")
-      .mockResolvedValueOnce("secret_from_prompt")
-      .mockResolvedValueOnce("oc_group_1");
+      .mockResolvedValueOnce("secret_from_prompt");
     const prompter = createTestWizardPrompter({
       text,
       confirm: vi.fn(async () => true),
       select: vi.fn(
-        async ({ initialValue }: { initialValue?: string }) => initialValue ?? "allowlist",
+        async ({ initialValue }: { initialValue?: string }) => initialValue ?? "bot",
       ) as never,
     });
 
@@ -149,131 +98,6 @@ describe("feishu setup wizard", () => {
         runtime: createNonExitingTypedRuntimeEnv<FeishuConfigureRuntime>(),
       }),
     ).resolves.toBeTruthy();
-  });
-
-  it("writes selected-account credentials instead of overwriting the channel root", async () => {
-    const prompter = createTestWizardPrompter({
-      text: vi.fn(async ({ message }: { message: string }) => {
-        if (message === "Enter Feishu App Secret") {
-          return "work-secret"; // pragma: allowlist secret
-        }
-        if (message === "Enter Feishu App ID") {
-          return "work-app";
-        }
-        if (message === "Group chat allowlist (chat_ids)") {
-          return "";
-        }
-        throw new Error(`Unexpected prompt: ${message}`);
-      }) as WizardPrompter["text"],
-      select: vi.fn(
-        async ({ initialValue }: { initialValue?: string }) => initialValue ?? "websocket",
-      ) as never,
-    });
-
-    const result = await runSetupWizardConfigure({
-      configure: feishuConfigure,
-      cfg: {
-        channels: {
-          feishu: {
-            appId: "top-level-app",
-            appSecret: "top-level-secret", // pragma: allowlist secret
-            accounts: {
-              work: {
-                appId: "",
-              },
-            },
-          },
-        },
-      } as never,
-      prompter,
-      accountOverrides: {
-        feishu: "work",
-      },
-      runtime: createNonExitingTypedRuntimeEnv<FeishuConfigureRuntime>(),
-    });
-
-    expect(result.cfg.channels?.feishu?.appId).toBe("top-level-app");
-    expect(result.cfg.channels?.feishu?.appSecret).toBe("top-level-secret");
-    expect(result.cfg.channels?.feishu?.accounts?.work).toMatchObject({
-      enabled: true,
-      appId: "work-app",
-      appSecret: "work-secret",
-    });
-  });
-
-  it("uses configured defaultAccount for omitted finalize writes", async () => {
-    const prompter = createTestWizardPrompter({
-      text: vi.fn(async ({ message }: { message: string }) => {
-        if (message === "Enter Feishu App Secret") {
-          return "work-secret"; // pragma: allowlist secret
-        }
-        if (message === "Enter Feishu App ID") {
-          return "work-app";
-        }
-        if (message === "Feishu webhook path") {
-          return "/feishu/events";
-        }
-        if (message === "Group chat allowlist (chat_ids)") {
-          return "";
-        }
-        throw new Error(`Unexpected prompt: ${message}`);
-      }) as WizardPrompter["text"],
-      select: vi.fn(
-        async ({ message, initialValue }: { message: string; initialValue?: string }) => {
-          if (message === "Feishu connection mode") {
-            return initialValue ?? "websocket";
-          }
-          if (message === "Which Feishu domain?") {
-            return initialValue ?? "feishu";
-          }
-          if (message === "Group chat policy") {
-            return "disabled";
-          }
-          return initialValue ?? "websocket";
-        },
-      ) as never,
-      note: vi.fn(async () => {}),
-    });
-
-    const setupWizard = feishuSetupPlugin.setupWizard;
-    if (!setupWizard || !("finalize" in setupWizard) || !setupWizard.finalize) {
-      throw new Error("feishu setupWizard.finalize unavailable");
-    }
-
-    const result = await setupWizard.finalize({
-      cfg: {
-        channels: {
-          feishu: {
-            appId: "top-level-app",
-            appSecret: "top-level-secret", // pragma: allowlist secret
-            defaultAccount: "work",
-            accounts: {
-              work: {
-                appId: "",
-              },
-            },
-          },
-        },
-      } as never,
-      accountId: "work",
-      credentialValues: {},
-      forceAllowFrom: false,
-      prompter,
-      runtime: createNonExitingTypedRuntimeEnv<FeishuConfigureRuntime>(),
-      options: {},
-    });
-
-    expect(result && typeof result === "object" && "cfg" in result).toBe(true);
-    const nextCfg =
-      result && typeof result === "object" && "cfg" in result ? result.cfg : undefined;
-    expect(nextCfg?.channels?.feishu).toBeDefined();
-    expect(nextCfg?.channels?.feishu?.appId).toBe("top-level-app");
-    expect(nextCfg?.channels?.feishu?.appSecret).toBe("top-level-secret");
-    expect(nextCfg?.channels?.feishu?.accounts?.work).toMatchObject({
-      enabled: true,
-      appId: "work-app",
-      appSecret: "work-secret",
-    });
   });
 });
 
@@ -317,97 +141,6 @@ describe("feishu setup wizard status", () => {
     });
 
     expect(status.configured).toBe(false);
-  });
-
-  it("setup status honors the selected named account", async () => {
-    const status = await feishuGetStatus({
-      cfg: {
-        channels: {
-          feishu: {
-            appId: "top_level_app",
-            appSecret: "top-level-secret", // pragma: allowlist secret
-            accounts: {
-              work: {
-                appId: "",
-                appSecret: "work-secret", // pragma: allowlist secret
-              },
-            },
-          },
-        },
-      } as never,
-      accountOverrides: {
-        feishu: "work",
-      },
-    });
-
-    expect(status.configured).toBe(false);
-    expect(status.statusLines).toEqual(["Feishu: needs app credentials"]);
-  });
-
-  it("uses configured defaultAccount for omitted setup configured state", async () => {
-    const status = await feishuGetStatus({
-      cfg: {
-        channels: {
-          feishu: {
-            defaultAccount: "work",
-            appId: "top_level_app",
-            appSecret: "top-level-secret", // pragma: allowlist secret
-            accounts: {
-              alerts: {
-                appId: "alerts-app",
-                appSecret: "alerts-secret", // pragma: allowlist secret
-              },
-              work: {
-                appId: "",
-                appSecret: "work-secret", // pragma: allowlist secret
-              },
-            },
-          },
-        },
-      } as never,
-      accountOverrides: {},
-    });
-
-    expect(status.configured).toBe(false);
-    expect(status.statusLines).toEqual(["Feishu: needs app credentials"]);
-  });
-
-  it("uses configured defaultAccount for omitted DM policy account context", async () => {
-    const cfg = {
-      channels: {
-        feishu: {
-          allowFrom: ["ou_root"],
-          defaultAccount: "work",
-          accounts: {
-            work: {
-              appId: "work-app",
-              appSecret: "work-secret", // pragma: allowlist secret
-              dmPolicy: "allowlist",
-              allowFrom: ["ou_work"],
-            },
-          },
-        },
-      },
-    } as const;
-
-    expect(feishuSetupWizard.dmPolicy?.getCurrent?.(cfg as never)).toBe("allowlist");
-    expect(feishuSetupWizard.dmPolicy?.resolveConfigKeys?.(cfg as never)).toEqual({
-      policyKey: "channels.feishu.accounts.work.dmPolicy",
-      allowFromKey: "channels.feishu.accounts.work.allowFrom",
-    });
-
-    const next = feishuSetupWizard.dmPolicy?.setPolicy?.(cfg as never, "open");
-    const workAccount = next?.channels?.feishu?.accounts?.work as
-      | {
-          dmPolicy?: string;
-          allowFrom?: string[];
-        }
-      | undefined;
-
-    expect(next?.channels?.feishu?.dmPolicy).toBeUndefined();
-    expect(next?.channels?.feishu?.allowFrom).toEqual(["ou_root"]);
-    expect(workAccount?.dmPolicy).toBe("open");
-    expect(workAccount?.allowFrom).toEqual(["ou_work", "*"]);
   });
 
   it("treats env SecretRef appId as not configured when env var is missing", async () => {

--- a/extensions/feishu/src/setup-surface.ts
+++ b/extensions/feishu/src/setup-surface.ts
@@ -1,5 +1,4 @@
 import {
-  buildSingleChannelSecretPromptState,
   createTopLevelChannelAllowFromSetter,
   createTopLevelChannelDmPolicy,
   createTopLevelChannelGroupPolicySetter,
@@ -16,7 +15,7 @@ import {
   type OpenClawConfig,
   type SecretInput,
 } from "openclaw/plugin-sdk/setup";
-import { inspectFeishuCredentials, listFeishuAccountIds } from "./accounts.js";
+import { inspectFeishuCredentials } from "./accounts.js";
 import {
   beginAppRegistration,
   getAppOwnerOpenId,
@@ -26,7 +25,6 @@ import {
   type AppRegistrationResult,
 } from "./app-registration.js";
 import { probeFeishu } from "./probe.js";
-import { feishuSetupAdapter } from "./setup-core.js";
 import type { FeishuAppMode, FeishuConfig, FeishuDomain } from "./types.js";
 
 const channel = "feishu" as const;
@@ -37,39 +35,6 @@ const setFeishuGroupPolicy = createTopLevelChannelGroupPolicySetter({
   channel,
   enabled: true,
 });
-
-// ---------------------------------------------------------------------------
-// Skills lists (from requirements doc)
-// ---------------------------------------------------------------------------
-
-/** Tools skills — enabled in "As bot" mode, disabled in "As you" mode. */
-const TOOLS_SKILLS = [
-  "lark-mail",
-  "lark-minutes",
-  "lark-openapi-explorer",
-  "lark-skill-maker",
-  "lark-calendar",
-  "lark-workflow-standup-report",
-  "lark-wiki",
-  "lark-doc",
-  "lark-contact",
-  "lark-vc",
-  "lark-drive",
-  "lark-workflow-meeting-summary",
-  "lark-shared",
-  "lark-base",
-  "lark-im",
-  "lark-sheets",
-  "lark-task",
-  "lark-whiteboard",
-  "feishu-doc",
-  "feishu-drive",
-  "feishu-perm",
-  "feishu-wiki",
-] as const;
-
-/** lark-cli skills — no longer managed by onboarding. */
-const LARKCLI_SKILLS: readonly string[] = [];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -123,19 +88,6 @@ function isFeishuConfigured(cfg: OpenClawConfig): boolean {
   });
 
   return topLevelConfigured || accountConfigured;
-}
-
-function setFeishuGroupAllowFrom(cfg: OpenClawConfig, groupAllowFrom: string[]): OpenClawConfig {
-  return {
-    ...cfg,
-    channels: {
-      ...cfg.channels,
-      feishu: {
-        ...cfg.channels?.feishu,
-        groupAllowFrom,
-      },
-    },
-  };
 }
 
 function setFeishuGroupSenderAllowFrom(
@@ -213,114 +165,11 @@ const feishuDmPolicy: ChannelSetupDmPolicy = createTopLevelChannelDmPolicy({
 type WizardPrompter = Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["prompter"];
 
 // ---------------------------------------------------------------------------
-// Mode selection
-// ---------------------------------------------------------------------------
-
-async function promptAppMode(
-  prompter: WizardPrompter,
-  options?: {
-    disableUser?: boolean;
-    currentMode?: FeishuAppMode;
-  },
-): Promise<FeishuAppMode> {
-  const userHint = options?.disableUser
-    ? "Works under your identity, managing messages, docs, calendar, and more as you upon authorization. (\u26a0\ufe0f Unavailable with multiple linked bots. Remove unused bots to enable this option.)"
-    : "Works under your identity, managing messages, docs, calendar, and more as you upon authorization.";
-
-  const botOption = {
-    value: "bot" as const,
-    label: "As bot (recommended)",
-    hint: "Works under its own identity. Best for group chats, team notifications, and shared documents.",
-  };
-  const userOption = {
-    value: "user" as const,
-    label: "As you",
-    hint: userHint,
-  };
-
-  const selectOptions = options?.disableUser ? [botOption] : [botOption, userOption];
-
-  return (await prompter.select({
-    message: "How should the AI work with you?",
-    options: selectOptions,
-    initialValue: options?.currentMode ?? "bot",
-  })) as FeishuAppMode;
-}
-
-// ---------------------------------------------------------------------------
-// Skills configuration
-// ---------------------------------------------------------------------------
-
-/** Skills that are always disabled regardless of mode. */
-const ALWAYS_DISABLED_SKILLS = ["lark-event"] as const;
-
-/**
- * Returns which skills to disable and which to enable (remove from entries).
- *
- * - As you (user mode): disable tools skills
- * - As bot (bot mode): enable tools skills (remove disabled entries)
- * - lark-event is always disabled
- *
- * Disable = set `{ enabled: false }` in `skills.entries`
- * Enable  = remove the key from `skills.entries` so default behavior takes over
- */
-function buildSkillsConfig(appMode: FeishuAppMode): {
-  disable: Record<string, { enabled: false }>;
-  enable: readonly string[];
-} {
-  const disable: Record<string, { enabled: false }> = {};
-
-  // Always-disabled skills.
-  for (const skill of ALWAYS_DISABLED_SKILLS) {
-    disable[skill] = { enabled: false };
-  }
-
-  if (appMode === "user") {
-    // User mode: enable lark-cli skills, disable tools skills.
-    for (const skill of TOOLS_SKILLS) {
-      disable[skill] = { enabled: false };
-    }
-    return { disable, enable: LARKCLI_SKILLS };
-  }
-  // Bot mode: enable tools skills, disable lark-cli skills.
-  for (const skill of LARKCLI_SKILLS) {
-    disable[skill] = { enabled: false };
-  }
-  return { disable, enable: TOOLS_SKILLS };
-}
-
-/** Apply skills config: disable target skills, remove opposite skills from entries. */
-function applySkillsConfig(cfg: OpenClawConfig, appMode: FeishuAppMode): OpenClawConfig {
-  const { disable, enable } = buildSkillsConfig(appMode);
-
-  const existingSkills = (cfg as Record<string, unknown>).skills as
-    | Record<string, unknown>
-    | undefined;
-  const existingEntries = (existingSkills?.entries ?? {}) as Record<string, unknown>;
-
-  // Clone entries, remove keys that should be enabled, then merge disabled ones.
-  const newEntries = { ...existingEntries };
-  for (const skill of enable) {
-    delete newEntries[skill];
-  }
-  Object.assign(newEntries, disable);
-
-  return {
-    ...cfg,
-    skills: {
-      ...existingSkills,
-      entries: newEntries,
-    },
-  } as OpenClawConfig;
-}
-
-// ---------------------------------------------------------------------------
 // Security policy helpers
 // ---------------------------------------------------------------------------
 
 function applyNewAppSecurityPolicy(
   cfg: OpenClawConfig,
-  appMode: FeishuAppMode,
   openId: string | undefined,
 ): OpenClawConfig {
   let next = cfg;
@@ -329,33 +178,16 @@ function applyNewAppSecurityPolicy(
     return next;
   }
 
-  // Both modes: dmPolicy=allowlist, allowFrom=[openId]
+  // dmPolicy=allowlist, allowFrom=[openId]
   next = patchTopLevelChannelConfigSection({
     cfg: next,
     channel,
     patch: { dmPolicy: "allowlist" },
-  }) as OpenClawConfig;
+  });
   next = setFeishuAllowFrom(next, [openId]);
 
-  // Both modes: groupPolicy=open
+  // groupPolicy=open
   next = setFeishuGroupPolicy(next, "open");
-
-  // Enable wildcard groups.
-  next = patchTopLevelChannelConfigSection({
-    cfg: next,
-    channel,
-    patch: {
-      groups: {
-        ...((next.channels?.feishu as FeishuConfig | undefined)?.groups ?? {}),
-        "*": { enabled: true },
-      },
-    },
-  }) as OpenClawConfig;
-
-  if (appMode === "user") {
-    // User mode: also set groupSenderAllowFrom=[openId]
-    next = setFeishuGroupSenderAllowFrom(next, [openId]);
-  }
 
   return next;
 }
@@ -364,10 +196,7 @@ function applyNewAppSecurityPolicy(
 // Scan-to-create flow
 // ---------------------------------------------------------------------------
 
-async function runScanToCreate(
-  prompter: WizardPrompter,
-  appMode: FeishuAppMode,
-): Promise<AppRegistrationResult | null> {
+async function runScanToCreate(prompter: WizardPrompter): Promise<AppRegistrationResult | null> {
   try {
     await initAppRegistration("feishu");
   } catch {
@@ -385,13 +214,12 @@ async function runScanToCreate(
 
   const progress = prompter.progress("Fetching configuration results...");
 
-  const tp = appMode === "user" ? "ob_user" : "ob_app";
   const outcome = await pollAppRegistration({
     deviceCode: begin.deviceCode,
     interval: begin.interval,
     expireIn: begin.expireIn,
     initialDomain: "feishu",
-    tp,
+    tp: "ob_app",
   });
 
   switch (outcome.status) {
@@ -414,35 +242,6 @@ async function runScanToCreate(
 }
 
 // ---------------------------------------------------------------------------
-// Install helpers
-// ---------------------------------------------------------------------------
-
-async function ensureLarkCliInstalled(): Promise<void> {
-  try {
-    const { execSync } = await import("node:child_process");
-    try {
-      execSync("lark-cli --version", { stdio: "ignore" });
-    } catch {
-      execSync("npm install -g @larksuite/cli", { stdio: "ignore", timeout: 120_000 });
-    }
-  } catch {
-    // install failed or node:child_process unavailable — skip silently.
-  }
-}
-
-async function installLarkSkills(): Promise<void> {
-  try {
-    const { execSync } = await import("node:child_process");
-    execSync("npx skills add larksuite/cli -y -g -a openclaw", {
-      stdio: "ignore",
-      timeout: 120_000,
-    });
-  } catch {
-    // install failed or node:child_process unavailable — skip silently.
-  }
-}
-
-// ---------------------------------------------------------------------------
 // New app configuration flow
 // ---------------------------------------------------------------------------
 
@@ -450,20 +249,9 @@ async function runNewAppFlow(params: {
   cfg: OpenClawConfig;
   prompter: WizardPrompter;
   options: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["options"];
-  appMode: FeishuAppMode;
-  skipModeSelection?: boolean;
 }): Promise<{ cfg: OpenClawConfig }> {
   const { prompter, options } = params;
   let next = params.cfg;
-  const appMode = params.appMode;
-
-  // Apply appMode to config.
-  next = patchTopLevelChannelConfigSection({
-    cfg: next,
-    channel,
-    enabled: true,
-    patch: { appMode },
-  }) as OpenClawConfig;
 
   // ----- QR scan flow -----
   let appId: string | null = null;
@@ -472,7 +260,7 @@ async function runNewAppFlow(params: {
   let scanDomain: FeishuDomain | undefined;
   let scanOpenId: string | undefined;
 
-  const scanResult = await runScanToCreate(prompter, appMode);
+  const scanResult = await runScanToCreate(prompter);
   if (scanResult) {
     appId = scanResult.appId;
     appSecret = scanResult.appSecret;
@@ -480,7 +268,7 @@ async function runNewAppFlow(params: {
     scanDomain = scanResult.domain;
     scanOpenId = scanResult.openId;
   } else {
-    // Fallback to manual input.
+    // Fallback to manual input: collect domain, appId, appSecret.
     const feishuCfg = next.channels?.feishu as FeishuConfig | undefined;
     await noteFeishuCredentialHelp(prompter);
 
@@ -519,11 +307,19 @@ async function runNewAppFlow(params: {
       appSecret = appSecretResult.value;
       appSecretProbeValue = appSecretResult.resolvedValue;
     }
+
+    // Fetch openId via API for manual flow.
+    if (appId && appSecretProbeValue) {
+      scanOpenId = await getAppOwnerOpenId({
+        appId,
+        appSecret: appSecretProbeValue,
+        domain: scanDomain,
+      });
+    }
   }
 
-  // ----- Apply credentials, policies, skills & install (under one spinner) -----
+  // ----- Apply credentials & security policy -----
   const configProgress = prompter.progress("Configuring...");
-  // Yield to let the spinner render before sync work and execSync block the event loop.
   await new Promise((resolve) => setTimeout(resolve, 50));
 
   if (appId && appSecret) {
@@ -537,7 +333,7 @@ async function runNewAppFlow(params: {
         connectionMode: "websocket",
         ...(scanDomain ? { domain: scanDomain } : {}),
       },
-    }) as OpenClawConfig;
+    });
   }
 
   if (scanDomain) {
@@ -545,13 +341,19 @@ async function runNewAppFlow(params: {
       cfg: next,
       channel,
       patch: { domain: scanDomain },
-    }) as OpenClawConfig;
+    });
   }
 
-  next = applyNewAppSecurityPolicy(next, appMode, scanOpenId);
-  next = applySkillsConfig(next, appMode);
-  await ensureLarkCliInstalled();
-  await installLarkSkills();
+  next = applyNewAppSecurityPolicy(next, scanOpenId);
+
+  // Always set appMode to bot.
+  next = patchTopLevelChannelConfigSection({
+    cfg: next,
+    channel,
+    enabled: true,
+    patch: { appMode: "bot" },
+  });
+
   configProgress.stop("Bot configured.");
 
   return { cfg: next };
@@ -592,40 +394,40 @@ async function recommendSecurityPolicyChanges(params: {
     });
   }
 
+  await prompter.note(
+    "To keep your data safe while acting as you, we suggest these policy updates:",
+    "Security recommendation",
+  );
+
   const recommendations: string[] = [];
   let dmPatch: Partial<FeishuConfig> = {};
   let dmAllowFrom: string[] | undefined;
   let groupPatch: Partial<FeishuConfig> = {};
   let groupSenderAllowFrom: string[] | undefined;
 
-  await prompter.note(
-    "To keep your data safe while acting as you, we suggest these policy updates:",
-    "Security recommendation",
-  );
-
   if (needDmRecommendation) {
     if (ownerOpenId) {
       dmPatch = { dmPolicy: "allowlist" };
       dmAllowFrom = [ownerOpenId];
-      recommendations.push("DMs: Only the owner");
+      recommendations.push("- DMs: Only the owner");
     } else {
       dmPatch = { dmPolicy: "pairing" };
-      recommendations.push("DMs: Only the paired user");
+      recommendations.push("- DMs: Only the paired user");
     }
   }
 
   if (needGroupRecommendation) {
     if (ownerOpenId) {
       groupSenderAllowFrom = [ownerOpenId];
-      recommendations.push("Group chats: Only when mentioned by the owner");
+      recommendations.push("- Group chats: Only when mentioned by the owner");
     } else {
       groupPatch = { groupPolicy: "disabled" };
-      recommendations.push("Group chats: Disabled");
+      recommendations.push("- Group chats: Disabled");
     }
   }
 
   for (const rec of recommendations) {
-    await prompter.note(`- ${rec}`, "");
+    await prompter.note(rec, "");
   }
 
   const apply = await prompter.confirm({
@@ -643,7 +445,7 @@ async function recommendSecurityPolicyChanges(params: {
       cfg: next,
       channel,
       patch: dmPatch,
-    }) as OpenClawConfig;
+    });
   }
   if (dmAllowFrom) {
     next = setFeishuAllowFrom(next, dmAllowFrom);
@@ -653,7 +455,7 @@ async function recommendSecurityPolicyChanges(params: {
       cfg: next,
       channel,
       patch: groupPatch,
-    }) as OpenClawConfig;
+    });
   }
   if (groupSenderAllowFrom) {
     next = setFeishuGroupSenderAllowFrom(next, groupSenderAllowFrom);
@@ -674,28 +476,8 @@ async function runEditFlow(params: {
   const { prompter, options } = params;
   let next = params.cfg;
   const feishuCfg = next.channels?.feishu as FeishuConfig | undefined;
-  const currentAppMode = (feishuCfg as Record<string, unknown> | undefined)?.appMode as
-    | FeishuAppMode
-    | undefined;
 
-  // Framework already handles "already configured → update/skip" prompt.
-  // Proceed directly to mode selection.
-  const accountKeys = Object.keys(feishuCfg?.accounts ?? {});
-  const hasMultipleAccounts = accountKeys.length > 1;
-
-  const appMode = await promptAppMode(prompter, {
-    disableUser: hasMultipleAccounts,
-    currentMode: currentAppMode,
-  });
-
-  // Apply appMode.
-  next = patchTopLevelChannelConfigSection({
-    cfg: next,
-    channel,
-    patch: { appMode },
-  }) as OpenClawConfig;
-
-  // Step 3: Check existing appId.
+  // Check existing appId.
   const existingAppId = normalizeString(feishuCfg?.appId);
   if (existingAppId) {
     const useExisting = await prompter.confirm({
@@ -704,9 +486,13 @@ async function runEditFlow(params: {
     });
 
     if (useExisting) {
-      // Using existing bot.
-      if (appMode === "bot") {
-        // Bot mode with existing bot — skip to skills step.
+      // Step 3: Check current appMode for security recommendations.
+      const currentAppMode = (feishuCfg as Record<string, unknown> | undefined)?.appMode as
+        | FeishuAppMode
+        | undefined;
+
+      if (currentAppMode !== "user") {
+        // Bot mode (or unset) — skip to last step.
       } else {
         // User mode — recommend security policy changes.
         const resolvedSecret = inspectFeishuCredentials(feishuCfg);
@@ -719,35 +505,41 @@ async function runEditFlow(params: {
         });
       }
     } else {
-      // User wants a new bot — run new app flow (skip mode selection).
-      return runNewAppFlow({
-        cfg: next,
-        prompter,
-        options,
-        appMode,
-        skipModeSelection: true,
-      });
+      // Step 4: User wants a new bot — run new app flow.
+      return runNewAppFlow({ cfg: next, prompter, options });
     }
   } else {
-    // No existing appId — run new app flow (skip mode selection).
-    return runNewAppFlow({
-      cfg: next,
-      prompter,
-      options,
-      appMode,
-      skipModeSelection: true,
-    });
+    // No existing appId — run new app flow.
+    return runNewAppFlow({ cfg: next, prompter, options });
   }
 
-  // ----- Skills configuration & install -----
-  const configProgress = prompter.progress("Configuring...");
-  await new Promise((resolve) => setTimeout(resolve, 50));
-  next = applySkillsConfig(next, appMode);
-  await ensureLarkCliInstalled();
-  await installLarkSkills();
-  configProgress.stop("Bot configured.");
+  await prompter.note("Bot configured.", "");
 
   return { cfg: next };
+}
+
+// ---------------------------------------------------------------------------
+// Standalone login entry point (for `channels login --channel feishu`)
+// ---------------------------------------------------------------------------
+
+export async function runFeishuLogin(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+}): Promise<OpenClawConfig> {
+  const { cfg, prompter } = params;
+  const options = {};
+  const alreadyConfigured = isFeishuConfigured(cfg);
+
+  if (alreadyConfigured) {
+    const result = await runEditFlow({ cfg, prompter, options });
+    if (result === null) {
+      return cfg;
+    }
+    return result.cfg;
+  }
+
+  const result = await runNewAppFlow({ cfg, prompter, options });
+  return result.cfg;
 }
 
 // ---------------------------------------------------------------------------
@@ -790,17 +582,15 @@ export const feishuSetupWizard: ChannelSetupWizard = {
   // -------------------------------------------------------------------------
   // prepare: determine flow based on existing configuration
   // -------------------------------------------------------------------------
-  prepare: async ({ cfg, credentialValues, prompter }) => {
+  prepare: async ({ cfg, credentialValues }) => {
     const alreadyConfigured = isFeishuConfigured(cfg);
 
     if (alreadyConfigured) {
-      // Edit flow — mark for finalize.
       return {
         credentialValues: { ...credentialValues, _flow: "edit" },
       };
     }
 
-    // New app flow — mark for finalize.
     return {
       credentialValues: { ...credentialValues, _flow: "new" },
     };
@@ -817,15 +607,12 @@ export const feishuSetupWizard: ChannelSetupWizard = {
     if (flow === "edit") {
       const result = await runEditFlow({ cfg, prompter, options });
       if (result === null) {
-        // User chose to skip.
         return { cfg };
       }
       return result;
     }
 
-    // New app flow — prompt mode then run.
-    const appMode = await promptAppMode(prompter);
-    return runNewAppFlow({ cfg, prompter, options, appMode });
+    return runNewAppFlow({ cfg, prompter, options });
   },
 
   dmPolicy: feishuDmPolicy,

--- a/extensions/feishu/src/setup-surface.ts
+++ b/extensions/feishu/src/setup-surface.ts
@@ -1,5 +1,9 @@
 import {
   buildSingleChannelSecretPromptState,
+  createTopLevelChannelAllowFromSetter,
+  createTopLevelChannelDmPolicy,
+  createTopLevelChannelGroupPolicySetter,
+  createTopLevelChannelParsedAllowFromPrompt,
   DEFAULT_ACCOUNT_ID,
   formatDocsLink,
   hasConfiguredSecretInput,
@@ -12,87 +16,75 @@ import {
   type OpenClawConfig,
   type SecretInput,
 } from "openclaw/plugin-sdk/setup";
-import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
+import { inspectFeishuCredentials, listFeishuAccountIds } from "./accounts.js";
 import {
-  inspectFeishuCredentials,
-  resolveDefaultFeishuAccountId,
-  resolveFeishuAccount,
-} from "./accounts.js";
-import { normalizeString } from "./comment-shared.js";
+  beginAppRegistration,
+  getAppOwnerOpenId,
+  initAppRegistration,
+  pollAppRegistration,
+  printQrCode,
+  type AppRegistrationResult,
+} from "./app-registration.js";
 import { probeFeishu } from "./probe.js";
-import type { FeishuAccountConfig, FeishuConfig } from "./types.js";
+import { feishuSetupAdapter } from "./setup-core.js";
+import type { FeishuAppMode, FeishuConfig, FeishuDomain } from "./types.js";
 
 const channel = "feishu" as const;
+const setFeishuAllowFrom = createTopLevelChannelAllowFromSetter({
+  channel,
+});
+const setFeishuGroupPolicy = createTopLevelChannelGroupPolicySetter({
+  channel,
+  enabled: true,
+});
 
-type ScopedFeishuConfig = Partial<FeishuConfig> & Partial<FeishuAccountConfig>;
+// ---------------------------------------------------------------------------
+// Skills lists (from requirements doc)
+// ---------------------------------------------------------------------------
 
-function getScopedFeishuConfig(cfg: OpenClawConfig, accountId: string): ScopedFeishuConfig {
-  const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
-  if (accountId === DEFAULT_ACCOUNT_ID) {
-    return feishuCfg ?? {};
+/** Tools skills — enabled in "As bot" mode, disabled in "As you" mode. */
+const TOOLS_SKILLS = [
+  "lark-mail",
+  "lark-minutes",
+  "lark-openapi-explorer",
+  "lark-skill-maker",
+  "lark-calendar",
+  "lark-workflow-standup-report",
+  "lark-wiki",
+  "lark-doc",
+  "lark-contact",
+  "lark-vc",
+  "lark-drive",
+  "lark-workflow-meeting-summary",
+  "lark-shared",
+  "lark-base",
+  "lark-im",
+  "lark-sheets",
+  "lark-task",
+  "lark-whiteboard",
+  "feishu-doc",
+  "feishu-drive",
+  "feishu-perm",
+  "feishu-wiki",
+] as const;
+
+/** lark-cli skills — no longer managed by onboarding. */
+const LARKCLI_SKILLS: readonly string[] = [];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
   }
-  return feishuCfg?.accounts?.[accountId] ?? {};
+  const trimmed = value.trim();
+  return trimmed || undefined;
 }
 
-function patchFeishuConfig(
-  cfg: OpenClawConfig,
-  accountId: string,
-  patch: Record<string, unknown>,
-): OpenClawConfig {
+function isFeishuConfigured(cfg: OpenClawConfig): boolean {
   const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
-  if (accountId === DEFAULT_ACCOUNT_ID) {
-    return patchTopLevelChannelConfigSection({
-      cfg,
-      channel,
-      enabled: true,
-      patch,
-    });
-  }
-  const nextAccountPatch = {
-    ...(feishuCfg?.accounts?.[accountId] as Record<string, unknown> | undefined),
-    enabled: true,
-    ...patch,
-  };
-  return patchTopLevelChannelConfigSection({
-    cfg,
-    channel,
-    enabled: true,
-    patch: {
-      accounts: {
-        ...feishuCfg?.accounts,
-        [accountId]: nextAccountPatch,
-      },
-    },
-  });
-}
-
-function setFeishuAllowFrom(
-  cfg: OpenClawConfig,
-  accountId: string,
-  allowFrom: string[],
-): OpenClawConfig {
-  return patchFeishuConfig(cfg, accountId, { allowFrom });
-}
-
-function setFeishuGroupPolicy(
-  cfg: OpenClawConfig,
-  accountId: string,
-  groupPolicy: "open" | "allowlist" | "disabled",
-): OpenClawConfig {
-  return patchFeishuConfig(cfg, accountId, { groupPolicy });
-}
-
-function setFeishuGroupAllowFrom(
-  cfg: OpenClawConfig,
-  accountId: string,
-  groupAllowFrom: string[],
-): OpenClawConfig {
-  return patchFeishuConfig(cfg, accountId, { groupAllowFrom });
-}
-
-function isFeishuConfigured(cfg: OpenClawConfig, accountId?: string | null): boolean {
-  const feishuCfg = ((cfg.channels?.feishu as FeishuConfig | undefined) ?? {}) as FeishuConfig;
-  const resolvedAccountId = normalizeString(accountId) ?? resolveDefaultFeishuAccountId(cfg);
 
   const isAppIdConfigured = (value: unknown): boolean => {
     const asString = normalizeString(value);
@@ -103,7 +95,7 @@ function isFeishuConfigured(cfg: OpenClawConfig, accountId?: string | null): boo
       return false;
     }
     const rec = value as Record<string, unknown>;
-    const source = normalizeOptionalLowercaseString(normalizeString(rec.source));
+    const source = normalizeString(rec.source)?.toLowerCase();
     const id = normalizeString(rec.id);
     if (source === "env" && id) {
       return Boolean(normalizeString(process.env[id]));
@@ -115,59 +107,69 @@ function isFeishuConfigured(cfg: OpenClawConfig, accountId?: string | null): boo
     isAppIdConfigured(feishuCfg?.appId) && hasConfiguredSecretInput(feishuCfg?.appSecret),
   );
 
-  if (resolvedAccountId === DEFAULT_ACCOUNT_ID) {
-    return topLevelConfigured;
-  }
-
-  const account = feishuCfg.accounts?.[resolvedAccountId];
-  if (!account || typeof account !== "object") {
-    return topLevelConfigured;
-  }
-
-  const hasOwnAppId = Object.prototype.hasOwnProperty.call(account, "appId");
-  const hasOwnAppSecret = Object.prototype.hasOwnProperty.call(account, "appSecret");
-  const accountAppIdConfigured = hasOwnAppId
-    ? isAppIdConfigured((account as Record<string, unknown>).appId)
-    : isAppIdConfigured(feishuCfg?.appId);
-  const accountSecretConfigured = hasOwnAppSecret
-    ? hasConfiguredSecretInput((account as Record<string, unknown>).appSecret)
-    : hasConfiguredSecretInput(feishuCfg?.appSecret);
-
-  return Boolean(accountAppIdConfigured && accountSecretConfigured);
-}
-
-async function promptFeishuAllowFrom(params: {
-  cfg: OpenClawConfig;
-  accountId: string;
-  prompter: Parameters<NonNullable<ChannelSetupDmPolicy["promptAllowFrom"]>>[0]["prompter"];
-}): Promise<OpenClawConfig> {
-  const existingAllowFrom =
-    resolveFeishuAccount({
-      cfg: params.cfg,
-      accountId: params.accountId,
-    }).config.allowFrom ?? [];
-  await params.prompter.note(
-    [
-      "Allowlist Feishu DMs by open_id or user_id.",
-      "You can find user open_id in Feishu admin console or via API.",
-      "Examples:",
-      "- ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-      "- on_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    ].join("\n"),
-    "Feishu allowlist",
-  );
-  const entry = await params.prompter.text({
-    message: "Feishu allowFrom (user open_ids)",
-    placeholder: "ou_xxxxx, ou_yyyyy",
-    initialValue:
-      existingAllowFrom.length > 0 ? existingAllowFrom.map(String).join(", ") : undefined,
+  const accountConfigured = Object.values(feishuCfg?.accounts ?? {}).some((account) => {
+    if (!account || typeof account !== "object") {
+      return false;
+    }
+    const hasOwnAppId = Object.prototype.hasOwnProperty.call(account, "appId");
+    const hasOwnAppSecret = Object.prototype.hasOwnProperty.call(account, "appSecret");
+    const accountAppIdConfigured = hasOwnAppId
+      ? isAppIdConfigured((account as Record<string, unknown>).appId)
+      : isAppIdConfigured(feishuCfg?.appId);
+    const accountSecretConfigured = hasOwnAppSecret
+      ? hasConfiguredSecretInput((account as Record<string, unknown>).appSecret)
+      : hasConfiguredSecretInput(feishuCfg?.appSecret);
+    return Boolean(accountAppIdConfigured && accountSecretConfigured);
   });
-  const mergedAllowFrom = mergeAllowFromEntries(
-    existingAllowFrom,
-    splitSetupEntries(String(entry)),
-  );
-  return setFeishuAllowFrom(params.cfg, params.accountId, mergedAllowFrom);
+
+  return topLevelConfigured || accountConfigured;
 }
+
+function setFeishuGroupAllowFrom(cfg: OpenClawConfig, groupAllowFrom: string[]): OpenClawConfig {
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      feishu: {
+        ...cfg.channels?.feishu,
+        groupAllowFrom,
+      },
+    },
+  };
+}
+
+function setFeishuGroupSenderAllowFrom(
+  cfg: OpenClawConfig,
+  groupSenderAllowFrom: string[],
+): OpenClawConfig {
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      feishu: {
+        ...cfg.channels?.feishu,
+        groupSenderAllowFrom,
+      },
+    },
+  };
+}
+
+const promptFeishuAllowFrom = createTopLevelChannelParsedAllowFromPrompt({
+  channel,
+  defaultAccountId: DEFAULT_ACCOUNT_ID,
+  noteTitle: "Feishu allowlist",
+  noteLines: [
+    "Allowlist Feishu DMs by open_id or user_id.",
+    "You can find user open_id in Feishu admin console or via API.",
+    "Examples:",
+    "- ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "- on_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  ],
+  message: "Feishu allowFrom (user open_ids)",
+  placeholder: "ou_xxxxx, ou_yyyyy",
+  parseEntries: (raw) => ({ entries: splitSetupEntries(raw) }),
+  mergeEntries: ({ existing, parsed }) => mergeAllowFromEntries(existing, parsed),
+});
 
 async function noteFeishuCredentialHelp(
   prompter: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["prompter"],
@@ -199,53 +201,564 @@ async function promptFeishuAppId(params: {
   ).trim();
 }
 
-const feishuDmPolicy: ChannelSetupDmPolicy = {
+const feishuDmPolicy: ChannelSetupDmPolicy = createTopLevelChannelDmPolicy({
   label: "Feishu",
   channel,
   policyKey: "channels.feishu.dmPolicy",
   allowFromKey: "channels.feishu.allowFrom",
-  resolveConfigKeys: (_cfg, accountId) => {
-    const resolvedAccountId = accountId ?? resolveDefaultFeishuAccountId(_cfg);
-    return resolvedAccountId !== DEFAULT_ACCOUNT_ID
-      ? {
-          policyKey: `channels.feishu.accounts.${resolvedAccountId}.dmPolicy`,
-          allowFromKey: `channels.feishu.accounts.${resolvedAccountId}.allowFrom`,
-        }
-      : {
-          policyKey: "channels.feishu.dmPolicy",
-          allowFromKey: "channels.feishu.allowFrom",
-        };
+  getCurrent: (cfg) => (cfg.channels?.feishu as FeishuConfig | undefined)?.dmPolicy ?? "pairing",
+  promptAllowFrom: promptFeishuAllowFrom,
+});
+
+type WizardPrompter = Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["prompter"];
+
+// ---------------------------------------------------------------------------
+// Mode selection
+// ---------------------------------------------------------------------------
+
+async function promptAppMode(
+  prompter: WizardPrompter,
+  options?: {
+    disableUser?: boolean;
+    currentMode?: FeishuAppMode;
   },
-  getCurrent: (cfg, accountId) =>
-    resolveFeishuAccount({
-      cfg,
-      accountId: accountId ?? resolveDefaultFeishuAccountId(cfg),
-    }).config.dmPolicy ?? "pairing",
-  setPolicy: (cfg, policy, accountId) => {
-    const resolvedAccountId = accountId ?? resolveDefaultFeishuAccountId(cfg);
-    const currentAllowFrom = resolveFeishuAccount({
-      cfg,
-      accountId: resolvedAccountId,
-    }).config.allowFrom;
-    return patchFeishuConfig(cfg, resolvedAccountId, {
-      dmPolicy: policy,
-      ...(policy === "open" ? { allowFrom: mergeAllowFromEntries(currentAllowFrom, ["*"]) } : {}),
+): Promise<FeishuAppMode> {
+  const userHint = options?.disableUser
+    ? "Works under your identity, managing messages, docs, calendar, and more as you upon authorization. (\u26a0\ufe0f Unavailable with multiple linked bots. Remove unused bots to enable this option.)"
+    : "Works under your identity, managing messages, docs, calendar, and more as you upon authorization.";
+
+  const botOption = {
+    value: "bot" as const,
+    label: "As bot (recommended)",
+    hint: "Works under its own identity. Best for group chats, team notifications, and shared documents.",
+  };
+  const userOption = {
+    value: "user" as const,
+    label: "As you",
+    hint: userHint,
+  };
+
+  const selectOptions = options?.disableUser ? [botOption] : [botOption, userOption];
+
+  return (await prompter.select({
+    message: "How should the AI work with you?",
+    options: selectOptions,
+    initialValue: options?.currentMode ?? "bot",
+  })) as FeishuAppMode;
+}
+
+// ---------------------------------------------------------------------------
+// Skills configuration
+// ---------------------------------------------------------------------------
+
+/** Skills that are always disabled regardless of mode. */
+const ALWAYS_DISABLED_SKILLS = ["lark-event"] as const;
+
+/**
+ * Returns which skills to disable and which to enable (remove from entries).
+ *
+ * - As you (user mode): disable tools skills
+ * - As bot (bot mode): enable tools skills (remove disabled entries)
+ * - lark-event is always disabled
+ *
+ * Disable = set `{ enabled: false }` in `skills.entries`
+ * Enable  = remove the key from `skills.entries` so default behavior takes over
+ */
+function buildSkillsConfig(appMode: FeishuAppMode): {
+  disable: Record<string, { enabled: false }>;
+  enable: readonly string[];
+} {
+  const disable: Record<string, { enabled: false }> = {};
+
+  // Always-disabled skills.
+  for (const skill of ALWAYS_DISABLED_SKILLS) {
+    disable[skill] = { enabled: false };
+  }
+
+  if (appMode === "user") {
+    // User mode: enable lark-cli skills, disable tools skills.
+    for (const skill of TOOLS_SKILLS) {
+      disable[skill] = { enabled: false };
+    }
+    return { disable, enable: LARKCLI_SKILLS };
+  }
+  // Bot mode: enable tools skills, disable lark-cli skills.
+  for (const skill of LARKCLI_SKILLS) {
+    disable[skill] = { enabled: false };
+  }
+  return { disable, enable: TOOLS_SKILLS };
+}
+
+/** Apply skills config: disable target skills, remove opposite skills from entries. */
+function applySkillsConfig(cfg: OpenClawConfig, appMode: FeishuAppMode): OpenClawConfig {
+  const { disable, enable } = buildSkillsConfig(appMode);
+
+  const existingSkills = (cfg as Record<string, unknown>).skills as
+    | Record<string, unknown>
+    | undefined;
+  const existingEntries = (existingSkills?.entries ?? {}) as Record<string, unknown>;
+
+  // Clone entries, remove keys that should be enabled, then merge disabled ones.
+  const newEntries = { ...existingEntries };
+  for (const skill of enable) {
+    delete newEntries[skill];
+  }
+  Object.assign(newEntries, disable);
+
+  return {
+    ...cfg,
+    skills: {
+      ...existingSkills,
+      entries: newEntries,
+    },
+  } as OpenClawConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Security policy helpers
+// ---------------------------------------------------------------------------
+
+function applyNewAppSecurityPolicy(
+  cfg: OpenClawConfig,
+  appMode: FeishuAppMode,
+  openId: string | undefined,
+): OpenClawConfig {
+  let next = cfg;
+
+  if (!openId) {
+    return next;
+  }
+
+  // Both modes: dmPolicy=allowlist, allowFrom=[openId]
+  next = patchTopLevelChannelConfigSection({
+    cfg: next,
+    channel,
+    patch: { dmPolicy: "allowlist" },
+  }) as OpenClawConfig;
+  next = setFeishuAllowFrom(next, [openId]);
+
+  // Both modes: groupPolicy=open
+  next = setFeishuGroupPolicy(next, "open");
+
+  // Enable wildcard groups.
+  next = patchTopLevelChannelConfigSection({
+    cfg: next,
+    channel,
+    patch: {
+      groups: {
+        ...((next.channels?.feishu as FeishuConfig | undefined)?.groups ?? {}),
+        "*": { enabled: true },
+      },
+    },
+  }) as OpenClawConfig;
+
+  if (appMode === "user") {
+    // User mode: also set groupSenderAllowFrom=[openId]
+    next = setFeishuGroupSenderAllowFrom(next, [openId]);
+  }
+
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Scan-to-create flow
+// ---------------------------------------------------------------------------
+
+async function runScanToCreate(
+  prompter: WizardPrompter,
+  appMode: FeishuAppMode,
+): Promise<AppRegistrationResult | null> {
+  try {
+    await initAppRegistration("feishu");
+  } catch {
+    await prompter.note(
+      "Scan-to-create is not available in this environment. Falling back to manual input.",
+      "Feishu setup",
+    );
+    return null;
+  }
+
+  const begin = await beginAppRegistration("feishu");
+
+  await prompter.note("Scan the QR with Lark/Feishu on your phone.", "Feishu scan-to-create");
+  await printQrCode(begin.qrUrl);
+
+  const progress = prompter.progress("Fetching configuration results...");
+
+  const tp = appMode === "user" ? "ob_user" : "ob_app";
+  const outcome = await pollAppRegistration({
+    deviceCode: begin.deviceCode,
+    interval: begin.interval,
+    expireIn: begin.expireIn,
+    initialDomain: "feishu",
+    tp,
+  });
+
+  switch (outcome.status) {
+    case "success":
+      progress.stop("Scan completed.");
+      return outcome.result;
+    case "access_denied":
+      progress.stop("User denied authorization. Falling back to manual input.");
+      return null;
+    case "expired":
+      progress.stop("Session expired. Falling back to manual input.");
+      return null;
+    case "timeout":
+      progress.stop("Scan timed out. Falling back to manual input.");
+      return null;
+    case "error":
+      progress.stop(`Registration error: ${outcome.message}. Falling back to manual input.`);
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Install helpers
+// ---------------------------------------------------------------------------
+
+async function ensureLarkCliInstalled(): Promise<void> {
+  try {
+    const { execSync } = await import("node:child_process");
+    try {
+      execSync("lark-cli --version", { stdio: "ignore" });
+    } catch {
+      execSync("npm install -g @larksuite/cli", { stdio: "ignore", timeout: 120_000 });
+    }
+  } catch {
+    // install failed or node:child_process unavailable — skip silently.
+  }
+}
+
+async function installLarkSkills(): Promise<void> {
+  try {
+    const { execSync } = await import("node:child_process");
+    execSync("npx skills add larksuite/cli -y -g -a openclaw", {
+      stdio: "ignore",
+      timeout: 120_000,
     });
-  },
-  promptAllowFrom: async ({ cfg, accountId, prompter }) =>
-    await promptFeishuAllowFrom({
-      cfg,
-      accountId: accountId ?? resolveDefaultFeishuAccountId(cfg),
+  } catch {
+    // install failed or node:child_process unavailable — skip silently.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// New app configuration flow
+// ---------------------------------------------------------------------------
+
+async function runNewAppFlow(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  options: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["options"];
+  appMode: FeishuAppMode;
+  skipModeSelection?: boolean;
+}): Promise<{ cfg: OpenClawConfig }> {
+  const { prompter, options } = params;
+  let next = params.cfg;
+  const appMode = params.appMode;
+
+  // Apply appMode to config.
+  next = patchTopLevelChannelConfigSection({
+    cfg: next,
+    channel,
+    enabled: true,
+    patch: { appMode },
+  }) as OpenClawConfig;
+
+  // ----- QR scan flow -----
+  let appId: string | null = null;
+  let appSecret: SecretInput | null = null;
+  let appSecretProbeValue: string | null = null;
+  let scanDomain: FeishuDomain | undefined;
+  let scanOpenId: string | undefined;
+
+  const scanResult = await runScanToCreate(prompter, appMode);
+  if (scanResult) {
+    appId = scanResult.appId;
+    appSecret = scanResult.appSecret;
+    appSecretProbeValue = scanResult.appSecret;
+    scanDomain = scanResult.domain;
+    scanOpenId = scanResult.openId;
+  } else {
+    // Fallback to manual input.
+    const feishuCfg = next.channels?.feishu as FeishuConfig | undefined;
+    await noteFeishuCredentialHelp(prompter);
+
+    // Domain selection first (needed for API calls).
+    const currentDomain = feishuCfg?.domain ?? "feishu";
+    const domain = (await prompter.select({
+      message: "Which Feishu domain?",
+      options: [
+        { value: "feishu", label: "Feishu (feishu.cn) - China" },
+        { value: "lark", label: "Lark (larksuite.com) - International" },
+      ],
+      initialValue: currentDomain,
+    })) as FeishuDomain;
+    scanDomain = domain;
+
+    appId = await promptFeishuAppId({
       prompter,
-    }),
-};
+      initialValue: normalizeString(process.env.FEISHU_APP_ID),
+    });
+
+    const appSecretResult = await promptSingleChannelSecretInput({
+      cfg: next,
+      prompter,
+      providerHint: "feishu",
+      credentialLabel: "App Secret",
+      secretInputMode: options?.secretInputMode,
+      accountConfigured: false,
+      canUseEnv: false,
+      hasConfigToken: false,
+      envPrompt: "",
+      keepPrompt: "Feishu App Secret already configured. Keep it?",
+      inputPrompt: "Enter Feishu App Secret",
+      preferredEnvVar: "FEISHU_APP_SECRET",
+    });
+    if (appSecretResult.action === "set") {
+      appSecret = appSecretResult.value;
+      appSecretProbeValue = appSecretResult.resolvedValue;
+    }
+  }
+
+  // ----- Apply credentials, policies, skills & install (under one spinner) -----
+  const configProgress = prompter.progress("Configuring...");
+  // Yield to let the spinner render before sync work and execSync block the event loop.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  if (appId && appSecret) {
+    next = patchTopLevelChannelConfigSection({
+      cfg: next,
+      channel,
+      enabled: true,
+      patch: {
+        appId,
+        appSecret,
+        connectionMode: "websocket",
+        ...(scanDomain ? { domain: scanDomain } : {}),
+      },
+    }) as OpenClawConfig;
+  }
+
+  if (scanDomain) {
+    next = patchTopLevelChannelConfigSection({
+      cfg: next,
+      channel,
+      patch: { domain: scanDomain },
+    }) as OpenClawConfig;
+  }
+
+  next = applyNewAppSecurityPolicy(next, appMode, scanOpenId);
+  next = applySkillsConfig(next, appMode);
+  await ensureLarkCliInstalled();
+  await installLarkSkills();
+  configProgress.stop("Bot configured.");
+
+  return { cfg: next };
+}
+
+// ---------------------------------------------------------------------------
+// Edit configuration flow — security policy recommendation
+// ---------------------------------------------------------------------------
+
+async function recommendSecurityPolicyChanges(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  appId: string;
+  appSecret: string | undefined;
+  domain: FeishuDomain | undefined;
+}): Promise<OpenClawConfig> {
+  const { prompter } = params;
+  let next = params.cfg;
+  const feishuCfg = next.channels?.feishu as FeishuConfig | undefined;
+
+  const currentDmPolicy = feishuCfg?.dmPolicy ?? "pairing";
+  const currentGroupPolicy = feishuCfg?.groupPolicy ?? "allowlist";
+
+  const needDmRecommendation = currentDmPolicy === "open";
+  const needGroupRecommendation = currentGroupPolicy === "open";
+
+  if (!needDmRecommendation && !needGroupRecommendation) {
+    return next;
+  }
+
+  // Try to get owner open_id.
+  let ownerOpenId: string | undefined;
+  if (params.appSecret) {
+    ownerOpenId = await getAppOwnerOpenId({
+      appId: params.appId,
+      appSecret: params.appSecret,
+      domain: params.domain,
+    });
+  }
+
+  const recommendations: string[] = [];
+  let dmPatch: Partial<FeishuConfig> = {};
+  let dmAllowFrom: string[] | undefined;
+  let groupPatch: Partial<FeishuConfig> = {};
+  let groupSenderAllowFrom: string[] | undefined;
+
+  await prompter.note(
+    "To keep your data safe while acting as you, we suggest these policy updates:",
+    "Security recommendation",
+  );
+
+  if (needDmRecommendation) {
+    if (ownerOpenId) {
+      dmPatch = { dmPolicy: "allowlist" };
+      dmAllowFrom = [ownerOpenId];
+      recommendations.push("DMs: Only the owner");
+    } else {
+      dmPatch = { dmPolicy: "pairing" };
+      recommendations.push("DMs: Only the paired user");
+    }
+  }
+
+  if (needGroupRecommendation) {
+    if (ownerOpenId) {
+      groupSenderAllowFrom = [ownerOpenId];
+      recommendations.push("Group chats: Only when mentioned by the owner");
+    } else {
+      groupPatch = { groupPolicy: "disabled" };
+      recommendations.push("Group chats: Disabled");
+    }
+  }
+
+  for (const rec of recommendations) {
+    await prompter.note(`- ${rec}`, "");
+  }
+
+  const apply = await prompter.confirm({
+    message: "Apply?",
+    initialValue: true,
+  });
+
+  if (!apply) {
+    return next;
+  }
+
+  // Apply recommendations.
+  if (Object.keys(dmPatch).length > 0) {
+    next = patchTopLevelChannelConfigSection({
+      cfg: next,
+      channel,
+      patch: dmPatch,
+    }) as OpenClawConfig;
+  }
+  if (dmAllowFrom) {
+    next = setFeishuAllowFrom(next, dmAllowFrom);
+  }
+  if (Object.keys(groupPatch).length > 0) {
+    next = patchTopLevelChannelConfigSection({
+      cfg: next,
+      channel,
+      patch: groupPatch,
+    }) as OpenClawConfig;
+  }
+  if (groupSenderAllowFrom) {
+    next = setFeishuGroupSenderAllowFrom(next, groupSenderAllowFrom);
+  }
+
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Edit configuration flow
+// ---------------------------------------------------------------------------
+
+async function runEditFlow(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  options: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["options"];
+}): Promise<{ cfg: OpenClawConfig } | null> {
+  const { prompter, options } = params;
+  let next = params.cfg;
+  const feishuCfg = next.channels?.feishu as FeishuConfig | undefined;
+  const currentAppMode = (feishuCfg as Record<string, unknown> | undefined)?.appMode as
+    | FeishuAppMode
+    | undefined;
+
+  // Framework already handles "already configured → update/skip" prompt.
+  // Proceed directly to mode selection.
+  const accountKeys = Object.keys(feishuCfg?.accounts ?? {});
+  const hasMultipleAccounts = accountKeys.length > 1;
+
+  const appMode = await promptAppMode(prompter, {
+    disableUser: hasMultipleAccounts,
+    currentMode: currentAppMode,
+  });
+
+  // Apply appMode.
+  next = patchTopLevelChannelConfigSection({
+    cfg: next,
+    channel,
+    patch: { appMode },
+  }) as OpenClawConfig;
+
+  // Step 3: Check existing appId.
+  const existingAppId = normalizeString(feishuCfg?.appId);
+  if (existingAppId) {
+    const useExisting = await prompter.confirm({
+      message: `We found an existing bot (App ID: ${existingAppId}). Use it for this setup?`,
+      initialValue: true,
+    });
+
+    if (useExisting) {
+      // Using existing bot.
+      if (appMode === "bot") {
+        // Bot mode with existing bot — skip to skills step.
+      } else {
+        // User mode — recommend security policy changes.
+        const resolvedSecret = inspectFeishuCredentials(feishuCfg);
+        next = await recommendSecurityPolicyChanges({
+          cfg: next,
+          prompter,
+          appId: existingAppId,
+          appSecret: resolvedSecret?.appSecret,
+          domain: resolvedSecret?.domain,
+        });
+      }
+    } else {
+      // User wants a new bot — run new app flow (skip mode selection).
+      return runNewAppFlow({
+        cfg: next,
+        prompter,
+        options,
+        appMode,
+        skipModeSelection: true,
+      });
+    }
+  } else {
+    // No existing appId — run new app flow (skip mode selection).
+    return runNewAppFlow({
+      cfg: next,
+      prompter,
+      options,
+      appMode,
+      skipModeSelection: true,
+    });
+  }
+
+  // ----- Skills configuration & install -----
+  const configProgress = prompter.progress("Configuring...");
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  next = applySkillsConfig(next, appMode);
+  await ensureLarkCliInstalled();
+  await installLarkSkills();
+  configProgress.stop("Bot configured.");
+
+  return { cfg: next };
+}
+
+// ---------------------------------------------------------------------------
+// Exported wizard
+// ---------------------------------------------------------------------------
 
 export { feishuSetupAdapter } from "./setup-core.js";
 
 export const feishuSetupWizard: ChannelSetupWizard = {
   channel,
-  resolveAccountIdForConfigure: ({ accountOverride, defaultAccountId }) =>
-    normalizeString(accountOverride) ?? defaultAccountId,
+  resolveAccountIdForConfigure: () => DEFAULT_ACCOUNT_ID,
   resolveShouldPromptAccountIds: () => false,
   status: {
     configuredLabel: "configured",
@@ -254,22 +767,10 @@ export const feishuSetupWizard: ChannelSetupWizard = {
     unconfiguredHint: "needs app creds",
     configuredScore: 2,
     unconfiguredScore: 0,
-    resolveConfigured: ({ cfg, accountId }) => isFeishuConfigured(cfg, accountId),
-    resolveStatusLines: async ({ cfg, accountId, configured }) => {
-      const resolvedCredentials = accountId
-        ? (() => {
-            const account = resolveFeishuAccount({ cfg, accountId });
-            return account.configured && account.appId && account.appSecret
-              ? {
-                  appId: account.appId,
-                  appSecret: account.appSecret,
-                  encryptKey: account.encryptKey,
-                  verificationToken: account.verificationToken,
-                  domain: account.domain,
-                }
-              : null;
-          })()
-        : inspectFeishuCredentials(cfg.channels?.feishu as FeishuConfig | undefined);
+    resolveConfigured: ({ cfg }) => isFeishuConfigured(cfg),
+    resolveStatusLines: async ({ cfg, configured }) => {
+      const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
+      const resolvedCredentials = inspectFeishuCredentials(feishuCfg);
       let probeResult = null;
       if (configured && resolvedCredentials) {
         try {
@@ -285,215 +786,48 @@ export const feishuSetupWizard: ChannelSetupWizard = {
       return ["Feishu: configured (connection not verified)"];
     },
   },
-  credentials: [],
-  finalize: async ({ cfg, accountId, prompter, options }) => {
-    const resolvedAccountId = accountId ?? resolveDefaultFeishuAccountId(cfg);
-    const resolvedAccount = resolveFeishuAccount({ cfg, accountId: resolvedAccountId });
-    const scopedConfig = getScopedFeishuConfig(cfg, resolvedAccountId);
-    const resolved =
-      resolvedAccount.configured && resolvedAccount.appId && resolvedAccount.appSecret
-        ? {
-            appId: resolvedAccount.appId,
-            appSecret: resolvedAccount.appSecret,
-            encryptKey: resolvedAccount.encryptKey,
-            verificationToken: resolvedAccount.verificationToken,
-            domain: resolvedAccount.domain,
-          }
-        : null;
-    const hasConfigSecret = hasConfiguredSecretInput(scopedConfig.appSecret);
-    const hasConfigCreds = Boolean(
-      typeof scopedConfig.appId === "string" && scopedConfig.appId.trim() && hasConfigSecret,
-    );
-    const appSecretPromptState = buildSingleChannelSecretPromptState({
-      accountConfigured: Boolean(resolved),
-      hasConfigToken: hasConfigSecret,
-      allowEnv: !hasConfigCreds && Boolean(process.env.FEISHU_APP_ID?.trim()),
-      envValue: process.env.FEISHU_APP_SECRET,
-    });
 
-    let next = cfg;
-    let appId: string | null = null;
-    let appSecret: SecretInput | null = null;
-    let appSecretProbeValue: string | null = null;
+  // -------------------------------------------------------------------------
+  // prepare: determine flow based on existing configuration
+  // -------------------------------------------------------------------------
+  prepare: async ({ cfg, credentialValues, prompter }) => {
+    const alreadyConfigured = isFeishuConfigured(cfg);
 
-    if (!resolved) {
-      await noteFeishuCredentialHelp(prompter);
+    if (alreadyConfigured) {
+      // Edit flow — mark for finalize.
+      return {
+        credentialValues: { ...credentialValues, _flow: "edit" },
+      };
     }
 
-    const appSecretResult = await promptSingleChannelSecretInput({
-      cfg: next,
-      prompter,
-      providerHint: "feishu",
-      credentialLabel: "App Secret",
-      secretInputMode: options?.secretInputMode,
-      accountConfigured: appSecretPromptState.accountConfigured,
-      canUseEnv: appSecretPromptState.canUseEnv,
-      hasConfigToken: appSecretPromptState.hasConfigToken,
-      envPrompt: "FEISHU_APP_ID + FEISHU_APP_SECRET detected. Use env vars?",
-      keepPrompt: "Feishu App Secret already configured. Keep it?",
-      inputPrompt: "Enter Feishu App Secret",
-      preferredEnvVar: "FEISHU_APP_SECRET",
-    });
-
-    if (appSecretResult.action === "use-env") {
-      next = patchFeishuConfig(next, resolvedAccountId, {});
-    } else if (appSecretResult.action === "set") {
-      appSecret = appSecretResult.value;
-      appSecretProbeValue = appSecretResult.resolvedValue;
-      appId = await promptFeishuAppId({
-        prompter,
-        initialValue:
-          normalizeString(scopedConfig.appId) ?? normalizeString(process.env.FEISHU_APP_ID),
-      });
-    }
-
-    if (appId && appSecret) {
-      next = patchFeishuConfig(next, resolvedAccountId, {
-        appId,
-        appSecret,
-      });
-
-      try {
-        const probe = await probeFeishu({
-          appId,
-          appSecret: appSecretProbeValue ?? undefined,
-          domain: resolveFeishuAccount({ cfg: next, accountId: resolvedAccountId }).domain,
-        });
-        if (probe.ok) {
-          await prompter.note(
-            `Connected as ${probe.botName ?? probe.botOpenId ?? "bot"}`,
-            "Feishu connection test",
-          );
-        } else {
-          await prompter.note(
-            `Connection failed: ${probe.error ?? "unknown error"}`,
-            "Feishu connection test",
-          );
-        }
-      } catch (err) {
-        await prompter.note(`Connection test failed: ${String(err)}`, "Feishu connection test");
-      }
-    }
-
-    const currentMode =
-      resolveFeishuAccount({ cfg: next, accountId: resolvedAccountId }).config.connectionMode ??
-      "websocket";
-    const connectionMode = (await prompter.select({
-      message: "Feishu connection mode",
-      options: [
-        { value: "websocket", label: "WebSocket (default)" },
-        { value: "webhook", label: "Webhook" },
-      ],
-      initialValue: currentMode,
-    })) as "websocket" | "webhook";
-    next = patchFeishuConfig(next, resolvedAccountId, { connectionMode });
-
-    if (connectionMode === "webhook") {
-      const currentVerificationToken = getScopedFeishuConfig(
-        next,
-        resolvedAccountId,
-      ).verificationToken;
-      const verificationTokenResult = await promptSingleChannelSecretInput({
-        cfg: next,
-        prompter,
-        providerHint: "feishu-webhook",
-        credentialLabel: "verification token",
-        secretInputMode: options?.secretInputMode,
-        ...buildSingleChannelSecretPromptState({
-          accountConfigured: hasConfiguredSecretInput(currentVerificationToken),
-          hasConfigToken: hasConfiguredSecretInput(currentVerificationToken),
-          allowEnv: false,
-        }),
-        envPrompt: "",
-        keepPrompt: "Feishu verification token already configured. Keep it?",
-        inputPrompt: "Enter Feishu verification token",
-        preferredEnvVar: "FEISHU_VERIFICATION_TOKEN",
-      });
-      if (verificationTokenResult.action === "set") {
-        next = patchFeishuConfig(next, resolvedAccountId, {
-          verificationToken: verificationTokenResult.value,
-        });
-      }
-
-      const currentEncryptKey = getScopedFeishuConfig(next, resolvedAccountId).encryptKey;
-      const encryptKeyResult = await promptSingleChannelSecretInput({
-        cfg: next,
-        prompter,
-        providerHint: "feishu-webhook",
-        credentialLabel: "encrypt key",
-        secretInputMode: options?.secretInputMode,
-        ...buildSingleChannelSecretPromptState({
-          accountConfigured: hasConfiguredSecretInput(currentEncryptKey),
-          hasConfigToken: hasConfiguredSecretInput(currentEncryptKey),
-          allowEnv: false,
-        }),
-        envPrompt: "",
-        keepPrompt: "Feishu encrypt key already configured. Keep it?",
-        inputPrompt: "Enter Feishu encrypt key",
-        preferredEnvVar: "FEISHU_ENCRYPT_KEY",
-      });
-      if (encryptKeyResult.action === "set") {
-        next = patchFeishuConfig(next, resolvedAccountId, {
-          encryptKey: encryptKeyResult.value,
-        });
-      }
-
-      const currentWebhookPath = getScopedFeishuConfig(next, resolvedAccountId).webhookPath;
-      const webhookPath = String(
-        await prompter.text({
-          message: "Feishu webhook path",
-          initialValue: currentWebhookPath ?? "/feishu/events",
-          validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
-        }),
-      ).trim();
-      next = patchFeishuConfig(next, resolvedAccountId, { webhookPath });
-    }
-
-    const currentDomain = resolveFeishuAccount({ cfg: next, accountId: resolvedAccountId }).domain;
-    const domain = await prompter.select({
-      message: "Which Feishu domain?",
-      options: [
-        { value: "feishu", label: "Feishu (feishu.cn) - China" },
-        { value: "lark", label: "Lark (larksuite.com) - International" },
-      ],
-      initialValue: currentDomain,
-    });
-    next = patchFeishuConfig(next, resolvedAccountId, {
-      domain: domain as "feishu" | "lark",
-    });
-
-    const groupPolicy = (await prompter.select({
-      message: "Group chat policy",
-      options: [
-        { value: "allowlist", label: "Allowlist - only respond in specific groups" },
-        { value: "open", label: "Open - respond in all groups (requires mention)" },
-        { value: "disabled", label: "Disabled - don't respond in groups" },
-      ],
-      initialValue:
-        resolveFeishuAccount({ cfg: next, accountId: resolvedAccountId }).config.groupPolicy ??
-        "allowlist",
-    })) as "allowlist" | "open" | "disabled";
-    next = setFeishuGroupPolicy(next, resolvedAccountId, groupPolicy);
-
-    if (groupPolicy === "allowlist") {
-      const existing =
-        resolveFeishuAccount({ cfg: next, accountId: resolvedAccountId }).config.groupAllowFrom ??
-        [];
-      const entry = await prompter.text({
-        message: "Group chat allowlist (chat_ids)",
-        placeholder: "oc_xxxxx, oc_yyyyy",
-        initialValue: existing.length > 0 ? existing.map(String).join(", ") : undefined,
-      });
-      if (entry) {
-        const parts = splitSetupEntries(String(entry));
-        if (parts.length > 0) {
-          next = setFeishuGroupAllowFrom(next, resolvedAccountId, parts);
-        }
-      }
-    }
-
-    return { cfg: next };
+    // New app flow — mark for finalize.
+    return {
+      credentialValues: { ...credentialValues, _flow: "new" },
+    };
   },
+
+  credentials: [],
+
+  // -------------------------------------------------------------------------
+  // finalize: run the appropriate flow
+  // -------------------------------------------------------------------------
+  finalize: async ({ cfg, prompter, options, credentialValues }) => {
+    const flow = credentialValues._flow ?? "new";
+
+    if (flow === "edit") {
+      const result = await runEditFlow({ cfg, prompter, options });
+      if (result === null) {
+        // User chose to skip.
+        return { cfg };
+      }
+      return result;
+    }
+
+    // New app flow — prompt mode then run.
+    const appMode = await promptAppMode(prompter);
+    return runNewAppFlow({ cfg, prompter, options, appMode });
+  },
+
   dmPolicy: feishuDmPolicy,
   disable: (cfg) =>
     patchTopLevelChannelConfigSection({

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -3,7 +3,8 @@
  */
 
 import type { Client } from "@larksuiteoapi/node-sdk";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard } from "../runtime-api.js";
+import { getFeishuUserAgent } from "./client.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
@@ -76,7 +77,7 @@ async function getToken(creds: Credentials): Promise<string> {
     url: `${resolveApiBase(creds.domain)}/auth/v3/tenant_access_token/internal`,
     init: {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "User-Agent": getFeishuUserAgent() },
       body: JSON.stringify({ app_id: creds.appId, app_secret: creds.appSecret }),
     },
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
@@ -221,6 +222,7 @@ export class FeishuStreamingSession {
         headers: {
           Authorization: `Bearer ${await getToken(this.creds)}`,
           "Content-Type": "application/json",
+          "User-Agent": getFeishuUserAgent(),
         },
         body: JSON.stringify({ type: "card_json", data: JSON.stringify(cardJson) }),
       },
@@ -305,6 +307,7 @@ export class FeishuStreamingSession {
         headers: {
           Authorization: `Bearer ${await getToken(this.creds)}`,
           "Content-Type": "application/json",
+          "User-Agent": getFeishuUserAgent(),
         },
         body: JSON.stringify({
           content: text,
@@ -370,6 +373,7 @@ export class FeishuStreamingSession {
         headers: {
           Authorization: `Bearer ${await getToken(this.creds)}`,
           "Content-Type": "application/json",
+          "User-Agent": getFeishuUserAgent(),
         },
         body: JSON.stringify({
           content: `<font color='grey'>${note}</font>`,
@@ -421,6 +425,7 @@ export class FeishuStreamingSession {
         headers: {
           Authorization: `Bearer ${await getToken(this.creds)}`,
           "Content-Type": "application/json; charset=utf-8",
+          "User-Agent": getFeishuUserAgent(),
         },
         body: JSON.stringify({
           settings: JSON.stringify({

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -7,6 +7,7 @@ const createFeishuClientMock = vi.fn((account: { appId?: string } | undefined) =
 }));
 
 vi.mock("./client.js", () => ({
+  setFeishuUserAgentMode: vi.fn(),
   createFeishuClient: (account: { appId?: string } | undefined) => createFeishuClientMock(account),
 }));
 

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -11,6 +11,7 @@ export type FeishuConfig = z.infer<typeof FeishuConfigSchema>;
 export type FeishuGroupConfig = z.infer<typeof FeishuGroupSchema>;
 export type FeishuAccountConfig = z.infer<typeof FeishuAccountConfigSchema>;
 
+export type FeishuAppMode = "user" | "bot";
 export type FeishuDomain = "feishu" | "lark" | (string & {});
 export type FeishuConnectionMode = "websocket" | "webhook";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,12 @@ importers:
       '@sinclair/typebox':
         specifier: 0.34.49
         version: 0.34.49
+      https-proxy-agent:
+        specifier: ^8.0.0
+        version: 8.0.0
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -4158,6 +4164,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agent-base@8.0.0:
+    resolution: {integrity: sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==}
+    engines: {node: '>= 14'}
+
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
@@ -5195,6 +5205,10 @@ packages:
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@8.0.0:
+    resolution: {integrity: sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==}
     engines: {node: '>= 14'}
 
   https-proxy-agent@9.0.0:
@@ -10722,6 +10736,8 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agent-base@8.0.0: {}
+
   agent-base@9.0.0: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
@@ -11837,6 +11853,13 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@8.0.0:
+    dependencies:
+      agent-base: 8.0.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -249,6 +249,7 @@ export async function runPreparedReply(
       })
     : "";
   const groupSystemPrompt = normalizeOptionalString(sessionCtx.GroupSystemPrompt) ?? "";
+  const dmSystemPrompt = normalizeOptionalString(sessionCtx.DirectMessageSystemPrompt) ?? "";
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
     { includeFormattingHints: !useFastReplyRuntime },
@@ -258,6 +259,7 @@ export async function runPreparedReply(
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
+    dmSystemPrompt,
     buildExecOverridePromptHint({
       execOverrides,
       elevatedLevel: resolvedElevatedLevel,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -129,6 +129,8 @@ export type MsgContext = {
   GroupSpace?: string;
   GroupMembers?: string;
   GroupSystemPrompt?: string;
+  /** System prompt injected for direct-message conversations (e.g. channel-specific DM context). */
+  DirectMessageSystemPrompt?: string;
   /** Untrusted metadata that must not be treated as system instructions. */
   UntrustedContext?: string[];
   /** System-attached provenance for the current inbound message. */

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -3145,6 +3145,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         defaultAccount: {
           type: "string",
         },
+        appMode: {
+          type: "string",
+          enum: ["user", "bot"],
+        },
         appId: {
           type: "string",
         },

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -75,6 +75,7 @@ export type { RuntimeEnv } from "../runtime.js";
 export { formatDocsLink } from "../terminal/links.js";
 export { evaluateSenderGroupAccessForPolicy } from "./group-access.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
+export { createClackPrompter } from "../wizard/clack-prompter.js";
 export { feishuSetupWizard, feishuSetupAdapter } from "./feishu-setup.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
 export { readJsonFileWithFallback } from "./json-store.js";


### PR DESCRIPTION
## Summary

- Problem: Feishu OAPI requests lack source tracking; no warning when user mode + open policy creates identity escalation risk
- Why it matters: Cannot distinguish request sources; other users may trigger operations under Owner's identity
- What changed: UA header injection on all OAPI requests; one-time security warning card for risky policy; probe endpoint aligned with larksuite/openclaw-lark
- What did NOT change: Message handling, tool registration, streaming, onboard flow, channel startup

## Change Type (select all)

- [x] Feature
- [x] Security hardening

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related: onboard migration (same branch, separate commits by @mazhe.nerd)

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — UA injection covered by `client.test.ts`.

## User-visible / Behavior Changes

- OAPI requests carry `User-Agent: openclaw-feishu-builtin/{ver}/{platform}/{appMode}`
- Owner receives orange warning card when `appMode=user` with open dm/group policy (one-time, suppressible via `disableSecurityWarning: true`)
- Probe endpoint changed internally (no user-visible impact)

## Diagram (if applicable)

```text
gateway start / config hot reload
  → checkAndWarnOpenPolicyRisk()
    → disableSecurityWarning? skip
    → appMode != "user"?      skip
    → no open policy?         skip
    → record exists?          skip
    → resolve Owner via OAPI  → fail? skip
    → send warning card → write record
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- New OAPI call `GET /application/v6/applications/{appId}` to resolve Owner. Requires `application:application:self_manage`. Failure is non-blocking. SDK UA interceptor replaced (same approach as larksuite/openclaw-lark).

## Repro + Verification

### Steps

1. Set `appMode: "user"`, `dmPolicy: "open"`, delete `~/.openclaw/feishu/open-policy-warning.json`
2. Restart gateway with Charles proxy
3. Verify UA header on `open.feishu.cn` requests
4. Verify Owner receives orange warning card

### Expected

- UA: `openclaw-feishu-builtin/{ver}/darwin/user`
- Warning card delivered, record written

### Actual

- Verified as expected

## Evidence

- [x] Trace/log snippets
- [x] Screenshot/recording

## Human Verification (required)

- Verified: UA on all OAPI endpoints; warning trigger/dedup/hot-reload/opt-out; probe switch
- Not verified: Multi-account scenario; sandbox record persistence

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — `channels.feishu.appMode` (set by switch script), `channels.feishu.disableSecurityWarning` (optional)
- Migration needed? No

## Risks and Mitigations

- Risk: SDK interceptor replacement may break if SDK adds other request interceptors
  - Mitigation: Matches larksuite/openclaw-lark approach; only request interceptors cleared, response untouched
- Risk: `application:application:self_manage` scope not granted
  - Mitigation: Non-blocking, silent skip
