### PR TITLE
memory-lancedb: isolate per-agent lancedb by agentId

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -246,7 +246,9 @@ describe("memory plugin e2e", () => {
           debug: vi.fn(),
         },
         registerTool: (tool: any, opts: any) => {
-          registeredTools.push({ tool, opts });
+          // Tools are registered as OpenClawPluginToolFactory functions; resolve with a mock context.
+          const resolved = typeof tool === "function" ? tool({ agentId: undefined }) : tool;
+          registeredTools.push({ tool: resolved, opts });
         },
         registerCli: vi.fn(),
         registerService: vi.fn(),
@@ -327,6 +329,242 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");
     expect(detectCategory("Random note")).toBe("other");
+  });
+});
+
+describe("per-agent memory isolation", () => {
+  const { getDbPath } = installTmpDirHarness({ prefix: "openclaw-memory-isolation-test-" });
+
+  /**
+   * Returns a lancedb connect mock plus a minimal table stub.
+   * Each connect() call returns the same stub so we can focus on
+   * how many times connect was called and with which paths.
+   */
+  function buildLanceDbMocks() {
+    const openTable = vi.fn(async () => ({
+      vectorSearch: vi.fn(() => ({
+        limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+      })),
+      countRows: vi.fn(async () => 0),
+      add: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    }));
+    const connect = vi.fn(async (_dbPath: string) => ({
+      tableNames: vi.fn(async () => ["memories"]),
+      openTable,
+    }));
+    return { connect, openTable };
+  }
+
+  function buildMockApi(overrides: {
+    dbPath: string;
+    autoRecall?: boolean;
+    autoCapture?: boolean;
+  }) {
+    const hookHandlers = new Map<string, (...args: unknown[]) => unknown>();
+    const factories: Array<{ factory: unknown; opts: unknown }> = [];
+    const mockApi = {
+      id: "memory-lancedb",
+      pluginConfig: {
+        embedding: { apiKey: "test-key", model: "text-embedding-3-small" },
+        dbPath: overrides.dbPath,
+        autoCapture: overrides.autoCapture ?? false,
+        autoRecall: overrides.autoRecall ?? false,
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      registerTool: (tool: unknown, opts: unknown) => {
+        factories.push({ factory: tool, opts });
+      },
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      on: (eventName: string, handler: (...args: unknown[]) => unknown) => {
+        hookHandlers.set(eventName, handler);
+      },
+      resolvePath: (p: string) => p,
+    };
+    return { mockApi, hookHandlers, factories };
+  }
+
+  test("tools with different agentIds connect to separate DB subdirectories", async () => {
+    const { connect } = buildLanceDbMocks();
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2] }] })) };
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule: vi.fn(async () => ({ connect })),
+    }));
+
+    try {
+      const { default: plugin } = await import("./index.js");
+      const baseDbPath = getDbPath();
+      const { mockApi, factories } = buildMockApi({ dbPath: baseDbPath });
+
+      plugin.register(mockApi as never);
+
+      // Call the memory_recall factory with three different contexts
+      const recallFactory = factories.find(
+        (f) => (f.opts as { name?: string })?.name === "memory_recall",
+      )!.factory as (ctx: { agentId?: string }) => {
+        execute: (...a: unknown[]) => Promise<unknown>;
+      };
+      const toolA = recallFactory({ agentId: "agent-a" });
+      const toolB = recallFactory({ agentId: "agent-b" });
+      const toolLegacy = recallFactory({ agentId: undefined });
+
+      // Execute each to trigger DB initialization
+      await toolA.execute("call-a", { query: "test" });
+      await toolB.execute("call-b", { query: "test" });
+      await toolLegacy.execute("call-legacy", { query: "test" });
+
+      const calledPaths = connect.mock.calls.map((c) => c[0]);
+      expect(calledPaths).toHaveLength(3);
+
+      // Each agent gets a subdirectory; no-agentId falls back to the root dbPath
+      expect(calledPaths.some((p) => p.endsWith("agent-a"))).toBe(true);
+      expect(calledPaths.some((p) => p.endsWith("agent-b"))).toBe(true);
+      expect(calledPaths.some((p) => p === baseDbPath)).toBe(true);
+
+      // All three paths are distinct
+      expect(new Set(calledPaths).size).toBe(3);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("same agentId reuses a single DB instance across tool types", async () => {
+    const { connect } = buildLanceDbMocks();
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2] }] })) };
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule: vi.fn(async () => ({ connect })),
+    }));
+
+    try {
+      const { default: plugin } = await import("./index.js");
+      const { mockApi, factories } = buildMockApi({ dbPath: getDbPath() });
+
+      plugin.register(mockApi as never);
+
+      type ToolLike = { execute: (...a: unknown[]) => Promise<unknown> };
+      type Factory = (ctx: { agentId?: string }) => ToolLike;
+      const getFactory = (name: string) =>
+        factories.find((f) => (f.opts as { name?: string })?.name === name)!.factory as Factory;
+
+      // Two different tool types, same agentId
+      const recallTool = getFactory("memory_recall")({ agentId: "shared-agent" });
+      const storeTool = getFactory("memory_store")({ agentId: "shared-agent" });
+
+      await recallTool.execute("r", { query: "test" });
+      await storeTool.execute("s", {
+        text: "I prefer TypeScript",
+        importance: 0.8,
+        category: "preference",
+      });
+
+      // Only one connect call: both tools share the same MemoryDB instance
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(connect.mock.calls[0][0]).toMatch(/shared-agent$/);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("before_agent_start hook connects to agent-specific DB path", async () => {
+    const { connect } = buildLanceDbMocks();
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2] }] })) };
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule: vi.fn(async () => ({ connect })),
+    }));
+
+    try {
+      const { default: plugin } = await import("./index.js");
+      const { mockApi, hookHandlers } = buildMockApi({
+        dbPath: getDbPath(),
+        autoRecall: true,
+      });
+
+      plugin.register(mockApi as never);
+
+      const hook = hookHandlers.get("before_agent_start")!;
+      // Fire the hook for two agents
+      await hook({ prompt: "what do I prefer?" }, { agentId: "hook-agent-1" });
+      await hook({ prompt: "what do I prefer?" }, { agentId: "hook-agent-2" });
+
+      const calledPaths = connect.mock.calls.map((c) => c[0]);
+      expect(calledPaths.some((p) => p.endsWith("hook-agent-1"))).toBe(true);
+      expect(calledPaths.some((p) => p.endsWith("hook-agent-2"))).toBe(true);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("no agentId falls back to root dbPath (backward compat)", async () => {
+    const { connect } = buildLanceDbMocks();
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2] }] })) };
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule: vi.fn(async () => ({ connect })),
+    }));
+
+    try {
+      const { default: plugin } = await import("./index.js");
+      const baseDbPath = getDbPath();
+      const { mockApi, factories } = buildMockApi({ dbPath: baseDbPath });
+
+      plugin.register(mockApi as never);
+
+      type ToolLike = { execute: (...a: unknown[]) => Promise<unknown> };
+      const recallFactory = factories.find(
+        (f) => (f.opts as { name?: string })?.name === "memory_recall",
+      )!.factory as (ctx: { agentId?: string }) => ToolLike;
+      await recallFactory({ agentId: undefined }).execute("c", { query: "test" });
+
+      // Must connect to exactly the root path, not a subdirectory
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(connect.mock.calls[0][0]).toBe(baseDbPath);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
   });
 });
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import type * as LanceDB from "@lancedb/lancedb";
 import { Type } from "@sinclair/typebox";
 import OpenAI from "openai";
@@ -47,8 +48,8 @@ type MemorySearchResult = {
 const TABLE_NAME = "memories";
 
 class MemoryDB {
-  private db: LanceDB.Connection | null = null;
-  private table: LanceDB.Table | null = null;
+  private db?: LanceDB.Connection;
+  private table?: LanceDB.Table;
   private initPromise: Promise<void> | null = null;
 
   constructor(
@@ -293,8 +294,21 @@ export default definePluginEntry({
     const { model, dimensions, apiKey, baseUrl } = cfg.embedding;
 
     const vectorDim = dimensions ?? vectorDimsForModel(model);
-    const db = new MemoryDB(resolvedDbPath, vectorDim);
     const embeddings = new Embeddings(apiKey, model, baseUrl, dimensions);
+
+    // Per-agent DB map. Key is agentId; empty string is the legacy/no-agentId fallback.
+    // When agentId is provided each agent gets an isolated subdirectory under resolvedDbPath.
+    // When absent (CLI, legacy single-agent installs) the original resolvedDbPath is used as-is,
+    // which preserves backward compatibility with existing data.
+    const dbMap = new Map<string, MemoryDB>();
+    function getAgentDb(agentId: string | undefined): MemoryDB {
+      const key = agentId ?? "";
+      if (!dbMap.has(key)) {
+        const agentDbPath = agentId ? join(resolvedDbPath, agentId) : resolvedDbPath;
+        dbMap.set(key, new MemoryDB(agentDbPath, vectorDim));
+      }
+      return dbMap.get(key)!;
+    }
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 
@@ -303,7 +317,7 @@ export default definePluginEntry({
     // ========================================================================
 
     api.registerTool(
-      {
+      (ctx) => ({
         name: "memory_recall",
         label: "Memory Recall",
         description:
@@ -314,6 +328,7 @@ export default definePluginEntry({
         }),
         async execute(_toolCallId, params) {
           const { query, limit = 5 } = params as { query: string; limit?: number };
+          const db = getAgentDb(ctx.agentId);
 
           const vector = await embeddings.embed(query);
           const results = await db.search(vector, limit, 0.1);
@@ -346,12 +361,12 @@ export default definePluginEntry({
             details: { count: results.length, memories: sanitizedResults },
           };
         },
-      },
+      }),
       { name: "memory_recall" },
     );
 
     api.registerTool(
-      {
+      (ctx) => ({
         name: "memory_store",
         label: "Memory Store",
         description:
@@ -376,6 +391,7 @@ export default definePluginEntry({
             importance?: number;
             category?: MemoryEntry["category"];
           };
+          const db = getAgentDb(ctx.agentId);
 
           const vector = await embeddings.embed(text);
 
@@ -409,12 +425,12 @@ export default definePluginEntry({
             details: { action: "created", id: entry.id },
           };
         },
-      },
+      }),
       { name: "memory_store" },
     );
 
     api.registerTool(
-      {
+      (ctx) => ({
         name: "memory_forget",
         label: "Memory Forget",
         description: "Delete specific memories. GDPR-compliant.",
@@ -424,6 +440,7 @@ export default definePluginEntry({
         }),
         async execute(_toolCallId, params) {
           const { query, memoryId } = params as { query?: string; memoryId?: string };
+          const db = getAgentDb(ctx.agentId);
 
           if (memoryId) {
             await db.delete(memoryId);
@@ -480,7 +497,7 @@ export default definePluginEntry({
             details: { error: "missing_param" },
           };
         },
-      },
+      }),
       { name: "memory_forget" },
     );
 
@@ -496,7 +513,7 @@ export default definePluginEntry({
           .command("list")
           .description("List memories")
           .action(async () => {
-            const count = await db.count();
+            const count = await getAgentDb(undefined).count();
             console.log(`Total memories: ${count}`);
           });
 
@@ -507,7 +524,7 @@ export default definePluginEntry({
           .option("--limit <n>", "Max results", "5")
           .action(async (query, opts) => {
             const vector = await embeddings.embed(query);
-            const results = await db.search(vector, parseInt(opts.limit), 0.3);
+            const results = await getAgentDb(undefined).search(vector, parseInt(opts.limit), 0.3);
             // Strip vectors for output
             const output = results.map((r) => ({
               id: r.entry.id,
@@ -523,7 +540,7 @@ export default definePluginEntry({
           .command("stats")
           .description("Show memory statistics")
           .action(async () => {
-            const count = await db.count();
+            const count = await getAgentDb(undefined).count();
             console.log(`Total memories: ${count}`);
           });
       },
@@ -536,40 +553,46 @@ export default definePluginEntry({
 
     // Auto-recall: inject relevant memories before agent starts
     if (cfg.autoRecall) {
-      api.on("before_agent_start", async (event) => {
-        if (!event.prompt || event.prompt.length < 5) {
-          return;
-        }
-
-        try {
-          const vector = await embeddings.embed(event.prompt);
-          const results = await db.search(vector, 3, 0.3);
-
-          if (results.length === 0) {
-            return;
+      api.on(
+        "before_agent_start",
+        async (event, ctx): Promise<{ prependContext: string } | undefined> => {
+          if (!event.prompt || event.prompt.length < 5) {
+            return undefined;
           }
 
-          api.logger.info?.(`memory-lancedb: injecting ${results.length} memories into context`);
+          try {
+            const db = getAgentDb(ctx?.agentId);
+            const vector = await embeddings.embed(event.prompt);
+            const results = await db.search(vector, 3, 0.3);
 
-          return {
-            prependContext: formatRelevantMemoriesContext(
-              results.map((r) => ({ category: r.entry.category, text: r.entry.text })),
-            ),
-          };
-        } catch (err) {
-          api.logger.warn(`memory-lancedb: recall failed: ${String(err)}`);
-        }
-      });
+            if (results.length === 0) {
+              return undefined;
+            }
+
+            api.logger.info?.(`memory-lancedb: injecting ${results.length} memories into context`);
+
+            return {
+              prependContext: formatRelevantMemoriesContext(
+                results.map((r) => ({ category: r.entry.category, text: r.entry.text })),
+              ),
+            };
+          } catch (err) {
+            api.logger.warn(`memory-lancedb: recall failed: ${String(err)}`);
+            return undefined;
+          }
+        },
+      );
     }
 
     // Auto-capture: analyze and store important information after agent ends
     if (cfg.autoCapture) {
-      api.on("agent_end", async (event) => {
+      api.on("agent_end", async (event, ctx) => {
         if (!event.success || !event.messages || event.messages.length === 0) {
           return;
         }
 
         try {
+          const db = getAgentDb(ctx?.agentId);
           // Extract text content from messages (handling unknown[] type)
           const texts: string[] = [];
           for (const msg of event.messages) {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                   
  - **Problem:** In the `memory-lancedb` plugin, all configured agents in a single openclaw instance share one LanceDB instance. When multiple agents are defined via `agents.list`, agent A's stored memories are recalled by agent B, leaking context across agents.             
  - **Why it matters:** Any user who runs two or more agents (e.g., a customer-facing Telegram bot and an internal Discord assistant) within one openclaw instance will have their agents' memories contaminated by each other silently — the model receives irrelevant context without any warning.                                                                                                                                                                                                                                                             
  - **What changed:** Replaced the single `MemoryDB` instance with a `Map<string, MemoryDB>` keyed by `agentId`. Each agent now gets an isolated subdirectory `<dbPath>/<agentId>/`. All three tools (`memory_recall`, `memory_store`, `memory_forget`) and both lifecycle hooks
  (`before_agent_start`, `agent_end`) are migrated to `OpenClawPluginToolFactory` so `ctx.agentId` is available at execution time.                                                                                                                                                 
  - **What did NOT change:** Single-agent installs (no `agents.list`) are fully backward compatible — when `agentId` is absent, the original `dbPath` is used unchanged. CLI commands (`ltm list/search/stats`) also fall back to the root path.
                                                                                                                                                                                                                                                                                   
  ## Change Type (select all)                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                   
  - [x] Bug fix                                                                                                                                                                                                                                                                    
  - [ ] Feature                                             
  - [ ] Refactor required for the fix
  - [ ] Docs                                                                                                                                                                                                                                                                       
  - [ ] Security hardening
  - [ ] Chore/infra                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                   
  ## Scope (select all touched areas)
                                                                                                                                                                                                                                                                                   
  - [ ] Gateway / orchestration                             
  - [ ] Skills / tool execution
  - [ ] Auth / tokens                                                                                                                                                                                                                                                              
  - [x] Memory / storage
  - [ ] Integrations                                                                                                                                                                                                                                                               
  - [ ] API / contracts                                                                                                                                                                                                                                                            
  - [ ] UI / DX
  - [ ] CI/CD / infra                                                                                                                                                                                                                                                              
                                                            
  ## Linked Issue/PR                                                                                                                                                                                                                                                               
   
  - Closes #41451                                                                                                                                                                                                                                                                  
  - [ ] This PR fixes a bug or regression                   

  ## Root Cause (if applicable)

  - **Root cause:** The `register()` function constructed a single `new MemoryDB(resolvedDbPath, vectorDim)` at plugin load time and captured it in closure. All tool `execute` callbacks and lifecycle hooks referenced this shared instance regardless of which agent triggered  
  them. The old `AnyAgentTool` pattern used by the tools had no access to `agentId` at call time; `OpenClawPluginToolFactory` was available but not used.
  - **Missing detection / guardrail:** No test existed for multi-agent DB isolation at the plugin level.                                                                                                                                                                           
  - **Contributing context:** `DEFAULT_AGENT_ID = "main"` means single-agent users are never affected, which masked the bug in practice.                                                                                                                                           
                                                                                                                                                                                                                                                                                   
  ## Regression Test Plan (if applicable)                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                   
  - Coverage level that should have caught this:            
    - [x] Unit test
    - [ ] Seam / integration test                                                                                                                                                                                                                                                  
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient                                                                                                                                                                                                                                     
  - **Target test or file:** `extensions/memory-lancedb/index.test.ts`
  - **Scenario the test should lock in:** Tools with different `agentId`s must call `lancedb.connect()` with distinct paths; same `agentId` must reuse a single instance; missing `agentId` must fall back to the root `dbPath` exactly.                                           
  - **Why this is the smallest reliable guardrail:** The `lancedb.connect` call is the boundary — mocking it and asserting the path argument is sufficient to verify isolation without requiring a real LanceDB installation.                                                      
  - **Existing test that already covers this:** None — added 4 new tests in the `per-agent memory isolation` describe block.                                                                                                                                                       
  - **If no new test is added, why not:** N/A — tests were added.                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                   
  ## User-visible / Behavior Changes                                                                                                                                                                                                                                               
                                                            
  - Users with a **single agent** (the majority): no change. DB path is identical to before.                                                                                                                                                                                       
  - Users with **multiple agents configured** (`agents.list`): each agent now writes to and reads from `<dbPath>/<agentId>/` instead of the shared root. **Existing memories in the root are not migrated automatically** — users upgrading with a multi-agent setup should be
  aware their pre-existing data remains in the root path and is no longer visible to named agents.                                                                                                                                                                                 
                                                            
  ## Diagram (if applicable)                                                                                                                                                                                                                                                       
                                                            
  ```text
  Before:
  [agent-a recall] -> lancedb.connect(<dbPath>)  ← shared
  [agent-b recall] -> lancedb.connect(<dbPath>)  ← shared                                                                                                                                                                                                                          
   
  After:                                                                                                                                                                                                                                                                           
  [agent-a recall] -> lancedb.connect(<dbPath>/agent-a/)  ← isolated
  [agent-b recall] -> lancedb.connect(<dbPath>/agent-b/)  ← isolated                                                                                                                                                                                                               
  [CLI / no agentId] -> lancedb.connect(<dbPath>)          ← backward compat                                                                                                                                                                                                       
   
  Security Impact (required)                                                                                                                                                                                                                                                       
                                                            
  - New permissions/capabilities? No                                                                                                                                                                                                                                               
  - Secrets/tokens handling changed? No
  - New/changed network calls? No                                                                                                                                                                                                                                                  
  - Command/tool execution surface changed? No              
  - Data access scope changed? Yes — agents that previously could read each other's memories can no longer do so. This is a reduction in data access scope and is intentional. No new cross-agent data access is introduced.                                                       
                                                                                                                                                                                                                                                                                   
  Repro + Verification                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                   
  Environment                                                                                                                                                                                                                                                                      
   
  - OS: Linux                                                                                                                                                                                                                                                                      
  - Runtime/container: Node 22 / Bun                        
  - Model/provider: any
  - Integration/channel: any (bug is at the storage layer)
  - Relevant config: agents.list with two or more agents, both with memory-lancedb enabled
                                                                                                                                                                                                                                                                                   
  Steps
                                                                                                                                                                                                                                                                                   
  1. Configure two agents (id: work, id: personal) in openclaw.yaml, both using memory-lancedb.                                                                                                                                                                                    
  2. With agent work, store a memory: memory_store("My work API key prefix is sk-work").
  3. Switch to agent personal and recall: memory_recall("API key").                                                                                                                                                                                                                
                                                            
  Expected                                                                                                                                                                                                                                                                         
                                                            
  - Agent personal finds no results (isolated DB).

  Actual (before fix)

  - Agent personal recalls the work API key memory — cross-agent leak.                                                                                                                                                                                                             
   
  Evidence                                                                                                                                                                                                                                                                         
                                                            
  - Failing test/log before + passing after — 4 new unit tests in index.test.ts (20/20 pass)

  Human Verification (required)                                                                                                                                                                                                                                                    
   
  - Verified scenarios: Single-agent fallback path (no agentId) produces the original dbPath unchanged; two distinct agentId values produce two distinct connect paths; same agentId called twice reuses one MemoryDB instance (no duplicate connections).                         
  - Edge cases checked: agentId = undefined, agentId = "" (both map to root path key ""); before_agent_start hook with and without ctx.
  - What you did not verify: Live multi-agent end-to-end with a real LanceDB installation; data migration path for existing multi-agent deployments.                                                                                                                               
                                                                                                                                                                                                                                                                                   
  Review Conversations                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                   
  - I replied to or resolved every bot review conversation I addressed in this PR.
  - I left unresolved only the conversations that still need reviewer or maintainer judgment.
                                                                                                                                                                                                                                                                                   
  Compatibility / Migration
                                                                                                                                                                                                                                                                                   
  - Backward compatible? Yes — single-agent users see no change. Multi-agent users will have isolated DBs going forward; pre-existing data in the shared root is not auto-migrated (documented above). 