### PR TITLE
 feat(control-ui): add me-context PR1 scaffold

### DIFF
--- a/HANDOFF-2026-04-10-FAILED-MULTIUSER-BETA.md
+++ b/HANDOFF-2026-04-10-FAILED-MULTIUSER-BETA.md
@@ -1,0 +1,122 @@
+# Handoff 2026-04-10, failed multiuser beta push
+
+## What happened
+
+The target was to deliver a rough but usable multiuser web GUI beta by the morning of 2026-04-10.
+That did not happen.
+
+The work produced some real wiring progress, but not a finished usable beta. Igor explicitly called the miss and chose to restore the VPS checkpoint. This file exists so that after restore the same mistake does not repeat.
+
+## Truthful repo state before restore
+
+Canonical repo path:
+- `/home/ogmabot/.openclaw/workspace/repos/openclaw`
+
+Working branch:
+- `feat/control-ui-me-context-pr1`
+
+Relevant commits on that branch:
+- `c126061f91` - `feat(control-ui): add me-context PR1 scaffold`
+- `2c462ef7b2` - `feat(control-ui): add session-type aware me-context step`
+- `91c43d205d` - `feat(control-ui): wire scope selection into me-context session state`
+
+Remote state:
+- pushed to Igor fork remote `igor`
+- branch `igor/feat/control-ui-me-context-pr1` includes all three commits above
+
+## What is actually implemented
+
+### Commit `c126061f91`
+- shared me-context contract/types
+- backend `GET /api/me/context`
+- frontend me-context loader/state
+- chat context bar
+- scope selector scaffold
+- me-context load moved out of chat render and into connect flow
+
+### Commit `2c462ef7b2`
+- added `currentSessionType` into me-context model
+- backend/frontend plumbing for session-type-aware context
+- UI context bar moved toward showing actual current session type instead of only first launchable type
+- partial removal of the dumbest placeholder behavior from PR1
+
+### Commit `91c43d205d`
+- fixed the UI state hole where `currentSessionType` was not actually stored/updated in the me-context client state
+- reload me-context when switching chat session or switching current agent in chat
+- scope selection now updates `sessionKey` based on selected scope instead of only changing the visible label
+
+## What is NOT actually done
+
+This is the critical part.
+
+The branch still does **not** provide a finished working multiuser beta flow.
+
+Specifically still missing / unreliable:
+- end-to-end tested multiuser login and usage flow
+- confidence that scope switching maps to the right real session semantics instead of only changing UI/session naming
+- proper runtime identity/auth context flowing from real device/operator state all the way into useful multiuser behavior
+- enough functional validation to call the branch beta-ready
+
+## Main failure mode
+
+The mistake was not one bad line of code. The mistake was execution shape.
+
+The push spent too much time in:
+- inspection
+- partial wiring
+- validation friction on this host
+- making the state look more correct without forcing the narrowest end-to-end beta path first
+
+The result was progress without delivery.
+
+## Lessons that must be followed after restore
+
+1. **Do not promise a time unless the path is already narrowed to one end-to-end flow.**
+2. **Working path first, architecture second, cleanup later.** Igor already explicitly said this.
+3. **Do not treat me-context/UI polish as delivery.** A correct-looking context bar is not the beta.
+4. **Before touching more abstractions, force one minimal scenario through:**
+   - one operator identity
+   - one private scope
+   - one group scope
+   - one global/shared scope if role allows
+   - switching scope must lead to a meaningfully different session target/state
+5. **When validation tooling is broken on the host, stop trying to make validation perfect.** Do the fastest functional proof that the narrow flow works.
+6. **When behind schedule, stop widening the model.** Hardcode or simplify if needed, as long as the beta path becomes usable.
+
+## Recommended restart plan after restore
+
+Use git as the source of truth.
+
+### Recover branch
+```bash
+git fetch igor
+git checkout feat/control-ui-me-context-pr1
+git reset --hard igor/feat/control-ui-me-context-pr1
+```
+
+### Then execute in this order
+
+1. Verify the branch builds/runs enough to manually test the Control UI.
+2. Pick exactly one concrete beta scenario and finish it before anything else.
+3. Recommended narrow scenario:
+   - operator connects
+   - me-context loads user/scopes
+   - scope switch changes actual chat/session target meaningfully
+   - user can send in each visible scope without the UI lying about where they are
+4. Only after that, widen to better identity/auth mapping.
+
+## Brutal scope rule for retry
+
+Acceptable beta:
+- rough UI
+- partial hardcoding
+- simplified role model
+- incomplete final policy enforcement
+
+Not acceptable:
+- more elegant scaffolding without a working end-to-end flow
+- more promises based on partial wiring
+
+## User-impact note
+
+Igor explicitly said the missed deadline was unacceptable and restored checkpoint became the reasonable fallback. Treat future time estimates on this project as trust-sensitive.

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -22,6 +22,12 @@ export type PrivacyMode = "private" | "group_shared" | "global_shared" | "admin"
 export type SessionType = "private_chat" | "group_chat" | "global_chat" | "operator_chat";
 export type LaunchableSessionType = SessionType;
 
+export type OperatorAuthContext = {
+  role: string;
+  scopes: string[];
+  deviceTokenIssuedAtMs: number | null;
+};
+
 export type ScopeRef = {
   type: ScopeType;
   id: string;
@@ -42,11 +48,9 @@ export type ControlUiMeContextResponse = {
   groups: string[];
   visibleScopes: ScopeRef[];
   launchableSessionTypes: LaunchableSessionType[];
+  currentSessionType: SessionType;
   shareTargets: ScopeRef[];
   selectedScope: ScopeRef | null;
   selectedPrivacyMode: PrivacyMode;
-  operator: {
-    role: typeof CONTROL_UI_OPERATOR_ROLE;
-    scopes: string[];
-  };
+  operator: OperatorAuthContext;
 };

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -1,7 +1,52 @@
 export const CONTROL_UI_BOOTSTRAP_CONFIG_PATH = "/__openclaw/control-ui-config.json";
+export const CONTROL_UI_ME_CONTEXT_PATH = "/api/me/context";
+
+export const CONTROL_UI_OPERATOR_ROLE = "operator";
+export const CONTROL_UI_OPERATOR_SCOPES = [
+  "operator.admin",
+  "operator.read",
+  "operator.write",
+  "operator.approvals",
+  "operator.pairing",
+] as const;
 
 export type ControlUiBootstrapConfig = {
   basePath: string;
   assistantName: string;
   assistantAvatar: string;
+};
+
+export type RoleId = "user" | "admin" | "main_operator";
+export type ScopeType = "private" | "group" | "global";
+export type PrivacyMode = "private" | "group_shared" | "global_shared" | "admin";
+export type SessionType = "private_chat" | "group_chat" | "global_chat" | "operator_chat";
+export type LaunchableSessionType = SessionType;
+
+export type ScopeRef = {
+  type: ScopeType;
+  id: string;
+  label: string;
+  privacyMode: PrivacyMode;
+};
+
+export type RuntimeUser = {
+  id: string;
+  displayName: string;
+  role: RoleId;
+  roleLabel: string;
+  groups: string[];
+};
+
+export type ControlUiMeContextResponse = {
+  user: RuntimeUser;
+  groups: string[];
+  visibleScopes: ScopeRef[];
+  launchableSessionTypes: LaunchableSessionType[];
+  shareTargets: ScopeRef[];
+  selectedScope: ScopeRef | null;
+  selectedPrivacyMode: PrivacyMode;
+  operator: {
+    role: typeof CONTROL_UI_OPERATOR_ROLE;
+    scopes: string[];
+  };
 };

--- a/src/gateway/control-ui-me-context.ts
+++ b/src/gateway/control-ui-me-context.ts
@@ -2,31 +2,14 @@ import type { IncomingMessage } from "node:http";
 import {
   CONTROL_UI_OPERATOR_ROLE,
   CONTROL_UI_OPERATOR_SCOPES,
-} from "../gateway/control-ui-contract.js";
-import type {
-  ControlUiMeContextResponse,
-  LaunchableSessionType,
-  PrivacyMode,
-  RuntimeUser,
-  ScopeRef,
+  type ControlUiMeContextResponse,
+  type LaunchableSessionType,
+  type PrivacyMode,
+  type RuntimeUser,
+  type ScopeRef,
+  type SessionType,
 } from "./control-ui-contract.js";
-
-function readRequestHeader(req: IncomingMessage, name: string): string | null {
-  const value = req.headers[name];
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const trimmed = entry.trim();
-      if (trimmed.length > 0) {
-        return trimmed;
-      }
-    }
-  }
-  return null;
-}
+import { getHeader } from "./http-utils.js";
 
 function titleCaseWords(value: string): string {
   return value
@@ -36,29 +19,23 @@ function titleCaseWords(value: string): string {
     .join(" ");
 }
 
-function normalizeUserId(raw: string | null): string {
-  if (!raw) {
-    return "operator";
+function normalizeUserIdFromHeaders(req: IncomingMessage): string {
+  const deviceId = getHeader(req, "x-openclaw-device-id")?.trim();
+  if (deviceId) {
+    return deviceId.toLowerCase();
   }
-  const normalized = raw
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-");
-  return normalized || "operator";
+  return "control-ui-operator";
 }
 
-function deriveDisplayName(userId: string, fallback: string | null): string {
-  if (fallback && fallback.trim()) {
-    return fallback.trim();
-  }
-  return titleCaseWords(userId.replace(/[._-]+/g, " "));
+function deriveDisplayName(userId: string): string {
+  return titleCaseWords(userId.replace(/[._:-]+/g, " "));
 }
 
-function deriveRole(userId: string): RuntimeUser["role"] {
-  if (userId === "igor") {
+function deriveRoleFromOperatorScopes(scopes: string[]): RuntimeUser["role"] {
+  if (scopes.includes("operator.admin")) {
     return "main_operator";
   }
-  if (userId === "stipe") {
+  if (scopes.includes("operator.write") || scopes.includes("operator.approvals")) {
     return "admin";
   }
   return "user";
@@ -75,11 +52,15 @@ function deriveRoleLabel(role: RuntimeUser["role"]): string {
   }
 }
 
-function deriveGroups(userId: string): string[] {
-  if (userId === "igor" || userId === "stipe" || userId === "ivan") {
-    return ["OGMA"];
+function deriveGroupsFromHeaders(req: IncomingMessage): string[] {
+  const raw = getHeader(req, "x-openclaw-groups")?.trim();
+  if (!raw) {
+    return [];
   }
-  return [];
+  return raw
+    .split(",")
+    .map((groupId) => groupId.trim())
+    .filter((groupId) => groupId.length > 0);
 }
 
 function buildPrivateScope(user: RuntimeUser): ScopeRef {
@@ -121,7 +102,10 @@ function deriveVisibleScopes(user: RuntimeUser): ScopeRef[] {
 }
 
 function deriveLaunchableSessionTypes(user: RuntimeUser): LaunchableSessionType[] {
-  const types: LaunchableSessionType[] = ["private_chat", "group_chat"];
+  const types: LaunchableSessionType[] = ["private_chat"];
+  if (user.groups.length > 0) {
+    types.push("group_chat");
+  }
   if (user.role === "admin" || user.role === "main_operator") {
     types.push("global_chat");
   }
@@ -129,6 +113,19 @@ function deriveLaunchableSessionTypes(user: RuntimeUser): LaunchableSessionType[
     types.push("operator_chat");
   }
   return types;
+}
+
+function deriveCurrentSessionType(user: RuntimeUser): SessionType {
+  if (user.role === "main_operator") {
+    return "operator_chat";
+  }
+  if (user.role === "admin") {
+    return "global_chat";
+  }
+  if (user.groups.length > 0) {
+    return "group_chat";
+  }
+  return "private_chat";
 }
 
 function deriveShareTargets(user: RuntimeUser): ScopeRef[] {
@@ -142,25 +139,55 @@ function deriveShareTargets(user: RuntimeUser): ScopeRef[] {
   return targets;
 }
 
-function deriveSelectedScope(visibleScopes: ScopeRef[]): ScopeRef | null {
+function deriveSelectedScope(
+  visibleScopes: ScopeRef[],
+  currentSessionType: SessionType,
+): ScopeRef | null {
+  if (currentSessionType === "global_chat") {
+    return visibleScopes.find((scope) => scope.type === "global") ?? visibleScopes[0] ?? null;
+  }
+  if (currentSessionType === "group_chat") {
+    return visibleScopes.find((scope) => scope.type === "group") ?? visibleScopes[0] ?? null;
+  }
   return visibleScopes[0] ?? null;
 }
 
+function parseOperatorScopes(req: IncomingMessage): string[] {
+  const raw = getHeader(req, "x-openclaw-scopes")?.trim();
+  if (!raw) {
+    return [...CONTROL_UI_OPERATOR_SCOPES];
+  }
+  return raw
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+}
+
+function parseIssuedAt(req: IncomingMessage): number | null {
+  const raw = getHeader(req, "x-openclaw-auth-issued-at")?.trim();
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export function buildControlUiMeContextResponse(req: IncomingMessage): ControlUiMeContextResponse {
-  const headerUserId = readRequestHeader(req, "x-openclaw-user-id");
-  const headerDisplayName = readRequestHeader(req, "x-openclaw-user-name");
-  const userId = normalizeUserId(headerUserId);
-  const role = deriveRole(userId);
+  const scopes = parseOperatorScopes(req);
+  const userId = normalizeUserIdFromHeaders(req);
+  const groups = deriveGroupsFromHeaders(req);
+  const role = deriveRoleFromOperatorScopes(scopes);
   const user: RuntimeUser = {
     id: userId,
-    displayName: deriveDisplayName(userId, headerDisplayName),
+    displayName: deriveDisplayName(userId),
     role,
     roleLabel: deriveRoleLabel(role),
-    groups: deriveGroups(userId),
+    groups,
   };
 
   const visibleScopes = deriveVisibleScopes(user);
-  const selectedScope = deriveSelectedScope(visibleScopes);
+  const currentSessionType = deriveCurrentSessionType(user);
+  const selectedScope = deriveSelectedScope(visibleScopes, currentSessionType);
   const selectedPrivacyMode: PrivacyMode = selectedScope?.privacyMode ?? "private";
 
   return {
@@ -168,12 +195,14 @@ export function buildControlUiMeContextResponse(req: IncomingMessage): ControlUi
     groups: [...user.groups],
     visibleScopes,
     launchableSessionTypes: deriveLaunchableSessionTypes(user),
+    currentSessionType,
     shareTargets: deriveShareTargets(user),
     selectedScope,
     selectedPrivacyMode,
     operator: {
-      role: CONTROL_UI_OPERATOR_ROLE,
-      scopes: [...CONTROL_UI_OPERATOR_SCOPES],
+      role: getHeader(req, "x-openclaw-role")?.trim() || CONTROL_UI_OPERATOR_ROLE,
+      scopes,
+      deviceTokenIssuedAtMs: parseIssuedAt(req),
     },
   };
 }

--- a/src/gateway/control-ui-me-context.ts
+++ b/src/gateway/control-ui-me-context.ts
@@ -1,0 +1,179 @@
+import type { IncomingMessage } from "node:http";
+import {
+  CONTROL_UI_OPERATOR_ROLE,
+  CONTROL_UI_OPERATOR_SCOPES,
+} from "../gateway/control-ui-contract.js";
+import type {
+  ControlUiMeContextResponse,
+  LaunchableSessionType,
+  PrivacyMode,
+  RuntimeUser,
+  ScopeRef,
+} from "./control-ui-contract.js";
+
+function readRequestHeader(req: IncomingMessage, name: string): string | null {
+  const value = req.headers[name];
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+  return null;
+}
+
+function titleCaseWords(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function normalizeUserId(raw: string | null): string {
+  if (!raw) {
+    return "operator";
+  }
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-");
+  return normalized || "operator";
+}
+
+function deriveDisplayName(userId: string, fallback: string | null): string {
+  if (fallback && fallback.trim()) {
+    return fallback.trim();
+  }
+  return titleCaseWords(userId.replace(/[._-]+/g, " "));
+}
+
+function deriveRole(userId: string): RuntimeUser["role"] {
+  if (userId === "igor") {
+    return "main_operator";
+  }
+  if (userId === "stipe") {
+    return "admin";
+  }
+  return "user";
+}
+
+function deriveRoleLabel(role: RuntimeUser["role"]): string {
+  switch (role) {
+    case "main_operator":
+      return "Main operator";
+    case "admin":
+      return "Admin";
+    default:
+      return "User";
+  }
+}
+
+function deriveGroups(userId: string): string[] {
+  if (userId === "igor" || userId === "stipe" || userId === "ivan") {
+    return ["OGMA"];
+  }
+  return [];
+}
+
+function buildPrivateScope(user: RuntimeUser): ScopeRef {
+  return {
+    type: "private",
+    id: `private:${user.id}`,
+    label: `${user.displayName} private`,
+    privacyMode: "private",
+  };
+}
+
+function buildGroupScope(groupId: string): ScopeRef {
+  return {
+    type: "group",
+    id: `group:${groupId.toLowerCase()}`,
+    label: groupId,
+    privacyMode: "group_shared",
+  };
+}
+
+function buildGlobalScope(): ScopeRef {
+  return {
+    type: "global",
+    id: "global:shared",
+    label: "Global",
+    privacyMode: "global_shared",
+  };
+}
+
+function deriveVisibleScopes(user: RuntimeUser): ScopeRef[] {
+  const scopes: ScopeRef[] = [buildPrivateScope(user)];
+  for (const groupId of user.groups) {
+    scopes.push(buildGroupScope(groupId));
+  }
+  if (user.role === "admin" || user.role === "main_operator") {
+    scopes.push(buildGlobalScope());
+  }
+  return scopes;
+}
+
+function deriveLaunchableSessionTypes(user: RuntimeUser): LaunchableSessionType[] {
+  const types: LaunchableSessionType[] = ["private_chat", "group_chat"];
+  if (user.role === "admin" || user.role === "main_operator") {
+    types.push("global_chat");
+  }
+  if (user.role === "main_operator") {
+    types.push("operator_chat");
+  }
+  return types;
+}
+
+function deriveShareTargets(user: RuntimeUser): ScopeRef[] {
+  const targets: ScopeRef[] = [];
+  for (const groupId of user.groups) {
+    targets.push(buildGroupScope(groupId));
+  }
+  if (user.role === "admin" || user.role === "main_operator") {
+    targets.push(buildGlobalScope());
+  }
+  return targets;
+}
+
+function deriveSelectedScope(visibleScopes: ScopeRef[]): ScopeRef | null {
+  return visibleScopes[0] ?? null;
+}
+
+export function buildControlUiMeContextResponse(req: IncomingMessage): ControlUiMeContextResponse {
+  const headerUserId = readRequestHeader(req, "x-openclaw-user-id");
+  const headerDisplayName = readRequestHeader(req, "x-openclaw-user-name");
+  const userId = normalizeUserId(headerUserId);
+  const role = deriveRole(userId);
+  const user: RuntimeUser = {
+    id: userId,
+    displayName: deriveDisplayName(userId, headerDisplayName),
+    role,
+    roleLabel: deriveRoleLabel(role),
+    groups: deriveGroups(userId),
+  };
+
+  const visibleScopes = deriveVisibleScopes(user);
+  const selectedScope = deriveSelectedScope(visibleScopes);
+  const selectedPrivacyMode: PrivacyMode = selectedScope?.privacyMode ?? "private";
+
+  return {
+    user,
+    groups: [...user.groups],
+    visibleScopes,
+    launchableSessionTypes: deriveLaunchableSessionTypes(user),
+    shareTargets: deriveShareTargets(user),
+    selectedScope,
+    selectedPrivacyMode,
+    operator: {
+      role: CONTROL_UI_OPERATOR_ROLE,
+      scopes: [...CONTROL_UI_OPERATOR_SCOPES],
+    },
+  };
+}

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -14,6 +14,7 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import {
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
+  CONTROL_UI_ME_CONTEXT_PATH,
   type ControlUiBootstrapConfig,
 } from "./control-ui-contract.js";
 import { buildControlUiCspHeader, computeInlineScriptHashes } from "./control-ui-csp.js";
@@ -22,6 +23,7 @@ import {
   respondNotFound as respondControlUiNotFound,
   respondPlainText,
 } from "./control-ui-http-utils.js";
+import { buildControlUiMeContextResponse } from "./control-ui-me-context.js";
 import { classifyControlUiRequest } from "./control-ui-routing.js";
 import {
   buildControlUiAvatarUrl,
@@ -344,6 +346,20 @@ export function handleControlUiHttpRequest(
   const bootstrapConfigPath = basePath
     ? `${basePath}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`
     : CONTROL_UI_BOOTSTRAP_CONFIG_PATH;
+  const meContextPath = basePath
+    ? `${basePath}${CONTROL_UI_ME_CONTEXT_PATH}`
+    : CONTROL_UI_ME_CONTEXT_PATH;
+  if (pathname === meContextPath) {
+    if (req.method === "HEAD") {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("Cache-Control", "no-cache");
+      res.end();
+      return true;
+    }
+    sendJson(res, 200, buildControlUiMeContextResponse(req));
+    return true;
+  }
   if (pathname === bootstrapConfigPath) {
     const config = opts?.config;
     const identity = config

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -23,6 +23,9 @@ vi.mock("./controllers/agents.ts", () => ({
 vi.mock("./controllers/assistant-identity.ts", () => ({
   loadAssistantIdentity: vi.fn(),
 }));
+vi.mock("./controllers/me-context.ts", () => ({
+  loadMeContext: vi.fn(),
+}));
 vi.mock("./controllers/chat.ts", () => ({
   loadChatHistory: vi.fn(),
   handleChatEvent: vi.fn(() => "idle"),

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -33,6 +33,7 @@ import {
   removeExecApproval,
 } from "./controllers/exec-approval.ts";
 import { loadHealthState } from "./controllers/health.ts";
+import { loadMeContext } from "./controllers/me-context.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadSessions, subscribeSessions } from "./controllers/sessions.ts";
 import {
@@ -250,6 +251,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       }
       void subscribeSessions(host as unknown as OpenClawApp);
       void loadAssistantIdentity(host as unknown as OpenClawApp);
+      void loadMeContext(host as unknown as OpenClawApp);
       void loadAgents(host as unknown as OpenClawApp);
       void loadHealthState(host as unknown as OpenClawApp);
       void loadNodes(host as unknown as OpenClawApp, { quiet: true });

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1562,6 +1562,7 @@ export function renderApp(state: AppViewState) {
                   lastActiveSessionKey: next,
                 });
                 void state.loadAssistantIdentity();
+                void state.loadMeContext();
                 void loadChatHistory(state);
                 void refreshChatAvatar(state);
               },
@@ -1638,6 +1639,7 @@ export function renderApp(state: AppViewState) {
                 });
                 void loadChatHistory(state);
                 void state.loadAssistantIdentity();
+                void state.loadMeContext();
               },
               onNavigateToAgent: () => {
                 state.agentsSelectedId = resolvedAgentId;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1659,6 +1659,15 @@ export function renderApp(state: AppViewState) {
               assistantName: state.assistantName,
               assistantAvatar: state.assistantAvatar,
               basePath: state.basePath ?? "",
+              meContextLoading: state.meContextLoading,
+              meContextError: state.meContextError,
+              currentUser: state.currentUser,
+              visibleScopes: state.visibleScopes,
+              selectedScope: state.selectedScope,
+              selectedPrivacyMode: state.selectedPrivacyMode,
+              launchableSessionTypes: state.launchableSessionTypes,
+              onLoadMeContext: () => void state.loadMeContext(),
+              onScopeChange: (scopeId: string) => state.selectMeContextScope(scopeId),
             })
           : nothing}
         ${state.tab === "config"

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1666,6 +1666,7 @@ export function renderApp(state: AppViewState) {
               selectedScope: state.selectedScope,
               selectedPrivacyMode: state.selectedPrivacyMode,
               launchableSessionTypes: state.launchableSessionTypes,
+              currentSessionType: state.currentSessionType,
               onLoadMeContext: () => void state.loadMeContext(),
               onScopeChange: (scopeId: string) => state.selectMeContextScope(scopeId),
             })

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,3 +1,8 @@
+import type {
+  ControlUiMeContextResponse,
+  PrivacyMode,
+  ScopeRef,
+} from "../../../src/gateway/control-ui-contract.js";
 import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
 import type { CronModelSuggestionsState, CronState } from "./controllers/cron.ts";
@@ -61,6 +66,14 @@ export type AppViewState = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAgentId: string | null;
+  meContextLoading: boolean;
+  meContextError: string | null;
+  currentUser: ControlUiMeContextResponse["user"] | null;
+  visibleScopes: ScopeRef[];
+  launchableSessionTypes: ControlUiMeContextResponse["launchableSessionTypes"];
+  shareTargets: ScopeRef[];
+  selectedScope: ScopeRef | null;
+  selectedPrivacyMode: PrivacyMode | null;
   sessionKey: string;
   chatLoading: boolean;
   chatSending: boolean;
@@ -349,6 +362,8 @@ export type AppViewState = {
     applySettings: (next: UiSettings) => void;
     loadOverview: () => Promise<void>;
     loadAssistantIdentity: () => Promise<void>;
+    loadMeContext: () => Promise<void>;
+    selectMeContextScope: (scopeId: string) => void;
     loadCron: () => Promise<void>;
     handleWhatsAppStart: (force: boolean) => Promise<void>;
     handleWhatsAppWait: () => Promise<void>;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -71,6 +71,7 @@ export type AppViewState = {
   currentUser: ControlUiMeContextResponse["user"] | null;
   visibleScopes: ScopeRef[];
   launchableSessionTypes: ControlUiMeContextResponse["launchableSessionTypes"];
+  currentSessionType: ControlUiMeContextResponse["currentSessionType"] | null;
   shareTargets: ScopeRef[];
   selectedScope: ScopeRef | null;
   selectedPrivacyMode: PrivacyMode | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -170,6 +170,7 @@ export class OpenClawApp extends LitElement {
   @state() currentUser: ControlUiMeContextResponse["user"] | null = null;
   @state() visibleScopes: ScopeRef[] = [];
   @state() launchableSessionTypes: ControlUiMeContextResponse["launchableSessionTypes"] = [];
+  @state() currentSessionType: ControlUiMeContextResponse["currentSessionType"] | null = null;
   @state() shareTargets: ScopeRef[] = [];
   @state() selectedScope: ScopeRef | null = null;
   @state() selectedPrivacyMode: PrivacyMode | null = null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1,5 +1,10 @@
 import { LitElement } from "lit";
 import { state } from "lit/decorators.js";
+import type {
+  ControlUiMeContextResponse,
+  PrivacyMode,
+  ScopeRef,
+} from "../../../src/gateway/control-ui-contract.js";
 import { i18n, I18nController, isSupportedLocale } from "../i18n/index.ts";
 import {
   handleChannelConfigReload as handleChannelConfigReloadInternal,
@@ -63,6 +68,10 @@ import type { DevicePairingList } from "./controllers/devices.ts";
 import type { DreamingStatus } from "./controllers/dreaming.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import {
+  loadMeContext as loadMeContextInternal,
+  selectMeContextScope as selectMeContextScopeInternal,
+} from "./controllers/me-context.ts";
 import type {
   ClawHubSearchResult,
   ClawHubSkillDetail,
@@ -156,6 +165,14 @@ export class OpenClawApp extends LitElement {
   @state() assistantAvatar = bootAssistantIdentity.avatar;
   @state() assistantAgentId = bootAssistantIdentity.agentId ?? null;
   @state() serverVersion: string | null = null;
+  @state() meContextLoading = false;
+  @state() meContextError: string | null = null;
+  @state() currentUser: ControlUiMeContextResponse["user"] | null = null;
+  @state() visibleScopes: ScopeRef[] = [];
+  @state() launchableSessionTypes: ControlUiMeContextResponse["launchableSessionTypes"] = [];
+  @state() shareTargets: ScopeRef[] = [];
+  @state() selectedScope: ScopeRef | null = null;
+  @state() selectedPrivacyMode: PrivacyMode | null = null;
 
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
@@ -599,6 +616,14 @@ export class OpenClawApp extends LitElement {
 
   async loadAssistantIdentity() {
     await loadAssistantIdentityInternal(this);
+  }
+
+  async loadMeContext() {
+    await loadMeContextInternal(this);
+  }
+
+  selectMeContextScope(scopeId: string) {
+    selectMeContextScopeInternal(this, scopeId);
   }
 
   applySettings(next: UiSettings) {

--- a/ui/src/ui/controllers/me-context.ts
+++ b/ui/src/ui/controllers/me-context.ts
@@ -15,6 +15,7 @@ export type MeContextState = {
   currentUser: ControlUiMeContextResponse["user"] | null;
   visibleScopes: ScopeRef[];
   launchableSessionTypes: ControlUiMeContextResponse["launchableSessionTypes"];
+  currentSessionType: ControlUiMeContextResponse["currentSessionType"] | null;
   shareTargets: ScopeRef[];
   selectedScope: ScopeRef | null;
   selectedPrivacyMode: PrivacyMode | null;
@@ -52,6 +53,7 @@ export async function loadMeContext(state: MeContextState): Promise<void> {
     state.launchableSessionTypes = Array.isArray(context.launchableSessionTypes)
       ? context.launchableSessionTypes
       : [];
+    state.currentSessionType = context.currentSessionType ?? null;
     state.shareTargets = Array.isArray(context.shareTargets) ? context.shareTargets : [];
     state.selectedScope = context.selectedScope ?? state.visibleScopes[0] ?? null;
     state.selectedPrivacyMode =
@@ -67,4 +69,26 @@ export function selectMeContextScope(state: MeContextState, scopeId: string): vo
   const nextScope = state.visibleScopes.find((scope) => scope.id === scopeId) ?? null;
   state.selectedScope = nextScope;
   state.selectedPrivacyMode = nextScope?.privacyMode ?? null;
+  state.currentSessionType = nextScope
+    ? nextScope.type === "global"
+      ? "global_chat"
+      : nextScope.type === "group"
+        ? "group_chat"
+        : "private_chat"
+    : null;
+
+  const sessionState = state as MeContextState & {
+    sessionKey?: string;
+    currentUser?: { id: string } | null;
+  };
+  if (!nextScope || !sessionState.currentUser) {
+    return;
+  }
+
+  const agentPrefix =
+    typeof sessionState.sessionKey === "string" && sessionState.sessionKey.startsWith("agent:")
+      ? sessionState.sessionKey.split(":").slice(0, 3).join(":")
+      : "agent:main:main";
+
+  sessionState.sessionKey = `${agentPrefix}:${nextScope.id}`;
 }

--- a/ui/src/ui/controllers/me-context.ts
+++ b/ui/src/ui/controllers/me-context.ts
@@ -1,0 +1,70 @@
+import {
+  CONTROL_UI_ME_CONTEXT_PATH,
+  type ControlUiMeContextResponse,
+  type PrivacyMode,
+  type ScopeRef,
+} from "../../../../src/gateway/control-ui-contract.js";
+import type { GatewayBrowserClient } from "../gateway.ts";
+
+export type MeContextState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  basePath?: string;
+  meContextLoading: boolean;
+  meContextError: string | null;
+  currentUser: ControlUiMeContextResponse["user"] | null;
+  visibleScopes: ScopeRef[];
+  launchableSessionTypes: ControlUiMeContextResponse["launchableSessionTypes"];
+  shareTargets: ScopeRef[];
+  selectedScope: ScopeRef | null;
+  selectedPrivacyMode: PrivacyMode | null;
+};
+
+function buildMeContextPath(basePath?: string): string {
+  if (!basePath) {
+    return CONTROL_UI_ME_CONTEXT_PATH;
+  }
+  return `${basePath}${CONTROL_UI_ME_CONTEXT_PATH}`;
+}
+
+export async function loadMeContext(state: MeContextState): Promise<void> {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  state.meContextLoading = true;
+  state.meContextError = null;
+  try {
+    const response = await state.client.request<ControlUiMeContextResponse>("http.fetch", {
+      path: buildMeContextPath(state.basePath),
+      method: "GET",
+    });
+    const payload =
+      response && typeof response === "object" && "body" in (response as Record<string, unknown>)
+        ? JSON.parse(
+            typeof (response as { body?: unknown }).body === "string"
+              ? (response as { body?: string }).body
+              : "{}",
+          )
+        : response;
+    const context = payload as ControlUiMeContextResponse;
+    state.currentUser = context.user;
+    state.visibleScopes = Array.isArray(context.visibleScopes) ? context.visibleScopes : [];
+    state.launchableSessionTypes = Array.isArray(context.launchableSessionTypes)
+      ? context.launchableSessionTypes
+      : [];
+    state.shareTargets = Array.isArray(context.shareTargets) ? context.shareTargets : [];
+    state.selectedScope = context.selectedScope ?? state.visibleScopes[0] ?? null;
+    state.selectedPrivacyMode =
+      context.selectedPrivacyMode ?? state.selectedScope?.privacyMode ?? null;
+  } catch (err) {
+    state.meContextError = String(err);
+  } finally {
+    state.meContextLoading = false;
+  }
+}
+
+export function selectMeContextScope(state: MeContextState, scopeId: string): void {
+  const nextScope = state.visibleScopes.find((scope) => scope.id === scopeId) ?? null;
+  state.selectedScope = nextScope;
+  state.selectedPrivacyMode = nextScope?.privacyMode ?? null;
+}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2,6 +2,11 @@ import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import type {
+  ControlUiMeContextResponse,
+  PrivacyMode,
+  ScopeRef,
+} from "../../../../src/gateway/control-ui-contract.js";
+import type {
   CompactionStatus as CompactionIndicatorStatus,
   FallbackStatus as FallbackIndicatorStatus,
 } from "../app-tool-stream.ts";
@@ -98,6 +103,15 @@ export type ChatProps = {
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
   basePath?: string;
+  meContextLoading?: boolean;
+  meContextError?: string | null;
+  currentUser?: ControlUiMeContextResponse["user"] | null;
+  visibleScopes?: ScopeRef[];
+  selectedScope?: ScopeRef | null;
+  selectedPrivacyMode?: PrivacyMode | null;
+  launchableSessionTypes?: ControlUiMeContextResponse["launchableSessionTypes"];
+  onLoadMeContext?: () => void;
+  onScopeChange?: (scopeId: string) => void;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
@@ -628,6 +642,67 @@ const WELCOME_SUGGESTIONS = [
   "Help me configure a channel",
   "Check system health",
 ];
+
+function renderPrivacyBadgeLabel(mode: PrivacyMode | null | undefined): string {
+  switch (mode) {
+    case "group_shared":
+      return "Group shared";
+    case "global_shared":
+      return "Global shared";
+    case "admin":
+      return "Admin";
+    default:
+      return "Private";
+  }
+}
+
+function renderContextBar(props: ChatProps): TemplateResult | typeof nothing {
+  if (props.meContextLoading) {
+    return html`<div class="chat-context-bar"><span class="pill">Loading context…</span></div>`;
+  }
+  if (props.meContextError) {
+    return html`<div class="chat-context-bar">
+      <span class="pill danger">${props.meContextError}</span>
+    </div>`;
+  }
+  const user = props.currentUser;
+  const selectedScope = props.selectedScope;
+  const visibleScopes = props.visibleScopes ?? [];
+  if (!user || !selectedScope) {
+    return nothing;
+  }
+  const launchable = props.launchableSessionTypes ?? [];
+  return html`
+    <div class="chat-context-bar">
+      <div class="chat-context-bar__summary">
+        <span class="pill">${user.displayName}</span>
+        <span class="pill">${user.roleLabel}</span>
+        <span class="pill">${selectedScope.label}</span>
+        <span class="pill"
+          >${renderPrivacyBadgeLabel(props.selectedPrivacyMode ?? selectedScope.privacyMode)}</span
+        >
+        ${launchable[0] ? html`<span class="pill">${launchable[0]}</span>` : nothing}
+      </div>
+      ${visibleScopes.length > 0 && props.onScopeChange
+        ? html`
+            <label class="chat-context-bar__scope-select">
+              <span>Scope</span>
+              <select
+                .value=${selectedScope.id}
+                @change=${(event: Event) => {
+                  props.onScopeChange?.((event.target as HTMLSelectElement).value);
+                }}
+              >
+                ${visibleScopes.map(
+                  (scope) => html`<option value=${scope.id}>${scope.label}</option>`,
+                )}
+              </select>
+            </label>
+          `
+        : nothing}
+    </div>
+  `;
+}
 
 function renderWelcomeState(props: ChatProps): TemplateResult {
   const name = props.assistantName || "Assistant";
@@ -1164,6 +1239,7 @@ export function renderChat(props: ChatProps) {
     >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
+      ${renderContextBar(props)}
       ${props.focusMode
         ? html`
             <button

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -110,6 +110,7 @@ export type ChatProps = {
   selectedScope?: ScopeRef | null;
   selectedPrivacyMode?: PrivacyMode | null;
   launchableSessionTypes?: ControlUiMeContextResponse["launchableSessionTypes"];
+  currentSessionType?: ControlUiMeContextResponse["currentSessionType"] | null;
   onLoadMeContext?: () => void;
   onScopeChange?: (scopeId: string) => void;
 };
@@ -681,7 +682,11 @@ function renderContextBar(props: ChatProps): TemplateResult | typeof nothing {
         <span class="pill"
           >${renderPrivacyBadgeLabel(props.selectedPrivacyMode ?? selectedScope.privacyMode)}</span
         >
-        ${launchable[0] ? html`<span class="pill">${launchable[0]}</span>` : nothing}
+        ${props.currentSessionType
+          ? html`<span class="pill">${props.currentSessionType}</span>`
+          : launchable[0]
+            ? html`<span class="pill">${launchable[0]}</span>`
+            : nothing}
       </div>
       ${visibleScopes.length > 0 && props.onScopeChange
         ? html`


### PR DESCRIPTION
```text
  This PR lands the first narrow Phase 2 foothold for the Control UI.

  It adds a dedicated `GET /api/me/context` endpoint, frontend me-context loading/state, and a visible chat context bar with a scope selector. The goal is to make user, scope, and privacy context explicit in the UI without spilling into
the larger Phase 2 resolver and launcher work.

  Included in PR1:
  - shared Control UI me-context contract/types
  - backend `GET /api/me/context`
  - backend me-context response helper
  - frontend me-context loader/controller
  - frontend app state for current user, visible scopes, privacy, and launchable session types
  - chat context bar
  - chat scope selector

  Intentionally not included:
  - full session resolver
  - launcher rewrite
  - promotion flow
  - audit trail
  - deep session metadata persistence
  - final role-aware session compatibility enforcement

  Notes:
  - me-context loading was moved out of chat render and into the gateway connect flow
  - the current resolver is still an intentional PR1 stub, not the final runtime identity/group wiring

  Validation:
  - branch: `feat/control-ui-me-context-pr1`
  - commit: `c126061f91`
  - `oxlint` on touched PR1 files: green
  - `oxfmt --check` on touched PR1 files: green
  - full `tsc` / `vitest` confirmation still needs a cleaner host/tooling path

  Recommended follow-up:
  1. wire real runtime identity/group resolution
  2. replace the placeholder session-type badge with actual current-mode/session-type state
  3. run full validation in a normal `pnpm` environment
```
