### PR TITLE
test: narrow followup runner config cast

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1145,7 +1145,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
                   },
                 },
               },
-            } as OpenClawConfig,
+            } as unknown as OpenClawConfig,
           },
         }),
       ),


### PR DESCRIPTION
## Summary
- replace the partial config cast in followup-runner.test with an explicit unknown-to-OpenClawConfig test cast
- keep the change scoped to the failing type-check lane

## Testing
- not run locally in full because this machine's git/xcrun toolchain is broken, but this PR targets the current CI TS2352 failure in check