### PR TITLE
test(followup): cast runtime config fixtures explicitly

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -395,7 +395,7 @@ function createAsyncReplySpy() {
 
 describe("createFollowupRunner runtime config", () => {
   it("uses the active runtime snapshot for queued embedded followup runs", async () => {
-    const sourceConfig: OpenClawConfig = {
+    const sourceConfig = {
       models: {
         providers: {
           openai: {
@@ -409,8 +409,8 @@ describe("createFollowupRunner runtime config", () => {
           },
         },
       },
-    };
-    const runtimeConfig: OpenClawConfig = {
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
       models: {
         providers: {
           openai: {
@@ -420,7 +420,7 @@ describe("createFollowupRunner runtime config", () => {
           },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [],
@@ -452,7 +452,7 @@ describe("createFollowupRunner runtime config", () => {
   });
 
   it("resolves queued embedded followups before preflight helpers read config", async () => {
-    const sourceConfig: OpenClawConfig = {
+    const sourceConfig = {
       skills: {
         entries: {
           whisper: {
@@ -464,8 +464,8 @@ describe("createFollowupRunner runtime config", () => {
           },
         },
       },
-    };
-    const runtimeConfig: OpenClawConfig = {
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
       skills: {
         entries: {
           whisper: {
@@ -473,7 +473,7 @@ describe("createFollowupRunner runtime config", () => {
           },
         },
       },
-    };
+    } as unknown as OpenClawConfig;
     resolveCommandSecretRefsViaGatewayMock.mockResolvedValueOnce({
       resolvedConfig: runtimeConfig,
       diagnostics: [],
@@ -1145,7 +1145,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
                   },
                 },
               },
-            } as OpenClawConfig,
+            } as unknown as OpenClawConfig,
           },
         }),
       ),


### PR DESCRIPTION
## Problem

Recent CI runs for otherwise unrelated PRs are failing in the shared  job with a TypeScript conversion error in . The failing fixture objects are intentionally partial runtime/source snapshots used only by these tests, but TS now flags the direct  assertion as an unsafe structural conversion.

## Fix

Cast the partial test fixtures through  before . This keeps the test focused on runtime snapshot behavior instead of deep config structural completeness.

## Validation

- 
 RUN  v4.1.2 /Users/plaud/workspace/openclaw-followup-config


 Test Files  1 passed (1)
      Tests  1 passed | 18 skipped (19)
   Start at  21:32:17
   Duration  606ms (transform 222ms, setup 94ms, import 4ms, tests 451ms, environment 0ms)
- 
 RUN  v4.1.2 /Users/plaud/workspace/openclaw-followup-config


 Test Files  1 passed (1)
      Tests  1 passed | 18 skipped (19)
   Start at  21:32:36
   Duration  541ms (transform 183ms, setup 85ms, import 4ms, tests 397ms, environment 0ms)
- 
 RUN  v4.1.2 /Users/plaud/workspace/openclaw-followup-config


 Test Files  1 passed (1)
      Tests  1 passed | 18 skipped (19)
   Start at  21:32:56
   Duration  544ms (transform 182ms, setup 84ms, import 5ms, tests 404ms, environment 0ms)
- Found 0 warnings and 0 errors.
Finished in 6ms on 1 file with 117 rules using 12 threads.