### PR TITLE
fix(telegram): archive orphaned reasoning bubbles in streaming mode

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -776,6 +776,18 @@ export const dispatchTelegramMessage = async ({
                 // stream starts. Splitting at reasoning-end can orphan the active
                 // preview and cause duplicate reasoning sends on reasoning final.
                 if (splitReasoningOnNextStream) {
+                  // Archive the current reasoning bubble's message ID before forceNewMessage()
+                  // discards it. Mirrors the pattern used in
+                  // rotateAnswerLaneForNewAssistantMessage for the answer lane.
+                  if (reasoningLane.hasStreamedMessage) {
+                    const prevReasoningMessageId = reasoningLane.stream?.messageId();
+                    if (
+                      typeof prevReasoningMessageId === "number" &&
+                      !archivedReasoningPreviewIds.includes(prevReasoningMessageId)
+                    ) {
+                      archivedReasoningPreviewIds.push(prevReasoningMessageId);
+                    }
+                  }
                   reasoningLane.stream?.forceNewMessage();
                   resetDraftLaneState(reasoningLane);
                   splitReasoningOnNextStream = false;


### PR DESCRIPTION
## Problem

When a reasoning response spans multiple draft bubbles (long reasoning with many steps), only the last two bubbles disappear after the message. All earlier reasoning bubbles persist as orphan messages in Telegram.

## Why it matters

Users see leftover "Reasoning:" text bubbles cluttering their Telegram chat after the assistant responds. These orphaned bubbles are confusing and degrade the user experience.

## What changed

In `extensions/telegram/src/bot-message-dispatch.ts`, `onReasoningStream` handler: before calling `forceNewMessage()` (which discards the current message ID), we now archive the message ID into `archivedReasoningPreviewIds` so it gets deleted in the finally block cleanup.

## Root cause

In `onReasoningStream`, when `splitReasoningOnNextStream` is true, `forceNewMessage()` is called to create a fresh bubble. However, this sets `streamMessageId = undefined` without archiving the previous bubble's ID so it never gets cleaned up.

The answer lane has the same pattern but guards against this in `rotateAnswerLaneForNewAssistantMessage` by archiving the message ID before calling `forceNewMessage()`. The reasoning lane was missing this guard.

## What did NOT change (scope boundary)

- No changes to the answer lane (it already handles this correctly)
- No changes to other channels
- No new tests added (the `onSupersededPreview` callback and existing test coverage are sufficient)

## Coverage level that should have caught this

Existing coverage already sufficient. `onSupersededPreview` archives reasoning IDs but only fires in a racing condition. The normal `forceNewMessage()` path had no guard.

## Backward compatible

Yes.

## Risk

Minimal — the fix only archives a message ID that would otherwise be discarded. Adds a null-check and deduplication guard before pushing to the existing cleanup array.