### PR TITLE
fix: preserve active memory capability across plugin loader state restores

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -33,8 +33,11 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   buildMemoryPromptSection,
+  clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryRuntime,
   listMemoryCorpusSupplements,
+  registerMemoryCapability,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
   registerMemoryPromptSupplement,
@@ -1506,6 +1509,14 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
   it("does not replace active memory plugin registries during non-activating loads", () => {
     useNoBundledPlugins();
+    registerMemoryCapability("active-memory", {
+      promptBuilder: () => ["active capability section"],
+      publicArtifacts: {
+        async listArtifacts() {
+          return [];
+        },
+      },
+    });
     registerMemoryEmbeddingProvider({
       id: "active",
       create: async () => ({ provider: null }),
@@ -1540,6 +1551,14 @@ module.exports = { id: "throws-after-import", register() {} };`,
         id: "snapshot-memory",
         kind: "memory",
         register(api) {
+          api.registerMemoryCapability({
+            promptBuilder: () => ["snapshot capability section"],
+            publicArtifacts: {
+              async listArtifacts() {
+                return [];
+              },
+            },
+          });
           api.registerMemoryEmbeddingProvider({
             id: "snapshot",
             create: async () => ({ provider: null }),
@@ -1581,13 +1600,68 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-memory")?.status).toBe("loaded");
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
-      "active memory section",
+      "active capability section",
       "active wiki supplement",
     ]);
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "active-memory",
+    });
     expect(listMemoryCorpusSupplements()).toHaveLength(1);
     expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/active.md");
     expect(getMemoryRuntime()).toBe(activeRuntime);
     expect(listMemoryEmbeddingProviders().map((adapter) => adapter.id)).toEqual(["active"]);
+  });
+
+  it("restores cached memory capability registrations when serving registry state from cache", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cached-memory",
+      filename: "cached-memory.cjs",
+      body: `module.exports = {
+        id: "cached-memory",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            promptBuilder: () => ["cached capability section"],
+            publicArtifacts: {
+              async listArtifacts() {
+                return [];
+              },
+            },
+          });
+        },
+      };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["cached-memory"],
+          slots: { memory: "cached-memory" },
+        },
+      },
+    } satisfies Parameters<typeof loadOpenClawPlugins>[0];
+
+    loadOpenClawPlugins(options);
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "cached-memory",
+    });
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
+      "cached capability section",
+    ]);
+
+    clearMemoryPluginState();
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
+
+    loadOpenClawPlugins(options);
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "cached-memory",
+    });
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
+      "cached capability section",
+    ]);
   });
 
   it("clears newly-registered memory plugin registries when plugin register fails", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1699,6 +1699,9 @@ module.exports = { id: "throws-after-import", register() {} };`,
               return { backend: "builtin" };
             },
           });
+          api.registerMemoryCapability({
+            promptBuilder: () => ["stale failure capability section"],
+          });
           throw new Error("memory register failed");
         },
       };`,
@@ -1718,6 +1721,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     });
 
     expect(registry.plugins.find((entry) => entry.id === "failing-memory")?.status).toBe("error");
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([]);
     expect(listMemoryCorpusSupplements()).toEqual([]);
     expect(resolveMemoryFlushPlan({})).toBeNull();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -42,6 +42,7 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
@@ -148,6 +149,7 @@ export class PluginLoadReentryError extends Error {
 
 type CachedPluginState = {
   registry: PluginRegistry;
+  memoryCapability: ReturnType<typeof getMemoryCapabilityRegistration>;
   memoryCorpusSupplements: ReturnType<typeof listMemoryCorpusSupplements>;
   compactionProviders: ReturnType<typeof listRegisteredCompactionProviders>;
   memoryEmbeddingProviders: ReturnType<typeof listRegisteredMemoryEmbeddingProviders>;
@@ -1109,6 +1111,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       restoreRegisteredCompactionProviders(cached.compactionProviders);
       restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
       restoreMemoryPluginState({
+        capability: cached.memoryCapability,
         corpusSupplements: cached.memoryCorpusSupplements,
         promptBuilder: cached.memoryPromptBuilder,
         promptSupplements: cached.memoryPromptSupplements,
@@ -1714,6 +1717,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
       const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
       const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
+      const previousMemoryCapability = getMemoryCapabilityRegistration();
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
       const previousMemoryRuntime = getMemoryRuntime();
@@ -1733,6 +1737,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           restoreRegisteredCompactionProviders(previousCompactionProviders);
           restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
           restoreMemoryPluginState({
+            capability: previousMemoryCapability,
             corpusSupplements: previousMemoryCorpusSupplements,
             promptBuilder: previousMemoryPromptBuilder,
             promptSupplements: previousMemoryPromptSupplements,
@@ -1746,6 +1751,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         restoreRegisteredCompactionProviders(previousCompactionProviders);
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
         restoreMemoryPluginState({
+          capability: previousMemoryCapability,
           corpusSupplements: previousMemoryCorpusSupplements,
           promptBuilder: previousMemoryPromptBuilder,
           promptSupplements: previousMemoryPromptSupplements,
@@ -1800,6 +1806,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     if (cacheEnabled) {
       setCachedPluginRegistry(cacheKey, {
+        memoryCapability: getMemoryCapabilityRegistration(),
         memoryCorpusSupplements: listMemoryCorpusSupplements(),
         registry,
         compactionProviders: listRegisteredCompactionProviders(),


### PR DESCRIPTION
## Summary

Fix `memory-wiki` bridge imports staying empty when the plugin loader restores memory-related state without restoring the active memory capability registration.

## Root cause

`memory-wiki` bridge reads public artifacts from the active memory capability registration in `memoryPluginState.capability`.

The plugin loader was already snapshotting and restoring other memory-related state, but it did not preserve the active memory capability in two places:

1. cached plugin registry snapshot / restore
2. temporary memory-state preservation around plugin registration during non-activating loads and register failures

That could leave bridge-visible public artifacts unavailable even when `memory-core` was active and exporting them correctly.

## Changes

- cache and restore `memoryCapability` in `src/plugins/loader.ts`
- preserve and restore the active memory capability around plugin registration
- add loader tests covering both non-activating loads and cached registry restores

## Validation

Local runtime validation before the source patch reproduced:

- `openclaw wiki status --json` → `bridgePublicArtifactCount: 0`
- `openclaw wiki bridge import --json` → `artifactCount: 0`, `workspaces: 0`

After applying the fix locally:

- `openclaw wiki status --json` → `bridgePublicArtifactCount: 145`
- `openclaw wiki bridge import --json` discovered real bridge source pages/artifacts

Source validation:

- targeted loader tests passed locally
- `codex review --base origin/main` did not identify a discrete regression introduced by this patch

## AI assistance

- AI-assisted: yes
- Testing: targeted local loader tests passed
- Additional validation: local runtime reproduction and validation of `openclaw wiki status --json` / `openclaw wiki bridge import --json`
- Full repo test suite: not run in this environment

## Linked issues

Fixes #63092
Related to #63197