### PR TITLE
fix(webchat): preserve image attachments for text-only models

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,113 @@
+## Summary
+
+- **Problem:** When the primary model (e.g. GLM-4.7) does not support image input, image attachments from webchat/Control UI are silently dropped. Users receive no feedback and cannot analyze images even when `agents.defaults.imageModel` is configured with a vision-capable model.
+- **Why it matters:** This makes webchat appear broken for image uploads on any non-vision primary model, regardless of imageModel configuration.
+- **What changed:** Instead of discarding attachments when `supportsImages=false`, `parseMessageWithAttachments` now saves images to the media store and injects `media://inbound/...` references into the message text. This allows the `image` tool (which uses `imageModel`) to analyze them via the standard media:// resolution path.
+- **What did NOT change:** The behavior for vision-capable primary models is unchanged. The `supportsImages` gate itself is unchanged. No changes to `detectAndLoadPromptImages` or the agent runner.
+
+## Change Type
+
+- [x] Bug fix
+
+## Scope
+
+- [x] Gateway / orchestration
+
+## Linked Issue
+
+- Closes #60644
+- Related #61103
+- [x] This PR fixes a bug
+
+## Root Cause
+
+- **Root cause:** `parseMessageWithAttachments` in `chat-attachments.ts` treats `supportsImages=false` as a signal to silently discard all image data. The design assumes that if the primary model can't see images, there's no value in preserving them.
+- **Missing detection / guardrail:** No consideration for the case where `agents.defaults.imageModel` provides a separate vision-capable model. The image tool can process media:// references regardless of the primary model's capabilities.
+- **Contributing context:** The original code comment explicitly warns against leaking `media://` markers to text-only models, but these markers are opaque strings that don't cause issues — they're resolved by the image tool, not the primary model.
+
+## Regression Test Plan
+
+- [x] Unit test
+- Target test: `src/gateway/chat-attachments.test.ts` — new `describe("parseMessageWithAttachments with supportsImages=false")` block
+- Scenario: When `supportsImages=false`, images should be saved to disk with `media://` refs injected into message text, not dropped. Non-images should be skipped. Empty attachments should return empty.
+- Why this is the smallest reliable guardrail: The test directly exercises the changed code path (`supportsImages=false` branch) and verifies the contract (media refs injected, images array empty, offloadedRefs populated).
+
+## User-visible / Behavior Changes
+
+- Users on text-only primary models (e.g. GLM-4.7) with a vision-capable imageModel configured can now successfully upload and analyze images in webchat/Control UI.
+- Previously: images were silently dropped with a log warning `attachment(s) dropped — model does not support images`.
+- Now: images are saved and a `media://` reference appears in the message, allowing the `image` tool to process them.
+
+## Diagram
+
+```text
+Before:
+[webchat image] → [chat.send] → supportsImages=false → DROP all attachments → user sees nothing
+
+After:
+[webchat image] → [chat.send] → supportsImages=false → save to disk → inject media:// ref in message
+  → [agent receives message with media:// ref] → [image tool reads file via media://] → [imageModel analyzes] → response
+```
+
+## Security Impact
+
+- New permissions/capabilities? No
+- Secrets/tokens handling changed? No
+- New/changed network calls? No
+- Command/tool execution surface changed? No
+- Data access scope changed? No — images are saved to the same `media/inbound` directory that was already used for large image offloading.
+
+## Repro + Verification
+
+### Environment
+
+- OS: macOS (ARM)
+- Runtime: Node.js 25.8.1
+- Model/provider: zai/glm-4.7 (primary, text-only), zai/glm-4.6v (imageModel)
+- Integration/channel: webchat / Control UI
+
+### Steps
+
+1. Configure a text-only primary model (e.g. glm-4.7) and a vision imageModel (e.g. glm-4.6v)
+2. Open OpenClaw Control UI (webchat)
+3. Take a screenshot and paste into the chat input
+4. Send the message with "analyze this image"
+
+### Expected
+
+The agent receives the message with a `[media attached: media://inbound/<id>]` reference and can use the image tool to analyze it.
+
+### Actual (before fix)
+
+Gateway log shows: `parseMessageWithAttachments: 1 attachment(s) dropped — model does not support images`. The agent receives the text message only, with no indication an image was attached.
+
+## Evidence
+
+- [x] Failing test/log before + passing after
+  - Before: `attachment(s) dropped — model does not support images` in gateway.err.log
+  - After: `attachment(s) saved for text-only model` in gateway.log, agent successfully analyzes image
+
+## Human Verification
+
+- Verified scenarios:
+  - Pasted screenshot in webchat → agent received media:// ref → image tool analyzed successfully
+  - Multiple consecutive image uploads → all processed correctly
+  - Non-image attachment → correctly skipped
+- Edge cases checked: empty message with image, large image (>100KB)
+- What I did **not** verify: ACP bridge clients (the `persistChatSendImages` function returns early for ACP clients, which is existing behavior)
+
+## Review Conversations
+
+- [x] I replied to or resolved every bot review conversation I addressed in this PR.
+- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.
+
+## Compatibility / Migration
+
+- Backward compatible? Yes
+- Config/env changes? No
+- Migration needed? No
+
+## Risks and Mitigations
+
+- Risk: Additional disk I/O for text-only models — images are now saved even when the primary model can't use them.
+  - Mitigation: This matches the existing behavior for large images (>2MB offload threshold). The media store has existing cleanup mechanisms. For models that support images, the code path is unchanged.

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -178,3 +178,75 @@ describe("shared attachment validation", () => {
     }
   });
 });
+
+describe("parseMessageWithAttachments with supportsImages=false", () => {
+  it("saves attachments to disk and injects media:// refs instead of dropping them", async () => {
+    const logs: string[] = [];
+    const parsed = await parseMessageWithAttachments(
+      "analyze this",
+      [
+        {
+          type: "image",
+          mimeType: "image/png",
+          fileName: "dot.png",
+          content: PNG_1x1,
+        },
+      ],
+      {
+        supportsImages: false,
+        log: {
+          warn: (msg: string) => logs.push(msg),
+          info: (msg: string) => logs.push(msg),
+        },
+      },
+    );
+    // Should NOT drop silently — should save and inject media:// ref
+    expect(parsed.message).not.toBe("analyze this");
+    expect(parsed.message).toMatch(/media:\/\/inbound\//);
+    expect(parsed.message).toContain("[media attached:");
+    // No inline images since the model can't process them
+    expect(parsed.images).toHaveLength(0);
+    // Offloaded refs should be populated
+    expect(parsed.offloadedRefs.length).toBeGreaterThanOrEqual(1);
+    expect(parsed.offloadedRefs[0]?.mediaRef).toMatch(/media:\/\/inbound\//);
+    expect(parsed.imageOrder).toContain("offloaded");
+    // Should log info, not the old "dropped" warning
+    expect(logs.some((l) => /saved for text-only model/.test(l))).toBe(true);
+    expect(logs.some((l) => /dropped/.test(l))).toBe(false);
+  });
+
+  it("returns empty result when no attachments", async () => {
+    const parsed = await parseMessageWithAttachments("hello", [], {
+      supportsImages: false,
+    });
+    expect(parsed.message).toBe("hello");
+    expect(parsed.images).toHaveLength(0);
+    expect(parsed.offloadedRefs).toHaveLength(0);
+  });
+
+  it("skips non-image attachments when model does not support images", async () => {
+    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
+    const logs: string[] = [];
+    const parsed = await parseMessageWithAttachments(
+      "x",
+      [
+        {
+          type: "file",
+          mimeType: "application/pdf",
+          fileName: "doc.pdf",
+          content: pdf,
+        },
+      ],
+      {
+        supportsImages: false,
+        log: {
+          warn: (msg: string) => logs.push(msg),
+          info: (msg: string) => logs.push(msg),
+        },
+      },
+    );
+    // Non-image should be skipped, no media:// injected
+    expect(parsed.offloadedRefs).toHaveLength(0);
+    expect(parsed.message).not.toMatch(/media:\/\//);
+  });
+});

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -342,6 +342,11 @@ export async function parseMessageWithAttachments(
           log?.warn?.(`attachment ${label}: detected non-image (${sniffedMime}), skipping`);
           continue;
         }
+        // When sniffing fails, check provided mime — skip declared non-images
+        if (!sniffedMime && finalMime && !isImageMime(finalMime)) {
+          log?.warn?.(`attachment ${label}: non-image mime (${finalMime}), skipping`);
+          continue;
+        }
         try {
           const buffer = Buffer.from(b64, "base64");
           const labelWithExt = ensureExtension(label, finalMime);
@@ -368,12 +373,9 @@ export async function parseMessageWithAttachments(
           log?.warn?.(
             `attachment ${label}: failed to save for text-only offload: ${formatErrorMessage(err)}`,
           );
-          // Best-effort cleanup + reset state so we don't return refs to deleted files
+          // Best-effort cleanup, then throw — callers handle MediaOffloadError
           await Promise.allSettled(savedMediaIds.map((id) => deleteMediaBuffer(id, "inbound")));
-          offloadedRefs.length = 0;
-          imageOrder.length = 0;
-          updatedMessage = message;
-          break;
+          throw err;
         }
       }
     } catch (err) {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -58,9 +58,9 @@ export type ParsedMessageWithImages = {
    * It is intentionally separate from `images` because downstream model calls
    * do not receive these as inline image blocks.
    *
-   * ⚠️  Call sites (chat.ts, agent.ts, server-node-events.ts) MUST also pass
-   * `supportsImages: modelSupportsImages(model)` so that text-only model runs
-   * do not inject unresolvable media:// markers into prompt text.
+   * ⚠️  When `supportsImages: false` is passed, images are saved to the media
+   * store and `media://inbound/...` markers are injected into prompt text so
+   * that the `image` tool (backed by `imageModel`) can resolve and analyze them.
    */
   offloadedRefs: OffloadedRef[];
 };
@@ -271,12 +271,12 @@ function validateAttachmentBase64OrThrow(
  * because they are not passed inline to the model.
  *
  * ## Text-only model runs
- * Pass `supportsImages: false` for text-only model runs so that no media://
- * markers are injected into prompt text.
+ * Pass `supportsImages: false` for text-only model runs. Images are saved to
+ * the media store and `media://inbound/...` markers are injected into prompt
+ * text, allowing the `image` tool (using `imageModel`) to analyze them.
  *
  * ⚠️  Call sites in chat.ts, agent.ts, and server-node-events.ts MUST be
- * updated to pass `supportsImages: modelSupportsImages(model)`. Until they do,
- * text-only model runs receive unresolvable media:// markers in their prompt.
+ * updated to pass `supportsImages: modelSupportsImages(model)`.
  *
  * ## Cleanup on failure
  * On any parse failure after files have already been offloaded, best-effort
@@ -309,9 +309,6 @@ export async function parseMessageWithAttachments(
   // imageModel) can still access them. Do not return inline images since the
   // primary model cannot process them directly.
   if (opts?.supportsImages === false) {
-    if (attachments.length === 0) {
-      return { message, images: [], imageOrder: [], offloadedRefs: [] };
-    }
     const offloadedRefs: OffloadedRef[] = [];
     const imageOrder: PromptImageOrderEntry[] = [];
     let updatedMessage = message;
@@ -371,8 +368,11 @@ export async function parseMessageWithAttachments(
           log?.warn?.(
             `attachment ${label}: failed to save for text-only offload: ${formatErrorMessage(err)}`,
           );
-          // Best-effort cleanup
+          // Best-effort cleanup + reset state so we don't return refs to deleted files
           await Promise.allSettled(savedMediaIds.map((id) => deleteMediaBuffer(id, "inbound")));
+          offloadedRefs.length = 0;
+          imageOrder.length = 0;
+          updatedMessage = message;
           break;
         }
       }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -304,16 +304,92 @@ export async function parseMessageWithAttachments(
     return { message, images: [], imageOrder: [], offloadedRefs: [] };
   }
 
-  // For text-only models drop all attachments cleanly. Do not save files or
-  // inject media:// markers that would never be resolved and would leak
-  // internal path references into the model's prompt.
+  // For text-only models, save attachments to disk and inject media:// markers
+  // into the message text so that downstream tool calls (e.g. image tool using
+  // imageModel) can still access them. Do not return inline images since the
+  // primary model cannot process them directly.
   if (opts?.supportsImages === false) {
-    if (attachments.length > 0) {
-      log?.warn(
-        `parseMessageWithAttachments: ${attachments.length} attachment(s) dropped — model does not support images`,
+    if (attachments.length === 0) {
+      return { message, images: [], imageOrder: [], offloadedRefs: [] };
+    }
+    const offloadedRefs: OffloadedRef[] = [];
+    const imageOrder: PromptImageOrderEntry[] = [];
+    let updatedMessage = message;
+    const savedMediaIds: string[] = [];
+    try {
+      for (const [idx, att] of attachments.entries()) {
+        const normalized = normalizeAttachment(att, idx, {
+          stripDataUrlPrefix: true,
+          requireImageMime: false,
+        });
+        const { base64: b64, label, mime } = normalized;
+        if (!isValidBase64(b64)) {
+          log?.warn?.(`attachment ${label}: invalid base64 content, skipping`);
+          continue;
+        }
+        const sizeBytes = estimateBase64DecodedBytes(b64);
+        if (sizeBytes <= 0) {
+          log?.warn?.(`attachment ${label}: estimated size is zero, skipping`);
+          continue;
+        }
+        if (sizeBytes > maxBytes) {
+          log?.warn?.(
+            `attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes), skipping`,
+          );
+          continue;
+        }
+        const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
+        const providedMime = normalizeMime(mime);
+        const finalMime = sniffedMime ?? providedMime ?? normalizeMime(mime) ?? mime;
+        if (sniffedMime && !isImageMime(sniffedMime)) {
+          log?.warn?.(`attachment ${label}: detected non-image (${sniffedMime}), skipping`);
+          continue;
+        }
+        try {
+          const buffer = Buffer.from(b64, "base64");
+          const labelWithExt = ensureExtension(label, finalMime);
+          const rawResult = await saveMediaBuffer(
+            buffer,
+            finalMime,
+            "inbound",
+            maxBytes,
+            labelWithExt,
+          );
+          const savedMedia = assertSavedMedia(rawResult, label);
+          savedMediaIds.push(savedMedia.id);
+          const mediaRef = `media://inbound/${savedMedia.id}`;
+          updatedMessage += `\n[media attached: ${mediaRef}]`;
+          offloadedRefs.push({
+            mediaRef,
+            id: savedMedia.id,
+            path: savedMedia.path ?? "",
+            mimeType: finalMime,
+            label,
+          });
+          imageOrder.push("offloaded");
+        } catch (err) {
+          log?.warn?.(
+            `attachment ${label}: failed to save for text-only offload: ${formatErrorMessage(err)}`,
+          );
+          // Best-effort cleanup
+          await Promise.allSettled(savedMediaIds.map((id) => deleteMediaBuffer(id, "inbound")));
+          break;
+        }
+      }
+    } catch (err) {
+      log?.warn?.(
+        `parseMessageWithAttachments: unexpected error during text-only offload: ${formatErrorMessage(err)}`,
       );
     }
-    return { message, images: [], imageOrder: [], offloadedRefs: [] };
+    log?.info?.(
+      `parseMessageWithAttachments: ${offloadedRefs.length} attachment(s) saved for text-only model (media:// refs injected)`,
+    );
+    return {
+      message: updatedMessage !== message ? updatedMessage.trimEnd() : message,
+      images: [],
+      imageOrder,
+      offloadedRefs,
+    };
   }
 
   const images: ChatImageContent[] = [];


### PR DESCRIPTION
## Summary

- **Problem:** When the primary model (e.g. GLM-4.7) does not support image input, image attachments from webchat/Control UI are silently dropped. Users receive no feedback and cannot analyze images even when `agents.defaults.imageModel` is configured with a vision-capable model.
- **Why it matters:** This makes webchat appear broken for image uploads on any non-vision primary model, regardless of imageModel configuration.
- **What changed:** Instead of discarding attachments when `supportsImages=false`, `parseMessageWithAttachments` now saves images to the media store and injects `media://inbound/...` references into the message text. This allows the `image` tool (which uses `imageModel`) to analyze them via the standard media:// resolution path.
- **What did NOT change:** The behavior for vision-capable primary models is unchanged. The `supportsImages` gate itself is unchanged. No changes to `detectAndLoadPromptImages` or the agent runner.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration

## Linked Issue
- Closes #60644
- Related #61103
- [x] This PR fixes a bug

## Root Cause

- **Root cause:** `parseMessageWithAttachments` in `chat-attachments.ts` treats `supportsImages=false` as a signal to silently discard all image data. The design assumes that if the primary model can't see images, there's no value in preserving them.
- **Missing detection / guardrail:** No consideration for the case where `agents.defaults.imageModel` provides a separate vision-capable model. The image tool can process media:// references regardless of the primary model's capabilities.
- **Contributing context:** The original code comment explicitly warns against leaking `media://` markers to text-only models, but these markers are opaque strings that don't cause issues — they're resolved by the image tool, not the primary model.

## Regression Test Plan
- [x] Unit test
- Target test: `src/gateway/chat-attachments.test.ts` — new `describe("parseMessageWithAttachments with supportsImages=false")` block
- Scenario: When `supportsImages=false`, images should be saved to disk with `media://` refs injected into message text, not dropped. Non-images should be skipped. Empty attachments should return empty.
- Why this is the smallest reliable guardrail: The test directly exercises the changed code path (`supportsImages=false` branch) and verifies the contract (media refs injected, images array empty, offloadedRefs populated).

## User-visible / Behavior Changes
- Users on text-only primary models (e.g. GLM-4.7) with a vision-capable imageModel configured can now successfully upload and analyze images in webchat/Control UI.
- Previously: images were silently dropped with a log warning `attachment(s) dropped — model does not support images`.
- Now: images are saved and a `media://` reference appears in the message, allowing the `image` tool to process them.

## Diagram

```text
Before:
[webchat image] → [chat.send] → supportsImages=false → DROP all attachments → user sees nothing

After:
[webchat image] → [chat.send] → supportsImages=false → save to disk → inject media:// ref in message
  → [agent receives message with media:// ref] → [image tool reads file via media://] → [imageModel analyzes] → response
```

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — images are saved to the same `media/inbound` directory that was already used for large image offloading.

## Repro + Verification

### Environment
- OS: macOS (ARM)
- Runtime: Node.js 25.8.1
- Model/provider: zai/glm-4.7 (primary, text-only), zai/glm-4.6v (imageModel)
- Integration/channel: webchat / Control UI

### Steps
1. Configure a text-only primary model (e.g. glm-4.7) and a vision imageModel (e.g. glm-4.6v)
2. Open OpenClaw Control UI (webchat)
3. Take a screenshot and paste into the chat input
4. Send the message with "analyze this image"

### Expected
The agent receives the message with a `[media attached: media://inbound/<id>]` reference and can use the image tool to analyze it.

### Actual (before fix)
Gateway log shows: `parseMessageWithAttachments: 1 attachment(s) dropped — model does not support images`. The agent receives the text message only, with no indication an image was attached.

## Evidence
- [x] Failing test/log before + passing after
  - Before: `attachment(s) dropped — model does not support images` in gateway.err.log
  - After: `attachment(s) saved for text-only model` in gateway.log, agent successfully analyzes image

## Human Verification
- Verified scenarios:
  - Pasted screenshot in webchat → agent received media:// ref → image tool analyzed successfully
  - Multiple consecutive image uploads → all processed correctly
  - Non-image attachment → correctly skipped
- Edge cases checked: empty message with image, large image (>100KB)
- What I did **not** verify: ACP bridge clients (the `persistChatSendImages` function returns early for ACP clients, which is existing behavior)

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Additional disk I/O for text-only models — images are now saved even when the primary model can't use them.
  - Mitigation: This matches the existing behavior for large images (>2MB offload threshold). The media store has existing cleanup mechanisms. For models that support images, the code path is unchanged.
