### PR TITLE
fix: allow non-memory writes during memory flush compaction

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -525,15 +525,24 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         containerWorkdir: options.containerWorkdir,
       });
 
-      if (resolvedPath === allowedAbsolutePath) {
+      // Normalize for case-insensitive filesystems (macOS HFS+/APFS, Windows NTFS).
+      const ciFs = process.platform === "darwin" || process.platform === "win32";
+      const normPath = (p: string): string => {
+        const n = path.normalize(p);
+        return ciFs ? n.toLowerCase() : n;
+      };
+      const normResolved = normPath(resolvedPath);
+
+      if (normResolved === normPath(allowedAbsolutePath)) {
         // Exact match — fall through to append logic below.
       } else {
         // Block writes to other files inside the memory directory (e.g. a different date's
         // memory file). Writes to unrelated workspace files are passed through to the
         // underlying tool so normal edits are not blocked during a flush run.
+        const normMemDir = normPath(memoryDirAbsolutePath);
         const isInMemoryDir =
-          resolvedPath === memoryDirAbsolutePath ||
-          resolvedPath.startsWith(memoryDirAbsolutePath + path.sep);
+          normResolved === normMemDir ||
+          normResolved.startsWith(normMemDir + path.sep);
         if (isInMemoryDir) {
           throw new Error(
             `Memory flush writes are restricted to ${options.relativePath}; use that path only.`,

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -503,6 +503,9 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
   options: MemoryFlushAppendOnlyWriteOptions,
 ): AnyAgentTool {
   const allowedAbsolutePath = path.resolve(options.root, options.relativePath);
+  // The directory that owns memory flush files (e.g. <root>/memory/).
+  // Writes to other files inside this dir are blocked; writes outside it pass through.
+  const memoryDirAbsolutePath = path.dirname(allowedAbsolutePath);
   return {
     ...tool,
     description: `${tool.description} During memory flush, this tool may only append to ${options.relativePath}.`,
@@ -521,10 +524,22 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         root: options.root,
         containerWorkdir: options.containerWorkdir,
       });
-      if (resolvedPath !== allowedAbsolutePath) {
-        throw new Error(
-          `Memory flush writes are restricted to ${options.relativePath}; use that path only.`,
-        );
+
+      if (resolvedPath === allowedAbsolutePath) {
+        // Exact match — fall through to append logic below.
+      } else {
+        // Block writes to other files inside the memory directory (e.g. a different date's
+        // memory file). Writes to unrelated workspace files are passed through to the
+        // underlying tool so normal edits are not blocked during a flush run.
+        const isInMemoryDir =
+          resolvedPath === memoryDirAbsolutePath ||
+          resolvedPath.startsWith(memoryDirAbsolutePath + path.sep);
+        if (isInMemoryDir) {
+          throw new Error(
+            `Memory flush writes are restricted to ${options.relativePath}; use that path only.`,
+          );
+        }
+        return tool.execute(toolCallId, args, signal, onUpdate);
       }
 
       await appendMemoryFlushContent({

--- a/src/agents/pi-tools.workspace-only-false.test.ts
+++ b/src/agents/pi-tools.workspace-only-false.test.ts
@@ -220,12 +220,21 @@ describe("FS tools with workspaceOnly=false", () => {
     expect(writeTool).toBeDefined();
     expect(tools.map((tool) => tool.name).toSorted()).toEqual(["read", "write"]);
 
+    // A different date's memory file (same directory) must be blocked.
     await expect(
       writeTool!.execute("test-call-memory-deny", {
-        path: outsideFile,
+        path: "memory/2026-03-08.md",
         content: "should not write here",
       }),
     ).rejects.toThrow(/Memory flush writes are restricted to memory\/2026-03-07\.md/);
+
+    // A non-memory workspace file must pass through to the underlying tool (not blocked).
+    const nonMemoryFile = path.join(workspaceDir, "template.html");
+    await writeTool!.execute("test-call-non-memory-passthrough", {
+      path: nonMemoryFile,
+      content: "<html></html>",
+    });
+    await expect(fs.readFile(nonMemoryFile, "utf-8")).resolves.toBe("<html></html>");
 
     const result = await writeTool!.execute("test-call-memory-append", {
       path: allowedRelativePath,


### PR DESCRIPTION
## Summary

During a memory flush run, `wrapToolMemoryFlushAppendOnlyWrite` was blocking ALL writes that weren't to the exact flush target file. This prevented users from editing unrelated workspace files (template.html, scripts, etc.) while compaction was running.

- Restrict the guard to files within the memory directory only (e.g. other dated memory files)
- Writes to any file outside that directory are now delegated to the underlying write tool, which already enforces its own workspace / sandbox guards
- Update the workspace-only-false test to use a same-directory memory file as the "deny" case, and add a pass-through assertion for a non-memory workspace file

Closes #63664

---
> This PR was developed with AI assistance (Claude). All code has been reviewed and tested.
> Built with [islo.dev](https://islo.dev)