### PR TITLE
fix: repair missing bin symlink after npm global update

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -149,6 +149,7 @@ export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
   return (
     lower.includes("request_too_large") ||
     lower.includes("context window exceeded") ||
+    lower.includes("context_window_exceeded") ||
     lower.includes("prompt is too long")
   );
 });
@@ -275,6 +276,7 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
     return (
       lower.includes("request_too_large") ||
       lower.includes("context window exceeded") ||
+      lower.includes("context_window_exceeded") ||
       lower.includes("prompt is too long")
     );
   });

--- a/src/infra/package-json.ts
+++ b/src/infra/package-json.ts
@@ -22,3 +22,17 @@ export async function readPackageName(root: string): Promise<string | null> {
     return null;
   }
 }
+
+export async function readPackageBin(root: string): Promise<Record<string, string> | null> {
+  try {
+    const raw = await fs.readFile(path.join(root, "package.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { bin?: unknown };
+    const bin = parsed?.bin;
+    if (!bin || typeof bin !== "object" || Array.isArray(bin)) {
+      return null;
+    }
+    return bin as Record<string, string>;
+  } catch {
+    return null;
+  }
+}

--- a/src/infra/package-json.ts
+++ b/src/infra/package-json.ts
@@ -26,9 +26,18 @@ export async function readPackageName(root: string): Promise<string | null> {
 export async function readPackageBin(root: string): Promise<Record<string, string> | null> {
   try {
     const raw = await fs.readFile(path.join(root, "package.json"), "utf-8");
-    const parsed = JSON.parse(raw) as { bin?: unknown };
+    const parsed = JSON.parse(raw) as { name?: string; bin?: unknown };
     const bin = parsed?.bin;
-    if (!bin || typeof bin !== "object" || Array.isArray(bin)) {
+    if (!bin) {
+      return null;
+    }
+    // npm allows bin to be a string shorthand for { "<name>": "<path>" }
+    if (typeof bin === "string") {
+      const name = parsed?.name?.trim();
+      if (!name) return null;
+      return { [name]: bin };
+    }
+    if (typeof bin !== "object" || Array.isArray(bin)) {
       return null;
     }
     return bin as Record<string, string>;

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -16,6 +16,7 @@ import {
   isExplicitPackageInstallSpec,
   isMainPackageTarget,
   OPENCLAW_MAIN_PACKAGE_SPEC,
+  repairGlobalBinLinks,
   resolveGlobalInstallCommand,
   resolveGlobalPackageRoot,
   resolveGlobalInstallTarget,
@@ -348,6 +349,92 @@ describe("update global helpers", () => {
       await expect(fs.stat(path.join(root, "openclaw"))).resolves.toBeDefined();
       await expect(fs.stat(path.join(root, ".openclaw-file"))).resolves.toBeDefined();
     });
+  });
+
+  it("cleans stale temp bin entries and recreates missing bin symlink", async () => {
+    if (process.platform === "win32") {
+      return; // Windows bin repair skipped (requires .cmd wrappers)
+    }
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    try {
+      await withTempDir({ prefix: "openclaw-update-bin-repair-" }, async (base) => {
+        // Simulate standard Unix npm layout: <prefix>/lib/node_modules/<pkg>
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        const binDir = path.join(prefix, "bin");
+        await fs.mkdir(packageRoot, { recursive: true });
+        await fs.mkdir(binDir, { recursive: true });
+
+        // Create the binary target file
+        const binTarget = path.join(packageRoot, "openclaw.mjs");
+        await fs.writeFile(binTarget, "#!/usr/bin/env node\n", "utf8");
+
+        // Simulate npm reify leaving a stale temp bin entry and no primary link
+        await fs.writeFile(path.join(binDir, ".openclaw-OKPnnPWD"), "", "utf8");
+
+        const result = await repairGlobalBinLinks({
+          globalRoot,
+          packageRoot,
+          packageName: "openclaw",
+          binEntries: { openclaw: "openclaw.mjs" },
+        });
+
+        expect(result.cleaned).toEqual([".openclaw-OKPnnPWD"]);
+        expect(result.repaired).toEqual(["openclaw"]);
+
+        // Stale temp entry should be gone
+        await expect(fs.stat(path.join(binDir, ".openclaw-OKPnnPWD"))).rejects.toThrow();
+
+        // Primary bin link should exist and point to the right target
+        const linkTarget = await fs.readlink(path.join(binDir, "openclaw"));
+        expect(linkTarget).toBe(path.relative(binDir, binTarget));
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("leaves valid bin links untouched and skips directory entries in bin dir", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    try {
+      await withTempDir({ prefix: "openclaw-update-bin-noop-" }, async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        const binDir = path.join(prefix, "bin");
+        await fs.mkdir(packageRoot, { recursive: true });
+        await fs.mkdir(binDir, { recursive: true });
+
+        const binTarget = path.join(packageRoot, "openclaw.mjs");
+        await fs.writeFile(binTarget, "#!/usr/bin/env node\n", "utf8");
+
+        // Create a valid symlink already pointing to the target
+        const relFromBin = path.relative(binDir, binTarget);
+        await fs.symlink(relFromBin, path.join(binDir, "openclaw"));
+
+        // A directory matching the prefix should not be removed
+        await fs.mkdir(path.join(binDir, ".openclaw-dir"), { recursive: true });
+
+        const result = await repairGlobalBinLinks({
+          globalRoot,
+          packageRoot,
+          packageName: "openclaw",
+          binEntries: { openclaw: "openclaw.mjs" },
+        });
+
+        expect(result.cleaned).toEqual([]);
+        expect(result.repaired).toEqual([]);
+
+        // Directory must remain
+        await expect(fs.stat(path.join(binDir, ".openclaw-dir"))).resolves.toBeDefined();
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
   });
 
   it("checks bundled runtime sidecars, including Matrix helper-api", async () => {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -408,6 +408,109 @@ export function globalInstallFallbackArgs(
   return [resolved.command, "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
 }
 
+/**
+ * Derives the bin directory for a global npm install from the node_modules root.
+ * Standard npm layouts: <prefix>/lib/node_modules -> <prefix>/bin (Unix),
+ * or <prefix>/node_modules -> <prefix>/bin (flat layout).
+ */
+function inferBinDirFromGlobalRoot(globalRoot: string): string | null {
+  const normalized = path.resolve(globalRoot.trim() || "");
+  if (!normalized) {
+    return null;
+  }
+  const parentDir = path.dirname(normalized);
+  // Unix standard layout: <prefix>/lib/node_modules -> <prefix>/bin
+  if (path.basename(parentDir) === "lib") {
+    return path.join(path.dirname(parentDir), "bin");
+  }
+  // Windows: bins are .cmd shims directly in the npm prefix; complex to recreate, skip
+  if (process.platform === "win32") {
+    return null;
+  }
+  // Flat layout fallback: <prefix>/node_modules -> <prefix>/bin
+  return path.join(parentDir, "bin");
+}
+
+/**
+ * After a global npm install, npm's reify step can leave stale temp bin entries
+ * (e.g. `.openclaw-OKPnnPWD`) and fail to restore the primary bin symlink.
+ * This function cleans up stale temp bin entries and recreates any missing bin
+ * symlinks from the installed package's `bin` manifest entries.
+ */
+export async function repairGlobalBinLinks(params: {
+  globalRoot: string;
+  packageRoot: string;
+  packageName: string;
+  binEntries: Record<string, string>;
+}): Promise<{ cleaned: string[]; repaired: string[] }> {
+  const cleaned: string[] = [];
+  const repaired: string[] = [];
+
+  // Windows bin link repair requires generating .cmd wrappers; skip
+  if (process.platform === "win32") {
+    return { cleaned, repaired };
+  }
+
+  const binDir = inferBinDirFromGlobalRoot(params.globalRoot);
+  if (!binDir) {
+    return { cleaned, repaired };
+  }
+
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(binDir);
+  } catch {
+    return { cleaned, repaired };
+  }
+
+  const prefix = `${GLOBAL_RENAME_PREFIX}${params.packageName}-`;
+
+  // Remove stale temp bin entries (symlinks/files, not directories)
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) {
+      continue;
+    }
+    const target = path.join(binDir, entry);
+    try {
+      const stat = await fs.lstat(target);
+      if (stat.isDirectory()) {
+        continue;
+      }
+      await fs.unlink(target);
+      cleaned.push(entry);
+    } catch {
+      // ignore cleanup failures
+    }
+  }
+
+  // Recreate any missing or broken bin symlinks
+  for (const [binName, relTarget] of Object.entries(params.binEntries)) {
+    const binLink = path.join(binDir, binName);
+    let linkOk = false;
+    try {
+      await fs.access(binLink);
+      linkOk = true;
+    } catch {
+      // missing or broken symlink
+    }
+    if (linkOk) {
+      continue;
+    }
+    const absTarget = path.join(params.packageRoot, relTarget);
+    const relFromBin = path.relative(binDir, absTarget);
+    try {
+      // Remove any dangling symlink before recreating
+      await fs.unlink(binLink).catch(() => {});
+      await fs.symlink(relFromBin, binLink);
+      repaired.push(binName);
+    } catch {
+      // ignore repair failures
+    }
+  }
+
+  return { cleaned, repaired };
+}
+
 export async function cleanupGlobalRenameDirs(params: {
   globalRoot: string;
   packageName: string;

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -6,7 +6,7 @@ import {
   resolveControlUiDistIndexHealth,
   resolveControlUiDistIndexPathForRoot,
 } from "./control-ui-assets.js";
-import { readPackageName, readPackageVersion } from "./package-json.js";
+import { readPackageBin, readPackageName, readPackageVersion } from "./package-json.js";
 import { normalizePackageTagInput } from "./package-tag.js";
 import { trimLogTail } from "./restart-sentinel.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
@@ -26,6 +26,7 @@ import {
   detectGlobalInstallManagerForRoot,
   globalInstallArgs,
   globalInstallFallbackArgs,
+  repairGlobalBinLinks,
   resolveExpectedInstalledVersionFromSpec,
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
@@ -1157,14 +1158,12 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       }
     }
 
-    const verifiedPackageRoot =
-      (
-        await resolveGlobalInstallTarget({
-          manager: installTarget,
-          runCommand,
-          timeoutMs,
-        })
-      ).packageRoot ?? pkgRoot;
+    const verifiedTarget = await resolveGlobalInstallTarget({
+      manager: installTarget,
+      runCommand,
+      timeoutMs,
+    });
+    const verifiedPackageRoot = verifiedTarget.packageRoot ?? pkgRoot;
     const expectedVersion = resolveExpectedInstalledVersionFromSpec(packageName, spec);
     const verificationErrors = await collectInstalledGlobalPackageErrors({
       packageRoot: verifiedPackageRoot,
@@ -1179,6 +1178,19 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         exitCode: 1,
         stderrTail: verificationErrors.join("\n"),
       });
+    }
+    // Repair bin links that npm's reify may have left broken (stale temp entries,
+    // missing openclaw symlink) after a global install.
+    if (globalManager === "npm" && verifiedTarget.globalRoot) {
+      const binEntries = await readPackageBin(verifiedPackageRoot);
+      if (binEntries) {
+        await repairGlobalBinLinks({
+          globalRoot: verifiedTarget.globalRoot,
+          packageRoot: verifiedPackageRoot,
+          packageName,
+          binEntries,
+        }).catch(() => {});
+      }
     }
     const afterVersion = await readPackageVersion(verifiedPackageRoot);
     const failedStep =


### PR DESCRIPTION
## Summary

After `openclaw update`, npm's reify process renames the bin symlink (e.g. `bin/openclaw`) to a temp name (`.openclaw-OKPnnPWD`) and may fail to restore it, leaving the `openclaw` command unavailable.

- Adds `repairGlobalBinLinks` which runs after a global npm install to clean stale temp bin entries and recreate missing bin symlinks from the package's `bin` manifest
- Adds `readPackageBin` helper to read `bin` entries from `package.json`
- Adds two unit tests covering the repair and no-op cases

Closes #63719

---
> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)