### PR TITLE
[codex] Gateway: add offline APNs chat reply alerts

### DIFF
--- a/src/gateway/chat-apns-notify.test.ts
+++ b/src/gateway/chat-apns-notify.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadApnsRegistrationMock = vi.fn();
+const resolveApnsAuthConfigFromEnvMock = vi.fn();
+const resolveApnsRelayConfigFromEnvMock = vi.fn();
+const sendApnsAlertMock = vi.fn();
+const clearApnsRegistrationIfCurrentMock = vi.fn();
+const shouldClearStoredApnsRegistrationMock = vi.fn();
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({ gateway: {}, session: { mainKey: "main" } })),
+}));
+
+vi.mock("../infra/push-apns.js", () => ({
+  loadApnsRegistration: loadApnsRegistrationMock,
+  resolveApnsAuthConfigFromEnv: resolveApnsAuthConfigFromEnvMock,
+  resolveApnsRelayConfigFromEnv: resolveApnsRelayConfigFromEnvMock,
+  sendApnsAlert: sendApnsAlertMock,
+  clearApnsRegistrationIfCurrent: clearApnsRegistrationIfCurrentMock,
+  shouldClearStoredApnsRegistration: shouldClearStoredApnsRegistrationMock,
+}));
+
+describe("maybeSendChatReplyApnsAlert", () => {
+  let maybeSendChatReplyApnsAlert: (typeof import("./chat-apns-notify.js"))["maybeSendChatReplyApnsAlert"];
+
+  beforeAll(async () => {
+    ({ maybeSendChatReplyApnsAlert } = await import("./chat-apns-notify.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadApnsRegistrationMock.mockResolvedValue({
+      nodeId: "ios-device-1",
+      transport: "direct",
+      token: "apns-token",
+      topic: "ai.openclaw.ios.test",
+      environment: "sandbox",
+      updatedAtMs: 1,
+    });
+    resolveApnsAuthConfigFromEnvMock.mockResolvedValue({
+      ok: true,
+      value: { teamId: "team", keyId: "key", privateKey: "private-key" },
+    });
+    resolveApnsRelayConfigFromEnvMock.mockReturnValue({ ok: false, error: "unused" });
+    sendApnsAlertMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      environment: "sandbox",
+      topic: "ai.openclaw.ios.test",
+      tokenSuffix: "token",
+      transport: "direct",
+    });
+    shouldClearStoredApnsRegistrationMock.mockReturnValue(false);
+  });
+
+  it("sends APNs alert for offline main-session reply devices", async () => {
+    await maybeSendChatReplyApnsAlert({
+      sessionKey: "main",
+      requestDeviceId: "ios-device-1",
+      requestConnId: "conn-1",
+      replyText: "  long\n\nreply body  ",
+      isConnIdConnected: () => false,
+      hasConnectedClientForDevice: () => false,
+    });
+
+    expect(loadApnsRegistrationMock).toHaveBeenCalledWith("ios-device-1");
+    expect(sendApnsAlertMock).toHaveBeenCalledTimes(1);
+    expect(sendApnsAlertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "ios-device-1",
+        title: "OpenClaw",
+        body: "long reply body",
+      }),
+    );
+  });
+
+  it("skips APNs while the requester connection is still active", async () => {
+    await maybeSendChatReplyApnsAlert({
+      sessionKey: "main",
+      requestDeviceId: "ios-device-1",
+      requestConnId: "conn-1",
+      replyText: "reply body",
+      isConnIdConnected: () => true,
+      hasConnectedClientForDevice: () => false,
+    });
+
+    expect(loadApnsRegistrationMock).not.toHaveBeenCalled();
+    expect(sendApnsAlertMock).not.toHaveBeenCalled();
+  });
+
+  it("skips APNs for non-main sessions", async () => {
+    await maybeSendChatReplyApnsAlert({
+      sessionKey: "subagent:demo",
+      requestDeviceId: "ios-device-1",
+      requestConnId: "conn-1",
+      replyText: "reply body",
+      isConnIdConnected: () => false,
+      hasConnectedClientForDevice: () => false,
+    });
+
+    expect(loadApnsRegistrationMock).not.toHaveBeenCalled();
+    expect(sendApnsAlertMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/chat-apns-notify.ts
+++ b/src/gateway/chat-apns-notify.ts
@@ -1,0 +1,121 @@
+import { loadConfig } from "../config/config.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import {
+  clearApnsRegistrationIfCurrent,
+  loadApnsRegistration,
+  resolveApnsAuthConfigFromEnv,
+  resolveApnsRelayConfigFromEnv,
+  sendApnsAlert,
+  shouldClearStoredApnsRegistration,
+} from "../infra/push-apns.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+const CHAT_REPLY_APNS_TITLE = "OpenClaw";
+const CHAT_REPLY_APNS_BODY_MAX_CHARS = 240;
+const CHAT_REPLY_MAIN_SESSION_FALLBACK = "main";
+
+export function normalizeChatReplyNotificationBody(rawText: string): string {
+  const collapsed = rawText.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= CHAT_REPLY_APNS_BODY_MAX_CHARS) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, CHAT_REPLY_APNS_BODY_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+export async function maybeSendChatReplyApnsAlert(params: {
+  sessionKey: string;
+  mainSessionKey?: string | null;
+  requestDeviceId?: string | null;
+  requestConnId?: string | null;
+  replyText: string;
+  isConnIdConnected?: (connId: string) => boolean;
+  hasConnectedClientForDevice?: (deviceId: string, opts?: { excludeConnId?: string }) => boolean;
+  logWarn?: (message: string) => void;
+}): Promise<void> {
+  const cfg = loadConfig();
+  const mainSessionKey =
+    normalizeOptionalString(params.mainSessionKey) ??
+    normalizeOptionalString(cfg.session?.mainKey) ??
+    CHAT_REPLY_MAIN_SESSION_FALLBACK;
+  if (params.sessionKey !== mainSessionKey) {
+    return;
+  }
+
+  const deviceId = normalizeOptionalString(params.requestDeviceId) ?? "";
+  if (!deviceId) {
+    return;
+  }
+
+  const requestConnId = normalizeOptionalString(params.requestConnId) ?? undefined;
+  if (requestConnId && params.isConnIdConnected?.(requestConnId)) {
+    return;
+  }
+  if (params.hasConnectedClientForDevice?.(deviceId, { excludeConnId: requestConnId })) {
+    return;
+  }
+
+  const body = normalizeChatReplyNotificationBody(params.replyText);
+  if (!body) {
+    return;
+  }
+
+  try {
+    const registration = await loadApnsRegistration(deviceId);
+    if (!registration) {
+      return;
+    }
+
+    const result =
+      registration.transport === "relay"
+        ? await (async () => {
+            const relay = resolveApnsRelayConfigFromEnv(process.env, cfg.gateway);
+            if (!relay.ok) {
+              params.logWarn?.(`chat APNs relay unavailable device=${deviceId}: ${relay.error}`);
+              return null;
+            }
+            return await sendApnsAlert({
+              registration,
+              nodeId: deviceId,
+              title: CHAT_REPLY_APNS_TITLE,
+              body,
+              relayConfig: relay.value,
+            });
+          })()
+        : await (async () => {
+            const auth = await resolveApnsAuthConfigFromEnv(process.env);
+            if (!auth.ok) {
+              params.logWarn?.(`chat APNs auth unavailable device=${deviceId}: ${auth.error}`);
+              return null;
+            }
+            return await sendApnsAlert({
+              registration,
+              nodeId: deviceId,
+              title: CHAT_REPLY_APNS_TITLE,
+              body,
+              auth: auth.value,
+            });
+          })();
+
+    if (!result) {
+      return;
+    }
+    if (
+      shouldClearStoredApnsRegistration({
+        registration,
+        result,
+      })
+    ) {
+      await clearApnsRegistrationIfCurrent({
+        nodeId: deviceId,
+        registration,
+      });
+    }
+    if (!result.ok) {
+      params.logWarn?.(
+        `chat APNs send failed device=${deviceId} status=${result.status} reason=${result.reason ?? "-"}`,
+      );
+    }
+  } catch (error) {
+    params.logWarn?.(`chat APNs send threw device=${deviceId}: ${formatErrorMessage(error)}`);
+  }
+}

--- a/src/gateway/chat-apns-notify.ts
+++ b/src/gateway/chat-apns-notify.ts
@@ -65,40 +65,35 @@ export async function maybeSendChatReplyApnsAlert(params: {
       return;
     }
 
-    const result =
-      registration.transport === "relay"
-        ? await (async () => {
-            const relay = resolveApnsRelayConfigFromEnv(process.env, cfg.gateway);
-            if (!relay.ok) {
-              params.logWarn?.(`chat APNs relay unavailable device=${deviceId}: ${relay.error}`);
-              return null;
-            }
-            return await sendApnsAlert({
-              registration,
-              nodeId: deviceId,
-              title: CHAT_REPLY_APNS_TITLE,
-              body,
-              relayConfig: relay.value,
-            });
-          })()
-        : await (async () => {
-            const auth = await resolveApnsAuthConfigFromEnv(process.env);
-            if (!auth.ok) {
-              params.logWarn?.(`chat APNs auth unavailable device=${deviceId}: ${auth.error}`);
-              return null;
-            }
-            return await sendApnsAlert({
-              registration,
-              nodeId: deviceId,
-              title: CHAT_REPLY_APNS_TITLE,
-              body,
-              auth: auth.value,
-            });
-          })();
-
-    if (!result) {
-      return;
+    let result;
+    if (registration.transport === "relay") {
+      const relay = resolveApnsRelayConfigFromEnv(process.env, cfg.gateway);
+      if (!relay.ok) {
+        params.logWarn?.(`chat APNs relay unavailable device=${deviceId}: ${relay.error}`);
+        return;
+      }
+      result = await sendApnsAlert({
+        registration,
+        nodeId: deviceId,
+        title: CHAT_REPLY_APNS_TITLE,
+        body,
+        relayConfig: relay.value,
+      });
+    } else {
+      const auth = await resolveApnsAuthConfigFromEnv(process.env);
+      if (!auth.ok) {
+        params.logWarn?.(`chat APNs auth unavailable device=${deviceId}: ${auth.error}`);
+        return;
+      }
+      result = await sendApnsAlert({
+        registration,
+        nodeId: deviceId,
+        title: CHAT_REPLY_APNS_TITLE,
+        body,
+        auth: auth.value,
+      });
     }
+
     if (
       shouldClearStoredApnsRegistration({
         registration,

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
 
 const persistGatewaySessionLifecycleEventMock = vi.fn();
+const maybeSendChatReplyApnsAlertMock = vi.fn();
 
 vi.mock("./server-chat.persist-session-lifecycle.runtime.js", () => ({
   persistGatewaySessionLifecycleEvent: (...args: unknown[]) =>
@@ -24,6 +25,10 @@ vi.mock("./server-chat.load-gateway-session-row.runtime.js", () => ({
   loadGatewaySessionRow: vi.fn(),
 }));
 
+vi.mock("./chat-apns-notify.js", () => ({
+  maybeSendChatReplyApnsAlert: (...args: unknown[]) => maybeSendChatReplyApnsAlertMock(...args),
+}));
+
 import { loadConfig } from "../config/config.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import {
@@ -44,6 +49,7 @@ describe("agent event handler", () => {
     });
     vi.mocked(loadGatewaySessionRow).mockReset().mockReturnValue(null);
     persistGatewaySessionLifecycleEventMock.mockReset().mockResolvedValue(undefined);
+    maybeSendChatReplyApnsAlertMock.mockReset().mockResolvedValue(undefined);
     resetAgentRunContextForTest();
   });
 
@@ -57,6 +63,8 @@ describe("agent event handler", () => {
     resolveSessionKeyForRun?: (runId: string) => string | undefined;
     lifecycleErrorRetryGraceMs?: number;
     isChatSendRunActive?: (runId: string) => boolean;
+    isConnIdConnected?: (connId: string) => boolean;
+    hasConnectedClientForDevice?: (deviceId: string, opts?: { excludeConnId?: string }) => boolean;
   }) {
     const nowSpy =
       params?.now === undefined ? undefined : vi.spyOn(Date, "now").mockReturnValue(params.now);
@@ -81,6 +89,8 @@ describe("agent event handler", () => {
       sessionEventSubscribers,
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
+      isConnIdConnected: params?.isConnIdConnected,
+      hasConnectedClientForDevice: params?.hasConnectedClientForDevice,
     });
 
     return {
@@ -1347,6 +1357,41 @@ describe("agent event handler", () => {
 
     expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
     expect(nodeSendToSession).not.toHaveBeenCalled();
+  });
+
+  it("triggers APNs chat alert for offline requester devices on final assistant text", () => {
+    const { chatRunState, handler } = createHarness({
+      isConnIdConnected: () => false,
+      hasConnectedClientForDevice: () => false,
+    });
+    chatRunState.registry.add("run-offline", {
+      sessionKey: "main",
+      clientRunId: "client-offline",
+    });
+    registerAgentRunContext("run-offline", {
+      sessionKey: "main",
+      requestConnId: "conn-offline",
+      requestDeviceId: "ios-device-1",
+    });
+
+    handler({
+      runId: "run-offline",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "reply from assistant" },
+    });
+    emitLifecycleEnd(handler, "run-offline");
+
+    expect(maybeSendChatReplyApnsAlertMock).toHaveBeenCalledTimes(1);
+    expect(maybeSendChatReplyApnsAlertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main",
+        requestConnId: "conn-offline",
+        requestDeviceId: "ios-device-1",
+        replyText: "reply from assistant",
+      }),
+    );
   });
 
   it("uses agent event sessionKey when run-context lookup cannot resolve", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -10,6 +10,7 @@ import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-event
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+import { maybeSendChatReplyApnsAlert } from "./chat-apns-notify.js";
 import {
   isSuppressedControlReplyLeadFragment,
   isSuppressedControlReplyText,
@@ -469,6 +470,9 @@ export type AgentEventHandlerOptions = {
   sessionEventSubscribers: SessionEventSubscriberRegistry;
   lifecycleErrorRetryGraceMs?: number;
   isChatSendRunActive?: (runId: string) => boolean;
+  isConnIdConnected?: (connId: string) => boolean;
+  hasConnectedClientForDevice?: (deviceId: string, opts?: { excludeConnId?: string }) => boolean;
+  logWarn?: (message: string) => void;
 };
 
 export function createAgentEventHandler({
@@ -483,6 +487,9 @@ export function createAgentEventHandler({
   sessionEventSubscribers,
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
+  isConnIdConnected = () => false,
+  hasConnectedClientForDevice = () => false,
+  logWarn,
 }: AgentEventHandlerOptions) {
   const pendingTerminalLifecycleErrors = new Map<string, NodeJS.Timeout>();
 
@@ -823,6 +830,7 @@ export function createAgentEventHandler({
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {
+      const runContext = getAgentRunContext(sourceRunId) ?? getAgentRunContext(clientRunId);
       const payload = {
         runId: clientRunId,
         sessionKey,
@@ -840,6 +848,17 @@ export function createAgentEventHandler({
       };
       broadcast("chat", payload);
       nodeSendToSession(sessionKey, "chat", payload);
+      if (text && !shouldSuppressSilent) {
+        void maybeSendChatReplyApnsAlert({
+          sessionKey,
+          requestDeviceId: runContext?.requestDeviceId,
+          requestConnId: runContext?.requestConnId,
+          replyText: text,
+          isConnIdConnected,
+          hasConnectedClientForDevice,
+          logWarn,
+        });
+      }
       return;
     }
     const payload = {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -14,6 +14,7 @@ import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.j
 import type { MsgContext } from "../../auto-reply/templating.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
+import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
@@ -90,7 +91,6 @@ import type {
   GatewayRequestHandlerOptions,
   GatewayRequestHandlers,
 } from "./types.js";
-
 type TranscriptAppendResult = {
   ok: boolean;
   messageId?: string;
@@ -1779,6 +1779,11 @@ export const chatHandlers: GatewayRequestHandlers = {
           imageOrder: parsedImageOrder.length > 0 ? parsedImageOrder : undefined,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
+            registerAgentRunContext(runId, {
+              sessionKey,
+              requestConnId: normalizeOptionalString(client?.connId) ?? undefined,
+              requestDeviceId: normalizeOptionalString(client?.connect?.device?.id) ?? undefined,
+            });
             void emitUserTranscriptUpdate();
             const connId = typeof client?.connId === "string" ? client.connId : undefined;
             const wantsToolEvents = hasGatewayClientCap(

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -59,6 +59,8 @@ export type GatewayRequestContext = {
   hasConnectedMobileNode: () => boolean;
   hasExecApprovalClients?: (excludeConnId?: string) => boolean;
   disconnectClientsForDevice?: (deviceId: string, opts?: { role?: string }) => void;
+  isConnIdConnected?: (connId: string) => boolean;
+  hasConnectedClientForDevice?: (deviceId: string, opts?: { excludeConnId?: string }) => boolean;
   disconnectClientsUsingSharedGatewayAuth?: () => void;
   enforceSharedGatewayAuthGenerationForConfigWrite?: (nextConfig: OpenClawConfig) => void;
   nodeRegistry: NodeRegistry;

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -32,6 +32,9 @@ export function startGatewayEventSubscriptions(params: {
   sessionEventSubscribers: SessionEventSubscriberRegistry;
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   chatAbortControllers: Map<string, unknown>;
+  isConnIdConnected?: (connId: string) => boolean;
+  hasConnectedClientForDevice?: (deviceId: string, opts?: { excludeConnId?: string }) => boolean;
+  logWarn?: (message: string) => void;
 }) {
   const agentUnsub = params.minimalTestGateway
     ? null
@@ -47,6 +50,9 @@ export function startGatewayEventSubscriptions(params: {
           toolEventRecipients: params.toolEventRecipients,
           sessionEventSubscribers: params.sessionEventSubscribers,
           isChatSendRunActive: (runId) => params.chatAbortControllers.has(runId),
+          isConnIdConnected: params.isConnIdConnected,
+          hasConnectedClientForDevice: params.hasConnectedClientForDevice,
+          logWarn: params.logWarn,
         }),
       );
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -599,6 +599,27 @@ export async function startGatewayServer(
         sessionEventSubscribers,
         sessionMessageSubscribers,
         chatAbortControllers,
+        isConnIdConnected: (connId) => {
+          for (const gatewayClient of clients) {
+            if (gatewayClient.connId === connId) {
+              return true;
+            }
+          }
+          return false;
+        },
+        hasConnectedClientForDevice: (deviceId, opts) => {
+          for (const gatewayClient of clients) {
+            if (gatewayClient.connect.device?.id !== deviceId) {
+              continue;
+            }
+            if (opts?.excludeConnId && gatewayClient.connId === opts.excludeConnId) {
+              continue;
+            }
+            return true;
+          }
+          return false;
+        },
+        logWarn: (message) => log.warn(message),
       }),
     );
 
@@ -673,6 +694,26 @@ export async function startGatewayServer(
       },
       getSessionEventSubscriberConnIds: sessionEventSubscribers.getAll,
       registerToolEventRecipient: toolEventRecipients.add,
+      isConnIdConnected: (connId: string) => {
+        for (const gatewayClient of clients) {
+          if (gatewayClient.connId === connId) {
+            return true;
+          }
+        }
+        return false;
+      },
+      hasConnectedClientForDevice: (deviceId: string, opts?: { excludeConnId?: string }) => {
+        for (const gatewayClient of clients) {
+          if (gatewayClient.connect.device?.id !== deviceId) {
+            continue;
+          }
+          if (opts?.excludeConnId && gatewayClient.connId === opts.excludeConnId) {
+            continue;
+          }
+          return true;
+        }
+        return false;
+      },
       dedupe,
       wizardSessions,
       findRunningWizard,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -584,6 +584,27 @@ export async function startGatewayServer(
       runtimeState.mediaCleanup = earlyRuntime.maintenance.mediaCleanup;
     }
 
+    const isConnIdConnected = (connId: string) => {
+      for (const gatewayClient of clients) {
+        if (gatewayClient.connId === connId) {
+          return true;
+        }
+      }
+      return false;
+    };
+    const hasConnectedClientForDevice = (deviceId: string, opts?: { excludeConnId?: string }) => {
+      for (const gatewayClient of clients) {
+        if (gatewayClient.connect.device?.id !== deviceId) {
+          continue;
+        }
+        if (opts?.excludeConnId && gatewayClient.connId === opts.excludeConnId) {
+          continue;
+        }
+        return true;
+      }
+      return false;
+    };
+
     Object.assign(
       runtimeState,
       startGatewayEventSubscriptions({
@@ -599,26 +620,8 @@ export async function startGatewayServer(
         sessionEventSubscribers,
         sessionMessageSubscribers,
         chatAbortControllers,
-        isConnIdConnected: (connId) => {
-          for (const gatewayClient of clients) {
-            if (gatewayClient.connId === connId) {
-              return true;
-            }
-          }
-          return false;
-        },
-        hasConnectedClientForDevice: (deviceId, opts) => {
-          for (const gatewayClient of clients) {
-            if (gatewayClient.connect.device?.id !== deviceId) {
-              continue;
-            }
-            if (opts?.excludeConnId && gatewayClient.connId === opts.excludeConnId) {
-              continue;
-            }
-            return true;
-          }
-          return false;
-        },
+        isConnIdConnected,
+        hasConnectedClientForDevice,
         logWarn: (message) => log.warn(message),
       }),
     );
@@ -694,26 +697,8 @@ export async function startGatewayServer(
       },
       getSessionEventSubscriberConnIds: sessionEventSubscribers.getAll,
       registerToolEventRecipient: toolEventRecipients.add,
-      isConnIdConnected: (connId: string) => {
-        for (const gatewayClient of clients) {
-          if (gatewayClient.connId === connId) {
-            return true;
-          }
-        }
-        return false;
-      },
-      hasConnectedClientForDevice: (deviceId: string, opts?: { excludeConnId?: string }) => {
-        for (const gatewayClient of clients) {
-          if (gatewayClient.connect.device?.id !== deviceId) {
-            continue;
-          }
-          if (opts?.excludeConnId && gatewayClient.connId === opts.excludeConnId) {
-            continue;
-          }
-          return true;
-        }
-        return false;
-      },
+      isConnIdConnected,
+      hasConnectedClientForDevice,
       dedupe,
       wizardSessions,
       findRunningWizard,

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -115,6 +115,8 @@ export type AgentRunContext = {
   registeredAt?: number;
   /** Timestamp of last activity (updated on every emitAgentEvent). */
   lastActiveAt?: number;
+  requestConnId?: string;
+  requestDeviceId?: string;
 };
 
 type AgentEventState = {


### PR DESCRIPTION
## What changed

This adds Gateway-side offline APNs reply alerts for chat runs.

When a main-session chat reply finishes after the requesting iOS client has disconnected, the Gateway now reuses the existing APNs registration/send path to deliver a short alert back to that device.

## Why

The iOS chat flow can leave the app while a longer reply is still running. We already had APNs registration and push primitives, but chat completion did not use them.

## User impact

If an iOS user starts a long-running reply, leaves the app, and the reply completes later, the Gateway can now send an offline APNs alert back to the requesting device.

## Notes

This PR is intended to land together with the iOS chat UI companion PR #63697. The iOS UI PR updates the client-side chat surface; this PR adds the Gateway-side offline notification path. They are complementary and should ship together for the full experience.

## Validation

- `corepack pnpm test src/gateway/chat-apns-notify.test.ts src/gateway/server-chat.agent-events.test.ts src/gateway/server.chat.gateway-server-chat.test.ts`