### PR TITLE
Avoid runtime plugin loads during status inspection

### DIFF
--- a/src/channels/plugins/index.ts
+++ b/src/channels/plugins/index.ts
@@ -2,6 +2,7 @@ export {
   getChannelPlugin,
   getLoadedChannelPlugin,
   listChannelPlugins,
+  listChannelPluginsFromRegistry,
   normalizeChannelId,
 } from "./registry.js";
 export {

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -37,14 +37,9 @@ const EMPTY_CHANNEL_PLUGIN_CACHE: CachedChannelPlugins = {
 
 let cachedChannelPlugins = EMPTY_CHANNEL_PLUGIN_CACHE;
 
-function resolveCachedChannelPlugins(): CachedChannelPlugins {
-  const registry = requireActivePluginChannelRegistry();
-  const registryVersion = getActivePluginChannelRegistryVersion();
-  const cached = cachedChannelPlugins;
-  if (cached.registryVersion === registryVersion && cached.registryRef === registry) {
-    return cached;
-  }
-
+export function listChannelPluginsFromRegistry(registry: {
+  channels?: Array<{ plugin?: ChannelPlugin | null } | null>;
+}): ChannelPlugin[] {
   const channelPlugins: ChannelPlugin[] = [];
   if (Array.isArray(registry.channels)) {
     for (const entry of registry.channels) {
@@ -54,7 +49,7 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
     }
   }
 
-  const sorted = dedupeChannels(channelPlugins).toSorted((a, b) => {
+  return dedupeChannels(channelPlugins).toSorted((a, b) => {
     const indexA = CHAT_CHANNEL_ORDER.indexOf(a.id as ChatChannelId);
     const indexB = CHAT_CHANNEL_ORDER.indexOf(b.id as ChatChannelId);
     const orderA = a.meta.order ?? (indexA === -1 ? 999 : indexA);
@@ -64,6 +59,17 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
     }
     return a.id.localeCompare(b.id);
   });
+}
+
+function resolveCachedChannelPlugins(): CachedChannelPlugins {
+  const registry = requireActivePluginChannelRegistry();
+  const registryVersion = getActivePluginChannelRegistryVersion();
+  const cached = cachedChannelPlugins;
+  if (cached.registryVersion === registryVersion && cached.registryRef === registry) {
+    return cached;
+  }
+
+  const sorted = listChannelPluginsFromRegistry(registry);
   const byId = new Map<string, ChannelPlugin>();
   for (const plugin of sorted) {
     byId.set(plugin.id, plugin);

--- a/src/commands/status-all/channels.mattermost-token-summary.test.ts
+++ b/src/commands/status-all/channels.mattermost-token-summary.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { listChannelPluginsFromRegistry } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import { loadPluginMetadataRegistrySnapshot } from "../../plugins/runtime/metadata-registry-loader.js";
 import { makeDirectPlugin } from "../../test-utils/channel-plugin-test-fixtures.js";
 import { buildChannelsTable } from "./channels.js";
 
 vi.mock("../../channels/plugins/index.js", () => ({
-  listChannelPlugins: vi.fn(),
+  listChannelPluginsFromRegistry: vi.fn(),
+}));
+
+vi.mock("../../plugins/runtime/metadata-registry-loader.js", () => ({
+  loadPluginMetadataRegistrySnapshot: vi.fn(() => ({ channels: [] })),
 }));
 
 function makeMattermostPlugin(): ChannelPlugin {
@@ -219,7 +224,8 @@ async function buildTestTable(
   plugins: ChannelPlugin[],
   params?: { cfg?: Record<string, unknown>; sourceConfig?: Record<string, unknown> },
 ) {
-  vi.mocked(listChannelPlugins).mockReturnValue(plugins);
+  vi.mocked(loadPluginMetadataRegistrySnapshot).mockReturnValue({ channels: [] } as never);
+  vi.mocked(listChannelPluginsFromRegistry).mockReturnValue(plugins);
   return await buildChannelsTable((params?.cfg ?? { channels: {} }) as never, {
     showSecrets: false,
     sourceConfig: params?.sourceConfig as never,

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -10,7 +10,7 @@ import {
   resolveChannelAccountEnabled,
 } from "../../channels/account-summary.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
-import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { listChannelPluginsFromRegistry } from "../../channels/plugins/index.js";
 import type {
   ChannelAccountSnapshot,
   ChannelId,
@@ -19,6 +19,7 @@ import type {
 import { inspectReadOnlyChannelAccount } from "../../channels/read-only-account-inspect.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { sha256HexPrefix } from "../../logging/redact-identifier.js";
+import { loadPluginMetadataRegistrySnapshot } from "../../plugins/runtime/metadata-registry-loader.js";
 import { asRecord } from "../../shared/record-coerce.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { formatTimeAgo } from "./format.js";
@@ -486,8 +487,16 @@ export async function buildChannelsTable(
     columns: string[];
     rows: Array<Record<string, string>>;
   }> = [];
+  const sourceConfig = opts?.sourceConfig ?? cfg;
+  const channelPlugins = listChannelPluginsFromRegistry(
+    loadPluginMetadataRegistrySnapshot({
+      config: cfg,
+      activationSourceConfig: sourceConfig,
+      loadModules: false,
+    }),
+  );
 
-  for (const plugin of listChannelPlugins()) {
+  for (const plugin of channelPlugins) {
     const accountIds = plugin.config.listAccountIds(cfg);
     const defaultAccountId = resolveChannelDefaultAccountId({
       plugin,
@@ -497,7 +506,6 @@ export async function buildChannelsTable(
     const resolvedAccountIds = accountIds.length > 0 ? accountIds : [defaultAccountId];
 
     const accounts: ChannelAccountRow[] = [];
-    const sourceConfig = opts?.sourceConfig ?? cfg;
     for (const accountId of resolvedAccountIds) {
       accounts.push(
         await resolveChannelAccountRow({

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -1,18 +1,51 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { normalizePluginsConfig } from "./config-state.js";
 import { resolveRuntimePluginRegistry } from "./loader.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import { getMemoryRuntime } from "./memory-state.js";
+import { hasKind } from "./slots.js";
 import {
   buildPluginRuntimeLoadOptions,
   resolvePluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
+
+function resolveMemoryBootstrapPluginIds(params: {
+  cfg: OpenClawConfig;
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+}): string[] {
+  const pluginIds = new Set<string>();
+  const normalizedPlugins = normalizePluginsConfig(params.cfg.plugins);
+  if (normalizedPlugins.slots.memory && normalizedPlugins.slots.memory !== "none") {
+    pluginIds.add(normalizedPlugins.slots.memory);
+  }
+  for (const plugin of loadPluginManifestRegistry({
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  }).plugins) {
+    if (hasKind(plugin.kind, "memory")) {
+      pluginIds.add(plugin.id);
+    }
+  }
+  return [...pluginIds];
+}
 
 function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   const current = getMemoryRuntime();
   if (current || !cfg) {
     return current;
   }
+  const context = resolvePluginRuntimeLoadContext({ config: cfg });
+  const onlyPluginIds = resolveMemoryBootstrapPluginIds({
+    cfg: context.config,
+    workspaceDir: context.workspaceDir,
+    env: context.env,
+  });
   resolveRuntimePluginRegistry(
-    buildPluginRuntimeLoadOptions(resolvePluginRuntimeLoadContext({ config: cfg })),
+    buildPluginRuntimeLoadOptions(context, {
+      ...(onlyPluginIds.length > 0 ? { onlyPluginIds } : {}),
+    }),
   );
   return getMemoryRuntime();
 }

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -15,7 +15,7 @@ import { resolveSkillSource } from "../agents/skills/source.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
-import { listChannelPlugins } from "../channels/plugins/index.js";
+import { listChannelPluginsFromRegistry } from "../channels/plugins/index.js";
 import { inspectReadOnlyChannelAccount } from "../channels/read-only-account-inspect.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
@@ -26,6 +26,7 @@ import { resolveOAuthDir } from "../config/paths.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
 import { readInstalledPackageVersion } from "../infra/package-update-utils.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
+import { loadPluginMetadataRegistrySnapshot } from "../plugins/runtime/metadata-registry-loader.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import {
   normalizeOptionalLowercaseString,
@@ -631,9 +632,15 @@ export async function collectPluginsTrustFindings(params: {
     const allow = params.cfg.plugins?.allow;
     const allowConfigured = Array.isArray(allow) && allow.length > 0;
     if (!allowConfigured) {
+      const configuredChannelPlugins = listChannelPluginsFromRegistry(
+        loadPluginMetadataRegistrySnapshot({
+          config: params.cfg,
+          loadModules: false,
+        }),
+      );
       const skillCommandsLikelyExposed = (
         await Promise.all(
-          listChannelPlugins().map(async (plugin) => {
+          configuredChannelPlugins.map(async (plugin) => {
             if (
               plugin.capabilities.nativeCommands !== true &&
               plugin.commands?.nativeSkillsAutoEnabled !== true

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -124,9 +124,6 @@ let auditNonDeepModulePromise: Promise<typeof import("./audit.nondeep.runtime.js
 let auditChannelModulePromise:
   | Promise<typeof import("./audit-channel.collect.runtime.js")>
   | undefined;
-let pluginRegistryLoaderModulePromise:
-  | Promise<typeof import("../plugins/runtime/runtime-registry-loader.js")>
-  | undefined;
 let pluginMetadataRegistryLoaderModulePromise:
   | Promise<typeof import("../plugins/runtime/metadata-registry-loader.js")>
   | undefined;
@@ -152,11 +149,6 @@ async function loadAuditNonDeepModule() {
 async function loadAuditChannelModule() {
   auditChannelModulePromise ??= import("./audit-channel.collect.runtime.js");
   return await auditChannelModulePromise;
-}
-
-async function loadPluginRegistryLoaderModule() {
-  pluginRegistryLoaderModulePromise ??= import("../plugins/runtime/runtime-registry-loader.js");
-  return await pluginRegistryLoaderModulePromise;
 }
 
 async function loadPluginMetadataRegistryLoaderModule() {
@@ -1366,15 +1358,16 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
     context.includeChannelSecurity &&
     (context.plugins !== undefined || hasPotentialConfiguredChannels(cfg, env));
   if (shouldAuditChannelSecurity) {
-    if (context.plugins === undefined) {
-      (await loadPluginRegistryLoaderModule()).ensurePluginRegistryLoaded({
-        scope: "configured-channels",
-        config: cfg,
-        activationSourceConfig: context.sourceConfig,
-        env,
-      });
-    }
-    const channelPlugins = context.plugins ?? (await loadChannelPlugins()).listChannelPlugins();
+    const channelPlugins =
+      context.plugins ??
+      (await loadChannelPlugins()).listChannelPluginsFromRegistry(
+        (await loadPluginMetadataRegistryLoaderModule()).loadPluginMetadataRegistrySnapshot({
+          config: cfg,
+          activationSourceConfig: context.sourceConfig,
+          env,
+          loadModules: false,
+        }),
+      );
     const { collectChannelSecurityFindings } = await loadAuditChannelModule();
     findings.push(
       ...(await collectChannelSecurityFindings({


### PR DESCRIPTION
## Summary
- use metadata registry snapshots for channel status and security-audit paths so status-style inspection can read configured plugins without activating plugin runtime
- add `listChannelPluginsFromRegistry(...)` for snapshot-based channel enumeration and update the affected command test mocks for the new path
- narrow memory runtime bootstrap to memory-capable plugins so status and memory inspection do not wake unrelated plugins

## Test plan
- [x] `node --no-maglev ./node_modules/vitest/vitest.mjs run --config vitest.plugins.config.ts src/plugins/memory-runtime.test.ts`
- [x] `node --no-maglev ./node_modules/vitest/vitest.mjs run --config vitest.unit.config.ts src/security/audit-plugins-trust.test.ts`
- [x] `node --no-maglev ./node_modules/vitest/vitest.mjs run --config vitest.commands.config.ts src/commands/status-all/channels.mattermost-token-summary.test.ts`
- [ ] `corepack pnpm exec tsc -p tsconfig.json --noEmit --pretty false` *(blocked locally: Node 22 SIGABRT in this environment)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)