### PR TITLE
fix: include QA scenario pack in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docs/",
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
+    "qa/",
     "skills/",
     "scripts/npm-runner.mjs",
     "scripts/postinstall-bundled-plugins.mjs",


### PR DESCRIPTION
## Summary
- include `qa/` in the published npm package files allowlist
- ship the QA scenario pack assets that packaged runtime code already expects
- fix completion cache update / QA scenario loading failures in installed npm builds

## Problem
The published `openclaw@2026.4.9` npm package ships runtime code that expects QA scenario assets at `qa/scenarios/index.md`, but `package.json` excludes `qa/` from the `files` allowlist.

That causes installed builds to fail with errors like:

```text
Completion cache update failed ([openclaw] Failed to start CLI: Error: qa scenario pack not found: qa/scenarios/index.md)
```

## Root cause
In the published package:
- `dist/suite-*.js` reads `qa/scenarios/index.md`
- `package.json` includes `assets/`, `dist/`, `docs/`, `skills/`, etc.
- but it does **not** include `qa/`

So the packaged runtime references files that are never shipped.

## Evidence
On an installed `openclaw@2026.4.9` package:
- package root contains `assets/`, `dist/`, `docs/`, `skills/`, `scripts/`
- package root does **not** contain `qa/`
- packaged runtime still references `qa/scenarios/index.md`

## Fix
Add `qa/` to the npm package `files` allowlist in `package.json`.

## Related
- Fixes the completion-cache failure seen after `openclaw update`
- Related issue: #63815
