### PR TITLE
feat: add SiliconFlow model provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -261,6 +261,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/arcee/**"
+"extensions: siliconflow":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/siliconflow/**"
+          - "docs/providers/siliconflow.md"
 "extensions: byteplus":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Google: add Gemma 4 model support and keep Google fallback resolution on the requested provider path so native Google Gemma routes work again. (#61507) Thanks @eyjohn.
 - Providers/Google: preserve explicit thinking-off semantics for Gemma 4 while still enabling Gemma reasoning support in compatibility wrappers. (#62127) Thanks @romgenie.
 - Providers/Arcee AI: add a bundled Arcee AI provider plugin with Trinity catalog entries, OpenRouter support, and updated onboarding/auth guidance. (#62068) Thanks @arthurbr11.
+- Providers/SiliconFlow: add a bundled SiliconFlow (硅基流动) provider plugin with Qwen and DeepSeek model catalog entries, OpenAI-compatible API support, and onboarding guidance.
 - Providers/Anthropic: restore Claude CLI as the preferred local Anthropic path in onboarding, model-auth guidance, doctor flows, and Docker Claude CLI live lanes again.
 - Providers/Ollama: detect vision capability from the `/api/show` response and set image input on models that support it so Ollama vision models accept image attachments. (#62193) Thanks @BruceMacD.
 - Memory/dreaming: ingest redacted session transcripts into the dreaming corpus with per-day session-corpus notes, cursor checkpointing, and promotion/doctor support. (#62227) Thanks @vignesh07.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1269,6 +1269,7 @@
                   "providers/qwen",
                   "providers/runway",
                   "providers/sglang",
+                  "providers/siliconflow",
                   "providers/stepfun",
                   "providers/synthetic",
                   "providers/together",

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -59,6 +59,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Qwen Cloud](/providers/qwen)
 - [Runway](/providers/runway)
 - [SGLang (local models)](/providers/sglang)
+- [SiliconFlow](/providers/siliconflow)
 - [StepFun](/providers/stepfun)
 - [Synthetic](/providers/synthetic)
 - [Together AI](/providers/together)

--- a/docs/providers/siliconflow.md
+++ b/docs/providers/siliconflow.md
@@ -1,0 +1,79 @@
+---
+title: "SiliconFlow"
+summary: "SiliconFlow setup (auth + model selection)"
+read_when:
+  - You want to use SiliconFlow with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+# SiliconFlow
+
+[SiliconFlow](https://siliconflow.cn) provides access to a wide range of popular open-source models through an OpenAI-compatible API.
+
+- Provider: `siliconflow`
+- Auth: `SILICONFLOW_API_KEY`
+- API: OpenAI-compatible
+- Base URL: `https://api.siliconflow.cn/v1`
+
+## Quick start
+
+1. Get an API key from the [SiliconFlow platform dashboard](https://siliconflow.cn).
+
+2. Set the API key (recommended: store it for the Gateway):
+
+```bash
+openclaw onboard --auth-choice siliconflow-api-key
+```
+
+3. Set a default model:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "siliconflow/Qwen/Qwen2.5-7B-Instruct" },
+    },
+  },
+}
+```
+
+## Non-interactive example
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice siliconflow-api-key \
+  --siliconflow-api-key "$SILICONFLOW_API_KEY"
+```
+
+This will set `siliconflow/Qwen/Qwen2.5-7B-Instruct` as the default model.
+
+## Environment note
+
+If the Gateway runs as a daemon (launchd/systemd), make sure `SILICONFLOW_API_KEY`
+is available to that process (for example, in `~/.openclaw/.env` or via
+`env.shellEnv`).
+
+## Built-in catalog
+
+OpenClaw currently ships this bundled SiliconFlow catalog:
+
+| Model ref                               | Name                 | Input | Context | Cost (in/out per 1M) | Notes                             |
+| --------------------------------------- | -------------------- | ----- | ------- | -------------------- | --------------------------------- |
+| `siliconflow/Qwen/Qwen2.5-7B-Instruct`  | Qwen2.5-7B-Instruct  | text  | 128K    | $0.10 / $0.10        | Default model; fast and efficient |
+| `siliconflow/Qwen/Qwen2.5-72B-Instruct` | Qwen2.5-72B-Instruct | text  | 128K    | $0.10 / $0.10        | High-performance model            |
+| `siliconflow/deepseek-ai/DeepSeek-V3`   | DeepSeek-V3          | text  | 128K    | $0.10 / $0.10        | General-purpose                   |
+| `siliconflow/deepseek-ai/DeepSeek-R1`   | DeepSeek-R1          | text  | 128K    | $0.10 / $0.10        | Reasoning enabled                 |
+
+The onboarding preset sets `siliconflow/Qwen/Qwen2.5-7B-Instruct` as the default model.
+
+## Supported features
+
+- Streaming
+- Tool use / function calling
+- Structured output (JSON mode and JSON schema)
+- Extended thinking (DeepSeek-R1)
+
+---
+
+Note: This is a community-contributed integration, not an official SiliconFlow contribution.

--- a/extensions/siliconflow/api.ts
+++ b/extensions/siliconflow/api.ts
@@ -1,0 +1,6 @@
+export {
+  buildSiliconFlowModelDefinition,
+  SILICONFLOW_BASE_URL,
+  SILICONFLOW_MODEL_CATALOG,
+} from "./models.js";
+export { buildSiliconFlowProvider } from "./provider-catalog.js";

--- a/extensions/siliconflow/index.test.ts
+++ b/extensions/siliconflow/index.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import siliconflowPlugin from "./index.js";
+
+describe("siliconflow provider plugin", () => {
+  it("registers SiliconFlow with api-key auth wizard metadata", async () => {
+    const provider = await registerSingleProviderPlugin(siliconflowPlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "siliconflow-api-key",
+    });
+
+    expect(provider.id).toBe("siliconflow");
+    expect(provider.label).toBe("SiliconFlow");
+    expect(provider.envVars).toEqual(["SILICONFLOW_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    expect(resolved).not.toBeNull();
+    expect(resolved?.provider.id).toBe("siliconflow");
+    expect(resolved?.method.id).toBe("api-key");
+  });
+
+  it("builds the static SiliconFlow model catalog", async () => {
+    const provider = await registerSingleProviderPlugin(siliconflowPlugin);
+    expect(provider.catalog).toBeDefined();
+
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as never);
+
+    expect(catalog && "provider" in catalog).toBe(true);
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected single-provider catalog");
+    }
+
+    expect(catalog.provider.api).toBe("openai-completions");
+    expect(catalog.provider.baseUrl).toBe("https://api.siliconflow.cn/v1");
+    expect(catalog.provider.models?.map((model) => model.id)).toEqual([
+      "Qwen/Qwen2.5-7B-Instruct",
+      "Qwen/Qwen2.5-72B-Instruct",
+      "deepseek-ai/DeepSeek-V3",
+      "deepseek-ai/DeepSeek-R1",
+    ]);
+    expect(
+      catalog.provider.models?.find((model) => model.id === "deepseek-ai/DeepSeek-R1")?.reasoning,
+    ).toBe(true);
+  });
+
+  it("publishes configured SiliconFlow models through plugin-owned catalog augmentation", async () => {
+    const provider = await registerSingleProviderPlugin(siliconflowPlugin);
+
+    expect(
+      provider.augmentModelCatalog?.({
+        config: {
+          models: {
+            providers: {
+              siliconflow: {
+                models: [
+                  {
+                    id: "Qwen/Qwen2.5-7B-Instruct",
+                    name: "Qwen2.5-7B-Instruct",
+                    input: ["text"],
+                    reasoning: false,
+                    contextWindow: 131072,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as never),
+    ).toEqual([
+      {
+        provider: "siliconflow",
+        id: "Qwen/Qwen2.5-7B-Instruct",
+        name: "Qwen2.5-7B-Instruct",
+        input: ["text"],
+        reasoning: false,
+        contextWindow: 131072,
+      },
+    ]);
+  });
+});

--- a/extensions/siliconflow/index.ts
+++ b/extensions/siliconflow/index.ts
@@ -1,0 +1,46 @@
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { applySiliconFlowConfig, SILICONFLOW_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildSiliconFlowProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "siliconflow";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "SiliconFlow Provider",
+  description: "Bundled SiliconFlow provider plugin",
+  provider: {
+    label: "SiliconFlow",
+    docsPath: "/providers/siliconflow",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "SiliconFlow API key",
+        hint: "API key",
+        optionKey: "siliconflowApiKey",
+        flagName: "--siliconflow-api-key",
+        envVar: "SILICONFLOW_API_KEY",
+        promptMessage: "Enter SiliconFlow API key",
+        defaultModel: SILICONFLOW_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applySiliconFlowConfig(cfg),
+        wizard: {
+          choiceId: "siliconflow-api-key",
+          choiceLabel: "SiliconFlow API key",
+          groupId: "siliconflow",
+          groupLabel: "SiliconFlow",
+          groupHint: "API key",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildSiliconFlowProvider,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    matchesContextOverflowError: ({ errorMessage }) =>
+      /\bsiliconflow\b.*(?:input.*too long|context.*exceed)/i.test(errorMessage),
+  },
+});

--- a/extensions/siliconflow/models.ts
+++ b/extensions/siliconflow/models.ts
@@ -1,0 +1,62 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1";
+
+const SILICONFLOW_COST = {
+  input: 0.1,
+  output: 0.1,
+  cacheRead: 0.01,
+  cacheWrite: 0,
+};
+
+export const SILICONFLOW_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "Qwen/Qwen2.5-7B-Instruct",
+    name: "Qwen2.5-7B-Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+    cost: SILICONFLOW_COST,
+    compat: { supportsUsageInStreaming: true },
+  },
+  {
+    id: "Qwen/Qwen2.5-72B-Instruct",
+    name: "Qwen2.5-72B-Instruct",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+    cost: SILICONFLOW_COST,
+    compat: { supportsUsageInStreaming: true },
+  },
+  {
+    id: "deepseek-ai/DeepSeek-V3",
+    name: "DeepSeek-V3",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+    cost: SILICONFLOW_COST,
+    compat: { supportsUsageInStreaming: true },
+  },
+  {
+    id: "deepseek-ai/DeepSeek-R1",
+    name: "DeepSeek-R1",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 65536,
+    cost: SILICONFLOW_COST,
+    compat: { supportsUsageInStreaming: true },
+  },
+];
+
+export function buildSiliconFlowModelDefinition(
+  model: (typeof SILICONFLOW_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: "openai-completions",
+  };
+}

--- a/extensions/siliconflow/onboard.ts
+++ b/extensions/siliconflow/onboard.ts
@@ -1,0 +1,35 @@
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalog,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildSiliconFlowModelDefinition,
+  SILICONFLOW_BASE_URL,
+  SILICONFLOW_MODEL_CATALOG,
+} from "./api.js";
+
+export const SILICONFLOW_DEFAULT_MODEL_REF = "siliconflow/Qwen/Qwen2.5-7B-Instruct";
+
+export function applySiliconFlowProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[SILICONFLOW_DEFAULT_MODEL_REF] = {
+    ...models[SILICONFLOW_DEFAULT_MODEL_REF],
+    alias: models[SILICONFLOW_DEFAULT_MODEL_REF]?.alias ?? "SiliconFlow",
+  };
+
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "siliconflow",
+    api: "openai-completions",
+    baseUrl: SILICONFLOW_BASE_URL,
+    catalogModels: SILICONFLOW_MODEL_CATALOG.map(buildSiliconFlowModelDefinition),
+  });
+}
+
+export function applySiliconFlowConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applySiliconFlowProviderConfig(cfg),
+    SILICONFLOW_DEFAULT_MODEL_REF,
+  );
+}

--- a/extensions/siliconflow/openclaw.plugin.json
+++ b/extensions/siliconflow/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "siliconflow",
+  "enabledByDefault": true,
+  "providers": ["siliconflow"],
+  "providerAuthEnvVars": {
+    "siliconflow": ["SILICONFLOW_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "siliconflow",
+      "method": "api-key",
+      "choiceId": "siliconflow-api-key",
+      "choiceLabel": "SiliconFlow API key",
+      "groupId": "siliconflow",
+      "groupLabel": "SiliconFlow",
+      "groupHint": "API key",
+      "optionKey": "siliconflowApiKey",
+      "cliFlag": "--siliconflow-api-key",
+      "cliOption": "--siliconflow-api-key <key>",
+      "cliDescription": "SiliconFlow API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/siliconflow/package.json
+++ b/extensions/siliconflow/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/siliconflow-provider",
+  "version": "2026.4.9",
+  "private": true,
+  "description": "OpenClaw SiliconFlow provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/siliconflow/provider-catalog.ts
+++ b/extensions/siliconflow/provider-catalog.ts
@@ -1,0 +1,14 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildSiliconFlowModelDefinition,
+  SILICONFLOW_BASE_URL,
+  SILICONFLOW_MODEL_CATALOG,
+} from "./api.js";
+
+export function buildSiliconFlowProvider(): ModelProviderConfig {
+  return {
+    baseUrl: SILICONFLOW_BASE_URL,
+    api: "openai-completions",
+    models: SILICONFLOW_MODEL_CATALOG.map(buildSiliconFlowModelDefinition),
+  };
+}

--- a/extensions/siliconflow/provider-catalog.ts
+++ b/extensions/siliconflow/provider-catalog.ts
@@ -3,7 +3,7 @@ import {
   buildSiliconFlowModelDefinition,
   SILICONFLOW_BASE_URL,
   SILICONFLOW_MODEL_CATALOG,
-} from "./api.js";
+} from "./models.js";
 
 export function buildSiliconFlowProvider(): ModelProviderConfig {
   return {

--- a/extensions/siliconflow/tsconfig.json
+++ b/extensions/siliconflow/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1022,6 +1022,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/siliconflow:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/slack:
     dependencies:
       '@slack/bolt':


### PR DESCRIPTION
AI-assisted

## Summary

Add a bundled SiliconFlow provider plugin with Qwen and DeepSeek model catalog entries, OpenAI-compatible API support, and onboarding guidance.

## Changes

- Provider: SiliconFlow (硅基流动)
- API: OpenAI-compatible
- Base URL: https://api.siliconflow.cn/v1
- Models: Qwen2.5-7B, Qwen2.5-72B, DeepSeek-V3, DeepSeek-R1

---

This is a community-contributed provider for SiliconFlow,
using their official OpenAI-compatible API.
Not affiliated with SiliconFlow.
