### PR TITLE
fix(cli): load plugins for memory commands so embedding providers register

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -36,6 +36,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["directory"], policy: { loadPlugins: "always" } },
   { commandPath: ["agents"], policy: { loadPlugins: "always" } },
   { commandPath: ["configure"], policy: { loadPlugins: "always" } },
+  { commandPath: ["memory"], policy: { loadPlugins: "always" } },
   {
     commandPath: ["status"],
     policy: {

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -62,6 +62,18 @@ describe("command-startup-policy", () => {
         jsonOutputMode: false,
       }),
     ).toBe(true);
+    expect(
+      shouldLoadPluginsForCommandPath({
+        commandPath: ["memory", "index"],
+        jsonOutputMode: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldLoadPluginsForCommandPath({
+        commandPath: ["memory", "index"],
+        jsonOutputMode: true,
+      }),
+    ).toBe(true);
   });
 
   it("matches banner suppression policy", () => {


### PR DESCRIPTION
## Summary

The `memory` CLI command was missing from the command catalog, so `ensureCliExecutionBootstrap` never loaded the plugin registry before running memory subcommands. Without plugin loading, the Ollama plugin's embedding provider adapter was never registered, causing `"Unknown memory embedding provider: ollama"` errors.

Adding `memory` to the catalog with `loadPlugins: "always"` ensures all plugins are registered before any memory CLI command executes.

Closes #63681

## Changes

- Added `memory` to the CLI command catalog with `loadPlugins: "always"`

## Testing

- Verified that `openclaw memory index` no longer throws "Unknown memory embedding provider: ollama" when the Ollama plugin is configured

---
> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)