### PR TITLE
fix(plugins): preserve memory capability state across loader restores

### DIFF
--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -61,6 +61,7 @@ function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi 
     registerCommand() {},
     registerContextEngine() {},
     registerMemoryPromptSection() {},
+    registerMemoryCapability() {},
     registerMemoryFlushPlan() {},
     registerMemoryRuntime() {},
     registerMemoryEmbeddingProvider() {},

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -40,6 +40,7 @@ export type BuildPluginApiParams = {
       | "registerCommand"
       | "registerContextEngine"
       | "registerMemoryPromptSection"
+      | "registerMemoryCapability"
       | "registerMemoryFlushPlan"
       | "registerMemoryRuntime"
       | "registerMemoryEmbeddingProvider"
@@ -76,6 +77,7 @@ const noopOnConversationBindingResolved: OpenClawPluginApi["onConversationBindin
 const noopRegisterCommand: OpenClawPluginApi["registerCommand"] = () => {};
 const noopRegisterContextEngine: OpenClawPluginApi["registerContextEngine"] = () => {};
 const noopRegisterMemoryPromptSection: OpenClawPluginApi["registerMemoryPromptSection"] = () => {};
+const noopRegisterMemoryCapability: OpenClawPluginApi["registerMemoryCapability"] = () => {};
 const noopRegisterMemoryFlushPlan: OpenClawPluginApi["registerMemoryFlushPlan"] = () => {};
 const noopRegisterMemoryRuntime: OpenClawPluginApi["registerMemoryRuntime"] = () => {};
 const noopRegisterMemoryEmbeddingProvider: OpenClawPluginApi["registerMemoryEmbeddingProvider"] =
@@ -126,6 +128,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     registerContextEngine: handlers.registerContextEngine ?? noopRegisterContextEngine,
     registerMemoryPromptSection:
       handlers.registerMemoryPromptSection ?? noopRegisterMemoryPromptSection,
+    registerMemoryCapability: handlers.registerMemoryCapability ?? noopRegisterMemoryCapability,
     registerMemoryFlushPlan: handlers.registerMemoryFlushPlan ?? noopRegisterMemoryFlushPlan,
     registerMemoryRuntime: handlers.registerMemoryRuntime ?? noopRegisterMemoryRuntime,
     registerMemoryEmbeddingProvider:

--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -47,6 +47,7 @@ describe("captured plugin registration", () => {
 
     expect(captured.tools.map((tool) => tool.name)).toEqual(["captured-tool"]);
     expect(captured.providers.map((provider) => provider.id)).toEqual(["captured-provider"]);
+    expect(captured.api.registerMemoryCapability).toBeTypeOf("function");
     expect(captured.api.registerMemoryEmbeddingProvider).toBeTypeOf("function");
   });
 });

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -27,7 +27,10 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   buildMemoryPromptSection,
+  clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryRuntime,
+  registerMemoryCapability,
   registerMemoryFlushPlanResolver,
   registerMemoryPromptSection,
   registerMemoryRuntime,
@@ -1381,6 +1384,17 @@ module.exports = { id: "throws-after-import", register() {} };`,
       id: "active",
       create: async () => ({ provider: null }),
     });
+    registerMemoryCapability("active-memory", {
+      promptBuilder: () => ["active capability section"],
+      flushPlanResolver: () => ({
+        softThresholdTokens: 11,
+        forceFlushTranscriptBytes: 12,
+        reserveTokensFloor: 13,
+        prompt: "active-capability",
+        systemPrompt: "active-capability",
+        relativePath: "memory/active-capability.md",
+      }),
+    });
     registerMemoryPromptSection(() => ["active memory section"]);
     registerMemoryFlushPlanResolver(() => ({
       softThresholdTokens: 1,
@@ -1447,9 +1461,10 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-memory")?.status).toBe("loaded");
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
-      "active memory section",
+      "active capability section",
     ]);
-    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/active.md");
+    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/active-capability.md");
+    expect(getMemoryCapabilityRegistration()?.pluginId).toBe("active-memory");
     expect(getMemoryRuntime()).toBe(activeRuntime);
     expect(listMemoryEmbeddingProviders().map((adapter) => adapter.id)).toEqual(["active"]);
   });
@@ -1505,8 +1520,72 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(registry.plugins.find((entry) => entry.id === "failing-memory")?.status).toBe("error");
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([]);
     expect(resolveMemoryFlushPlan({})).toBeNull();
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
     expect(getMemoryRuntime()).toBeUndefined();
     expect(listMemoryEmbeddingProviders()).toEqual([]);
+  });
+
+  it("restores cached memory capability registrations on cache hits", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cached-memory-capability",
+      filename: "cached-memory-capability.cjs",
+      body: `module.exports = {
+        id: "cached-memory-capability",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            promptBuilder: () => ["cached capability section"],
+            flushPlanResolver: () => ({
+              softThresholdTokens: 10,
+              forceFlushTranscriptBytes: 20,
+              reserveTokensFloor: 30,
+              prompt: "cached",
+              systemPrompt: "cached",
+              relativePath: "memory/cached.md",
+            }),
+          });
+          api.registerMemoryRuntime({
+            async getMemorySearchManager() {
+              return { manager: null, error: "cached" };
+            },
+            resolveMemoryBackendConfig() {
+              return { backend: "builtin" };
+            },
+          });
+        },
+      };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["cached-memory-capability"],
+          slots: { memory: "cached-memory-capability" },
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins(options);
+    expect(first.plugins.find((entry) => entry.id === "cached-memory-capability")?.status).toBe(
+      "loaded",
+    );
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
+      "cached capability section",
+    ]);
+
+    clearMemoryPluginState();
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
+
+    const second = loadOpenClawPlugins(options);
+    expect(second).toBe(first);
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
+      "cached capability section",
+    ]);
+    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/cached.md");
+    expect(getMemoryCapabilityRegistration()?.pluginId).toBe("cached-memory-capability");
   });
 
   it("throws when activate:false is used without cache:false", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -35,6 +35,7 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
@@ -129,6 +130,7 @@ export class PluginLoadFailureError extends Error {
 type CachedPluginState = {
   registry: PluginRegistry;
   memoryEmbeddingProviders: ReturnType<typeof listRegisteredMemoryEmbeddingProviders>;
+  memoryCapability: ReturnType<typeof getMemoryCapabilityRegistration>;
   memoryFlushPlanResolver: ReturnType<typeof getMemoryFlushPlanResolver>;
   memoryPromptBuilder: ReturnType<typeof getMemoryPromptSectionBuilder>;
   memoryRuntime: ReturnType<typeof getMemoryRuntime>;
@@ -982,6 +984,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (cached) {
       restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
       restoreMemoryPluginState({
+        capability: cached.memoryCapability,
         promptBuilder: cached.memoryPromptBuilder,
         flushPlanResolver: cached.memoryFlushPlanResolver,
         runtime: cached.memoryRuntime,
@@ -1542,6 +1545,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       registrationMode,
     });
     const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
+    const previousMemoryCapability = getMemoryCapabilityRegistration();
     const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
     const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
     const previousMemoryRuntime = getMemoryRuntime();
@@ -1560,6 +1564,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       if (!shouldActivate) {
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
         restoreMemoryPluginState({
+          capability: previousMemoryCapability,
           promptBuilder: previousMemoryPromptBuilder,
           flushPlanResolver: previousMemoryFlushPlanResolver,
           runtime: previousMemoryRuntime,
@@ -1570,6 +1575,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     } catch (err) {
       restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
       restoreMemoryPluginState({
+        capability: previousMemoryCapability,
         promptBuilder: previousMemoryPromptBuilder,
         flushPlanResolver: previousMemoryFlushPlanResolver,
         runtime: previousMemoryRuntime,
@@ -1623,6 +1629,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     setCachedPluginRegistry(cacheKey, {
       registry,
       memoryEmbeddingProviders: listRegisteredMemoryEmbeddingProviders(),
+      memoryCapability: getMemoryCapabilityRegistration(),
       memoryFlushPlanResolver: getMemoryFlushPlanResolver(),
       memoryPromptBuilder: getMemoryPromptSectionBuilder(),
       memoryRuntime: getMemoryRuntime(),

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -3,14 +3,17 @@ import {
   _resetMemoryPluginState,
   buildMemoryPromptSection,
   clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
+  registerMemoryCapability,
   registerMemoryFlushPlanResolver,
   registerMemoryPromptSection,
   registerMemoryRuntime,
   resolveMemoryFlushPlan,
   restoreMemoryPluginState,
+  listActiveMemoryPublicArtifacts,
 } from "./memory-state.js";
 
 function createMemoryRuntime() {
@@ -39,10 +42,12 @@ function expectClearedMemoryState() {
   expect(resolveMemoryFlushPlan({})).toBeNull();
   expect(buildMemoryPromptSection({ availableTools: new Set(["memory_search"]) })).toEqual([]);
   expect(getMemoryRuntime()).toBeUndefined();
+  expect(getMemoryCapabilityRegistration()).toBeUndefined();
 }
 
 function createMemoryStateSnapshot() {
   return {
+    capability: getMemoryCapabilityRegistration(),
     promptBuilder: getMemoryPromptSectionBuilder(),
     flushPlanResolver: getMemoryFlushPlanResolver(),
     runtime: getMemoryRuntime(),
@@ -128,6 +133,43 @@ describe("memory plugin state", () => {
         agentId: "main",
       }),
     ).resolves.toEqual({ manager: null, error: "missing" });
+  });
+
+  it("prefers capability registrations and preserves them across restore", async () => {
+    const runtime = createMemoryRuntime();
+    const artifact = {
+      workspaceDir: "/tmp/workspace",
+      relativePath: "memory/today.md",
+      absolutePath: "/tmp/workspace/memory/today.md",
+      kind: "markdown",
+      contentType: "text/markdown",
+      agentIds: ["main"],
+    };
+
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["capability section"],
+      flushPlanResolver: () => createMemoryFlushPlan("memory/capability.md"),
+      runtime,
+      publicArtifacts: {
+        listArtifacts: async () => [artifact],
+      },
+    });
+
+    const snapshot = createMemoryStateSnapshot();
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["capability section"]);
+    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/capability.md");
+    expect(getMemoryRuntime()).toBe(runtime);
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      artifact,
+    ]);
+
+    clearMemoryPluginState();
+    restoreMemoryPluginState(snapshot);
+
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["capability section"]);
+    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/capability.md");
+    expect(getMemoryRuntime()).toBe(runtime);
+    expect(getMemoryCapabilityRegistration()?.pluginId).toBe("memory-core");
   });
 
   it("restoreMemoryPluginState swaps both prompt and flush state", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -67,13 +67,56 @@ export type MemoryPluginRuntime = {
   closeAllMemorySearchManagers?(): Promise<void>;
 };
 
+export type MemoryPublicArtifact = {
+  workspaceDir: string;
+  relativePath: string;
+  absolutePath: string;
+  kind: string;
+  contentType: string;
+  agentIds: string[];
+};
+
+export type MemoryPluginCapability = {
+  promptBuilder?: MemoryPromptSectionBuilder;
+  flushPlanResolver?: MemoryFlushPlanResolver;
+  runtime?: MemoryPluginRuntime;
+  publicArtifacts?: {
+    listArtifacts(params: { cfg: OpenClawConfig }): Promise<MemoryPublicArtifact[]>;
+  };
+};
+
+export type MemoryCapabilityRegistration = {
+  pluginId: string;
+  capability: MemoryPluginCapability;
+};
+
 type MemoryPluginState = {
+  capability?: MemoryCapabilityRegistration;
   promptBuilder?: MemoryPromptSectionBuilder;
   flushPlanResolver?: MemoryFlushPlanResolver;
   runtime?: MemoryPluginRuntime;
 };
 
 const memoryPluginState: MemoryPluginState = {};
+
+export function registerMemoryCapability(
+  pluginId: string,
+  capability: MemoryPluginCapability,
+): void {
+  memoryPluginState.capability = {
+    pluginId,
+    capability: { ...capability },
+  };
+}
+
+export function getMemoryCapabilityRegistration(): MemoryCapabilityRegistration | undefined {
+  return memoryPluginState.capability
+    ? {
+        pluginId: memoryPluginState.capability.pluginId,
+        capability: { ...memoryPluginState.capability.capability },
+      }
+    : undefined;
+}
 
 export function registerMemoryPromptSection(builder: MemoryPromptSectionBuilder): void {
   memoryPluginState.promptBuilder = builder;
@@ -83,11 +126,15 @@ export function buildMemoryPromptSection(params: {
   availableTools: Set<string>;
   citationsMode?: MemoryCitationsMode;
 }): string[] {
-  return memoryPluginState.promptBuilder?.(params) ?? [];
+  return (
+    memoryPluginState.capability?.capability.promptBuilder?.(params) ??
+    memoryPluginState.promptBuilder?.(params) ??
+    []
+  );
 }
 
 export function getMemoryPromptSectionBuilder(): MemoryPromptSectionBuilder | undefined {
-  return memoryPluginState.promptBuilder;
+  return memoryPluginState.capability?.capability.promptBuilder ?? memoryPluginState.promptBuilder;
 }
 
 export function registerMemoryFlushPlanResolver(resolver: MemoryFlushPlanResolver): void {
@@ -98,11 +145,18 @@ export function resolveMemoryFlushPlan(params: {
   cfg?: OpenClawConfig;
   nowMs?: number;
 }): MemoryFlushPlan | null {
-  return memoryPluginState.flushPlanResolver?.(params) ?? null;
+  return (
+    memoryPluginState.capability?.capability.flushPlanResolver?.(params) ??
+    memoryPluginState.flushPlanResolver?.(params) ??
+    null
+  );
 }
 
 export function getMemoryFlushPlanResolver(): MemoryFlushPlanResolver | undefined {
-  return memoryPluginState.flushPlanResolver;
+  return (
+    memoryPluginState.capability?.capability.flushPlanResolver ??
+    memoryPluginState.flushPlanResolver
+  );
 }
 
 export function registerMemoryRuntime(runtime: MemoryPluginRuntime): void {
@@ -110,20 +164,42 @@ export function registerMemoryRuntime(runtime: MemoryPluginRuntime): void {
 }
 
 export function getMemoryRuntime(): MemoryPluginRuntime | undefined {
-  return memoryPluginState.runtime;
+  return memoryPluginState.capability?.capability.runtime ?? memoryPluginState.runtime;
 }
 
 export function hasMemoryRuntime(): boolean {
-  return memoryPluginState.runtime !== undefined;
+  return getMemoryRuntime() !== undefined;
+}
+
+function cloneMemoryPublicArtifact(artifact: MemoryPublicArtifact): MemoryPublicArtifact {
+  return {
+    ...artifact,
+    agentIds: [...artifact.agentIds],
+  };
+}
+
+export async function listActiveMemoryPublicArtifacts(params: {
+  cfg: OpenClawConfig;
+}): Promise<MemoryPublicArtifact[]> {
+  const listed =
+    (await memoryPluginState.capability?.capability.publicArtifacts?.listArtifacts(params)) ?? [];
+  return listed.map(cloneMemoryPublicArtifact);
 }
 
 export function restoreMemoryPluginState(state: MemoryPluginState): void {
+  memoryPluginState.capability = state.capability
+    ? {
+        pluginId: state.capability.pluginId,
+        capability: { ...state.capability.capability },
+      }
+    : undefined;
   memoryPluginState.promptBuilder = state.promptBuilder;
   memoryPluginState.flushPlanResolver = state.flushPlanResolver;
   memoryPluginState.runtime = state.runtime;
 }
 
 export function clearMemoryPluginState(): void {
+  memoryPluginState.capability = undefined;
   memoryPluginState.promptBuilder = undefined;
   memoryPluginState.flushPlanResolver = undefined;
   memoryPluginState.runtime = undefined;

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -22,6 +22,7 @@ import {
   registerMemoryEmbeddingProvider,
 } from "./memory-embedding-providers.js";
 import {
+  registerMemoryCapability,
   registerMemoryFlushPlanResolver,
   registerMemoryPromptSection,
   registerMemoryRuntime,
@@ -1154,6 +1155,32 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   return;
                 }
                 registerMemoryPromptSection(builder);
+              },
+              registerMemoryCapability: (capability) => {
+                if (!hasKind(record.kind, "memory")) {
+                  pushDiagnostic({
+                    level: "error",
+                    pluginId: record.id,
+                    source: record.source,
+                    message: "only memory plugins can register a memory capability",
+                  });
+                  return;
+                }
+                if (
+                  Array.isArray(record.kind) &&
+                  record.kind.length > 1 &&
+                  !record.memorySlotSelected
+                ) {
+                  pushDiagnostic({
+                    level: "warn",
+                    pluginId: record.id,
+                    source: record.source,
+                    message:
+                      "dual-kind plugin not selected for memory slot; skipping memory capability registration",
+                  });
+                  return;
+                }
+                registerMemoryCapability(record.id, capability);
               },
               registerMemoryFlushPlan: (resolver) => {
                 if (!hasKind(record.kind, "memory")) {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2063,6 +2063,10 @@ export type OpenClawPluginApi = {
   registerMemoryPromptSection: (
     builder: import("./memory-state.js").MemoryPromptSectionBuilder,
   ) => void;
+  /** Register the active memory capability bundle for this memory plugin (exclusive slot). */
+  registerMemoryCapability: (
+    capability: import("./memory-state.js").MemoryPluginCapability,
+  ) => void;
   /** Register the pre-compaction flush plan resolver for this memory plugin (exclusive slot). */
   registerMemoryFlushPlan: (resolver: import("./memory-state.js").MemoryFlushPlanResolver) => void;
   /** Register the active memory runtime adapter for this memory plugin (exclusive slot). */

--- a/test/helpers/plugins/plugin-api.ts
+++ b/test/helpers/plugins/plugin-api.ts
@@ -32,6 +32,7 @@ export function createTestPluginApi(api: TestPluginApiInput): OpenClawPluginApi 
     registerCommand() {},
     registerContextEngine() {},
     registerMemoryPromptSection() {},
+    registerMemoryCapability() {},
     registerMemoryFlushPlan() {},
     registerMemoryRuntime() {},
     registerMemoryEmbeddingProvider() {},


### PR DESCRIPTION
## Summary
- preserve the active memory capability snapshot when plugin registries are restored from cache
- restore the previous memory capability during non-activating loads and register rollback paths
- add focused coverage for capability-backed memory state restoration and cache reuse

## Problem
`memory-core` can register a capability bundle that owns prompt building, flush planning, runtime access, and public artifact export. The plugin loader already snapshots and restores several pieces of memory plugin state, but it was not preserving the active capability registration.

In practice, that lets a later restore path wipe the capability back to `undefined` after registration succeeds. Once that happens, capability-backed features like public artifact export disappear even though the memory plugin loaded successfully.

## Fix
- extend `memory-state` with explicit capability registration/state helpers
- include the capability in loader cache snapshots
- restore the capability in both non-activating loads and register rollback paths
- keep plugin test helpers aligned with the expanded plugin API surface

## Validation
- `pnpm exec vitest run src/plugins/memory-state.test.ts src/plugins/loader.test.ts src/plugins/captured-registration.test.ts`
- `pnpm tsgo` *(currently still fails on pre-existing issues in `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`; no additional failures from this change)*
