### PR TITLE
fix: the cron isolated agent in openclaw unconditiona (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: deduplicate delivered completion announces so retry or re-entry cleanup does not inject duplicate internal-context completion turns into the parent session. (#61525) Thanks @100yenadmin.
 - Agents/exec: keep sandboxed `tools.exec.host=auto` sessions from honoring per-call `host=node` or `host=gateway` overrides while a sandbox runtime is active, and stop advertising node routing in that state so exec stays on the sandbox host. (#63880)
 
+- Cron/isolated agent: run scheduled agent turns as non-owner senders so owner-only tools stay unavailable during cron execution. (#63878)
 ## 2026.4.9
 
 ### Changes

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -131,7 +131,7 @@ export function createCronPromptExecutor(params: {
           agentId: params.agentId,
           trigger: "cron",
           allowGatewaySubagentBinding: true,
-          senderIsOwner: true,
+          senderIsOwner: false,
           messageChannel: params.messageChannel,
           agentAccountId: params.resolvedDelivery.accountId,
           sessionFile,

--- a/src/cron/isolated-agent/run.owner-auth.test.ts
+++ b/src/cron/isolated-agent/run.owner-auth.test.ts
@@ -58,14 +58,14 @@ describe("runCronIsolatedAgentTurn owner auth", () => {
   });
 
   it(
-    "passes senderIsOwner=true to isolated cron agent runs",
+    "passes senderIsOwner=false to isolated cron agent runs",
     { timeout: RUN_OWNER_AUTH_TIMEOUT_MS },
     async () => {
       await runCronIsolatedAgentTurn(makeParams());
 
       expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
       const senderIsOwner = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.senderIsOwner;
-      expect(senderIsOwner).toBe(true);
+      expect(senderIsOwner).toBe(false);
     },
   );
 });


### PR DESCRIPTION
## Summary

- Problem: isolated cron agent runs always passed `senderIsOwner: true` into `runEmbeddedPiAgent()`, so scheduled turns inherited owner-only tool access by default.
- Why it matters: cron jobs can process externally sourced content, and owner-only tools should not unlock automatically for those runs.
- What changed: the cron isolated executor now runs embedded agent turns with `senderIsOwner: false`, and the closest regression test now locks in the non-owner behavior.
- What did NOT change (scope boundary): this does not add a new cron payload capability, broaden tool policy, or change unrelated cron delivery/session behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #383
- Related #383
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `createCronPromptExecutor()` hardcoded `senderIsOwner: true` for every isolated cron agent run instead of treating cron content as untrusted by default.
- Missing detection / guardrail: the only direct regression coverage asserted the privileged behavior, so the owner-only tool boundary was locked to the wrong default.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #383 traced the behavior to `src/cron/isolated-agent/run-executor.ts` and the adjacent `run.owner-auth.test.ts` expectation.
- Why this regressed now: cron isolated-agent execution kept owner semantics even after cron support expanded to process external hook content and other externally sourced inputs.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/run.owner-auth.test.ts`
- Scenario the test should lock in: isolated cron agent runs pass `senderIsOwner: false` into `runEmbeddedPiAgent()`.
- Why this is the smallest reliable guardrail: the bug is a single privileged parameter at the executor boundary, and this test exercises that exact call site without pulling in unrelated runtime behavior.
- Existing test that already covers this (if any): none; the prior test asserted the opposite behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Scheduled isolated cron agent runs no longer inherit owner-only tool access by default.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: cron turns now run with less privilege, which removes owner-only tool access from this path instead of expanding it.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree
- Model/provider: N/A
- Integration/channel (if any): cron isolated agent
- Relevant config (redacted): default test harness config

### Steps

1. Run an isolated cron agent turn through the existing cron test harness.
2. Inspect the `runEmbeddedPiAgent()` call arguments.
3. Confirm `senderIsOwner` stays `false`.

### Expected

- Isolated cron runs do not present as owner senders.

### Actual

- After the fix, the focused regression confirms `senderIsOwner: false`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: inspected the executor boundary, updated the regression, and ran the focused cron owner-auth test locally.
- Edge cases checked: confirmed the change is scoped to the isolated cron executor call and does not alter model fallback, delivery, or session wiring.
- What you did **not** verify: full repo build; the service-managed `pnpm build` post-turn validation is expected to cover that.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): No
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `senderIsOwner` change in `src/cron/isolated-agent/run-executor.ts`.
- Files/config to restore: `src/cron/isolated-agent/run-executor.ts`, `src/cron/isolated-agent/run.owner-auth.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: cron jobs that previously depended on owner-only tools will stop seeing those tools until a separate explicit capability is introduced.

## Risks and Mitigations

- Risk: existing cron jobs that implicitly depended on owner-only tools may lose access.
  - Mitigation: keep the change narrowly scoped to isolated cron runs, document the behavior change in the changelog, and defer any future explicit opt-in design to a separate follow-up.
