### PR TITLE
fix: a sandboxed agent can request host node in an ex (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/migration: keep packaged warning-only crypto migrations from being misclassified as actionable when only helper chunks are present, so startup and doctor stay on the warning-only path instead of creating unnecessary migration snapshots. (#64373) Thanks @gumadeiras.
 - Matrix/ACP thread bindings: preserve canonical room casing and parent conversation routing during ACP session spawn so mixed-case room ids bind correctly from top-level rooms and existing Matrix threads. (#64343) Thanks @gumadeiras.
 - Agents/subagents: deduplicate delivered completion announces so retry or re-entry cleanup does not inject duplicate internal-context completion turns into the parent session. (#61525) Thanks @100yenadmin.
+- Agents/exec: keep sandboxed `tools.exec.host=auto` sessions from honoring per-call `host=node` or `host=gateway` overrides while a sandbox runtime is active, and stop advertising node routing in that state so exec stays on the sandbox host. (#63880)
 
 ## 2026.4.9
 

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -127,7 +127,20 @@ describe("resolveExecTarget", () => {
         sandboxAvailable: true,
       }),
     ).toThrow(
-      "exec host not allowed (requested gateway; configured host is auto; set tools.exec.host=gateway or auto to allow this override).",
+      "exec host not allowed (requested gateway; configured host is auto; set tools.exec.host=gateway to allow this override).",
+    );
+  });
+
+  it("rejects per-call host=node override from auto when sandbox is available", () => {
+    expect(() =>
+      resolveExecTarget({
+        configuredTarget: "auto",
+        requestedTarget: "node",
+        elevatedRequested: false,
+        sandboxAvailable: true,
+      }),
+    ).toThrow(
+      "exec host not allowed (requested node; configured host is auto; set tools.exec.host=node to allow this override).",
     );
   });
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -228,7 +228,10 @@ export function isRequestedExecTargetAllowed(params: {
     return true;
   }
   if (params.configuredTarget === "auto") {
-    if (params.sandboxAvailable && params.requestedTarget === "gateway") {
+    if (
+      params.sandboxAvailable &&
+      (params.requestedTarget === "gateway" || params.requestedTarget === "node")
+    ) {
       return false;
     }
     return true;
@@ -254,9 +257,13 @@ export function resolveExecTarget(params: {
   ) {
     const allowedConfig = Array.from(
       new Set(
-        requestedTarget === "gateway" && !params.sandboxAvailable
-          ? ["gateway", "auto"]
-          : [renderExecTargetLabel(requestedTarget), "auto"],
+        configuredTarget === "auto" &&
+          params.sandboxAvailable &&
+          (requestedTarget === "gateway" || requestedTarget === "node")
+          ? [renderExecTargetLabel(requestedTarget)]
+          : requestedTarget === "gateway" && !params.sandboxAvailable
+            ? ["gateway", "auto"]
+            : [renderExecTargetLabel(requestedTarget), "auto"],
       ),
     ).join(" or ");
     throw new Error(

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import * as execApprovals from "../infra/exec-approvals.js";
-import { resolveExecDefaults } from "./exec-defaults.js";
+import { canExecRequestNode, resolveExecDefaults } from "./exec-defaults.js";
 
 describe("resolveExecDefaults", () => {
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe("resolveExecDefaults", () => {
     ).toBe(false);
   });
 
-  it("keeps node routing available when exec host is auto", () => {
+  it("does not advertise node routing when exec host is auto and sandbox is available", () => {
     expect(
       resolveExecDefaults({
         cfg: {
@@ -42,6 +42,25 @@ describe("resolveExecDefaults", () => {
     ).toMatchObject({
       host: "auto",
       effectiveHost: "sandbox",
+      canRequestNode: false,
+    });
+  });
+
+  it("keeps node routing available when exec host is auto without sandbox", () => {
+    expect(
+      resolveExecDefaults({
+        cfg: {
+          tools: {
+            exec: {
+              host: "auto",
+            },
+          },
+        },
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      host: "auto",
+      effectiveHost: "gateway",
       canRequestNode: true,
     });
   });
@@ -103,5 +122,20 @@ describe("resolveExecDefaults", () => {
       security: "deny",
       ask: "off",
     });
+  });
+
+  it("blocks node advertising in helper calls when sandbox is available", () => {
+    expect(
+      canExecRequestNode({
+        cfg: {
+          tools: {
+            exec: {
+              host: "auto",
+            },
+          },
+        },
+        sandboxAvailable: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/agents/exec-defaults.ts
+++ b/src/agents/exec-defaults.ts
@@ -53,16 +53,38 @@ function resolveExecConfigState(params: {
   };
 }
 
+function resolveExecSandboxAvailability(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  sandboxAvailable?: boolean;
+}) {
+  return (
+    params.sandboxAvailable ??
+    (params.sessionKey
+      ? resolveSandboxRuntimeStatus({
+          cfg: params.cfg,
+          sessionKey: params.sessionKey,
+        }).sandboxed
+      : false)
+  );
+}
+
 export function canExecRequestNode(params: {
   cfg?: OpenClawConfig;
   sessionEntry?: SessionEntry;
   agentId?: string;
   sessionKey?: string;
+  sandboxAvailable?: boolean;
 }): boolean {
-  const { host } = resolveExecConfigState(params);
+  const { cfg, host } = resolveExecConfigState(params);
   return isRequestedExecTargetAllowed({
     configuredTarget: host,
     requestedTarget: "node",
+    sandboxAvailable: resolveExecSandboxAvailability({
+      cfg,
+      sessionKey: params.sessionKey,
+      sandboxAvailable: params.sandboxAvailable,
+    }),
   });
 }
 
@@ -81,14 +103,11 @@ export function resolveExecDefaults(params: {
   canRequestNode: boolean;
 } {
   const { cfg, host, agentExec, globalExec } = resolveExecConfigState(params);
-  const sandboxAvailable =
-    params.sandboxAvailable ??
-    (params.sessionKey
-      ? resolveSandboxRuntimeStatus({
-          cfg,
-          sessionKey: params.sessionKey,
-        }).sandboxed
-      : false);
+  const sandboxAvailable = resolveExecSandboxAvailability({
+    cfg,
+    sessionKey: params.sessionKey,
+    sandboxAvailable: params.sandboxAvailable,
+  });
   const resolved = resolveExecTarget({
     configuredTarget: host,
     elevatedRequested: false,
@@ -115,6 +134,7 @@ export function resolveExecDefaults(params: {
     canRequestNode: isRequestedExecTargetAllowed({
       configuredTarget: host,
       requestedTarget: "node",
+      sandboxAvailable,
     }),
   };
 }


### PR DESCRIPTION
# PR Template

## Summary

- Problem: sandboxed `tools.exec.host=auto` sessions still accepted per-call `host=node` requests, which let exec route off the sandbox onto a connected node.
- Why it matters: the operator explicitly enabled sandboxing for isolation, but the per-call host override bypassed that boundary.
- What changed: `isRequestedExecTargetAllowed()` now rejects both `gateway` and `node` overrides while sandbox-backed `auto` routing is active, and exec default helpers now pass sandbox availability through before advertising node routing.
- What did NOT change (scope boundary): no changes to explicit `tools.exec.host=node` configurations, approval semantics, node execution behavior outside sandbox-backed `auto`, or unrelated exec policy defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #384
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the `auto` host override guard in `src/agents/bash-tools.exec-runtime.ts` only blocked `gateway` when a sandbox runtime was available, so `host=node` still passed allowance checks and resolved to `effectiveHost: "node"`.
- Missing detection / guardrail: there was no regression test covering sandbox-backed `auto` plus per-call `host=node`, and the exec-default advertising helpers did not thread sandbox availability into `canRequestNode`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `git blame` points the relevant allowance branch to `d98eaba4c3b`, which added the sandbox-aware override logic but only rejected `gateway`.
- Why this regressed now: the sandbox-aware override check was only partially restored, so the node path remained open after the earlier host-override fix.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/bash-tools.exec-runtime.test.ts`, `src/agents/exec-defaults.test.ts`
- Scenario the test should lock in: sandbox-backed `tools.exec.host=auto` must reject per-call `host=node`, and default capability helpers must not advertise node routing while sandbox is active.
- Why this is the smallest reliable guardrail: the bypass lives entirely in local host-target allowance/default resolution, so direct unit coverage on those functions proves the real behavior without broader exec orchestration.
- Existing test that already covers this (if any): existing `host=gateway` sandbox override coverage in `src/agents/bash-tools.exec-runtime.test.ts` covered the adjacent path but not the node variant.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Sandbox-backed `tools.exec.host=auto` sessions now reject per-call `host=node` overrides the same way they already rejected `host=gateway`.
- Surfaces that advertise available exec routing no longer present node as available while the session is actively sandboxed under `host=auto`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this narrows the exec routing surface for sandbox-backed `auto` sessions by denying host overrides that escape the sandbox; explicit non-auto host configs keep their existing behavior.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree shell
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `tools.exec.host=auto`, sandbox available

### Steps

1. Run `resolveExecTarget()` with `configuredTarget: "auto"`, `requestedTarget: "node"`, and `sandboxAvailable: true`.
2. Run `resolveExecDefaults()` or `canExecRequestNode()` for the same sandbox-backed `tools.exec.host=auto` state.
3. Run the focused exec tests.

### Expected

- Sandbox-backed `auto` rejects the per-call `host=node` override.
- Exec default helpers report `canRequestNode: false` while sandbox is active.
- Focused tests pass.

### Actual

- After the patch, the override is rejected, node advertising is disabled for sandbox-backed `auto`, and the focused tests pass.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation output:

- `pnpm exec oxfmt --write src/agents/bash-tools.exec-runtime.ts src/agents/exec-defaults.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/exec-defaults.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm test src/agents/bash-tools.exec-runtime.test.ts src/agents/exec-defaults.test.ts`
- Note: the same `pnpm test ...` command without `OPENCLAW_LOCAL_CHECK=0` fails in this worktree because `scripts/test-projects.mjs` tries to create `.git/openclaw-local-checks`, but this worktree uses a `.git` pointer file instead of a directory.

## Human Verification (required)

- Verified scenarios: sandbox-backed `auto` rejects `host=node`; sandbox-backed `auto` no longer advertises node routing; non-sandbox `auto` still allows `host=node`; existing sandbox `host=gateway` rejection remains covered.
- Edge cases checked: explicit `host=node` configs remain allowed; error text for sandbox-blocked `gateway` and `node` overrides now points to the concrete host config instead of claiming `auto` would allow the request.
- What you did **not** verify: full repo build, end-to-end exec flows, and remote node runtime execution. The service-managed post-turn validation will run `pnpm build`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the allowance/default helper changes in `src/agents/bash-tools.exec-runtime.ts` and `src/agents/exec-defaults.ts`.
- Files/config to restore: `src/agents/bash-tools.exec-runtime.ts`, `src/agents/exec-defaults.ts`
- Known bad symptoms reviewers should watch for: sandbox-backed `host=auto` sessions unexpectedly rejecting legitimate explicit non-sandbox configs, or node advertising disappearing when sandbox is not active.

## Risks and Mitigations

- Risk: callers that depended on the previous incorrect `canExecRequestNode()` behavior could have stale expectations in sandbox-backed `auto` sessions.
  - Mitigation: direct tests now cover both the runtime allowance boundary and the advertised capability surface, and explicit `host=node` configs are unchanged.
