### PR TITLE
fix(browser): apply three-phase interaction navigation guard to pressKey and type(submit) [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Docs: https://docs.openclaw.ai
 - Discord/sandbox: include `image` in sandbox media param normalization so Discord event cover images cannot bypass sandbox path rewriting. (#64377) Thanks @mmaps.
 - Agents/exec: extend exec completion detection to cover local background exec formats so the owner-downgrade fires correctly for all exec paths. (#64376) Thanks @mmaps.
 - Security/dependencies: pin axios to 1.15.0 and add a plugin install dependency denylist that blocks known malicious packages before install. (#63891) Thanks @mmaps.
+- Browser/security: apply three-phase interaction navigation guard to pressKey and type(submit) so delayed JS redirects from keypress cannot bypass SSRF policy. (#63889) Thanks @mmaps.
 ## 2026.4.9
 
 ### Changes

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -398,6 +398,115 @@ describe("pw-tools-core interaction navigation guard", () => {
     });
   });
 
+  it("runs the post-keypress navigation guard when navigation starts shortly after the keypress resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const listeners = new Set<() => void>();
+      let currentUrl = "http://127.0.0.1:9222/json/version";
+      const page = {
+        keyboard: {
+          press: vi.fn(async () => {
+            setTimeout(() => {
+              currentUrl = "http://127.0.0.1:9222/private-target";
+              for (const listener of listeners) {
+                listener();
+              }
+            }, 10);
+          }),
+        },
+        on: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.add(listener);
+          }
+        }),
+        off: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.delete(listener);
+          }
+        }),
+        url: vi.fn(() => currentUrl),
+      };
+      setPwToolsCoreCurrentPage(page);
+
+      const task = mod.pressKeyViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        key: "Enter",
+        ssrfPolicy: { allowPrivateNetwork: false },
+      });
+
+      await vi.advanceTimersByTimeAsync(10);
+      await task;
+
+      expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
+        {
+          cdpUrl: "http://127.0.0.1:18792",
+          page,
+          response: null,
+          ssrfPolicy: { allowPrivateNetwork: false },
+          targetId: "T1",
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("propagates blocked delayed submit navigation instead of reporting type success", async () => {
+    vi.useFakeTimers();
+    try {
+      const listeners = new Set<() => void>();
+      let currentUrl = "https://example.com/form";
+      const locator = {
+        fill: vi.fn(async () => {}),
+        press: vi.fn(async () => {
+          setTimeout(() => {
+            currentUrl = "http://127.0.0.1:9222/private-target";
+            for (const listener of listeners) {
+              listener();
+            }
+          }, 10);
+        }),
+      };
+      const page = {
+        on: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.add(listener);
+          }
+        }),
+        off: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.delete(listener);
+          }
+        }),
+        url: vi.fn(() => currentUrl),
+      };
+      setPwToolsCoreCurrentRefLocator(locator);
+      setPwToolsCoreCurrentPage(page);
+
+      const blocked = new Error("blocked delayed interaction navigation");
+      getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely.mockRejectedValueOnce(
+        blocked,
+      );
+
+      const task = mod.typeViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "1",
+        text: "hello",
+        submit: true,
+        ssrfPolicy: { allowPrivateNetwork: false },
+      });
+      const rejection = expect(task).rejects.toThrow("blocked delayed interaction navigation");
+
+      await vi.advanceTimersByTimeAsync(10);
+      await rejection;
+      expect(listeners.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not run the post-click navigation guard when the url is unchanged", async () => {
     const click = vi.fn(async () => {});
     const page = { url: vi.fn(() => "http://127.0.0.1:9222/json/version") };

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -379,25 +379,6 @@ function createAbortPromiseWithListener(
     },
   };
 }
-
-async function assertPostInteractionNavigationSafe(opts: {
-  cdpUrl: string;
-  page: Awaited<ReturnType<typeof getPageForTargetId>>;
-  ssrfPolicy?: SsrFPolicy;
-  targetId?: string;
-}): Promise<void> {
-  if (!opts.ssrfPolicy) {
-    return;
-  }
-  await assertPageNavigationCompletedSafely({
-    cdpUrl: opts.cdpUrl,
-    page: opts.page,
-    response: null,
-    ssrfPolicy: opts.ssrfPolicy,
-    targetId: opts.targetId,
-  });
-}
-
 export async function highlightViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -559,12 +540,16 @@ export async function pressKeyViaPlaywright(opts: {
   }
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
-  await page.keyboard.press(key, {
-    delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
-  });
-  await assertPostInteractionNavigationSafe({
+  const previousUrl = page.url();
+  await assertInteractionNavigationCompletedSafely({
+    action: async () => {
+      await page.keyboard.press(key, {
+        delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
+      });
+    },
     cdpUrl: opts.cdpUrl,
     page,
+    previousUrl,
     ssrfPolicy: opts.ssrfPolicy,
     targetId: opts.targetId,
   });
@@ -597,10 +582,14 @@ export async function typeViaPlaywright(opts: {
       await locator.fill(text, { timeout });
     }
     if (opts.submit) {
-      await locator.press("Enter", { timeout });
-      await assertPostInteractionNavigationSafe({
+      const previousUrl = page.url();
+      await assertInteractionNavigationCompletedSafely({
+        action: async () => {
+          await locator.press("Enter", { timeout });
+        },
         cdpUrl: opts.cdpUrl,
         page,
+        previousUrl,
         ssrfPolicy: opts.ssrfPolicy,
         targetId: opts.targetId,
       });


### PR DESCRIPTION
## Summary

- **Problem:** `pressKeyViaPlaywright` and `typeViaPlaywright` with `submit=true` used a legacy one-shot post-action URL check (`assertPostInteractionNavigationSafe`) that performs no `framenavigated` listener and no delayed-navigation grace window.
- **Why it matters:** A delayed JS redirect triggered by an Enter/submit keypress (e.g. `setTimeout(() => location.href = ..., 100)`) completes after the synchronous URL check returns, bypassing the configured SSRF policy entirely.
- **What changed:** Both functions now wrap their keypress action inside `assertInteractionNavigationCompletedSafely`, matching the three-phase guard already applied to `clickViaPlaywright`, `evaluateViaPlaywright`, and `batchViaPlaywright`. The now-unused `assertPostInteractionNavigationSafe` helper is removed.
- **What did NOT change:** No public API or config surface changes. No behavioral change for non-SSRF-policy paths. No other interaction functions touched.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Commits that introduced `assertInteractionNavigationCompletedSafely` migrated `click`, `evaluate`, and `batch` paths but left `pressKey` and `type(submit)` on the older single-check helper.
- **Missing detection / guardrail:** No regression test for delayed navigation via keypress/submit.
- **Contributing context:** The three-phase guard and legacy helper coexisted in the same file, making the gap non-obvious during the original migration.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
- **Target test:** `extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts`
- **Scenarios added:**
  1. `pressKeyViaPlaywright` — navigation fires 10ms after `keyboard.press` resolves; asserts the grace-window guard calls `assertPageNavigationCompletedSafely`.
  2. `typeViaPlaywright(submit=true)` — delayed navigation is blocked; asserts the rejection propagates and all `framenavigated` listeners are cleaned up (`listeners.size === 0`).
- **Why smallest reliable guardrail:** Both scenarios use fake timers and the existing test-harness mock for `assertPageNavigationCompletedSafely`, directly exercising the previously unguarded code paths with no network or browser process required.

## User-visible / Behavior Changes

None under normal operation. Under SSRF policy enforcement, delayed navigations triggered by Enter/submit keypresses are now correctly blocked instead of silently allowed.

## Diagram (if applicable)

```text
Before (pressKey / type+submit):
[keyboard.press / locator.press] -> [action returns] -> [one-shot URL check]
                                                          ↑ delayed nav fires here → undetected

After:
[framenavigated listener ON] -> [keyboard.press / locator.press] -> [action returns]
-> [listener OFF] -> [grace-window guard: 250ms framenavigated window]
                          ↑ delayed nav fires here → detected → SSRF check runs
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — narrows the SSRF bypass window
- Data access scope changed? No
- **Risk eliminated:** Delayed-redirect SSRF bypass via keypress/submit interactions when SSRF policy is configured.

## Repro + Verification

### Environment

- OS: Linux (CI); Darwin arm64 (local analysis)
- Runtime: Node 22+, Bun
- Model/provider: N/A (browser extension unit tests)
- Integration/channel: Browser extension

### Steps

1. Run scoped test: `pnpm test extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts`
2. Observe both new test cases pass (grace-window guard fires for pressKey; rejection propagates and listeners clean up for type+submit)
3. Confirm no regressions in existing navigation guard tests

### Expected

- All navigation guard tests pass, including the two new cases

### Actual

- All tests pass

## Evidence

- [x] Failing test/log before + passing after — two new test cases added that would have failed against the pre-fix code (no `assertPageNavigationCompletedSafely` call on delayed nav, no rejection propagation)

## Human Verification (required)

- **Verified scenarios:** Code path analysis confirming `assertPostInteractionNavigationSafe` had no `framenavigated` listener and no grace-window scheduling; confirmed `assertInteractionNavigationCompletedSafely` provides both; confirmed removal of the now-dead helper leaves no remaining callers.
- **Edge cases checked:** `ssrfPolicy` absent (early-return path unchanged); `submit=false` in `typeViaPlaywright` (unaffected path); listener cleanup on both success and rejection paths.
- **What was not verified:** Live browser round-trip with a real delayed-redirect page.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Grace-window timer (250ms) adds latency to `pressKey` and `type+submit` when no navigation occurs.
  - **Mitigation:** 250ms matches the existing grace window already accepted for `clickViaPlaywright`; same tradeoff, already product-approved for the click path.