### PR TITLE
fix(voice-call): reject oversized realtime WebSocket frames to prevent gateway DoS [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ Docs: https://docs.openclaw.ai
 - Gateway/restart sentinel: route restart notices only from stored canonical delivery metadata and skip outbound guessing from lossy session keys, avoiding misdelivery on case-sensitive channels like Matrix. (#64391) Thanks @gumadeiras.
 
 - Cron/isolated agent: run scheduled agent turns as non-owner senders so owner-only tools stay unavailable during cron execution. (#63878)
+- Voice Call/realtime: reject oversized realtime WebSocket frames before bridge setup so large pre-start payloads cannot crash the gateway. (#63890) Thanks @mmaps.
+
 ## 2026.4.9
 
 ### Changes

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -192,23 +192,29 @@ describe("RealtimeCallHandler websocket hardening", () => {
 
     try {
       const ws = await connectWs(server.url);
-      ws.send(
-        JSON.stringify({
-          event: "start",
-          start: {
-            streamSid: "MZ-oversized",
-            callSid: "CA-oversized",
-            padding: "A".repeat(300 * 1024),
-          },
-        }),
-      );
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: {
+              streamSid: "MZ-oversized",
+              callSid: "CA-oversized",
+              padding: "A".repeat(300 * 1024),
+            },
+          }),
+        );
 
-      const closed = await waitForClose(ws);
+        const closed = await waitForClose(ws);
 
-      expect(closed.code).toBe(1009);
-      expect(createBridge).not.toHaveBeenCalled();
-      expect(processEvent).not.toHaveBeenCalled();
-      expect(getCallByProviderCallId).not.toHaveBeenCalled();
+        expect(closed.code).toBe(1009);
+        expect(createBridge).not.toHaveBeenCalled();
+        expect(processEvent).not.toHaveBeenCalled();
+        expect(getCallByProviderCallId).not.toHaveBeenCalled();
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
     } finally {
       await server.close();
     }

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1,9 +1,11 @@
+import { once } from "node:events";
 import http from "node:http";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
@@ -30,14 +32,25 @@ function makeBridge(): RealtimeVoiceBridge {
   };
 }
 
-const realtimeProvider: RealtimeVoiceProviderPlugin = {
-  id: "openai",
-  label: "OpenAI",
-  isConfigured: () => true,
-  createBridge: () => makeBridge(),
-};
+function makeRealtimeProvider(
+  createBridge: () => RealtimeVoiceBridge,
+): RealtimeVoiceProviderPlugin {
+  return {
+    id: "openai",
+    label: "OpenAI",
+    isConfigured: () => true,
+    createBridge,
+  };
+}
 
-function makeHandler(overrides?: Partial<VoiceCallRealtimeConfig>) {
+function makeHandler(
+  overrides?: Partial<VoiceCallRealtimeConfig>,
+  deps?: {
+    manager?: Partial<CallManager>;
+    provider?: Partial<VoiceCallProvider>;
+    realtimeProvider?: RealtimeVoiceProviderPlugin;
+  },
+) {
   return new RealtimeCallHandler(
     {
       enabled: true,
@@ -50,6 +63,7 @@ function makeHandler(overrides?: Partial<VoiceCallRealtimeConfig>) {
     {
       processEvent: vi.fn(),
       getCallByProviderCallId: vi.fn(),
+      ...deps?.manager,
     } as unknown as CallManager,
     {
       name: "twilio",
@@ -61,12 +75,83 @@ function makeHandler(overrides?: Partial<VoiceCallRealtimeConfig>) {
       startListening: vi.fn(),
       stopListening: vi.fn(),
       getCallStatus: vi.fn(),
+      ...deps?.provider,
     } as unknown as VoiceCallProvider,
-    realtimeProvider,
+    deps?.realtimeProvider ?? makeRealtimeProvider(() => makeBridge()),
     { apiKey: "test-key" },
     "/voice/webhook",
   );
 }
+
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs = 2000): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
+const startRealtimeServer = async (
+  handler: RealtimeCallHandler,
+): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}> => {
+  const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook"));
+  const match = payload.body.match(/wss:\/\/[^/]+(\/[^"]+)/);
+  if (!match) {
+    throw new Error("Failed to extract realtime stream path");
+  }
+
+  const server = http.createServer();
+  server.on("upgrade", (request, socket, head) => {
+    handler.handleWebSocketUpgrade(request, socket, head);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to resolve test server address");
+  }
+
+  return {
+    url: `ws://127.0.0.1:${address.port}${match[1]}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+};
+
+const connectWs = async (url: string): Promise<WebSocket> => {
+  const ws = new WebSocket(url);
+  await withTimeout(once(ws, "open") as Promise<[unknown]>);
+  return ws;
+};
+
+const waitForClose = async (
+  ws: WebSocket,
+): Promise<{
+  code: number;
+  reason: string;
+}> => {
+  const [code, reason] = (await withTimeout(once(ws, "close") as Promise<[number, Buffer]>)) ?? [];
+  return {
+    code,
+    reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason || ""),
+  };
+};
 
 describe("RealtimeCallHandler path routing", () => {
   it("uses the request host and stream path in TwiML", () => {
@@ -88,5 +173,44 @@ describe("RealtimeCallHandler path routing", () => {
     expect(payload.body).toMatch(
       /wss:\/\/public\.example\/api\/custom\/stream\/realtime\/[0-9a-f-]{36}/,
     );
+  });
+});
+
+describe("RealtimeCallHandler websocket hardening", () => {
+  it("rejects oversized pre-start frames before bridge setup", async () => {
+    const createBridge = vi.fn(() => makeBridge());
+    const processEvent = vi.fn();
+    const getCallByProviderCallId = vi.fn();
+    const handler = makeHandler(undefined, {
+      manager: {
+        processEvent,
+        getCallByProviderCallId,
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: {
+            streamSid: "MZ-oversized",
+            callSid: "CA-oversized",
+            padding: "A".repeat(300 * 1024),
+          },
+        }),
+      );
+
+      const closed = await waitForClose(ws);
+
+      expect(closed.code).toBe(1009);
+      expect(createBridge).not.toHaveBeenCalled();
+      expect(processEvent).not.toHaveBeenCalled();
+      expect(getCallByProviderCallId).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -141,8 +141,7 @@ export class RealtimeCallHandler {
       maxPayload: MAX_REALTIME_MESSAGE_BYTES,
     });
     wss.handleUpgrade(request, socket, head, (ws) => {
-      let bridge!: ActiveRealtimeVoiceBridge;
-      let hasBridge = false;
+      const bridgeRef: { current?: ActiveRealtimeVoiceBridge } = {};
       let initialized = false;
 
       ws.on("message", (data: Buffer) => {
@@ -161,11 +160,11 @@ export class RealtimeCallHandler {
             if (!nextBridge) {
               return;
             }
-            bridge = nextBridge;
-            hasBridge = true;
+            bridgeRef.current = nextBridge;
             return;
           }
-          if (!hasBridge) {
+          const bridge = bridgeRef.current;
+          if (!bridge) {
             return;
           }
           const mediaData =
@@ -194,8 +193,8 @@ export class RealtimeCallHandler {
       });
 
       ws.on("close", () => {
-        if (hasBridge) {
-          bridge.close();
+        if (bridgeRef.current) {
+          bridgeRef.current.close();
         }
       });
 
@@ -258,6 +257,7 @@ export class RealtimeCallHandler {
       this.endCallInManager(callSid, callId, reason);
     };
 
+    const bridgeRef: { current?: ActiveRealtimeVoiceBridge } = {};
     const bridge = this.realtimeProvider.createBridge({
       providerConfig: this.providerConfig,
       instructions: this.config.instructions,
@@ -313,8 +313,12 @@ export class RealtimeCallHandler {
         });
       },
       onToolCall: (toolEvent) => {
+        const activeBridge = bridgeRef.current;
+        if (!activeBridge) {
+          return;
+        }
         void this.executeToolCall(
-          bridge,
+          activeBridge,
           callId,
           toolEvent.callId || toolEvent.itemId,
           toolEvent.name,
@@ -354,6 +358,7 @@ export class RealtimeCallHandler {
       ws.close(1011, "Failed to connect");
     });
 
+    bridgeRef.current = bridge;
     return bridge;
   }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -141,7 +141,7 @@ export class RealtimeCallHandler {
       maxPayload: MAX_REALTIME_MESSAGE_BYTES,
     });
     wss.handleUpgrade(request, socket, head, (ws) => {
-      const bridgeRef: { current?: ActiveRealtimeVoiceBridge } = {};
+      let bridge: ActiveRealtimeVoiceBridge | null = null;
       let initialized = false;
 
       ws.on("message", (data: Buffer) => {
@@ -160,10 +160,9 @@ export class RealtimeCallHandler {
             if (!nextBridge) {
               return;
             }
-            bridgeRef.current = nextBridge;
+            bridge = nextBridge;
             return;
           }
-          const bridge = bridgeRef.current;
           if (!bridge) {
             return;
           }
@@ -193,9 +192,7 @@ export class RealtimeCallHandler {
       });
 
       ws.on("close", () => {
-        if (bridgeRef.current) {
-          bridgeRef.current.close();
-        }
+        bridge?.close();
       });
 
       ws.on("error", (error) => {
@@ -240,7 +237,7 @@ export class RealtimeCallHandler {
     callSid: string,
     ws: WebSocket,
     callerMeta: Omit<PendingStreamToken, "expiry">,
-  ) {
+  ): ActiveRealtimeVoiceBridge | null {
     const registration = this.registerCallInManager(callSid, callerMeta);
     if (!registration) {
       ws.close(1008, "Caller rejected by policy");
@@ -326,7 +323,7 @@ export class RealtimeCallHandler {
         );
       },
       onReady: () => {
-        bridge?.triggerGreeting?.(initialGreetingInstructions);
+        bridgeRef.current?.triggerGreeting?.(initialGreetingInstructions);
       },
       onError: (error) => {
         console.error("[voice-call] realtime voice error:", error.message);
@@ -351,14 +348,15 @@ export class RealtimeCallHandler {
       },
     });
 
+    bridgeRef.current = bridge;
+
     bridge.connect().catch((error: Error) => {
       console.error("[voice-call] Failed to connect realtime bridge:", error);
-      bridge?.close();
+      bridge.close();
       emitCallEnd("error");
       ws.close(1011, "Failed to connect");
     });
 
-    bridgeRef.current = bridge;
     return bridge;
   }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 import type { Duplex } from "node:stream";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type {
+  RealtimeVoiceBridge,
   RealtimeVoiceProviderConfig,
   RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
@@ -58,17 +59,16 @@ type CallRegistration = {
   initialGreetingInstructions?: string;
 };
 
-// Keep this local seam narrow because the SDK bridge type currently degrades to `any`
-// under the commit-time lint/type pass in this file.
-type ActiveRealtimeVoiceBridge = {
-  connect(): Promise<void>;
-  sendAudio(audio: Buffer): void;
-  setMediaTimestamp(ts: number): void;
-  submitToolResult(callId: string, result: unknown): void;
-  acknowledgeMark(): void;
-  close(): void;
-  triggerGreeting?(instructions?: string): void;
-};
+type ActiveRealtimeVoiceBridge = Pick<
+  RealtimeVoiceBridge,
+  | "connect"
+  | "sendAudio"
+  | "setMediaTimestamp"
+  | "submitToolResult"
+  | "acknowledgeMark"
+  | "close"
+  | "triggerGreeting"
+>;
 
 export class RealtimeCallHandler {
   private readonly toolHandlers = new Map<string, ToolHandlerFn>();
@@ -141,7 +141,8 @@ export class RealtimeCallHandler {
       maxPayload: MAX_REALTIME_MESSAGE_BYTES,
     });
     wss.handleUpgrade(request, socket, head, (ws) => {
-      let bridge: ActiveRealtimeVoiceBridge | null = null;
+      let bridge!: ActiveRealtimeVoiceBridge;
+      let hasBridge = false;
       let initialized = false;
 
       ws.on("message", (data: Buffer) => {
@@ -156,10 +157,15 @@ export class RealtimeCallHandler {
             const streamSid =
               typeof startData?.streamSid === "string" ? startData.streamSid : "unknown";
             const callSid = typeof startData?.callSid === "string" ? startData.callSid : "unknown";
-            bridge = this.handleCall(streamSid, callSid, ws, callerMeta);
+            const nextBridge = this.handleCall(streamSid, callSid, ws, callerMeta);
+            if (!nextBridge) {
+              return;
+            }
+            bridge = nextBridge;
+            hasBridge = true;
             return;
           }
-          if (!bridge) {
+          if (!hasBridge) {
             return;
           }
           const mediaData =
@@ -188,7 +194,9 @@ export class RealtimeCallHandler {
       });
 
       ws.on("close", () => {
-        bridge?.close();
+        if (hasBridge) {
+          bridge.close();
+        }
       });
 
       ws.on("error", (error) => {
@@ -233,7 +241,7 @@ export class RealtimeCallHandler {
     callSid: string,
     ws: WebSocket,
     callerMeta: Omit<PendingStreamToken, "expiry">,
-  ): ActiveRealtimeVoiceBridge | null {
+  ) {
     const registration = this.registerCallInManager(callSid, callerMeta);
     if (!registration) {
       ws.close(1008, "Caller rejected by policy");
@@ -241,7 +249,6 @@ export class RealtimeCallHandler {
     }
 
     const { callId, initialGreetingInstructions } = registration;
-    let bridge: ActiveRealtimeVoiceBridge | null = null;
     let callEndEmitted = false;
     const emitCallEnd = (reason: "completed" | "error") => {
       if (callEndEmitted) {
@@ -251,7 +258,7 @@ export class RealtimeCallHandler {
       this.endCallInManager(callSid, callId, reason);
     };
 
-    bridge = this.realtimeProvider.createBridge({
+    const bridge = this.realtimeProvider.createBridge({
       providerConfig: this.providerConfig,
       instructions: this.config.instructions,
       tools: this.config.tools,
@@ -306,9 +313,6 @@ export class RealtimeCallHandler {
         });
       },
       onToolCall: (toolEvent) => {
-        if (!bridge) {
-          return;
-        }
         void this.executeToolCall(
           bridge,
           callId,

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -58,10 +58,12 @@ type CallRegistration = {
   initialGreetingInstructions?: string;
 };
 
+// Keep this local seam narrow because the SDK bridge type currently degrades to `any`
+// under the commit-time lint/type pass in this file.
 type ActiveRealtimeVoiceBridge = {
   connect(): Promise<void>;
   sendAudio(audio: Buffer): void;
-  setMediaTimestamp(timestamp: number): void;
+  setMediaTimestamp(ts: number): void;
   submitToolResult(callId: string, result: unknown): void;
   acknowledgeMark(): void;
   close(): void;

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -3,7 +3,6 @@ import http from "node:http";
 import type { Duplex } from "node:stream";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type {
-  RealtimeVoiceBridge,
   RealtimeVoiceProviderConfig,
   RealtimeVoiceProviderPlugin,
 } from "openclaw/plugin-sdk/realtime-voice";
@@ -18,6 +17,7 @@ export type ToolHandlerFn = (args: unknown, callId: string) => Promise<unknown>;
 
 const STREAM_TOKEN_TTL_MS = 30_000;
 const DEFAULT_HOST = "localhost:8443";
+const MAX_REALTIME_MESSAGE_BYTES = 256 * 1024;
 
 function normalizePath(pathname: string): string {
   const trimmed = pathname.trim();
@@ -56,6 +56,16 @@ type PendingStreamToken = {
 type CallRegistration = {
   callId: string;
   initialGreetingInstructions?: string;
+};
+
+type ActiveRealtimeVoiceBridge = {
+  connect(): Promise<void>;
+  sendAudio(audio: Buffer): void;
+  setMediaTimestamp(timestamp: number): void;
+  submitToolResult(callId: string, result: unknown): void;
+  acknowledgeMark(): void;
+  close(): void;
+  triggerGreeting?(instructions?: string): void;
 };
 
 export class RealtimeCallHandler {
@@ -123,9 +133,13 @@ export class RealtimeCallHandler {
       return;
     }
 
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({
+      noServer: true,
+      // Reject oversized realtime frames before JSON parsing or bridge setup runs.
+      maxPayload: MAX_REALTIME_MESSAGE_BYTES,
+    });
     wss.handleUpgrade(request, socket, head, (ws) => {
-      let bridge: RealtimeVoiceBridge | null = null;
+      let bridge: ActiveRealtimeVoiceBridge | null = null;
       let initialized = false;
 
       ws.on("message", (data: Buffer) => {
@@ -174,6 +188,10 @@ export class RealtimeCallHandler {
       ws.on("close", () => {
         bridge?.close();
       });
+
+      ws.on("error", (error) => {
+        console.error("[voice-call] realtime WS error:", error);
+      });
     });
   }
 
@@ -213,7 +231,7 @@ export class RealtimeCallHandler {
     callSid: string,
     ws: WebSocket,
     callerMeta: Omit<PendingStreamToken, "expiry">,
-  ): RealtimeVoiceBridge | null {
+  ): ActiveRealtimeVoiceBridge | null {
     const registration = this.registerCallInManager(callSid, callerMeta);
     if (!registration) {
       ws.close(1008, "Caller rejected by policy");
@@ -221,7 +239,7 @@ export class RealtimeCallHandler {
     }
 
     const { callId, initialGreetingInstructions } = registration;
-    let bridge: RealtimeVoiceBridge | null = null;
+    let bridge: ActiveRealtimeVoiceBridge | null = null;
     let callEndEmitted = false;
     const emitCallEnd = (reason: "completed" | "error") => {
       if (callEndEmitted) {
@@ -397,7 +415,7 @@ export class RealtimeCallHandler {
   }
 
   private async executeToolCall(
-    bridge: RealtimeVoiceBridge,
+    bridge: ActiveRealtimeVoiceBridge,
     callId: string,
     bridgeCallId: string,
     name: string,


### PR DESCRIPTION
## Summary

- **Problem:** The `voice-call` realtime WebSocket endpoint (`RealtimeCallHandler.handleWebSocketUpgrade`) created a `WebSocketServer` with no `maxPayload` limit and no `error` event handler. Sending an oversized frame caused the `ws` runtime to throw an uncaught `RangeError`, crashing the entire gateway process.
- **Why it matters:** Any caller who can reach the realtime stream URL (valid token required) could crash the gateway, dropping all active sessions across all channels.
- **What changed:** Added `maxPayload: 256 KB` to the per-connection `WebSocketServer` so the `ws` library rejects oversized frames with a 1009 close code before JSON parsing or bridge setup runs. Added a `ws.on("error", ...)` handler to absorb the resulting error event. Refactored `ActiveRealtimeVoiceBridge` as `Pick<RealtimeVoiceBridge, ...>` to keep the local type anchored to the SDK definition.
- **What did NOT change:** No changes to auth, routing, config schema, the bridge protocol, or any other channel.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `WebSocketServer` was constructed without `maxPayload`, so the `ws` library had no frame-size bound. On receipt of an oversized frame it emits an `error` event; with no handler registered, Node.js treats it as an uncaught exception and terminates the process.
- Missing detection / guardrail: No frame-size limit and no error event handler on the per-connection WebSocket instance.
- Contributing context (if known): The gateway runs voice-call in-process, so a single crashed WebSocket tears down the whole gateway.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `extensions/voice-call/src/webhook/realtime-handler.test.ts`
- Scenario the test should lock in: A WebSocket client that sends a >256 KB frame receives a 1009 close code, and `createBridge` / `processEvent` / `getCallByProviderCallId` are never called.
- Why this is the smallest reliable guardrail: Exercises the real `ws` `maxPayload` enforcement path end-to-end without requiring a live Twilio session.
- Existing test that already covers this (if any): None — new test added.

## User-visible / Behavior Changes

Realtime stream clients that send frames larger than 256 KB will now receive a WebSocket 1009 (Message Too Big) close frame instead of crashing the gateway. Normal Twilio Media Stream control frames are well under this limit.

## Diagram (if applicable)

```text
Before:
[oversized frame] -> ws runtime throws RangeError -> uncaught exception -> gateway crash

After:
[oversized frame] -> ws maxPayload check -> 1009 close sent -> error event logged -> session closed cleanly
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22, gateway in-process
- Integration/channel: voice-call realtime WebSocket

### Steps

1. Start gateway with voice-call realtime enabled
2. Obtain a valid stream token via the `/voice/webhook` TwiML endpoint
3. Connect a WebSocket client and send a frame > 256 KB

### Expected

- Client receives close code 1009
- Gateway continues running; all other sessions unaffected

### Actual (before fix)

- Gateway process crashes with `RangeError: Max payload size exceeded`

## Evidence

- [x] Failing test/log before + passing after — new integration test `RealtimeCallHandler websocket hardening > rejects oversized pre-start frames before bridge setup` added and passing.

## Human Verification (required)

- Verified scenarios: Integration test runs end-to-end against a real HTTP/WebSocket server; asserts 1009 close code and confirms bridge/manager mocks are never invoked.
- Edge cases checked: Frame sent before `start` event (pre-bridge); `hasBridge` flag correctly prevents access to uninitialized bridge on close.
- What you did **not** verify: Live Twilio session with real media frames; Windows/macOS gateway restart behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: 256 KB limit could reject unexpectedly large but legitimate frames in future protocol extensions.
  - Mitigation: Limit is 4× the largest documented Twilio Media Stream frame. If a legitimate use case requires larger frames, `MAX_REALTIME_MESSAGE_BYTES` is a named constant easy to adjust with a test update.