### PR TITLE
fix(security): pin axios to 1.15.0 and add dependency denylist for plugin installs [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Docs: https://docs.openclaw.ai
 
 - Discord/sandbox: include `image` in sandbox media param normalization so Discord event cover images cannot bypass sandbox path rewriting. (#64377) Thanks @mmaps.
 - Agents/exec: extend exec completion detection to cover local background exec formats so the owner-downgrade fires correctly for all exec paths. (#64376) Thanks @mmaps.
+- Security/dependencies: pin axios to 1.15.0 and add a plugin install dependency denylist that blocks known malicious packages before install. (#63891) Thanks @mmaps.
 ## 2026.4.9
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1427,6 +1427,9 @@
     "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
     "openshell": "0.1.0"
   },
+  "overrides": {
+    "axios": "1.14.0"
+  },
   "engines": {
     "node": ">=22.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -1428,7 +1428,7 @@
     "openshell": "0.1.0"
   },
   "overrides": {
-    "axios": "1.14.0"
+    "axios": "1.15.0"
   },
   "engines": {
     "node": ">=22.14.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
   - "acpx"
+  - "axios"
   - "basic-ftp"
   - "hono"
   - "openclaw"

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -163,7 +163,10 @@ export async function installPackageDir(params: {
   hasDeps: boolean;
   depsLogMessage: string;
   afterCopy?: (installedDir: string) => void | Promise<void>;
-}): Promise<{ ok: true } | { ok: false; error: string }> {
+  afterInstall?: (
+    installedDir: string,
+  ) => Promise<{ ok: true } | { ok: false; error: string; code?: string }>;
+}): Promise<{ ok: true } | { ok: false; error: string; code?: string }> {
   params.logger?.info?.(`Installing to ${params.targetDir}…`);
   const installBaseDir = path.dirname(params.targetDir);
   await fs.mkdir(installBaseDir, { recursive: true });
@@ -196,6 +199,10 @@ export async function installPackageDir(params: {
       }
     }
     return { ok: false as const, error };
+  };
+  const failWithCode = async (params: { error: string; code?: string }, cause?: unknown) => {
+    const failed = await fail(params.error, cause);
+    return params.code ? { ...failed, code: params.code } : failed;
   };
   const restoreBackup = async () => {
     if (!backupDir) {
@@ -247,6 +254,17 @@ export async function installPackageDir(params: {
       }
     } catch (error) {
       return await fail(`npm install failed: ${String(error)}`, error);
+    }
+  }
+
+  if (params.afterInstall) {
+    try {
+      const postInstallResult = await params.afterInstall(stageDir);
+      if (!postInstallResult.ok) {
+        return await failWithCode(postInstallResult);
+      }
+    } catch (err) {
+      return await fail(`post-install validation failed: ${String(err)}`, err);
     }
   }
 

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -5,6 +5,7 @@ import {
   blockedInstallDependencyPackageNames,
   findBlockedManifestDependencies,
   findBlockedNodeModulesDirectory,
+  findBlockedNodeModulesFileAlias,
 } from "./dependency-denylist.js";
 
 type RootPackageManifest = {
@@ -107,10 +108,29 @@ describe("dependency denylist guardrails", () => {
     });
   });
 
+  it("finds blocked package file aliases under node_modules regardless of casing", () => {
+    expect(
+      findBlockedNodeModulesFileAlias({
+        fileRelativePath: "vendor/Node_Modules/Plain-Crypto-Js.Js",
+      }),
+    ).toEqual({
+      dependencyName: "Plain-Crypto-Js",
+      fileRelativePath: "vendor/Node_Modules/Plain-Crypto-Js.Js",
+    });
+  });
+
   it("does not treat similarly named non-node_modules segments as package-resolution paths", () => {
     expect(
       findBlockedNodeModulesDirectory({
         directoryRelativePath: "vendor/node_modules_backup/plain-crypto-js",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not treat similarly named non-node_modules file aliases as package-resolution paths", () => {
+    expect(
+      findBlockedNodeModulesFileAlias({
+        fileRelativePath: "vendor/plain-crypto-js.js",
       }),
     ).toBeUndefined();
   });

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -26,6 +26,19 @@ function readRootLockfile(): string {
 }
 
 describe("dependency denylist guardrails", () => {
+  it("finds blocked package names on vendored manifests", () => {
+    expect(
+      findBlockedManifestDependencies({
+        name: "plain-crypto-js",
+      }),
+    ).toEqual([
+      {
+        dependencyName: "plain-crypto-js",
+        field: "name",
+      },
+    ]);
+  });
+
   it("finds blocked packages declared through npm alias specs", () => {
     expect(
       findBlockedManifestDependencies({

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -26,6 +26,25 @@ function readRootLockfile(): string {
 }
 
 describe("dependency denylist guardrails", () => {
+  it("finds blocked packages declared through npm alias specs", () => {
+    expect(
+      findBlockedManifestDependencies({
+        dependencies: {
+          "safe-name": "npm:plain-crypto-js@^4.2.1",
+        },
+        peerDependencies: {
+          "@alias/safe": "npm:@scope/ok@^1.0.0",
+        },
+      }),
+    ).toEqual([
+      {
+        dependencyName: "plain-crypto-js",
+        declaredAs: "safe-name",
+        field: "dependencies",
+      },
+    ]);
+  });
+
   it("pins the axios override to an exact version", () => {
     const manifest = readRootManifest();
     expect(manifest.pnpm?.overrides?.axios).toMatch(/^\d+\.\d+\.\d+$/);

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -26,9 +26,9 @@ function readRootLockfile(): string {
 }
 
 describe("dependency denylist guardrails", () => {
-  it("pins the axios override to the official 1.14.0 release", () => {
+  it("pins the axios override to an exact version", () => {
     const manifest = readRootManifest();
-    expect(manifest.pnpm?.overrides?.axios).toBe("1.14.0");
+    expect(manifest.pnpm?.overrides?.axios).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
   it("keeps blocked packages out of the root manifest", () => {

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   blockedInstallDependencyPackageNames,
   findBlockedManifestDependencies,
+  findBlockedNodeModulesDirectory,
 } from "./dependency-denylist.js";
 
 type RootPackageManifest = {
@@ -82,6 +83,25 @@ describe("dependency denylist guardrails", () => {
     const manifest = readRootManifest();
     expect(manifest.overrides?.axios).toMatch(/^\d+\.\d+\.\d+$/);
     expect(manifest.pnpm?.overrides?.axios).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("finds blocked package directories under node_modules regardless of node_modules casing", () => {
+    expect(
+      findBlockedNodeModulesDirectory({
+        directoryRelativePath: "vendor/Node_Modules/plain-crypto-js",
+      }),
+    ).toEqual({
+      dependencyName: "plain-crypto-js",
+      directoryRelativePath: "vendor/Node_Modules/plain-crypto-js",
+    });
+  });
+
+  it("does not treat similarly named non-node_modules segments as package-resolution paths", () => {
+    expect(
+      findBlockedNodeModulesDirectory({
+        directoryRelativePath: "vendor/node_modules_backup/plain-crypto-js",
+      }),
+    ).toBeUndefined();
   });
 
   it("keeps blocked packages out of the root manifest", () => {

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -96,6 +96,17 @@ describe("dependency denylist guardrails", () => {
     });
   });
 
+  it("finds blocked package directories regardless of blocked package segment casing", () => {
+    expect(
+      findBlockedNodeModulesDirectory({
+        directoryRelativePath: "vendor/node_modules/Plain-Crypto-Js",
+      }),
+    ).toEqual({
+      dependencyName: "Plain-Crypto-Js",
+      directoryRelativePath: "vendor/node_modules/Plain-Crypto-Js",
+    });
+  });
+
   it("does not treat similarly named non-node_modules segments as package-resolution paths", () => {
     expect(
       findBlockedNodeModulesDirectory({

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  blockedInstallDependencyPackageNames,
+  findBlockedManifestDependencies,
+} from "./dependency-denylist.js";
+
+type RootPackageManifest = {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  pnpm?: {
+    overrides?: Record<string, string>;
+  };
+};
+
+function readRootManifest(): RootPackageManifest {
+  return JSON.parse(
+    fs.readFileSync(path.resolve(process.cwd(), "package.json"), "utf8"),
+  ) as RootPackageManifest;
+}
+
+function readRootLockfile(): string {
+  return fs.readFileSync(path.resolve(process.cwd(), "pnpm-lock.yaml"), "utf8");
+}
+
+describe("dependency denylist guardrails", () => {
+  it("pins the axios override to the official 1.14.0 release", () => {
+    const manifest = readRootManifest();
+    expect(manifest.pnpm?.overrides?.axios).toBe("1.14.0");
+  });
+
+  it("keeps blocked packages out of the root manifest", () => {
+    const manifest = readRootManifest();
+    expect(findBlockedManifestDependencies(manifest)).toEqual([]);
+  });
+
+  it("keeps blocked packages out of the lockfile graph", () => {
+    const lockfile = readRootLockfile();
+    for (const packageName of blockedInstallDependencyPackageNames) {
+      expect(lockfile).not.toContain(`\n  ${packageName}@`);
+      expect(lockfile).not.toContain(`\n      ${packageName}: `);
+    }
+  });
+});

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -119,6 +119,17 @@ describe("dependency denylist guardrails", () => {
     });
   });
 
+  it("finds blocked extensionless package file aliases under node_modules", () => {
+    expect(
+      findBlockedNodeModulesFileAlias({
+        fileRelativePath: "vendor/Node_Modules/Plain-Crypto-Js",
+      }),
+    ).toEqual({
+      dependencyName: "Plain-Crypto-Js",
+      fileRelativePath: "vendor/Node_Modules/Plain-Crypto-Js",
+    });
+  });
+
   it("does not treat similarly named non-node_modules segments as package-resolution paths", () => {
     expect(
       findBlockedNodeModulesDirectory({
@@ -131,6 +142,14 @@ describe("dependency denylist guardrails", () => {
     expect(
       findBlockedNodeModulesFileAlias({
         fileRelativePath: "vendor/plain-crypto-js.js",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not treat dotted non-loadable file aliases as blocked package paths", () => {
+    expect(
+      findBlockedNodeModulesFileAlias({
+        fileRelativePath: "vendor/node_modules/plain-crypto-js.txt",
       }),
     ).toBeUndefined();
   });

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -9,7 +9,7 @@ import {
 type RootPackageManifest = {
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
-  overrides?: Record<string, string>;
+  overrides?: Record<string, string | Record<string, string>>;
   peerDependencies?: Record<string, string>;
   pnpm?: {
     overrides?: Record<string, string>;
@@ -63,7 +63,7 @@ describe("dependency denylist guardrails", () => {
     expect(
       findBlockedManifestDependencies({
         overrides: {
-          axios: "1.14.0",
+          axios: "1.15.0",
           "@scope/parent": {
             "safe-name": "npm:plain-crypto-js@^4.2.1",
           },

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   blockedInstallDependencyPackageNames,
+  findBlockedPackageDirectoryInPath,
+  findBlockedPackageFileAliasInPath,
   findBlockedManifestDependencies,
   findBlockedNodeModulesDirectory,
   findBlockedNodeModulesFileAlias,
@@ -130,6 +132,28 @@ describe("dependency denylist guardrails", () => {
     });
   });
 
+  it("finds blocked package directories anywhere in a resolved path", () => {
+    expect(
+      findBlockedPackageDirectoryInPath({
+        pathRelativeToRoot: "vendor/Plain-Crypto-Js/dist/index.js",
+      }),
+    ).toEqual({
+      dependencyName: "Plain-Crypto-Js",
+      directoryRelativePath: "vendor/Plain-Crypto-Js/dist/index.js",
+    });
+  });
+
+  it("finds blocked package file aliases anywhere in a resolved path", () => {
+    expect(
+      findBlockedPackageFileAliasInPath({
+        pathRelativeToRoot: "vendor/Plain-Crypto-Js.Js",
+      }),
+    ).toEqual({
+      dependencyName: "Plain-Crypto-Js",
+      fileRelativePath: "vendor/Plain-Crypto-Js.Js",
+    });
+  });
+
   it("does not treat similarly named non-node_modules segments as package-resolution paths", () => {
     expect(
       findBlockedNodeModulesDirectory({
@@ -150,6 +174,14 @@ describe("dependency denylist guardrails", () => {
     expect(
       findBlockedNodeModulesFileAlias({
         fileRelativePath: "vendor/node_modules/plain-crypto-js.txt",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not treat similarly named non-package paths as blocked package directories", () => {
+    expect(
+      findBlockedPackageDirectoryInPath({
+        pathRelativeToRoot: "vendor/safe-plain-crypto-js-notes/index.js",
       }),
     ).toBeUndefined();
   });

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -9,6 +9,7 @@ import {
 type RootPackageManifest = {
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  overrides?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   pnpm?: {
     overrides?: Record<string, string>;
@@ -58,8 +59,28 @@ describe("dependency denylist guardrails", () => {
     ]);
   });
 
+  it("finds blocked packages declared through nested override alias specs", () => {
+    expect(
+      findBlockedManifestDependencies({
+        overrides: {
+          axios: "1.14.0",
+          "@scope/parent": {
+            "safe-name": "npm:plain-crypto-js@^4.2.1",
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        dependencyName: "plain-crypto-js",
+        declaredAs: "@scope/parent > safe-name",
+        field: "overrides",
+      },
+    ]);
+  });
+
   it("pins the axios override to an exact version", () => {
     const manifest = readRootManifest();
+    expect(manifest.overrides?.axios).toMatch(/^\d+\.\d+\.\d+$/);
     expect(manifest.pnpm?.overrides?.axios).toMatch(/^\d+\.\d+\.\d+$/);
   });
 

--- a/src/plugins/dependency-denylist.test.ts
+++ b/src/plugins/dependency-denylist.test.ts
@@ -186,6 +186,14 @@ describe("dependency denylist guardrails", () => {
     ).toBeUndefined();
   });
 
+  it("does not flag the unscoped name segment from an allowed scoped package path", () => {
+    expect(
+      findBlockedPackageDirectoryInPath({
+        pathRelativeToRoot: "vendor/@scope/plain-crypto-js/dist/index.js",
+      }),
+    ).toBeUndefined();
+  });
+
   it("keeps blocked packages out of the root manifest", () => {
     const manifest = readRootManifest();
     expect(findBlockedManifestDependencies(manifest)).toEqual([]);

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -10,17 +10,26 @@ export type BlockedManifestDependencyFinding = {
   field: "dependencies" | "name" | "optionalDependencies" | "overrides" | "peerDependencies";
 };
 
-type PackageDependencyFields = {
-  name?: string;
-} & Partial<
-  Record<Exclude<BlockedManifestDependencyFinding["field"], "name">, Record<string, string>>
+type PackageDependencyMapFields = Partial<
+  Record<
+    Exclude<BlockedManifestDependencyFinding["field"], "name" | "overrides">,
+    Record<string, string>
+  >
 >;
 
-type PackageOverrideFields = {
-  overrides?: PackageOverrideValue;
-};
+type PackageDependencyFields = {
+  name?: string;
+} & PackageDependencyMapFields;
 
-type PackageOverrideValue = string | Record<string, PackageOverrideValue>;
+interface PackageOverrideObject {
+  [key: string]: PackageOverrideValue;
+}
+
+type PackageOverrideValue = string | PackageOverrideObject;
+
+type PackageOverrideFields = {
+  overrides?: unknown;
+};
 
 const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET = new Set<string>(
   blockedInstallDependencyPackageNames,
@@ -108,6 +117,10 @@ function collectBlockedOverrideFindings(
   return findings;
 }
 
+function isPackageOverrideObject(value: unknown): value is PackageOverrideObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function findBlockedManifestDependencies(
   manifest: PackageDependencyFields & PackageOverrideFields,
 ): BlockedManifestDependencyFinding[] {
@@ -115,7 +128,7 @@ export function findBlockedManifestDependencies(
   if (manifest.name && BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(manifest.name)) {
     findings.push({ dependencyName: manifest.name, field: "name" });
   }
-  if (manifest.overrides) {
+  if (isPackageOverrideObject(manifest.overrides)) {
     findings.push(...collectBlockedOverrideFindings(manifest.overrides));
   }
   for (const field of ["dependencies", "optionalDependencies", "peerDependencies"] as const) {

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -6,6 +6,7 @@ export const blockedInstallDependencyPackageNames = [
 
 export type BlockedManifestDependencyFinding = {
   dependencyName: string;
+  declaredAs?: string;
   field: "dependencies" | "optionalDependencies" | "peerDependencies";
 };
 
@@ -17,6 +18,30 @@ const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET = new Set<string>(
   blockedInstallDependencyPackageNames,
 );
 
+function parseNpmAliasTargetPackageName(spec: string): string | undefined {
+  const normalized = spec.trim();
+  if (!normalized.startsWith("npm:")) {
+    return undefined;
+  }
+
+  const aliasTarget = normalized.slice("npm:".length).trim();
+  if (!aliasTarget) {
+    return undefined;
+  }
+
+  if (aliasTarget.startsWith("@")) {
+    const slashIndex = aliasTarget.indexOf("/");
+    if (slashIndex < 0) {
+      return undefined;
+    }
+    const versionSeparatorIndex = aliasTarget.indexOf("@", slashIndex + 1);
+    return versionSeparatorIndex < 0 ? aliasTarget : aliasTarget.slice(0, versionSeparatorIndex);
+  }
+
+  const versionSeparatorIndex = aliasTarget.indexOf("@");
+  return versionSeparatorIndex < 0 ? aliasTarget : aliasTarget.slice(0, versionSeparatorIndex);
+}
+
 export function findBlockedManifestDependencies(
   manifest: PackageDependencyFields,
 ): BlockedManifestDependencyFinding[] {
@@ -27,10 +52,23 @@ export function findBlockedManifestDependencies(
       continue;
     }
     for (const dependencyName of Object.keys(dependencyMap).toSorted()) {
-      if (!BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(dependencyName)) {
+      if (BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(dependencyName)) {
+        findings.push({ dependencyName, field });
         continue;
       }
-      findings.push({ dependencyName, field });
+
+      const aliasTargetPackageName = parseNpmAliasTargetPackageName(dependencyMap[dependencyName]);
+      if (!aliasTargetPackageName) {
+        continue;
+      }
+      if (!BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(aliasTargetPackageName)) {
+        continue;
+      }
+      findings.push({
+        dependencyName: aliasTargetPackageName,
+        declaredAs: dependencyName,
+        field,
+      });
     }
   }
   return findings;

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -1,0 +1,37 @@
+const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAMES = ["plain-crypto-js"] as const;
+
+export const blockedInstallDependencyPackageNames = [
+  ...BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAMES,
+] as const;
+
+export type BlockedManifestDependencyFinding = {
+  dependencyName: string;
+  field: "dependencies" | "optionalDependencies" | "peerDependencies";
+};
+
+type PackageDependencyFields = Partial<
+  Record<BlockedManifestDependencyFinding["field"], Record<string, string>>
+>;
+
+const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET = new Set<string>(
+  blockedInstallDependencyPackageNames,
+);
+
+export function findBlockedManifestDependencies(
+  manifest: PackageDependencyFields,
+): BlockedManifestDependencyFinding[] {
+  const findings: BlockedManifestDependencyFinding[] = [];
+  for (const field of ["dependencies", "optionalDependencies", "peerDependencies"] as const) {
+    const dependencyMap = manifest[field];
+    if (!dependencyMap) {
+      continue;
+    }
+    for (const dependencyName of Object.keys(dependencyMap).toSorted()) {
+      if (!BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(dependencyName)) {
+        continue;
+      }
+      findings.push({ dependencyName, field });
+    }
+  }
+  return findings;
+}

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -286,6 +286,7 @@ export function findBlockedPackageDirectoryInPath(params: {
       }
       const scopedPackageId = `${packageScopeOrName}/${packageName}`;
       if (!isBlockedInstallDependencyPackagePathName(scopedPackageId)) {
+        index += 1;
         continue;
       }
       return {

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -15,6 +15,11 @@ export type BlockedPackageDirectoryFinding = {
   directoryRelativePath: string;
 };
 
+export type BlockedPackageFileFinding = {
+  dependencyName: string;
+  fileRelativePath: string;
+};
+
 type PackageDependencyMapFields = Partial<
   Record<
     Exclude<BlockedManifestDependencyFinding["field"], "name" | "overrides">,
@@ -50,6 +55,52 @@ function isBlockedInstallDependencyPackageName(packageName: string): boolean {
 
 function isBlockedInstallDependencyPackagePathName(packageName: string): boolean {
   return BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_LOWER_SET.has(packageName.toLowerCase());
+}
+
+function normalizePathSegments(relativePath: string): string[] {
+  return relativePath
+    .split(/[\\/]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function parseBlockedNodeModulesPackageId(
+  segments: string[],
+  packageNameSegmentTransform: (packageNameSegment: string) => string | undefined,
+): string | undefined {
+  for (let index = 0; index < segments.length; index += 1) {
+    if (segments[index]?.toLowerCase() !== "node_modules") {
+      continue;
+    }
+    const packageScopeOrName = segments[index + 1];
+    if (!packageScopeOrName) {
+      continue;
+    }
+
+    if (packageScopeOrName.startsWith("@")) {
+      const packageNameSegment = segments[index + 2];
+      if (!packageNameSegment) {
+        continue;
+      }
+      const packageName = packageNameSegmentTransform(packageNameSegment);
+      if (!packageName) {
+        continue;
+      }
+      const scopedPackageId = `${packageScopeOrName}/${packageName}`;
+      if (!isBlockedInstallDependencyPackagePathName(scopedPackageId)) {
+        continue;
+      }
+      return scopedPackageId;
+    }
+
+    const packageName = packageNameSegmentTransform(packageScopeOrName);
+    if (!packageName || !isBlockedInstallDependencyPackagePathName(packageName)) {
+      continue;
+    }
+    return packageName;
+  }
+
+  return undefined;
 }
 
 function parseNpmAliasTargetPackageName(spec: string): string | undefined {
@@ -179,43 +230,37 @@ export function findBlockedManifestDependencies(
 export function findBlockedNodeModulesDirectory(params: {
   directoryRelativePath: string;
 }): BlockedPackageDirectoryFinding | undefined {
-  const segments = params.directoryRelativePath
-    .split(/[\\/]+/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-
-  for (let index = 0; index < segments.length; index += 1) {
-    if (segments[index]?.toLowerCase() !== "node_modules") {
-      continue;
-    }
-    const packageScopeOrName = segments[index + 1];
-    if (!packageScopeOrName) {
-      continue;
-    }
-
-    if (packageScopeOrName.startsWith("@")) {
-      const packageName = segments[index + 2];
-      if (!packageName) {
-        continue;
-      }
-      const scopedPackageId = `${packageScopeOrName}/${packageName}`;
-      if (!isBlockedInstallDependencyPackagePathName(scopedPackageId)) {
-        continue;
-      }
-      return {
-        dependencyName: scopedPackageId,
+  const dependencyName = parseBlockedNodeModulesPackageId(
+    normalizePathSegments(params.directoryRelativePath),
+    (packageNameSegment) => packageNameSegment,
+  );
+  return dependencyName
+    ? {
+        dependencyName,
         directoryRelativePath: params.directoryRelativePath,
-      };
-    }
+      }
+    : undefined;
+}
 
-    if (!isBlockedInstallDependencyPackagePathName(packageScopeOrName)) {
-      continue;
-    }
-    return {
-      dependencyName: packageScopeOrName,
-      directoryRelativePath: params.directoryRelativePath,
-    };
+function parseBlockedPackageFileAliasName(fileName: string): string | undefined {
+  const extensionMatch = /^(.+)\.(js|json|node)$/i.exec(fileName);
+  if (!extensionMatch) {
+    return undefined;
   }
+  return extensionMatch[1];
+}
 
-  return undefined;
+export function findBlockedNodeModulesFileAlias(params: {
+  fileRelativePath: string;
+}): BlockedPackageFileFinding | undefined {
+  const dependencyName = parseBlockedNodeModulesPackageId(
+    normalizePathSegments(params.fileRelativePath),
+    parseBlockedPackageFileAliasName,
+  );
+  return dependencyName
+    ? {
+        dependencyName,
+        fileRelativePath: params.fileRelativePath,
+      }
+    : undefined;
 }

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -40,8 +40,16 @@ const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET = new Set<string>(
   blockedInstallDependencyPackageNames,
 );
 
+const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_LOWER_SET = new Set<string>(
+  blockedInstallDependencyPackageNames.map((packageName) => packageName.toLowerCase()),
+);
+
 function isBlockedInstallDependencyPackageName(packageName: string): boolean {
   return BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(packageName);
+}
+
+function isBlockedInstallDependencyPackagePathName(packageName: string): boolean {
+  return BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_LOWER_SET.has(packageName.toLowerCase());
 }
 
 function parseNpmAliasTargetPackageName(spec: string): string | undefined {
@@ -191,7 +199,7 @@ export function findBlockedNodeModulesDirectory(params: {
         continue;
       }
       const scopedPackageId = `${packageScopeOrName}/${packageName}`;
-      if (!isBlockedInstallDependencyPackageName(scopedPackageId)) {
+      if (!isBlockedInstallDependencyPackagePathName(scopedPackageId)) {
         continue;
       }
       return {
@@ -200,7 +208,7 @@ export function findBlockedNodeModulesDirectory(params: {
       };
     }
 
-    if (!isBlockedInstallDependencyPackageName(packageScopeOrName)) {
+    if (!isBlockedInstallDependencyPackagePathName(packageScopeOrName)) {
       continue;
     }
     return {

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -244,10 +244,13 @@ export function findBlockedNodeModulesDirectory(params: {
 
 function parseBlockedPackageFileAliasName(fileName: string): string | undefined {
   const extensionMatch = /^(.+)\.(js|json|node)$/i.exec(fileName);
-  if (!extensionMatch) {
+  if (extensionMatch) {
+    return extensionMatch[1];
+  }
+  if (fileName.includes(".")) {
     return undefined;
   }
-  return extensionMatch[1];
+  return fileName;
 }
 
 export function findBlockedNodeModulesFileAlias(params: {

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -267,3 +267,59 @@ export function findBlockedNodeModulesFileAlias(params: {
       }
     : undefined;
 }
+
+export function findBlockedPackageDirectoryInPath(params: {
+  pathRelativeToRoot: string;
+}): BlockedPackageDirectoryFinding | undefined {
+  const segments = normalizePathSegments(params.pathRelativeToRoot);
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const packageScopeOrName = segments[index];
+    if (!packageScopeOrName) {
+      continue;
+    }
+
+    if (packageScopeOrName.startsWith("@")) {
+      const packageName = segments[index + 1];
+      if (!packageName) {
+        continue;
+      }
+      const scopedPackageId = `${packageScopeOrName}/${packageName}`;
+      if (!isBlockedInstallDependencyPackagePathName(scopedPackageId)) {
+        continue;
+      }
+      return {
+        dependencyName: scopedPackageId,
+        directoryRelativePath: params.pathRelativeToRoot,
+      };
+    }
+
+    if (!isBlockedInstallDependencyPackagePathName(packageScopeOrName)) {
+      continue;
+    }
+    return {
+      dependencyName: packageScopeOrName,
+      directoryRelativePath: params.pathRelativeToRoot,
+    };
+  }
+
+  return undefined;
+}
+
+export function findBlockedPackageFileAliasInPath(params: {
+  pathRelativeToRoot: string;
+}): BlockedPackageFileFinding | undefined {
+  const segments = normalizePathSegments(params.pathRelativeToRoot);
+  const fileName = segments.at(-1);
+  if (!fileName) {
+    return undefined;
+  }
+  const dependencyName = parseBlockedPackageFileAliasName(fileName);
+  if (!dependencyName || !isBlockedInstallDependencyPackagePathName(dependencyName)) {
+    return undefined;
+  }
+  return {
+    dependencyName,
+    fileRelativePath: params.pathRelativeToRoot,
+  };
+}

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -7,7 +7,7 @@ export const blockedInstallDependencyPackageNames = [
 export type BlockedManifestDependencyFinding = {
   dependencyName: string;
   declaredAs?: string;
-  field: "dependencies" | "name" | "optionalDependencies" | "peerDependencies";
+  field: "dependencies" | "name" | "optionalDependencies" | "overrides" | "peerDependencies";
 };
 
 type PackageDependencyFields = {
@@ -15,6 +15,12 @@ type PackageDependencyFields = {
 } & Partial<
   Record<Exclude<BlockedManifestDependencyFinding["field"], "name">, Record<string, string>>
 >;
+
+type PackageOverrideFields = {
+  overrides?: PackageOverrideValue;
+};
+
+type PackageOverrideValue = string | Record<string, PackageOverrideValue>;
 
 const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET = new Set<string>(
   blockedInstallDependencyPackageNames,
@@ -44,12 +50,73 @@ function parseNpmAliasTargetPackageName(spec: string): string | undefined {
   return versionSeparatorIndex < 0 ? aliasTarget : aliasTarget.slice(0, versionSeparatorIndex);
 }
 
+function parsePackageNameFromOverrideSelector(selector: string): string | undefined {
+  const normalized = selector.trim();
+  if (!normalized || normalized === ".") {
+    return undefined;
+  }
+
+  if (normalized.startsWith("@")) {
+    const slashIndex = normalized.indexOf("/");
+    if (slashIndex < 0) {
+      return undefined;
+    }
+    const versionSeparatorIndex = normalized.indexOf("@", slashIndex + 1);
+    return versionSeparatorIndex < 0 ? normalized : normalized.slice(0, versionSeparatorIndex);
+  }
+
+  const versionSeparatorIndex = normalized.indexOf("@");
+  return versionSeparatorIndex < 0 ? normalized : normalized.slice(0, versionSeparatorIndex);
+}
+
+function collectBlockedOverrideFindings(
+  value: PackageOverrideValue,
+  path: string[] = [],
+): BlockedManifestDependencyFinding[] {
+  if (typeof value === "string") {
+    const aliasTargetPackageName = parseNpmAliasTargetPackageName(value);
+    if (!aliasTargetPackageName) {
+      return [];
+    }
+    if (!BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(aliasTargetPackageName)) {
+      return [];
+    }
+    return [
+      {
+        dependencyName: aliasTargetPackageName,
+        declaredAs: path.join(" > "),
+        field: "overrides",
+      },
+    ];
+  }
+
+  const findings: BlockedManifestDependencyFinding[] = [];
+  for (const overrideKey of Object.keys(value).toSorted()) {
+    const overrideSelectorPackageName = parsePackageNameFromOverrideSelector(overrideKey);
+    if (
+      overrideSelectorPackageName &&
+      BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(overrideSelectorPackageName)
+    ) {
+      findings.push({
+        dependencyName: overrideSelectorPackageName,
+        declaredAs: [...path, overrideKey].join(" > "),
+        field: "overrides",
+      });
+    }
+    findings.push(...collectBlockedOverrideFindings(value[overrideKey], [...path, overrideKey]));
+  }
+  return findings;
+}
+
 export function findBlockedManifestDependencies(
-  manifest: PackageDependencyFields,
+  manifest: PackageDependencyFields & PackageOverrideFields,
 ): BlockedManifestDependencyFinding[] {
   const findings: BlockedManifestDependencyFinding[] = [];
   if (manifest.name && BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(manifest.name)) {
     findings.push({ dependencyName: manifest.name, field: "name" });
+  }
+  if (manifest.overrides) {
+    findings.push(...collectBlockedOverrideFindings(manifest.overrides));
   }
   for (const field of ["dependencies", "optionalDependencies", "peerDependencies"] as const) {
     const dependencyMap = manifest[field];

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -7,11 +7,13 @@ export const blockedInstallDependencyPackageNames = [
 export type BlockedManifestDependencyFinding = {
   dependencyName: string;
   declaredAs?: string;
-  field: "dependencies" | "optionalDependencies" | "peerDependencies";
+  field: "dependencies" | "name" | "optionalDependencies" | "peerDependencies";
 };
 
-type PackageDependencyFields = Partial<
-  Record<BlockedManifestDependencyFinding["field"], Record<string, string>>
+type PackageDependencyFields = {
+  name?: string;
+} & Partial<
+  Record<Exclude<BlockedManifestDependencyFinding["field"], "name">, Record<string, string>>
 >;
 
 const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET = new Set<string>(
@@ -46,6 +48,9 @@ export function findBlockedManifestDependencies(
   manifest: PackageDependencyFields,
 ): BlockedManifestDependencyFinding[] {
   const findings: BlockedManifestDependencyFinding[] = [];
+  if (manifest.name && BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(manifest.name)) {
+    findings.push({ dependencyName: manifest.name, field: "name" });
+  }
   for (const field of ["dependencies", "optionalDependencies", "peerDependencies"] as const) {
     const dependencyMap = manifest[field];
     if (!dependencyMap) {

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -10,6 +10,11 @@ export type BlockedManifestDependencyFinding = {
   field: "dependencies" | "name" | "optionalDependencies" | "overrides" | "peerDependencies";
 };
 
+export type BlockedPackageDirectoryFinding = {
+  dependencyName: string;
+  directoryRelativePath: string;
+};
+
 type PackageDependencyMapFields = Partial<
   Record<
     Exclude<BlockedManifestDependencyFinding["field"], "name" | "overrides">,
@@ -34,6 +39,10 @@ type PackageOverrideFields = {
 const BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET = new Set<string>(
   blockedInstallDependencyPackageNames,
 );
+
+function isBlockedInstallDependencyPackageName(packageName: string): boolean {
+  return BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(packageName);
+}
 
 function parseNpmAliasTargetPackageName(spec: string): string | undefined {
   const normalized = spec.trim();
@@ -125,7 +134,7 @@ export function findBlockedManifestDependencies(
   manifest: PackageDependencyFields & PackageOverrideFields,
 ): BlockedManifestDependencyFinding[] {
   const findings: BlockedManifestDependencyFinding[] = [];
-  if (manifest.name && BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(manifest.name)) {
+  if (manifest.name && isBlockedInstallDependencyPackageName(manifest.name)) {
     findings.push({ dependencyName: manifest.name, field: "name" });
   }
   if (isPackageOverrideObject(manifest.overrides)) {
@@ -137,7 +146,7 @@ export function findBlockedManifestDependencies(
       continue;
     }
     for (const dependencyName of Object.keys(dependencyMap).toSorted()) {
-      if (BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(dependencyName)) {
+      if (isBlockedInstallDependencyPackageName(dependencyName)) {
         findings.push({ dependencyName, field });
         continue;
       }
@@ -146,7 +155,7 @@ export function findBlockedManifestDependencies(
       if (!aliasTargetPackageName) {
         continue;
       }
-      if (!BLOCKED_INSTALL_DEPENDENCY_PACKAGE_NAME_SET.has(aliasTargetPackageName)) {
+      if (!isBlockedInstallDependencyPackageName(aliasTargetPackageName)) {
         continue;
       }
       findings.push({
@@ -157,4 +166,48 @@ export function findBlockedManifestDependencies(
     }
   }
   return findings;
+}
+
+export function findBlockedNodeModulesDirectory(params: {
+  directoryRelativePath: string;
+}): BlockedPackageDirectoryFinding | undefined {
+  const segments = params.directoryRelativePath
+    .split(/[\\/]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  for (let index = 0; index < segments.length; index += 1) {
+    if (segments[index] !== "node_modules") {
+      continue;
+    }
+    const packageScopeOrName = segments[index + 1];
+    if (!packageScopeOrName) {
+      continue;
+    }
+
+    if (packageScopeOrName.startsWith("@")) {
+      const packageName = segments[index + 2];
+      if (!packageName) {
+        continue;
+      }
+      const scopedPackageId = `${packageScopeOrName}/${packageName}`;
+      if (!isBlockedInstallDependencyPackageName(scopedPackageId)) {
+        continue;
+      }
+      return {
+        dependencyName: scopedPackageId,
+        directoryRelativePath: params.directoryRelativePath,
+      };
+    }
+
+    if (!isBlockedInstallDependencyPackageName(packageScopeOrName)) {
+      continue;
+    }
+    return {
+      dependencyName: packageScopeOrName,
+      directoryRelativePath: params.directoryRelativePath,
+    };
+  }
+
+  return undefined;
 }

--- a/src/plugins/dependency-denylist.ts
+++ b/src/plugins/dependency-denylist.ts
@@ -177,7 +177,7 @@ export function findBlockedNodeModulesDirectory(params: {
     .filter(Boolean);
 
   for (let index = 0; index < segments.length; index += 1) {
-    if (segments[index] !== "node_modules") {
+    if (segments[index]?.toLowerCase() !== "node_modules") {
       continue;
     }
     const packageScopeOrName = segments[index + 1];

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import { scanDirectoryWithSummary } from "../security/skill-scanner.js";
 import {
+  findBlockedPackageDirectoryInPath,
+  findBlockedPackageFileAliasInPath,
   findBlockedManifestDependencies,
   findBlockedNodeModulesDirectory,
   findBlockedNodeModulesFileAlias,
@@ -157,21 +159,6 @@ function pathContainsNodeModulesSegment(relativePath: string): boolean {
     .includes("node_modules");
 }
 
-function buildSyntheticNodeModulesTargetPath(targetRelativePath: string): string | undefined {
-  const segments = targetRelativePath
-    .split(/[\\/]+/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-  const targetLeaf = segments.at(-1);
-  if (!targetLeaf) {
-    return undefined;
-  }
-  const targetParent = segments.at(-2);
-  return targetParent?.startsWith("@")
-    ? path.posix.join("node_modules", targetParent, targetLeaf)
-    : path.posix.join("node_modules", targetLeaf);
-}
-
 async function inspectNodeModulesSymlinkTarget(params: {
   rootRealPath: string;
   symlinkPath: string;
@@ -198,56 +185,14 @@ async function inspectNodeModulesSymlinkTarget(params: {
   }
 
   const resolvedTargetRelativePath = path.relative(params.rootRealPath, resolvedTargetPath);
-
-  let resolvedTargetStats: Awaited<ReturnType<typeof fs.stat>>;
-  try {
-    resolvedTargetStats = await fs.stat(resolvedTargetPath);
-  } catch (error) {
-    throw new Error(
-      `manifest dependency scan could not stat symlink target ${params.symlinkRelativePath}: ${String(error)}`,
-      {
-        cause: error,
-      },
-    );
-  }
-
-  if (resolvedTargetStats.isDirectory()) {
-    const syntheticTargetPath = buildSyntheticNodeModulesTargetPath(resolvedTargetRelativePath);
-    const blockedDirectoryFinding = syntheticTargetPath
-      ? findBlockedNodeModulesDirectory({
-          directoryRelativePath: syntheticTargetPath,
-        })
-      : undefined;
-    return {
-      blockedDirectoryFinding: blockedDirectoryFinding
-        ? {
-            ...blockedDirectoryFinding,
-            directoryRelativePath: resolvedTargetRelativePath,
-          }
-        : undefined,
-    };
-  }
-
-  if (resolvedTargetStats.isFile()) {
-    const syntheticTargetPath = buildSyntheticNodeModulesTargetPath(resolvedTargetRelativePath);
-    const blockedFileFinding = syntheticTargetPath
-      ? findBlockedNodeModulesFileAlias({
-          fileRelativePath: syntheticTargetPath,
-        })
-      : undefined;
-    return {
-      blockedFileFinding: blockedFileFinding
-        ? {
-            ...blockedFileFinding,
-            fileRelativePath: resolvedTargetRelativePath,
-          }
-        : undefined,
-    };
-  }
-
-  throw new Error(
-    `manifest dependency scan found unsupported node_modules symlink target type at ${params.symlinkRelativePath}`,
-  );
+  return {
+    blockedDirectoryFinding: findBlockedPackageDirectoryInPath({
+      pathRelativeToRoot: resolvedTargetRelativePath,
+    }),
+    blockedFileFinding: findBlockedPackageFileAliasInPath({
+      pathRelativeToRoot: resolvedTargetRelativePath,
+    }),
+  };
 }
 
 function buildBuiltinScanFromError(error: unknown): BuiltinInstallScan {

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -33,6 +33,7 @@ type PackageManifest = {
   name?: string;
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  overrides?: Record<string, unknown>;
   peerDependencies?: Record<string, string>;
 };
 
@@ -85,7 +86,7 @@ function buildBlockedDependencyReason(params: {
   findings: Array<{
     dependencyName: string;
     declaredAs?: string;
-    field: "dependencies" | "name" | "optionalDependencies" | "peerDependencies";
+    field: "dependencies" | "name" | "optionalDependencies" | "overrides" | "peerDependencies";
   }>;
   manifestPackageName?: string;
   manifestRelativePath: string;

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import { scanDirectoryWithSummary } from "../security/skill-scanner.js";
-import { findBlockedManifestDependencies } from "./dependency-denylist.js";
+import {
+  findBlockedManifestDependencies,
+  findBlockedNodeModulesDirectory,
+} from "./dependency-denylist.js";
 import { getGlobalHookRunner } from "./hook-runner-global.js";
 import { createBeforeInstallHookPayload } from "./install-policy-context.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.js";
@@ -41,6 +44,16 @@ type PackageManifestTraversalLimits = {
   maxDepth: number;
   maxDirectories: number;
   maxManifests: number;
+};
+
+type BlockedPackageDirectoryFinding = {
+  dependencyName: string;
+  directoryRelativePath: string;
+};
+
+type PackageManifestTraversalResult = {
+  blockedDirectoryFinding?: BlockedPackageDirectoryFinding;
+  packageManifestPaths: string[];
 };
 
 type PluginInstallRequestKind =
@@ -114,6 +127,14 @@ function buildBlockedDependencyReason(params: {
   return `${params.targetLabel} blocked: blocked dependencies ${findingSummary} declared in ${manifestLabel}.`;
 }
 
+function buildBlockedDependencyDirectoryReason(params: {
+  dependencyName: string;
+  directoryRelativePath: string;
+  targetLabel: string;
+}) {
+  return `${params.targetLabel} blocked: blocked dependency directory "${params.dependencyName}" declared at ${params.directoryRelativePath}.`;
+}
+
 function buildBuiltinScanFromError(error: unknown): BuiltinInstallScan {
   return {
     status: "error",
@@ -178,7 +199,9 @@ function resolvePackageManifestTraversalLimits(): PackageManifestTraversalLimits
   };
 }
 
-async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
+async function collectPackageManifestPaths(
+  rootDir: string,
+): Promise<PackageManifestTraversalResult> {
   const limits = resolvePackageManifestTraversalLimits();
   const queue: Array<{ depth: number; dir: string }> = [{ depth: 0, dir: rootDir }];
   const packageManifestPaths: string[] = [];
@@ -229,7 +252,17 @@ async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
         continue;
       }
       const nextPath = path.join(currentDir, entry.name);
+      const relativeNextPath = path.relative(rootDir, nextPath) || entry.name;
       if (entry.isDirectory()) {
+        const blockedDirectoryFinding = findBlockedNodeModulesDirectory({
+          directoryRelativePath: relativeNextPath,
+        });
+        if (blockedDirectoryFinding) {
+          return {
+            blockedDirectoryFinding,
+            packageManifestPaths,
+          };
+        }
         queue.push({ depth: current.depth + 1, dir: nextPath });
         continue;
       }
@@ -244,7 +277,7 @@ async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
     }
   }
 
-  return packageManifestPaths;
+  return { packageManifestPaths };
 }
 
 async function scanManifestDependencyDenylist(params: {
@@ -252,7 +285,23 @@ async function scanManifestDependencyDenylist(params: {
   packageDir: string;
   targetLabel: string;
 }): Promise<InstallSecurityScanResult | undefined> {
-  const packageManifestPaths = await collectPackageManifestPaths(params.packageDir);
+  const traversalResult = await collectPackageManifestPaths(params.packageDir);
+  if (traversalResult.blockedDirectoryFinding) {
+    const reason = buildBlockedDependencyDirectoryReason({
+      dependencyName: traversalResult.blockedDirectoryFinding.dependencyName,
+      directoryRelativePath: traversalResult.blockedDirectoryFinding.directoryRelativePath,
+      targetLabel: params.targetLabel,
+    });
+    params.logger.warn?.(`WARNING: ${reason}`);
+    return {
+      blocked: {
+        code: "security_scan_blocked",
+        reason,
+      },
+    };
+  }
+
+  const packageManifestPaths = traversalResult.packageManifestPaths;
   for (const manifestPath of packageManifestPaths) {
     let manifest: PackageManifest;
     try {

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -70,18 +70,34 @@ function buildScanFailureBlockReason(params: { error: string; targetLabel: strin
   return `${params.targetLabel} blocked: code safety scan failed (${params.error}). Run "openclaw security audit --deep" for details.`;
 }
 
-function buildBlockedDependencyReason(params: {
-  dependencyName: string;
-  field: "dependencies" | "optionalDependencies" | "peerDependencies";
+function buildBlockedDependencyManifestLabel(params: {
   manifestPackageName?: string;
   manifestRelativePath: string;
-  targetLabel: string;
 }) {
   const manifestLabel =
     typeof params.manifestPackageName === "string" && params.manifestPackageName.trim()
       ? `${params.manifestPackageName.trim()} (${params.manifestRelativePath})`
       : params.manifestRelativePath;
-  return `${params.targetLabel} blocked: blocked dependency "${params.dependencyName}" declared in ${params.field} of ${manifestLabel}.`;
+  return manifestLabel;
+}
+
+function buildBlockedDependencyReason(params: {
+  findings: Array<{
+    dependencyName: string;
+    field: "dependencies" | "optionalDependencies" | "peerDependencies";
+  }>;
+  manifestPackageName?: string;
+  manifestRelativePath: string;
+  targetLabel: string;
+}) {
+  const manifestLabel = buildBlockedDependencyManifestLabel({
+    manifestPackageName: params.manifestPackageName,
+    manifestRelativePath: params.manifestRelativePath,
+  });
+  const findingSummary = params.findings
+    .map((finding) => `"${finding.dependencyName}" in ${finding.field}`)
+    .join(", ");
+  return `${params.targetLabel} blocked: blocked dependencies ${findingSummary} declared in ${manifestLabel}.`;
 }
 
 function buildBuiltinScanFromError(error: unknown): BuiltinInstallScan {
@@ -123,7 +139,15 @@ async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
       continue;
     }
 
-    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    let entries: Awaited<ReturnType<typeof fs.readdir>>;
+    try {
+      entries = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    // Intentionally walk vendored/node_modules trees so bundled transitive
+    // manifests cannot hide blocked packages from install-time policy checks.
     for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
       const nextPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
@@ -158,15 +182,9 @@ async function scanManifestDependencyDenylist(params: {
       continue;
     }
 
-    const finding = blockedDependencies[0];
-    if (!finding) {
-      continue;
-    }
-
     const manifestRelativePath = path.relative(params.packageDir, manifestPath) || "package.json";
     const reason = buildBlockedDependencyReason({
-      dependencyName: finding.dependencyName,
-      field: finding.field,
+      findings: blockedDependencies,
       manifestPackageName: manifest.name,
       manifestRelativePath,
       targetLabel: params.targetLabel,

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -33,7 +33,7 @@ type PackageManifest = {
   name?: string;
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
-  overrides?: Record<string, unknown>;
+  overrides?: unknown;
   peerDependencies?: Record<string, string>;
 };
 
@@ -147,9 +147,9 @@ async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
       continue;
     }
 
-    let entries: Awaited<ReturnType<typeof fs.readdir>>;
+    let entries: Array<{ name: string; isDirectory(): boolean; isFile(): boolean }>;
     try {
-      entries = await fs.readdir(currentDir, { withFileTypes: true });
+      entries = await fs.readdir(currentDir, { encoding: "utf8", withFileTypes: true });
     } catch {
       continue;
     }

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -538,6 +538,18 @@ export async function scanPackageInstallSourceRuntime(
   return hookResult?.blocked ? hookResult : builtinBlocked;
 }
 
+export async function scanInstalledPackageDependencyTreeRuntime(params: {
+  logger: InstallScanLogger;
+  packageDir: string;
+  pluginId: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  return await scanManifestDependencyDenylist({
+    logger: params.logger,
+    packageDir: params.packageDir,
+    targetLabel: `Plugin "${params.pluginId}" installation`,
+  });
+}
+
 export async function scanFileInstallSourceRuntime(
   params: InstallSafetyOverrides & {
     filePath: string;

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -248,11 +248,20 @@ async function collectPackageManifestPaths(
     // Intentionally walk vendored/node_modules trees so bundled transitive
     // manifests cannot hide blocked packages from install-time policy checks.
     for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
-      if (entry.isSymbolicLink()) {
-        continue;
-      }
       const nextPath = path.join(currentDir, entry.name);
       const relativeNextPath = path.relative(rootDir, nextPath) || entry.name;
+      if (entry.isSymbolicLink()) {
+        const blockedDirectoryFinding = findBlockedNodeModulesDirectory({
+          directoryRelativePath: relativeNextPath,
+        });
+        if (blockedDirectoryFinding) {
+          return {
+            blockedDirectoryFinding,
+            packageManifestPaths,
+          };
+        }
+        continue;
+      }
       if (entry.isDirectory()) {
         const blockedDirectoryFinding = findBlockedNodeModulesDirectory({
           directoryRelativePath: relativeNextPath,

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -37,6 +37,12 @@ type PackageManifest = {
   peerDependencies?: Record<string, string>;
 };
 
+type PackageManifestTraversalLimits = {
+  maxDepth: number;
+  maxDirectories: number;
+  maxManifests: number;
+};
+
 type PluginInstallRequestKind =
   | "skill-install"
   | "plugin-dir"
@@ -137,19 +143,79 @@ function buildBuiltinScanFromSummary(summary: {
   };
 }
 
+const DEFAULT_PACKAGE_MANIFEST_TRAVERSAL_LIMITS: PackageManifestTraversalLimits = {
+  maxDepth: 64,
+  maxDirectories: 10_000,
+  maxManifests: 10_000,
+};
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const rawValue = process.env[name];
+  if (!rawValue) {
+    return fallback;
+  }
+  const parsedValue = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsedValue) || parsedValue < 1) {
+    return fallback;
+  }
+  return parsedValue;
+}
+
+function resolvePackageManifestTraversalLimits(): PackageManifestTraversalLimits {
+  return {
+    maxDepth: readPositiveIntegerEnv(
+      "OPENCLAW_INSTALL_SCAN_MAX_DEPTH",
+      DEFAULT_PACKAGE_MANIFEST_TRAVERSAL_LIMITS.maxDepth,
+    ),
+    maxDirectories: readPositiveIntegerEnv(
+      "OPENCLAW_INSTALL_SCAN_MAX_DIRECTORIES",
+      DEFAULT_PACKAGE_MANIFEST_TRAVERSAL_LIMITS.maxDirectories,
+    ),
+    maxManifests: readPositiveIntegerEnv(
+      "OPENCLAW_INSTALL_SCAN_MAX_MANIFESTS",
+      DEFAULT_PACKAGE_MANIFEST_TRAVERSAL_LIMITS.maxManifests,
+    ),
+  };
+}
+
 async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
-  const queue = [rootDir];
+  const limits = resolvePackageManifestTraversalLimits();
+  const queue: Array<{ depth: number; dir: string }> = [{ depth: 0, dir: rootDir }];
   const packageManifestPaths: string[] = [];
+  const visitedDirectories = new Set<string>();
   let queueIndex = 0;
 
   while (queueIndex < queue.length) {
-    const currentDir = queue[queueIndex];
+    const current = queue[queueIndex];
     queueIndex += 1;
-    if (!currentDir) {
+    if (!current) {
       continue;
     }
 
-    let entries: Array<{ name: string; isDirectory(): boolean; isFile(): boolean }>;
+    if (current.depth > limits.maxDepth) {
+      throw new Error(
+        `manifest dependency scan exceeded max depth (${limits.maxDepth}) at ${current.dir}`,
+      );
+    }
+
+    const currentDir = current.dir;
+    const currentRealPath = await fs.realpath(currentDir).catch(() => currentDir);
+    if (visitedDirectories.has(currentRealPath)) {
+      continue;
+    }
+    visitedDirectories.add(currentRealPath);
+    if (visitedDirectories.size > limits.maxDirectories) {
+      throw new Error(
+        `manifest dependency scan exceeded max directories (${limits.maxDirectories}) under ${rootDir}`,
+      );
+    }
+
+    let entries: Array<{
+      name: string;
+      isDirectory(): boolean;
+      isFile(): boolean;
+      isSymbolicLink(): boolean;
+    }>;
     try {
       entries = await fs.readdir(currentDir, { encoding: "utf8", withFileTypes: true });
     } catch {
@@ -159,13 +225,21 @@ async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
     // Intentionally walk vendored/node_modules trees so bundled transitive
     // manifests cannot hide blocked packages from install-time policy checks.
     for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
       const nextPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
-        queue.push(nextPath);
+        queue.push({ depth: current.depth + 1, dir: nextPath });
         continue;
       }
       if (entry.isFile() && entry.name === "package.json") {
         packageManifestPaths.push(nextPath);
+        if (packageManifestPaths.length > limits.maxManifests) {
+          throw new Error(
+            `manifest dependency scan exceeded max manifests (${limits.maxManifests}) under ${rootDir}`,
+          );
+        }
       }
     }
   }

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -150,6 +150,106 @@ function buildBlockedDependencyFileReason(params: {
   return `${params.targetLabel} blocked: blocked dependency file alias "${params.dependencyName}" declared at ${params.fileRelativePath}.`;
 }
 
+function pathContainsNodeModulesSegment(relativePath: string): boolean {
+  return relativePath
+    .split(/[\\/]+/)
+    .map((segment) => segment.trim().toLowerCase())
+    .includes("node_modules");
+}
+
+function buildSyntheticNodeModulesTargetPath(targetRelativePath: string): string | undefined {
+  const segments = targetRelativePath
+    .split(/[\\/]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  const targetLeaf = segments.at(-1);
+  if (!targetLeaf) {
+    return undefined;
+  }
+  const targetParent = segments.at(-2);
+  return targetParent?.startsWith("@")
+    ? path.posix.join("node_modules", targetParent, targetLeaf)
+    : path.posix.join("node_modules", targetLeaf);
+}
+
+async function inspectNodeModulesSymlinkTarget(params: {
+  rootRealPath: string;
+  symlinkPath: string;
+  symlinkRelativePath: string;
+}): Promise<
+  Pick<PackageManifestTraversalResult, "blockedDirectoryFinding" | "blockedFileFinding">
+> {
+  let resolvedTargetPath: string;
+  try {
+    resolvedTargetPath = await fs.realpath(params.symlinkPath);
+  } catch (error) {
+    throw new Error(
+      `manifest dependency scan could not resolve symlink target ${params.symlinkRelativePath}: ${String(error)}`,
+      {
+        cause: error,
+      },
+    );
+  }
+
+  if (!isPathInside(params.rootRealPath, resolvedTargetPath)) {
+    throw new Error(
+      `manifest dependency scan found node_modules symlink target outside install root at ${params.symlinkRelativePath}`,
+    );
+  }
+
+  const resolvedTargetRelativePath = path.relative(params.rootRealPath, resolvedTargetPath);
+
+  let resolvedTargetStats: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    resolvedTargetStats = await fs.stat(resolvedTargetPath);
+  } catch (error) {
+    throw new Error(
+      `manifest dependency scan could not stat symlink target ${params.symlinkRelativePath}: ${String(error)}`,
+      {
+        cause: error,
+      },
+    );
+  }
+
+  if (resolvedTargetStats.isDirectory()) {
+    const syntheticTargetPath = buildSyntheticNodeModulesTargetPath(resolvedTargetRelativePath);
+    const blockedDirectoryFinding = syntheticTargetPath
+      ? findBlockedNodeModulesDirectory({
+          directoryRelativePath: syntheticTargetPath,
+        })
+      : undefined;
+    return {
+      blockedDirectoryFinding: blockedDirectoryFinding
+        ? {
+            ...blockedDirectoryFinding,
+            directoryRelativePath: resolvedTargetRelativePath,
+          }
+        : undefined,
+    };
+  }
+
+  if (resolvedTargetStats.isFile()) {
+    const syntheticTargetPath = buildSyntheticNodeModulesTargetPath(resolvedTargetRelativePath);
+    const blockedFileFinding = syntheticTargetPath
+      ? findBlockedNodeModulesFileAlias({
+          fileRelativePath: syntheticTargetPath,
+        })
+      : undefined;
+    return {
+      blockedFileFinding: blockedFileFinding
+        ? {
+            ...blockedFileFinding,
+            fileRelativePath: resolvedTargetRelativePath,
+          }
+        : undefined,
+    };
+  }
+
+  throw new Error(
+    `manifest dependency scan found unsupported node_modules symlink target type at ${params.symlinkRelativePath}`,
+  );
+}
+
 function buildBuiltinScanFromError(error: unknown): BuiltinInstallScan {
   return {
     status: "error",
@@ -218,6 +318,7 @@ async function collectPackageManifestPaths(
   rootDir: string,
 ): Promise<PackageManifestTraversalResult> {
   const limits = resolvePackageManifestTraversalLimits();
+  const rootRealPath = await fs.realpath(rootDir).catch(() => rootDir);
   const queue: Array<{ depth: number; dir: string }> = [{ depth: 0, dir: rootDir }];
   const packageManifestPaths: string[] = [];
   const visitedDirectories = new Set<string>();
@@ -276,6 +377,34 @@ async function collectPackageManifestPaths(
             blockedDirectoryFinding,
             packageManifestPaths,
           };
+        }
+        const blockedFileFinding = findBlockedNodeModulesFileAlias({
+          fileRelativePath: relativeNextPath,
+        });
+        if (blockedFileFinding) {
+          return {
+            blockedFileFinding,
+            packageManifestPaths,
+          };
+        }
+        if (pathContainsNodeModulesSegment(relativeNextPath)) {
+          const symlinkTargetInspection = await inspectNodeModulesSymlinkTarget({
+            rootRealPath,
+            symlinkPath: nextPath,
+            symlinkRelativePath: relativeNextPath,
+          });
+          if (symlinkTargetInspection.blockedDirectoryFinding) {
+            return {
+              blockedDirectoryFinding: symlinkTargetInspection.blockedDirectoryFinding,
+              packageManifestPaths,
+            };
+          }
+          if (symlinkTargetInspection.blockedFileFinding) {
+            return {
+              blockedFileFinding: symlinkTargetInspection.blockedFileFinding,
+              packageManifestPaths,
+            };
+          }
         }
         continue;
       }

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -84,6 +84,7 @@ function buildBlockedDependencyManifestLabel(params: {
 function buildBlockedDependencyReason(params: {
   findings: Array<{
     dependencyName: string;
+    declaredAs?: string;
     field: "dependencies" | "optionalDependencies" | "peerDependencies";
   }>;
   manifestPackageName?: string;
@@ -95,7 +96,11 @@ function buildBlockedDependencyReason(params: {
     manifestRelativePath: params.manifestRelativePath,
   });
   const findingSummary = params.findings
-    .map((finding) => `"${finding.dependencyName}" in ${finding.field}`)
+    .map((finding) =>
+      finding.declaredAs
+        ? `"${finding.dependencyName}" via alias "${finding.declaredAs}" in ${finding.field}`
+        : `"${finding.dependencyName}" in ${finding.field}`,
+    )
     .join(", ");
   return `${params.targetLabel} blocked: blocked dependencies ${findingSummary} declared in ${manifestLabel}.`;
 }

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -411,6 +411,15 @@ export async function scanBundleInstallSourceRuntime(
     version?: string;
   },
 ): Promise<InstallSecurityScanResult | undefined> {
+  const dependencyBlocked = await scanManifestDependencyDenylist({
+    logger: params.logger,
+    packageDir: params.sourceDir,
+    targetLabel: `Bundle "${params.pluginId}" installation`,
+  });
+  if (dependencyBlocked) {
+    return dependencyBlocked;
+  }
+
   const builtinScan = await scanDirectoryTarget({
     logger: params.logger,
     path: params.sourceDir,

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -5,6 +5,7 @@ import { scanDirectoryWithSummary } from "../security/skill-scanner.js";
 import {
   findBlockedManifestDependencies,
   findBlockedNodeModulesDirectory,
+  findBlockedNodeModulesFileAlias,
 } from "./dependency-denylist.js";
 import { getGlobalHookRunner } from "./hook-runner-global.js";
 import { createBeforeInstallHookPayload } from "./install-policy-context.js";
@@ -51,8 +52,14 @@ type BlockedPackageDirectoryFinding = {
   directoryRelativePath: string;
 };
 
+type BlockedPackageFileFinding = {
+  dependencyName: string;
+  fileRelativePath: string;
+};
+
 type PackageManifestTraversalResult = {
   blockedDirectoryFinding?: BlockedPackageDirectoryFinding;
+  blockedFileFinding?: BlockedPackageFileFinding;
   packageManifestPaths: string[];
 };
 
@@ -133,6 +140,14 @@ function buildBlockedDependencyDirectoryReason(params: {
   targetLabel: string;
 }) {
   return `${params.targetLabel} blocked: blocked dependency directory "${params.dependencyName}" declared at ${params.directoryRelativePath}.`;
+}
+
+function buildBlockedDependencyFileReason(params: {
+  dependencyName: string;
+  fileRelativePath: string;
+  targetLabel: string;
+}) {
+  return `${params.targetLabel} blocked: blocked dependency file alias "${params.dependencyName}" declared at ${params.fileRelativePath}.`;
 }
 
 function buildBuiltinScanFromError(error: unknown): BuiltinInstallScan {
@@ -277,6 +292,17 @@ async function collectPackageManifestPaths(
         queue.push({ depth: current.depth + 1, dir: nextPath });
         continue;
       }
+      if (entry.isFile()) {
+        const blockedFileFinding = findBlockedNodeModulesFileAlias({
+          fileRelativePath: relativeNextPath,
+        });
+        if (blockedFileFinding) {
+          return {
+            blockedFileFinding,
+            packageManifestPaths,
+          };
+        }
+      }
       if (entry.isFile() && entry.name === "package.json") {
         packageManifestPaths.push(nextPath);
         if (packageManifestPaths.length > limits.maxManifests) {
@@ -301,6 +327,20 @@ async function scanManifestDependencyDenylist(params: {
     const reason = buildBlockedDependencyDirectoryReason({
       dependencyName: traversalResult.blockedDirectoryFinding.dependencyName,
       directoryRelativePath: traversalResult.blockedDirectoryFinding.directoryRelativePath,
+      targetLabel: params.targetLabel,
+    });
+    params.logger.warn?.(`WARNING: ${reason}`);
+    return {
+      blocked: {
+        code: "security_scan_blocked",
+        reason,
+      },
+    };
+  }
+  if (traversalResult.blockedFileFinding) {
+    const reason = buildBlockedDependencyFileReason({
+      dependencyName: traversalResult.blockedFileFinding.dependencyName,
+      fileRelativePath: traversalResult.blockedFileFinding.fileRelativePath,
       targetLabel: params.targetLabel,
     });
     params.logger.warn?.(`WARNING: ${reason}`);

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -85,7 +85,7 @@ function buildBlockedDependencyReason(params: {
   findings: Array<{
     dependencyName: string;
     declaredAs?: string;
-    field: "dependencies" | "optionalDependencies" | "peerDependencies";
+    field: "dependencies" | "name" | "optionalDependencies" | "peerDependencies";
   }>;
   manifestPackageName?: string;
   manifestRelativePath: string;
@@ -97,9 +97,11 @@ function buildBlockedDependencyReason(params: {
   });
   const findingSummary = params.findings
     .map((finding) =>
-      finding.declaredAs
-        ? `"${finding.dependencyName}" via alias "${finding.declaredAs}" in ${finding.field}`
-        : `"${finding.dependencyName}" in ${finding.field}`,
+      finding.field === "name"
+        ? `"${finding.dependencyName}" as package name`
+        : finding.declaredAs
+          ? `"${finding.dependencyName}" via alias "${finding.declaredAs}" in ${finding.field}`
+          : `"${finding.dependencyName}" in ${finding.field}`,
     )
     .join(", ");
   return `${params.targetLabel} blocked: blocked dependencies ${findingSummary} declared in ${manifestLabel}.`;

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import { scanDirectoryWithSummary } from "../security/skill-scanner.js";
+import { findBlockedManifestDependencies } from "./dependency-denylist.js";
 import { getGlobalHookRunner } from "./hook-runner-global.js";
 import { createBeforeInstallHookPayload } from "./install-policy-context.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.js";
@@ -25,6 +27,13 @@ type BuiltinInstallScan = {
   info: number;
   findings: InstallScanFinding[];
   error?: string;
+};
+
+type PackageManifest = {
+  name?: string;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
 };
 
 type PluginInstallRequestKind =
@@ -61,6 +70,20 @@ function buildScanFailureBlockReason(params: { error: string; targetLabel: strin
   return `${params.targetLabel} blocked: code safety scan failed (${params.error}). Run "openclaw security audit --deep" for details.`;
 }
 
+function buildBlockedDependencyReason(params: {
+  dependencyName: string;
+  field: "dependencies" | "optionalDependencies" | "peerDependencies";
+  manifestPackageName?: string;
+  manifestRelativePath: string;
+  targetLabel: string;
+}) {
+  const manifestLabel =
+    typeof params.manifestPackageName === "string" && params.manifestPackageName.trim()
+      ? `${params.manifestPackageName.trim()} (${params.manifestRelativePath})`
+      : params.manifestRelativePath;
+  return `${params.targetLabel} blocked: blocked dependency "${params.dependencyName}" declared in ${params.field} of ${manifestLabel}.`;
+}
+
 function buildBuiltinScanFromError(error: unknown): BuiltinInstallScan {
   return {
     status: "error",
@@ -88,6 +111,75 @@ function buildBuiltinScanFromSummary(summary: {
     info: summary.info,
     findings: summary.findings,
   };
+}
+
+async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
+  const queue = [rootDir];
+  const packageManifestPaths: string[] = [];
+
+  while (queue.length > 0) {
+    const currentDir = queue.shift();
+    if (!currentDir) {
+      continue;
+    }
+
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+      const nextPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(nextPath);
+        continue;
+      }
+      if (entry.isFile() && entry.name === "package.json") {
+        packageManifestPaths.push(nextPath);
+      }
+    }
+  }
+
+  return packageManifestPaths;
+}
+
+async function scanManifestDependencyDenylist(params: {
+  logger: InstallScanLogger;
+  packageDir: string;
+  targetLabel: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  const packageManifestPaths = await collectPackageManifestPaths(params.packageDir);
+  for (const manifestPath of packageManifestPaths) {
+    let manifest: PackageManifest;
+    try {
+      manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as PackageManifest;
+    } catch {
+      continue;
+    }
+
+    const blockedDependencies = findBlockedManifestDependencies(manifest);
+    if (blockedDependencies.length === 0) {
+      continue;
+    }
+
+    const finding = blockedDependencies[0];
+    if (!finding) {
+      continue;
+    }
+
+    const manifestRelativePath = path.relative(params.packageDir, manifestPath) || "package.json";
+    const reason = buildBlockedDependencyReason({
+      dependencyName: finding.dependencyName,
+      field: finding.field,
+      manifestPackageName: manifest.name,
+      manifestRelativePath,
+      targetLabel: params.targetLabel,
+    });
+    params.logger.warn?.(`WARNING: ${reason}`);
+    return {
+      blocked: {
+        code: "security_scan_blocked",
+        reason,
+      },
+    };
+  }
+  return undefined;
 }
 
 async function scanDirectoryTarget(params: {
@@ -346,6 +438,15 @@ export async function scanPackageInstallSourceRuntime(
     version?: string;
   },
 ): Promise<InstallSecurityScanResult | undefined> {
+  const dependencyBlocked = await scanManifestDependencyDenylist({
+    logger: params.logger,
+    packageDir: params.packageDir,
+    targetLabel: `Plugin "${params.pluginId}" installation`,
+  });
+  if (dependencyBlocked) {
+    return dependencyBlocked;
+  }
+
   const forcedScanEntries: string[] = [];
   for (const entry of params.extensions) {
     const resolvedEntry = path.resolve(params.packageDir, entry);

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -241,8 +241,10 @@ async function collectPackageManifestPaths(
     }>;
     try {
       entries = await fs.readdir(currentDir, { encoding: "utf8", withFileTypes: true });
-    } catch {
-      continue;
+    } catch (error) {
+      throw new Error(`manifest dependency scan could not read ${currentDir}: ${String(error)}`, {
+        cause: error,
+      });
     }
 
     // Intentionally walk vendored/node_modules trees so bundled transitive

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -140,9 +140,11 @@ function buildBuiltinScanFromSummary(summary: {
 async function collectPackageManifestPaths(rootDir: string): Promise<string[]> {
   const queue = [rootDir];
   const packageManifestPaths: string[] = [];
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const currentDir = queue.shift();
+  while (queueIndex < queue.length) {
+    const currentDir = queue[queueIndex];
+    queueIndex += 1;
     if (!currentDir) {
       continue;
     }

--- a/src/plugins/install-security-scan.ts
+++ b/src/plugins/install-security-scan.ts
@@ -72,6 +72,15 @@ export async function scanPackageInstallSource(
   return await scanPackageInstallSourceRuntime(params);
 }
 
+export async function scanInstalledPackageDependencyTree(params: {
+  logger: InstallScanLogger;
+  packageDir: string;
+  pluginId: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  const { scanInstalledPackageDependencyTreeRuntime } = await loadInstallSecurityScanRuntime();
+  return await scanInstalledPackageDependencyTreeRuntime(params);
+}
+
 export async function scanFileInstallSource(
   params: InstallSafetyOverrides & {
     filePath: string;

--- a/src/plugins/install.runtime.ts
+++ b/src/plugins/install.runtime.ts
@@ -23,6 +23,7 @@ import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { resolveCompatibilityHostVersion, resolveRuntimeServiceVersion } from "../version.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "./bundle-manifest.js";
 import {
+  scanInstalledPackageDependencyTree,
   scanBundleInstallSource,
   scanFileInstallSource,
   scanPackageInstallSource,
@@ -59,6 +60,7 @@ export {
   resolveCompatibilityHostVersion,
   resolveRuntimeServiceVersion,
   resolveTimedInstallModeOptions,
+  scanInstalledPackageDependencyTree,
   scanBundleInstallSource,
   scanFileInstallSource,
   scanPackageInstallSource,

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1115,6 +1115,35 @@ describe("installPluginFromArchive", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "does not block package installs when node_modules symlink targets an allowed scoped package path",
+    async () => {
+      const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "allowed-scoped-symlink-target-plugin",
+          version: "1.0.0",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+      const scopedTargetDir = path.join(pluginDir, "vendor", "@scope", "plain-crypto-js");
+      fs.mkdirSync(scopedTargetDir, { recursive: true });
+      fs.writeFileSync(path.join(scopedTargetDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync("../@scope/plain-crypto-js", path.join(nodeModulesDir, "safe-name"), "dir");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "fails package installs when node_modules symlink target escapes the install root",
     async () => {
       const { pluginDir, extensionsDir, tmpDir } = setupPluginInstallDirs();

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -918,6 +918,33 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it("blocks package installs when node_modules contains a blocked package file alias", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "blocked-package-file-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const nodeModulesDir = path.join(pluginDir, "vendor", "Node_Modules");
+    fs.mkdirSync(nodeModulesDir, { recursive: true });
+    fs.writeFileSync(path.join(nodeModulesDir, "Plain-Crypto-Js.Js"), "module.exports = {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('blocked dependency file alias "Plain-Crypto-Js"');
+      expect(result.error).toContain("vendor/Node_Modules/Plain-Crypto-Js.Js");
+    }
+  });
+
   it.runIf(process.platform !== "win32")(
     "blocks package installs when node_modules contains a blocked package symlink",
     async () => {
@@ -968,6 +995,26 @@ describe("installPluginFromArchive", () => {
     const innocuousDir = path.join(pluginDir, "assets", "plain-crypto-js");
     fs.mkdirSync(innocuousDir, { recursive: true });
     fs.writeFileSync(path.join(innocuousDir, "index.js"), "export {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("does not block package installs for blocked package file aliases outside node_modules", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "non-node-modules-file-alias-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+    fs.mkdirSync(path.join(pluginDir, "assets"), { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, "assets", "plain-crypto-js.js"), "export {};\n");
 
     const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
@@ -1320,6 +1367,26 @@ describe("installPluginFromArchive", () => {
       expect(result.error).toContain('Bundle "blocked-package-dir-bundle" installation blocked');
       expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
       expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
+    }
+  });
+
+  it("blocks bundle installs when node_modules contains a blocked package file alias", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Blocked Package File Bundle",
+    });
+    const nodeModulesDir = path.join(pluginDir, "vendor", "Node_Modules");
+    fs.mkdirSync(nodeModulesDir, { recursive: true });
+    fs.writeFileSync(path.join(nodeModulesDir, "Plain-Crypto-Js.Js"), "module.exports = {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('Bundle "blocked-package-file-bundle" installation blocked');
+      expect(result.error).toContain('blocked dependency file alias "Plain-Crypto-Js"');
+      expect(result.error).toContain("vendor/Node_Modules/Plain-Crypto-Js.Js");
     }
   });
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -786,11 +786,11 @@ describe("installPluginFromArchive", () => {
     if (!result.ok) {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
       expect(result.error).toContain('Plugin "blocked-dependency-plugin" installation blocked');
-      expect(result.error).toContain('blocked dependency "plain-crypto-js"');
-      expect(result.error).toContain("dependencies of blocked-dependency-plugin (package.json)");
+      expect(result.error).toContain('blocked dependencies "plain-crypto-js" in dependencies');
+      expect(result.error).toContain("declared in blocked-dependency-plugin (package.json)");
     }
     expect(warnings).toContain(
-      'WARNING: Plugin "blocked-dependency-plugin" installation blocked: blocked dependency "plain-crypto-js" declared in dependencies of blocked-dependency-plugin (package.json).',
+      'WARNING: Plugin "blocked-dependency-plugin" installation blocked: blocked dependencies "plain-crypto-js" in dependencies declared in blocked-dependency-plugin (package.json).',
     );
   });
 
@@ -823,8 +823,38 @@ describe("installPluginFromArchive", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain('blocked dependency "plain-crypto-js"');
-      expect(result.error).toContain("dependencies of axios (vendor/axios/package.json)");
+      expect(result.error).toContain('blocked dependencies "plain-crypto-js" in dependencies');
+      expect(result.error).toContain("declared in axios (vendor/axios/package.json)");
+    }
+  });
+
+  it("reports all blocked dependencies from the same manifest", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "multiple-blocked-dependencies-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+        dependencies: {
+          "plain-crypto-js": "^4.2.1",
+        },
+        peerDependencies: {
+          "plain-crypto-js": "^4.2.1",
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('"plain-crypto-js" in dependencies');
+      expect(result.error).toContain('"plain-crypto-js" in peerDependencies');
+      expect(result.error).toContain("multiple-blocked-dependencies-plugin (package.json)");
     }
   });
 
@@ -885,11 +915,11 @@ describe("installPluginFromArchive", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain('blocked dependency "plain-crypto-js"');
+      expect(result.error).toContain('blocked dependencies "plain-crypto-js" in dependencies');
     }
     expect(
       warnings.some((warning) =>
-        warning.includes('blocked dependency "plain-crypto-js" declared in dependencies'),
+        warning.includes('blocked dependencies "plain-crypto-js" in dependencies'),
       ),
     ).toBe(true);
     expect(

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1420,6 +1420,50 @@ describe("installPluginFromDir", () => {
     expect(manifest.devDependencies?.vitest).toBe("^3.0.0");
   });
 
+  it("blocks install when resolved dependencies introduce a denied package", async () => {
+    const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();
+
+    const run = vi.mocked(runCommandWithTimeout);
+    run.mockImplementation(async (_command, opts) => {
+      const cwd = opts?.cwd;
+      if (!cwd) {
+        throw new Error("expected cwd for npm install");
+      }
+      const blockedPkgDir = path.join(cwd, "node_modules", "plain-crypto-js");
+      fs.mkdirSync(blockedPkgDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(blockedPkgDir, "package.json"),
+        JSON.stringify({
+          name: "plain-crypto-js",
+          version: "4.2.1",
+        }),
+        "utf-8",
+      );
+      return {
+        code: 0,
+        stdout: "",
+        stderr: "",
+        signal: null,
+        killed: false,
+        termination: "exit" as const,
+      };
+    });
+
+    const result = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('"plain-crypto-js" as package name');
+      expect(result.error).toContain(
+        "declared in plain-crypto-js (node_modules/plain-crypto-js/package.json)",
+      );
+    }
+  });
+
   it.each([
     {
       name: "rejects plugins whose minHostVersion is newer than the current host",

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1009,6 +1009,35 @@ describe("installPluginFromArchive", () => {
     ).toBe(true);
   });
 
+  it("blocks bundle installs when a vendored manifest uses a blocked package name", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Blocked Vendored Package Name Bundle",
+    });
+    fs.mkdirSync(path.join(pluginDir, "vendor", "plain-crypto-js"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "vendor", "plain-crypto-js", "package.json"),
+      JSON.stringify({
+        name: "plain-crypto-js",
+        version: "4.2.1",
+      }),
+    );
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain(
+        'Bundle "blocked-vendored-package-name-bundle" installation blocked',
+      );
+      expect(result.error).toContain('"plain-crypto-js" as package name');
+      expect(result.error).toContain(
+        "declared in plain-crypto-js (vendor/plain-crypto-js/package.json)",
+      );
+    }
+  });
+
   it("surfaces plugin scanner findings from before_install", async () => {
     const handler = vi.fn().mockReturnValue({
       findings: [

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -891,6 +891,55 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it("blocks package installs when node_modules contains a blocked package directory without package.json", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "blocked-package-dir-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const blockedPackageDir = path.join(pluginDir, "vendor", "node_modules", "plain-crypto-js");
+    fs.mkdirSync(blockedPackageDir, { recursive: true });
+    fs.writeFileSync(path.join(blockedPackageDir, "index.js"), "module.exports = {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+      expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
+    }
+  });
+
+  it("does not block package installs for blocked-looking names outside node_modules", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "non-node-modules-path-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const innocuousDir = path.join(pluginDir, "assets", "plain-crypto-js");
+    fs.mkdirSync(innocuousDir, { recursive: true });
+    fs.writeFileSync(path.join(innocuousDir, "index.js"), "export {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("blocks package installs when a broad vendored tree contains a deeply nested blocked manifest", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
@@ -1180,6 +1229,26 @@ describe("installPluginFromArchive", () => {
       expect(result.error).toContain(
         "declared in plain-crypto-js (vendor/plain-crypto-js/package.json)",
       );
+    }
+  });
+
+  it("blocks bundle installs when node_modules contains a blocked package directory without package.json", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Blocked Package Dir Bundle",
+    });
+    const blockedPackageDir = path.join(pluginDir, "vendor", "node_modules", "plain-crypto-js");
+    fs.mkdirSync(blockedPackageDir, { recursive: true });
+    fs.writeFileSync(path.join(blockedPackageDir, "index.js"), "module.exports = {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('Bundle "blocked-package-dir-bundle" installation blocked');
+      expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+      expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
     }
   });
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -794,6 +794,34 @@ describe("installPluginFromArchive", () => {
     );
   });
 
+  it("blocks package installs when a dependency aliases to a blocked package", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "aliased-blocked-dependency-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+        dependencies: {
+          "safe-name": "npm:plain-crypto-js@^4.2.1",
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('"plain-crypto-js" via alias "safe-name" in dependencies');
+      expect(result.error).toContain(
+        "declared in aliased-blocked-dependency-plugin (package.json)",
+      );
+    }
+  });
+
   it("blocks package installs when a nested vendored package manifest declares a blocked dependency", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -918,6 +918,40 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it.runIf(process.platform !== "win32")(
+    "blocks package installs when node_modules contains a blocked package symlink",
+    async () => {
+      const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "blocked-package-symlink-plugin",
+          version: "1.0.0",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+      const actualDir = path.join(pluginDir, "vendor", "actual-package");
+      fs.mkdirSync(actualDir, { recursive: true });
+      fs.writeFileSync(path.join(actualDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync("../actual-package", path.join(nodeModulesDir, "plain-crypto-js"), "dir");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+        expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
+      }
+    },
+  );
+
   it("does not block package installs for blocked-looking names outside node_modules", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
@@ -1251,6 +1285,35 @@ describe("installPluginFromArchive", () => {
       expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "blocks bundle installs when node_modules contains a blocked package symlink",
+    async () => {
+      const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+        bundleFormat: "codex",
+        name: "Blocked Package Symlink Bundle",
+      });
+      const actualDir = path.join(pluginDir, "vendor", "actual-package");
+      fs.mkdirSync(actualDir, { recursive: true });
+      fs.writeFileSync(path.join(actualDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync("../actual-package", path.join(nodeModulesDir, "plain-crypto-js"), "dir");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain(
+          'Bundle "blocked-package-symlink-bundle" installation blocked',
+        );
+        expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+        expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
+      }
+    },
+  );
 
   it("surfaces plugin scanner findings from before_install", async () => {
     const handler = vi.fn().mockReturnValue({

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -945,6 +945,33 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it("blocks package installs when node_modules contains a blocked extensionless package file alias", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "blocked-package-extensionless-file-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const nodeModulesDir = path.join(pluginDir, "vendor", "Node_Modules");
+    fs.mkdirSync(nodeModulesDir, { recursive: true });
+    fs.writeFileSync(path.join(nodeModulesDir, "Plain-Crypto-Js"), "module.exports = {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('blocked dependency file alias "Plain-Crypto-Js"');
+      expect(result.error).toContain("vendor/Node_Modules/Plain-Crypto-Js");
+    }
+  });
+
   it.runIf(process.platform !== "win32")(
     "blocks package installs when node_modules contains a blocked package symlink",
     async () => {
@@ -975,6 +1002,109 @@ describe("installPluginFromArchive", () => {
         expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
         expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
         expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "blocks package installs when node_modules safe-name symlink targets a blocked package directory",
+    async () => {
+      const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "blocked-package-symlink-target-plugin",
+          version: "1.0.0",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+      const targetDir = path.join(pluginDir, "vendor", "plain-crypto-js");
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(path.join(targetDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync("../plain-crypto-js", path.join(nodeModulesDir, "safe-name"), "dir");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+        expect(result.error).toContain("vendor/plain-crypto-js");
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "blocks package installs when node_modules safe-name symlink targets a blocked package file alias",
+    async () => {
+      const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "blocked-package-file-symlink-target-plugin",
+          version: "1.0.0",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+      fs.mkdirSync(path.join(pluginDir, "vendor"), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDir, "vendor", "plain-crypto-js.js"),
+        "module.exports = {};\n",
+      );
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync("../plain-crypto-js.js", path.join(nodeModulesDir, "safe-name"), "file");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain('blocked dependency file alias "plain-crypto-js"');
+        expect(result.error).toContain("vendor/plain-crypto-js.js");
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "fails package installs when node_modules symlink target escapes the install root",
+    async () => {
+      const { pluginDir, extensionsDir, tmpDir } = setupPluginInstallDirs();
+
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "outside-root-symlink-plugin",
+          version: "1.0.0",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+      const externalDir = path.join(tmpDir, "external-package");
+      fs.mkdirSync(externalDir, { recursive: true });
+      fs.writeFileSync(path.join(externalDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync(externalDir, path.join(nodeModulesDir, "safe-name"), "dir");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+        expect(result.error).toContain("symlink target outside install root");
       }
     },
   );
@@ -1390,6 +1520,28 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it("blocks bundle installs when node_modules contains a blocked extensionless package file alias", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Blocked Package Extensionless File Bundle",
+    });
+    const nodeModulesDir = path.join(pluginDir, "vendor", "Node_Modules");
+    fs.mkdirSync(nodeModulesDir, { recursive: true });
+    fs.writeFileSync(path.join(nodeModulesDir, "Plain-Crypto-Js"), "module.exports = {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain(
+        'Bundle "blocked-package-extensionless-file-bundle" installation blocked',
+      );
+      expect(result.error).toContain('blocked dependency file alias "Plain-Crypto-Js"');
+      expect(result.error).toContain("vendor/Node_Modules/Plain-Crypto-Js");
+    }
+  });
+
   it.runIf(process.platform !== "win32")(
     "blocks bundle installs when node_modules contains a blocked package symlink",
     async () => {
@@ -1415,6 +1567,66 @@ describe("installPluginFromArchive", () => {
         );
         expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
         expect(result.error).toContain("vendor/node_modules/plain-crypto-js");
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "blocks bundle installs when node_modules safe-name symlink targets a blocked package directory",
+    async () => {
+      const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+        bundleFormat: "codex",
+        name: "Blocked Package Symlink Target Bundle",
+      });
+      const targetDir = path.join(pluginDir, "vendor", "plain-crypto-js");
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(path.join(targetDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync("../plain-crypto-js", path.join(nodeModulesDir, "safe-name"), "dir");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain(
+          'Bundle "blocked-package-symlink-target-bundle" installation blocked',
+        );
+        expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+        expect(result.error).toContain("vendor/plain-crypto-js");
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "blocks bundle installs when node_modules safe-name symlink targets a blocked package file alias",
+    async () => {
+      const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+        bundleFormat: "codex",
+        name: "Blocked Package File Symlink Target Bundle",
+      });
+      fs.mkdirSync(path.join(pluginDir, "vendor"), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDir, "vendor", "plain-crypto-js.js"),
+        "module.exports = {};\n",
+      );
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync("../plain-crypto-js.js", path.join(nodeModulesDir, "safe-name"), "file");
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain(
+          'Bundle "blocked-package-file-symlink-target-bundle" installation blocked',
+        );
+        expect(result.error).toContain('blocked dependency file alias "plain-crypto-js"');
+        expect(result.error).toContain("vendor/plain-crypto-js.js");
       }
     },
   );

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -563,6 +563,9 @@ beforeAll(async () => {
 beforeEach(() => {
   resetGlobalHookRunner();
   vi.clearAllMocks();
+  const run = vi.mocked(runCommandWithTimeout);
+  run.mockReset();
+  mockSuccessfulCommandRun(run);
   vi.unstubAllEnvs();
   resolveCompatibilityHostVersionMock.mockReturnValue("2026.3.28-beta.1");
 });
@@ -1425,7 +1428,7 @@ describe("installPluginFromDir", () => {
 
     const run = vi.mocked(runCommandWithTimeout);
     run.mockImplementation(async (_command, opts) => {
-      const cwd = opts?.cwd;
+      const cwd = typeof opts === "number" ? undefined : opts?.cwd;
       if (!cwd) {
         throw new Error("expected cwd for npm install");
       }

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1084,6 +1084,43 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it.runIf(process.platform !== "win32")(
+    "fails package installs when manifest traversal cannot read a directory",
+    async () => {
+      const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "unreadable-dir-plugin",
+          version: "1.0.0",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+      const blockedDir = path.join(pluginDir, "vendor", "sealed");
+      fs.mkdirSync(blockedDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(blockedDir, "package.json"),
+        JSON.stringify({ name: "plain-crypto-js" }),
+      );
+      fs.chmodSync(blockedDir, 0o000);
+
+      try {
+        const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+          expect(result.error).toContain("manifest dependency scan could not read");
+          expect(result.error).toContain("vendor/sealed");
+        }
+      } finally {
+        fs.chmodSync(blockedDir, 0o755);
+      }
+    },
+  );
+
   it("reports all blocked dependencies from the same manifest", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -764,6 +764,70 @@ describe("installPluginFromArchive", () => {
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
+  it("blocks package installs when a package manifest declares a blocked dependency", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "blocked-dependency-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+        dependencies: {
+          "plain-crypto-js": "^4.2.1",
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('Plugin "blocked-dependency-plugin" installation blocked');
+      expect(result.error).toContain('blocked dependency "plain-crypto-js"');
+      expect(result.error).toContain("dependencies of blocked-dependency-plugin (package.json)");
+    }
+    expect(warnings).toContain(
+      'WARNING: Plugin "blocked-dependency-plugin" installation blocked: blocked dependency "plain-crypto-js" declared in dependencies of blocked-dependency-plugin (package.json).',
+    );
+  });
+
+  it("blocks package installs when a nested vendored package manifest declares a blocked dependency", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "vendored-blocked-dependency-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+    fs.mkdirSync(path.join(pluginDir, "vendor", "axios"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "vendor", "axios", "package.json"),
+      JSON.stringify({
+        name: "axios",
+        version: "1.14.1",
+        dependencies: {
+          "plain-crypto-js": "^4.2.1",
+        },
+      }),
+    );
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('blocked dependency "plain-crypto-js"');
+      expect(result.error).toContain("dependencies of axios (vendor/axios/package.json)");
+    }
+  });
+
   it("allows package installs with dangerous code patterns when forced unsafe install is set", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
@@ -794,6 +858,47 @@ describe("installPluginFromArchive", () => {
         ),
       ),
     ).toBe(true);
+  });
+
+  it("keeps blocked dependency package checks active when forced unsafe install is set", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "forced-blocked-dependency-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+        dependencies: {
+          "plain-crypto-js": "^4.2.1",
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const { result, warnings } = await installFromDirWithWarnings({
+      pluginDir,
+      extensionsDir,
+      dangerouslyForceUnsafeInstall: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('blocked dependency "plain-crypto-js"');
+    }
+    expect(
+      warnings.some((warning) =>
+        warning.includes('blocked dependency "plain-crypto-js" declared in dependencies'),
+      ),
+    ).toBe(true);
+    expect(
+      warnings.some((warning) =>
+        warning.includes(
+          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
+        ),
+      ),
+    ).toBe(false);
   });
 
   it("blocks bundle installs when bundle contains dangerous code patterns", async () => {

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1077,6 +1077,44 @@ describe("installPluginFromArchive", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "blocks package installs when node_modules safe-name symlink targets a file under a blocked package directory",
+    async () => {
+      const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "blocked-package-nested-file-symlink-target-plugin",
+          version: "1.0.0",
+          openclaw: { extensions: ["index.js"] },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+      const blockedPackageDir = path.join(pluginDir, "vendor", "plain-crypto-js", "dist");
+      fs.mkdirSync(blockedPackageDir, { recursive: true });
+      fs.writeFileSync(path.join(blockedPackageDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync(
+        "../plain-crypto-js/dist/index.js",
+        path.join(nodeModulesDir, "safe-name"),
+        "file",
+      );
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+        expect(result.error).toContain("vendor/plain-crypto-js/dist/index.js");
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "fails package installs when node_modules symlink target escapes the install root",
     async () => {
       const { pluginDir, extensionsDir, tmpDir } = setupPluginInstallDirs();
@@ -1627,6 +1665,39 @@ describe("installPluginFromArchive", () => {
         );
         expect(result.error).toContain('blocked dependency file alias "plain-crypto-js"');
         expect(result.error).toContain("vendor/plain-crypto-js.js");
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "blocks bundle installs when node_modules safe-name symlink targets a file under a blocked package directory",
+    async () => {
+      const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+        bundleFormat: "codex",
+        name: "Blocked Package Nested File Symlink Target Bundle",
+      });
+      const blockedPackageDir = path.join(pluginDir, "vendor", "plain-crypto-js", "dist");
+      fs.mkdirSync(blockedPackageDir, { recursive: true });
+      fs.writeFileSync(path.join(blockedPackageDir, "index.js"), "module.exports = {};\n");
+
+      const nodeModulesDir = path.join(pluginDir, "vendor", "node_modules");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+      fs.symlinkSync(
+        "../plain-crypto-js/dist/index.js",
+        path.join(nodeModulesDir, "safe-name"),
+        "file",
+      );
+
+      const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+        expect(result.error).toContain(
+          'Bundle "blocked-package-nested-file-symlink-target-bundle" installation blocked',
+        );
+        expect(result.error).toContain('blocked dependency directory "plain-crypto-js"');
+        expect(result.error).toContain("vendor/plain-crypto-js/dist/index.js");
       }
     },
   );

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -976,6 +976,39 @@ describe("installPluginFromArchive", () => {
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
+  it("blocks bundle installs when a vendored manifest declares a blocked dependency", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Blocked Dependency Bundle",
+    });
+    fs.mkdirSync(path.join(pluginDir, "vendor", "axios"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "vendor", "axios", "package.json"),
+      JSON.stringify({
+        name: "axios",
+        version: "1.14.1",
+        dependencies: {
+          "plain-crypto-js": "^4.2.1",
+        },
+      }),
+    );
+
+    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('Bundle "blocked-dependency-bundle" installation blocked');
+      expect(result.error).toContain('blocked dependencies "plain-crypto-js" in dependencies');
+      expect(result.error).toContain("declared in axios (vendor/axios/package.json)");
+    }
+    expect(
+      warnings.some((warning) =>
+        warning.includes('blocked dependencies "plain-crypto-js" in dependencies'),
+      ),
+    ).toBe(true);
+  });
+
   it("surfaces plugin scanner findings from before_install", async () => {
     const handler = vi.fn().mockReturnValue({
       findings: [

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -822,6 +822,38 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it("blocks package installs when overrides alias to a blocked package", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "override-aliased-blocked-dependency-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+        overrides: {
+          "@scope/parent": {
+            "safe-name": "npm:plain-crypto-js@^4.2.1",
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain(
+        '"plain-crypto-js" via alias "@scope/parent > safe-name" in overrides',
+      );
+      expect(result.error).toContain(
+        "declared in override-aliased-blocked-dependency-plugin (package.json)",
+      );
+    }
+  });
+
   it("blocks package installs when a nested vendored package manifest declares a blocked dependency", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -891,6 +891,55 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it("blocks package installs when a broad vendored tree contains a deeply nested blocked manifest", async () => {
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "wide-vendored-tree-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const vendorRoot = path.join(pluginDir, "vendor");
+    for (let index = 0; index < 128; index += 1) {
+      fs.mkdirSync(path.join(vendorRoot, `pkg-${String(index).padStart(3, "0")}`), {
+        recursive: true,
+      });
+    }
+
+    const blockedManifestDir = path.join(
+      vendorRoot,
+      "pkg-127",
+      "node_modules",
+      "nested-safe",
+      "node_modules",
+      "plain-crypto-js",
+    );
+    fs.mkdirSync(blockedManifestDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(blockedManifestDir, "package.json"),
+      JSON.stringify({
+        name: "plain-crypto-js",
+        version: "4.2.1",
+      }),
+    );
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('"plain-crypto-js" as package name');
+      expect(result.error).toContain(
+        "declared in plain-crypto-js (vendor/pkg-127/node_modules/nested-safe/node_modules/plain-crypto-js/package.json)",
+      );
+    }
+  });
+
   it("reports all blocked dependencies from the same manifest", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -940,6 +940,67 @@ describe("installPluginFromArchive", () => {
     }
   });
 
+  it("fails package installs when manifest traversal exceeds the directory cap", async () => {
+    vi.stubEnv("OPENCLAW_INSTALL_SCAN_MAX_DIRECTORIES", "4");
+
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "directory-cap-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const vendorRoot = path.join(pluginDir, "vendor");
+    for (let index = 0; index < 8; index += 1) {
+      fs.mkdirSync(path.join(vendorRoot, `pkg-${index}`), { recursive: true });
+    }
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+      expect(result.error).toContain("manifest dependency scan exceeded max directories (4)");
+    }
+  });
+
+  it("fails package installs when manifest traversal exceeds the depth cap", async () => {
+    vi.stubEnv("OPENCLAW_INSTALL_SCAN_MAX_DEPTH", "2");
+
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "depth-cap-plugin",
+        version: "1.0.0",
+        openclaw: { extensions: ["index.js"] },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
+
+    const nestedDir = path.join(pluginDir, "vendor", "a", "b", "c");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nestedDir, "package.json"),
+      JSON.stringify({
+        name: "plain-crypto-js",
+        version: "4.2.1",
+      }),
+    );
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+      expect(result.error).toContain("manifest dependency scan exceeded max depth (2)");
+    }
+  });
+
   it("reports all blocked dependencies from the same manifest", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -359,6 +359,9 @@ async function installPluginDirectoryIntoExtensions(params: {
   hasDeps: boolean;
   depsLogMessage: string;
   afterCopy?: (installedDir: string) => Promise<void>;
+  afterInstall?: (
+    installedDir: string,
+  ) => Promise<Extract<InstallPluginResult, { ok: false }> | null>;
   nameEncoder?: (pluginId: string) => string;
 }): Promise<InstallPluginResult> {
   const runtime = await loadPluginInstallRuntime();
@@ -404,9 +407,24 @@ async function installPluginDirectoryIntoExtensions(params: {
     hasDeps: params.hasDeps,
     depsLogMessage: params.depsLogMessage,
     afterCopy: params.afterCopy,
+    afterInstall: async (installedDir) => {
+      const postInstallResult = await params.afterInstall?.(installedDir);
+      if (!postInstallResult) {
+        return { ok: true as const };
+      }
+      return {
+        ok: false as const,
+        error: postInstallResult.error,
+        ...(postInstallResult.code ? { code: postInstallResult.code } : {}),
+      };
+    },
   });
   if (!installRes.ok) {
-    return installRes;
+    return {
+      ok: false,
+      error: installRes.error,
+      ...(installRes.code ? { code: installRes.code as PluginInstallErrorCode } : {}),
+    };
   }
 
   return buildDirectoryInstallResult({
@@ -752,6 +770,16 @@ async function installPluginFromPackageDir(
         }
       }
     },
+    afterInstall: async (installedDir) =>
+      await runInstallSourceScan({
+        subject: `Plugin "${pluginId}"`,
+        scan: async () =>
+          await runtime.scanInstalledPackageDependencyTree({
+            logger,
+            packageDir: installedDir,
+            pluginId,
+          }),
+      }),
   });
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** fresh installs could resolve an unexpected `axios` version through a broad optional dependency range, and plugin installs had no manifest-level denylist check for known bad packages.
- **Why it matters:** installs could pull in unwanted transitive packages, and plugin trees with vendored dependencies were not blocked early enough.
- **What changed:**
  - Confirmed with `npm view axios version` that `1.15.0` is the latest published release as of April 9, 2026, and pinned `axios` to `1.15.0` in `package.json` and lockfile.
  - Added `src/plugins/dependency-denylist.ts` with a named blocked-package list (`plain-crypto-js` currently) and a `findBlockedManifestDependencies` helper.
  - Extended `src/plugins/install-security-scan.runtime.ts` to scan all `package.json` files in a plugin tree, including vendored and `node_modules` subtrees, before install.
  - Applied the denylist scan to both package and bundle install paths, kept it non-bypassable via `--dangerously-force-unsafe-install`, and added `node_modules` directory-name enforcement for blocked package ids even when a vendored package omits `package.json`.
  - Hardened manifest traversal with linear queue semantics, explicit symlink skipping, realpath dedupe, and bounded depth/directory/manifest limits.
  - The `axios` update also changes one transitive proxy helper path to `proxy-from-env@2.1.0` while other parts of the tree still carry `1.1.0`; this PR does not change direct proxy configuration logic, but the lockfile reflects that transitive version split.
- **What did NOT change:** Existing code-pattern scan, hook runner, and the rest of the install-security flow remain in place.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Integrations
- [x] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: a broad optional dependency range allowed installs to select an unexpected `axios` version during fresh resolution.
- Missing detection / guardrail: no exact override pin for `axios`, and no install-time manifest denylist for known blocked packages inside plugin trees.
- Contributing context: lockfile-based installs were more stable, but fresh resolution paths still needed stronger constraints.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/plugins/dependency-denylist.test.ts`, `src/plugins/install.test.ts`
- Scenario the test should lock in:
  - Denylist test: root manifest carries an exact-version pin for `axios`; `plain-crypto-js` is absent from both root manifest and lockfile graph.
  - Install tests: plugin or bundle installs with a blocked dependency in `dependencies`, `peerDependencies`, nested vendored `package.json` files, or `node_modules/<blocked-package>` directories are blocked at install time; `--dangerously-force-unsafe-install` does not bypass the denylist.
  - Traversal tests: broad and deep vendored trees still surface blocked nested manifests, while depth and directory caps fail cleanly.
- Why this is the smallest reliable guardrail: The denylist scan runs before the code-pattern scan and returns early; integration tests exercise the real install paths.
- Existing test that already covers this: None — new tests added.

## User-visible / Behavior Changes

Plugin and bundle installs that declare `plain-crypto-js` directly, in vendored `package.json` files, or as a vendored `node_modules/plain-crypto-js` directory are now blocked with a clear error naming the offending manifest or directory. This denylist check cannot be bypassed with `--dangerously-force-unsafe-install`.

## Diagram (if applicable)

```text
Before:
[plugin install] -> [code-pattern scan] -> [install]

After:
[plugin install] -> [denylist scan (not bypassable)] -> [code-pattern scan] -> [install]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node 22, pnpm
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: None

### Steps

1. Verify the root override and lockfile resolve `axios@1.15.0`.
2. Attempt to install a plugin or bundle with `plain-crypto-js` in `package.json`, a vendored nested manifest, or a vendored `node_modules/plain-crypto-js` directory.
3. Attempt installs against broad/deep vendored trees to confirm bounded traversal and clean failures when limits are exceeded.

### Expected

- `axios` resolves to `1.15.0`.
- Plugin and bundle installs declaring `plain-crypto-js` are blocked before install completes.
- Pathological manifest trees fail with clear traversal-limit errors instead of unbounded walking.

### Actual

- Confirmed by targeted tests and local verification.

## Evidence

- [x] Failing test/log before + passing after
- New tests in `src/plugins/dependency-denylist.test.ts` and `src/plugins/install.test.ts` cover the denylist and traversal scenarios.

## Human Verification (required)

- Verified scenarios: lockfile updated to `axios@1.15.0`; `plain-crypto-js` absent from lockfile graph; package and bundle denylist scans block offending manifests and blocked `node_modules` package directories; traversal caps fail cleanly.
- Edge cases checked: vendored nested manifests blocked; vendored blocked package directories under `node_modules` blocked even without `package.json`; similarly named paths outside `node_modules` not blocked; `--dangerously-force-unsafe-install` does not bypass the denylist; broad/deep trees still surface nested blocked manifests.
- What you did **not** verify: live end-to-end install from a fresh external machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: legitimate plugins that vendor a package depending on `plain-crypto-js` will be blocked.
  - Mitigation: the error message names the offending manifest or `node_modules` directory precisely, making remediation straightforward. The denylist is intentionally narrow.
