### PR TITLE
fix: allow TTS tool media delivery to channels

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -47,7 +47,8 @@ export function normalizeReplyPayload(
       },
     );
   const trimmed = normalizeOptionalString(payload.text) ?? "";
-  if (!hasContent(trimmed)) {
+  const hasMediaContent = payload.mediaUrls?.some((u) => Boolean(u)) || Boolean(payload.mediaUrl);
+  if (!hasContent(trimmed) && !hasMediaContent && !payload.audioAsVoice) {
     opts.onSkip?.("empty");
     return null;
   }
@@ -98,7 +99,7 @@ export function normalizeReplyPayload(
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
   }
-  if (!hasContent(text)) {
+  if (!hasContent(text) && !hasMediaContent && !payload.audioAsVoice) {
     opts.onSkip?.("empty");
     return null;
   }

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -7,6 +7,7 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
+import { POSIX_OPENCLAW_TMP_DIR } from "../../infra/tmp-openclaw-dir.js";
 import { saveMediaSource } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
@@ -40,6 +41,11 @@ function isAllowedAbsoluteReplyMediaPath(params: {
   sandboxRoot?: string;
 }): boolean {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
+    return true;
+  }
+  // TTS tool outputs audio files to /tmp/openclaw/tts-* which is a
+  // well-known managed directory that persists across sessions.
+  if (isPathInside(POSIX_OPENCLAW_TMP_DIR, params.candidate)) {
     return true;
   }
   const volatileRoots = [params.workspaceDir, params.sandboxRoot]


### PR DESCRIPTION
## Problem

TTS tool audio files were generated successfully but never delivered to channels (Telegram, etc.). The `[[tts:text]]` tag approach worked fine, but calling the `tts()` tool directly produced no voice message.

## Root Cause

Two compounding issues:

### 1. `normalizeReplyPayload()` drops media-only payloads

The function's early-exit guards only checked text content:
```ts
if (!hasContent(trimmed)) {
  opts.onSkip?.("empty");
  return null;
}
```

When the TTS tool's audio is delivered as a media-only block reply (`text=undefined`, `audioAsVoice=true`, `mediaUrls=["/tmp/openclaw/tts-.../voice-*.opus"]`), the function treated it as empty and returned `null`. This happened in **two places** in the function.

### 2. `isAllowedAbsoluteReplyMediaPath()` blocks `/tmp/openclaw` paths

The TTS tool writes audio to `POSIX_OPENCLAW_TMP_DIR` (`/tmp/openclaw`), which is a managed temp directory. But `isAllowedAbsoluteReplyMediaPath()` only allowed paths inside workspace/sandbox `.openclaw/media` or global `~/.openclaw/media/outbound`. On macOS where `TMPDIR=/var/folders/...`, the hardcoded `/tmp/openclaw` path was rejected, causing `normalizeMediaPaths` to strip the path.

## Fix

1. **`normalize-reply.ts`**: Added `hasMediaContent` and `audioAsVoice` checks before the early-exit guards. A payload with media URLs or audio-as-voice flag is no longer treated as empty even without text.

2. **`reply-media-paths.ts`**: Added `POSIX_OPENCLAW_TMP_DIR` to the allowed absolute paths in `isAllowedAbsoluteReplyMediaPath()`. This allows TTS audio files (and any other tool output in `/tmp/openclaw`) to pass through media path normalization.

## Testing

Manually tested on macOS with Telegram channel:
- Before fix: TTS tool call → audio generated but not delivered
- After fix: TTS tool call → voice message delivered to Telegram ✅

## Files Changed

- `src/auto-reply/reply/normalize-reply.ts` — Two early-exit guards updated
- `src/auto-reply/reply/reply-media-paths.ts` — Added `/tmp/openclaw` to allowed paths