### PR TITLE
Fix: allow self-hosted Firecrawl baseUrl with http on private networks (Resolves #63877)

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -42,13 +42,22 @@ function isPrivateOrLocalHost(hostname: string): boolean {
   if (h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]") {
     return true;
   }
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10) — bare or bracketed
+  const bare = h.startsWith("[") && h.endsWith("]") ? h.slice(1, -1) : h;
+  if (/^f[cd][0-9a-f]{2}:/i.test(bare) || /^fe[89ab][0-9a-f]:/i.test(bare)) {
+    return true;
+  }
   if (h.endsWith(".localhost") || h.endsWith(".local") || h.endsWith(".internal")) {
     return true;
   }
-  // RFC 1918 / link-local / carrier-grade NAT IPv4 ranges
+  // RFC 1918 / link-local / carrier-grade NAT / loopback IPv4 ranges
   const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
   if (ipv4Match) {
     const [, a, b] = ipv4Match.map(Number);
+    // 127.0.0.0/8 (full loopback subnet)
+    if (a === 127) {
+      return true;
+    }
     // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 100.64.0.0/10
     if (a === 10) {
       return true;

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -8,6 +8,7 @@ import {
   resolveCacheTtlMs,
   truncateText,
   withStrictWebToolsEndpoint,
+  withTrustedWebToolsEndpoint,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-fetch";
 import { normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
@@ -127,6 +128,14 @@ function resolveEndpoint(baseUrl: string, pathname: "/v2/search" | "/v2/scrape")
   return url.toString();
 }
 
+function isPrivateOrLocalEndpoint(url: string): boolean {
+  try {
+    return isPrivateOrLocalHost(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
 async function postFirecrawlJson<T>(
   params: {
     url: string;
@@ -138,7 +147,13 @@ async function postFirecrawlJson<T>(
   parse: (response: Response) => Promise<T>,
 ): Promise<T> {
   const apiKey = normalizeSecretInput(params.apiKey);
-  return await withStrictWebToolsEndpoint(
+  // Admin-configured private/local Firecrawl baseUrl (loopback, RFC 1918, mDNS,
+  // IPv6 ULA/link-local) goes through the trusted fetch guard so the strict
+  // SSRF policy does not block the outbound request to the configured host.
+  const guardedFetch = isPrivateOrLocalEndpoint(params.url)
+    ? withTrustedWebToolsEndpoint
+    : withStrictWebToolsEndpoint;
+  return await guardedFetch(
     {
       url: params.url,
       timeoutSeconds: params.timeoutSeconds,
@@ -543,6 +558,7 @@ export async function runFirecrawlScrape(
 }
 
 export const __testing = {
+  isPrivateOrLocalEndpoint,
   parseFirecrawlScrapePayload,
   postFirecrawlJson,
   resolveEndpoint,

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -31,7 +31,43 @@ const SCRAPE_CACHE = new Map<
 >();
 const DEFAULT_SEARCH_COUNT = 5;
 const DEFAULT_SCRAPE_MAX_CHARS = 50_000;
-const ALLOWED_FIRECRAWL_HOSTS = new Set(["api.firecrawl.dev"]);
+
+/**
+ * Returns true when the hostname looks like a private/local network address
+ * where cleartext HTTP is acceptable (loopback, RFC 1918 IPs, mDNS .local,
+ * .internal, .localhost suffixes).
+ */
+function isPrivateOrLocalHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]") {
+    return true;
+  }
+  if (h.endsWith(".localhost") || h.endsWith(".local") || h.endsWith(".internal")) {
+    return true;
+  }
+  // RFC 1918 / link-local / carrier-grade NAT IPv4 ranges
+  const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
+  if (ipv4Match) {
+    const [, a, b] = ipv4Match.map(Number);
+    // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 100.64.0.0/10
+    if (a === 10) {
+      return true;
+    }
+    if (a === 172 && b >= 16 && b <= 31) {
+      return true;
+    }
+    if (a === 192 && b === 168) {
+      return true;
+    }
+    if (a === 169 && b === 254) {
+      return true;
+    }
+    if (a === 100 && b >= 64 && b <= 127) {
+      return true;
+    }
+  }
+  return false;
+}
 
 type FirecrawlSearchItem = {
   title: string;
@@ -66,11 +102,13 @@ export type FirecrawlScrapeParams = {
 
 function resolveEndpoint(baseUrl: string, pathname: "/v2/search" | "/v2/scrape"): string {
   const url = new URL(baseUrl.trim() || "https://api.firecrawl.dev");
-  if (url.protocol !== "https:") {
-    throw new Error("Firecrawl baseUrl must use https.");
+  if (url.protocol !== "https:" && !isPrivateOrLocalHost(url.hostname)) {
+    throw new Error(
+      "Firecrawl baseUrl must use https for public hosts. Use https, or use a private/local network address with http.",
+    );
   }
-  if (!ALLOWED_FIRECRAWL_HOSTS.has(url.hostname)) {
-    throw new Error(`Firecrawl baseUrl host is not allowed: ${url.hostname}`);
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Firecrawl baseUrl must use http or https.");
   }
   url.username = "";
   url.password = "";

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -651,6 +651,21 @@ describe("firecrawl tools", () => {
     expect(firecrawlClientTesting.resolveEndpoint("http://myhost.local:3002", "/v2/scrape")).toBe(
       "http://myhost.local:3002/v2/scrape",
     );
+    // Full loopback subnet (127.x.x.x)
+    expect(firecrawlClientTesting.resolveEndpoint("http://127.0.0.2:3002", "/v2/scrape")).toBe(
+      "http://127.0.0.2:3002/v2/scrape",
+    );
+    expect(firecrawlClientTesting.resolveEndpoint("http://127.255.0.1:3002", "/v2/search")).toBe(
+      "http://127.255.0.1:3002/v2/search",
+    );
+    // IPv6 unique-local (fc00::/7)
+    expect(firecrawlClientTesting.resolveEndpoint("http://[fd12::1]:3002", "/v2/scrape")).toBe(
+      "http://[fd12::1]:3002/v2/scrape",
+    );
+    // IPv6 link-local (fe80::/10)
+    expect(firecrawlClientTesting.resolveEndpoint("http://[fe80::1]:3002", "/v2/search")).toBe(
+      "http://[fe80::1]:3002/v2/search",
+    );
   });
 
   it("respects positive numeric overrides for scrape and cache behavior", () => {

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -181,6 +181,59 @@ describe("firecrawl tools", () => {
     ).rejects.toThrow(/<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
   });
 
+  it("classifies private/local endpoints for trusted fetch routing", () => {
+    expect(firecrawlClientTesting.isPrivateOrLocalEndpoint("http://127.0.0.1:3002/v2/search")).toBe(
+      true,
+    );
+    expect(
+      firecrawlClientTesting.isPrivateOrLocalEndpoint("http://192.168.1.100:3002/v2/scrape"),
+    ).toBe(true);
+    expect(
+      firecrawlClientTesting.isPrivateOrLocalEndpoint("http://myhost.local:3002/v2/search"),
+    ).toBe(true);
+    expect(firecrawlClientTesting.isPrivateOrLocalEndpoint("http://[fd12::1]:3002/v2/scrape")).toBe(
+      true,
+    );
+    expect(
+      firecrawlClientTesting.isPrivateOrLocalEndpoint("https://api.firecrawl.dev/v2/search"),
+    ).toBe(false);
+    expect(
+      firecrawlClientTesting.isPrivateOrLocalEndpoint(
+        "https://firecrawl.internal.corp:8443/v2/scrape",
+      ),
+    ).toBe(false);
+  });
+
+  it("reaches a self-hosted private-network Firecrawl baseUrl through the trusted fetch guard", async () => {
+    // Point the pinned resolver at a private IPv4 so the strict SSRF guard
+    // would reject the request. If routing picks the trusted guard, the
+    // dangerouslyAllowPrivateNetwork policy permits the fetch.
+    ssrfMock?.mockRestore();
+    ssrfMock = mockPinnedHostnameResolution(["127.0.0.1"]);
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ success: true, data: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    global.fetch = fetchSpy as typeof fetch;
+
+    const result = await firecrawlClientTesting.postFirecrawlJson(
+      {
+        url: "http://127.0.0.1:3002/v2/search",
+        timeoutSeconds: 5,
+        apiKey: "firecrawl-key",
+        body: { query: "openclaw" },
+        errorLabel: "Firecrawl search",
+      },
+      async (response) => (await response.json()) as Record<string, unknown>,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ success: true });
+  });
+
   it("normalizes Firecrawl authorization headers before requests", async () => {
     let capturedInit: RequestInit | undefined;
     const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -605,19 +605,52 @@ describe("firecrawl tools", () => {
     expect(resolveFirecrawlApiKey(cfg)).toBeUndefined();
   });
 
-  it("only allows the official Firecrawl API host for fetch endpoints", () => {
+  it("allows the official Firecrawl API host", () => {
     expect(firecrawlClientTesting.resolveEndpoint("https://api.firecrawl.dev", "/v2/scrape")).toBe(
       "https://api.firecrawl.dev/v2/scrape",
     );
+  });
+
+  it("requires https for public hosts", () => {
     expect(() =>
       firecrawlClientTesting.resolveEndpoint("http://api.firecrawl.dev", "/v2/scrape"),
-    ).toThrow("Firecrawl baseUrl must use https.");
+    ).toThrow("Firecrawl baseUrl must use https for public hosts");
     expect(() =>
-      firecrawlClientTesting.resolveEndpoint("https://127.0.0.1:8787", "/v2/scrape"),
-    ).toThrow("Firecrawl baseUrl host is not allowed");
-    expect(() =>
-      firecrawlClientTesting.resolveEndpoint("https://attacker.example", "/v2/search"),
-    ).toThrow("Firecrawl baseUrl host is not allowed");
+      firecrawlClientTesting.resolveEndpoint("http://attacker.example", "/v2/search"),
+    ).toThrow("Firecrawl baseUrl must use https for public hosts");
+  });
+
+  it("allows custom public hosts over https", () => {
+    expect(
+      firecrawlClientTesting.resolveEndpoint("https://my-firecrawl.example.com", "/v2/scrape"),
+    ).toBe("https://my-firecrawl.example.com/v2/scrape");
+    expect(
+      firecrawlClientTesting.resolveEndpoint("https://firecrawl.internal.corp:8443", "/v2/search"),
+    ).toBe("https://firecrawl.internal.corp:8443/v2/search");
+  });
+
+  it("allows http for private/local network hosts", () => {
+    expect(firecrawlClientTesting.resolveEndpoint("http://localhost:3002", "/v2/search")).toBe(
+      "http://localhost:3002/v2/search",
+    );
+    expect(firecrawlClientTesting.resolveEndpoint("http://127.0.0.1:8787", "/v2/scrape")).toBe(
+      "http://127.0.0.1:8787/v2/scrape",
+    );
+    expect(firecrawlClientTesting.resolveEndpoint("http://192.168.1.100:3002", "/v2/search")).toBe(
+      "http://192.168.1.100:3002/v2/search",
+    );
+    expect(firecrawlClientTesting.resolveEndpoint("http://10.0.0.5:3002", "/v2/scrape")).toBe(
+      "http://10.0.0.5:3002/v2/scrape",
+    );
+    expect(
+      firecrawlClientTesting.resolveEndpoint(
+        "http://host.openshell.internal:3002/v1",
+        "/v2/search",
+      ),
+    ).toBe("http://host.openshell.internal:3002/v2/search");
+    expect(firecrawlClientTesting.resolveEndpoint("http://myhost.local:3002", "/v2/scrape")).toBe(
+      "http://myhost.local:3002/v2/scrape",
+    );
   });
 
   it("respects positive numeric overrides for scrape and cache behavior", () => {


### PR DESCRIPTION
Fixes #63877.

## Problem

`resolveEndpoint()` in the Firecrawl extension hardcodes `ALLOWED_FIRECRAWL_HOSTS` to only `api.firecrawl.dev` and requires HTTPS unconditionally. This blocks users who self-host Firecrawl on their local/private network from using it, even when they explicitly configure a `baseUrl`.

## Changes

- Removed the `ALLOWED_FIRECRAWL_HOSTS` allowlist — the baseUrl is admin-configured, not untrusted user input, so any host should be allowed
- Added `isPrivateOrLocalHost()` helper that detects private/local network addresses (loopback, RFC 1918 IPs, `.local`/`.internal`/`.localhost` suffixes)
- HTTP is now allowed for private/local network hosts; HTTPS is still required for public hosts to prevent credential leakage
- URL sanitization (credential/query/hash stripping) is preserved

## Test plan

- [x] Updated existing endpoint validation test to reflect new behavior
- [x] Added tests for: custom public hosts over HTTPS, HTTP on private/local hosts (localhost, 127.0.0.1, 192.168.x.x, 10.x.x.x, .internal, .local)
- [x] Verified HTTPS is still required for public hosts
- [x] Ran `pnpm test extensions/firecrawl/src/firecrawl-tools.test.ts` — 21 passed, 2 failed (pre-existing DNS failures on main, unrelated)

AI-assisted (Claude). Fully tested. I understand what the code does.