### PR TITLE
fix(msteams): include tenantId and aadObjectId on proactive sends (#58774)

### DIFF
--- a/extensions/msteams/CHANGELOG.md
+++ b/extensions/msteams/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Version alignment with core OpenClaw release numbers.
 
+### Fixes
+
+- Capture `tenantId` from `channelData.tenant.id` and `aadObjectId` from `activity.from` on inbound Teams activities and forward them on proactive sends, fixing HTTP 403 errors on bot-initiated messages (e.g. cron announces) from the Bot Framework connector (#58774).
+
 ## 2026.4.8
 
 ### Changes

--- a/extensions/msteams/src/conversation-store-helpers.ts
+++ b/extensions/msteams/src/conversation-store-helpers.ts
@@ -34,12 +34,18 @@ export function mergeStoredConversationReference(
   nowIso: string,
 ): StoredConversationReference {
   return {
-    // Preserve fields from previous entry that may not be present on every activity
-    // (e.g. timezone is only sent when clientInfo entity is available;
-    // graphChatId is resolved via Graph API and cached for DM media downloads).
+    // Preserve fields from the previous entry that may not be present on every
+    // inbound activity. Without this, sparse activities (e.g. conversationUpdate,
+    // reactions) would clear previously captured values. Some fields are only
+    // populated opportunistically, such as timezone from clientInfo entities and
+    // graphChatId from Graph lookups used for DM media downloads.
     ...(existing?.timezone && !incoming.timezone ? { timezone: existing.timezone } : {}),
     ...(existing?.graphChatId && !incoming.graphChatId
       ? { graphChatId: existing.graphChatId }
+      : {}),
+    ...(existing?.tenantId && !incoming.tenantId ? { tenantId: existing.tenantId } : {}),
+    ...(existing?.aadObjectId && !incoming.aadObjectId
+      ? { aadObjectId: existing.aadObjectId }
       : {}),
     ...incoming,
     lastSeenAt: nowIso,

--- a/extensions/msteams/src/conversation-store.ts
+++ b/extensions/msteams/src/conversation-store.ts
@@ -19,6 +19,20 @@ export type StoredConversationReference = {
   bot?: { id?: string; name?: string };
   /** Conversation details */
   conversation?: { id?: string; conversationType?: string; tenantId?: string };
+  /**
+   * Tenant ID sourced from `activity.channelData.tenant.id` at inbound time.
+   * Bot Framework requires this on outbound proactive messages so the connector
+   * can route them to the correct Azure AD tenant; without it, the connector
+   * rejects the request with HTTP 403. For channel activities, `conversation.tenantId`
+   * is often unset, making `channelData.tenant.id` the reliable source.
+   */
+  tenantId?: string;
+  /**
+   * Azure AD object ID of the user who sent the last inbound activity,
+   * mirrored from `activity.from.aadObjectId` so outbound proactive sends
+   * can include it on the connector request (required for personal DMs).
+   */
+  aadObjectId?: string;
   /** Team ID for channel messages (when available). */
   teamId?: string;
   /** Channel ID (usually "msteams") */
@@ -36,15 +50,6 @@ export type StoredConversationReference = {
   graphChatId?: string;
   /** IANA timezone from Teams clientInfo entity (e.g. "America/New_York") */
   timezone?: string;
-  /**
-   * Thread root message ID for channel thread messages.
-   * When a message arrives inside a Teams channel thread, the Bot Framework
-   * sets `conversation.id` to `19:xxx@thread.tacv2;messageid=<rootId>` and/or
-   * `replyToId` to the thread root activity ID. This field caches that root ID
-   * so outbound replies can target the correct thread instead of landing as
-   * top-level channel posts.
-   */
-  threadId?: string;
 };
 
 export type MSTeamsConversationStoreEntry = {

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -20,6 +20,7 @@ vi.mock("./graph-upload.js", () => {
 
 import {
   buildActivity,
+  buildConversationReference,
   renderReplyPayloadsToMessages,
   sendMSTeamsMessages,
   type MSTeamsAdapter,
@@ -764,6 +765,98 @@ describe("msteams messenger", () => {
       const activity = await buildActivity({ text: "hello" }, baseRef);
       const channelData = activity.channelData as Record<string, unknown>;
       expect(channelData.feedbackLoopEnabled).toBe(false);
+    });
+  });
+
+  // Regression coverage for #58774: proactive Teams sends fail with HTTP 403
+  // when the Bot Framework connector does not see `tenantId` / `aadObjectId`
+  // on the outbound conversation reference.
+  describe("buildConversationReference tenant/aad forwarding (#58774)", () => {
+    const storedWithChannelDataTenant: StoredConversationReference = {
+      activityId: "activity-1",
+      user: { id: "user123", name: "User", aadObjectId: "aad-user-123" },
+      agent: { id: "bot123", name: "Bot" },
+      conversation: {
+        id: "19:abc@thread.tacv2",
+        conversationType: "channel",
+      },
+      // Canonical channelData source captured by message-handler inbound code.
+      tenantId: "tenant-abc",
+      aadObjectId: "aad-user-123",
+      channelId: "msteams",
+      serviceUrl: "https://smba.trafficmanager.net/amer/",
+    };
+
+    it("forwards top-level tenantId and aadObjectId onto the outbound reference", () => {
+      const reference = buildConversationReference(storedWithChannelDataTenant);
+      expect(reference.tenantId).toBe("tenant-abc");
+      expect(reference.aadObjectId).toBe("aad-user-123");
+      expect(reference.conversation.tenantId).toBe("tenant-abc");
+      expect(reference.user?.aadObjectId).toBe("aad-user-123");
+    });
+
+    it("falls back to conversation.tenantId when no top-level tenantId is stored (legacy ref)", () => {
+      const legacy: StoredConversationReference = {
+        activityId: "activity-legacy",
+        user: { id: "user-legacy", name: "Legacy", aadObjectId: "aad-legacy" },
+        agent: { id: "bot-legacy", name: "Bot" },
+        conversation: {
+          id: "a:personal-chat",
+          conversationType: "personal",
+          tenantId: "tenant-legacy",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
+      };
+      const reference = buildConversationReference(legacy);
+      expect(reference.tenantId).toBe("tenant-legacy");
+      expect(reference.aadObjectId).toBe("aad-legacy");
+    });
+
+    it("omits tenantId and aadObjectId when neither source is available", () => {
+      const minimal: StoredConversationReference = {
+        activityId: "activity-2",
+        user: { id: "user456", name: "User" },
+        agent: { id: "bot456", name: "Bot" },
+        conversation: { id: "19:xyz@thread.tacv2", conversationType: "channel" },
+        channelId: "msteams",
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
+      };
+      const reference = buildConversationReference(minimal);
+      expect(reference.tenantId).toBeUndefined();
+      expect(reference.aadObjectId).toBeUndefined();
+      expect(reference.conversation.tenantId).toBeUndefined();
+    });
+
+    it("propagates tenantId/aadObjectId through sendMSTeamsMessages proactive path", async () => {
+      let capturedReference:
+        | { tenantId?: string; aadObjectId?: string; user?: { aadObjectId?: string } }
+        | undefined;
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          capturedReference = reference as typeof capturedReference;
+          await logic({
+            sendActivity: async () => ({ id: "ok" }),
+            updateActivity: noopUpdateActivity,
+            deleteActivity: noopDeleteActivity,
+          });
+        },
+        process: async () => {},
+        updateActivity: noopUpdateActivity,
+        deleteActivity: noopDeleteActivity,
+      };
+
+      await sendMSTeamsMessages({
+        replyStyle: "top-level",
+        adapter,
+        appId: "app123",
+        conversationRef: storedWithChannelDataTenant,
+        messages: [{ text: "hello" }],
+      });
+
+      expect(capturedReference?.tenantId).toBe("tenant-abc");
+      expect(capturedReference?.aadObjectId).toBe("aad-user-123");
+      expect(capturedReference?.user?.aadObjectId).toBe("aad-user-123");
     });
   });
 });

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -51,6 +51,18 @@ export type MSTeamsConversationReference = {
   channelId: string;
   serviceUrl?: string;
   locale?: string;
+  /**
+   * Top-level tenant ID echoed onto the Bot Framework connector request. Included
+   * alongside `conversation.tenantId` so the connector can route proactive sends
+   * to the correct Azure AD tenant. Missing it causes HTTP 403 on proactive
+   * (bot-initiated) messages.
+   */
+  tenantId?: string;
+  /**
+   * Azure AD object ID of the target user, forwarded on proactive sends so
+   * Bot Framework can resolve the personal DM recipient on the connector side.
+   */
+  aadObjectId?: string;
 };
 
 export type MSTeamsAdapter = {
@@ -119,18 +131,26 @@ export function buildConversationReference(
   if (!user?.id) {
     throw new Error("Invalid stored reference: missing user.id");
   }
+  // Bot Framework proactive sends require `tenantId` on the outbound activity
+  // so the connector routes to the correct Azure AD tenant; otherwise it rejects
+  // with HTTP 403. Prefer the explicit top-level `ref.tenantId` (captured from
+  // `channelData.tenant.id` inbound) and fall back to `conversation.tenantId`.
+  const tenantId = ref.tenantId ?? ref.conversation?.tenantId;
+  const aadObjectId = ref.aadObjectId ?? user.aadObjectId;
   return {
     activityId: ref.activityId,
-    user,
+    user: aadObjectId ? { ...user, aadObjectId } : user,
     agent,
     conversation: {
       id: normalizeConversationId(conversationId),
       conversationType: ref.conversation?.conversationType,
-      tenantId: ref.conversation?.tenantId,
+      tenantId,
     },
     channelId: ref.channelId ?? "msteams",
     serviceUrl: ref.serviceUrl,
     locale: ref.locale,
+    ...(tenantId ? { tenantId } : {}),
+    ...(aadObjectId ? { aadObjectId } : {}),
   };
 }
 

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -446,6 +446,8 @@ describe("msteams monitor handler authz", () => {
         conversationType: "personal",
         tenantId: "tenant-1",
       },
+      tenantId: "tenant-1",
+      aadObjectId: "new-user-aad",
       channelId: "msteams",
       serviceUrl: "https://smba.trafficmanager.net/amer/",
       locale: "en-US",
@@ -453,6 +455,115 @@ describe("msteams monitor handler authz", () => {
     });
     expect(recordInboundSession).not.toHaveBeenCalled();
     expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
+  });
+
+  // Regression coverage for #58774: proactive sends fail with HTTP 403 when
+  // inbound code drops tenantId/aadObjectId. Capture must prefer the canonical
+  // `channelData.tenant.id` source and expose top-level fields on the stored ref.
+  it("captures tenantId from channelData.tenant.id and aadObjectId from from (#58774)", async () => {
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "allowlist",
+          allowFrom: ["sender-aad"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["sender-aad"],
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-channel",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "sender-id",
+          aadObjectId: "sender-aad",
+          name: "Sender",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:team-channel@thread.tacv2",
+          conversationType: "channel",
+          // Intentionally no tenantId here: channel activities typically
+          // carry tenantId only in channelData.tenant.id.
+        },
+        channelId: "msteams",
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
+        channelData: {
+          tenant: { id: "tenant-from-channel-data" },
+          team: { id: "team-1" },
+          channel: { id: "19:team-channel@thread.tacv2" },
+        },
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(conversationStore.upsert).toHaveBeenCalledWith(
+      "19:team-channel@thread.tacv2",
+      expect.objectContaining({
+        tenantId: "tenant-from-channel-data",
+        aadObjectId: "sender-aad",
+        conversation: expect.objectContaining({
+          id: "19:team-channel@thread.tacv2",
+          tenantId: "tenant-from-channel-data",
+        }),
+      }),
+    );
+  });
+
+  it("does not crash when channelData.tenant is missing and stores no tenantId", async () => {
+    const { conversationStore, deps } = createDeps({
+      channels: {
+        msteams: {
+          dmPolicy: "allowlist",
+          allowFrom: ["sender-aad"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["sender-aad"],
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler({
+      activity: {
+        id: "msg-no-tenant",
+        type: "message",
+        text: "hello",
+        from: {
+          id: "sender-id",
+          aadObjectId: "sender-aad",
+          name: "Sender",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:no-tenant@thread.tacv2",
+          conversationType: "channel",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
+        // No channelData at all: capture must degrade gracefully.
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(conversationStore.upsert).toHaveBeenCalledTimes(1);
+    const storedArg = conversationStore.upsert.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(storedArg).toBeDefined();
+    // Top-level tenantId must not be present when no source is available.
+    expect(storedArg.tenantId).toBeUndefined();
+    // aadObjectId still captured from `from.aadObjectId` when present.
+    expect(storedArg.aadObjectId).toBe("sender-aad");
   });
 
   it("logs an info drop reason when dmPolicy allowlist rejects a sender", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -104,6 +104,13 @@ function buildStoredConversationReference(params: {
   const clientInfo = activity.entities?.find((e) => e.type === "clientInfo") as
     | { timezone?: string }
     | undefined;
+  // Bot Framework requires `tenantId` on outbound proactive activities so the
+  // connector can route them to the correct Azure AD tenant; missing it causes
+  // HTTP 403. Channel activities often leave `conversation.tenantId` unset, so
+  // prefer the canonical `channelData.tenant.id` source when available.
+  const channelDataTenantId = activity.channelData?.tenant?.id;
+  const tenantId = channelDataTenantId ?? conversation?.tenantId;
+  const aadObjectId = from?.aadObjectId;
   return {
     activityId: activity.id,
     user: from ? { id: from.id, name: from.name, aadObjectId: from.aadObjectId } : undefined,
@@ -112,8 +119,10 @@ function buildStoredConversationReference(params: {
     conversation: {
       id: conversationId,
       conversationType,
-      tenantId: conversation?.tenantId,
+      tenantId,
     },
+    ...(tenantId ? { tenantId } : {}),
+    ...(aadObjectId ? { aadObjectId } : {}),
     teamId,
     channelId: activity.channelId,
     serviceUrl: activity.serviceUrl,

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -156,6 +156,8 @@ function createSendContext(params: {
    * correct tenant. Missing `tenantId` causes HTTP 403 on proactive sends.
    */
   tenantId?: string;
+  /** Target user's Teams user ID (e.g. `29:xxx`); included on the recipient field for routing. */
+  recipientId?: string;
   /** Target user's Azure AD object ID; included as the recipient on personal DMs. */
   recipientAadObjectId?: string;
 }): MSTeamsSendContext {
@@ -201,8 +203,15 @@ function createSendContext(params: {
           conversationType: params.conversationType ?? "personal",
           ...(params.tenantId ? { tenantId: params.tenantId } : {}),
         },
-        ...(params.recipientAadObjectId
-          ? { recipient: { aadObjectId: params.recipientAadObjectId } }
+        ...(params.recipientId || params.recipientAadObjectId
+          ? {
+              recipient: {
+                ...(params.recipientId ? { id: params.recipientId } : {}),
+                ...(params.recipientAadObjectId
+                  ? { aadObjectId: params.recipientAadObjectId }
+                  : {}),
+              },
+            }
           : {}),
         ...(params.replyToActivityId && !msg.replyToId
           ? { replyToId: params.replyToActivityId }
@@ -400,6 +409,8 @@ export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MST
       const tenantId = reference.tenantId ?? reference.conversation?.tenantId;
       const recipientAadObjectId = reference.aadObjectId ?? reference.user?.aadObjectId;
 
+      const recipientId = reference.user?.id;
+
       const sendContext = createSendContext({
         sdk,
         serviceUrl,
@@ -408,6 +419,7 @@ export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MST
         bot: reference.agent ?? undefined,
         getToken: createBotTokenGetter(app),
         tenantId,
+        recipientId,
         recipientAadObjectId,
       });
 

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -150,6 +150,14 @@ function createSendContext(params: {
   replyToActivityId?: string;
   getToken: () => Promise<string | undefined>;
   treatInvokeResponseAsNoop?: boolean;
+  /**
+   * Azure AD tenant ID for the target conversation. Bot Framework requires this
+   * on outbound proactive activities so the connector can route them to the
+   * correct tenant. Missing `tenantId` causes HTTP 403 on proactive sends.
+   */
+  tenantId?: string;
+  /** Target user's Azure AD object ID; included as the recipient on personal DMs. */
+  recipientAadObjectId?: string;
 }): MSTeamsSendContext {
   const apiClient =
     params.serviceUrl && params.conversationId
@@ -166,16 +174,36 @@ function createSendContext(params: {
         return { id: "unknown" };
       }
 
+      // Merge caller-provided channelData with the tenant metadata so Bot
+      // Framework receives `channelData.tenant.id` (the canonical source it
+      // uses to route proactive sends). Preserve any existing channelData
+      // fields the caller set (e.g. feedbackLoopEnabled).
+      const existingChannelData =
+        msg.channelData && typeof msg.channelData === "object"
+          ? (msg.channelData as Record<string, unknown>)
+          : undefined;
+      const channelData = params.tenantId
+        ? {
+            ...existingChannelData,
+            tenant: { id: params.tenantId },
+          }
+        : existingChannelData;
+
       return await apiClient.conversations.activities(params.conversationId).create({
         type: "message",
         ...msg,
+        ...(channelData ? { channelData } : {}),
         from: params.bot?.id
           ? { id: params.bot.id, name: params.bot.name ?? "", role: "bot" }
           : undefined,
         conversation: {
           id: params.conversationId,
           conversationType: params.conversationType ?? "personal",
+          ...(params.tenantId ? { tenantId: params.tenantId } : {}),
         },
+        ...(params.recipientAadObjectId
+          ? { recipient: { aadObjectId: params.recipientAadObjectId } }
+          : {}),
         ...(params.replyToActivityId && !msg.replyToId
           ? { replyToId: params.replyToActivityId }
           : {}),
@@ -364,6 +392,14 @@ export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MST
         throw new Error("Missing conversation.id in conversation reference");
       }
 
+      // Bot Framework requires `tenantId` on proactive sends so the connector
+      // can route them to the correct Azure AD tenant. Without it, requests
+      // fail with HTTP 403. Prefer the top-level `reference.tenantId` (captured
+      // from `activity.channelData.tenant.id` at inbound time) and fall back
+      // to `conversation.tenantId` for older stored references.
+      const tenantId = reference.tenantId ?? reference.conversation?.tenantId;
+      const recipientAadObjectId = reference.aadObjectId ?? reference.user?.aadObjectId;
+
       const sendContext = createSendContext({
         sdk,
         serviceUrl,
@@ -371,6 +407,8 @@ export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MST
         conversationType: reference.conversation?.conversationType,
         bot: reference.agent ?? undefined,
         getToken: createBotTokenGetter(app),
+        tenantId,
+        recipientAadObjectId,
       });
 
       await logic(sendContext);


### PR DESCRIPTION
## Summary

Fixes HTTP 403 on proactive Teams messages by capturing `tenantId` and `aadObjectId` from inbound activities and forwarding them on outbound proactive sends.

## Root cause

The Bot Framework's connector requires `tenantId` and `aadObjectId` in the conversation reference for proactive (bot-initiated) sends. The msteams plugin was discarding these from inbound activities, so when cron / scheduled messages tried to send proactively, the resulting connector request was rejected with 403.

## Fix

- Extract `tenantId` from `activity.channelData?.tenant?.id` at inbound time (channel activities often leave `conversation.tenantId` unset, so `channelData.tenant.id` is the canonical source)
- Extract `aadObjectId` from `activity.from?.aadObjectId` at inbound time
- Store both on `StoredConversationReference`
- Forward them on outbound proactive sends in `messenger.ts` and on the Bot Framework connector request in `sdk.ts` (via `channelData.tenant.id`, `conversation.tenantId`, and `recipient.aadObjectId`)

Fixes #58774

## Test plan

- [x] Unit tests for inbound capture (channel activity with `channelData.tenant.id`, plus graceful degradation when `channelData` is missing)
- [x] Unit tests for outbound forwarding via `buildConversationReference` and `sendMSTeamsMessages`
- [x] Full msteams suite passes (583 tests)
- [ ] Manual: trigger a cron announce to a Teams channel and verify it succeeds