### PR TITLE
fix: package qa scenarios and guard discovery refs

### DIFF
--- a/extensions/qa-lab/src/discovery-eval.missing-pack.test.ts
+++ b/extensions/qa-lab/src/discovery-eval.missing-pack.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("./scenario-catalog.js");
+});
+
+describe("qa discovery evaluation without packaged scenarios", () => {
+  it("falls back to default refs when the QA scenario pack is unavailable", async () => {
+    vi.doMock("./scenario-catalog.js", () => ({
+      readQaScenarioExecutionConfig: () => {
+        throw new Error("qa scenario pack not found: qa/scenarios/index.md");
+      },
+    }));
+
+    const { reportsMissingDiscoveryFiles } = await import("./discovery-eval.js");
+
+    const report = `
+Worked
+- Read all three requested files: repo/qa/scenarios/index.md, repo/extensions/qa-lab/src/suite.ts, and repo/docs/help/testing.md.
+Failed
+- None.
+Blocked
+- Runtime execution not attempted here.
+Follow-up
+- Run the live suite next.
+`.trim();
+
+    expect(reportsMissingDiscoveryFiles(report)).toBe(false);
+  });
+});

--- a/extensions/qa-lab/src/discovery-eval.ts
+++ b/extensions/qa-lab/src/discovery-eval.ts
@@ -2,16 +2,24 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtim
 import { readQaScenarioExecutionConfig } from "./scenario-catalog.js";
 
 function readRequiredDiscoveryRefs() {
-  const config = readQaScenarioExecutionConfig("source-docs-discovery-report") as
-    | { requiredFiles?: string[] }
-    | undefined;
-  return (
-    config?.requiredFiles ?? [
+  try {
+    const config = readQaScenarioExecutionConfig("source-docs-discovery-report") as
+      | { requiredFiles?: string[] }
+      | undefined;
+    return (
+      config?.requiredFiles ?? [
+        "repo/qa/scenarios/index.md",
+        "repo/extensions/qa-lab/src/suite.ts",
+        "repo/docs/help/testing.md",
+      ]
+    );
+  } catch {
+    return [
       "repo/qa/scenarios/index.md",
       "repo/extensions/qa-lab/src/suite.ts",
       "repo/docs/help/testing.md",
-    ]
-  );
+    ];
+  }
 }
 
 const REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docs/",
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
+    "qa/",
     "skills/",
     "scripts/npm-runner.mjs",
     "scripts/postinstall-bundled-plugins.mjs",


### PR DESCRIPTION
## Summary
- include `qa/` in the published npm package so `qa/scenarios/index.md` is available outside the monorepo
- guard QA discovery ref loading so CLI startup falls back cleanly if the QA pack is unavailable
- add a regression test covering the missing-pack fallback path

## Testing
- `npm pack --ignore-scripts --silent`
- verified tarball contains `package/qa/scenarios/index.md`
- verified tarball contains `package/qa/scenarios/source-docs-discovery-report.md`

Closes #63510
