### PR TITLE
fix(gateway): include selected memory slot in startup plugin scope

### DIFF
--- a/src/commands/doctor-bootstrap-size.test.ts
+++ b/src/commands/doctor-bootstrap-size.test.ts
@@ -24,6 +24,7 @@ vi.mock("../agents/bootstrap-files.js", () => ({
 vi.mock("../agents/pi-embedded-helpers.js", () => ({
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
+  sanitizeUserFacingText: (text?: string) => text ?? "",
 }));
 
 import { noteBootstrapFileSize } from "./doctor-bootstrap-size.js";

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -273,4 +273,35 @@ describe("resolveGatewayStartupPluginIds", () => {
       expected: ["demo-channel", "browser", "memory-alt"],
     });
   });
+
+  it("excludes all memory plugins when memory slot is explicitly disabled", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        plugins: {
+          slots: {
+            memory: "none",
+          },
+        },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser"],
+    });
+  });
+
+  it("does not include a selected memory slot plugin when it is explicitly disabled", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        plugins: {
+          slots: {
+            memory: "memory-alt",
+          },
+          entries: {
+            "memory-alt": {
+              enabled: false,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser"],
+    });
+  });
 });

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -42,6 +42,24 @@ function createManifestRegistryFixture() {
         cliBackends: [],
       },
       {
+        id: "memory-core",
+        kind: "memory",
+        channels: [],
+        origin: "bundled",
+        enabledByDefault: true,
+        providers: [],
+        cliBackends: [],
+      },
+      {
+        id: "memory-alt",
+        kind: "memory",
+        channels: [],
+        origin: "bundled",
+        enabledByDefault: true,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "demo-provider-plugin",
         channels: [],
         origin: "bundled",
@@ -180,26 +198,26 @@ describe("resolveGatewayStartupPluginIds", () => {
         enabledPluginIds: ["voice-call"],
         modelId: "demo-cli/demo-model",
       }),
-      ["demo-channel", "browser", "voice-call"],
+      ["demo-channel", "browser", "memory-core", "voice-call"],
     ],
     [
       "keeps bundled startup sidecars with enabledByDefault at idle startup",
       {} as OpenClawConfig,
-      ["demo-channel", "browser"],
+      ["demo-channel", "browser", "memory-core"],
     ],
     [
       "keeps provider plugins out of idle startup when only provider config references them",
       createStartupConfig({
         providerIds: ["demo-provider"],
       }),
-      ["demo-channel", "browser"],
+      ["demo-channel", "browser", "memory-core"],
     ],
     [
       "includes explicitly enabled non-channel sidecars in startup scope",
       createStartupConfig({
         enabledPluginIds: ["demo-global-sidecar", "voice-call"],
       }),
-      ["demo-channel", "browser", "voice-call", "demo-global-sidecar"],
+      ["demo-channel", "browser", "memory-core", "voice-call", "demo-global-sidecar"],
     ],
     [
       "keeps default-enabled startup sidecars when a restrictive allowlist permits them",
@@ -207,14 +225,14 @@ describe("resolveGatewayStartupPluginIds", () => {
         allowPluginIds: ["browser"],
         noConfiguredChannels: true,
       }),
-      ["browser"],
+      ["browser", "memory-core"],
     ],
     [
       "includes every configured channel plugin and excludes other channels",
       createStartupConfig({
         channelIds: ["demo-channel", "demo-other-channel"],
       }),
-      ["demo-channel", "demo-other-channel", "browser"],
+      ["demo-channel", "demo-other-channel", "browser", "memory-core"],
     ],
   ] as const)("%s", (_name, config, expected) => {
     expectStartupPluginIdsCase({ config, expected });
@@ -239,7 +257,20 @@ describe("resolveGatewayStartupPluginIds", () => {
     expectStartupPluginIdsCase({
       config: effectiveConfig,
       activationSourceConfig: rawConfig,
-      expected: ["demo-channel", "browser"],
+      expected: ["demo-channel", "browser", "memory-core"],
+    });
+  });
+
+  it("includes only the selected memory slot plugin in startup scope", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        plugins: {
+          slots: {
+            memory: "memory-alt",
+          },
+        },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser", "memory-alt"],
     });
   });
 });

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -87,6 +87,7 @@ export function resolveGatewayStartupPluginIds(params: {
     listPotentialConfiguredChannelIds(params.config, params.env).map((id) => id.trim()),
   );
   const pluginsConfig = normalizePluginsConfig(params.config.plugins);
+  const memorySlotPluginId = pluginsConfig.slots.memory;
   // Startup must classify allowlist exceptions against the raw config snapshot,
   // not the auto-enabled effective snapshot, or configured-only channels can be
   // misclassified as explicit enablement.
@@ -101,6 +102,23 @@ export function resolveGatewayStartupPluginIds(params: {
     .plugins.filter((plugin) => {
       if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
         return true;
+      }
+      if (hasKind(plugin.kind, "memory") && plugin.id === memorySlotPluginId) {
+        const activationState = resolveEffectivePluginActivationState({
+          id: plugin.id,
+          origin: plugin.origin,
+          config: pluginsConfig,
+          rootConfig: params.config,
+          enabledByDefault: plugin.enabledByDefault,
+          activationSource,
+        });
+        if (!activationState.enabled) {
+          return false;
+        }
+        if (plugin.origin !== "bundled") {
+          return activationState.explicitlyEnabled;
+        }
+        return activationState.source === "explicit" || activationState.source === "default";
       }
       if (!isGatewayStartupSidecar(plugin)) {
         return false;


### PR DESCRIPTION
## Summary
- Problem: gateway startup plugin selection did not explicitly include the selected memory-slot plugin when it was not also a configured channel plugin or startup sidecar.
- Why it matters: memory-slot startup surfaces can be skipped, which can prevent memory-driven startup reconciliation behaviors from running reliably.
- What changed: `resolveGatewayStartupPluginIds` now includes the selected memory-slot plugin when activation state permits it.
- What did NOT change: no cron execution internals, no plugin runtime API changes, no config schema changes.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #63936
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: startup plugin ID resolution only included configured channel plugins plus startup sidecars; the selected memory-slot plugin can fall outside both sets.
- Missing detection / guardrail: no startup invariant test that asserted selected memory slot plugin inclusion.
- Contributing context (if known): related reports (#62920, #63465) show the same symptom family; #63097 addresses overlapping startup reconciliation behavior.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/channel-plugin-ids.test.ts`
- Scenario the test should lock in:
  - default startup includes `memory-core` when selected in memory slot
  - custom memory slot selection includes only the selected memory plugin in startup IDs
  - restrictive allowlist expectations still include the selected memory-slot plugin
- Why this is the smallest reliable guardrail: the bug is in startup plugin-ID classification, fully exercised by resolver unit tests.
- Existing test that already covers this (if any): existing startup resolver table tests now extended.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Gateway startup now consistently includes the selected memory-slot plugin in startup plugin scope.

## Diagram (if applicable)
```text
Before:
[gateway startup] -> [resolve startup plugin IDs]
                -> [memory-slot plugin may be excluded]
                -> [memory startup reconciliation may not run]

After:
[gateway startup] -> [resolve startup plugin IDs]
                -> [selected memory-slot plugin included]
                -> [memory startup reconciliation path available]
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: Windows (dev), issue reports from macOS/Linux environments
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default and custom `plugins.slots.memory`

### Steps
1. Select memory slot plugin in config (`memory-core` default or custom memory plugin).
2. Resolve gateway startup plugin IDs.
3. Verify selected memory-slot plugin is present in startup scope.

### Expected
- selected memory-slot plugin is included in startup plugin IDs.

### Actual
- verified by focused tests in `src/plugins/channel-plugin-ids.test.ts`.

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
- Verified scenarios: ran `pnpm test -- src/plugins/channel-plugin-ids.test.ts` and confirmed all resolver scenarios pass with the new memory-slot startup invariant.
- Edge cases checked: restrictive allowlist startup case, custom memory slot selection, default startup path.
- What you did **not** verify: full end-to-end gateway restart reproduction on a live memory-core installation.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations
- Risk: could load one additional plugin at startup in setups where memory slot is selected but previously omitted.
  - Mitigation: startup inclusion is constrained to selected memory slot plugin and existing activation-state checks.
- Risk: overlap with #63097 implementation details.
  - Mitigation: this PR remains narrowly scoped to startup plugin ID classification and has focused regression tests.
