### PR TITLE
fix(ci): repair checks-node-test failures

### DIFF
--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -198,24 +198,14 @@ describe("qa multipass runtime", () => {
 
   it("does not leave a temp guest transfer script behind when multipass is missing", async () => {
     const outputDir = path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-missing-test");
-    vi.spyOn(Date, "now").mockReturnValue(1_717_171_717_171);
-    vi.spyOn(Math, "random").mockReturnValue(0.123456789);
+    const preferredTmpDir = resolvePreferredOpenClawTmpDir();
+    const beforeEntries = new Set(fs.readdirSync(preferredTmpDir));
     (execFileMock as unknown as Mock).mockImplementation((...args: unknown[]) => {
       const callback = args[3] as (error: Error | null, stdout: string, stderr: string) => void;
       const error = new Error("spawn multipass ENOENT") as NodeJS.ErrnoException;
       error.code = "ENOENT";
       callback(error, "", "");
     });
-
-    const expectedVmName = createQaMultipassPlan({
-      repoRoot: process.cwd(),
-      outputDir,
-      scenarioIds: ["channel-chat-baseline"],
-    }).vmName;
-    const expectedTransferDir = path.join(
-      resolvePreferredOpenClawTmpDir(),
-      `${expectedVmName}-qa-suite-`,
-    );
 
     await expect(
       runQaMultipass({
@@ -226,8 +216,9 @@ describe("qa multipass runtime", () => {
     ).rejects.toThrow("Multipass is not installed on this host.");
 
     const tempEntries = fs
-      .readdirSync(resolvePreferredOpenClawTmpDir())
-      .filter((entry) => entry.startsWith(path.basename(expectedTransferDir)));
+      .readdirSync(preferredTmpDir)
+      .filter((entry) => !beforeEntries.has(entry))
+      .filter((entry) => entry.startsWith("openclaw-qa-") && entry.includes("-qa-suite-"));
     expect(tempEntries).toEqual([]);
     fs.rmSync(outputDir, { recursive: true, force: true });
   });

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { access, appendFile, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -149,7 +150,7 @@ function createOutputStamp() {
 }
 
 function createVmSuffix() {
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
 }
 
 function sleep(ms: number) {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -134,6 +134,7 @@ export const mockedFormatBillingErrorMessage = vi.fn(() => "");
 export const mockedClassifyFailoverReason = vi.fn<(raw: string) => FailoverReason | null>(
   () => null,
 );
+export const mockedSanitizeUserFacingText = vi.fn((text: string) => text);
 export const mockedExtractObservedOverflowTokenCount = vi.fn((msg?: string) => {
   const match = msg?.match(/prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i);
   return match?.[1] ? Number(match[1].replaceAll(",", "")) : undefined;
@@ -250,6 +251,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
 
   mockedClassifyFailoverReason.mockReset();
   mockedClassifyFailoverReason.mockReturnValue(null);
+  mockedSanitizeUserFacingText.mockReset();
+  mockedSanitizeUserFacingText.mockImplementation((text: string) => text);
   mockedFormatBillingErrorMessage.mockReset();
   mockedFormatBillingErrorMessage.mockReturnValue("");
   mockedFormatAssistantErrorText.mockReset();
@@ -379,6 +382,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
   vi.doMock("../pi-embedded-helpers.js", () => ({
     formatBillingErrorMessage: mockedFormatBillingErrorMessage,
     classifyFailoverReason: mockedClassifyFailoverReason,
+    sanitizeUserFacingText: mockedSanitizeUserFacingText,
     extractObservedOverflowTokenCount: mockedExtractObservedOverflowTokenCount,
     formatAssistantErrorText: mockedFormatAssistantErrorText,
     isAuthAssistantError: mockedIsAuthAssistantError,

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -113,6 +113,24 @@ export function resolveConversationDeliveryTarget(params: {
       : typeof params.parentConversationId === "string"
         ? normalizeOptionalString(params.parentConversationId)
         : undefined;
+  const isThreadChild =
+    conversationId && parentConversationId && parentConversationId !== conversationId;
+  if (
+    channel &&
+    isThreadChild &&
+    (channel === "matrix" ||
+      channel === "slack" ||
+      channel === "mattermost" ||
+      channel === "telegram")
+  ) {
+    return {
+      to: formatConversationTarget({
+        channel,
+        conversationId: parentConversationId,
+      }),
+      threadId: conversationId,
+    };
+  }
   const pluginTarget =
     channel && conversationId
       ? getChannelPlugin(
@@ -127,24 +145,6 @@ export function resolveConversationDeliveryTarget(params: {
       ...(pluginTarget.to?.trim() ? { to: pluginTarget.to.trim() } : {}),
       ...(pluginTarget.threadId?.trim() ? { threadId: pluginTarget.threadId.trim() } : {}),
     };
-  }
-  const isThreadChild =
-    conversationId && parentConversationId && parentConversationId !== conversationId;
-  if (channel && isThreadChild) {
-    if (
-      channel === "matrix" ||
-      channel === "slack" ||
-      channel === "mattermost" ||
-      channel === "telegram"
-    ) {
-      return {
-        to: formatConversationTarget({
-          channel,
-          conversationId: parentConversationId,
-        }),
-        threadId: conversationId,
-      };
-    }
   }
   const to = formatConversationTarget(params);
   return { to };


### PR DESCRIPTION
## Summary
- fix the mocked `pi-embedded-helpers` harness export so `checks-node-test` no longer fails on missing `sanitizeUserFacingText`
- restore parent-thread delivery targeting for Telegram and the other parent-scoped threaded channels
- finish the `qa-lab` multipass guardrail cleanup by removing weak randomness and asserting temp-dir cleanup against the preferred OpenClaw tmp root

## Changes
- update `src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts` to mock and reset `sanitizeUserFacingText`
- update `src/utils/delivery-context.ts` so threaded child conversations resolve to the parent channel target before plugin-specific target shaping
- update `extensions/qa-lab/src/multipass.runtime.ts` to use `randomUUID()` for VM suffix generation
- update `extensions/qa-lab/src/multipass.runtime.test.ts` to verify no new multipass staging dir remains under `resolvePreferredOpenClawTmpDir()`

## Validation
- `pnpm test src/agents/pi-embedded-runner/usage-reporting.test.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts src/utils/delivery-context.test.ts src/security/temp-path-guard.test.ts extensions/qa-lab/src/multipass.runtime.test.ts`
- `scripts/committer "fix(ci): repair checks-node-test failures" src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts src/utils/delivery-context.ts extensions/qa-lab/src/multipass.runtime.ts extensions/qa-lab/src/multipass.runtime.test.ts`

## Linked Issues
- fixes the `checks-node-test` failures called out in GitHub Actions job 70701752315
