### PR TITLE
fix: route to sendMedia when mediaUrl is present in dep override

### DIFF
--- a/src/cli/send-runtime/channel-outbound-send.ts
+++ b/src/cli/send-runtime/channel-outbound-send.ts
@@ -26,12 +26,10 @@ export function createChannelOutboundRuntimeSend(params: {
       if (!outbound?.sendText) {
         throw new Error(params.unavailableMessage);
       }
-      return await outbound.sendText({
+      const commonCtx = {
         cfg: opts.cfg ?? loadConfig(),
         to,
         text,
-        mediaUrl: opts.mediaUrl,
-        mediaLocalRoots: opts.mediaLocalRoots,
         accountId: opts.accountId,
         threadId: opts.messageThreadId,
         replyToId:
@@ -42,6 +40,21 @@ export function createChannelOutboundRuntimeSend(params: {
         forceDocument: opts.forceDocument,
         gifPlayback: opts.gifPlayback,
         gatewayClientScopes: opts.gatewayClientScopes,
+      };
+
+      // Route to sendMedia when a media URL is provided and the adapter supports it.
+      // Without this, media payloads are silently dropped because sendText ignores mediaUrl.
+      if (opts.mediaUrl && outbound.sendMedia) {
+        return await outbound.sendMedia({
+          ...commonCtx,
+          mediaUrl: opts.mediaUrl,
+          mediaLocalRoots: opts.mediaLocalRoots,
+        });
+      }
+
+      return await outbound.sendText({
+        ...commonCtx,
+        mediaLocalRoots: opts.mediaLocalRoots,
       });
     },
   };


### PR DESCRIPTION
## Summary

Fixes #63720 — WhatsApp (and other channels) silently drop media attachments when sending via the message tool or CLI.

## Root Cause

`createChannelOutboundRuntimeSend` in `src/cli/send-runtime/channel-outbound-send.ts` always calls `outbound.sendText`, even when `opts.mediaUrl` is provided. Since `sendText` ignores `mediaUrl`, media payloads are silently dropped on all channels that go through the dep override path.

### Call chain

1. Agent calls message tool with `filePath`/`media` ✅
2. Gateway `send` handler passes `mediaUrl` to `deliverOutboundPayloads` ✅
3. Delivery correctly identifies media, calls `handler.sendMedia(caption, mediaUrl, overrides)` ✅
4. Channel outbound adapter receives `mediaUrl` ✅
5. `resolveOutboundSendDep` returns the dep override from `createLazySender` → `createChannelOutboundRuntimeSend`
6. **Bug:** `sendMessage` calls `outbound.sendText` which ignores `mediaUrl` ❌

### Debug evidence

```
[outbound] payloadSummary mediaUrls=["https://..."] text=Debug test
[WA-OUTBOUND-sendMedia] mediaUrl=https://..., using=DEP-OVERRIDE
[whatsapp] Sending message -> sha256:... [mediaUrl=NONE, keys=verbose,cfg,accountId,gifPlayback]
```

## Fix

Route to `outbound.sendMedia` when `opts.mediaUrl` is present and the adapter supports it. Falls back to `sendText` otherwise (unchanged behavior for text-only sends).

## Impact

Affects all channels that use `deliveryMode: "gateway"` and go through the dep override path. Confirmed on WhatsApp; likely affects Telegram and others too.