### PR TITLE
fix(bluebubbles): strip SSRF dispatcher from fetchImpl to fix attachment downloads

### DIFF
--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -122,12 +122,23 @@ export async function downloadBlueBubblesAttachment(
         : trustedHostname && (allowPrivateNetworkConfig !== false || !trustedHostnameIsPrivate)
           ? { allowedHostnames: [trustedHostname] }
           : undefined,
-      fetchImpl: async (input, init) =>
-        await blueBubblesFetchWithTimeout(
+      // Strip the SSRF guard's pinned dispatcher from the init object before
+      // delegating to blueBubblesFetchWithTimeout. The guard creates an undici
+      // Agent that may be incompatible with the fetch implementation used by
+      // the BlueBubbles timeout wrapper (Node's built-in fetch). Passing the
+      // dispatcher through causes "invalid onRequestStart method" errors when
+      // the bundled undici major version differs from Node's built-in one.
+      fetchImpl: async (input, init) => {
+        const { dispatcher: _d, ...safeInit } = (init as Record<string, unknown>) ?? {};
+        return await blueBubblesFetchWithTimeout(
           resolveRequestUrl(input),
-          { ...init, method: init?.method ?? "GET" },
+          {
+            ...safeInit,
+            method: ((safeInit as Record<string, unknown>)?.method as string) ?? "GET",
+          } as RequestInit,
           opts.timeoutMs,
-        ),
+        );
+      },
     });
     return {
       buffer: new Uint8Array(fetched.buffer),


### PR DESCRIPTION
## Problem

BlueBubbles attachment downloads silently fail with `invalid onRequestStart method` errors. No attachments (images, PDFs, files) are ever downloaded despite valid GUIDs and server connectivity.

## Root Cause

The SSRF guard creates a pinned undici Agent (dispatcher) using the bundled undici 8.x and passes it through the `init` object to the BlueBubbles `fetchImpl` wrapper. `blueBubblesFetchWithTimeout` delegates to Node's built-in `fetch()`, which uses Node 24's built-in undici 7.x. The undici 8 Agent's interceptor API (`onRequestStart`) is incompatible with undici 7's fetch, causing every download to throw.

## Fix

Strip the `dispatcher` property from the `init` object before passing it to `blueBubblesFetchWithTimeout`. This lets Node's built-in fetch handle the request with its own connection management while the SSRF hostname validation still runs upstream (the DNS pinning check happens before the fetch call).

## Impact

Affects any OpenClaw deployment using BlueBubbles on Node 24+ where the bundled undici version differs from Node's built-in one.