### PR TITLE
fix(exec): harden lifecycle update teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(exec): disable live exec updates as soon as a run aborts or settles, and shorten hard-kill fallback settling so late output and missing exit events do not leave exec runs hanging or re-enter dead listeners.
 - fix(agents): guard nodes tool outPath against workspace boundary [AI-assisted]. (#63551) Thanks @pgondhi987.
 - fix(qqbot): enforce media storage boundary for all outbound local file paths [AI]. (#63271) Thanks @pgondhi987.
 - iMessage/self-chat: distinguish normal DM outbound rows from true self-chat using `destination_caller_id` plus chat participants, while preserving multi-handle self-chat aliases so outbound DM replies stop looping back as inbound messages. (#61619) Thanks @neeravmakwana.

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -206,6 +206,7 @@ export type ExecProcessHandle = {
   startedAt: number;
   pid?: number;
   promise: Promise<ExecProcessOutcome>;
+  disableUpdates: () => void;
   kill: () => void;
 };
 
@@ -580,8 +581,13 @@ export async function runExecProcess(opts: {
   };
   addSession(session);
 
+  let updatesEnabled = true;
+  const disableUpdates = () => {
+    updatesEnabled = false;
+  };
+
   const emitUpdate = () => {
-    if (!opts.onUpdate) {
+    if (!opts.onUpdate || !updatesEnabled) {
       return;
     }
     if (session.backgrounded || session.exited) {
@@ -589,17 +595,22 @@ export async function runExecProcess(opts: {
     }
     const tailText = session.tail || session.aggregated;
     const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
-    opts.onUpdate({
-      content: [{ type: "text", text: warningText + (tailText || "") }],
-      details: {
-        status: "running",
-        sessionId,
-        pid: session.pid ?? undefined,
-        startedAt,
-        cwd: session.cwd,
-        tail: session.tail,
-      },
-    });
+    try {
+      opts.onUpdate({
+        content: [{ type: "text", text: warningText + (tailText || "") }],
+        details: {
+          status: "running",
+          sessionId,
+          pid: session.pid ?? undefined,
+          startedAt,
+          cwd: session.cwd,
+          tail: session.tail,
+        },
+      });
+    } catch (error) {
+      disableUpdates();
+      logWarn(`exec: disabling live updates for session ${sessionId}: ${String(error)}`);
+    }
   };
 
   const handleStdout = (data: string) => {
@@ -776,6 +787,7 @@ export async function runExecProcess(opts: {
   const promise = managedRun
     .wait()
     .then(async (exit): Promise<ExecProcessOutcome> => {
+      disableUpdates();
       const durationMs = Date.now() - startedAt;
       const outcome = buildExecExitOutcome({
         exit,
@@ -800,6 +812,7 @@ export async function runExecProcess(opts: {
       return outcome;
     })
     .catch((err): ExecProcessOutcome => {
+      disableUpdates();
       markExited(session, null, null, "failed");
       maybeNotifyOnExit(session, "failed");
       return buildExecRuntimeErrorOutcome({
@@ -814,7 +827,9 @@ export async function runExecProcess(opts: {
     startedAt,
     pid: session.pid ?? undefined,
     promise,
+    disableUpdates,
     kill: () => {
+      disableUpdates();
       managedRun?.cancel("manual-cancel");
     },
   };

--- a/src/agents/bash-tools.exec.on-update-lifecycle.test.ts
+++ b/src/agents/bash-tools.exec.on-update-lifecycle.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
+let resetProcessRegistryForTests: typeof import("./bash-process-registry.js").resetProcessRegistryForTests;
+
+const TEST_EXEC_DEFAULTS = {
+  host: "gateway" as const,
+  security: "full" as const,
+  ask: "off" as const,
+};
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ createExecTool } = await import("./bash-tools.exec.js"));
+  ({ resetProcessRegistryForTests } = await import("./bash-process-registry.js"));
+});
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  vi.clearAllMocks();
+});
+
+test("disables future live exec updates when onUpdate throws", async () => {
+  const tool = createExecTool(TEST_EXEC_DEFAULTS);
+  const onUpdateSpy = vi.fn(() => {
+    throw new Error("Agent listener invoked outside active run");
+  });
+
+  const result = await tool.execute(
+    "toolcall",
+    {
+      command:
+        "node -e 'process.stdout.write(\"first\\n\"); setTimeout(() => process.stdout.write(\"second\\n\"), 25); setTimeout(() => process.exit(0), 60)'",
+    },
+    undefined,
+    onUpdateSpy,
+  );
+
+  expect(result.details.status).toBe("completed");
+  expect(onUpdateSpy).toHaveBeenCalledTimes(1);
+});
+
+test("disables live exec updates immediately when the tool aborts", async () => {
+  const tool = createExecTool(TEST_EXEC_DEFAULTS);
+  const abortController = new AbortController();
+  const onUpdateSpy = vi.fn(() => {
+    abortController.abort();
+  });
+
+  const result = await tool.execute(
+    "toolcall",
+    {
+      command:
+        "node -e 'process.stdout.write(\"first\\n\"); setTimeout(() => process.stdout.write(\"second\\n\"), 25); setTimeout(() => process.exit(0), 60)'",
+    },
+    abortController.signal,
+    onUpdateSpy,
+  );
+
+  expect(result.details.status).toBe("failed");
+  expect(onUpdateSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1745,6 +1745,7 @@ export function createExecTool(
         if (yielded || run.session.backgrounded) {
           return;
         }
+        run.disableUpdates();
         run.kill();
       };
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -5,7 +5,7 @@ import { resolveWindowsCommandShim } from "../../windows-command.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
-const FORCE_KILL_WAIT_FALLBACK_MS = 4000;
+const FORCE_KILL_WAIT_FALLBACK_MS = 1000;
 
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -2,7 +2,7 @@ import { killProcessTree } from "../../kill-tree.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
-const FORCE_KILL_WAIT_FALLBACK_MS = 4000;
+const FORCE_KILL_WAIT_FALLBACK_MS = 1000;
 
 type PtyExitEvent = { exitCode: number; signal?: number };
 type PtyDisposable = { dispose: () => void };


### PR DESCRIPTION
## Summary
- disable live exec updates as soon as a foreground exec aborts or settles so late stdout chunks cannot re-enter dead listeners
- add focused lifecycle coverage for both throwing `onUpdate` callbacks and tool aborts that arrive between streamed chunks
- shorten supervisor hard-kill fallback settling so background exec timeouts still finish promptly when child or PTY exit events never arrive

## Validation
- `pnpm vitest run src/agents/bash-tools.exec.on-update-lifecycle.test.ts src/agents/bash-tools.exec.background-abort.test.ts --reporter=dot`

## Context
- Supersedes the closed attempt in #62340 with the additional abort and timeout-settle fix.
- Full repo check currently trips unrelated extension TypeScript breakage outside the touched exec/runtime files, including googlechat, line, nostr, qqbot, synology-chat, tlon, and zalouser, so validation here is targeted to the touched regression surface.
