### PR TITLE
fix(ui): single assistant group for Control UI streaming chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Docs: https://docs.openclaw.ai
 - Gateway/thread routing: preserve Slack, Telegram, and Mattermost thread-child delivery targets so bound subagent completion messages land in the originating thread instead of top-level channels. (#54840) Thanks @yzzymt.
 - ACP/stream relay: pass parent delivery context to ACP stream relay system events so `streamTo="parent"` updates route to the correct thread or topic instead of falling back to the main DM. (#57056) Thanks @pingren.
 - Agents/sessions: preserve announce `threadId` when `sessions.list` fallback rehydrates agent-to-agent announce targets so final announce messages stay in the originating thread/topic. (#63506) Thanks @SnowSky1.
+- Control UI/chat: render in-flight assistant streaming in a single message group so tool runs no longer spawn multiple assistant avatars before the turn completes. (#63956) Thanks @neeravmakwana.
+
 ## 2026.4.9
 
 ### Changes

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -7,7 +7,7 @@ import { toSanitizedMarkdownHtml } from "../markdown.ts";
 import { openExternalUrlSafe } from "../open-external-url.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import { detectTextDirection } from "../text-direction.ts";
-import type { MessageGroup, ToolCard } from "../types/chat-types.ts";
+import type { MessageGroup, StreamRunPart, ToolCard } from "../types/chat-types.ts";
 import { agentLogoUrl } from "../views/agents-utils.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import {
@@ -15,7 +15,11 @@ import {
   extractThinkingCached,
   formatReasoningMarkdown,
 } from "./message-extract.ts";
-import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
+import {
+  isToolResultMessage,
+  normalizeMessage,
+  normalizeRoleForGrouping,
+} from "./message-normalizer.ts";
 import { isTtsSupported, speakText, stopTts, isTtsSpeaking } from "./speech.ts";
 import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
 
@@ -91,47 +95,97 @@ function extractAudioClips(message: unknown): AudioClip[] {
   return clips;
 }
 
-export function renderReadingIndicatorGroup(assistant?: AssistantIdentity, basePath?: string) {
-  return html`
-    <div class="chat-group assistant">
-      ${renderAvatar("assistant", assistant, basePath)}
-      <div class="chat-group-messages">
-        <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
-          <span class="chat-reading-indicator__dots">
-            <span></span><span></span><span></span>
-          </span>
-        </div>
-      </div>
-    </div>
-  `;
+type StreamRunLive = { type: "text"; text: string; startedAt: number } | { type: "reading" } | null;
+
+function streamRunFooterTimestamp(parts: StreamRunPart[], live: StreamRunLive): number {
+  let ts = 0;
+  for (const p of parts) {
+    if (p.type === "text") {
+      ts = Math.max(ts, p.startedAt);
+    } else {
+      ts = Math.max(ts, normalizeMessage(p.message).timestamp);
+    }
+  }
+  if (live?.type === "text") {
+    ts = Math.max(ts, live.startedAt);
+  }
+  return ts > 0 ? ts : Date.now();
 }
 
-export function renderStreamingGroup(
-  text: string,
-  startedAt: number,
-  onOpenSidebar?: (content: string) => void,
-  assistant?: AssistantIdentity,
-  basePath?: string,
+/**
+ * Renders one in-flight assistant turn: a single outer chat-group with interleaved
+ * inner bubbles (text chunks, tool cards, live tail) so streaming does not spawn
+ * multiple assistant rows with repeated avatars.
+ */
+export function renderStreamingRun(
+  parts: StreamRunPart[],
+  live: StreamRunLive,
+  opts: {
+    onOpenSidebar?: (content: string) => void;
+    assistant?: AssistantIdentity;
+    basePath?: string;
+    showToolCalls: boolean;
+    showReasoning: boolean;
+    assistantName?: string;
+  },
 ) {
-  const timestamp = new Date(startedAt).toLocaleTimeString([], {
+  const name = opts.assistantName ?? opts.assistant?.name ?? "Assistant";
+  const footerTs = streamRunFooterTimestamp(parts, live);
+  const timestamp = new Date(footerTs).toLocaleTimeString([], {
     hour: "numeric",
     minute: "2-digit",
   });
-  const name = assistant?.name ?? "Assistant";
 
   return html`
     <div class="chat-group assistant">
-      ${renderAvatar("assistant", assistant, basePath)}
+      ${renderAvatar("assistant", opts.assistant, opts.basePath)}
       <div class="chat-group-messages">
-        ${renderGroupedMessage(
-          {
-            role: "assistant",
-            content: [{ type: "text", text }],
-            timestamp: startedAt,
-          },
-          { isStreaming: true, showReasoning: false },
-          onOpenSidebar,
+        ${parts.map((p) =>
+          p.type === "text"
+            ? renderGroupedMessage(
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: p.text }],
+                  timestamp: p.startedAt,
+                },
+                {
+                  isStreaming: false,
+                  showReasoning: opts.showReasoning,
+                  showToolCalls: opts.showToolCalls,
+                },
+                opts.onOpenSidebar,
+              )
+            : renderGroupedMessage(
+                p.message,
+                {
+                  isStreaming: false,
+                  showReasoning: opts.showReasoning,
+                  showToolCalls: opts.showToolCalls,
+                },
+                opts.onOpenSidebar,
+              ),
         )}
+        ${live?.type === "text"
+          ? renderGroupedMessage(
+              {
+                role: "assistant",
+                content: [{ type: "text", text: live.text }],
+                timestamp: live.startedAt,
+              },
+              {
+                isStreaming: true,
+                showReasoning: false,
+                showToolCalls: opts.showToolCalls,
+              },
+              opts.onOpenSidebar,
+            )
+          : live?.type === "reading"
+            ? html` <div class="chat-bubble chat-reading-indicator" aria-hidden="true">
+                <span class="chat-reading-indicator__dots">
+                  <span></span><span></span><span></span>
+                </span>
+              </div>`
+            : nothing}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${name}</span>
           <span class="chat-group-timestamp">${timestamp}</span>

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -2,12 +2,21 @@
  * Chat message types for the UI layer.
  */
 
+/** One interleaved chunk inside an in-flight assistant turn (stream-run). */
+export type StreamRunPart =
+  | { type: "text"; text: string; startedAt: number }
+  | { type: "tool"; message: unknown; key: string };
+
 /** Union type for items in the chat thread */
 export type ChatItem =
   | { kind: "message"; key: string; message: unknown }
   | { kind: "divider"; key: string; label: string; timestamp: number }
-  | { kind: "stream"; key: string; text: string; startedAt: number }
-  | { kind: "reading-indicator"; key: string };
+  | {
+      kind: "stream-run";
+      key: string;
+      parts: StreamRunPart[];
+      live: { type: "text"; text: string; startedAt: number } | { type: "reading" } | null;
+    };
 
 /** A group of consecutive messages from the same role (Slack-style layout) */
 export type MessageGroup = {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -321,6 +321,54 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("757.3k / 200k");
   });
 
+  it("uses one assistant chat-group for streaming with segments, tools, and live text", async () => {
+    const container = document.createElement("div");
+    const toolMsg = {
+      role: "assistant",
+      toolCallId: "call-1",
+      content: [{ type: "toolcall", name: "demo", arguments: {} }],
+      timestamp: 10,
+    };
+    render(
+      renderChat(
+        createProps({
+          streamSegments: [{ text: "Before tool.", ts: 1 }],
+          toolMessages: [toolMsg],
+          stream: " After tool.",
+          streamStartedAt: 2,
+          showToolCalls: true,
+        }),
+      ),
+      container,
+    );
+    await flushTasks();
+    expect(container.querySelectorAll(".chat-group.assistant").length).toBe(1);
+  });
+
+  it("uses one assistant chat-group when tool calls are hidden and streamed text is merged", async () => {
+    const container = document.createElement("div");
+    const toolMsg = {
+      role: "assistant",
+      toolCallId: "call-2",
+      content: [{ type: "toolcall", name: "demo", arguments: {} }],
+      timestamp: 10,
+    };
+    render(
+      renderChat(
+        createProps({
+          streamSegments: [{ text: "Part one", ts: 1 }],
+          toolMessages: [toolMsg],
+          stream: " part two",
+          streamStartedAt: 2,
+          showToolCalls: false,
+        }),
+      ),
+      container,
+    );
+    await flushTasks();
+    expect(container.querySelectorAll(".chat-group.assistant").length).toBe(1);
+  });
+
   it("uses totalTokens for the context notice detail when current usage is high", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -11,11 +11,7 @@ import {
 } from "../chat/attachment-support.ts";
 import { DeletedMessages } from "../chat/deleted-messages.ts";
 import { exportChatMarkdown } from "../chat/export.ts";
-import {
-  renderMessageGroup,
-  renderReadingIndicatorGroup,
-  renderStreamingGroup,
-} from "../chat/grouped-render.ts";
+import { renderMessageGroup, renderStreamingRun } from "../chat/grouped-render.ts";
 import { InputHistory } from "../chat/input-history.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "../chat/message-normalizer.ts";
 import { PinnedMessages } from "../chat/pinned-messages.ts";
@@ -34,7 +30,7 @@ import { icons } from "../icons.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
-import type { ChatItem, MessageGroup } from "../types/chat-types.ts";
+import type { ChatItem, MessageGroup, StreamRunPart } from "../types/chat-types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
 import { agentLogoUrl, resolveAgentAvatarUrl } from "./agents-utils.ts";
 import { renderMarkdownSidebar } from "./markdown-sidebar.ts";
@@ -1000,17 +996,15 @@ export function renderChat(props: ChatProps) {
                 </div>
               `;
             }
-            if (item.kind === "reading-indicator") {
-              return renderReadingIndicatorGroup(assistantIdentity, props.basePath);
-            }
-            if (item.kind === "stream") {
-              return renderStreamingGroup(
-                item.text,
-                item.startedAt,
-                props.onOpenSidebar,
-                assistantIdentity,
-                props.basePath,
-              );
+            if (item.kind === "stream-run") {
+              return renderStreamingRun(item.parts, item.live, {
+                onOpenSidebar: props.onOpenSidebar,
+                assistant: assistantIdentity,
+                basePath: props.basePath,
+                showToolCalls: props.showToolCalls,
+                showReasoning,
+                assistantName: props.assistantName,
+              });
             }
             if (item.kind === "group") {
               if (deleted.has(item.key)) {
@@ -1503,40 +1497,79 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       message: msg,
     });
   }
-  // Interleave stream segments and tool cards in order. Each segment
-  // contains text that was streaming before the corresponding tool started.
-  // This ensures correct visual ordering: text → tool → text → tool → ...
+  // One assistant row for the whole in-flight turn: inner bubbles interleave
+  // streamed text and tool cards (when tool calls are visible). When tool calls
+  // are hidden, merge segment + live text into a single updating bubble.
   const segments = props.streamSegments ?? [];
-  const maxLen = Math.max(segments.length, tools.length);
-  for (let i = 0; i < maxLen; i++) {
-    if (i < segments.length && segments[i].text.trim().length > 0) {
-      items.push({
-        kind: "stream" as const,
-        key: `stream-seg:${props.sessionKey}:${i}`,
-        text: segments[i].text,
-        startedAt: segments[i].ts,
-      });
-    }
-    if (i < tools.length && props.showToolCalls) {
-      items.push({
-        kind: "message",
-        key: messageKey(tools[i], i + history.length),
-        message: tools[i],
-      });
-    }
-  }
+  const shouldShowStreamRun = segments.length > 0 || props.stream !== null;
+  if (shouldShowStreamRun) {
+    const streamRunKey = `stream-run:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
 
-  if (props.stream !== null) {
-    const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
-    if (props.stream.trim().length > 0) {
-      items.push({
-        kind: "stream",
-        key,
-        text: props.stream,
-        startedAt: props.streamStartedAt ?? Date.now(),
-      });
+    if (!props.showToolCalls) {
+      const merged = segments.map((s) => s.text).join("") + (props.stream ?? "");
+      let live: { type: "text"; text: string; startedAt: number } | { type: "reading" } | null =
+        null;
+      if (props.stream !== null) {
+        if (!merged.trim()) {
+          live = { type: "reading" };
+        } else {
+          live = {
+            type: "text",
+            text: merged,
+            startedAt: props.streamStartedAt ?? segments[0]?.ts ?? Date.now(),
+          };
+        }
+      }
+      if (live !== null) {
+        items.push({
+          kind: "stream-run",
+          key: streamRunKey,
+          parts: [],
+          live,
+        });
+      }
     } else {
-      items.push({ kind: "reading-indicator", key });
+      const parts: StreamRunPart[] = [];
+      const maxLen = Math.max(segments.length, tools.length);
+      for (let i = 0; i < maxLen; i++) {
+        if (i < segments.length && segments[i].text.trim().length > 0) {
+          parts.push({
+            type: "text",
+            text: segments[i].text,
+            startedAt: segments[i].ts,
+          });
+        }
+        if (i < tools.length) {
+          parts.push({
+            type: "tool",
+            message: tools[i],
+            key: messageKey(tools[i], i + history.length),
+          });
+        }
+      }
+
+      let live: { type: "text"; text: string; startedAt: number } | { type: "reading" } | null =
+        null;
+      if (props.stream !== null) {
+        if (props.stream.trim().length > 0) {
+          live = {
+            type: "text",
+            text: props.stream,
+            startedAt: props.streamStartedAt ?? Date.now(),
+          };
+        } else {
+          live = { type: "reading" };
+        }
+      }
+
+      if (parts.length > 0 || live !== null) {
+        items.push({
+          kind: "stream-run",
+          key: streamRunKey,
+          parts,
+          live,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Problem: In-flight assistant replies in the Control UI webchat rendered each streamed segment (and the live tail) as a separate outer `chat-group`, so users saw multiple assistant avatars and bubbles during one turn; when the run finished, history replaced that with a normal grouped message.
- Why it matters: Jarring layout and the appearance of fragments merging when the response completed (see #63956).
- What changed: Introduced a single `stream-run` chat item that renders one assistant column with interleaved inner bubbles for committed segment text, tool cards (when shown), and the live streaming tail (or reading indicator). When tool calls are hidden, segment + live text merge into one updating bubble within that same group.
- What did NOT change: Gateway streaming protocol, chat event handling, or persisted message shapes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63956
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The chat list emitted one `kind: "stream"` item per segment and one for the live buffer, and each was rendered with `renderStreamingGroup`, which wraps a full `chat-group` (avatar + column) per chunk.
- Missing detection / guardrail: N/A (layout choice).
- Contributing context (if known): Tool streaming commits text into `chatStreamSegments` at each tool boundary, which multiplied outer groups.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: With `streamSegments`, `toolMessages`, and `stream` set, the DOM contains exactly one `.chat-group.assistant` for the in-flight turn (and the same when tool calls are hidden with merged text).
- Why this is the smallest reliable guardrail: Asserts the structural fix (single outer group) without driving a full gateway session.
- Existing test that already covers this (if any): None for this regression before this PR.
- If no new test is added, why not: N/A — tests added.

## User-visible / Behavior Changes

- Control UI chat: Streaming assistant turns use one assistant column; inner bubbles still separate pre-tool text, tool cards (when visible), and the live tail. With tool calls toggled off, streamed text is merged into one bubble for the active turn.

## Diagram (if applicable)

```text
Before:
[assistant group: segment 1] [assistant group: tool?] [assistant group: live]  (multiple avatars)

After:
[assistant group: segment 1 | tool | live ...]  (one avatar column)
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: any (UI change)
- Control UI webchat with streaming + optional tool use

### Steps

1. Open Control UI chat and send a message that streams assistant output (ideally with at least one tool call).
2. Observe the in-flight layout: one assistant column for the active turn.

### Expected

- Single assistant avatar column while the response streams; inner bubbles for text/tool/live as appropriate.

### Actual

- Matches expected after this change (please confirm visually).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Unit tests for DOM structure (`pnpm exec vitest run ui/src/ui/views/chat.test.ts`); `pnpm check` clean.
- Edge cases checked: Tool calls visible vs hidden (merged text path).
- What you did not verify: Full manual browser run against a live gateway in this environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- None material — layout-only change; message state and protocols unchanged.

## Testing

- `pnpm check`
- `pnpm exec vitest run ui/src/ui/views/chat.test.ts`
- **Screenshots:** Please verify locally in Control UI (`pnpm` dev / gateway) for a streaming run with tools — one assistant column during the turn.

## PR checklist (CONTRIBUTING)

- [x] Mark degree of testing: **unit tests + lint/typecheck** (`pnpm check`, targeted Vitest).
- [x] Confirm understanding of the change: yes — rendering-only; state from `chatStream` / `chatStreamSegments` / `chatToolMessages` unchanged.
