### PR TITLE
fix(qwen): allow qwen3.6-plus opt-in on Coding Plan #63654

### DIFF
--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -3,31 +3,75 @@ import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-
 import qwenPlugin from "./index.js";
 import { QWEN_36_PLUS_MODEL_ID, QWEN_CN_BASE_URL } from "./models.js";
 
-describe("qwen provider config normalization", () => {
-  it("does not drop explicitly configured qwen3.6-plus on Coding Plan endpoints", async () => {
+describe("qwen provider hooks (Coding Plan vs explicit qwen3.6-plus)", () => {
+  it("does not register normalizeConfig (no user-config mutation hook)", async () => {
     const provider = await registerSingleProviderPlugin(qwenPlugin);
+    expect(provider.normalizeConfig).toBeUndefined();
+  });
 
-    const normalized = provider.normalizeConfig?.({
+  it("suppresses qwen3.6-plus from built-in resolution on Coding Plan when not explicitly configured", async () => {
+    const provider = await registerSingleProviderPlugin(qwenPlugin);
+    const result = provider.suppressBuiltInModel?.({
+      env: process.env,
       provider: "qwen",
-      providerConfig: {
-        baseUrl: QWEN_CN_BASE_URL,
-        api: "openai-completions",
-        models: [
-          {
-            id: QWEN_36_PLUS_MODEL_ID,
-            name: QWEN_36_PLUS_MODEL_ID,
-            reasoning: false,
-            input: ["text", "image"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 1_000_000,
-            maxTokens: 65_536,
+      modelId: QWEN_36_PLUS_MODEL_ID,
+      baseUrl: QWEN_CN_BASE_URL,
+      config: undefined,
+    });
+    expect(result?.suppress).toBe(true);
+    expect(result?.errorMessage).toContain("qwen3.6-plus");
+  });
+
+  it("does not suppress qwen3.6-plus when the model is explicitly listed under qwen provider config", async () => {
+    const provider = await registerSingleProviderPlugin(qwenPlugin);
+    const result = provider.suppressBuiltInModel?.({
+      env: process.env,
+      provider: "qwen",
+      modelId: QWEN_36_PLUS_MODEL_ID,
+      baseUrl: QWEN_CN_BASE_URL,
+      config: {
+        models: {
+          providers: {
+            qwen: {
+              baseUrl: QWEN_CN_BASE_URL,
+              api: "openai-completions",
+              models: [
+                {
+                  id: QWEN_36_PLUS_MODEL_ID,
+                  name: QWEN_36_PLUS_MODEL_ID,
+                  reasoning: false,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1_000_000,
+                  maxTokens: 65_536,
+                },
+              ],
+            },
           },
-        ],
+        },
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("does not suppress when explicit listing uses legacy modelstudio provider key", async () => {
+    const provider = await registerSingleProviderPlugin(qwenPlugin);
+    const result = provider.suppressBuiltInModel?.({
+      env: process.env,
+      provider: "qwen",
+      modelId: QWEN_36_PLUS_MODEL_ID,
+      baseUrl: QWEN_CN_BASE_URL,
+      config: {
+        models: {
+          providers: {
+            modelstudio: {
+              baseUrl: QWEN_CN_BASE_URL,
+              models: [{ id: QWEN_36_PLUS_MODEL_ID }],
+            },
+          },
+        },
       },
     } as never);
-
-    // The provider intentionally advertises qwen3.6-plus only on Standard endpoints
-    // in its built-in catalog, but users should still be able to opt-in explicitly.
-    expect(normalized).toBeUndefined();
+    expect(result).toBeUndefined();
   });
 });

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import qwenPlugin from "./index.js";
+import { QWEN_36_PLUS_MODEL_ID, QWEN_CN_BASE_URL } from "./models.js";
+
+describe("qwen provider config normalization", () => {
+  it("does not drop explicitly configured qwen3.6-plus on Coding Plan endpoints", async () => {
+    const provider = await registerSingleProviderPlugin(qwenPlugin);
+
+    const normalized = provider.normalizeConfig?.({
+      provider: "qwen",
+      providerConfig: {
+        baseUrl: QWEN_CN_BASE_URL,
+        api: "openai-completions",
+        models: [
+          {
+            id: QWEN_36_PLUS_MODEL_ID,
+            name: QWEN_36_PLUS_MODEL_ID,
+            reasoning: false,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 1_000_000,
+            maxTokens: 65_536,
+          },
+        ],
+      },
+    } as never);
+
+    // The provider intentionally advertises qwen3.6-plus only on Standard endpoints
+    // in its built-in catalog, but users should still be able to opt-in explicitly.
+    expect(normalized).toBeUndefined();
+  });
+});

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -165,15 +165,6 @@ export default defineSingleProviderPluginEntry({
     },
     applyNativeStreamingUsageCompat: ({ providerConfig }) =>
       applyQwenNativeStreamingUsageCompat(providerConfig),
-    normalizeConfig: ({ providerConfig }) => {
-      if (!isQwenCodingPlanBaseUrl(providerConfig.baseUrl)) {
-        return undefined;
-      }
-      const models = providerConfig.models?.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
-      return models && models.length !== providerConfig.models?.length
-        ? { ...providerConfig, models }
-        : undefined;
-    },
     suppressBuiltInModel: (ctx) => {
       const provider = normalizeProviderId(ctx.provider);
       if (

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -46,6 +46,30 @@ function isQwen36PlusUnsupportedForConfig(params: {
   return isQwenCodingPlanBaseUrl(params.baseUrl ?? resolveConfiguredQwenBaseUrl(params.config));
 }
 
+/**
+ * When the user explicitly lists `qwen3.6-plus` under a `qwen` / `modelstudio`
+ * provider entry, runtime resolution must not treat it as a suppressed built-in
+ * row (see `resolveExplicitModelWithRegistry` suppression before inline match).
+ */
+function hasExplicitQwen36PlusInProviderConfig(
+  config: Parameters<typeof resolveConfiguredQwenBaseUrl>[0],
+): boolean {
+  const providers = config?.models?.providers;
+  if (!providers) {
+    return false;
+  }
+  for (const [key, entry] of Object.entries(providers)) {
+    const pid = normalizeProviderId(key);
+    if (pid !== PROVIDER_ID && pid !== LEGACY_PROVIDER_ID) {
+      continue;
+    }
+    if (entry?.models?.some((model) => model.id === QWEN_36_PLUS_MODEL_ID)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "Qwen Provider",
@@ -172,6 +196,9 @@ export default defineSingleProviderPluginEntry({
         ctx.modelId !== QWEN_36_PLUS_MODEL_ID ||
         !isQwen36PlusUnsupportedForConfig({ config: ctx.config, baseUrl: ctx.baseUrl })
       ) {
+        return undefined;
+      }
+      if (hasExplicitQwen36PlusInProviderConfig(ctx.config)) {
         return undefined;
       }
       return {


### PR DESCRIPTION
## Summary

- Problem: The bundled `qwen` provider drops `qwen3.6-plus` from user config when `baseUrl` points at the Qwen Coding Plan endpoint, which makes vision/image flows fail with `Unknown model`.
- Why it matters: Coding Plan users cannot opt-in to try `qwen3.6-plus` for image understanding even when they explicitly configure it.
- What changed: Removed the `qwen` provider `normalizeConfig` filter that stripped `qwen3.6-plus` on Coding Plan endpoints. Built-in catalog suppression behavior remains unchanged.
- What did NOT change (scope boundary): The bundled catalog still does not advertise `qwen3.6-plus` for Coding Plan endpoints by default, and the existing suppression hint remains.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63654

## User-visible / Behavior Changes

Users can now explicitly configure `models.providers.qwen.models: [{ id: "qwen3.6-plus", input: ["text","image"], ... }]` on Coding Plan endpoints without OpenClaw removing it during provider config normalization.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Linux
- Model/provider: Qwen (`qwen`)
- Endpoint: `https://coding.dashscope.aliyuncs.com/v1`

### Steps

1. Configure `models.providers.qwen.baseUrl` to a Coding Plan endpoint and explicitly include `qwen3.6-plus` in `models.providers.qwen.models`.
2. Run a vision flow (e.g. `image` tool / media-understanding pipeline) using `qwen/qwen3.6-plus`.

### Expected

- The explicitly configured model remains available for runtime lookup.

### Actual (before)

- Provider config normalization removed `qwen3.6-plus`, leading to `Unknown model` at runtime.

## Evidence

- Added test coverage to ensure explicit config is not mutated on Coding Plan endpoints.

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/qwen/provider-catalog.test.ts`
  - `pnpm test extensions/qwen/index.test.ts`
- Edge cases checked:
  - Built-in catalog behavior unchanged for Coding Plan endpoints.
- What I did **not** verify:
  - Live calls against DashScope/Coding Plan with real credentials.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

- Risk: Users may opt-in to a model that the Coding Plan endpoint still rejects at runtime.
  - Mitigation: Built-in catalog suppression/default docs remain conservative; this only changes explicit user opt-in behavior.