### PR TITLE
fix(tui): reset footer activity to idle on session switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Cron/tool schemas: keep cron tool schemas strict-model-friendly while still preserving `failureAlert=false`, nullable `agentId`/`sessionKey`, and flattened add/update recovery for the newly exposed cron job fields. (#55043) Thanks @brunolorente.
 - Git metadata: read commit ids from packed refs as well as loose refs so version and status metadata stay accurate after repository maintenance. (#63943)
 - Gateway: keep `commands.list` skill entries categorized under tools and include provider-aware plugin `nativeName` metadata even when `scope=text`, so remote clients can group skills correctly and map text-surface plugin commands back to native aliases.
+- TUI: reset footer activity to idle when switching sessions so a stale streaming indicator cannot persist after the selection changes. (#63988) Thanks @neeravmakwana.
 
 ## 2026.4.9
 

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -246,6 +246,7 @@ describe("tui session actions", () => {
       lastCtrlCAt: 0,
     };
 
+    const setActivityStatus = vi.fn();
     const { setSession } = createSessionActions({
       client: {
         listSessions,
@@ -266,11 +267,12 @@ describe("tui session actions", () => {
       updateHeader: vi.fn(),
       updateFooter: vi.fn(),
       updateAutocompleteProvider: vi.fn(),
-      setActivityStatus: vi.fn(),
+      setActivityStatus,
     });
 
     await setSession("agent:main:other");
 
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
     expect(loadHistory).toHaveBeenCalledWith({
       sessionKey: "agent:main:other",
       limit: 200,
@@ -280,5 +282,70 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.modelProvider).toBe("openai");
     expect(state.sessionInfo.updatedAt).toBe(50);
     expect(btw.clear).toHaveBeenCalled();
+  });
+
+  it("resets activity status to idle when switching sessions after streaming", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 0,
+      defaults: {},
+      sessions: [],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-b",
+      messages: [],
+    });
+    const setActivityStatus = vi.fn();
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: "run-1",
+      historyLoaded: true,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "streaming",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { setSession } = createSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as GatewayChatClient,
+      chatLog: {
+        addSystem: vi.fn(),
+        clearAll: vi.fn(),
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      btw: createBtwPresenter(),
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn((raw?: string) => raw ?? "agent:main:main"),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus,
+    });
+
+    await setSession("agent:main:other");
+
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBeNull();
   });
 });

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -363,6 +363,9 @@ export function createSessionActions(context: SessionActionContext) {
     updateAgentFromSessionKey(nextKey);
     state.currentSessionKey = nextKey;
     state.activeChatRunId = null;
+    // Chat finals for the previous session are ignored after the switch; clear any
+    // busy footer state (for example streaming) so it cannot stick indefinitely.
+    setActivityStatus("idle");
     state.currentSessionId = null;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness
     // so refresh data for the newly selected session isn't rejected as stale.

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -363,8 +363,6 @@ export function createSessionActions(context: SessionActionContext) {
     updateAgentFromSessionKey(nextKey);
     state.currentSessionKey = nextKey;
     state.activeChatRunId = null;
-    // Chat finals for the previous session are ignored after the switch; clear any
-    // busy footer state (for example streaming) so it cannot stick indefinitely.
     setActivityStatus("idle");
     state.currentSessionId = null;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness


### PR DESCRIPTION
## Summary

- **Problem:** After streaming output, switching to another session could leave the TUI footer stuck on a busy state (for example `streaming`) because completion events for the previous session are no longer applied, so nothing cleared the activity label.
- **Why it matters:** The status line and timer can suggest work is still in progress when it is not.
- **What changed:** `setSession` now calls `setActivityStatus("idle")` when the selected session changes, after clearing `activeChatRunId`.
- **What did NOT change:** Per-event chat finalization for a single session, gateway session listing, and unrelated TUI behavior.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #63979

## Root cause

Session switch cleared the active run id but not the footer activity state. Chat events for the previous session are filtered by session key after the switch, so the handler never ran the path that sets activity back to idle.

## Regression tests

- Unit tests in `src/tui/tui-session-actions.test.ts`: assert `setActivityStatus("idle")` on session switch; dedicated case after a streaming-style busy state.

## User-visible changes

TUI: switching sessions resets the footer activity line to idle so a stale busy label (for example streaming) does not persist.

## Security Impact

- New permissions/capabilities: No


Made with [Cursor](https://cursor.com)