### PR TITLE
fix(discord): normalize channel snowflakes for ACP thread binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Docs: https://docs.openclaw.ai
 - Gateway/thread routing: preserve Slack, Telegram, and Mattermost thread-child delivery targets so bound subagent completion messages land in the originating thread instead of top-level channels. (#54840) Thanks @yzzymt.
 - ACP/stream relay: pass parent delivery context to ACP stream relay system events so `streamTo="parent"` updates route to the correct thread or topic instead of falling back to the main DM. (#57056) Thanks @pingren.
 - Agents/sessions: preserve announce `threadId` when `sessions.list` fallback rehydrates agent-to-agent announce targets so final announce messages stay in the originating thread/topic. (#63506) Thanks @SnowSky1.
+- Discord/ACP: normalize `channel:<snowflake>` conversation ids to numeric snowflakes before Discord REST channel resolution so `sessions_spawn` with `runtime: "acp"` and `thread: true` can bind in guild channels. (#63927) Thanks @neeravmakwana.
+
 ## 2026.4.9
 
 ### Changes

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
@@ -1,4 +1,4 @@
-import { ChannelType } from "discord-api-types/v10";
+import { ChannelType, Routes } from "discord-api-types/v10";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as discordClientModule from "../client.js";
@@ -68,6 +68,35 @@ describe("resolveChannelIdForBinding", () => {
     expect(resolved).toBe("channel-explicit");
     expect(createDiscordRestClient).not.toHaveBeenCalled();
     expect(restGet).not.toHaveBeenCalled();
+  });
+
+  it("normalizes explicit channel:<snowflake> to a REST snowflake without resolving route", async () => {
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "thread-1",
+      channelId: "channel:987654321098765432",
+    });
+
+    expect(resolved).toBe("987654321098765432");
+    expect(createDiscordRestClient).not.toHaveBeenCalled();
+    expect(restGet).not.toHaveBeenCalled();
+  });
+
+  it("normalizes channel:<snowflake> threadId before Discord REST channel lookup", async () => {
+    restGet.mockResolvedValueOnce({
+      id: "111222333444555666",
+      type: ChannelType.GuildText,
+      parent_id: "category-1",
+    });
+
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "channel:111222333444555666",
+    });
+
+    expect(resolved).toBe("111222333444555666");
+    expect(restGet).toHaveBeenCalledTimes(1);
+    expect(restGet.mock.calls[0]?.[0]).toBe(Routes.channel("111222333444555666"));
   });
 
   it("returns parent channel for thread channels", async () => {

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -226,6 +226,17 @@ export function findReusableWebhook(params: { accountId: string; channelId: stri
   return {};
 }
 
+/**
+ * Discord REST routes expect numeric snowflake ids. Inbound routing often uses
+ * OpenClaw `channel:<snowflake>` targets; pass those through here before
+ * `Routes.channel(...)` (for example ACP `sessions_spawn` thread binding).
+ */
+function discordChannelSnowflakeForRest(raw: string): string {
+  const trimmed = raw.trim();
+  const prefixed = /^channel:(\d+)$/i.exec(trimmed);
+  return prefixed?.[1] ?? trimmed;
+}
+
 export async function resolveChannelIdForBinding(params: {
   cfg?: OpenClawConfig;
   accountId: string;
@@ -235,8 +246,9 @@ export async function resolveChannelIdForBinding(params: {
 }): Promise<string | null> {
   const explicit = params.channelId?.trim();
   if (explicit) {
-    return explicit;
+    return discordChannelSnowflakeForRest(explicit);
   }
+  const routeThreadId = discordChannelSnowflakeForRest(params.threadId);
   try {
     const rest = createDiscordRestClient(
       {
@@ -245,7 +257,7 @@ export async function resolveChannelIdForBinding(params: {
       },
       params.cfg,
     ).rest;
-    const channel = (await rest.get(Routes.channel(params.threadId))) as {
+    const channel = (await rest.get(Routes.channel(routeThreadId))) as {
       id?: string;
       type?: number;
       parent_id?: string;
@@ -267,7 +279,7 @@ export async function resolveChannelIdForBinding(params: {
     return channelId || null;
   } catch (err) {
     logVerbose(
-      `discord thread binding channel resolve failed for ${params.threadId}: ${summarizeDiscordError(err)}`,
+      `discord thread binding channel resolve failed for ${routeThreadId}: ${summarizeDiscordError(err)}`,
     );
     return null;
   }


### PR DESCRIPTION
## Summary

- Problem: `sessions_spawn` with `runtime: "acp"` and `thread: true` failed on Discord with `Session binding adapter failed to bind target conversation` because thread binding called Discord REST `Routes.channel()` using OpenClaw `channel:<snowflake>` conversation ids instead of raw snowflakes.
- Why it matters: ACP session spawns could not bind to a new thread in guild channels despite correct permissions and config.
- What changed: Strip `channel:<digits>` to the numeric snowflake in `resolveChannelIdForBinding` before REST lookup (and when an explicit `channelId` override uses the same form).
- What did NOT change (scope boundary): No changes to conversation identity strings outside this REST resolution path; other channels and binding flows are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63927
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Discord plugin `resolveInboundConversation` returns normalized targets like `channel:<id>`; `resolveChannelIdForBinding` passed that string to `Routes.channel()`, which requires a numeric snowflake, so the GET failed and binding returned null.
- Missing detection / guardrail: Unit tests used raw snowflake ids; prefixed form was not covered.
- Contributing context (if known): Same channel targets are normalized for other Discord actions (e.g. `thread-create`) via `resolveDiscordChannelId`, but thread binding used the raw string.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/thread-bindings.discord-api.test.ts`
- Scenario the test should lock in: `resolveChannelIdForBinding` with `threadId` / explicit `channelId` of `channel:<snowflake>` issues REST `Routes.channel(<snowflake>)` and returns the resolved parent or channel id.
- Why this is the smallest reliable guardrail: Exercises the exact REST route construction that failed in production.
- Existing test that already covers this (if any): N/A for prefixed ids.
- If no new test is added, why not: N/A — tests added.

## User-visible / Behavior Changes

- Discord: `sessions_spawn` with ACP and `thread: true` can complete thread binding in guild channels when the active conversation id uses the `channel:<snowflake>` form.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)

Made with [Cursor](https://cursor.com)