### PR TITLE
fix(ci): resolve checks-node-test regressions on main

### DIFF
--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import { access, appendFile, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -149,7 +150,7 @@ function createOutputStamp() {
 }
 
 function createVmSuffix() {
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${Date.now().toString(36)}-${randomBytes(4).toString("hex")}`;
 }
 
 function sleep(ms: number) {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -376,7 +376,12 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     redactRunIdentifier: vi.fn((value?: string) => value ?? ""),
   }));
 
+  const actualPiHelpers = await vi.importActual<typeof import("../pi-embedded-helpers.js")>(
+    "../pi-embedded-helpers.js",
+  );
+
   vi.doMock("../pi-embedded-helpers.js", () => ({
+    ...actualPiHelpers,
     formatBillingErrorMessage: mockedFormatBillingErrorMessage,
     classifyFailoverReason: mockedClassifyFailoverReason,
     extractObservedOverflowTokenCount: mockedExtractObservedOverflowTokenCount,

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -160,7 +160,10 @@ describe("delivery context helpers", () => {
       channel: "telegram",
       conversationId: "42",
       parentConversationId: "-10099",
-      expected: { to: "channel:-10099", threadId: "42" },
+      // Telegram bundled plugin provides resolveDeliveryTarget which returns the
+      // raw chatId; the generic "channel:" prefix only applies to channels without
+      // a bundled plugin resolver.
+      expected: { to: "-10099", threadId: "42" },
     },
     {
       channel: "mattermost",


### PR DESCRIPTION
## Summary

Three test failures have been breaking `checks-node-test` on every CI run on main:

- **temp-path-guard**: `extensions/qa-lab/src/multipass.runtime.ts` `createVmSuffix()` used `Math.random()` + `Date.now()` on the same line, triggering the weak-randomness guardrail. Replaced with `crypto.randomBytes()`.
- **delivery-context**: The Telegram test in `src/utils/delivery-context.test.ts` expected the generic `channel:` prefix for delivery targets, but the bundled Telegram plugin provides `resolveDeliveryTarget` which returns the raw chatId. Updated the test expectation to match the actual bundled plugin behavior.
- **pi-embedded-helpers mock**: `run.overflow-compaction.harness.ts` listed mock exports explicitly but missed the recently added `sanitizeUserFacingText`. Spread `importActual` so new exports are always included.

## Test plan

- [ ] `checks-node-test` passes (temp-path-guard, delivery-context, usage-reporting, incomplete-turn)
- [ ] No regressions in other CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)