### PR TITLE
fix(imessage): strip length-prefixed UTF-8 from imsg rpc text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify OpenRouter `404 No endpoints found for <model>` responses as `model_not_found` so fallback chains continue past retired OpenRouter candidates. (#61472) Thanks @MonkeyLeeT.
 - Browser/plugin SDK: route browser auth, profile, host-inspection, and doctor readiness helpers through browser plugin public facades so core compatibility helpers stop carrying duplicate runtime implementations. (#63957) Thanks @joshavant.
 - Agents/failover: allow cooldown probes for `timeout` (including network outage classifications) so the primary model can recover after failover without a gateway restart. (#63996) Thanks @neeravmakwana.
-- iMessage (imsg): strip an accidental protobuf length-delimited UTF-8 wrapper from inbound `text` and `reply_to_text` when it fully consumes the field, fixing leading garbage before the real message. (#63868) Thanks @neeravmakwana.
+- iMessage (imsg): strip an accidental protobuf length-delimited UTF-8 field wrapper from inbound `text` and `reply_to_text` when it fully consumes the field, fixing leading garbage before the real message. (#63868) Thanks @neeravmakwana.
 
 ## 2026.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify OpenRouter `404 No endpoints found for <model>` responses as `model_not_found` so fallback chains continue past retired OpenRouter candidates. (#61472) Thanks @MonkeyLeeT.
 - Browser/plugin SDK: route browser auth, profile, host-inspection, and doctor readiness helpers through browser plugin public facades so core compatibility helpers stop carrying duplicate runtime implementations. (#63957) Thanks @joshavant.
 - Agents/failover: allow cooldown probes for `timeout` (including network outage classifications) so the primary model can recover after failover without a gateway restart. (#63996) Thanks @neeravmakwana.
+- iMessage (imsg): strip an accidental protobuf length-delimited UTF-8 wrapper from inbound `text` and `reply_to_text` when it fully consumes the field, fixing leading garbage before the real message. (#63868) Thanks @neeravmakwana.
 
 ## 2026.4.9
 

--- a/extensions/imessage/src/monitor/parse-notification.test.ts
+++ b/extensions/imessage/src/monitor/parse-notification.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { parseIMessageNotification } from "./parse-notification.js";
 
 describe("parseIMessageNotification", () => {
-  it("strips a length-prefixed UTF-8 wrapper from text and reply_to_text", () => {
-    const wrappedText = `${String.fromCharCode(11)}hello world`;
-    const wrappedReply = `${String.fromCharCode(5)}quote`;
+  it("strips a length-delimited field wrapper from text and reply_to_text", () => {
+    const wrappedText = `${String.fromCharCode(0x0a, 11)}hello world`;
+    const wrappedReply = `${String.fromCharCode(0x0a, 5)}quote`;
     const raw = {
       message: {
         id: 1,

--- a/extensions/imessage/src/monitor/parse-notification.test.ts
+++ b/extensions/imessage/src/monitor/parse-notification.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parseIMessageNotification } from "./parse-notification.js";
+
+describe("parseIMessageNotification", () => {
+  it("strips a length-prefixed UTF-8 wrapper from text and reply_to_text", () => {
+    const wrappedText = `${String.fromCharCode(11)}hello world`;
+    const wrappedReply = `${String.fromCharCode(5)}quote`;
+    const raw = {
+      message: {
+        id: 1,
+        guid: "g",
+        chat_id: 2,
+        sender: "+10000000000",
+        destination_caller_id: null,
+        is_from_me: false,
+        text: wrappedText,
+        reply_to_id: null,
+        reply_to_text: wrappedReply,
+        reply_to_sender: null,
+        created_at: null,
+        attachments: null,
+        chat_identifier: null,
+        chat_guid: null,
+        chat_name: null,
+        participants: null,
+        is_group: false,
+      },
+    };
+
+    const parsed = parseIMessageNotification(raw);
+    expect(parsed?.text).toBe("hello world");
+    expect(parsed?.reply_to_text).toBe("quote");
+  });
+});

--- a/extensions/imessage/src/monitor/parse-notification.ts
+++ b/extensions/imessage/src/monitor/parse-notification.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "openclaw/plugin-sdk/text-runtime";
+import { stripImessageLengthPrefixedUtf8Text } from "./strip-imsg-length-prefixed-text.js";
 import type { IMessagePayload } from "./types.js";
 
 function isOptionalString(value: unknown): value is string | null | undefined {
@@ -78,5 +79,15 @@ export function parseIMessageNotification(raw: unknown): IMessagePayload | null 
     return null;
   }
 
-  return message;
+  return {
+    ...message,
+    text:
+      typeof message.text === "string"
+        ? stripImessageLengthPrefixedUtf8Text(message.text)
+        : message.text,
+    reply_to_text:
+      typeof message.reply_to_text === "string"
+        ? stripImessageLengthPrefixedUtf8Text(message.reply_to_text)
+        : message.reply_to_text,
+  };
 }

--- a/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts
+++ b/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts
@@ -1,31 +1,54 @@
 import { describe, expect, it } from "vitest";
-import { stripImessageLengthPrefixedUtf8Text } from "./strip-imsg-length-prefixed-text.js";
+import {
+  stripImessageLengthPrefixedUtf8Text,
+  tryStripImessageLengthPrefixedUtf8Buffer,
+} from "./strip-imsg-length-prefixed-text.js";
 
 describe("stripImessageLengthPrefixedUtf8Text", () => {
-  it("removes a single-byte length prefix that wraps the full remainder", () => {
-    const raw = `${String.fromCharCode(5)}hello`;
+  it("removes a length-delimited field wrapper from text", () => {
+    const raw = `${String.fromCharCode(0x0a, 5)}hello`;
     expect(stripImessageLengthPrefixedUtf8Text(raw)).toBe("hello");
   });
 
-  it("removes a multi-byte varint length when it wraps the full remainder", () => {
-    const inner = "a".repeat(127);
-    const buf = Buffer.allocUnsafe(1 + inner.length);
-    buf.writeUInt8(0x7f, 0);
-    buf.write(inner, 1, "utf8");
-    expect(stripImessageLengthPrefixedUtf8Text(buf.toString("utf8"))).toBe(inner);
+  it("removes a wrapped payload when the payload length byte is ASCII-printable", () => {
+    const inner = "Mrrrrow! 🐱 Ich bin wach und bereit!";
+    const raw = `${String.fromCharCode(0x0a, Buffer.byteLength(inner, "utf8"))}${inner}`;
+    expect(stripImessageLengthPrefixedUtf8Text(raw)).toBe(inner);
+  });
+
+  it("removes a payload behind a two-byte varint length (raw buffer)", () => {
+    const inner = "a".repeat(128);
+    const buf = Buffer.allocUnsafe(3 + Buffer.byteLength(inner, "utf8"));
+    buf.writeUInt8(0x0a, 0);
+    buf.writeUInt8(0x80, 1);
+    buf.writeUInt8(0x01, 2);
+    buf.write(inner, 3, "utf8");
+    expect(Buffer.from(tryStripImessageLengthPrefixedUtf8Buffer(buf) ?? []).toString("utf8")).toBe(
+      inner,
+    );
+  });
+
+  it("does not strip plain text whose first bytes can mimic a naked length prefix", () => {
+    const inner = `A${"b".repeat(65)}`;
+    expect(stripImessageLengthPrefixedUtf8Text(inner)).toBe(inner);
+  });
+
+  it("does not strip plain text that starts with a different length-delimited field tag", () => {
+    const inner = `B${"a".repeat(98)}`;
+    expect(stripImessageLengthPrefixedUtf8Text(inner)).toBe(inner);
   });
 
   it("preserves plain text", () => {
     expect(stripImessageLengthPrefixedUtf8Text("Mrrrrow! 🐱")).toBe("Mrrrrow! 🐱");
   });
 
-  it("preserves text when the length does not consume the whole string", () => {
-    const raw = `${String.fromCharCode(5)}hi`;
+  it("preserves text when the wrapped length does not consume the whole string", () => {
+    const raw = `${String.fromCharCode(0x0a, 5)}hi`;
     expect(stripImessageLengthPrefixedUtf8Text(raw)).toBe(raw);
   });
 
-  it("preserves text when extra bytes follow the wrapped payload", () => {
-    const raw = `${String.fromCharCode(5)}hello!`;
+  it("preserves text when the field tag is missing", () => {
+    const raw = `${String.fromCharCode(5)}hello`;
     expect(stripImessageLengthPrefixedUtf8Text(raw)).toBe(raw);
   });
 

--- a/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts
+++ b/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { stripImessageLengthPrefixedUtf8Text } from "./strip-imsg-length-prefixed-text.js";
+
+describe("stripImessageLengthPrefixedUtf8Text", () => {
+  it("removes a single-byte length prefix that wraps the full remainder", () => {
+    const raw = `${String.fromCharCode(5)}hello`;
+    expect(stripImessageLengthPrefixedUtf8Text(raw)).toBe("hello");
+  });
+
+  it("removes a multi-byte varint length when it wraps the full remainder", () => {
+    const inner = "a".repeat(127);
+    const buf = Buffer.allocUnsafe(1 + inner.length);
+    buf.writeUInt8(0x7f, 0);
+    buf.write(inner, 1, "utf8");
+    expect(stripImessageLengthPrefixedUtf8Text(buf.toString("utf8"))).toBe(inner);
+  });
+
+  it("preserves plain text", () => {
+    expect(stripImessageLengthPrefixedUtf8Text("Mrrrrow! 🐱")).toBe("Mrrrrow! 🐱");
+  });
+
+  it("preserves text when the length does not consume the whole string", () => {
+    const raw = `${String.fromCharCode(5)}hi`;
+    expect(stripImessageLengthPrefixedUtf8Text(raw)).toBe(raw);
+  });
+
+  it("preserves text when extra bytes follow the wrapped payload", () => {
+    const raw = `${String.fromCharCode(5)}hello!`;
+    expect(stripImessageLengthPrefixedUtf8Text(raw)).toBe(raw);
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripImessageLengthPrefixedUtf8Text("")).toBe("");
+  });
+});

--- a/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.ts
+++ b/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.ts
@@ -1,0 +1,57 @@
+/**
+ * Some `imsg rpc` notification payloads include a protobuf-style length-delimited
+ * UTF-8 blob inside the JSON `text` (or `reply_to_text`) string. When the
+ * framing is not stripped upstream, a short binary prefix appears before the
+ * real message. This helper removes a leading varint length plus exactly that
+ * many following bytes only when they consume the entire string, so normal
+ * messages are unchanged.
+ */
+export function stripImessageLengthPrefixedUtf8Text(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= 1) {
+    return text;
+  }
+
+  let offset = 0;
+  let payloadLen = 0;
+  let shift = 0;
+  let varintBytes = 0;
+
+  while (offset < buf.length && varintBytes < 10) {
+    const b = buf[offset];
+    offset += 1;
+    varintBytes += 1;
+    payloadLen |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) {
+      break;
+    }
+    shift += 7;
+    if (shift > 35) {
+      return text;
+    }
+  }
+
+  if (varintBytes === 0) {
+    return text;
+  }
+
+  // Truncated varint (last byte still has continuation bit set).
+  const varintLast = buf[offset - 1];
+  if (varintLast !== undefined && (varintLast & 0x80) !== 0) {
+    return text;
+  }
+
+  if (payloadLen === 0 || payloadLen > buf.length - offset) {
+    return text;
+  }
+
+  if (offset + payloadLen !== buf.length) {
+    return text;
+  }
+
+  const inner = buf.subarray(offset, offset + payloadLen).toString("utf8");
+  return inner.length > 0 ? inner : text;
+}

--- a/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.ts
+++ b/extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.ts
@@ -1,57 +1,60 @@
-/**
- * Some `imsg rpc` notification payloads include a protobuf-style length-delimited
- * UTF-8 blob inside the JSON `text` (or `reply_to_text`) string. When the
- * framing is not stripped upstream, a short binary prefix appears before the
- * real message. This helper removes a leading varint length plus exactly that
- * many following bytes only when they consume the entire string, so normal
- * messages are unchanged.
- */
+type Varint = {
+  nextOffset: number;
+  value: number;
+};
+
+const utf8Decoder = new TextDecoder();
+
+function readVarint(buf: Uint8Array, start: number): Varint | null {
+  let offset = start;
+  let value = 0;
+  let shift = 0;
+
+  while (offset < buf.length && shift <= 28) {
+    const byte = buf[offset];
+    offset += 1;
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      return { nextOffset: offset, value };
+    }
+    shift += 7;
+  }
+
+  return null;
+}
+
+export function tryStripImessageLengthPrefixedUtf8Buffer(buf: Uint8Array): Uint8Array | null {
+  const key = readVarint(buf, 0);
+  if (!key || key.nextOffset >= buf.length) {
+    return null;
+  }
+
+  if (key.value !== 0x0a) {
+    return null;
+  }
+
+  const length = readVarint(buf, key.nextOffset);
+  if (!length || length.value === 0) {
+    return null;
+  }
+
+  if (length.nextOffset + length.value !== buf.length) {
+    return null;
+  }
+
+  return buf.subarray(length.nextOffset, buf.length);
+}
+
 export function stripImessageLengthPrefixedUtf8Text(text: string): string {
   if (!text) {
     return text;
   }
-  const buf = Buffer.from(text, "utf8");
-  if (buf.length <= 1) {
+
+  const stripped = tryStripImessageLengthPrefixedUtf8Buffer(Buffer.from(text, "utf8"));
+  if (!stripped) {
     return text;
   }
 
-  let offset = 0;
-  let payloadLen = 0;
-  let shift = 0;
-  let varintBytes = 0;
-
-  while (offset < buf.length && varintBytes < 10) {
-    const b = buf[offset];
-    offset += 1;
-    varintBytes += 1;
-    payloadLen |= (b & 0x7f) << shift;
-    if ((b & 0x80) === 0) {
-      break;
-    }
-    shift += 7;
-    if (shift > 35) {
-      return text;
-    }
-  }
-
-  if (varintBytes === 0) {
-    return text;
-  }
-
-  // Truncated varint (last byte still has continuation bit set).
-  const varintLast = buf[offset - 1];
-  if (varintLast !== undefined && (varintLast & 0x80) !== 0) {
-    return text;
-  }
-
-  if (payloadLen === 0 || payloadLen > buf.length - offset) {
-    return text;
-  }
-
-  if (offset + payloadLen !== buf.length) {
-    return text;
-  }
-
-  const inner = buf.subarray(offset, offset + payloadLen).toString("utf8");
+  const inner = utf8Decoder.decode(stripped);
   return inner.length > 0 ? inner : text;
 }


### PR DESCRIPTION
## Summary

- Problem: Inbound iMessage notifications from `imsg rpc` sometimes include a protobuf-style length-delimited UTF-8 blob inside the JSON `text` (and `reply_to_text`) string. Those bytes were passed through to the agent as literal prefix garbage.
- Why it matters: Wastes tokens, breaks tools expecting clean text, and matches reports in #63868.
- What changed: After validating the RPC payload, strip a leading varint length plus exactly that many following UTF-8 bytes only when they consume the entire field; otherwise leave the string unchanged. Applied to `text` and `reply_to_text`.
- What did NOT change: JSON-RPC transport, outbound send path, and behavior when the field is already plain text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63868
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Upstream `imsg` may embed a length-delimited UTF-8 payload inside the JSON string; OpenClaw previously forwarded that field with only `trim()`.
- Missing detection / guardrail: No normalization of `text` / `reply_to_text` after parse.
- Contributing context (if known): Conservative strip only when varint + payload exactly matches full UTF-8 byte length of the string.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/imessage/src/monitor/strip-imsg-length-prefixed-text.test.ts`, `extensions/imessage/src/monitor/parse-notification.test.ts`
- Scenario the test should lock in: Length-prefixed wrapper removed; plain text and non-matching layouts preserved.
- Why this is the smallest reliable guardrail: Pure string transformation with no I/O.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A — tests added.

## User-visible / Behavior Changes

Inbound iMessage text and quoted reply text may no longer show a short binary or mojibake prefix when the `imsg` bridge included a length-delimited UTF-8 wrapper inside the JSON field.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New network endpoints or listeners? (`No`)
- Touches auth/secrets/pairing? (`No`)
