### PR TITLE
fix(qqbot,webhooks): inline $defs/$ref in plugin manifests [AI-assisted]

### DIFF
--- a/extensions/qqbot/openclaw.plugin.json
+++ b/extensions/qqbot/openclaw.plugin.json
@@ -1,33 +1,42 @@
 {
   "id": "qqbot",
   "channels": ["qqbot"],
-  "channelEnvVars": {
-    "qqbot": ["QQBOT_APP_ID", "QQBOT_CLIENT_SECRET"]
-  },
+  "channelEnvVars": { "qqbot": ["QQBOT_APP_ID", "QQBOT_CLIENT_SECRET"] },
   "skills": ["./skills"],
   "configSchema": {
     "type": "object",
     "additionalProperties": true,
-    "$defs": {
+    "properties": {
+      "enabled": { "type": "boolean" },
+      "name": { "type": "string" },
+      "appId": { "type": "string" },
+      "clientSecret": {
+        "anyOf": [
+          { "type": "string", "minLength": 1 },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "source": { "type": "string", "enum": ["env", "file", "exec"] },
+              "provider": { "type": "string" },
+              "id": { "type": "string" }
+            },
+            "required": ["source", "provider", "id"]
+          }
+        ]
+      },
+      "clientSecretFile": { "type": "string" },
+      "allowFrom": { "type": "array", "items": { "type": "string" } },
+      "systemPrompt": { "type": "string" },
+      "markdownSupport": { "type": "boolean" },
+      "voiceDirectUploadFormats": { "type": "array", "items": { "type": "string" } },
       "audioFormatPolicy": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "sttDirectFormats": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
-          "uploadDirectFormats": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
+          "sttDirectFormats": { "type": "array", "items": { "type": "string" } },
+          "uploadDirectFormats": { "type": "array", "items": { "type": "string" } },
           "transcodeEnabled": { "type": "boolean" }
-        }
-      },
-      "speechQueryParams": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
         }
       },
       "tts": {
@@ -40,11 +49,8 @@
           "apiKey": { "type": "string" },
           "model": { "type": "string" },
           "voice": { "type": "string" },
-          "authStyle": {
-            "type": "string",
-            "enum": ["bearer", "api-key"]
-          },
-          "queryParams": { "$ref": "#/$defs/speechQueryParams" },
+          "authStyle": { "type": "string", "enum": ["bearer", "api-key"] },
+          "queryParams": { "type": "object", "additionalProperties": { "type": "string" } },
           "speed": { "type": "number" }
         }
       },
@@ -59,108 +65,17 @@
           "model": { "type": "string" }
         }
       },
-      "secretRef": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "source": {
-            "type": "string",
-            "enum": ["env", "file", "exec"]
-          },
-          "provider": { "type": "string" },
-          "id": { "type": "string" }
-        },
-        "required": ["source", "provider", "id"]
-      },
-      "secretInput": {
-        "anyOf": [{ "type": "string", "minLength": 1 }, { "$ref": "#/$defs/secretRef" }]
-      },
-      "account": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "enabled": { "type": "boolean" },
-          "name": { "type": "string" },
-          "appId": { "type": "string" },
-          "clientSecret": { "$ref": "#/$defs/secretInput" },
-          "clientSecretFile": { "type": "string" },
-          "allowFrom": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
-          "systemPrompt": { "type": "string" },
-          "markdownSupport": { "type": "boolean" },
-          "voiceDirectUploadFormats": {
-            "type": "array",
-            "items": { "type": "string" }
-          },
-          "audioFormatPolicy": { "$ref": "#/$defs/audioFormatPolicy" },
-          "urlDirectUpload": { "type": "boolean" },
-          "upgradeUrl": { "type": "string" },
-          "upgradeMode": {
-            "type": "string",
-            "enum": ["doc", "hot-reload"]
-          },
-          "streaming": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "object",
-                "additionalProperties": true,
-                "properties": {
-                  "mode": {
-                    "type": "string",
-                    "enum": ["off", "partial"],
-                    "default": "partial"
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
-    },
-    "properties": {
-      "enabled": { "type": "boolean" },
-      "name": { "type": "string" },
-      "appId": { "type": "string" },
-      "clientSecret": { "$ref": "#/$defs/secretInput" },
-      "clientSecretFile": { "type": "string" },
-      "allowFrom": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
-      "systemPrompt": { "type": "string" },
-      "markdownSupport": { "type": "boolean" },
-      "voiceDirectUploadFormats": {
-        "type": "array",
-        "items": { "type": "string" }
-      },
-      "audioFormatPolicy": { "$ref": "#/$defs/audioFormatPolicy" },
-      "tts": { "$ref": "#/$defs/tts" },
-      "stt": { "$ref": "#/$defs/stt" },
       "urlDirectUpload": { "type": "boolean" },
       "upgradeUrl": { "type": "string" },
-      "upgradeMode": {
-        "type": "string",
-        "enum": ["doc", "hot-reload"]
-      },
+      "upgradeMode": { "type": "string", "enum": ["doc", "hot-reload"] },
       "streaming": {
         "anyOf": [
-          {
-            "type": "boolean"
-          },
+          { "type": "boolean" },
           {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "mode": {
-                "type": "string",
-                "enum": ["off", "partial"],
-                "default": "partial"
-              }
+              "mode": { "type": "string", "enum": ["off", "partial"], "default": "partial" }
             }
           }
         ]
@@ -168,7 +83,57 @@
       "accounts": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/$defs/account"
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "name": { "type": "string" },
+            "appId": { "type": "string" },
+            "clientSecret": {
+              "anyOf": [
+                { "type": "string", "minLength": 1 },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "source": { "type": "string", "enum": ["env", "file", "exec"] },
+                    "provider": { "type": "string" },
+                    "id": { "type": "string" }
+                  },
+                  "required": ["source", "provider", "id"]
+                }
+              ]
+            },
+            "clientSecretFile": { "type": "string" },
+            "allowFrom": { "type": "array", "items": { "type": "string" } },
+            "systemPrompt": { "type": "string" },
+            "markdownSupport": { "type": "boolean" },
+            "voiceDirectUploadFormats": { "type": "array", "items": { "type": "string" } },
+            "audioFormatPolicy": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "sttDirectFormats": { "type": "array", "items": { "type": "string" } },
+                "uploadDirectFormats": { "type": "array", "items": { "type": "string" } },
+                "transcodeEnabled": { "type": "boolean" }
+              }
+            },
+            "urlDirectUpload": { "type": "boolean" },
+            "upgradeUrl": { "type": "string" },
+            "upgradeMode": { "type": "string", "enum": ["doc", "hot-reload"] },
+            "streaming": {
+              "anyOf": [
+                { "type": "boolean" },
+                {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "mode": { "type": "string", "enum": ["off", "partial"], "default": "partial" }
+                  }
+                }
+              ]
+            }
+          }
         }
       },
       "defaultAccount": { "type": "string" }

--- a/extensions/webhooks/openclaw.plugin.json
+++ b/extensions/webhooks/openclaw.plugin.json
@@ -5,42 +5,35 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "$defs": {
-      "secretRef": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "source": {
-            "type": "string",
-            "enum": ["env", "file", "exec"]
-          },
-          "provider": { "type": "string" },
-          "id": { "type": "string" }
-        },
-        "required": ["source", "provider", "id"]
-      },
-      "secretInput": {
-        "anyOf": [{ "type": "string", "minLength": 1 }, { "$ref": "#/$defs/secretRef" }]
-      },
-      "route": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "enabled": { "type": "boolean" },
-          "path": { "type": "string", "minLength": 1 },
-          "sessionKey": { "type": "string", "minLength": 1 },
-          "secret": { "$ref": "#/$defs/secretInput" },
-          "controllerId": { "type": "string", "minLength": 1 },
-          "description": { "type": "string" }
-        },
-        "required": ["sessionKey", "secret"]
-      }
-    },
     "properties": {
       "routes": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "#/$defs/route"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string", "minLength": 1 },
+            "sessionKey": { "type": "string", "minLength": 1 },
+            "secret": {
+              "anyOf": [
+                { "type": "string", "minLength": 1 },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "source": { "type": "string", "enum": ["env", "file", "exec"] },
+                    "provider": { "type": "string" },
+                    "id": { "type": "string" }
+                  },
+                  "required": ["source", "provider", "id"]
+                }
+              ]
+            },
+            "controllerId": { "type": "string", "minLength": 1 },
+            "description": { "type": "string" }
+          },
+          "required": ["sessionKey", "secret"]
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes broken `$ref` resolution in `openclaw config schema` output when the emitted schema is saved to a file and referenced via `"$schema"` in `openclaw.json`. Fixes #60759.

## Problem

The qqbot and webhooks `openclaw.plugin.json` manifests had hand-written `configSchema` blocks using JSON Schema `$defs` with `$ref` pointers (e.g. `"$ref": "#/$defs/route"`) for DRY-ness. These resolve correctly standalone, but `openclaw config schema` nests them inside the full config document tree at paths like `plugins.entries.qqbot.config` and `plugins.entries.webhooks.config`. In draft-07, `#/$defs/...` resolves from the **document root** — after nesting, the pointer breaks and editors report:

```
$ref '/$defs/route' in 'file:///.../openclaw.schema.json' can not be resolved.
```

## Changes

Inline each `$ref` target at its use site and remove the `$defs` block in both manifests. The resulting schemas are **semantically identical** to before — verified by deep `$ref` resolution + sorted-key JSON comparison against main.

| File | Change |
|------|--------|
| `extensions/qqbot/openclaw.plugin.json` | Inline 7 definitions (audioFormatPolicy, speechQueryParams, tts, stt, secretRef, secretInput, account); remove all 9 `$ref` pointers |
| `extensions/webhooks/openclaw.plugin.json` | Inline 3 definitions (secretRef, secretInput, route); remove all 3 `$ref` pointers |

Zero source code changes — data-only fix to two JSON manifest files. 108 insertions, 150 deletions.

## Testing

```
pnpm check    # clean (lint + typecheck + format)
pnpm build    # clean
pnpm test extensions/qqbot extensions/webhooks src/config/schema.test.ts  # all pass (129/129)
```

Verified by running `openclaw config schema` and confirming **zero `$defs`** and **zero `$ref`** in the 800 KB output, and that all qqbot/webhooks plugin entry fields are present in the emitted schema.

## AI Disclosure

- [x] Authored with Claude Opus 4.6 (Claude Code)
- [x] Inlining done programmatically — semantically identical to main, verified via deep schema comparison
- [x] Fully tested (`pnpm build && pnpm check && pnpm test`)
- [x] I understand what the code does