### PR TITLE
[codex] Support Volta-managed installs

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -743,7 +743,11 @@ async function maybeRestartService(params: {
 
   if (!params.opts.json) {
     defaultRuntime.log("");
-    if (params.result.mode === "npm" || params.result.mode === "pnpm") {
+    if (
+      params.result.mode === "npm" ||
+      params.result.mode === "pnpm" ||
+      params.result.mode === "volta"
+    ) {
       defaultRuntime.log(
         theme.muted(
           `Tip: Run \`${replaceCliName(formatCliCommand("openclaw doctor"), CLI_NAME)}\`, then \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\` to apply updates to a running gateway.`,

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   checkDepsStatus,
   checkUpdateStatus,
@@ -227,7 +228,7 @@ describe("checkUpdateStatus", () => {
     });
   });
 
-  it("detects package installs for non-git roots", async () => {
+  it("reports unknown install manager for non-git roots outside a global install", async () => {
     await withTempDir({ prefix: "openclaw-update-check-" }, async (root) => {
       await fs.writeFile(
         path.join(root, "package.json"),
@@ -242,12 +243,51 @@ describe("checkUpdateStatus", () => {
       ).resolves.toMatchObject({
         root,
         installKind: "package",
-        packageManager: "npm",
+        packageManager: "unknown",
         git: undefined,
         registry: undefined,
         deps: {
           manager: "npm",
         },
+      });
+    });
+  });
+
+  it("detects Volta package installs for non-git roots", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-" }, async (base) => {
+      const voltaHome = path.join(base, "volta-home");
+      const root = path.join(
+        voltaHome,
+        "tools",
+        "image",
+        "packages",
+        "openclaw",
+        "lib",
+        "node_modules",
+        "openclaw",
+      );
+      await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@10.0.0" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(root, "pnpm-lock.yaml"), "lock", "utf8");
+      await fs.writeFile(path.join(root, "node_modules", ".modules.yaml"), "marker", "utf8");
+
+      await withEnvAsync({ VOLTA_HOME: voltaHome }, async () => {
+        await expect(
+          checkUpdateStatus({ root, includeRegistry: false, fetchGit: false, timeoutMs: 1000 }),
+        ).resolves.toMatchObject({
+          root,
+          installKind: "package",
+          packageManager: "volta",
+          git: undefined,
+          registry: undefined,
+          deps: {
+            manager: "pnpm",
+          },
+        });
       });
     });
   });

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -5,8 +5,10 @@ import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import { channelToNpmTag, type UpdateChannel } from "./update-channels.js";
+import { detectGlobalInstallManagerForRoot, type GlobalInstallManager } from "./update-global.js";
 
-export type PackageManager = "pnpm" | "bun" | "npm" | "unknown";
+export type PackageManager = GlobalInstallManager | "unknown";
+type WorkspacePackageManager = Exclude<PackageManager, "volta">;
 
 export type GitUpdateStatus = {
   root: string;
@@ -81,7 +83,21 @@ async function exists(p: string): Promise<boolean> {
 }
 
 async function detectPackageManager(root: string): Promise<PackageManager> {
-  return (await detectPackageManagerImpl(root)) ?? "unknown";
+  return ((await detectPackageManagerImpl(root)) as WorkspacePackageManager | null) ?? "unknown";
+}
+
+async function detectInstalledPackageManager(
+  root: string,
+  timeoutMs: number,
+): Promise<GlobalInstallManager | null> {
+  return await detectGlobalInstallManagerForRoot(
+    async (argv, options) => {
+      const res = await runCommandWithTimeout(argv, options);
+      return { stdout: res.stdout, stderr: res.stderr, code: res.code };
+    },
+    root,
+    timeoutMs,
+  );
 }
 
 async function detectGitRoot(root: string): Promise<string | null> {
@@ -392,12 +408,15 @@ export async function checkUpdateStatus(params: {
     };
   }
 
-  const [pm, gitRoot, registry] = await Promise.all([
+  const [workspaceManager, gitRoot, registry] = await Promise.all([
     detectPackageManager(root),
     detectGitRoot(root),
     params.includeRegistry ? fetchNpmLatestVersion({ timeoutMs }) : Promise.resolve(undefined),
   ]);
   const isGit = gitRoot && path.resolve(gitRoot) === root;
+  const installedPackageManager = !isGit
+    ? await detectInstalledPackageManager(root, timeoutMs)
+    : null;
 
   const installKind: UpdateCheckResult["installKind"] = isGit ? "git" : "package";
   const [git, deps] = await Promise.all([
@@ -408,13 +427,13 @@ export async function checkUpdateStatus(params: {
           fetch: Boolean(params.fetchGit),
         })
       : Promise.resolve(undefined),
-    checkDepsStatus({ root, manager: pm }),
+    checkDepsStatus({ root, manager: workspaceManager }),
   ]);
 
   return {
     root,
     installKind,
-    packageManager: pm,
+    packageManager: isGit ? workspaceManager : (installedPackageManager ?? "unknown"),
     git,
     deps,
     registry,

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -51,6 +51,9 @@ describe("update global helpers", () => {
   });
 
   it("resolves global roots and package roots from runner output", async () => {
+    envSnapshot = captureEnv(["VOLTA_HOME"]);
+    process.env.VOLTA_HOME = path.join("/tmp", "volta-home");
+
     const runCommand: CommandRunner = async (argv) => {
       if (argv[0] === "npm") {
         return { stdout: "/tmp/npm-root\n", stderr: "", code: 0 };
@@ -66,9 +69,47 @@ describe("update global helpers", () => {
     await expect(resolveGlobalRoot("bun", runCommand, 1000)).resolves.toContain(
       path.join(".bun", "install", "global", "node_modules"),
     );
+    await expect(resolveGlobalRoot("volta", runCommand, 1000)).resolves.toBe(
+      path.join("/tmp", "volta-home", "tools", "image", "packages"),
+    );
     await expect(resolveGlobalPackageRoot("npm", runCommand, 1000)).resolves.toBe(
       path.join("/tmp/npm-root", "openclaw"),
     );
+    await expect(resolveGlobalPackageRoot("volta", runCommand, 1000)).resolves.toBe(
+      path.join(
+        "/tmp",
+        "volta-home",
+        "tools",
+        "image",
+        "packages",
+        "openclaw",
+        "lib",
+        "node_modules",
+        "openclaw",
+      ),
+    );
+    await expect(
+      resolveGlobalInstallTarget({
+        manager: "volta",
+        runCommand,
+        timeoutMs: 1000,
+      }),
+    ).resolves.toEqual({
+      manager: "volta",
+      command: "volta",
+      globalRoot: path.join("/tmp", "volta-home", "tools", "image", "packages"),
+      packageRoot: path.join(
+        "/tmp",
+        "volta-home",
+        "tools",
+        "image",
+        "packages",
+        "openclaw",
+        "lib",
+        "node_modules",
+        "openclaw",
+      ),
+    });
   });
 
   it("maps main and explicit install specs for global installs", () => {
@@ -110,13 +151,26 @@ describe("update global helpers", () => {
       const npmRoot = path.join(base, "npm-root");
       const pnpmRoot = path.join(base, "pnpm-root");
       const bunRoot = path.join(base, ".bun", "install", "global", "node_modules");
+      const voltaHome = path.join(base, ".volta");
+      const voltaPkgRoot = path.join(
+        voltaHome,
+        "tools",
+        "image",
+        "packages",
+        "openclaw",
+        "lib",
+        "node_modules",
+        "openclaw",
+      );
       const pkgRoot = path.join(pnpmRoot, "openclaw");
       await fs.mkdir(pkgRoot, { recursive: true });
       await fs.mkdir(path.join(npmRoot, "openclaw"), { recursive: true });
       await fs.mkdir(path.join(bunRoot, "openclaw"), { recursive: true });
+      await fs.mkdir(voltaPkgRoot, { recursive: true });
 
-      envSnapshot = captureEnv(["BUN_INSTALL"]);
+      envSnapshot = captureEnv(["BUN_INSTALL", "VOLTA_HOME"]);
       process.env.BUN_INSTALL = path.join(base, ".bun");
+      process.env.VOLTA_HOME = voltaHome;
 
       const runCommand: CommandRunner = async (argv) => {
         if (argv[0] === "npm") {
@@ -131,11 +185,15 @@ describe("update global helpers", () => {
       await expect(detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000)).resolves.toBe(
         "pnpm",
       );
+      await expect(detectGlobalInstallManagerForRoot(runCommand, voltaPkgRoot, 1000)).resolves.toBe(
+        "volta",
+      );
       await expect(detectGlobalInstallManagerByPresence(runCommand, 1000)).resolves.toBe("npm");
 
       await fs.rm(path.join(npmRoot, "openclaw"), { recursive: true, force: true });
       await fs.rm(path.join(pnpmRoot, "openclaw"), { recursive: true, force: true });
-      await expect(detectGlobalInstallManagerByPresence(runCommand, 1000)).resolves.toBe("bun");
+      await fs.rm(path.join(bunRoot, "openclaw"), { recursive: true, force: true });
+      await expect(detectGlobalInstallManagerByPresence(runCommand, 1000)).resolves.toBe("volta");
     });
   });
 
@@ -292,6 +350,10 @@ describe("update global helpers", () => {
       manager: "npm",
       command: "npm",
     });
+    expect(resolveGlobalInstallCommand("volta")).toEqual({
+      manager: "volta",
+      command: "volta",
+    });
     expect(globalInstallArgs("npm", "openclaw@latest")).toEqual([
       "npm",
       "i",
@@ -313,6 +375,11 @@ describe("update global helpers", () => {
       "-g",
       "openclaw@latest",
     ]);
+    expect(globalInstallArgs("volta", "openclaw@latest")).toEqual([
+      "volta",
+      "install",
+      "openclaw@latest",
+    ]);
 
     expect(globalInstallFallbackArgs("npm", "openclaw@latest")).toEqual([
       "npm",
@@ -325,6 +392,7 @@ describe("update global helpers", () => {
       "--loglevel=error",
     ]);
     expect(globalInstallFallbackArgs("pnpm", "openclaw@latest")).toBeNull();
+    expect(globalInstallFallbackArgs("volta", "openclaw@latest")).toBeNull();
     expect(
       globalInstallArgs({ manager: "pnpm", command: "/opt/homebrew/bin/pnpm" }, "openclaw@latest"),
     ).toEqual(["/opt/homebrew/bin/pnpm", "add", "-g", "openclaw@latest"]);

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -8,7 +8,7 @@ import { pathExists } from "../utils.js";
 import { readPackageVersion } from "./package-json.js";
 import { applyPathPrepend } from "./path-prepend.js";
 
-export type GlobalInstallManager = "npm" | "pnpm" | "bun";
+export type GlobalInstallManager = "npm" | "pnpm" | "bun" | "volta";
 
 export type CommandRunner = (
   argv: string[],
@@ -191,6 +191,18 @@ function resolveBunGlobalRoot(): string {
   return path.join(bunInstall, "install", "global", "node_modules");
 }
 
+function resolveVoltaHome(): string {
+  return process.env.VOLTA_HOME?.trim() || path.join(os.homedir(), ".volta");
+}
+
+function resolveVoltaPackagesRoot(): string {
+  return path.join(resolveVoltaHome(), "tools", "image", "packages");
+}
+
+function resolveVoltaPackageRoot(packageName: string): string {
+  return path.join(resolveVoltaPackagesRoot(), packageName, "lib", "node_modules", packageName);
+}
+
 function inferNpmPrefixFromPackageRoot(pkgRoot?: string | null): string | null {
   const trimmed = pkgRoot?.trim();
   if (!trimmed) {
@@ -260,6 +272,9 @@ export async function resolveGlobalRoot(
   pkgRoot?: string | null,
 ): Promise<string | null> {
   const resolved = normalizeGlobalInstallCommand(managerOrCommand, pkgRoot);
+  if (resolved.manager === "volta") {
+    return resolveVoltaPackagesRoot();
+  }
   if (resolved.manager === "bun") {
     return resolveBunGlobalRoot();
   }
@@ -278,7 +293,11 @@ export async function resolveGlobalPackageRoot(
   timeoutMs: number,
   pkgRoot?: string | null,
 ): Promise<string | null> {
-  const root = await resolveGlobalRoot(managerOrCommand, runCommand, timeoutMs, pkgRoot);
+  const resolved = normalizeGlobalInstallCommand(managerOrCommand, pkgRoot);
+  if (resolved.manager === "volta") {
+    return resolveVoltaPackageRoot(PRIMARY_PACKAGE_NAME);
+  }
+  const root = await resolveGlobalRoot(resolved, runCommand, timeoutMs, pkgRoot);
   if (!root) {
     return null;
   }
@@ -301,7 +320,12 @@ export async function resolveGlobalInstallTarget(params: {
   return {
     ...command,
     globalRoot,
-    packageRoot: globalRoot ? path.join(globalRoot, PRIMARY_PACKAGE_NAME) : null,
+    packageRoot:
+      command.manager === "volta"
+        ? resolveVoltaPackageRoot(PRIMARY_PACKAGE_NAME)
+        : globalRoot
+          ? path.join(globalRoot, PRIMARY_PACKAGE_NAME)
+          : null,
   };
 }
 
@@ -311,6 +335,13 @@ export async function detectGlobalInstallManagerForRoot(
   timeoutMs: number,
 ): Promise<GlobalInstallManager | null> {
   const pkgReal = await tryRealpath(pkgRoot);
+
+  for (const name of ALL_PACKAGE_NAMES) {
+    const voltaExpectedReal = await tryRealpath(resolveVoltaPackageRoot(name));
+    if (path.resolve(voltaExpectedReal) === path.resolve(pkgReal)) {
+      return "volta";
+    }
+  }
 
   const candidates: Array<{
     manager: "npm" | "pnpm";
@@ -378,6 +409,11 @@ export async function detectGlobalInstallManagerByPresence(
       return "bun";
     }
   }
+  for (const name of ALL_PACKAGE_NAMES) {
+    if (await pathExists(resolveVoltaPackageRoot(name))) {
+      return "volta";
+    }
+  }
   return null;
 }
 
@@ -387,6 +423,9 @@ export function globalInstallArgs(
   pkgRoot?: string | null,
 ): string[] {
   const resolved = normalizeGlobalInstallCommand(managerOrCommand, pkgRoot);
+  if (resolved.manager === "volta") {
+    return [resolved.command, "install", spec];
+  }
   if (resolved.manager === "pnpm") {
     return [resolved.command, "add", "-g", spec];
   }

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1286,6 +1286,39 @@ describe("runGatewayUpdate", () => {
     });
   });
 
+  it("updates global Volta installs when detected", async () => {
+    const voltaHome = path.join(tempDir, "volta-home");
+    const pkgRoot = path.join(
+      voltaHome,
+      "tools",
+      "image",
+      "packages",
+      "openclaw",
+      "lib",
+      "node_modules",
+      "openclaw",
+    );
+    await seedGlobalPackageRoot(pkgRoot);
+
+    const { calls, runCommand } = createGlobalInstallHarness({
+      pkgRoot,
+      installCommand: "volta install openclaw@latest",
+      onInstall: async () => {
+        await writeGlobalPackageVersion(pkgRoot);
+      },
+    });
+
+    await withEnvAsync({ VOLTA_HOME: voltaHome }, async () => {
+      const result = await runWithCommand(runCommand, { cwd: pkgRoot });
+
+      expect(result.status).toBe("ok");
+      expect(result.mode).toBe("volta");
+      expect(result.before?.version).toBe("1.0.0");
+      expect(result.after?.version).toBe("2.0.0");
+      expect(calls.some((call) => call === "volta install openclaw@latest")).toBe(true);
+    });
+  });
+
   it("rejects git roots that are not a openclaw checkout", async () => {
     await fs.mkdir(path.join(tempDir, ".git"));
     const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tempDir);

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -50,7 +50,7 @@ export type UpdateStepResult = {
 
 export type UpdateRunResult = {
   status: "ok" | "error" | "skipped";
-  mode: "git" | "pnpm" | "bun" | "npm" | "unknown";
+  mode: "git" | "pnpm" | "bun" | "npm" | "volta" | "unknown";
   root?: string;
   reason?: string;
   before?: { sha?: string | null; version?: string | null };


### PR DESCRIPTION
## What changed
- teach the updater to recognize Volta-managed OpenClaw installs as a supported global install target
- route global package updates through `volta install ...` when the running package comes from Volta
- report `packageManager: "volta"` for package installs in update status output
- extend the CLI restart hint and regression tests to cover Volta-managed installs

## Why this changed
Volta-installed OpenClaw packages were being treated as unsupported package installs. That caused the gateway update flow to stop at `not-git-install` instead of running the package-manager update path.

## Impact
- the Control UI update action now works for Volta-managed installs
- `openclaw update status` correctly identifies Volta as the install manager
- the updater keeps the existing npm, pnpm, and bun behavior unchanged

## Validation
- `pnpm test -- src/infra/update-global.test.ts src/infra/update-check.test.ts src/infra/update-runner.test.ts src/cli/update-cli/progress.test.ts src/commands/status.update.test.ts`
- `pnpm build`
