### PR TITLE
fix(cli): include qa scenarios in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docs/",
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
+    "qa/",
     "skills/",
     "scripts/npm-runner.mjs",
     "scripts/postinstall-bundled-plugins.mjs",

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -54,7 +54,7 @@ export type NpmDistTagMirrorAuth = {
 };
 const EXPECTED_REPOSITORY_URL = "https://github.com/openclaw/openclaw";
 const MAX_CALVER_DISTANCE_DAYS = 2;
-const REQUIRED_PACKED_PATHS = ["dist/control-ui/index.html"];
+const REQUIRED_PACKED_PATHS = ["dist/control-ui/index.html", "qa/scenarios/index.md"];
 const CONTROL_UI_ASSET_PREFIX = "dist/control-ui/assets/";
 const FORBIDDEN_PACKED_PATH_PREFIXES = ["docs/.generated/"] as const;
 const NPM_PACK_MAX_BUFFER_BYTES = 64 * 1024 * 1024;

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -278,16 +278,18 @@ describe("parseNpmPackJsonOutput", () => {
 });
 
 describe("collectControlUiPackErrors", () => {
-  it("rejects packs that ship the dashboard HTML without the asset payload", () => {
+  it("rejects packs that omit required QA scenario content", () => {
     expect(collectControlUiPackErrors(["dist/control-ui/index.html"])).toEqual([
+      'npm package is missing required path "qa/scenarios/index.md". Ensure UI assets are built and included before publish.',
       'npm package is missing Control UI asset payload under "dist/control-ui/assets/". Refuse release when the dashboard tarball would be empty.',
     ]);
   });
 
-  it("accepts packs that ship dashboard HTML and bundled assets", () => {
+  it("accepts packs that ship dashboard HTML, QA scenarios, and bundled assets", () => {
     expect(
       collectControlUiPackErrors([
         "dist/control-ui/index.html",
+        "qa/scenarios/index.md",
         "dist/control-ui/assets/index-Bu8rSoJV.js",
         "dist/control-ui/assets/index-BK0yXA_h.css",
       ]),


### PR DESCRIPTION
## Summary
- include the `qa/` scenario pack in the published npm package
- add a release-check guard that requires `qa/scenarios/index.md` in `npm pack --dry-run`
- cover the guard with a focused unit test update

## Verification
- `pnpm exec vitest run test/openclaw-npm-release-check.test.ts`
- `npm pack --json --dry-run --ignore-scripts`
- `pnpm exec oxfmt --check scripts/openclaw-npm-release-check.ts test/openclaw-npm-release-check.test.ts`

Closes #63968