### PR TITLE
fix(test): restore node baseline expectations

### DIFF
--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { access, appendFile, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -149,7 +150,7 @@ function createOutputStamp() {
 }
 
 function createVmSuffix() {
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return randomUUID().slice(0, 13);
 }
 
 function sleep(ms: number) {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -134,6 +134,7 @@ export const mockedFormatBillingErrorMessage = vi.fn(() => "");
 export const mockedClassifyFailoverReason = vi.fn<(raw: string) => FailoverReason | null>(
   () => null,
 );
+export const mockedSanitizeUserFacingText = vi.fn((text: string) => text);
 export const mockedExtractObservedOverflowTokenCount = vi.fn((msg?: string) => {
   const match = msg?.match(/prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i);
   return match?.[1] ? Number(match[1].replaceAll(",", "")) : undefined;
@@ -250,6 +251,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
 
   mockedClassifyFailoverReason.mockReset();
   mockedClassifyFailoverReason.mockReturnValue(null);
+  mockedSanitizeUserFacingText.mockReset();
+  mockedSanitizeUserFacingText.mockImplementation((text: string) => text);
   mockedFormatBillingErrorMessage.mockReset();
   mockedFormatBillingErrorMessage.mockReturnValue("");
   mockedFormatAssistantErrorText.mockReset();
@@ -379,6 +382,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
   vi.doMock("../pi-embedded-helpers.js", () => ({
     formatBillingErrorMessage: mockedFormatBillingErrorMessage,
     classifyFailoverReason: mockedClassifyFailoverReason,
+    sanitizeUserFacingText: mockedSanitizeUserFacingText,
     extractObservedOverflowTokenCount: mockedExtractObservedOverflowTokenCount,
     formatAssistantErrorText: mockedFormatAssistantErrorText,
     isAuthAssistantError: mockedIsAuthAssistantError,

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -160,7 +160,7 @@ describe("delivery context helpers", () => {
       channel: "telegram",
       conversationId: "42",
       parentConversationId: "-10099",
-      expected: { to: "channel:-10099", threadId: "42" },
+      expected: { to: "-10099", threadId: "42" },
     },
     {
       channel: "mattermost",


### PR DESCRIPTION
## Summary\n- replace the qa-lab multipass VM suffix weak-random helper with randomUUID\n- align the telegram delivery-context expectation with the plugin's current raw chat-id target\n- include sanitizeUserFacingText in the embedded overflow-compaction harness mock\n\n## Why\nThese are the current shared failures in the latest   run, and they also block otherwise-valid PRs like #59582 and #59592.