### PR TITLE
UI: consolidate control-ui refresh and controller flows

### DIFF
--- a/src/ui-app-settings.agents-files-refresh.test.ts
+++ b/src/ui-app-settings.agents-files-refresh.test.ts
@@ -44,7 +44,7 @@ vi.mock("../ui/src/ui/controllers/channels.ts", () => ({
 }));
 
 vi.mock("../ui/src/ui/controllers/cron.ts", () => ({
-  loadCronJobs: vi.fn(async () => undefined),
+  loadCronJobsPage: vi.fn(async () => undefined),
   loadCronRuns: vi.fn(async () => undefined),
   loadCronStatus: vi.fn(async () => undefined),
 }));

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -10,7 +10,6 @@ import {
 import { observeTopbar, scheduleChatScroll, scheduleLogsScroll } from "./app-scroll.ts";
 import {
   applySettingsFromUrl,
-  attachThemeListener,
   detachThemeListener,
   inferBasePath,
   syncTabWithLocation,
@@ -49,7 +48,6 @@ export function handleConnected(host: LifecycleHost) {
   const bootstrapReady = loadControlUiBootstrapConfig(host);
   syncTabWithLocation(host as unknown as Parameters<typeof syncTabWithLocation>[0], true);
   syncThemeWithSettings(host as unknown as Parameters<typeof syncThemeWithSettings>[0]);
-  attachThemeListener(host as unknown as Parameters<typeof attachThemeListener>[0]);
   window.addEventListener("popstate", host.popStateHandler);
   void bootstrapReady.finally(() => {
     if (host.connectGeneration !== connectGeneration) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -39,10 +39,9 @@ import {
   removeConfigFormValue,
 } from "./controllers/config.ts";
 import {
+  loadCronJobsPage,
   loadCronRuns,
-  loadMoreCronJobs,
   loadMoreCronRuns,
-  reloadCronJobs,
   toggleCronJob,
   runCronJob,
   removeCronJob,
@@ -1230,7 +1229,7 @@ export function renderApp(state: AppViewState) {
                   updateCronRunsFilter(state, { cronRunsScope: "job" });
                   await loadCronRuns(state, jobId);
                 },
-                onLoadMoreJobs: () => loadMoreCronJobs(state),
+                onLoadMoreJobs: () => loadCronJobsPage(state, { append: true }),
                 onJobsFiltersChange: async (patch) => {
                   updateCronJobsFilter(state, patch);
                   const shouldReload =
@@ -1239,7 +1238,7 @@ export function renderApp(state: AppViewState) {
                     Boolean(patch.cronJobsSortBy) ||
                     Boolean(patch.cronJobsSortDir);
                   if (shouldReload) {
-                    await reloadCronJobs(state);
+                    await loadCronJobsPage(state, { append: false });
                   }
                 },
                 onJobsFiltersReset: async () => {
@@ -1251,7 +1250,7 @@ export function renderApp(state: AppViewState) {
                     cronJobsSortBy: "nextRunAtMs",
                     cronJobsSortDir: "asc",
                   });
-                  await reloadCronJobs(state);
+                  await loadCronJobsPage(state, { append: false });
                 },
                 onLoadMoreRuns: () => loadMoreCronRuns(state),
                 onRunsFiltersChange: async (patch) => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -122,7 +122,7 @@ import {
 } from "./views/agents-utils.ts";
 import { renderChat } from "./views/chat.ts";
 import { renderCommandPalette } from "./views/command-palette.ts";
-import { renderConfig } from "./views/config.ts";
+import { renderConfig, type ConfigProps } from "./views/config.ts";
 import { renderDreaming } from "./views/dreaming.ts";
 import { renderExecApprovalPrompt } from "./views/exec-approval.ts";
 import { renderGatewayUrlConfirmation } from "./views/gateway-url-confirmation.ts";
@@ -320,11 +320,61 @@ const AI_AGENTS_SECTION_KEYS = [
   "memory",
   "session",
 ] as const;
-type CommunicationSectionKey = (typeof COMMUNICATION_SECTION_KEYS)[number];
-type AppearanceSectionKey = (typeof APPEARANCE_SECTION_KEYS)[number];
-type AutomationSectionKey = (typeof AUTOMATION_SECTION_KEYS)[number];
-type InfrastructureSectionKey = (typeof INFRASTRUCTURE_SECTION_KEYS)[number];
-type AiAgentsSectionKey = (typeof AI_AGENTS_SECTION_KEYS)[number];
+type ConfigSectionSelection = {
+  activeSection: string | null;
+  activeSubsection: string | null;
+};
+
+type ConfigTabOverrides = Pick<
+  ConfigProps,
+  | "formMode"
+  | "searchQuery"
+  | "activeSection"
+  | "activeSubsection"
+  | "onFormModeChange"
+  | "onSearchChange"
+  | "onSectionChange"
+  | "onSubsectionChange"
+> &
+  Partial<
+    Pick<
+      ConfigProps,
+      | "showModeToggle"
+      | "navRootLabel"
+      | "includeSections"
+      | "excludeSections"
+      | "includeVirtualSections"
+    >
+  >;
+
+const SCOPED_CONFIG_SECTION_KEYS = new Set<string>([
+  ...COMMUNICATION_SECTION_KEYS,
+  ...APPEARANCE_SECTION_KEYS,
+  ...AUTOMATION_SECTION_KEYS,
+  ...INFRASTRUCTURE_SECTION_KEYS,
+  ...AI_AGENTS_SECTION_KEYS,
+]);
+
+function normalizeMainConfigSelection(
+  activeSection: string | null,
+  activeSubsection: string | null,
+): ConfigSectionSelection {
+  if (activeSection && SCOPED_CONFIG_SECTION_KEYS.has(activeSection)) {
+    return { activeSection: null, activeSubsection: null };
+  }
+  return { activeSection, activeSubsection };
+}
+
+function normalizeScopedConfigSelection(
+  activeSection: string | null,
+  activeSubsection: string | null,
+  includedSections: readonly string[],
+): ConfigSectionSelection {
+  if (activeSection && !includedSections.includes(activeSection)) {
+    return { activeSection: null, activeSubsection: null };
+  }
+  return { activeSection, activeSubsection };
+}
 
 function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
   const list = state.agentsList?.agents ?? [];
@@ -459,6 +509,204 @@ export function renderApp(state: AppViewState) {
     state.cronForm.deliveryMode === "webhook"
       ? rawDeliveryToSuggestions.filter((value) => isHttpUrl(value))
       : rawDeliveryToSuggestions;
+  const commonConfigProps = {
+    raw: state.configRaw,
+    originalRaw: state.configRawOriginal,
+    valid: state.configValid,
+    issues: state.configIssues,
+    loading: state.configLoading,
+    saving: state.configSaving,
+    applying: state.configApplying,
+    updating: state.updateRunning,
+    connected: state.connected,
+    schema: state.configSchema,
+    schemaLoading: state.configSchemaLoading,
+    uiHints: state.configUiHints,
+    formValue: state.configForm,
+    originalValue: state.configFormOriginal,
+    onRawChange: (next: string) => {
+      state.configRaw = next;
+    },
+    onRequestUpdate: requestHostUpdate,
+    onFormPatch: (path: Array<string | number>, value: unknown) =>
+      updateConfigFormValue(state, path, value),
+    onReload: () => loadConfig(state),
+    onSave: () => saveConfig(state),
+    onApply: () => applyConfig(state),
+    onUpdate: () => runUpdate(state),
+    onOpenFile: () => openConfigFile(state),
+    version: state.hello?.server?.version ?? "",
+    theme: state.theme,
+    themeMode: state.themeMode,
+    setTheme: (theme, context) => state.setTheme(theme, context),
+    setThemeMode: (mode, context) => state.setThemeMode(mode, context),
+    borderRadius: state.settings.borderRadius,
+    setBorderRadius: (value) => state.setBorderRadius(value),
+    gatewayUrl: state.settings.gatewayUrl,
+    assistantName: state.assistantName,
+    configPath: state.configSnapshot?.path ?? null,
+    rawAvailable: typeof state.configSnapshot?.raw === "string",
+  } satisfies Omit<
+    ConfigProps,
+    | "formMode"
+    | "searchQuery"
+    | "activeSection"
+    | "activeSubsection"
+    | "onFormModeChange"
+    | "onSearchChange"
+    | "onSectionChange"
+    | "onSubsectionChange"
+    | "showModeToggle"
+    | "navRootLabel"
+    | "includeSections"
+    | "excludeSections"
+    | "includeVirtualSections"
+  >;
+  const renderConfigTab = (overrides: ConfigTabOverrides) =>
+    renderConfig({
+      ...commonConfigProps,
+      includeVirtualSections: false,
+      ...overrides,
+    });
+  const configSelection = normalizeMainConfigSelection(
+    state.configActiveSection,
+    state.configActiveSubsection,
+  );
+  const communicationsSelection = normalizeScopedConfigSelection(
+    state.communicationsActiveSection,
+    state.communicationsActiveSubsection,
+    COMMUNICATION_SECTION_KEYS,
+  );
+  const appearanceSelection = normalizeScopedConfigSelection(
+    state.appearanceActiveSection,
+    state.appearanceActiveSubsection,
+    APPEARANCE_SECTION_KEYS,
+  );
+  const automationSelection = normalizeScopedConfigSelection(
+    state.automationActiveSection,
+    state.automationActiveSubsection,
+    AUTOMATION_SECTION_KEYS,
+  );
+  const infrastructureSelection = normalizeScopedConfigSelection(
+    state.infrastructureActiveSection,
+    state.infrastructureActiveSubsection,
+    INFRASTRUCTURE_SECTION_KEYS,
+  );
+  const aiAgentsSelection = normalizeScopedConfigSelection(
+    state.aiAgentsActiveSection,
+    state.aiAgentsActiveSubsection,
+    AI_AGENTS_SECTION_KEYS,
+  );
+  const renderConfigTabForActiveTab = () => {
+    switch (state.tab) {
+      case "config":
+        return renderConfigTab({
+          formMode: state.configFormMode,
+          searchQuery: state.configSearchQuery,
+          activeSection: configSelection.activeSection,
+          activeSubsection: configSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.configFormMode = mode),
+          onSearchChange: (query) => (state.configSearchQuery = query),
+          onSectionChange: (section) => {
+            state.configActiveSection = section;
+            state.configActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.configActiveSubsection = section),
+          showModeToggle: true,
+          excludeSections: [
+            ...COMMUNICATION_SECTION_KEYS,
+            ...AUTOMATION_SECTION_KEYS,
+            ...INFRASTRUCTURE_SECTION_KEYS,
+            ...AI_AGENTS_SECTION_KEYS,
+            "ui",
+            "wizard",
+          ],
+        });
+      case "communications":
+        return renderConfigTab({
+          formMode: state.communicationsFormMode,
+          searchQuery: state.communicationsSearchQuery,
+          activeSection: communicationsSelection.activeSection,
+          activeSubsection: communicationsSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.communicationsFormMode = mode),
+          onSearchChange: (query) => (state.communicationsSearchQuery = query),
+          onSectionChange: (section) => {
+            state.communicationsActiveSection = section;
+            state.communicationsActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.communicationsActiveSubsection = section),
+          navRootLabel: "Communication",
+          includeSections: [...COMMUNICATION_SECTION_KEYS],
+        });
+      case "appearance":
+        return renderConfigTab({
+          formMode: state.appearanceFormMode,
+          searchQuery: state.appearanceSearchQuery,
+          activeSection: appearanceSelection.activeSection,
+          activeSubsection: appearanceSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.appearanceFormMode = mode),
+          onSearchChange: (query) => (state.appearanceSearchQuery = query),
+          onSectionChange: (section) => {
+            state.appearanceActiveSection = section;
+            state.appearanceActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.appearanceActiveSubsection = section),
+          navRootLabel: t("tabs.appearance"),
+          includeSections: [...APPEARANCE_SECTION_KEYS],
+          includeVirtualSections: true,
+        });
+      case "automation":
+        return renderConfigTab({
+          formMode: state.automationFormMode,
+          searchQuery: state.automationSearchQuery,
+          activeSection: automationSelection.activeSection,
+          activeSubsection: automationSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.automationFormMode = mode),
+          onSearchChange: (query) => (state.automationSearchQuery = query),
+          onSectionChange: (section) => {
+            state.automationActiveSection = section;
+            state.automationActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.automationActiveSubsection = section),
+          navRootLabel: "Automation",
+          includeSections: [...AUTOMATION_SECTION_KEYS],
+        });
+      case "infrastructure":
+        return renderConfigTab({
+          formMode: state.infrastructureFormMode,
+          searchQuery: state.infrastructureSearchQuery,
+          activeSection: infrastructureSelection.activeSection,
+          activeSubsection: infrastructureSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.infrastructureFormMode = mode),
+          onSearchChange: (query) => (state.infrastructureSearchQuery = query),
+          onSectionChange: (section) => {
+            state.infrastructureActiveSection = section;
+            state.infrastructureActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.infrastructureActiveSubsection = section),
+          navRootLabel: "Infrastructure",
+          includeSections: [...INFRASTRUCTURE_SECTION_KEYS],
+        });
+      case "aiAgents":
+        return renderConfigTab({
+          formMode: state.aiAgentsFormMode,
+          searchQuery: state.aiAgentsSearchQuery,
+          activeSection: aiAgentsSelection.activeSection,
+          activeSubsection: aiAgentsSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.aiAgentsFormMode = mode),
+          onSearchChange: (query) => (state.aiAgentsSearchQuery = query),
+          onSectionChange: (section) => {
+            state.aiAgentsActiveSection = section;
+            state.aiAgentsActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.aiAgentsActiveSubsection = section),
+          navRootLabel: "AI & Agents",
+          includeSections: [...AI_AGENTS_SECTION_KEYS],
+        });
+      default:
+        return nothing;
+    }
+  };
 
   return html`
     ${renderCommandPalette({
@@ -1659,419 +1907,7 @@ export function renderApp(state: AppViewState) {
               basePath: state.basePath ?? "",
             })
           : nothing}
-        ${state.tab === "config"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.configFormMode,
-              showModeToggle: true,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.configSearchQuery,
-              activeSection:
-                state.configActiveSection &&
-                (COMMUNICATION_SECTION_KEYS.includes(
-                  state.configActiveSection as CommunicationSectionKey,
-                ) ||
-                  APPEARANCE_SECTION_KEYS.includes(
-                    state.configActiveSection as AppearanceSectionKey,
-                  ) ||
-                  AUTOMATION_SECTION_KEYS.includes(
-                    state.configActiveSection as AutomationSectionKey,
-                  ) ||
-                  INFRASTRUCTURE_SECTION_KEYS.includes(
-                    state.configActiveSection as InfrastructureSectionKey,
-                  ) ||
-                  AI_AGENTS_SECTION_KEYS.includes(state.configActiveSection as AiAgentsSectionKey))
-                  ? null
-                  : state.configActiveSection,
-              activeSubsection:
-                state.configActiveSection &&
-                (COMMUNICATION_SECTION_KEYS.includes(
-                  state.configActiveSection as CommunicationSectionKey,
-                ) ||
-                  APPEARANCE_SECTION_KEYS.includes(
-                    state.configActiveSection as AppearanceSectionKey,
-                  ) ||
-                  AUTOMATION_SECTION_KEYS.includes(
-                    state.configActiveSection as AutomationSectionKey,
-                  ) ||
-                  INFRASTRUCTURE_SECTION_KEYS.includes(
-                    state.configActiveSection as InfrastructureSectionKey,
-                  ) ||
-                  AI_AGENTS_SECTION_KEYS.includes(state.configActiveSection as AiAgentsSectionKey))
-                  ? null
-                  : state.configActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.configFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.configSearchQuery = query),
-              onSectionChange: (section) => {
-                state.configActiveSection = section;
-                state.configActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.configActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              excludeSections: [
-                ...COMMUNICATION_SECTION_KEYS,
-                ...AUTOMATION_SECTION_KEYS,
-                ...INFRASTRUCTURE_SECTION_KEYS,
-                ...AI_AGENTS_SECTION_KEYS,
-                "ui",
-                "wizard",
-              ],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "communications"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.communicationsFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.communicationsSearchQuery,
-              activeSection:
-                state.communicationsActiveSection &&
-                !COMMUNICATION_SECTION_KEYS.includes(
-                  state.communicationsActiveSection as CommunicationSectionKey,
-                )
-                  ? null
-                  : state.communicationsActiveSection,
-              activeSubsection:
-                state.communicationsActiveSection &&
-                !COMMUNICATION_SECTION_KEYS.includes(
-                  state.communicationsActiveSection as CommunicationSectionKey,
-                )
-                  ? null
-                  : state.communicationsActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.communicationsFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.communicationsSearchQuery = query),
-              onSectionChange: (section) => {
-                state.communicationsActiveSection = section;
-                state.communicationsActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.communicationsActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "Communication",
-              includeSections: [...COMMUNICATION_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "appearance"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.appearanceFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.appearanceSearchQuery,
-              activeSection:
-                state.appearanceActiveSection &&
-                !APPEARANCE_SECTION_KEYS.includes(
-                  state.appearanceActiveSection as AppearanceSectionKey,
-                )
-                  ? null
-                  : state.appearanceActiveSection,
-              activeSubsection:
-                state.appearanceActiveSection &&
-                !APPEARANCE_SECTION_KEYS.includes(
-                  state.appearanceActiveSection as AppearanceSectionKey,
-                )
-                  ? null
-                  : state.appearanceActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.appearanceFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.appearanceSearchQuery = query),
-              onSectionChange: (section) => {
-                state.appearanceActiveSection = section;
-                state.appearanceActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.appearanceActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: t("tabs.appearance"),
-              includeSections: [...APPEARANCE_SECTION_KEYS],
-              includeVirtualSections: true,
-            })
-          : nothing}
-        ${state.tab === "automation"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.automationFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.automationSearchQuery,
-              activeSection:
-                state.automationActiveSection &&
-                !AUTOMATION_SECTION_KEYS.includes(
-                  state.automationActiveSection as AutomationSectionKey,
-                )
-                  ? null
-                  : state.automationActiveSection,
-              activeSubsection:
-                state.automationActiveSection &&
-                !AUTOMATION_SECTION_KEYS.includes(
-                  state.automationActiveSection as AutomationSectionKey,
-                )
-                  ? null
-                  : state.automationActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.automationFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.automationSearchQuery = query),
-              onSectionChange: (section) => {
-                state.automationActiveSection = section;
-                state.automationActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.automationActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "Automation",
-              includeSections: [...AUTOMATION_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "infrastructure"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.infrastructureFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.infrastructureSearchQuery,
-              activeSection:
-                state.infrastructureActiveSection &&
-                !INFRASTRUCTURE_SECTION_KEYS.includes(
-                  state.infrastructureActiveSection as InfrastructureSectionKey,
-                )
-                  ? null
-                  : state.infrastructureActiveSection,
-              activeSubsection:
-                state.infrastructureActiveSection &&
-                !INFRASTRUCTURE_SECTION_KEYS.includes(
-                  state.infrastructureActiveSection as InfrastructureSectionKey,
-                )
-                  ? null
-                  : state.infrastructureActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.infrastructureFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.infrastructureSearchQuery = query),
-              onSectionChange: (section) => {
-                state.infrastructureActiveSection = section;
-                state.infrastructureActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.infrastructureActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "Infrastructure",
-              includeSections: [...INFRASTRUCTURE_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "aiAgents"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.aiAgentsFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.aiAgentsSearchQuery,
-              activeSection:
-                state.aiAgentsActiveSection &&
-                !AI_AGENTS_SECTION_KEYS.includes(state.aiAgentsActiveSection as AiAgentsSectionKey)
-                  ? null
-                  : state.aiAgentsActiveSection,
-              activeSubsection:
-                state.aiAgentsActiveSection &&
-                !AI_AGENTS_SECTION_KEYS.includes(state.aiAgentsActiveSection as AiAgentsSectionKey)
-                  ? null
-                  : state.aiAgentsActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.aiAgentsFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.aiAgentsSearchQuery = query),
-              onSectionChange: (section) => {
-                state.aiAgentsActiveSection = section;
-                state.aiAgentsActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.aiAgentsActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "AI & Agents",
-              includeSections: [...AI_AGENTS_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
+        ${renderConfigTabForActiveTab()}
         ${state.tab === "debug"
           ? lazyRender(lazyDebug, (m) =>
               m.renderDebug({

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1347,12 +1347,7 @@ export function renderApp(state: AppViewState) {
                   }
                   if (state.agentsPanel === "tools" && refreshedAgentId) {
                     void loadToolsCatalog(state, refreshedAgentId);
-                    if (refreshedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                      void loadToolsEffective(state, {
-                        agentId: refreshedAgentId,
-                        sessionKey: state.sessionKey,
-                      });
-                    }
+                    void refreshVisibleToolsEffectiveForCurrentSession(state);
                   }
                   if (state.agentsPanel === "channels") {
                     void loadChannels(state, false);
@@ -1385,12 +1380,7 @@ export function renderApp(state: AppViewState) {
                   }
                   if (state.agentsPanel === "tools") {
                     void loadToolsCatalog(state, agentId);
-                    if (agentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                      void loadToolsEffective(state, {
-                        agentId,
-                        sessionKey: state.sessionKey,
-                      });
-                    }
+                    void refreshVisibleToolsEffectiveForCurrentSession(state);
                   }
                   if (state.agentsPanel === "skills") {
                     void loadAgentSkills(state, agentId);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -442,11 +442,12 @@ export function renderApp(state: AppViewState) {
     })();
   };
   const basePath = normalizeBasePath(state.basePath ?? "");
-  const resolvedAgentId =
+  const resolveSelectedAgentId = () =>
     state.agentsSelectedId ??
     state.agentsList?.defaultId ??
     state.agentsList?.agents?.[0]?.id ??
     null;
+  const resolvedAgentId = resolveSelectedAgentId();
   const activeSessionAgentId = resolveAgentIdFromSessionKey(state.sessionKey);
   const toolsPanelUsesActiveSession = Boolean(
     resolvedAgentId && activeSessionAgentId && resolvedAgentId === activeSessionAgentId,
@@ -1369,12 +1370,7 @@ export function renderApp(state: AppViewState) {
                   if (agentIds.length > 0) {
                     void loadAgentIdentities(state, agentIds);
                   }
-                  const refreshedAgentId =
-                    state.agentsSelectedId ??
-                    state.agentsList?.defaultId ??
-                    state.agentsList?.agents?.[0]?.id ??
-                    null;
-                  loadAgentPanelDataForSelectedAgent(refreshedAgentId);
+                  loadAgentPanelDataForSelectedAgent(resolveSelectedAgentId());
                   refreshAgentsPanelSupplementalData(state.agentsPanel);
                 },
                 onSelectAgent: (agentId) => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -22,6 +22,7 @@ import {
   loadAgents,
   loadToolsCatalog,
   loadToolsEffective,
+  resetToolsEffectiveState,
   refreshVisibleToolsEffectiveForCurrentSession,
   saveAgentsConfig,
 } from "./controllers/agents.ts";
@@ -1377,11 +1378,7 @@ export function renderApp(state: AppViewState) {
                   state.toolsCatalogResult = null;
                   state.toolsCatalogError = null;
                   state.toolsCatalogLoading = false;
-                  state.toolsEffectiveResult = null;
-                  state.toolsEffectiveResultKey = null;
-                  state.toolsEffectiveError = null;
-                  state.toolsEffectiveLoading = false;
-                  state.toolsEffectiveLoadingKey = null;
+                  resetToolsEffectiveState(state);
                   void loadAgentIdentity(state, agentId);
                   if (state.agentsPanel === "files") {
                     void loadAgentFiles(state, agentId);
@@ -1438,11 +1435,7 @@ export function renderApp(state: AppViewState) {
                         });
                       }
                     } else {
-                      state.toolsEffectiveResult = null;
-                      state.toolsEffectiveResultKey = null;
-                      state.toolsEffectiveError = null;
-                      state.toolsEffectiveLoading = false;
-                      state.toolsEffectiveLoadingKey = null;
+                      resetToolsEffectiveState(state);
                     }
                   }
                   if (panel === "channels") {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -568,6 +568,27 @@ export function renderApp(state: AppViewState) {
       includeVirtualSections: false,
       ...overrides,
     });
+  const buildScopedConfigTabOverrides = (params: {
+    formMode: ConfigProps["formMode"];
+    searchQuery: string;
+    selection: ConfigSectionSelection;
+    setFormMode: (mode: ConfigProps["formMode"]) => void;
+    setSearchQuery: (query: string) => void;
+    setActiveSection: (section: string | null) => void;
+    setActiveSubsection: (section: string | null) => void;
+  }): ConfigTabOverrides => ({
+    formMode: params.formMode,
+    searchQuery: params.searchQuery,
+    activeSection: params.selection.activeSection,
+    activeSubsection: params.selection.activeSubsection,
+    onFormModeChange: params.setFormMode,
+    onSearchChange: params.setSearchQuery,
+    onSectionChange: (section) => {
+      params.setActiveSection(section);
+      params.setActiveSubsection(null);
+    },
+    onSubsectionChange: params.setActiveSubsection,
+  });
   const configSelection = normalizeMainConfigSelection(
     state.configActiveSection,
     state.configActiveSubsection,
@@ -601,17 +622,15 @@ export function renderApp(state: AppViewState) {
     switch (state.tab) {
       case "config":
         return renderConfigTab({
-          formMode: state.configFormMode,
-          searchQuery: state.configSearchQuery,
-          activeSection: configSelection.activeSection,
-          activeSubsection: configSelection.activeSubsection,
-          onFormModeChange: (mode) => (state.configFormMode = mode),
-          onSearchChange: (query) => (state.configSearchQuery = query),
-          onSectionChange: (section) => {
-            state.configActiveSection = section;
-            state.configActiveSubsection = null;
-          },
-          onSubsectionChange: (section) => (state.configActiveSubsection = section),
+          ...buildScopedConfigTabOverrides({
+            formMode: state.configFormMode,
+            searchQuery: state.configSearchQuery,
+            selection: configSelection,
+            setFormMode: (mode) => (state.configFormMode = mode),
+            setSearchQuery: (query) => (state.configSearchQuery = query),
+            setActiveSection: (section) => (state.configActiveSection = section),
+            setActiveSubsection: (section) => (state.configActiveSubsection = section),
+          }),
           showModeToggle: true,
           excludeSections: [
             ...COMMUNICATION_SECTION_KEYS,
@@ -624,82 +643,72 @@ export function renderApp(state: AppViewState) {
         });
       case "communications":
         return renderConfigTab({
-          formMode: state.communicationsFormMode,
-          searchQuery: state.communicationsSearchQuery,
-          activeSection: communicationsSelection.activeSection,
-          activeSubsection: communicationsSelection.activeSubsection,
-          onFormModeChange: (mode) => (state.communicationsFormMode = mode),
-          onSearchChange: (query) => (state.communicationsSearchQuery = query),
-          onSectionChange: (section) => {
-            state.communicationsActiveSection = section;
-            state.communicationsActiveSubsection = null;
-          },
-          onSubsectionChange: (section) => (state.communicationsActiveSubsection = section),
+          ...buildScopedConfigTabOverrides({
+            formMode: state.communicationsFormMode,
+            searchQuery: state.communicationsSearchQuery,
+            selection: communicationsSelection,
+            setFormMode: (mode) => (state.communicationsFormMode = mode),
+            setSearchQuery: (query) => (state.communicationsSearchQuery = query),
+            setActiveSection: (section) => (state.communicationsActiveSection = section),
+            setActiveSubsection: (section) => (state.communicationsActiveSubsection = section),
+          }),
           navRootLabel: "Communication",
           includeSections: [...COMMUNICATION_SECTION_KEYS],
         });
       case "appearance":
         return renderConfigTab({
-          formMode: state.appearanceFormMode,
-          searchQuery: state.appearanceSearchQuery,
-          activeSection: appearanceSelection.activeSection,
-          activeSubsection: appearanceSelection.activeSubsection,
-          onFormModeChange: (mode) => (state.appearanceFormMode = mode),
-          onSearchChange: (query) => (state.appearanceSearchQuery = query),
-          onSectionChange: (section) => {
-            state.appearanceActiveSection = section;
-            state.appearanceActiveSubsection = null;
-          },
-          onSubsectionChange: (section) => (state.appearanceActiveSubsection = section),
+          ...buildScopedConfigTabOverrides({
+            formMode: state.appearanceFormMode,
+            searchQuery: state.appearanceSearchQuery,
+            selection: appearanceSelection,
+            setFormMode: (mode) => (state.appearanceFormMode = mode),
+            setSearchQuery: (query) => (state.appearanceSearchQuery = query),
+            setActiveSection: (section) => (state.appearanceActiveSection = section),
+            setActiveSubsection: (section) => (state.appearanceActiveSubsection = section),
+          }),
           navRootLabel: t("tabs.appearance"),
           includeSections: [...APPEARANCE_SECTION_KEYS],
           includeVirtualSections: true,
         });
       case "automation":
         return renderConfigTab({
-          formMode: state.automationFormMode,
-          searchQuery: state.automationSearchQuery,
-          activeSection: automationSelection.activeSection,
-          activeSubsection: automationSelection.activeSubsection,
-          onFormModeChange: (mode) => (state.automationFormMode = mode),
-          onSearchChange: (query) => (state.automationSearchQuery = query),
-          onSectionChange: (section) => {
-            state.automationActiveSection = section;
-            state.automationActiveSubsection = null;
-          },
-          onSubsectionChange: (section) => (state.automationActiveSubsection = section),
+          ...buildScopedConfigTabOverrides({
+            formMode: state.automationFormMode,
+            searchQuery: state.automationSearchQuery,
+            selection: automationSelection,
+            setFormMode: (mode) => (state.automationFormMode = mode),
+            setSearchQuery: (query) => (state.automationSearchQuery = query),
+            setActiveSection: (section) => (state.automationActiveSection = section),
+            setActiveSubsection: (section) => (state.automationActiveSubsection = section),
+          }),
           navRootLabel: "Automation",
           includeSections: [...AUTOMATION_SECTION_KEYS],
         });
       case "infrastructure":
         return renderConfigTab({
-          formMode: state.infrastructureFormMode,
-          searchQuery: state.infrastructureSearchQuery,
-          activeSection: infrastructureSelection.activeSection,
-          activeSubsection: infrastructureSelection.activeSubsection,
-          onFormModeChange: (mode) => (state.infrastructureFormMode = mode),
-          onSearchChange: (query) => (state.infrastructureSearchQuery = query),
-          onSectionChange: (section) => {
-            state.infrastructureActiveSection = section;
-            state.infrastructureActiveSubsection = null;
-          },
-          onSubsectionChange: (section) => (state.infrastructureActiveSubsection = section),
+          ...buildScopedConfigTabOverrides({
+            formMode: state.infrastructureFormMode,
+            searchQuery: state.infrastructureSearchQuery,
+            selection: infrastructureSelection,
+            setFormMode: (mode) => (state.infrastructureFormMode = mode),
+            setSearchQuery: (query) => (state.infrastructureSearchQuery = query),
+            setActiveSection: (section) => (state.infrastructureActiveSection = section),
+            setActiveSubsection: (section) => (state.infrastructureActiveSubsection = section),
+          }),
           navRootLabel: "Infrastructure",
           includeSections: [...INFRASTRUCTURE_SECTION_KEYS],
         });
       case "aiAgents":
         return renderConfigTab({
-          formMode: state.aiAgentsFormMode,
-          searchQuery: state.aiAgentsSearchQuery,
-          activeSection: aiAgentsSelection.activeSection,
-          activeSubsection: aiAgentsSelection.activeSubsection,
-          onFormModeChange: (mode) => (state.aiAgentsFormMode = mode),
-          onSearchChange: (query) => (state.aiAgentsSearchQuery = query),
-          onSectionChange: (section) => {
-            state.aiAgentsActiveSection = section;
-            state.aiAgentsActiveSubsection = null;
-          },
-          onSubsectionChange: (section) => (state.aiAgentsActiveSubsection = section),
+          ...buildScopedConfigTabOverrides({
+            formMode: state.aiAgentsFormMode,
+            searchQuery: state.aiAgentsSearchQuery,
+            selection: aiAgentsSelection,
+            setFormMode: (mode) => (state.aiAgentsFormMode = mode),
+            setSearchQuery: (query) => (state.aiAgentsSearchQuery = query),
+            setActiveSection: (section) => (state.aiAgentsActiveSection = section),
+            setActiveSubsection: (section) => (state.aiAgentsActiveSubsection = section),
+          }),
           navRootLabel: "AI & Agents",
           includeSections: [...AI_AGENTS_SECTION_KEYS],
         });
@@ -1387,20 +1396,20 @@ export function renderApp(state: AppViewState) {
                 },
                 onSelectPanel: (panel) => {
                   state.agentsPanel = panel;
-                  if (panel === "files" && resolvedAgentId) {
-                    if (state.agentFilesList?.agentId !== resolvedAgentId) {
-                      state.agentFilesList = null;
-                      state.agentFilesError = null;
-                      state.agentFileActive = null;
-                      state.agentFileContents = {};
-                      state.agentFileDrafts = {};
-                      void loadAgentFiles(state, resolvedAgentId);
-                    }
+                  if (
+                    panel === "files" &&
+                    resolvedAgentId &&
+                    state.agentFilesList?.agentId !== resolvedAgentId
+                  ) {
+                    state.agentFilesList = null;
+                    state.agentFilesError = null;
+                    state.agentFileActive = null;
+                    state.agentFileContents = {};
+                    state.agentFileDrafts = {};
+                    void loadAgentFiles(state, resolvedAgentId);
                   }
-                  if (panel === "skills") {
-                    if (resolvedAgentId) {
-                      void loadAgentSkills(state, resolvedAgentId);
-                    }
+                  if (panel === "skills" && resolvedAgentId) {
+                    void loadAgentSkills(state, resolvedAgentId);
                   }
                   if (panel === "tools" && resolvedAgentId) {
                     if (

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1387,20 +1387,20 @@ export function renderApp(state: AppViewState) {
                 },
                 onSelectPanel: (panel) => {
                   state.agentsPanel = panel;
-                  if (panel === "files" && resolvedAgentId) {
-                    if (state.agentFilesList?.agentId !== resolvedAgentId) {
-                      state.agentFilesList = null;
-                      state.agentFilesError = null;
-                      state.agentFileActive = null;
-                      state.agentFileContents = {};
-                      state.agentFileDrafts = {};
-                      void loadAgentFiles(state, resolvedAgentId);
-                    }
+                  if (
+                    panel === "files" &&
+                    resolvedAgentId &&
+                    state.agentFilesList?.agentId !== resolvedAgentId
+                  ) {
+                    state.agentFilesList = null;
+                    state.agentFilesError = null;
+                    state.agentFileActive = null;
+                    state.agentFileContents = {};
+                    state.agentFileDrafts = {};
+                    void loadAgentFiles(state, resolvedAgentId);
                   }
-                  if (panel === "skills") {
-                    if (resolvedAgentId) {
-                      void loadAgentSkills(state, resolvedAgentId);
-                    }
+                  if (panel === "skills" && resolvedAgentId) {
+                    void loadAgentSkills(state, resolvedAgentId);
                   }
                   if (panel === "tools" && resolvedAgentId) {
                     if (

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -724,6 +724,14 @@ export function renderApp(state: AppViewState) {
       void refreshVisibleToolsEffectiveForCurrentSession(state);
     }
   };
+  const refreshAgentsPanelSupplementalData = (panel: AppViewState["agentsPanel"]) => {
+    if (panel === "channels") {
+      return void loadChannels(state, false);
+    }
+    if (panel === "cron") {
+      void state.loadCron();
+    }
+  };
   const resetAgentFilesState = (clearLoading = false) => {
     state.agentFilesList = null;
     state.agentFilesError = null;
@@ -1367,12 +1375,7 @@ export function renderApp(state: AppViewState) {
                     state.agentsList?.agents?.[0]?.id ??
                     null;
                   loadAgentPanelDataForSelectedAgent(refreshedAgentId);
-                  if (state.agentsPanel === "channels") {
-                    void loadChannels(state, false);
-                  }
-                  if (state.agentsPanel === "cron") {
-                    void state.loadCron();
-                  }
+                  refreshAgentsPanelSupplementalData(state.agentsPanel);
                 },
                 onSelectAgent: (agentId) => {
                   if (state.agentsSelectedId === agentId) {
@@ -1428,12 +1431,7 @@ export function renderApp(state: AppViewState) {
                       resetToolsEffectiveState(state);
                     }
                   }
-                  if (panel === "channels") {
-                    void loadChannels(state, false);
-                  }
-                  if (panel === "cron") {
-                    void state.loadCron();
-                  }
+                  refreshAgentsPanelSupplementalData(panel);
                 },
                 onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
                 onSelectFile: (name) => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -568,27 +568,6 @@ export function renderApp(state: AppViewState) {
       includeVirtualSections: false,
       ...overrides,
     });
-  const buildScopedConfigTabOverrides = (params: {
-    formMode: ConfigProps["formMode"];
-    searchQuery: string;
-    selection: ConfigSectionSelection;
-    setFormMode: (mode: ConfigProps["formMode"]) => void;
-    setSearchQuery: (query: string) => void;
-    setActiveSection: (section: string | null) => void;
-    setActiveSubsection: (section: string | null) => void;
-  }): ConfigTabOverrides => ({
-    formMode: params.formMode,
-    searchQuery: params.searchQuery,
-    activeSection: params.selection.activeSection,
-    activeSubsection: params.selection.activeSubsection,
-    onFormModeChange: params.setFormMode,
-    onSearchChange: params.setSearchQuery,
-    onSectionChange: (section) => {
-      params.setActiveSection(section);
-      params.setActiveSubsection(null);
-    },
-    onSubsectionChange: params.setActiveSubsection,
-  });
   const configSelection = normalizeMainConfigSelection(
     state.configActiveSection,
     state.configActiveSubsection,
@@ -622,15 +601,17 @@ export function renderApp(state: AppViewState) {
     switch (state.tab) {
       case "config":
         return renderConfigTab({
-          ...buildScopedConfigTabOverrides({
-            formMode: state.configFormMode,
-            searchQuery: state.configSearchQuery,
-            selection: configSelection,
-            setFormMode: (mode) => (state.configFormMode = mode),
-            setSearchQuery: (query) => (state.configSearchQuery = query),
-            setActiveSection: (section) => (state.configActiveSection = section),
-            setActiveSubsection: (section) => (state.configActiveSubsection = section),
-          }),
+          formMode: state.configFormMode,
+          searchQuery: state.configSearchQuery,
+          activeSection: configSelection.activeSection,
+          activeSubsection: configSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.configFormMode = mode),
+          onSearchChange: (query) => (state.configSearchQuery = query),
+          onSectionChange: (section) => {
+            state.configActiveSection = section;
+            state.configActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.configActiveSubsection = section),
           showModeToggle: true,
           excludeSections: [
             ...COMMUNICATION_SECTION_KEYS,
@@ -643,72 +624,82 @@ export function renderApp(state: AppViewState) {
         });
       case "communications":
         return renderConfigTab({
-          ...buildScopedConfigTabOverrides({
-            formMode: state.communicationsFormMode,
-            searchQuery: state.communicationsSearchQuery,
-            selection: communicationsSelection,
-            setFormMode: (mode) => (state.communicationsFormMode = mode),
-            setSearchQuery: (query) => (state.communicationsSearchQuery = query),
-            setActiveSection: (section) => (state.communicationsActiveSection = section),
-            setActiveSubsection: (section) => (state.communicationsActiveSubsection = section),
-          }),
+          formMode: state.communicationsFormMode,
+          searchQuery: state.communicationsSearchQuery,
+          activeSection: communicationsSelection.activeSection,
+          activeSubsection: communicationsSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.communicationsFormMode = mode),
+          onSearchChange: (query) => (state.communicationsSearchQuery = query),
+          onSectionChange: (section) => {
+            state.communicationsActiveSection = section;
+            state.communicationsActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.communicationsActiveSubsection = section),
           navRootLabel: "Communication",
           includeSections: [...COMMUNICATION_SECTION_KEYS],
         });
       case "appearance":
         return renderConfigTab({
-          ...buildScopedConfigTabOverrides({
-            formMode: state.appearanceFormMode,
-            searchQuery: state.appearanceSearchQuery,
-            selection: appearanceSelection,
-            setFormMode: (mode) => (state.appearanceFormMode = mode),
-            setSearchQuery: (query) => (state.appearanceSearchQuery = query),
-            setActiveSection: (section) => (state.appearanceActiveSection = section),
-            setActiveSubsection: (section) => (state.appearanceActiveSubsection = section),
-          }),
+          formMode: state.appearanceFormMode,
+          searchQuery: state.appearanceSearchQuery,
+          activeSection: appearanceSelection.activeSection,
+          activeSubsection: appearanceSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.appearanceFormMode = mode),
+          onSearchChange: (query) => (state.appearanceSearchQuery = query),
+          onSectionChange: (section) => {
+            state.appearanceActiveSection = section;
+            state.appearanceActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.appearanceActiveSubsection = section),
           navRootLabel: t("tabs.appearance"),
           includeSections: [...APPEARANCE_SECTION_KEYS],
           includeVirtualSections: true,
         });
       case "automation":
         return renderConfigTab({
-          ...buildScopedConfigTabOverrides({
-            formMode: state.automationFormMode,
-            searchQuery: state.automationSearchQuery,
-            selection: automationSelection,
-            setFormMode: (mode) => (state.automationFormMode = mode),
-            setSearchQuery: (query) => (state.automationSearchQuery = query),
-            setActiveSection: (section) => (state.automationActiveSection = section),
-            setActiveSubsection: (section) => (state.automationActiveSubsection = section),
-          }),
+          formMode: state.automationFormMode,
+          searchQuery: state.automationSearchQuery,
+          activeSection: automationSelection.activeSection,
+          activeSubsection: automationSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.automationFormMode = mode),
+          onSearchChange: (query) => (state.automationSearchQuery = query),
+          onSectionChange: (section) => {
+            state.automationActiveSection = section;
+            state.automationActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.automationActiveSubsection = section),
           navRootLabel: "Automation",
           includeSections: [...AUTOMATION_SECTION_KEYS],
         });
       case "infrastructure":
         return renderConfigTab({
-          ...buildScopedConfigTabOverrides({
-            formMode: state.infrastructureFormMode,
-            searchQuery: state.infrastructureSearchQuery,
-            selection: infrastructureSelection,
-            setFormMode: (mode) => (state.infrastructureFormMode = mode),
-            setSearchQuery: (query) => (state.infrastructureSearchQuery = query),
-            setActiveSection: (section) => (state.infrastructureActiveSection = section),
-            setActiveSubsection: (section) => (state.infrastructureActiveSubsection = section),
-          }),
+          formMode: state.infrastructureFormMode,
+          searchQuery: state.infrastructureSearchQuery,
+          activeSection: infrastructureSelection.activeSection,
+          activeSubsection: infrastructureSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.infrastructureFormMode = mode),
+          onSearchChange: (query) => (state.infrastructureSearchQuery = query),
+          onSectionChange: (section) => {
+            state.infrastructureActiveSection = section;
+            state.infrastructureActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.infrastructureActiveSubsection = section),
           navRootLabel: "Infrastructure",
           includeSections: [...INFRASTRUCTURE_SECTION_KEYS],
         });
       case "aiAgents":
         return renderConfigTab({
-          ...buildScopedConfigTabOverrides({
-            formMode: state.aiAgentsFormMode,
-            searchQuery: state.aiAgentsSearchQuery,
-            selection: aiAgentsSelection,
-            setFormMode: (mode) => (state.aiAgentsFormMode = mode),
-            setSearchQuery: (query) => (state.aiAgentsSearchQuery = query),
-            setActiveSection: (section) => (state.aiAgentsActiveSection = section),
-            setActiveSubsection: (section) => (state.aiAgentsActiveSubsection = section),
-          }),
+          formMode: state.aiAgentsFormMode,
+          searchQuery: state.aiAgentsSearchQuery,
+          activeSection: aiAgentsSelection.activeSection,
+          activeSubsection: aiAgentsSelection.activeSubsection,
+          onFormModeChange: (mode) => (state.aiAgentsFormMode = mode),
+          onSearchChange: (query) => (state.aiAgentsSearchQuery = query),
+          onSectionChange: (section) => {
+            state.aiAgentsActiveSection = section;
+            state.aiAgentsActiveSubsection = null;
+          },
+          onSubsectionChange: (section) => (state.aiAgentsActiveSubsection = section),
           navRootLabel: "AI & Agents",
           includeSections: [...AI_AGENTS_SECTION_KEYS],
         });
@@ -1396,20 +1387,20 @@ export function renderApp(state: AppViewState) {
                 },
                 onSelectPanel: (panel) => {
                   state.agentsPanel = panel;
-                  if (
-                    panel === "files" &&
-                    resolvedAgentId &&
-                    state.agentFilesList?.agentId !== resolvedAgentId
-                  ) {
-                    state.agentFilesList = null;
-                    state.agentFilesError = null;
-                    state.agentFileActive = null;
-                    state.agentFileContents = {};
-                    state.agentFileDrafts = {};
-                    void loadAgentFiles(state, resolvedAgentId);
+                  if (panel === "files" && resolvedAgentId) {
+                    if (state.agentFilesList?.agentId !== resolvedAgentId) {
+                      state.agentFilesList = null;
+                      state.agentFilesError = null;
+                      state.agentFileActive = null;
+                      state.agentFileContents = {};
+                      state.agentFileDrafts = {};
+                      void loadAgentFiles(state, resolvedAgentId);
+                    }
                   }
-                  if (panel === "skills" && resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
+                  if (panel === "skills") {
+                    if (resolvedAgentId) {
+                      void loadAgentSkills(state, resolvedAgentId);
+                    }
                   }
                   if (panel === "tools" && resolvedAgentId) {
                     if (

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -457,6 +457,10 @@ export function renderApp(state: AppViewState) {
   const findAgentIndex = (agentId: string) =>
     findAgentConfigEntryIndex(getCurrentConfigValue(), agentId);
   const ensureAgentIndex = (agentId: string) => ensureAgentConfigEntry(state, agentId);
+  const resolveAgentToolsPath = (agentId: string, ensure: boolean) => {
+    const index = ensure ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
+    return index >= 0 ? (["agents", "list", index, "tools"] as const) : null;
+  };
   const cronAgentSuggestions = sortLocaleStrings(
     new Set(
       [
@@ -712,17 +716,14 @@ export function renderApp(state: AppViewState) {
     if (!agentId) {
       return;
     }
-    if (state.agentsPanel === "files") {
-      void loadAgentFiles(state, agentId);
-      return;
-    }
-    if (state.agentsPanel === "skills") {
-      void loadAgentSkills(state, agentId);
-      return;
-    }
-    if (state.agentsPanel === "tools") {
-      void loadToolsCatalog(state, agentId);
-      void refreshVisibleToolsEffectiveForCurrentSession(state);
+    switch (state.agentsPanel) {
+      case "files":
+        return void loadAgentFiles(state, agentId);
+      case "skills":
+        return void loadAgentSkills(state, agentId);
+      case "tools":
+        void loadToolsCatalog(state, agentId);
+        return void refreshVisibleToolsEffectiveForCurrentSession(state);
     }
   };
   const refreshAgentsPanelSupplementalData = (panel: AppViewState["agentsPanel"]) => {
@@ -1456,12 +1457,10 @@ export function renderApp(state: AppViewState) {
                   void saveAgentFile(state, resolvedAgentId, name, content);
                 },
                 onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  const index =
-                    profile || clearAllow ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
-                  if (index < 0) {
+                  const basePath = resolveAgentToolsPath(agentId, Boolean(profile || clearAllow));
+                  if (!basePath) {
                     return;
                   }
-                  const basePath = ["agents", "list", index, "tools"];
                   if (profile) {
                     updateConfigFormValue(state, [...basePath, "profile"], profile);
                   } else {
@@ -1472,14 +1471,13 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  const index =
-                    alsoAllow.length > 0 || deny.length > 0
-                      ? ensureAgentIndex(agentId)
-                      : findAgentIndex(agentId);
-                  if (index < 0) {
+                  const basePath = resolveAgentToolsPath(
+                    agentId,
+                    alsoAllow.length > 0 || deny.length > 0,
+                  );
+                  if (!basePath) {
                     return;
                   }
-                  const basePath = ["agents", "list", index, "tools"];
                   if (alsoAllow.length > 0) {
                     updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
                   } else {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -724,6 +724,16 @@ export function renderApp(state: AppViewState) {
       void refreshVisibleToolsEffectiveForCurrentSession(state);
     }
   };
+  const resetAgentFilesState = (clearLoading = false) => {
+    state.agentFilesList = null;
+    state.agentFilesError = null;
+    state.agentFileActive = null;
+    state.agentFileContents = {};
+    state.agentFileDrafts = {};
+    if (clearLoading) {
+      state.agentFilesLoading = false;
+    }
+  };
 
   return html`
     ${renderCommandPalette({
@@ -1369,12 +1379,7 @@ export function renderApp(state: AppViewState) {
                     return;
                   }
                   state.agentsSelectedId = agentId;
-                  state.agentFilesList = null;
-                  state.agentFilesError = null;
-                  state.agentFilesLoading = false;
-                  state.agentFileActive = null;
-                  state.agentFileContents = {};
-                  state.agentFileDrafts = {};
+                  resetAgentFilesState(true);
                   state.agentSkillsReport = null;
                   state.agentSkillsError = null;
                   state.agentSkillsAgentId = null;
@@ -1392,11 +1397,7 @@ export function renderApp(state: AppViewState) {
                     resolvedAgentId &&
                     state.agentFilesList?.agentId !== resolvedAgentId
                   ) {
-                    state.agentFilesList = null;
-                    state.agentFilesError = null;
-                    state.agentFileActive = null;
-                    state.agentFileContents = {};
-                    state.agentFileDrafts = {};
+                    resetAgentFilesState();
                     void loadAgentFiles(state, resolvedAgentId);
                   }
                   if (panel === "skills" && resolvedAgentId) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -743,6 +743,16 @@ export function renderApp(state: AppViewState) {
       state.agentFilesLoading = false;
     }
   };
+  const resetAgentSelectionPanelState = () => {
+    resetAgentFilesState(true);
+    state.agentSkillsReport = null;
+    state.agentSkillsError = null;
+    state.agentSkillsAgentId = null;
+    state.toolsCatalogResult = null;
+    state.toolsCatalogError = null;
+    state.toolsCatalogLoading = false;
+    resetToolsEffectiveState(state);
+  };
 
   return html`
     ${renderCommandPalette({
@@ -1378,14 +1388,7 @@ export function renderApp(state: AppViewState) {
                     return;
                   }
                   state.agentsSelectedId = agentId;
-                  resetAgentFilesState(true);
-                  state.agentSkillsReport = null;
-                  state.agentSkillsError = null;
-                  state.agentSkillsAgentId = null;
-                  state.toolsCatalogResult = null;
-                  state.toolsCatalogError = null;
-                  state.toolsCatalogLoading = false;
-                  resetToolsEffectiveState(state);
+                  resetAgentSelectionPanelState();
                   void loadAgentIdentity(state, agentId);
                   loadAgentPanelDataForSelectedAgent(agentId);
                 },

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -707,6 +707,23 @@ export function renderApp(state: AppViewState) {
         return nothing;
     }
   };
+  const loadAgentPanelDataForSelectedAgent = (agentId: string | null) => {
+    if (!agentId) {
+      return;
+    }
+    if (state.agentsPanel === "files") {
+      void loadAgentFiles(state, agentId);
+      return;
+    }
+    if (state.agentsPanel === "skills") {
+      void loadAgentSkills(state, agentId);
+      return;
+    }
+    if (state.agentsPanel === "tools") {
+      void loadToolsCatalog(state, agentId);
+      void refreshVisibleToolsEffectiveForCurrentSession(state);
+    }
+  };
 
   return html`
     ${renderCommandPalette({
@@ -1339,16 +1356,7 @@ export function renderApp(state: AppViewState) {
                     state.agentsList?.defaultId ??
                     state.agentsList?.agents?.[0]?.id ??
                     null;
-                  if (state.agentsPanel === "files" && refreshedAgentId) {
-                    void loadAgentFiles(state, refreshedAgentId);
-                  }
-                  if (state.agentsPanel === "skills" && refreshedAgentId) {
-                    void loadAgentSkills(state, refreshedAgentId);
-                  }
-                  if (state.agentsPanel === "tools" && refreshedAgentId) {
-                    void loadToolsCatalog(state, refreshedAgentId);
-                    void refreshVisibleToolsEffectiveForCurrentSession(state);
-                  }
+                  loadAgentPanelDataForSelectedAgent(refreshedAgentId);
                   if (state.agentsPanel === "channels") {
                     void loadChannels(state, false);
                   }
@@ -1375,16 +1383,7 @@ export function renderApp(state: AppViewState) {
                   state.toolsCatalogLoading = false;
                   resetToolsEffectiveState(state);
                   void loadAgentIdentity(state, agentId);
-                  if (state.agentsPanel === "files") {
-                    void loadAgentFiles(state, agentId);
-                  }
-                  if (state.agentsPanel === "tools") {
-                    void loadToolsCatalog(state, agentId);
-                    void refreshVisibleToolsEffectiveForCurrentSession(state);
-                  }
-                  if (state.agentsPanel === "skills") {
-                    void loadAgentSkills(state, agentId);
-                  }
+                  loadAgentPanelDataForSelectedAgent(agentId);
                 },
                 onSelectPanel: (panel) => {
                   state.agentsPanel = panel;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -461,6 +461,17 @@ export function renderApp(state: AppViewState) {
     const index = ensure ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
     return index >= 0 ? (["agents", "list", index, "tools"] as const) : null;
   };
+  const resolveAgentModelFormEntry = (index: number) => {
+    const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)?.agents
+      ?.list;
+    const existing = Array.isArray(list)
+      ? (list[index] as { model?: unknown } | undefined)?.model
+      : undefined;
+    return {
+      basePath: ["agents", "list", index, "model"] as Array<string | number>,
+      existing,
+    };
+  };
   const cronAgentSuggestions = sortLocaleStrings(
     new Set(
       [
@@ -1554,16 +1565,11 @@ export function renderApp(state: AppViewState) {
                   if (index < 0) {
                     return;
                   }
-                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
-                    ?.agents?.list;
-                  const basePath = ["agents", "list", index, "model"];
+                  const modelEntry = resolveAgentModelFormEntry(index);
+                  const { basePath, existing } = modelEntry;
                   if (!modelId) {
                     removeConfigFormValue(state, basePath);
                   } else {
-                    const entry = Array.isArray(list)
-                      ? (list[index] as { model?: unknown })
-                      : undefined;
-                    const existing = entry?.model;
                     if (existing && typeof existing === "object" && !Array.isArray(existing)) {
                       const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
                       const next = {
@@ -1599,13 +1605,7 @@ export function renderApp(state: AppViewState) {
                   if (index < 0) {
                     return;
                   }
-                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
-                    ?.agents?.list;
-                  const basePath = ["agents", "list", index, "model"];
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { model?: unknown })
-                    : undefined;
-                  const existing = entry?.model;
+                  const { basePath, existing } = resolveAgentModelFormEntry(index);
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {
                       return existing.trim() || null;

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -96,23 +96,36 @@ describe("refreshActiveTab", () => {
   const expectCommonAgentsTabRefresh = (host: ReturnType<typeof createHost>) => {
     expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
     expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentIdentitiesMock).toHaveBeenCalledWith(host, ["agent-a", "agent-b"]);
     expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
   };
 
-  it("loads agents panel files data for the resolved selected agent", async () => {
-    const host = createHost();
-    host.tab = "agents";
-    host.agentsPanel = "files";
+  for (const panel of ["files", "skills", "channels", "tools"] as const) {
+    it(`routes agents ${panel} panel refresh through the expected loaders`, async () => {
+      const host = createHost();
+      host.tab = "agents";
+      host.agentsPanel = panel;
 
-    await refreshActiveTab(host as never);
+      await refreshActiveTab(host as never);
 
-    expectCommonAgentsTabRefresh(host);
-    expect(mocks.loadAgentIdentitiesMock).toHaveBeenCalledWith(host, ["agent-a", "agent-b"]);
-    expect(mocks.loadAgentFilesMock).toHaveBeenCalledWith(host, "agent-b");
-    expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
-    expect(mocks.loadChannelsMock).not.toHaveBeenCalled();
-    expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
-  });
+      expectCommonAgentsTabRefresh(host);
+      expect(mocks.loadAgentFilesMock).toHaveBeenCalledTimes(panel === "files" ? 1 : 0);
+      expect(mocks.loadAgentSkillsMock).toHaveBeenCalledTimes(panel === "skills" ? 1 : 0);
+      expect(mocks.loadChannelsMock).toHaveBeenCalledTimes(panel === "channels" ? 1 : 0);
+      if (panel === "files") {
+        expect(mocks.loadAgentFilesMock).toHaveBeenCalledWith(host, "agent-b");
+      }
+      if (panel === "skills") {
+        expect(mocks.loadAgentSkillsMock).toHaveBeenCalledWith(host, "agent-b");
+      }
+      if (panel === "channels") {
+        expect(mocks.loadChannelsMock).toHaveBeenCalledWith(host, false);
+      }
+      expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
+      expect(mocks.loadCronJobsPageMock).not.toHaveBeenCalled();
+      expect(mocks.loadCronRunsMock).not.toHaveBeenCalled();
+    });
+  }
 
   it("routes agents cron panel refresh through cron loaders", async () => {
     const host = createHost();
@@ -130,22 +143,6 @@ describe("refreshActiveTab", () => {
     expect(mocks.loadCronRunsMock).toHaveBeenCalledWith(host, "job-123");
     expect(mocks.loadAgentFilesMock).not.toHaveBeenCalled();
     expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
-  });
-
-  it("keeps tools panel refresh narrow and skips files/skills/channels/cron loaders", async () => {
-    const host = createHost();
-    host.tab = "agents";
-    host.agentsPanel = "tools";
-
-    await refreshActiveTab(host as never);
-
-    expectCommonAgentsTabRefresh(host);
-    expect(mocks.loadAgentFilesMock).not.toHaveBeenCalled();
-    expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
-    expect(mocks.loadChannelsMock).not.toHaveBeenCalled();
-    expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
-    expect(mocks.loadCronJobsPageMock).not.toHaveBeenCalled();
-    expect(mocks.loadCronRunsMock).not.toHaveBeenCalled();
   });
 
   it("refreshes logs tab by resetting bottom-follow and scheduling scroll", async () => {

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -103,7 +103,6 @@ describe("refreshActiveTab", () => {
   for (const panel of ["files", "skills", "channels", "tools"] as const) {
     it(`routes agents ${panel} panel refresh through the expected loaders`, async () => {
       const host = createHost();
-      host.tab = "agents";
       host.agentsPanel = panel;
 
       await refreshActiveTab(host as never);
@@ -129,7 +128,6 @@ describe("refreshActiveTab", () => {
 
   it("routes agents cron panel refresh through cron loaders", async () => {
     const host = createHost();
-    host.tab = "agents";
     host.agentsPanel = "cron";
     host.cronRunsScope = "job";
     host.cronRunsJobId = "job-123";

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -65,23 +65,7 @@ vi.mock("./controllers/logs.ts", () => ({
 
 import { refreshActiveTab } from "./app-settings.ts";
 
-type RefreshHost = {
-  tab: string;
-  connected: boolean;
-  client: object;
-  agentsPanel: string;
-  agentsSelectedId: string;
-  agentsList: { defaultId: string; agents: Array<{ id: string }> };
-  chatHasAutoScrolled: boolean;
-  logsAtBottom: boolean;
-  eventLog: unknown[];
-  eventLogBuffer: unknown[];
-  cronRunsScope: string;
-  cronRunsJobId: string | null;
-  sessionKey: string;
-};
-
-function createHost(): RefreshHost {
+function createHost() {
   return {
     tab: "agents",
     connected: true,
@@ -97,7 +81,7 @@ function createHost(): RefreshHost {
     eventLog: [],
     eventLogBuffer: [],
     cronRunsScope: "all",
-    cronRunsJobId: null,
+    cronRunsJobId: null as string | null,
     sessionKey: "main",
   };
 }
@@ -109,6 +93,12 @@ describe("refreshActiveTab", () => {
     }
   });
 
+  const expectCommonAgentsTabRefresh = (host: ReturnType<typeof createHost>) => {
+    expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
+    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
+  };
+
   it("loads agents panel files data for the resolved selected agent", async () => {
     const host = createHost();
     host.tab = "agents";
@@ -116,10 +106,8 @@ describe("refreshActiveTab", () => {
 
     await refreshActiveTab(host as never);
 
-    expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
-    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expectCommonAgentsTabRefresh(host);
     expect(mocks.loadAgentIdentitiesMock).toHaveBeenCalledWith(host, ["agent-a", "agent-b"]);
-    expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
     expect(mocks.loadAgentFilesMock).toHaveBeenCalledWith(host, "agent-b");
     expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
     expect(mocks.loadChannelsMock).not.toHaveBeenCalled();
@@ -135,9 +123,7 @@ describe("refreshActiveTab", () => {
 
     await refreshActiveTab(host as never);
 
-    expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
-    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
-    expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
+    expectCommonAgentsTabRefresh(host);
     expect(mocks.loadChannelsMock).toHaveBeenCalledWith(host, false);
     expect(mocks.loadCronStatusMock).toHaveBeenCalledOnce();
     expect(mocks.loadCronJobsMock).toHaveBeenCalledOnce();
@@ -153,9 +139,7 @@ describe("refreshActiveTab", () => {
 
     await refreshActiveTab(host as never);
 
-    expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
-    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
-    expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
+    expectCommonAgentsTabRefresh(host);
     expect(mocks.loadAgentFilesMock).not.toHaveBeenCalled();
     expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
     expect(mocks.loadChannelsMock).not.toHaveBeenCalled();

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -21,44 +21,35 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./app-chat.ts", () => ({
   refreshChat: mocks.refreshChatMock,
 }));
-
 vi.mock("./app-scroll.ts", () => ({
   scheduleChatScroll: mocks.scheduleChatScrollMock,
   scheduleLogsScroll: mocks.scheduleLogsScrollMock,
 }));
-
 vi.mock("./controllers/agent-files.ts", () => ({
   loadAgentFiles: mocks.loadAgentFilesMock,
 }));
-
 vi.mock("./controllers/agent-identity.ts", () => ({
   loadAgentIdentities: mocks.loadAgentIdentitiesMock,
   loadAgentIdentity: mocks.loadAgentIdentityMock,
 }));
-
 vi.mock("./controllers/agent-skills.ts", () => ({
   loadAgentSkills: mocks.loadAgentSkillsMock,
 }));
-
 vi.mock("./controllers/agents.ts", () => ({
   loadAgents: mocks.loadAgentsMock,
 }));
-
 vi.mock("./controllers/channels.ts", () => ({
   loadChannels: mocks.loadChannelsMock,
 }));
-
 vi.mock("./controllers/config.ts", () => ({
   loadConfig: mocks.loadConfigMock,
   loadConfigSchema: mocks.loadConfigSchemaMock,
 }));
-
 vi.mock("./controllers/cron.ts", () => ({
   loadCronStatus: mocks.loadCronStatusMock,
   loadCronJobsPage: mocks.loadCronJobsPageMock,
   loadCronRuns: mocks.loadCronRunsMock,
 }));
-
 vi.mock("./controllers/logs.ts", () => ({
   loadLogs: mocks.loadLogsMock,
 }));
@@ -99,6 +90,17 @@ describe("refreshActiveTab", () => {
     expect(mocks.loadAgentIdentitiesMock).toHaveBeenCalledWith(host, ["agent-a", "agent-b"]);
     expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
   };
+  const expectNoCronLoaders = () => {
+    expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
+    expect(mocks.loadCronJobsPageMock).not.toHaveBeenCalled();
+    expect(mocks.loadCronRunsMock).not.toHaveBeenCalled();
+  };
+  const panelLoaderArgs = {
+    files: [mocks.loadAgentFilesMock, "agent-b"],
+    skills: [mocks.loadAgentSkillsMock, "agent-b"],
+    channels: [mocks.loadChannelsMock, false],
+    tools: null,
+  } as const;
 
   for (const panel of ["files", "skills", "channels", "tools"] as const) {
     it(`routes agents ${panel} panel refresh through the expected loaders`, async () => {
@@ -111,18 +113,12 @@ describe("refreshActiveTab", () => {
       expect(mocks.loadAgentFilesMock).toHaveBeenCalledTimes(panel === "files" ? 1 : 0);
       expect(mocks.loadAgentSkillsMock).toHaveBeenCalledTimes(panel === "skills" ? 1 : 0);
       expect(mocks.loadChannelsMock).toHaveBeenCalledTimes(panel === "channels" ? 1 : 0);
-      if (panel === "files") {
-        expect(mocks.loadAgentFilesMock).toHaveBeenCalledWith(host, "agent-b");
+      const expectedLoader = panelLoaderArgs[panel];
+      if (expectedLoader) {
+        const [loader, expectedArg] = expectedLoader;
+        expect(loader).toHaveBeenCalledWith(host, expectedArg);
       }
-      if (panel === "skills") {
-        expect(mocks.loadAgentSkillsMock).toHaveBeenCalledWith(host, "agent-b");
-      }
-      if (panel === "channels") {
-        expect(mocks.loadChannelsMock).toHaveBeenCalledWith(host, false);
-      }
-      expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
-      expect(mocks.loadCronJobsPageMock).not.toHaveBeenCalled();
-      expect(mocks.loadCronRunsMock).not.toHaveBeenCalled();
+      expectNoCronLoaders();
     });
   }
 
@@ -146,7 +142,6 @@ describe("refreshActiveTab", () => {
   it("refreshes logs tab by resetting bottom-follow and scheduling scroll", async () => {
     const host = createHost();
     host.tab = "logs";
-    host.logsAtBottom = false;
 
     await refreshActiveTab(host as never);
 

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   loadConfigMock: vi.fn(async () => {}),
   loadConfigSchemaMock: vi.fn(async () => {}),
   loadCronStatusMock: vi.fn(async () => {}),
-  loadCronJobsMock: vi.fn(async () => {}),
+  loadCronJobsPageMock: vi.fn(async () => {}),
   loadCronRunsMock: vi.fn(async () => {}),
   loadLogsMock: vi.fn(async () => {}),
 }));
@@ -55,7 +55,7 @@ vi.mock("./controllers/config.ts", () => ({
 
 vi.mock("./controllers/cron.ts", () => ({
   loadCronStatus: mocks.loadCronStatusMock,
-  loadCronJobs: mocks.loadCronJobsMock,
+  loadCronJobsPage: mocks.loadCronJobsPageMock,
   loadCronRuns: mocks.loadCronRunsMock,
 }));
 
@@ -126,7 +126,7 @@ describe("refreshActiveTab", () => {
     expectCommonAgentsTabRefresh(host);
     expect(mocks.loadChannelsMock).toHaveBeenCalledWith(host, false);
     expect(mocks.loadCronStatusMock).toHaveBeenCalledOnce();
-    expect(mocks.loadCronJobsMock).toHaveBeenCalledOnce();
+    expect(mocks.loadCronJobsPageMock).toHaveBeenCalledOnce();
     expect(mocks.loadCronRunsMock).toHaveBeenCalledWith(host, "job-123");
     expect(mocks.loadAgentFilesMock).not.toHaveBeenCalled();
     expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
@@ -144,7 +144,7 @@ describe("refreshActiveTab", () => {
     expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
     expect(mocks.loadChannelsMock).not.toHaveBeenCalled();
     expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
-    expect(mocks.loadCronJobsMock).not.toHaveBeenCalled();
+    expect(mocks.loadCronJobsPageMock).not.toHaveBeenCalled();
     expect(mocks.loadCronRunsMock).not.toHaveBeenCalled();
   });
 

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  refreshChatMock: vi.fn(async () => {}),
+  scheduleChatScrollMock: vi.fn(),
+  scheduleLogsScrollMock: vi.fn(),
+  loadAgentFilesMock: vi.fn(async () => {}),
+  loadAgentIdentitiesMock: vi.fn(async () => {}),
+  loadAgentIdentityMock: vi.fn(async () => {}),
+  loadAgentSkillsMock: vi.fn(async () => {}),
+  loadAgentsMock: vi.fn(async () => {}),
+  loadChannelsMock: vi.fn(async () => {}),
+  loadConfigMock: vi.fn(async () => {}),
+  loadConfigSchemaMock: vi.fn(async () => {}),
+  loadCronStatusMock: vi.fn(async () => {}),
+  loadCronJobsMock: vi.fn(async () => {}),
+  loadCronRunsMock: vi.fn(async () => {}),
+  loadLogsMock: vi.fn(async () => {}),
+}));
+
+vi.mock("./app-chat.ts", () => ({
+  refreshChat: mocks.refreshChatMock,
+}));
+
+vi.mock("./app-scroll.ts", () => ({
+  scheduleChatScroll: mocks.scheduleChatScrollMock,
+  scheduleLogsScroll: mocks.scheduleLogsScrollMock,
+}));
+
+vi.mock("./controllers/agent-files.ts", () => ({
+  loadAgentFiles: mocks.loadAgentFilesMock,
+}));
+
+vi.mock("./controllers/agent-identity.ts", () => ({
+  loadAgentIdentities: mocks.loadAgentIdentitiesMock,
+  loadAgentIdentity: mocks.loadAgentIdentityMock,
+}));
+
+vi.mock("./controllers/agent-skills.ts", () => ({
+  loadAgentSkills: mocks.loadAgentSkillsMock,
+}));
+
+vi.mock("./controllers/agents.ts", () => ({
+  loadAgents: mocks.loadAgentsMock,
+}));
+
+vi.mock("./controllers/channels.ts", () => ({
+  loadChannels: mocks.loadChannelsMock,
+}));
+
+vi.mock("./controllers/config.ts", () => ({
+  loadConfig: mocks.loadConfigMock,
+  loadConfigSchema: mocks.loadConfigSchemaMock,
+}));
+
+vi.mock("./controllers/cron.ts", () => ({
+  loadCronStatus: mocks.loadCronStatusMock,
+  loadCronJobs: mocks.loadCronJobsMock,
+  loadCronRuns: mocks.loadCronRunsMock,
+}));
+
+vi.mock("./controllers/logs.ts", () => ({
+  loadLogs: mocks.loadLogsMock,
+}));
+
+import { refreshActiveTab } from "./app-settings.ts";
+
+type RefreshHost = {
+  tab: string;
+  connected: boolean;
+  client: object;
+  agentsPanel: string;
+  agentsSelectedId: string;
+  agentsList: { defaultId: string; agents: Array<{ id: string }> };
+  chatHasAutoScrolled: boolean;
+  logsAtBottom: boolean;
+  eventLog: unknown[];
+  eventLogBuffer: unknown[];
+  cronRunsScope: string;
+  cronRunsJobId: string | null;
+  sessionKey: string;
+};
+
+function createHost(): RefreshHost {
+  return {
+    tab: "agents",
+    connected: true,
+    client: {},
+    agentsPanel: "overview",
+    agentsSelectedId: "agent-b",
+    agentsList: {
+      defaultId: "agent-a",
+      agents: [{ id: "agent-a" }, { id: "agent-b" }],
+    },
+    chatHasAutoScrolled: false,
+    logsAtBottom: false,
+    eventLog: [],
+    eventLogBuffer: [],
+    cronRunsScope: "all",
+    cronRunsJobId: null,
+    sessionKey: "main",
+  };
+}
+
+describe("refreshActiveTab", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(mocks)) {
+      fn.mockReset();
+    }
+  });
+
+  it("loads agents panel files data for the resolved selected agent", async () => {
+    const host = createHost();
+    host.tab = "agents";
+    host.agentsPanel = "files";
+
+    await refreshActiveTab(host as never);
+
+    expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
+    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentIdentitiesMock).toHaveBeenCalledWith(host, ["agent-a", "agent-b"]);
+    expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
+    expect(mocks.loadAgentFilesMock).toHaveBeenCalledWith(host, "agent-b");
+    expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
+    expect(mocks.loadChannelsMock).not.toHaveBeenCalled();
+    expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("routes agents cron panel refresh through cron loaders", async () => {
+    const host = createHost();
+    host.tab = "agents";
+    host.agentsPanel = "cron";
+    host.cronRunsScope = "job";
+    host.cronRunsJobId = "job-123";
+
+    await refreshActiveTab(host as never);
+
+    expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
+    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
+    expect(mocks.loadChannelsMock).toHaveBeenCalledWith(host, false);
+    expect(mocks.loadCronStatusMock).toHaveBeenCalledOnce();
+    expect(mocks.loadCronJobsMock).toHaveBeenCalledOnce();
+    expect(mocks.loadCronRunsMock).toHaveBeenCalledWith(host, "job-123");
+    expect(mocks.loadAgentFilesMock).not.toHaveBeenCalled();
+    expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps tools panel refresh narrow and skips files/skills/channels/cron loaders", async () => {
+    const host = createHost();
+    host.tab = "agents";
+    host.agentsPanel = "tools";
+
+    await refreshActiveTab(host as never);
+
+    expect(mocks.loadAgentsMock).toHaveBeenCalledOnce();
+    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(mocks.loadAgentIdentityMock).toHaveBeenCalledWith(host, "agent-b");
+    expect(mocks.loadAgentFilesMock).not.toHaveBeenCalled();
+    expect(mocks.loadAgentSkillsMock).not.toHaveBeenCalled();
+    expect(mocks.loadChannelsMock).not.toHaveBeenCalled();
+    expect(mocks.loadCronStatusMock).not.toHaveBeenCalled();
+    expect(mocks.loadCronJobsMock).not.toHaveBeenCalled();
+    expect(mocks.loadCronRunsMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes logs tab by resetting bottom-follow and scheduling scroll", async () => {
+    const host = createHost();
+    host.tab = "logs";
+    host.logsAtBottom = false;
+
+    await refreshActiveTab(host as never);
+
+    expect(host.logsAtBottom).toBe(true);
+    expect(mocks.loadLogsMock).toHaveBeenCalledWith(host, { reset: true });
+    expect(mocks.scheduleLogsScrollMock).toHaveBeenCalledWith(host, true);
+  });
+});

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -4,7 +4,6 @@ import {
   applyResolvedTheme,
   applySettings,
   applySettingsFromUrl,
-  attachThemeListener,
   setTabFromRoute,
   syncThemeWithSettings,
 } from "./app-settings.ts";
@@ -243,10 +242,10 @@ describe("setTabFromRoute", () => {
     });
 
     const host = createHost("chat");
-    host.theme = "knot" as unknown as ThemeName & ThemeMode;
-    host.themeMode = "system";
+    host.settings.theme = "knot" as unknown as ThemeName & ThemeMode;
+    host.settings.themeMode = "system";
 
-    attachThemeListener(host);
+    syncThemeWithSettings(host);
     listeners[0]?.({ matches: true } as MediaQueryListEvent);
     expect(host.themeResolved).toBe("openknot");
 

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -293,21 +293,6 @@ describe("applySettingsFromUrl", () => {
     expect(window.location.search).toBe("");
   });
 
-  it("keeps query token params pending when a gatewayUrl confirmation is required", () => {
-    setTestWindowUrl(
-      "https://control.example/ui/overview?gatewayUrl=wss://other-gateway.example/openclaw&token=abc123",
-    );
-    const host = createHost("overview");
-    host.settings.gatewayUrl = "wss://control.example/openclaw";
-
-    applySettingsFromUrl(host);
-
-    expect(host.settings.token).toBe("");
-    expect(host.pendingGatewayUrl).toBe("wss://other-gateway.example/openclaw");
-    expect(host.pendingGatewayToken).toBe("abc123");
-    expect(window.location.search).toBe("");
-  });
-
   it("prefers fragment tokens over legacy query tokens when both are present", () => {
     setTestWindowUrl("https://control.example/ui/overview?token=query-token#token=hash-token");
     const host = createHost("overview");
@@ -339,47 +324,76 @@ describe("applySettingsFromUrl", () => {
     expect(host.settings.lastActiveSessionKey).toBe("main");
   });
 
-  it("preserves an explicit session from the URL when token and session are both supplied", () => {
-    setTestWindowUrl(
-      "https://control.example/chat?session=agent%3Atest_new%3Amain#token=test-token",
-    );
-    const host = createHost("chat");
-    host.settings = {
-      ...host.settings,
-      gatewayUrl: "ws://localhost:18789",
-      token: "",
-      sessionKey: "agent:test_old:main",
-      lastActiveSessionKey: "agent:test_old:main",
-    };
-    host.sessionKey = "agent:test_old:main";
+  it("characterizes token, session, and gateway URL combinations", () => {
+    const scenarios = [
+      {
+        name: "same gateway applies token and session immediately",
+        url: "https://control.example/chat?session=agent%3Atest_new%3Amain#token=token-a",
+        settingsGatewayUrl: "ws://gateway-a.example:18789",
+        settingsToken: "",
+        expectedToken: "token-a",
+        expectedSession: "agent:test_new:main",
+        expectedPendingGatewayUrl: null,
+        expectedPendingGatewayToken: null,
+        expectedSearch: "?session=agent%3Atest_new%3Amain",
+      },
+      {
+        name: "different gateway defers token and keeps explicit session",
+        url: "https://control.example/chat?gatewayUrl=ws%3A%2F%2Fgateway-b.example%3A18789&session=agent%3Atest_new%3Amain#token=token-b",
+        settingsGatewayUrl: "ws://gateway-a.example:18789",
+        settingsToken: "",
+        expectedToken: "",
+        expectedSession: "agent:test_new:main",
+        expectedPendingGatewayUrl: "ws://gateway-b.example:18789",
+        expectedPendingGatewayToken: "token-b",
+        expectedSearch: "?session=agent%3Atest_new%3Amain",
+      },
+      {
+        name: "different gateway defers token without changing session",
+        url: "https://control.example/chat?gatewayUrl=ws%3A%2F%2Fgateway-b.example%3A18789#token=token-c",
+        settingsGatewayUrl: "ws://gateway-a.example:18789",
+        settingsToken: "",
+        expectedToken: "",
+        expectedSession: "agent:test_old:main",
+        expectedPendingGatewayUrl: "ws://gateway-b.example:18789",
+        expectedPendingGatewayToken: "token-c",
+        expectedSearch: "",
+      },
+      {
+        name: "different gateway without token clears pending token",
+        url: "https://control.example/chat?gatewayUrl=ws%3A%2F%2Fgateway-b.example%3A18789&session=agent%3Atest_new%3Amain",
+        settingsGatewayUrl: "ws://gateway-a.example:18789",
+        settingsToken: "existing-token",
+        expectedToken: "existing-token",
+        expectedSession: "agent:test_new:main",
+        expectedPendingGatewayUrl: "ws://gateway-b.example:18789",
+        expectedPendingGatewayToken: null,
+        expectedSearch: "?session=agent%3Atest_new%3Amain",
+      },
+    ] as const;
 
-    applySettingsFromUrl(host);
+    for (const scenario of scenarios) {
+      setTestWindowUrl(scenario.url);
+      const host = createHost("chat");
+      host.settings = {
+        ...host.settings,
+        gatewayUrl: scenario.settingsGatewayUrl,
+        token: scenario.settingsToken,
+        sessionKey: "agent:test_old:main",
+        lastActiveSessionKey: "agent:test_old:main",
+      };
+      host.sessionKey = "agent:test_old:main";
 
-    expect(host.sessionKey).toBe("agent:test_new:main");
-    expect(host.settings.sessionKey).toBe("agent:test_new:main");
-    expect(host.settings.lastActiveSessionKey).toBe("agent:test_new:main");
-  });
+      applySettingsFromUrl(host);
 
-  it("does not reset the current gateway session when a different gateway is pending confirmation", () => {
-    setTestWindowUrl(
-      "https://control.example/chat?gatewayUrl=ws%3A%2F%2Fgateway-b.example%3A18789#token=test-token",
-    );
-    const host = createHost("chat");
-    host.settings = {
-      ...host.settings,
-      gatewayUrl: "ws://gateway-a.example:18789",
-      token: "",
-      sessionKey: "agent:test_old:main",
-      lastActiveSessionKey: "agent:test_old:main",
-    };
-    host.sessionKey = "agent:test_old:main";
-
-    applySettingsFromUrl(host);
-
-    expect(host.sessionKey).toBe("agent:test_old:main");
-    expect(host.settings.sessionKey).toBe("agent:test_old:main");
-    expect(host.settings.lastActiveSessionKey).toBe("agent:test_old:main");
-    expect(host.pendingGatewayUrl).toBe("ws://gateway-b.example:18789");
-    expect(host.pendingGatewayToken).toBe("test-token");
+      expect(host.settings.token, scenario.name).toBe(scenario.expectedToken);
+      expect(host.sessionKey, scenario.name).toBe(scenario.expectedSession);
+      expect(host.settings.sessionKey, scenario.name).toBe(scenario.expectedSession);
+      expect(host.settings.lastActiveSessionKey, scenario.name).toBe(scenario.expectedSession);
+      expect(host.pendingGatewayUrl, scenario.name).toBe(scenario.expectedPendingGatewayUrl);
+      expect(host.pendingGatewayToken, scenario.name).toBe(scenario.expectedPendingGatewayToken);
+      expect(window.location.search, scenario.name).toBe(scenario.expectedSearch);
+      expect(window.location.hash, scenario.name).toBe("");
+    }
   });
 });

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -146,12 +146,10 @@ export function applySettingsFromUrl(host: SettingsHost) {
         "[openclaw] Auth token passed as query parameter (?token=). Use URL fragment instead: #token=<token>. Query parameters may appear in server logs.",
       );
     }
-    if (token) {
-      if (gatewayUrlChanged) {
-        host.pendingGatewayToken = token;
-      } else if (token !== host.settings.token) {
-        applySettings(host, { ...host.settings, token });
-      }
+    if (token && gatewayUrlChanged) {
+      host.pendingGatewayToken = token;
+    } else if (token && token !== host.settings.token) {
+      applySettings(host, { ...host.settings, token });
     }
     hashParams.delete("token");
     shouldCleanUrl = true;
@@ -178,13 +176,8 @@ export function applySettingsFromUrl(host: SettingsHost) {
   }
 
   if (gatewayUrlRaw != null) {
-    if (gatewayUrlChanged) {
-      host.pendingGatewayUrl = nextGatewayUrl;
-      host.pendingGatewayToken = token ?? null;
-    } else {
-      host.pendingGatewayUrl = null;
-      host.pendingGatewayToken = null;
-    }
+    host.pendingGatewayUrl = gatewayUrlChanged ? nextGatewayUrl : null;
+    host.pendingGatewayToken = gatewayUrlChanged ? (token ?? null) : null;
     params.delete("gatewayUrl");
     hashParams.delete("gatewayUrl");
     shouldCleanUrl = true;

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -237,91 +237,96 @@ export function setThemeMode(
 }
 
 export async function refreshActiveTab(host: SettingsHost) {
-  if (host.tab === "overview") {
-    await loadOverview(host);
-  }
-  if (host.tab === "channels") {
-    await loadChannelsTab(host);
-  }
-  if (host.tab === "instances") {
-    await loadPresence(host as unknown as OpenClawApp);
-  }
-  if (host.tab === "usage") {
-    await loadUsage(host as unknown as OpenClawApp);
-  }
-  if (host.tab === "sessions") {
-    await loadSessions(host as unknown as OpenClawApp);
-  }
-  if (host.tab === "cron") {
-    await loadCron(host);
-  }
-  if (host.tab === "skills") {
-    await loadSkills(host as unknown as OpenClawApp);
-  }
-  if (host.tab === "agents") {
-    await loadAgents(host as unknown as OpenClawApp);
-    await loadConfig(host as unknown as OpenClawApp);
-    const agentIds = host.agentsList?.agents?.map((entry) => entry.id) ?? [];
-    if (agentIds.length > 0) {
-      void loadAgentIdentities(host as unknown as OpenClawApp, agentIds);
+  const app = host as unknown as OpenClawApp;
+  switch (host.tab) {
+    case "overview":
+      await loadOverview(host);
+      return;
+    case "channels":
+      await loadChannelsTab(host);
+      return;
+    case "instances":
+      await loadPresence(app);
+      return;
+    case "usage":
+      await loadUsage(app);
+      return;
+    case "sessions":
+      await loadSessions(app);
+      return;
+    case "cron":
+      await loadCron(host);
+      return;
+    case "skills":
+      await loadSkills(app);
+      return;
+    case "agents": {
+      await loadAgents(app);
+      await loadConfig(app);
+      const agentIds = host.agentsList?.agents?.map((entry) => entry.id) ?? [];
+      if (agentIds.length > 0) {
+        void loadAgentIdentities(app, agentIds);
+      }
+      const agentId =
+        host.agentsSelectedId ?? host.agentsList?.defaultId ?? host.agentsList?.agents?.[0]?.id;
+      if (!agentId) {
+        return;
+      }
+      void loadAgentIdentity(app, agentId);
+      switch (host.agentsPanel) {
+        case "files":
+          void loadAgentFiles(app, agentId);
+          return;
+        case "skills":
+          void loadAgentSkills(app, agentId);
+          return;
+        case "channels":
+          void loadChannels(app, false);
+          return;
+        case "cron":
+          void loadCron(host);
+          return;
+        default:
+          return;
+      }
     }
-    const agentId =
-      host.agentsSelectedId ?? host.agentsList?.defaultId ?? host.agentsList?.agents?.[0]?.id;
-    if (agentId) {
-      void loadAgentIdentity(host as unknown as OpenClawApp, agentId);
-      if (host.agentsPanel === "files") {
-        void loadAgentFiles(host as unknown as OpenClawApp, agentId);
-      }
-      if (host.agentsPanel === "skills") {
-        void loadAgentSkills(host as unknown as OpenClawApp, agentId);
-      }
-      if (host.agentsPanel === "channels") {
-        void loadChannels(host as unknown as OpenClawApp, false);
-      }
-      if (host.agentsPanel === "cron") {
-        void loadCron(host);
-      }
-    }
-  }
-  if (host.tab === "nodes") {
-    await loadNodes(host as unknown as OpenClawApp);
-    await loadDevices(host as unknown as OpenClawApp);
-    await loadConfig(host as unknown as OpenClawApp);
-    await loadExecApprovals(host as unknown as OpenClawApp);
-  }
-  if (host.tab === "dreams") {
-    await loadConfig(host as unknown as OpenClawApp);
-    await Promise.all([
-      loadDreamingStatus(host as unknown as OpenClawApp),
-      loadDreamDiary(host as unknown as OpenClawApp),
-    ]);
-  }
-  if (host.tab === "chat") {
-    await refreshChat(host as unknown as Parameters<typeof refreshChat>[0]);
-    scheduleChatScroll(
-      host as unknown as Parameters<typeof scheduleChatScroll>[0],
-      !host.chatHasAutoScrolled,
-    );
-  }
-  if (
-    host.tab === "config" ||
-    host.tab === "communications" ||
-    host.tab === "appearance" ||
-    host.tab === "automation" ||
-    host.tab === "infrastructure" ||
-    host.tab === "aiAgents"
-  ) {
-    await loadConfigSchema(host as unknown as OpenClawApp);
-    await loadConfig(host as unknown as OpenClawApp);
-  }
-  if (host.tab === "debug") {
-    await loadDebug(host as unknown as OpenClawApp);
-    host.eventLog = host.eventLogBuffer;
-  }
-  if (host.tab === "logs") {
-    host.logsAtBottom = true;
-    await loadLogs(host as unknown as OpenClawApp, { reset: true });
-    scheduleLogsScroll(host as unknown as Parameters<typeof scheduleLogsScroll>[0], true);
+    case "nodes":
+      await loadNodes(app);
+      await loadDevices(app);
+      await loadConfig(app);
+      await loadExecApprovals(app);
+      return;
+    case "dreams":
+      await loadConfig(app);
+      await Promise.all([loadDreamingStatus(app), loadDreamDiary(app)]);
+      return;
+    case "chat":
+      await refreshChat(host as unknown as Parameters<typeof refreshChat>[0]);
+      scheduleChatScroll(
+        host as unknown as Parameters<typeof scheduleChatScroll>[0],
+        !host.chatHasAutoScrolled,
+      );
+      return;
+    case "config":
+    case "communications":
+    case "appearance":
+    case "automation":
+    case "infrastructure":
+    case "aiAgents":
+      await loadConfigSchema(app);
+      await loadConfig(app);
+      return;
+    case "debug":
+      await loadDebug(app);
+      host.eventLog = host.eventLogBuffer;
+      return;
+    case "logs":
+      host.logsAtBottom = true;
+      await loadLogs(app, { reset: true });
+      scheduleLogsScroll(host as unknown as Parameters<typeof scheduleLogsScroll>[0], true);
+      return;
+    default:
+      return;
   }
 }
 

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -126,11 +126,10 @@ export function applySettingsFromUrl(host: SettingsHost) {
   // for compatibility with older deep links.
   const queryToken = params.get("token");
   const hashToken = hashParams.get("token");
-  const tokenRaw = hashToken ?? queryToken;
+  const hasTokenParam = hashToken != null || queryToken != null;
   const passwordRaw = params.get("password") ?? hashParams.get("password");
-  const sessionParam = params.get("session") ?? hashParams.get("session");
-  const token = normalizeOptionalString(tokenRaw);
-  const session = normalizeOptionalString(sessionParam);
+  const token = normalizeOptionalString(hashToken ?? queryToken);
+  const session = normalizeOptionalString(params.get("session") ?? hashParams.get("session"));
   const shouldResetSessionForToken = Boolean(token && !session && !gatewayUrlChanged);
   let shouldCleanUrl = false;
 
@@ -139,7 +138,7 @@ export function applySettingsFromUrl(host: SettingsHost) {
     shouldCleanUrl = true;
   }
 
-  if (tokenRaw != null) {
+  if (hasTokenParam) {
     if (queryToken != null) {
       warnQueryToken = true;
       console.warn(

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -92,10 +92,7 @@ export function applySettings(host: SettingsHost, next: UiSettings) {
 
 export function setLastActiveSessionKey(host: SettingsHost, next: string) {
   const trimmed = next.trim();
-  if (!trimmed) {
-    return;
-  }
-  if (host.settings.lastActiveSessionKey === trimmed) {
+  if (!trimmed || host.settings.lastActiveSessionKey === trimmed) {
     return;
   }
   applySettings(host, { ...host.settings, lastActiveSessionKey: trimmed });
@@ -275,44 +272,42 @@ async function refreshAgentsTab(host: SettingsHost, app: OpenClawApp) {
     case "cron":
       void loadCron(host);
       return;
-    default:
-      return;
   }
 }
 
 export async function refreshActiveTab(host: SettingsHost) {
   const app = host as unknown as OpenClawApp;
-  if (
-    (
-      [
-        "config",
-        "communications",
-        "appearance",
-        "automation",
-        "infrastructure",
-        "aiAgents",
-      ] as Tab[]
-    ).includes(host.tab)
-  ) {
-    await loadConfigSchema(app);
-    await loadConfig(app);
-    return;
-  }
-  const simpleTabLoaders: Partial<Record<Tab, () => Promise<void>>> = {
-    overview: () => loadOverview(host),
-    channels: () => loadChannelsTab(host),
-    instances: () => loadPresence(app),
-    usage: () => loadUsage(app),
-    sessions: () => loadSessions(app),
-    cron: () => loadCron(host),
-    skills: () => loadSkills(app),
-  };
-  const simpleTabLoader = simpleTabLoaders[host.tab];
-  if (simpleTabLoader) {
-    await simpleTabLoader();
-    return;
-  }
   switch (host.tab) {
+    case "config":
+    case "communications":
+    case "appearance":
+    case "automation":
+    case "infrastructure":
+    case "aiAgents":
+      await loadConfigSchema(app);
+      await loadConfig(app);
+      return;
+    case "overview":
+      await loadOverview(host);
+      return;
+    case "channels":
+      await loadChannelsTab(host);
+      return;
+    case "instances":
+      await loadPresence(app);
+      return;
+    case "usage":
+      await loadUsage(app);
+      return;
+    case "sessions":
+      await loadSessions(app);
+      return;
+    case "cron":
+      await loadCron(host);
+      return;
+    case "skills":
+      await loadSkills(app);
+      return;
     case "agents":
       await refreshAgentsTab(host, app);
       return;
@@ -480,9 +475,7 @@ function applyTabSelection(
   options: { refreshPolicy: "always" | "connected"; syncUrl?: boolean },
 ) {
   const prev = host.tab;
-  if (host.tab !== next) {
-    host.tab = next;
-  }
+  host.tab = next;
 
   // Cleanup chat module state when navigating away from chat
   if (prev === "chat" && next !== "chat") {

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -171,10 +171,8 @@ export function applySettingsFromUrl(host: SettingsHost) {
     shouldCleanUrl = true;
   }
 
-  if (sessionRaw != null) {
-    if (session) {
-      applySessionSelection(host, session);
-    }
+  if (sessionRaw != null && session) {
+    applySessionSelection(host, session);
   }
 
   if (gatewayUrlRaw != null) {
@@ -224,9 +222,7 @@ export function setTheme(host: SettingsHost, next: ThemeName, context?: ThemeTra
   applyThemeTransition(
     host,
     resolveTheme(next, host.themeMode),
-    () => {
-      applySettings(host, { ...host.settings, theme: next });
-    },
+    () => applySettings(host, { ...host.settings, theme: next }),
     context,
   );
 }
@@ -239,9 +235,7 @@ export function setThemeMode(
   applyThemeTransition(
     host,
     resolveTheme(host.theme, next),
-    () => {
-      applySettings(host, { ...host.settings, themeMode: next });
-    },
+    () => applySettings(host, { ...host.settings, themeMode: next }),
     context,
   );
 }
@@ -336,8 +330,6 @@ export async function refreshActiveTab(host: SettingsHost) {
       host.logsAtBottom = true;
       await loadLogs(app, { reset: true });
       scheduleLogsScroll(host as unknown as Parameters<typeof scheduleLogsScroll>[0], true);
-      return;
-    default:
       return;
   }
 }

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -101,6 +101,15 @@ export function setLastActiveSessionKey(host: SettingsHost, next: string) {
   applySettings(host, { ...host.settings, lastActiveSessionKey: trimmed });
 }
 
+function applySessionSelection(host: SettingsHost, session: string) {
+  host.sessionKey = session;
+  applySettings(host, {
+    ...host.settings,
+    sessionKey: session,
+    lastActiveSessionKey: session,
+  });
+}
+
 /** Set to true when the token is read from a query string (?token=) instead of a URL fragment. */
 export let warnQueryToken = false;
 
@@ -167,12 +176,7 @@ export function applySettingsFromUrl(host: SettingsHost) {
 
   if (sessionRaw != null) {
     if (session) {
-      host.sessionKey = session;
-      applySettings(host, {
-        ...host.settings,
-        sessionKey: session,
-        lastActiveSessionKey: session,
-      });
+      applySessionSelection(host, session);
     }
   }
 
@@ -204,13 +208,14 @@ export function setTab(host: SettingsHost, next: Tab) {
   applyTabSelection(host, next, { refreshPolicy: "always", syncUrl: true });
 }
 
-export function setTheme(host: SettingsHost, next: ThemeName, context?: ThemeTransitionContext) {
-  const resolved = resolveTheme(next, host.themeMode);
-  const applyTheme = () => {
-    applySettings(host, { ...host.settings, theme: next });
-  };
+function applyThemeTransition(
+  host: SettingsHost,
+  nextTheme: ResolvedTheme,
+  applyTheme: () => void,
+  context?: ThemeTransitionContext,
+) {
   startThemeTransition({
-    nextTheme: resolved,
+    nextTheme,
     applyTheme,
     context,
     currentTheme: host.themeResolved,
@@ -218,22 +223,30 @@ export function setTheme(host: SettingsHost, next: ThemeName, context?: ThemeTra
   syncSystemThemeListener(host);
 }
 
+export function setTheme(host: SettingsHost, next: ThemeName, context?: ThemeTransitionContext) {
+  applyThemeTransition(
+    host,
+    resolveTheme(next, host.themeMode),
+    () => {
+      applySettings(host, { ...host.settings, theme: next });
+    },
+    context,
+  );
+}
+
 export function setThemeMode(
   host: SettingsHost,
   next: ThemeMode,
   context?: ThemeTransitionContext,
 ) {
-  const resolved = resolveTheme(host.theme, next);
-  const applyMode = () => {
-    applySettings(host, { ...host.settings, themeMode: next });
-  };
-  startThemeTransition({
-    nextTheme: resolved,
-    applyTheme: applyMode,
+  applyThemeTransition(
+    host,
+    resolveTheme(host.theme, next),
+    () => {
+      applySettings(host, { ...host.settings, themeMode: next });
+    },
     context,
-    currentTheme: host.themeResolved,
-  });
-  syncSystemThemeListener(host);
+  );
 }
 
 export async function refreshActiveTab(host: SettingsHost) {
@@ -443,12 +456,7 @@ export function onPopState(host: SettingsHost) {
   const url = new URL(window.location.href);
   const session = normalizeOptionalString(url.searchParams.get("session"));
   if (session) {
-    host.sessionKey = session;
-    applySettings(host, {
-      ...host.settings,
-      sessionKey: session,
-      lastActiveSessionKey: session,
-    });
+    applySessionSelection(host, session);
   }
 
   setTabFromRoute(host, resolved);
@@ -484,16 +492,12 @@ function applyTabSelection(
   if (next === "chat") {
     host.chatHasAutoScrolled = false;
   }
-  if (next === "logs") {
-    startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
-  } else {
-    stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
-  }
-  if (next === "debug") {
-    startDebugPolling(host as unknown as Parameters<typeof startDebugPolling>[0]);
-  } else {
-    stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);
-  }
+  (next === "logs" ? startLogsPolling : stopLogsPolling)(
+    host as unknown as Parameters<typeof startLogsPolling>[0],
+  );
+  (next === "debug" ? startDebugPolling : stopDebugPolling)(
+    host as unknown as Parameters<typeof startDebugPolling>[0],
+  );
 
   if (options.refreshPolicy === "always" || host.connected) {
     void refreshActiveTab(host);

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -442,10 +442,9 @@ export function setTabFromRoute(host: SettingsHost, next: Tab) {
 
 function updateBrowserHistory(url: URL, replace: boolean) {
   if (replace) {
-    window.history.replaceState({}, "", url.toString());
-    return;
+    return window.history.replaceState({}, "", url.toString());
   }
-  window.history.pushState({}, "", url.toString());
+  return window.history.pushState({}, "", url.toString());
 }
 
 function applyTabSelection(

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -248,17 +248,13 @@ async function refreshAgentsTab(host: SettingsHost, app: OpenClawApp) {
   void loadAgentIdentity(app, agentId);
   switch (host.agentsPanel) {
     case "files":
-      void loadAgentFiles(app, agentId);
-      return;
+      return void loadAgentFiles(app, agentId);
     case "skills":
-      void loadAgentSkills(app, agentId);
-      return;
+      return void loadAgentSkills(app, agentId);
     case "channels":
-      void loadChannels(app, false);
-      return;
+      return void loadChannels(app, false);
     case "cron":
-      void loadCron(host);
-      return;
+      return void loadCron(host);
   }
 }
 

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -128,9 +128,9 @@ export function applySettingsFromUrl(host: SettingsHost) {
   const hashToken = hashParams.get("token");
   const tokenRaw = hashToken ?? queryToken;
   const passwordRaw = params.get("password") ?? hashParams.get("password");
-  const sessionRaw = params.get("session") ?? hashParams.get("session");
+  const sessionParam = params.get("session") ?? hashParams.get("session");
   const token = normalizeOptionalString(tokenRaw);
-  const session = normalizeOptionalString(sessionRaw);
+  const session = normalizeOptionalString(sessionParam);
   const shouldResetSessionForToken = Boolean(token && !session && !gatewayUrlChanged);
   let shouldCleanUrl = false;
 
@@ -146,10 +146,12 @@ export function applySettingsFromUrl(host: SettingsHost) {
         "[openclaw] Auth token passed as query parameter (?token=). Use URL fragment instead: #token=<token>. Query parameters may appear in server logs.",
       );
     }
-    if (token && gatewayUrlChanged) {
-      host.pendingGatewayToken = token;
-    } else if (token && token !== host.settings.token) {
-      applySettings(host, { ...host.settings, token });
+    if (token) {
+      if (gatewayUrlChanged) {
+        host.pendingGatewayToken = token;
+      } else if (token !== host.settings.token) {
+        applySettings(host, { ...host.settings, token });
+      }
     }
     hashParams.delete("token");
     shouldCleanUrl = true;
@@ -171,16 +173,14 @@ export function applySettingsFromUrl(host: SettingsHost) {
     shouldCleanUrl = true;
   }
 
-  if (sessionRaw != null && session) {
+  if (session) {
     applySessionSelection(host, session);
   }
 
   if (gatewayUrlRaw != null) {
     if (gatewayUrlChanged) {
       host.pendingGatewayUrl = nextGatewayUrl;
-      if (!token) {
-        host.pendingGatewayToken = null;
-      }
+      host.pendingGatewayToken = token ?? null;
     } else {
       host.pendingGatewayUrl = null;
       host.pendingGatewayToken = null;

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -363,10 +363,6 @@ export function syncThemeWithSettings(host: SettingsHost) {
   syncSystemThemeListener(host);
 }
 
-export function attachThemeListener(host: SettingsHost) {
-  syncSystemThemeListener(host);
-}
-
 export function detachThemeListener(host: SettingsHost) {
   host.systemThemeCleanup?.();
   host.systemThemeCleanup = null;

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -197,7 +197,7 @@ export function applySettingsFromUrl(host: SettingsHost) {
   url.search = params.toString();
   const nextHash = hashParams.toString();
   url.hash = nextHash ? `#${nextHash}` : "";
-  window.history.replaceState({}, "", url.toString());
+  updateBrowserHistory(url, true);
 }
 
 export function setTab(host: SettingsHost, next: Tab) {
@@ -458,6 +458,14 @@ export function setTabFromRoute(host: SettingsHost, next: Tab) {
   applyTabSelection(host, next, { refreshPolicy: "connected" });
 }
 
+function updateBrowserHistory(url: URL, replace: boolean) {
+  if (replace) {
+    window.history.replaceState({}, "", url.toString());
+    return;
+  }
+  window.history.pushState({}, "", url.toString());
+}
+
 function applyTabSelection(
   host: SettingsHost,
   next: Tab,
@@ -514,11 +522,7 @@ export function syncUrlWithTab(host: SettingsHost, tab: Tab, replace: boolean) {
     url.pathname = targetPath;
   }
 
-  if (replace) {
-    window.history.replaceState({}, "", url.toString());
-  } else {
-    window.history.pushState({}, "", url.toString());
-  }
+  updateBrowserHistory(url, replace);
 }
 
 export function syncUrlWithSessionKey(host: SettingsHost, sessionKey: string, replace: boolean) {
@@ -527,11 +531,7 @@ export function syncUrlWithSessionKey(host: SettingsHost, sessionKey: string, re
   }
   const url = new URL(window.location.href);
   url.searchParams.set("session", sessionKey);
-  if (replace) {
-    window.history.replaceState({}, "", url.toString());
-  } else {
-    window.history.pushState({}, "", url.toString());
-  }
+  updateBrowserHistory(url, replace);
 }
 
 export async function loadOverview(host: SettingsHost) {
@@ -675,11 +675,8 @@ function buildAttentionItems(host: OpenClawApp) {
 }
 
 export async function loadChannelsTab(host: SettingsHost) {
-  await Promise.all([
-    loadChannels(host as unknown as OpenClawApp, true),
-    loadConfigSchema(host as unknown as OpenClawApp),
-    loadConfig(host as unknown as OpenClawApp),
-  ]);
+  const app = host as unknown as OpenClawApp;
+  await Promise.all([loadChannels(app, true), loadConfigSchema(app), loadConfig(app)]);
 }
 
 export async function loadCron(host: SettingsHost) {

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -249,60 +249,73 @@ export function setThemeMode(
   );
 }
 
-export async function refreshActiveTab(host: SettingsHost) {
-  const app = host as unknown as OpenClawApp;
-  switch (host.tab) {
-    case "overview":
-      await loadOverview(host);
-      return;
-    case "channels":
-      await loadChannelsTab(host);
-      return;
-    case "instances":
-      await loadPresence(app);
-      return;
-    case "usage":
-      await loadUsage(app);
-      return;
-    case "sessions":
-      await loadSessions(app);
-      return;
-    case "cron":
-      await loadCron(host);
+async function refreshAgentsTab(host: SettingsHost, app: OpenClawApp) {
+  await loadAgents(app);
+  await loadConfig(app);
+  const agentIds = host.agentsList?.agents?.map((entry) => entry.id) ?? [];
+  if (agentIds.length > 0) {
+    void loadAgentIdentities(app, agentIds);
+  }
+  const agentId =
+    host.agentsSelectedId ?? host.agentsList?.defaultId ?? host.agentsList?.agents?.[0]?.id;
+  if (!agentId) {
+    return;
+  }
+  void loadAgentIdentity(app, agentId);
+  switch (host.agentsPanel) {
+    case "files":
+      void loadAgentFiles(app, agentId);
       return;
     case "skills":
-      await loadSkills(app);
+      void loadAgentSkills(app, agentId);
       return;
-    case "agents": {
-      await loadAgents(app);
-      await loadConfig(app);
-      const agentIds = host.agentsList?.agents?.map((entry) => entry.id) ?? [];
-      if (agentIds.length > 0) {
-        void loadAgentIdentities(app, agentIds);
-      }
-      const agentId =
-        host.agentsSelectedId ?? host.agentsList?.defaultId ?? host.agentsList?.agents?.[0]?.id;
-      if (!agentId) {
-        return;
-      }
-      void loadAgentIdentity(app, agentId);
-      switch (host.agentsPanel) {
-        case "files":
-          void loadAgentFiles(app, agentId);
-          return;
-        case "skills":
-          void loadAgentSkills(app, agentId);
-          return;
-        case "channels":
-          void loadChannels(app, false);
-          return;
-        case "cron":
-          void loadCron(host);
-          return;
-        default:
-          return;
-      }
-    }
+    case "channels":
+      void loadChannels(app, false);
+      return;
+    case "cron":
+      void loadCron(host);
+      return;
+    default:
+      return;
+  }
+}
+
+export async function refreshActiveTab(host: SettingsHost) {
+  const app = host as unknown as OpenClawApp;
+  if (
+    (
+      [
+        "config",
+        "communications",
+        "appearance",
+        "automation",
+        "infrastructure",
+        "aiAgents",
+      ] as Tab[]
+    ).includes(host.tab)
+  ) {
+    await loadConfigSchema(app);
+    await loadConfig(app);
+    return;
+  }
+  const simpleTabLoaders: Partial<Record<Tab, () => Promise<void>>> = {
+    overview: () => loadOverview(host),
+    channels: () => loadChannelsTab(host),
+    instances: () => loadPresence(app),
+    usage: () => loadUsage(app),
+    sessions: () => loadSessions(app),
+    cron: () => loadCron(host),
+    skills: () => loadSkills(app),
+  };
+  const simpleTabLoader = simpleTabLoaders[host.tab];
+  if (simpleTabLoader) {
+    await simpleTabLoader();
+    return;
+  }
+  switch (host.tab) {
+    case "agents":
+      await refreshAgentsTab(host, app);
+      return;
     case "nodes":
       await loadNodes(app);
       await loadDevices(app);
@@ -319,15 +332,6 @@ export async function refreshActiveTab(host: SettingsHost) {
         host as unknown as Parameters<typeof scheduleChatScroll>[0],
         !host.chatHasAutoScrolled,
       );
-      return;
-    case "config":
-    case "communications":
-    case "appearance":
-    case "automation":
-    case "infrastructure":
-    case "aiAgents":
-      await loadConfigSchema(app);
-      await loadConfig(app);
       return;
     case "debug":
       await loadDebug(app);

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -127,7 +127,6 @@ export function applySettingsFromUrl(host: SettingsHost) {
   const queryToken = params.get("token");
   const hashToken = hashParams.get("token");
   const hasTokenParam = hashToken != null || queryToken != null;
-  const passwordRaw = params.get("password") ?? hashParams.get("password");
   const token = normalizeOptionalString(hashToken ?? queryToken);
   const session = normalizeOptionalString(params.get("session") ?? hashParams.get("session"));
   const shouldResetSessionForToken = Boolean(token && !session && !gatewayUrlChanged);
@@ -163,7 +162,7 @@ export function applySettingsFromUrl(host: SettingsHost) {
     });
   }
 
-  if (passwordRaw != null) {
+  if (params.has("password") || hashParams.has("password")) {
     // Never hydrate password from URL params; strip only.
     params.delete("password");
     hashParams.delete("password");

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -14,7 +14,7 @@ import { loadAgentSkills } from "./controllers/agent-skills.ts";
 import { loadAgents } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
 import { loadConfig, loadConfigSchema } from "./controllers/config.ts";
-import { loadCronJobs, loadCronRuns, loadCronStatus } from "./controllers/cron.ts";
+import { loadCronJobsPage, loadCronRuns, loadCronStatus } from "./controllers/cron.ts";
 import { loadDebug } from "./controllers/debug.ts";
 import { loadDevices } from "./controllers/devices.ts";
 import { loadDreamDiary, loadDreamingStatus } from "./controllers/dreaming.ts";
@@ -545,7 +545,7 @@ export async function loadOverview(host: SettingsHost) {
     loadPresence(app),
     loadSessions(app),
     loadCronStatus(app),
-    loadCronJobs(app),
+    loadCronJobsPage(app),
     loadDebug(app),
     loadSkills(app),
     loadUsage(app),
@@ -689,7 +689,7 @@ export async function loadCron(host: SettingsHost) {
   await Promise.all([
     loadChannels(app, false),
     loadCronStatus(app),
-    loadCronJobs(app),
+    loadCronJobsPage(app),
     loadCronRuns(app, activeCronJobId),
   ]);
 }

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -173,6 +173,30 @@ describe("loadToolsCatalog", () => {
     expect(state.toolsCatalogError).toContain("gateway unavailable");
     expect(state.toolsCatalogLoading).toBe(false);
   });
+
+  it("ignores catalog responses after selected agent changes mid-request", async () => {
+    const { state, request } = createState();
+    const resolvers: Array<(value: unknown) => void> = [];
+    request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const pending = loadToolsCatalog(state, "main");
+    state.agentsSelectedId = "other-agent";
+    resolvers.shift()?.({
+      agentId: "main",
+      profiles: [{ id: "full", label: "Full" }],
+      groups: [],
+    });
+    await pending;
+
+    expect(state.toolsCatalogResult).toBeNull();
+    expect(state.toolsCatalogError).toBeNull();
+    expect(state.toolsCatalogLoading).toBe(false);
+  });
 });
 
 describe("loadToolsEffective", () => {
@@ -221,6 +245,31 @@ describe("loadToolsEffective", () => {
     expect(state.toolsEffectiveResult).toBeNull();
     expect(state.toolsEffectiveResultKey).toBeNull();
     expect(state.toolsEffectiveError).toContain("gateway unavailable");
+    expect(state.toolsEffectiveLoading).toBe(false);
+  });
+
+  it("ignores effective-tool responses after selected agent changes mid-request", async () => {
+    const { state, request } = createState();
+    const resolvers: Array<(value: unknown) => void> = [];
+    request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const pending = loadToolsEffective(state, { agentId: "main", sessionKey: "main" });
+    state.agentsSelectedId = "other-agent";
+    resolvers.shift()?.({
+      agentId: "main",
+      profile: "coding",
+      groups: [],
+    });
+    await pending;
+
+    expect(state.toolsEffectiveResult).toBeNull();
+    expect(state.toolsEffectiveResultKey).toBeNull();
+    expect(state.toolsEffectiveError).toBeNull();
     expect(state.toolsEffectiveLoading).toBe(false);
   });
 

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -48,11 +48,17 @@ function hasSelectedAgentMismatch(state: AgentsState, agentId: string): boolean 
   return Boolean(state.agentsSelectedId && state.agentsSelectedId !== agentId);
 }
 
+function resolveToolsErrorMessage(
+  err: unknown,
+  target: "tools catalog" | "effective tools",
+): string {
+  return isMissingOperatorReadScopeError(err)
+    ? formatMissingOperatorReadScopeMessage(target)
+    : String(err);
+}
+
 export async function loadAgents(state: AgentsState) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  if (state.agentsLoading) {
+  if (!state.client || !state.connected || state.agentsLoading) {
     return;
   }
   state.agentsLoading = true;
@@ -62,8 +68,7 @@ export async function loadAgents(state: AgentsState) {
     if (res) {
       state.agentsList = res;
       const selected = state.agentsSelectedId;
-      const known = res.agents.some((entry) => entry.id === selected);
-      if (!selected || !known) {
+      if (!selected || !res.agents.some((entry) => entry.id === selected)) {
         state.agentsSelectedId = res.defaultId ?? res.agents[0]?.id ?? null;
       }
     }
@@ -81,15 +86,17 @@ export async function loadAgents(state: AgentsState) {
 
 export async function loadToolsCatalog(state: AgentsState, agentId: string) {
   const resolvedAgentId = agentId.trim();
-  if (!state.client || !state.connected || !resolvedAgentId) {
+  if (
+    !state.client ||
+    !state.connected ||
+    !resolvedAgentId ||
+    (state.toolsCatalogLoading && state.toolsCatalogLoadingAgentId === resolvedAgentId)
+  ) {
     return;
   }
   const shouldIgnoreResponse = () =>
     state.toolsCatalogLoadingAgentId !== resolvedAgentId ||
     hasSelectedAgentMismatch(state, resolvedAgentId);
-  if (state.toolsCatalogLoading && state.toolsCatalogLoadingAgentId === resolvedAgentId) {
-    return;
-  }
   state.toolsCatalogLoading = true;
   state.toolsCatalogLoadingAgentId = resolvedAgentId;
   state.toolsCatalogError = null;
@@ -107,10 +114,7 @@ export async function loadToolsCatalog(state: AgentsState, agentId: string) {
     if (shouldIgnoreResponse()) {
       return;
     }
-    state.toolsCatalogResult = null;
-    state.toolsCatalogError = isMissingOperatorReadScopeError(err)
-      ? formatMissingOperatorReadScopeMessage("tools catalog")
-      : String(err);
+    state.toolsCatalogError = resolveToolsErrorMessage(err, "tools catalog");
   } finally {
     if (state.toolsCatalogLoadingAgentId === resolvedAgentId) {
       state.toolsCatalogLoadingAgentId = null;
@@ -129,15 +133,18 @@ export async function loadToolsEffective(
     agentId: resolvedAgentId,
     sessionKey: resolvedSessionKey,
   });
-  if (!state.client || !state.connected || !resolvedAgentId || !resolvedSessionKey) {
+  if (
+    !state.client ||
+    !state.connected ||
+    !resolvedAgentId ||
+    !resolvedSessionKey ||
+    (state.toolsEffectiveLoading && state.toolsEffectiveLoadingKey === requestKey)
+  ) {
     return;
   }
   const shouldIgnoreResponse = () =>
     state.toolsEffectiveLoadingKey !== requestKey ||
     hasSelectedAgentMismatch(state, resolvedAgentId);
-  if (state.toolsEffectiveLoading && state.toolsEffectiveLoadingKey === requestKey) {
-    return;
-  }
   state.toolsEffectiveLoading = true;
   state.toolsEffectiveLoadingKey = requestKey;
   state.toolsEffectiveResultKey = null;
@@ -157,11 +164,7 @@ export async function loadToolsEffective(
     if (shouldIgnoreResponse()) {
       return;
     }
-    state.toolsEffectiveResult = null;
-    state.toolsEffectiveResultKey = null;
-    state.toolsEffectiveError = isMissingOperatorReadScopeError(err)
-      ? formatMissingOperatorReadScopeMessage("effective tools")
-      : String(err);
+    state.toolsEffectiveError = resolveToolsErrorMessage(err, "effective tools");
   } finally {
     if (state.toolsEffectiveLoadingKey === requestKey) {
       state.toolsEffectiveLoadingKey = null;

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -44,6 +44,10 @@ export type AgentsState = {
 
 export type AgentsConfigSaveState = AgentsState & ConfigState;
 
+function hasSelectedAgentMismatch(state: AgentsState, agentId: string): boolean {
+  return Boolean(state.agentsSelectedId && state.agentsSelectedId !== agentId);
+}
+
 export async function loadAgents(state: AgentsState) {
   if (!state.client || !state.connected) {
     return;
@@ -80,6 +84,9 @@ export async function loadToolsCatalog(state: AgentsState, agentId: string) {
   if (!state.client || !state.connected || !resolvedAgentId) {
     return;
   }
+  const shouldIgnoreResponse = () =>
+    state.toolsCatalogLoadingAgentId !== resolvedAgentId ||
+    hasSelectedAgentMismatch(state, resolvedAgentId);
   if (state.toolsCatalogLoading && state.toolsCatalogLoadingAgentId === resolvedAgentId) {
     return;
   }
@@ -92,18 +99,12 @@ export async function loadToolsCatalog(state: AgentsState, agentId: string) {
       agentId: resolvedAgentId,
       includePlugins: true,
     });
-    if (state.toolsCatalogLoadingAgentId !== resolvedAgentId) {
-      return;
-    }
-    if (state.agentsSelectedId && state.agentsSelectedId !== resolvedAgentId) {
+    if (shouldIgnoreResponse()) {
       return;
     }
     state.toolsCatalogResult = res;
   } catch (err) {
-    if (state.toolsCatalogLoadingAgentId !== resolvedAgentId) {
-      return;
-    }
-    if (state.agentsSelectedId && state.agentsSelectedId !== resolvedAgentId) {
+    if (shouldIgnoreResponse()) {
       return;
     }
     state.toolsCatalogResult = null;
@@ -131,6 +132,9 @@ export async function loadToolsEffective(
   if (!state.client || !state.connected || !resolvedAgentId || !resolvedSessionKey) {
     return;
   }
+  const shouldIgnoreResponse = () =>
+    state.toolsEffectiveLoadingKey !== requestKey ||
+    hasSelectedAgentMismatch(state, resolvedAgentId);
   if (state.toolsEffectiveLoading && state.toolsEffectiveLoadingKey === requestKey) {
     return;
   }
@@ -144,19 +148,13 @@ export async function loadToolsEffective(
       agentId: resolvedAgentId,
       sessionKey: resolvedSessionKey,
     });
-    if (state.toolsEffectiveLoadingKey !== requestKey) {
-      return;
-    }
-    if (state.agentsSelectedId && state.agentsSelectedId !== resolvedAgentId) {
+    if (shouldIgnoreResponse()) {
       return;
     }
     state.toolsEffectiveResultKey = requestKey;
     state.toolsEffectiveResult = res;
   } catch (err) {
-    if (state.toolsEffectiveLoadingKey !== requestKey) {
-      return;
-    }
-    if (state.agentsSelectedId && state.agentsSelectedId !== resolvedAgentId) {
+    if (shouldIgnoreResponse()) {
       return;
     }
     state.toolsEffectiveResult = null;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -134,11 +134,19 @@ function serializeFormForSubmit(state: ConfigState): string {
   return serializeConfigForm(form);
 }
 
-export async function saveConfig(state: ConfigState) {
+type ConfigSubmitMethod = "config.set" | "config.apply";
+type ConfigSubmitBusyKey = "configSaving" | "configApplying";
+
+async function submitConfigChange(
+  state: ConfigState,
+  method: ConfigSubmitMethod,
+  busyKey: ConfigSubmitBusyKey,
+  extraParams: Record<string, unknown> = {},
+) {
   if (!state.client || !state.connected) {
     return;
   }
-  state.configSaving = true;
+  state[busyKey] = true;
   state.lastError = null;
   try {
     const raw = serializeFormForSubmit(state);
@@ -147,41 +155,24 @@ export async function saveConfig(state: ConfigState) {
       state.lastError = "Config hash missing; reload and retry.";
       return;
     }
-    await state.client.request("config.set", { raw, baseHash });
+    await state.client.request(method, { raw, baseHash, ...extraParams });
     state.configFormDirty = false;
     await loadConfig(state);
   } catch (err) {
     state.lastError = String(err);
   } finally {
-    state.configSaving = false;
+    state[busyKey] = false;
   }
 }
 
+export async function saveConfig(state: ConfigState) {
+  await submitConfigChange(state, "config.set", "configSaving");
+}
+
 export async function applyConfig(state: ConfigState) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  state.configApplying = true;
-  state.lastError = null;
-  try {
-    const raw = serializeFormForSubmit(state);
-    const baseHash = state.configSnapshot?.hash;
-    if (!baseHash) {
-      state.lastError = "Config hash missing; reload and retry.";
-      return;
-    }
-    await state.client.request("config.apply", {
-      raw,
-      baseHash,
-      sessionKey: state.applySessionKey,
-    });
-    state.configFormDirty = false;
-    await loadConfig(state);
-  } catch (err) {
-    state.lastError = String(err);
-  } finally {
-    state.configApplying = false;
-  }
+  await submitConfigChange(state, "config.apply", "configApplying", {
+    sessionKey: state.applySessionKey,
+  });
 }
 
 export async function runUpdate(state: ConfigState) {
@@ -209,13 +200,9 @@ export async function runUpdate(state: ConfigState) {
   }
 }
 
-export function updateConfigFormValue(
-  state: ConfigState,
-  path: Array<string | number>,
-  value: unknown,
-) {
+function mutateConfigForm(state: ConfigState, mutate: (draft: Record<string, unknown>) => void) {
   const base = cloneConfigObject(state.configForm ?? state.configSnapshot?.config ?? {});
-  setPathValue(base, path, value);
+  mutate(base);
   state.configForm = base;
   state.configFormDirty = true;
   if (state.configFormMode === "form") {
@@ -223,14 +210,16 @@ export function updateConfigFormValue(
   }
 }
 
+export function updateConfigFormValue(
+  state: ConfigState,
+  path: Array<string | number>,
+  value: unknown,
+) {
+  mutateConfigForm(state, (draft) => setPathValue(draft, path, value));
+}
+
 export function removeConfigFormValue(state: ConfigState, path: Array<string | number>) {
-  const base = cloneConfigObject(state.configForm ?? state.configSnapshot?.config ?? {});
-  removePathValue(base, path);
-  state.configForm = base;
-  state.configFormDirty = true;
-  if (state.configFormMode === "form") {
-    state.configRaw = serializeConfigForm(base);
-  }
+  mutateConfigForm(state, (draft) => removePathValue(draft, path));
 }
 
 export function findAgentConfigEntryIndex(

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -248,7 +248,6 @@ export async function loadCronJobs(state: CronState) {
 
 function normalizeCronPageMeta(params: {
   totalRaw: unknown;
-  limitRaw: unknown;
   offsetRaw: unknown;
   nextOffsetRaw: unknown;
   hasMoreRaw: unknown;
@@ -258,10 +257,6 @@ function normalizeCronPageMeta(params: {
     typeof params.totalRaw === "number" && Number.isFinite(params.totalRaw)
       ? Math.max(0, Math.floor(params.totalRaw))
       : params.pageCount;
-  const limit =
-    typeof params.limitRaw === "number" && Number.isFinite(params.limitRaw)
-      ? Math.max(1, Math.floor(params.limitRaw))
-      : Math.max(1, params.pageCount);
   const offset =
     typeof params.offsetRaw === "number" && Number.isFinite(params.offsetRaw)
       ? Math.max(0, Math.floor(params.offsetRaw))
@@ -276,7 +271,7 @@ function normalizeCronPageMeta(params: {
       : hasMore
         ? offset + params.pageCount
         : null;
-  return { total, limit, offset, hasMore, nextOffset };
+  return { total, hasMore, nextOffset };
 }
 
 export async function loadCronJobsPage(state: CronState, opts?: { append?: boolean }) {
@@ -311,7 +306,6 @@ export async function loadCronJobsPage(state: CronState, opts?: { append?: boole
     state.cronJobs = append ? [...state.cronJobs, ...jobs] : jobs;
     const meta = normalizeCronPageMeta({
       totalRaw: res.total,
-      limitRaw: res.limit,
       offsetRaw: res.offset,
       nextOffsetRaw: res.nextOffset,
       hasMoreRaw: res.hasMore,
@@ -800,7 +794,6 @@ export async function loadCronRuns(
     }
     const meta = normalizeCronPageMeta({
       totalRaw: res.total,
-      limitRaw: res.limit,
       offsetRaw: res.offset,
       nextOffsetRaw: res.nextOffset,
       hasMoreRaw: res.hasMore,

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -223,6 +223,25 @@ export async function loadCronModelSuggestions(state: CronModelSuggestionsState)
   }
 }
 
+async function withCronBusy(
+  state: CronState,
+  run: (client: GatewayBrowserClient) => Promise<void>,
+) {
+  const client = state.client;
+  if (!client || !state.connected || state.cronBusy) {
+    return;
+  }
+  state.cronBusy = true;
+  state.cronError = null;
+  try {
+    await run(client);
+  } catch (err) {
+    state.cronError = String(err);
+  } finally {
+    state.cronBusy = false;
+  }
+}
+
 export async function loadCronJobs(state: CronState) {
   return await loadCronJobsPage(state, { append: false });
 }
@@ -627,12 +646,7 @@ function buildFailureAlert(form: CronFormState) {
 }
 
 export async function addCronJob(state: CronState) {
-  if (!state.client || !state.connected || state.cronBusy) {
-    return;
-  }
-  state.cronBusy = true;
-  state.cronError = null;
-  try {
+  await withCronBusy(state, async (client) => {
     const form = normalizeCronFormState(state.cronForm);
     if (form !== state.cronForm) {
       state.cronForm = form;
@@ -698,69 +712,42 @@ export async function addCronJob(state: CronState) {
       throw new Error(t("cron.errors.nameRequiredShort"));
     }
     if (state.cronEditingJobId) {
-      await state.client.request("cron.update", {
+      await client.request("cron.update", {
         id: state.cronEditingJobId,
         patch: job,
       });
       clearCronEditState(state);
     } else {
-      await state.client.request("cron.add", job);
+      await client.request("cron.add", job);
       resetCronFormToDefaults(state);
     }
     await loadCronJobs(state);
     await loadCronStatus(state);
-  } catch (err) {
-    state.cronError = String(err);
-  } finally {
-    state.cronBusy = false;
-  }
+  });
 }
 
 export async function toggleCronJob(state: CronState, job: CronJob, enabled: boolean) {
-  if (!state.client || !state.connected || state.cronBusy) {
-    return;
-  }
-  state.cronBusy = true;
-  state.cronError = null;
-  try {
-    await state.client.request("cron.update", { id: job.id, patch: { enabled } });
+  await withCronBusy(state, async (client) => {
+    await client.request("cron.update", { id: job.id, patch: { enabled } });
     await loadCronJobs(state);
     await loadCronStatus(state);
-  } catch (err) {
-    state.cronError = String(err);
-  } finally {
-    state.cronBusy = false;
-  }
+  });
 }
 
 export async function runCronJob(state: CronState, job: CronJob, mode: "force" | "due" = "force") {
-  if (!state.client || !state.connected || state.cronBusy) {
-    return;
-  }
-  state.cronBusy = true;
-  state.cronError = null;
-  try {
-    await state.client.request("cron.run", { id: job.id, mode });
+  await withCronBusy(state, async (client) => {
+    await client.request("cron.run", { id: job.id, mode });
     if (state.cronRunsScope === "all") {
       await loadCronRuns(state, null);
     } else {
       await loadCronRuns(state, job.id);
     }
-  } catch (err) {
-    state.cronError = String(err);
-  } finally {
-    state.cronBusy = false;
-  }
+  });
 }
 
 export async function removeCronJob(state: CronState, job: CronJob) {
-  if (!state.client || !state.connected || state.cronBusy) {
-    return;
-  }
-  state.cronBusy = true;
-  state.cronError = null;
-  try {
-    await state.client.request("cron.remove", { id: job.id });
+  await withCronBusy(state, async (client) => {
+    await client.request("cron.remove", { id: job.id });
     if (state.cronEditingJobId === job.id) {
       clearCronEditState(state);
     }
@@ -773,11 +760,7 @@ export async function removeCronJob(state: CronState, job: CronJob) {
     }
     await loadCronJobs(state);
     await loadCronStatus(state);
-  } catch (err) {
-    state.cronError = String(err);
-  } finally {
-    state.cronBusy = false;
-  }
+  });
 }
 
 export async function loadCronRuns(

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -403,6 +403,13 @@ function clearCronEditState(state: CronState) {
   state.cronEditingJobId = null;
 }
 
+function clearCronRunsPage(state: CronState) {
+  state.cronRuns = [];
+  state.cronRunsTotal = 0;
+  state.cronRunsHasMore = false;
+  state.cronRunsNextOffset = null;
+}
+
 function resetCronFormToDefaults(state: CronState) {
   state.cronForm = { ...DEFAULT_CRON_FORM };
   state.cronFieldErrors = validateCronForm(state.cronForm);
@@ -737,11 +744,7 @@ export async function toggleCronJob(state: CronState, job: CronJob, enabled: boo
 export async function runCronJob(state: CronState, job: CronJob, mode: "force" | "due" = "force") {
   await withCronBusy(state, async (client) => {
     await client.request("cron.run", { id: job.id, mode });
-    if (state.cronRunsScope === "all") {
-      await loadCronRuns(state, null);
-    } else {
-      await loadCronRuns(state, job.id);
-    }
+    await loadCronRuns(state, state.cronRunsScope === "all" ? null : job.id);
   });
 }
 
@@ -753,10 +756,7 @@ export async function removeCronJob(state: CronState, job: CronJob) {
     }
     if (state.cronRunsJobId === job.id) {
       state.cronRunsJobId = null;
-      state.cronRuns = [];
-      state.cronRunsTotal = 0;
-      state.cronRunsHasMore = false;
-      state.cronRunsNextOffset = null;
+      clearCronRunsPage(state);
     }
     await loadCronJobs(state);
     await loadCronStatus(state);
@@ -774,10 +774,7 @@ export async function loadCronRuns(
   const scope = state.cronRunsScope;
   const activeJobId = jobId ?? state.cronRunsJobId;
   if (scope === "job" && !activeJobId) {
-    state.cronRuns = [];
-    state.cronRunsTotal = 0;
-    state.cronRunsHasMore = false;
-    state.cronRunsNextOffset = null;
+    clearCronRunsPage(state);
     return;
   }
   const append = opts?.append === true;

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -344,21 +344,12 @@ export function updateCronJobsFilter(
   if (typeof patch.cronJobsQuery === "string") {
     state.cronJobsQuery = patch.cronJobsQuery;
   }
-  if (patch.cronJobsEnabledFilter) {
-    state.cronJobsEnabledFilter = patch.cronJobsEnabledFilter;
-  }
-  if (patch.cronJobsScheduleKindFilter) {
-    state.cronJobsScheduleKindFilter = patch.cronJobsScheduleKindFilter;
-  }
-  if (patch.cronJobsLastStatusFilter) {
-    state.cronJobsLastStatusFilter = patch.cronJobsLastStatusFilter;
-  }
-  if (patch.cronJobsSortBy) {
-    state.cronJobsSortBy = patch.cronJobsSortBy;
-  }
-  if (patch.cronJobsSortDir) {
-    state.cronJobsSortDir = patch.cronJobsSortDir;
-  }
+  state.cronJobsEnabledFilter = patch.cronJobsEnabledFilter ?? state.cronJobsEnabledFilter;
+  state.cronJobsScheduleKindFilter =
+    patch.cronJobsScheduleKindFilter ?? state.cronJobsScheduleKindFilter;
+  state.cronJobsLastStatusFilter = patch.cronJobsLastStatusFilter ?? state.cronJobsLastStatusFilter;
+  state.cronJobsSortBy = patch.cronJobsSortBy ?? state.cronJobsSortBy;
+  state.cronJobsSortDir = patch.cronJobsSortDir ?? state.cronJobsSortDir;
 }
 
 export function getVisibleCronJobs(
@@ -828,9 +819,7 @@ export function updateCronRunsFilter(
     >
   >,
 ) {
-  if (patch.cronRunsScope) {
-    state.cronRunsScope = patch.cronRunsScope;
-  }
+  state.cronRunsScope = patch.cronRunsScope ?? state.cronRunsScope;
   if (Array.isArray(patch.cronRunsStatuses)) {
     state.cronRunsStatuses = patch.cronRunsStatuses;
     state.cronRunsStatusFilter =
@@ -847,9 +836,7 @@ export function updateCronRunsFilter(
   if (typeof patch.cronRunsQuery === "string") {
     state.cronRunsQuery = patch.cronRunsQuery;
   }
-  if (patch.cronRunsSortDir) {
-    state.cronRunsSortDir = patch.cronRunsSortDir;
-  }
+  state.cronRunsSortDir = patch.cronRunsSortDir ?? state.cronRunsSortDir;
 }
 
 export function startCronEdit(state: CronState, job: CronJob) {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -278,10 +278,10 @@ export async function loadCronJobsPage(state: CronState, opts?: { append?: boole
     return;
   }
   const append = opts?.append === true;
+  if (append && !state.cronJobsHasMore) {
+    return;
+  }
   if (append) {
-    if (!state.cronJobsHasMore) {
-      return;
-    }
     state.cronJobsLoadingMore = true;
   } else {
     state.cronLoading = true;

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -337,14 +337,6 @@ export async function loadCronJobsPage(state: CronState, opts?: { append?: boole
   }
 }
 
-export async function loadMoreCronJobs(state: CronState) {
-  await loadCronJobsPage(state, { append: true });
-}
-
-export async function reloadCronJobs(state: CronState) {
-  await loadCronJobsPage(state, { append: false });
-}
-
 export function updateCronJobsFilter(
   state: CronState,
   patch: Partial<

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -242,10 +242,6 @@ async function withCronBusy(
   }
 }
 
-export async function loadCronJobs(state: CronState) {
-  return await loadCronJobsPage(state, { append: false });
-}
-
 function normalizeCronPageMeta(params: {
   totalRaw: unknown;
   offsetRaw: unknown;
@@ -714,7 +710,7 @@ export async function addCronJob(state: CronState) {
       await client.request("cron.add", job);
       resetCronFormToDefaults(state);
     }
-    await loadCronJobs(state);
+    await loadCronJobsPage(state);
     await loadCronStatus(state);
   });
 }
@@ -722,7 +718,7 @@ export async function addCronJob(state: CronState) {
 export async function toggleCronJob(state: CronState, job: CronJob, enabled: boolean) {
   await withCronBusy(state, async (client) => {
     await client.request("cron.update", { id: job.id, patch: { enabled } });
-    await loadCronJobs(state);
+    await loadCronJobsPage(state);
     await loadCronStatus(state);
   });
 }
@@ -744,7 +740,7 @@ export async function removeCronJob(state: CronState, job: CronJob) {
       state.cronRunsJobId = null;
       clearCronRunsPage(state);
     }
-    await loadCronJobs(state);
+    await loadCronJobsPage(state);
     await loadCronStatus(state);
   });
 }

--- a/ui/src/ui/controllers/logs.ts
+++ b/ui/src/ui/controllers/logs.ts
@@ -132,12 +132,8 @@ export async function loadLogs(state: LogsState, opts?: { reset?: boolean; quiet
     state.logsEntries = shouldReset
       ? entries
       : [...state.logsEntries, ...entries].slice(-LOG_BUFFER_LIMIT);
-    if (typeof payload.cursor === "number") {
-      state.logsCursor = payload.cursor;
-    }
-    if (typeof payload.file === "string") {
-      state.logsFile = payload.file;
-    }
+    state.logsCursor = typeof payload.cursor === "number" ? payload.cursor : state.logsCursor;
+    state.logsFile = typeof payload.file === "string" ? payload.file : state.logsFile;
     state.logsTruncated = Boolean(payload.truncated);
     state.logsLastFetchAt = Date.now();
   } catch (err) {

--- a/ui/src/ui/controllers/logs.ts
+++ b/ui/src/ui/controllers/logs.ts
@@ -67,35 +67,33 @@ export function parseLogLine(line: string): LogEntry {
     const contextCandidate =
       typeof obj["0"] === "string" ? obj["0"] : typeof meta?.name === "string" ? meta?.name : null;
     const contextObj = parseMaybeJsonString(contextCandidate);
-    let subsystem: string | null = null;
-    if (contextObj) {
-      if (typeof contextObj.subsystem === "string") {
-        subsystem = contextObj.subsystem;
-      } else if (typeof contextObj.module === "string") {
-        subsystem = contextObj.module;
-      }
-    }
+    let subsystem =
+      typeof contextObj?.subsystem === "string"
+        ? contextObj.subsystem
+        : typeof contextObj?.module === "string"
+          ? contextObj.module
+          : null;
     if (!subsystem && contextCandidate && contextCandidate.length < 120) {
       subsystem = contextCandidate;
     }
 
-    let message: string | null = null;
-    if (typeof obj["1"] === "string") {
-      message = obj["1"];
-    } else if (typeof obj["2"] === "string") {
-      message = obj["2"];
-    } else if (!contextObj && typeof obj["0"] === "string") {
-      message = obj["0"];
-    } else if (typeof obj.message === "string") {
-      message = obj.message;
-    }
+    const message =
+      typeof obj["1"] === "string"
+        ? obj["1"]
+        : typeof obj["2"] === "string"
+          ? obj["2"]
+          : !contextObj && typeof obj["0"] === "string"
+            ? obj["0"]
+            : typeof obj.message === "string"
+              ? obj.message
+              : line;
 
     return {
       raw: line,
       time,
       level,
       subsystem,
-      message: message ?? line,
+      message,
       meta: meta ?? undefined,
     };
   } catch {

--- a/ui/src/ui/controllers/logs.ts
+++ b/ui/src/ui/controllers/logs.ts
@@ -100,10 +100,7 @@ export function parseLogLine(line: string): LogEntry {
 
 export async function loadLogs(state: LogsState, opts?: { reset?: boolean; quiet?: boolean }) {
   const quiet = opts?.quiet === true;
-  if (!state.client || !state.connected) {
-    return;
-  }
-  if (state.logsLoading && !quiet) {
+  if (!state.client || !state.connected || (state.logsLoading && !quiet)) {
     return;
   }
   if (!quiet) {

--- a/ui/src/ui/controllers/logs.ts
+++ b/ui/src/ui/controllers/logs.ts
@@ -116,7 +116,6 @@ export async function loadLogs(state: LogsState, opts?: { reset?: boolean; quiet
     const payload = res as {
       file?: string;
       cursor?: number;
-      size?: number;
       lines?: unknown;
       truncated?: boolean;
       reset?: boolean;

--- a/ui/src/ui/controllers/logs.ts
+++ b/ui/src/ui/controllers/logs.ts
@@ -33,10 +33,7 @@ function parseMaybeJsonString(value: unknown) {
   }
   try {
     const parsed = JSON.parse(trimmed) as unknown;
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-    return parsed as Record<string, unknown>;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
   } catch {
     return null;
   }
@@ -102,13 +99,14 @@ export function parseLogLine(line: string): LogEntry {
 }
 
 export async function loadLogs(state: LogsState, opts?: { reset?: boolean; quiet?: boolean }) {
+  const quiet = opts?.quiet === true;
   if (!state.client || !state.connected) {
     return;
   }
-  if (state.logsLoading && !opts?.quiet) {
+  if (state.logsLoading && !quiet) {
     return;
   }
-  if (!opts?.quiet) {
+  if (!quiet) {
     state.logsLoading = true;
   }
   state.logsError = null;
@@ -150,7 +148,7 @@ export async function loadLogs(state: LogsState, opts?: { reset?: boolean; quiet
       state.logsError = String(err);
     }
   } finally {
-    if (!opts?.quiet) {
+    if (!quiet) {
       state.logsLoading = false;
     }
   }

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -90,6 +90,48 @@ async function fetchSessionCompactionCheckpoints(state: SessionsState, key: stri
   }
 }
 
+async function withSessionsLoading<T>(
+  state: SessionsState,
+  run: () => Promise<T>,
+): Promise<T | undefined> {
+  if (state.sessionsLoading) {
+    return undefined;
+  }
+  state.sessionsLoading = true;
+  state.sessionsError = null;
+  try {
+    return await run();
+  } finally {
+    state.sessionsLoading = false;
+  }
+}
+
+async function runCompactionMutation<T>(
+  state: SessionsState,
+  key: string,
+  checkpointId: string,
+  method: "sessions.compaction.branch" | "sessions.compaction.restore",
+  confirmMessage: string,
+): Promise<T | null> {
+  if (!state.client || !state.connected || !window.confirm(confirmMessage)) {
+    return null;
+  }
+  const client = state.client;
+  state.sessionsCheckpointBusyKey = checkpointId;
+  try {
+    const result = await client.request<T>(method, { key, checkpointId });
+    await loadSessions(state);
+    return result ?? null;
+  } catch (err) {
+    state.sessionsError = String(err);
+    return null;
+  } finally {
+    if (state.sessionsCheckpointBusyKey === checkpointId) {
+      state.sessionsCheckpointBusyKey = null;
+    }
+  }
+}
+
 export async function subscribeSessions(state: SessionsState) {
   if (!state.client || !state.connected) {
     return;
@@ -113,12 +155,8 @@ export async function loadSessions(
   if (!state.client || !state.connected) {
     return;
   }
-  if (state.sessionsLoading) {
-    return;
-  }
-  state.sessionsLoading = true;
-  state.sessionsError = null;
-  try {
+  const client = state.client;
+  await withSessionsLoading(state, async () => {
     const previousRows = new Map(
       (state.sessionsResult?.sessions ?? []).map((row) => [row.key, row] as const),
     );
@@ -136,7 +174,7 @@ export async function loadSessions(
     if (limit > 0) {
       params.limit = limit;
     }
-    const res = await state.client.request<SessionsListResult | undefined>("sessions.list", params);
+    const res = await client.request<SessionsListResult | undefined>("sessions.list", params);
     if (res) {
       state.sessionsResult = res;
       const nextKeys = new Set(res.sessions.map((row) => row.key));
@@ -164,16 +202,15 @@ export async function loadSessions(
         await fetchSessionCompactionCheckpoints(state, expandedKey);
       }
     }
-  } catch (err) {
-    if (isMissingOperatorReadScopeError(err)) {
-      state.sessionsResult = null;
-      state.sessionsError = formatMissingOperatorReadScopeMessage("sessions");
-    } else {
+    return undefined;
+  }).catch((err: unknown) => {
+    if (!isMissingOperatorReadScopeError(err)) {
       state.sessionsError = String(err);
+      return;
     }
-  } finally {
-    state.sessionsLoading = false;
-  }
+    state.sessionsResult = null;
+    state.sessionsError = formatMissingOperatorReadScopeMessage("sessions");
+  });
 }
 
 export async function patchSession(
@@ -191,20 +228,16 @@ export async function patchSession(
     return;
   }
   const params: Record<string, unknown> = { key };
-  if ("label" in patch) {
-    params.label = patch.label;
-  }
-  if ("thinkingLevel" in patch) {
-    params.thinkingLevel = patch.thinkingLevel;
-  }
-  if ("fastMode" in patch) {
-    params.fastMode = patch.fastMode;
-  }
-  if ("verboseLevel" in patch) {
-    params.verboseLevel = patch.verboseLevel;
-  }
-  if ("reasoningLevel" in patch) {
-    params.reasoningLevel = patch.reasoningLevel;
+  for (const field of [
+    "label",
+    "thinkingLevel",
+    "fastMode",
+    "verboseLevel",
+    "reasoningLevel",
+  ] as const) {
+    if (field in patch) {
+      params[field] = patch[field];
+    }
   }
   try {
     await state.client.request("sessions.patch", params);
@@ -221,32 +254,28 @@ export async function deleteSessionsAndRefresh(
   if (!state.client || !state.connected || keys.length === 0) {
     return [];
   }
+  const client = state.client;
   if (state.sessionsLoading) {
     return [];
   }
-  const noun = keys.length === 1 ? "session" : "sessions";
   const confirmed = window.confirm(
-    `Delete ${keys.length} ${noun}?\n\nThis will delete the session entries and archive their transcripts.`,
+    `Delete ${keys.length} ${keys.length === 1 ? "session" : "sessions"}?\n\nThis will delete the session entries and archive their transcripts.`,
   );
   if (!confirmed) {
     return [];
   }
-  state.sessionsLoading = true;
-  state.sessionsError = null;
   const deleted: string[] = [];
   const deleteErrors: string[] = [];
-  try {
+  await withSessionsLoading(state, async () => {
     for (const key of keys) {
       try {
-        await state.client.request("sessions.delete", { key, deleteTranscript: true });
+        await client.request("sessions.delete", { key, deleteTranscript: true });
         deleted.push(key);
       } catch (err) {
         deleteErrors.push(String(err));
       }
     }
-  } finally {
-    state.sessionsLoading = false;
-  }
+  });
   if (deleted.length > 0) {
     await loadSessions(state);
   }
@@ -277,31 +306,14 @@ export async function branchSessionFromCheckpoint(
   key: string,
   checkpointId: string,
 ): Promise<string | null> {
-  if (!state.client || !state.connected) {
-    return null;
-  }
-  const confirmed = window.confirm(
+  const result = await runCompactionMutation<SessionsCompactionBranchResult>(
+    state,
+    key,
+    checkpointId,
+    "sessions.compaction.branch",
     "Create a new child session from this pre-compaction checkpoint?",
   );
-  if (!confirmed) {
-    return null;
-  }
-  state.sessionsCheckpointBusyKey = checkpointId;
-  try {
-    const result = await state.client.request<SessionsCompactionBranchResult>(
-      "sessions.compaction.branch",
-      { key, checkpointId },
-    );
-    await loadSessions(state);
-    return result?.key ?? null;
-  } catch (err) {
-    state.sessionsError = String(err);
-    return null;
-  } finally {
-    if (state.sessionsCheckpointBusyKey === checkpointId) {
-      state.sessionsCheckpointBusyKey = null;
-    }
-  }
+  return result?.key ?? null;
 }
 
 export async function restoreSessionFromCheckpoint(
@@ -309,27 +321,11 @@ export async function restoreSessionFromCheckpoint(
   key: string,
   checkpointId: string,
 ) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  const confirmed = window.confirm(
+  await runCompactionMutation<SessionsCompactionRestoreResult>(
+    state,
+    key,
+    checkpointId,
+    "sessions.compaction.restore",
     "Restore this session to the selected pre-compaction checkpoint?\n\nThis replaces the current active transcript for the session key.",
   );
-  if (!confirmed) {
-    return;
-  }
-  state.sessionsCheckpointBusyKey = checkpointId;
-  try {
-    await state.client.request<SessionsCompactionRestoreResult>("sessions.compaction.restore", {
-      key,
-      checkpointId,
-    });
-    await loadSessions(state);
-  } catch (err) {
-    state.sessionsError = String(err);
-  } finally {
-    if (state.sessionsCheckpointBusyKey === checkpointId) {
-      state.sessionsCheckpointBusyKey = null;
-    }
-  }
 }

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -90,17 +90,14 @@ async function fetchSessionCompactionCheckpoints(state: SessionsState, key: stri
   }
 }
 
-async function withSessionsLoading<T>(
-  state: SessionsState,
-  run: () => Promise<T>,
-): Promise<T | undefined> {
+async function withSessionsLoading(state: SessionsState, run: () => Promise<void>) {
   if (state.sessionsLoading) {
-    return undefined;
+    return;
   }
   state.sessionsLoading = true;
   state.sessionsError = null;
   try {
-    return await run();
+    await run();
   } finally {
     state.sessionsLoading = false;
   }
@@ -121,7 +118,7 @@ async function runCompactionMutation<T>(
   try {
     const result = await client.request<T>(method, { key, checkpointId });
     await loadSessions(state);
-    return result ?? null;
+    return result;
   } catch (err) {
     state.sessionsError = String(err);
     return null;
@@ -202,7 +199,6 @@ export async function loadSessions(
         await fetchSessionCompactionCheckpoints(state, expandedKey);
       }
     }
-    return undefined;
   }).catch((err: unknown) => {
     if (!isMissingOperatorReadScopeError(err)) {
       state.sessionsError = String(err);

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -29,21 +29,17 @@ export type SessionsState = {
   sessionsCheckpointErrorByKey: Record<string, string>;
 };
 
-function checkpointSignature(
+function checkpointSummarySignature(
   row:
     | {
-        key: string;
         compactionCheckpointCount?: number;
         latestCompactionCheckpoint?: { checkpointId?: string; createdAt?: number } | null;
       }
     | undefined,
 ): string {
-  return JSON.stringify({
-    key: row?.key ?? "",
-    count: row?.compactionCheckpointCount ?? 0,
-    latestCheckpointId: row?.latestCompactionCheckpoint?.checkpointId ?? "",
-    latestCreatedAt: row?.latestCompactionCheckpoint?.createdAt ?? 0,
-  });
+  return `${row?.compactionCheckpointCount ?? 0}:${
+    row?.latestCompactionCheckpoint?.checkpointId ?? ""
+  }:${row?.latestCompactionCheckpoint?.createdAt ?? 0}`;
 }
 
 function invalidateCheckpointCacheForKey(state: SessionsState, key: string) {
@@ -183,7 +179,7 @@ export async function loadSessions(
       let expandedNeedsRefetch = false;
       for (const row of res.sessions) {
         const previous = previousRows.get(row.key);
-        if (checkpointSignature(previous) !== checkpointSignature(row)) {
+        if (checkpointSummarySignature(previous) !== checkpointSummarySignature(row)) {
           invalidateCheckpointCacheForKey(state, row.key);
           if (state.sessionsExpandedCheckpointKey === row.key) {
             expandedNeedsRefetch = true;

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   installSkill,
+  loadClawHubDetail,
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
@@ -112,6 +113,63 @@ describe("searchClawHub", () => {
     expect(state.clawhubSearchResults).toBeNull();
     expect(state.clawhubSearchError).toBeNull();
     expect(state.clawhubSearchLoading).toBe(false);
+  });
+
+  it("ignores stale search responses after query changes", async () => {
+    const { state, request } = createState();
+    const resolvers: Array<(value: unknown) => void> = [];
+    request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const pending = searchClawHub(state, "github");
+    setClawHubSearchQuery(state, "gitlab");
+    resolvers.shift()?.({
+      results: [{ score: 1, slug: "github", displayName: "GitHub" }],
+    });
+    await pending;
+
+    expect(state.clawhubSearchQuery).toBe("gitlab");
+    expect(state.clawhubSearchResults).toBeNull();
+    expect(state.clawhubSearchError).toBeNull();
+    expect(state.clawhubSearchLoading).toBe(false);
+  });
+});
+
+describe("loadClawHubDetail", () => {
+  it("ignores stale detail responses after slug changes", async () => {
+    const { state, request } = createState();
+    const resolvers: Array<(value: unknown) => void> = [];
+    request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const firstPending = loadClawHubDetail(state, "github");
+    const secondPending = loadClawHubDetail(state, "gitlab");
+
+    resolvers.shift()?.({
+      skill: { slug: "github", displayName: "GitHub", createdAt: 1, updatedAt: 2 },
+    });
+    await firstPending;
+
+    expect(state.clawhubDetailSlug).toBe("gitlab");
+    expect(state.clawhubDetail).toBeNull();
+    expect(state.clawhubDetailError).toBeNull();
+    expect(state.clawhubDetailLoading).toBe(true);
+
+    resolvers.shift()?.({
+      skill: { slug: "gitlab", displayName: "GitLab", createdAt: 3, updatedAt: 4 },
+    });
+    await secondPending;
+
+    expect(state.clawhubDetailLoading).toBe(false);
+    expect(state.clawhubDetail?.skill?.slug).toBe("gitlab");
   });
 });
 

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   installSkill,
+  loadClawHubDetail,
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
@@ -153,6 +154,29 @@ describe("searchClawHub", () => {
     expect(state.clawhubSearchResults).toBeNull();
     expect(state.clawhubSearchError).toBeNull();
     expect(state.clawhubSearchLoading).toBe(false);
+  });
+});
+
+describe("loadClawHubDetail", () => {
+  it("ignores stale detail responses after slug changes", async () => {
+    const { state, request } = createState();
+    const queue = createDeferredRequestQueue(request);
+
+    const firstPending = loadClawHubDetail(state, "github");
+    const secondPending = loadClawHubDetail(state, "gitlab");
+
+    queue.resolveNext({
+      skill: { slug: "github", displayName: "GitHub", createdAt: 1, updatedAt: 2 },
+    });
+    await firstPending;
+
+    queue.resolveNext({
+      skill: { slug: "gitlab", displayName: "GitLab", createdAt: 3, updatedAt: 4 },
+    });
+    await secondPending;
+
+    expect(state.clawhubDetailLoading).toBe(false);
+    expect(state.clawhubDetail?.skill?.slug).toBe("gitlab");
   });
 });
 

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { searchClawHub, setClawHubSearchQuery, type SkillsState } from "./skills.ts";
+import {
+  installSkill,
+  saveSkillApiKey,
+  searchClawHub,
+  setClawHubSearchQuery,
+  updateSkillEnabled,
+  type SkillsState,
+} from "./skills.ts";
 
 function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn> } {
   const request = vi.fn();
@@ -105,5 +112,88 @@ describe("searchClawHub", () => {
     expect(state.clawhubSearchResults).toBeNull();
     expect(state.clawhubSearchError).toBeNull();
     expect(state.clawhubSearchLoading).toBe(false);
+  });
+});
+
+describe("skill mutations", () => {
+  it("updates skill enablement and records a success message", async () => {
+    const { state, request } = createState();
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.status") {
+        return {};
+      }
+      return {};
+    });
+
+    await updateSkillEnabled(state, "github", true);
+
+    expect(request).toHaveBeenCalledWith("skills.update", { skillKey: "github", enabled: true });
+    expect(state.skillMessages.github).toEqual({ kind: "success", message: "Skill enabled" });
+    expect(state.skillsBusyKey).toBeNull();
+    expect(state.skillsError).toBeNull();
+  });
+
+  it("saves API keys and reports success", async () => {
+    const { state, request } = createState();
+    state.skillEdits.github = "sk-test";
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.status") {
+        return {};
+      }
+      return {};
+    });
+
+    await saveSkillApiKey(state, "github");
+
+    expect(request).toHaveBeenCalledWith("skills.update", {
+      skillKey: "github",
+      apiKey: "sk-test",
+    });
+    expect(state.skillMessages.github).toEqual({
+      kind: "success",
+      message: "API key saved — stored in openclaw.json (skills.entries.github)",
+    });
+    expect(state.skillsBusyKey).toBeNull();
+  });
+
+  it("installs skills and uses server success messages", async () => {
+    const { state, request } = createState();
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.install") {
+        return { message: "Installed from registry" };
+      }
+      if (method === "skills.status") {
+        return {};
+      }
+      return {};
+    });
+
+    await installSkill(state, "github", "GitHub", "install-123", true);
+
+    expect(request).toHaveBeenCalledWith("skills.install", {
+      name: "GitHub",
+      installId: "install-123",
+      dangerouslyForceUnsafeInstall: true,
+      timeoutMs: 120000,
+    });
+    expect(state.skillMessages.github).toEqual({
+      kind: "success",
+      message: "Installed from registry",
+    });
+    expect(state.skillsBusyKey).toBeNull();
+  });
+
+  it("records errors from failed mutations", async () => {
+    const { state, request } = createState();
+    request.mockRejectedValue(new Error("skills update failed"));
+
+    await updateSkillEnabled(state, "github", false);
+
+    expect(state.skillsError).toBe("skills update failed");
+    expect(state.skillMessages.github).toEqual({
+      kind: "error",
+      message: "skills update failed",
+    });
+    expect(state.skillsBusyKey).toBeNull();
   });
 });

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   installSkill,
-  loadClawHubDetail,
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
@@ -42,6 +41,30 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn> 
     clawhubInstallMessage: null,
   };
   return { state, request };
+}
+
+function createDeferredRequestQueue(request: ReturnType<typeof vi.fn>) {
+  const resolvers: Array<(value: unknown) => void> = [];
+  request.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolvers.push(resolve);
+      }),
+  );
+  return {
+    resolveNext(value: unknown) {
+      resolvers.shift()?.(value);
+    },
+  };
+}
+
+function mockSkillMutationRequests(request: ReturnType<typeof vi.fn>, installMessage?: string) {
+  request.mockImplementation(async (method: string) => {
+    if (method === "skills.install" && installMessage) {
+      return { message: installMessage };
+    }
+    return {};
+  });
 }
 
 describe("searchClawHub", () => {
@@ -117,17 +140,11 @@ describe("searchClawHub", () => {
 
   it("ignores stale search responses after query changes", async () => {
     const { state, request } = createState();
-    const resolvers: Array<(value: unknown) => void> = [];
-    request.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolvers.push(resolve);
-        }),
-    );
+    const queue = createDeferredRequestQueue(request);
 
     const pending = searchClawHub(state, "github");
     setClawHubSearchQuery(state, "gitlab");
-    resolvers.shift()?.({
+    queue.resolveNext({
       results: [{ score: 1, slug: "github", displayName: "GitHub" }],
     });
     await pending;
@@ -139,106 +156,49 @@ describe("searchClawHub", () => {
   });
 });
 
-describe("loadClawHubDetail", () => {
-  it("ignores stale detail responses after slug changes", async () => {
-    const { state, request } = createState();
-    const resolvers: Array<(value: unknown) => void> = [];
-    request.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolvers.push(resolve);
-        }),
-    );
-
-    const firstPending = loadClawHubDetail(state, "github");
-    const secondPending = loadClawHubDetail(state, "gitlab");
-
-    resolvers.shift()?.({
-      skill: { slug: "github", displayName: "GitHub", createdAt: 1, updatedAt: 2 },
-    });
-    await firstPending;
-
-    expect(state.clawhubDetailSlug).toBe("gitlab");
-    expect(state.clawhubDetail).toBeNull();
-    expect(state.clawhubDetailError).toBeNull();
-    expect(state.clawhubDetailLoading).toBe(true);
-
-    resolvers.shift()?.({
-      skill: { slug: "gitlab", displayName: "GitLab", createdAt: 3, updatedAt: 4 },
-    });
-    await secondPending;
-
-    expect(state.clawhubDetailLoading).toBe(false);
-    expect(state.clawhubDetail?.skill?.slug).toBe("gitlab");
-  });
-});
-
 describe("skill mutations", () => {
-  it("updates skill enablement and records a success message", async () => {
+  it.each([
+    {
+      name: "updates skill enablement and records a success message",
+      run: (state: SkillsState) => updateSkillEnabled(state, "github", true),
+      expectedRequest: ["skills.update", { skillKey: "github", enabled: true }],
+      expectedMessage: "Skill enabled",
+    },
+    {
+      name: "saves API keys and reports success",
+      run: async (state: SkillsState) => {
+        state.skillEdits.github = "sk-test";
+        await saveSkillApiKey(state, "github");
+      },
+      expectedRequest: ["skills.update", { skillKey: "github", apiKey: "sk-test" }],
+      expectedMessage: "API key saved — stored in openclaw.json (skills.entries.github)",
+    },
+    {
+      name: "installs skills and uses server success messages",
+      run: (state: SkillsState) => installSkill(state, "github", "GitHub", "install-123", true),
+      expectedRequest: [
+        "skills.install",
+        {
+          name: "GitHub",
+          installId: "install-123",
+          dangerouslyForceUnsafeInstall: true,
+          timeoutMs: 120000,
+        },
+      ],
+      expectedMessage: "Installed from registry",
+      installMessage: "Installed from registry",
+    },
+  ])("$name", async ({ run, expectedRequest, expectedMessage, installMessage }) => {
     const { state, request } = createState();
-    request.mockImplementation(async (method: string) => {
-      if (method === "skills.status") {
-        return {};
-      }
-      return {};
-    });
+    mockSkillMutationRequests(request, installMessage);
 
-    await updateSkillEnabled(state, "github", true);
+    await run(state);
 
-    expect(request).toHaveBeenCalledWith("skills.update", { skillKey: "github", enabled: true });
-    expect(state.skillMessages.github).toEqual({ kind: "success", message: "Skill enabled" });
+    const [method, params] = expectedRequest;
+    expect(request).toHaveBeenCalledWith(method, params);
+    expect(state.skillMessages.github).toEqual({ kind: "success", message: expectedMessage });
     expect(state.skillsBusyKey).toBeNull();
     expect(state.skillsError).toBeNull();
-  });
-
-  it("saves API keys and reports success", async () => {
-    const { state, request } = createState();
-    state.skillEdits.github = "sk-test";
-    request.mockImplementation(async (method: string) => {
-      if (method === "skills.status") {
-        return {};
-      }
-      return {};
-    });
-
-    await saveSkillApiKey(state, "github");
-
-    expect(request).toHaveBeenCalledWith("skills.update", {
-      skillKey: "github",
-      apiKey: "sk-test",
-    });
-    expect(state.skillMessages.github).toEqual({
-      kind: "success",
-      message: "API key saved — stored in openclaw.json (skills.entries.github)",
-    });
-    expect(state.skillsBusyKey).toBeNull();
-  });
-
-  it("installs skills and uses server success messages", async () => {
-    const { state, request } = createState();
-    request.mockImplementation(async (method: string) => {
-      if (method === "skills.install") {
-        return { message: "Installed from registry" };
-      }
-      if (method === "skills.status") {
-        return {};
-      }
-      return {};
-    });
-
-    await installSkill(state, "github", "GitHub", "install-123", true);
-
-    expect(request).toHaveBeenCalledWith("skills.install", {
-      name: "GitHub",
-      installId: "install-123",
-      dangerouslyForceUnsafeInstall: true,
-      timeoutMs: 120000,
-    });
-    expect(state.skillMessages.github).toEqual({
-      kind: "success",
-      message: "Installed from registry",
-    });
-    expect(state.skillsBusyKey).toBeNull();
   });
 
   it("records errors from failed mutations", async () => {

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -123,19 +123,21 @@ export function updateSkillEdit(state: SkillsState, skillKey: string, value: str
   state.skillEdits = { ...state.skillEdits, [skillKey]: value };
 }
 
-export async function updateSkillEnabled(state: SkillsState, skillKey: string, enabled: boolean) {
-  if (!state.client || !state.connected) {
+async function runSkillMutation(
+  state: SkillsState,
+  skillKey: string,
+  run: (client: GatewayBrowserClient) => Promise<SkillMessage>,
+) {
+  const client = state.client;
+  if (!client || !state.connected) {
     return;
   }
   state.skillsBusyKey = skillKey;
   state.skillsError = null;
   try {
-    await state.client.request("skills.update", { skillKey, enabled });
+    const message = await run(client);
     await loadSkills(state);
-    setSkillMessage(state, skillKey, {
-      kind: "success",
-      message: enabled ? "Skill enabled" : "Skill disabled",
-    });
+    setSkillMessage(state, skillKey, message);
   } catch (err) {
     const message = getErrorMessage(err);
     state.skillsError = message;
@@ -148,30 +150,25 @@ export async function updateSkillEnabled(state: SkillsState, skillKey: string, e
   }
 }
 
+export async function updateSkillEnabled(state: SkillsState, skillKey: string, enabled: boolean) {
+  await runSkillMutation(state, skillKey, async (client) => {
+    await client.request("skills.update", { skillKey, enabled });
+    return {
+      kind: "success",
+      message: enabled ? "Skill enabled" : "Skill disabled",
+    };
+  });
+}
+
 export async function saveSkillApiKey(state: SkillsState, skillKey: string) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  state.skillsBusyKey = skillKey;
-  state.skillsError = null;
-  try {
+  await runSkillMutation(state, skillKey, async (client) => {
     const apiKey = state.skillEdits[skillKey] ?? "";
-    await state.client.request("skills.update", { skillKey, apiKey });
-    await loadSkills(state);
-    setSkillMessage(state, skillKey, {
+    await client.request("skills.update", { skillKey, apiKey });
+    return {
       kind: "success",
       message: `API key saved — stored in openclaw.json (skills.entries.${skillKey})`,
-    });
-  } catch (err) {
-    const message = getErrorMessage(err);
-    state.skillsError = message;
-    setSkillMessage(state, skillKey, {
-      kind: "error",
-      message,
-    });
-  } finally {
-    state.skillsBusyKey = null;
-  }
+    };
+  });
 }
 
 export async function installSkill(
@@ -181,33 +178,18 @@ export async function installSkill(
   installId: string,
   dangerouslyForceUnsafeInstall = false,
 ) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  state.skillsBusyKey = skillKey;
-  state.skillsError = null;
-  try {
-    const result = await state.client.request<{ message?: string }>("skills.install", {
+  await runSkillMutation(state, skillKey, async (client) => {
+    const result = await client.request<{ message?: string }>("skills.install", {
       name,
       installId,
       dangerouslyForceUnsafeInstall,
       timeoutMs: 120000,
     });
-    await loadSkills(state);
-    setSkillMessage(state, skillKey, {
+    return {
       kind: "success",
       message: result?.message ?? "Installed",
-    });
-  } catch (err) {
-    const message = getErrorMessage(err);
-    state.skillsError = message;
-    setSkillMessage(state, skillKey, {
-      kind: "error",
-      message,
-    });
-  } finally {
-    state.skillsBusyKey = null;
-  }
+    };
+  });
 }
 
 export async function searchClawHub(state: SkillsState, query: string) {

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -87,6 +87,31 @@ function getErrorMessage(err: unknown) {
   return String(err);
 }
 
+async function runStaleAwareRequest<T>(
+  isCurrent: () => boolean,
+  request: () => Promise<T>,
+  onSuccess: (value: T) => void,
+  onError: (err: unknown) => void,
+  onFinally: () => void,
+) {
+  try {
+    const result = await request();
+    if (!isCurrent()) {
+      return;
+    }
+    onSuccess(result);
+  } catch (err) {
+    if (!isCurrent()) {
+      return;
+    }
+    onError(err);
+  } finally {
+    if (isCurrent()) {
+      onFinally();
+    }
+  }
+}
+
 export function setClawHubSearchQuery(state: SkillsState, query: string) {
   state.clawhubSearchQuery = query;
   state.clawhubInstallMessage = null;
@@ -202,56 +227,53 @@ export async function searchClawHub(state: SkillsState, query: string) {
     state.clawhubSearchLoading = false;
     return;
   }
+  const client = state.client;
   // Clear stale entries as soon as a new search begins so the UI cannot act on
   // results that no longer match the current query while the next request is in flight.
   state.clawhubSearchResults = null;
   state.clawhubSearchLoading = true;
   state.clawhubSearchError = null;
-  try {
-    const res = await state.client.request<{ results: ClawHubSearchResult[] }>("skills.search", {
-      query,
-      limit: 20,
-    });
-    if (query !== state.clawhubSearchQuery) {
-      return;
-    }
-    state.clawhubSearchResults = res?.results ?? [];
-  } catch (err) {
-    if (query !== state.clawhubSearchQuery) {
-      return;
-    }
-    state.clawhubSearchError = getErrorMessage(err);
-  } finally {
-    if (query === state.clawhubSearchQuery) {
+  await runStaleAwareRequest(
+    () => query === state.clawhubSearchQuery,
+    () =>
+      client.request<{ results: ClawHubSearchResult[] }>("skills.search", {
+        query,
+        limit: 20,
+      }),
+    (res) => {
+      state.clawhubSearchResults = res?.results ?? [];
+    },
+    (err) => {
+      state.clawhubSearchError = getErrorMessage(err);
+    },
+    () => {
       state.clawhubSearchLoading = false;
-    }
-  }
+    },
+  );
 }
 
 export async function loadClawHubDetail(state: SkillsState, slug: string) {
   if (!state.client || !state.connected) {
     return;
   }
+  const client = state.client;
   state.clawhubDetailSlug = slug;
   state.clawhubDetailLoading = true;
   state.clawhubDetailError = null;
   state.clawhubDetail = null;
-  try {
-    const res = await state.client.request<ClawHubSkillDetail>("skills.detail", { slug });
-    if (slug !== state.clawhubDetailSlug) {
-      return;
-    }
-    state.clawhubDetail = res ?? null;
-  } catch (err) {
-    if (slug !== state.clawhubDetailSlug) {
-      return;
-    }
-    state.clawhubDetailError = getErrorMessage(err);
-  } finally {
-    if (slug === state.clawhubDetailSlug) {
+  await runStaleAwareRequest(
+    () => slug === state.clawhubDetailSlug,
+    () => client.request<ClawHubSkillDetail>("skills.detail", { slug }),
+    (res) => {
+      state.clawhubDetail = res ?? null;
+    },
+    (err) => {
+      state.clawhubDetailError = getErrorMessage(err);
+    },
+    () => {
       state.clawhubDetailLoading = false;
-    }
-  }
+    },
+  );
 }
 
 export function closeClawHubDetail(state: SkillsState) {

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -84,21 +84,21 @@ async function runStaleAwareRequest<T>(
   onError: (err: unknown) => void,
   onFinally: () => void,
 ) {
+  let current = false;
   try {
     const result = await request();
-    if (!isCurrent()) {
-      return;
+    current = isCurrent();
+    if (current) {
+      onSuccess(result);
     }
-    onSuccess(result);
   } catch (err) {
-    if (!isCurrent()) {
-      return;
+    current = isCurrent();
+    if (current) {
+      onError(err);
     }
-    onError(err);
-  } finally {
-    if (isCurrent()) {
-      onFinally();
-    }
+  }
+  if (current) {
+    onFinally();
   }
 }
 

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -70,12 +70,7 @@ function setSkillMessage(state: SkillsState, key: string, message: SkillMessage)
   state.skillMessages = { ...state.skillMessages, [key]: message };
 }
 
-function getErrorMessage(err: unknown) {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
-}
+const getErrorMessage = (err: unknown) => (err instanceof Error ? err.message : String(err));
 
 async function runStaleAwareRequest<T>(
   isCurrent: () => boolean,
@@ -84,22 +79,19 @@ async function runStaleAwareRequest<T>(
   onError: (err: unknown) => void,
   onFinally: () => void,
 ) {
-  let current = false;
   try {
     const result = await request();
-    current = isCurrent();
-    if (current) {
-      onSuccess(result);
+    if (!isCurrent()) {
+      return;
     }
+    onSuccess(result);
   } catch (err) {
-    current = isCurrent();
-    if (current) {
-      onError(err);
+    if (!isCurrent()) {
+      return;
     }
+    onError(err);
   }
-  if (current) {
-    onFinally();
-  }
+  onFinally();
 }
 
 export function setClawHubSearchQuery(state: SkillsState, query: string) {

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -63,21 +63,11 @@ export type SkillMessage = {
 
 export type SkillMessageMap = Record<string, SkillMessage>;
 
-type LoadSkillsOptions = {
-  clearMessages?: boolean;
-};
-
-function setSkillMessage(state: SkillsState, key: string, message?: SkillMessage) {
+function setSkillMessage(state: SkillsState, key: string, message: SkillMessage) {
   if (!key.trim()) {
     return;
   }
-  const next = { ...state.skillMessages };
-  if (message) {
-    next[key] = message;
-  } else {
-    delete next[key];
-  }
-  state.skillMessages = next;
+  state.skillMessages = { ...state.skillMessages, [key]: message };
 }
 
 function getErrorMessage(err: unknown) {
@@ -120,14 +110,11 @@ export function setClawHubSearchQuery(state: SkillsState, query: string) {
   state.clawhubSearchLoading = false;
 }
 
-export async function loadSkills(state: SkillsState, options?: LoadSkillsOptions) {
+export async function loadSkills(state: SkillsState, options?: { clearMessages?: boolean }) {
   if (options?.clearMessages && Object.keys(state.skillMessages).length > 0) {
     state.skillMessages = {};
   }
-  if (!state.client || !state.connected) {
-    return;
-  }
-  if (state.skillsLoading) {
+  if (!state.client || !state.connected || state.skillsLoading) {
     return;
   }
   state.skillsLoading = true;

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -166,17 +166,6 @@ describe("usage controller date interpretation params", () => {
 
     vi.unstubAllGlobals();
   });
-});
-
-describe("usage session detail loaders", () => {
-  beforeEach(() => {
-    __test.resetLegacyUsageDateParamsCache();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("keeps optional loaders resilient when requests fail", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.usage.timeseries" || method === "sessions.usage.logs") {

--- a/ui/src/ui/controllers/usage.node.test.ts
+++ b/ui/src/ui/controllers/usage.node.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __test, loadUsage, type UsageState } from "./usage.ts";
+import {
+  __test,
+  loadSessionLogs,
+  loadSessionTimeSeries,
+  loadUsage,
+  type UsageState,
+} from "./usage.ts";
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 
@@ -159,6 +165,49 @@ describe("usage controller date interpretation params", () => {
     expect(__test.shouldSendLegacyDateInterpretation(state)).toBe(false);
 
     vi.unstubAllGlobals();
+  });
+});
+
+describe("usage session detail loaders", () => {
+  beforeEach(() => {
+    __test.resetLegacyUsageDateParamsCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps optional loaders resilient when requests fail", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.usage.timeseries" || method === "sessions.usage.logs") {
+        throw new Error("optional endpoint unavailable");
+      }
+      return {};
+    });
+    const state = createState(request);
+
+    await loadSessionTimeSeries(state, "session-1");
+    await loadSessionLogs(state, "session-1");
+
+    expect(state.usageTimeSeries).toBeNull();
+    expect(state.usageSessionLogs).toBeNull();
+    expect(state.usageTimeSeriesLoading).toBe(false);
+    expect(state.usageSessionLogsLoading).toBe(false);
+  });
+
+  it("normalizes usage logs payloads when logs is not an array", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.usage.logs") {
+        return { logs: "unexpected-shape" };
+      }
+      return {};
+    });
+    const state = createState(request);
+
+    await loadSessionLogs(state, "session-1");
+
+    expect(state.usageSessionLogs).toBeNull();
+    expect(state.usageSessionLogsLoading).toBe(false);
   });
 });
 

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -30,7 +30,6 @@ export type UsageState = {
 };
 
 const LEGACY_USAGE_DATE_PARAMS_STORAGE_KEY = "openclaw.control.usage.date-params.v1";
-const LEGACY_USAGE_DATE_PARAMS_DEFAULT_GATEWAY_KEY = "__default__";
 const LEGACY_USAGE_DATE_PARAMS_MODE_RE = /unexpected property ['"]mode['"]/i;
 const LEGACY_USAGE_DATE_PARAMS_OFFSET_RE = /unexpected property ['"]utcoffset['"]/i;
 const LEGACY_USAGE_DATE_PARAMS_INVALID_RE = /invalid sessions\.usage params/i;
@@ -38,21 +37,18 @@ const LEGACY_USAGE_DATE_PARAMS_INVALID_RE = /invalid sessions\.usage params/i;
 let legacyUsageDateParamsCache: Set<string> | null = null;
 
 function loadLegacyUsageDateParamsCache(): Set<string> {
-  const storage = getSafeLocalStorage();
-  if (!storage) {
+  const raw = getSafeLocalStorage()?.getItem(LEGACY_USAGE_DATE_PARAMS_STORAGE_KEY);
+  if (!raw) {
     return new Set<string>();
   }
   try {
-    const raw = storage.getItem(LEGACY_USAGE_DATE_PARAMS_STORAGE_KEY);
-    if (!raw) {
-      return new Set<string>();
-    }
-    const parsed = JSON.parse(raw) as { unsupportedGatewayKeys?: unknown } | null;
-    if (!parsed || !Array.isArray(parsed.unsupportedGatewayKeys)) {
+    const keys = (JSON.parse(raw) as { unsupportedGatewayKeys?: unknown } | null)
+      ?.unsupportedGatewayKeys;
+    if (!Array.isArray(keys)) {
       return new Set<string>();
     }
     return new Set(
-      parsed.unsupportedGatewayKeys
+      keys
         .filter((entry): entry is string => typeof entry === "string")
         .map((entry) => entry.trim())
         .filter(Boolean),
@@ -63,12 +59,8 @@ function loadLegacyUsageDateParamsCache(): Set<string> {
 }
 
 function persistLegacyUsageDateParamsCache(cache: Set<string>) {
-  const storage = getSafeLocalStorage();
-  if (!storage) {
-    return;
-  }
   try {
-    storage.setItem(
+    getSafeLocalStorage()?.setItem(
       LEGACY_USAGE_DATE_PARAMS_STORAGE_KEY,
       JSON.stringify({ unsupportedGatewayKeys: Array.from(cache) }),
     );
@@ -87,7 +79,7 @@ function getLegacyUsageDateParamsCache(): Set<string> {
 function normalizeGatewayCompatibilityKey(gatewayUrl?: string): string {
   const trimmed = gatewayUrl?.trim();
   if (!trimmed) {
-    return LEGACY_USAGE_DATE_PARAMS_DEFAULT_GATEWAY_KEY;
+    return "__default__";
   }
   try {
     const parsed = new URL(trimmed);

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -44,12 +44,8 @@ const LEGACY_USAGE_DATE_PARAMS_INVALID_RE = /invalid sessions\.usage params/i;
 
 let legacyUsageDateParamsCache: Set<string> | null = null;
 
-function getLocalStorage(): Storage | null {
-  return getSafeLocalStorage();
-}
-
 function loadLegacyUsageDateParamsCache(): Set<string> {
-  const storage = getLocalStorage();
+  const storage = getSafeLocalStorage();
   if (!storage) {
     return new Set<string>();
   }
@@ -74,7 +70,7 @@ function loadLegacyUsageDateParamsCache(): Set<string> {
 }
 
 function persistLegacyUsageDateParamsCache(cache: Set<string>) {
-  const storage = getLocalStorage();
+  const storage = getSafeLocalStorage();
   if (!storage) {
     return;
   }

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -29,10 +29,8 @@ export type UsageState = {
   settings?: { gatewayUrl?: string };
 };
 
-type DateInterpretationMode = "utc" | "gateway" | "specific";
-
 type UsageDateInterpretationParams = {
-  mode: DateInterpretationMode;
+  mode: "utc" | "specific";
   utcOffset?: string;
 };
 
@@ -105,17 +103,15 @@ function normalizeGatewayCompatibilityKey(gatewayUrl?: string): string {
   }
 }
 
-function resolveGatewayCompatibilityKey(state: UsageState): string {
-  return normalizeGatewayCompatibilityKey(state.settings?.gatewayUrl);
-}
-
 function shouldSendLegacyDateInterpretation(state: UsageState): boolean {
-  return !getLegacyUsageDateParamsCache().has(resolveGatewayCompatibilityKey(state));
+  return !getLegacyUsageDateParamsCache().has(
+    normalizeGatewayCompatibilityKey(state.settings?.gatewayUrl),
+  );
 }
 
 function rememberLegacyDateInterpretation(state: UsageState) {
   const cache = getLegacyUsageDateParamsCache();
-  cache.add(resolveGatewayCompatibilityKey(state));
+  cache.add(normalizeGatewayCompatibilityKey(state.settings?.gatewayUrl));
   persistLegacyUsageDateParamsCache(cache);
 }
 
@@ -143,11 +139,7 @@ const formatUtcOffset = (timezoneOffsetMinutes: number): string => {
 
 const buildDateInterpretationParams = (
   timeZone: "local" | "utc",
-  includeDateInterpretation: boolean,
-): UsageDateInterpretationParams | undefined => {
-  if (!includeDateInterpretation) {
-    return undefined;
-  }
+): UsageDateInterpretationParams => {
   if (timeZone === "utc") {
     return { mode: "utc" };
   }
@@ -174,6 +166,15 @@ function toErrorMessage(err: unknown): string {
   return "request failed";
 }
 
+function applyUsageResults(state: UsageState, sessionsRes: unknown, costRes: unknown) {
+  if (sessionsRes) {
+    state.usageResult = sessionsRes as SessionsUsageResult;
+  }
+  if (costRes) {
+    state.usageCostSummary = costRes as CostUsageSummary;
+  }
+}
+
 export async function loadUsage(
   state: UsageState,
   overrides?: {
@@ -192,10 +193,9 @@ export async function loadUsage(
     const startDate = overrides?.startDate ?? state.usageStartDate;
     const endDate = overrides?.endDate ?? state.usageEndDate;
     const runUsageRequests = (includeDateInterpretation: boolean) => {
-      const dateInterpretation = buildDateInterpretationParams(
-        state.usageTimeZone,
-        includeDateInterpretation,
-      );
+      const dateInterpretation = includeDateInterpretation
+        ? buildDateInterpretationParams(state.usageTimeZone)
+        : undefined;
       return Promise.all([
         client.request("sessions.usage", {
           startDate,
@@ -212,26 +212,17 @@ export async function loadUsage(
       ]);
     };
 
-    const applyUsageResults = (sessionsRes: unknown, costRes: unknown) => {
-      if (sessionsRes) {
-        state.usageResult = sessionsRes as SessionsUsageResult;
-      }
-      if (costRes) {
-        state.usageCostSummary = costRes as CostUsageSummary;
-      }
-    };
-
     const includeDateInterpretation = shouldSendLegacyDateInterpretation(state);
     try {
       const [sessionsRes, costRes] = await runUsageRequests(includeDateInterpretation);
-      applyUsageResults(sessionsRes, costRes);
+      applyUsageResults(state, sessionsRes, costRes);
     } catch (err) {
       if (includeDateInterpretation && isLegacyDateInterpretationUnsupportedError(err)) {
         // Older gateways reject `mode`/`utcOffset` in `sessions.usage`.
         // Remember this per gateway and retry once without those fields.
         rememberLegacyDateInterpretation(state);
         const [sessionsRes, costRes] = await runUsageRequests(false);
-        applyUsageResults(sessionsRes, costRes);
+        applyUsageResults(state, sessionsRes, costRes);
       } else {
         throw err;
       }

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -270,10 +270,7 @@ export const __test = {
 };
 
 export async function loadSessionTimeSeries(state: UsageState, sessionKey: string) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  if (state.usageTimeSeriesLoading) {
+  if (!state.client || !state.connected || state.usageTimeSeriesLoading) {
     return;
   }
   state.usageTimeSeriesLoading = true;
@@ -292,10 +289,7 @@ export async function loadSessionTimeSeries(state: UsageState, sessionKey: strin
 }
 
 export async function loadSessionLogs(state: UsageState, sessionKey: string) {
-  if (!state.client || !state.connected) {
-    return;
-  }
-  if (state.usageSessionLogsLoading) {
+  if (!state.client || !state.connected || state.usageSessionLogsLoading) {
     return;
   }
   state.usageSessionLogsLoading = true;

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -187,10 +187,7 @@ export async function loadUsage(
 ) {
   // Capture client for TS18047 work around on it being possibly null
   const client = state.client;
-  if (!client || !state.connected) {
-    return;
-  }
-  if (state.usageLoading) {
+  if (!client || !state.connected || state.usageLoading) {
     return;
   }
   state.usageLoading = true;

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -274,9 +274,7 @@ export async function loadSessionTimeSeries(state: UsageState, sessionKey: strin
   state.usageTimeSeries = null;
   try {
     const res = await state.client.request("sessions.usage.timeseries", { key: sessionKey });
-    if (res) {
-      state.usageTimeSeries = res as SessionUsageTimeSeries;
-    }
+    state.usageTimeSeries = res ? (res as SessionUsageTimeSeries) : null;
   } catch {
     // Silently fail - time series is optional.
   } finally {
@@ -291,14 +289,12 @@ export async function loadSessionLogs(state: UsageState, sessionKey: string) {
   state.usageSessionLogsLoading = true;
   state.usageSessionLogs = null;
   try {
-    const res = await state.client.request("sessions.usage.logs", {
+    const payload = (await state.client.request("sessions.usage.logs", {
       key: sessionKey,
       limit: 1000,
-    });
-    const logs = (res as { logs?: unknown } | null)?.logs;
-    if (Array.isArray(logs)) {
-      state.usageSessionLogs = logs as SessionLogEntry[];
-    }
+    })) as { logs?: unknown } | null;
+    const logs = payload?.logs;
+    state.usageSessionLogs = Array.isArray(logs) ? (logs as SessionLogEntry[]) : null;
   } catch {
     // Silently fail - logs are optional.
   } finally {

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -278,8 +278,7 @@ export async function loadSessionTimeSeries(state: UsageState, sessionKey: strin
       state.usageTimeSeries = res as SessionUsageTimeSeries;
     }
   } catch {
-    // Silently fail - time series is optional
-    state.usageTimeSeries = null;
+    // Silently fail - time series is optional.
   } finally {
     state.usageTimeSeriesLoading = false;
   }
@@ -296,12 +295,12 @@ export async function loadSessionLogs(state: UsageState, sessionKey: string) {
       key: sessionKey,
       limit: 1000,
     });
-    if (res && Array.isArray((res as { logs: SessionLogEntry[] }).logs)) {
-      state.usageSessionLogs = (res as { logs: SessionLogEntry[] }).logs;
+    const logs = (res as { logs?: unknown } | null)?.logs;
+    if (Array.isArray(logs)) {
+      state.usageSessionLogs = logs as SessionLogEntry[];
     }
   } catch {
-    // Silently fail - logs are optional
-    state.usageSessionLogs = null;
+    // Silently fail - logs are optional.
   } finally {
     state.usageSessionLogsLoading = false;
   }

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -170,10 +170,7 @@ function toErrorMessage(err: unknown): string {
   }
   if (err && typeof err === "object") {
     try {
-      const serialized = JSON.stringify(err);
-      if (serialized) {
-        return serialized;
-      }
+      return JSON.stringify(err) || "request failed";
     } catch {
       // ignore
     }
@@ -201,12 +198,12 @@ export async function loadUsage(
   try {
     const startDate = overrides?.startDate ?? state.usageStartDate;
     const endDate = overrides?.endDate ?? state.usageEndDate;
-    const runUsageRequests = async (includeDateInterpretation: boolean) => {
+    const runUsageRequests = (includeDateInterpretation: boolean) => {
       const dateInterpretation = buildDateInterpretationParams(
         state.usageTimeZone,
         includeDateInterpretation,
       );
-      return await Promise.all([
+      return Promise.all([
         client.request("sessions.usage", {
           startDate,
           endDate,

--- a/ui/src/ui/controllers/usage.ts
+++ b/ui/src/ui/controllers/usage.ts
@@ -29,11 +29,6 @@ export type UsageState = {
   settings?: { gatewayUrl?: string };
 };
 
-type UsageDateInterpretationParams = {
-  mode: "utc" | "specific";
-  utcOffset?: string;
-};
-
 const LEGACY_USAGE_DATE_PARAMS_STORAGE_KEY = "openclaw.control.usage.date-params.v1";
 const LEGACY_USAGE_DATE_PARAMS_DEFAULT_GATEWAY_KEY = "__default__";
 const LEGACY_USAGE_DATE_PARAMS_MODE_RE = /unexpected property ['"]mode['"]/i;
@@ -137,9 +132,7 @@ const formatUtcOffset = (timezoneOffsetMinutes: number): string => {
     : `UTC${sign}${hours}:${minutes.toString().padStart(2, "0")}`;
 };
 
-const buildDateInterpretationParams = (
-  timeZone: "local" | "utc",
-): UsageDateInterpretationParams => {
+const buildDateInterpretationParams = (timeZone: "local" | "utc") => {
   if (timeZone === "utc") {
     return { mode: "utc" };
   }
@@ -253,38 +246,41 @@ export const __test = {
   },
 };
 
-export async function loadSessionTimeSeries(state: UsageState, sessionKey: string) {
-  if (!state.client || !state.connected || state.usageTimeSeriesLoading) {
+async function runOptionalUsageDetailRequest(
+  state: UsageState,
+  loadingKey: "usageTimeSeriesLoading" | "usageSessionLogsLoading",
+  run: (client: GatewayBrowserClient) => Promise<void>,
+) {
+  const client = state.client;
+  if (!client || !state.connected || state[loadingKey]) {
     return;
   }
-  state.usageTimeSeriesLoading = true;
-  state.usageTimeSeries = null;
+  state[loadingKey] = true;
   try {
-    const res = await state.client.request("sessions.usage.timeseries", { key: sessionKey });
-    state.usageTimeSeries = res ? (res as SessionUsageTimeSeries) : null;
+    await run(client);
   } catch {
-    // Silently fail - time series is optional.
+    // Silently fail - optional detail endpoints
   } finally {
-    state.usageTimeSeriesLoading = false;
+    state[loadingKey] = false;
   }
 }
 
+export async function loadSessionTimeSeries(state: UsageState, sessionKey: string) {
+  await runOptionalUsageDetailRequest(state, "usageTimeSeriesLoading", async (client) => {
+    state.usageTimeSeries = null;
+    const res = await client.request("sessions.usage.timeseries", { key: sessionKey });
+    state.usageTimeSeries = res ? (res as SessionUsageTimeSeries) : null;
+  });
+}
+
 export async function loadSessionLogs(state: UsageState, sessionKey: string) {
-  if (!state.client || !state.connected || state.usageSessionLogsLoading) {
-    return;
-  }
-  state.usageSessionLogsLoading = true;
-  state.usageSessionLogs = null;
-  try {
-    const payload = (await state.client.request("sessions.usage.logs", {
+  await runOptionalUsageDetailRequest(state, "usageSessionLogsLoading", async (client) => {
+    state.usageSessionLogs = null;
+    const payload = (await client.request("sessions.usage.logs", {
       key: sessionKey,
       limit: 1000,
     })) as { logs?: unknown } | null;
     const logs = payload?.logs;
     state.usageSessionLogs = Array.isArray(logs) ? (logs as SessionLogEntry[]) : null;
-  } catch {
-    // Silently fail - logs are optional.
-  } finally {
-    state.usageSessionLogsLoading = false;
-  }
+  });
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI tab-refresh/config-render/controller flows accumulated duplicated logic across `app-render.ts`, `app-settings.ts`, and several controllers.
- Why it matters: duplicated request/loading/reset paths increase drift risk and make behavior changes harder to reason about.
- What changed: consolidated duplicated controller/tab/config plumbing into shared helpers, removed redundant wrappers, and normalized stale-response/optional-endpoint handling paths.
- What did NOT change (scope boundary): no protocol/schema/plugin-boundary changes and no intended runtime behavior changes for valid user configurations.

## Change Buckets
### 1) Runtime dedup/consolidation
- Consolidated config-tab render wiring and agent-panel helper paths:
  - `ui/src/ui/app-render.ts`
- Consolidated active-tab refresh/settings URL/theme listener plumbing:
  - `ui/src/ui/app-settings.ts`
  - `ui/src/ui/app-lifecycle.ts`
- Consolidated controller request/mutation/loading helpers and removed redundant wrappers:
  - `ui/src/ui/controllers/agents.ts`
  - `ui/src/ui/controllers/config.ts`
  - `ui/src/ui/controllers/cron.ts`
  - `ui/src/ui/controllers/logs.ts`
  - `ui/src/ui/controllers/sessions.ts`
  - `ui/src/ui/controllers/skills.ts`
  - `ui/src/ui/controllers/usage.ts`

### 2) Safety scaffolding and characterization coverage
- Added/expanded characterization coverage for active-tab routing and controller stale/optional-path behavior:
  - `ui/src/ui/app-settings.refresh-active-tab.node.test.ts`
  - `ui/src/ui/app-settings.test.ts`
  - `ui/src/ui/controllers/agents.test.ts`
  - `ui/src/ui/controllers/skills.test.ts`
  - `ui/src/ui/controllers/usage.node.test.ts`
  - `src/ui-app-settings.agents-files-refresh.test.ts`

## LoC Report
Measured against `origin/main...HEAD` via `git diff --numstat`.

- Overall: `+1308 / -1281` (net `+27`)
- Runtime/production code: `+860 / -1217` (net `-357`)
- Tests/contracts/guards: `+448 / -64` (net `+384`)

Interpretation: runtime dedup is strongly net-negative; characterization coverage additions account for the small positive total delta.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: duplicated control-flow branches for tab refresh, config rendering, and controller request lifecycle handling.
- Missing detection / guardrail: insufficient characterization tests around stale-response and per-panel refresh routing seams.
- Contributing context (if known): incremental feature additions across multiple files without a single shared helper seam.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/ui/app-settings.refresh-active-tab.node.test.ts`
  - `ui/src/ui/controllers/agents.test.ts`
  - `ui/src/ui/controllers/skills.test.ts`
  - `ui/src/ui/controllers/usage.node.test.ts`
- Scenario the test should lock in:
  - tab/panel refresh routing remains stable
  - stale responses are ignored for agent tools and skill search/detail paths
  - optional usage detail endpoints fail silently without corrupting state
- Why this is the smallest reliable guardrail:
  - these behaviors are controlled at controller + app orchestration seams, not by isolated pure functions.
- Existing test that already covers this (if any):
  - `ui/src/ui/app-settings.test.ts` covers URL/token/session behavior matrix.
- If no new test is added, why not:
  - N/A

## User-visible / Behavior Changes

- None intended; this PR is behavior-neutral refactor/consolidation.

## Diagram (if applicable)

```text
Before:
[tab/controller action] -> [many duplicated ad hoc branches]

After:
[tab/controller action] -> [shared helper seams] -> [same runtime outcomes]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Control UI controller/settings flows
- Relevant config (redacted): default local control-ui settings

### Steps

1. Run lint/type/guard gate.
2. Run build gate.
3. Run targeted controller/settings test bundle covering touched seams.

### Expected

- no regressions in targeted refresh/config/controller behavior; build/lint/type checks green.

### Actual

- matches expected on the targeted validation set.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - agents/tools stale-response guards and error handling paths
  - skills stale-response and mutation flows (including restored detail stale-response coverage)
  - usage optional detail loader resilience
  - active-tab refresh routing characterization coverage
- Edge cases checked:
  - selection changes while async loads are in flight
  - optional endpoint failures
  - empty/trimmed query handling in skills search
- What you did **not** verify:
  - full workspace `pnpm test` was not run in this pass.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Risks and Mitigations

- Risk:
  - consolidation touches broad UI-control orchestration seams.
  - Mitigation:
  - characterization tests added/expanded across touched controller + tab routing surfaces.
- Risk:
  - regressions hidden by async stale-response races.
  - Mitigation:
  - explicit stale-response tests for agents/skills and targeted verification commands.

## Gate Status (full landing gate run on April 9, 2026)

- `pnpm check` ✅
- `pnpm test` ❌
  - Failure: `src/agents/pi-tools.read.workspace-root-guard.test.ts:157` (`guards custom outPath params when configured`)
  - Failure: `extensions/acpx/src/runtime.test.ts` (`Cannot find package 'acpx/runtime'` from `extensions/acpx/src/runtime.ts`)
- `pnpm build` ✅ (warning: unresolved import `acpx/runtime` treated as external)

Branch attribution for these failures:
- Not introduced by this branch's touched scope (branch diff is UI-only: `ui/src/ui/**` and `src/ui-app-settings.agents-files-refresh.test.ts`).
- `src/agents/pi-tools.read.workspace-root-guard.test.ts` differs because `origin/main` has newer commit `004bab53fa` that is not yet in this branch.
- `extensions/acpx/src/runtime.ts` and `extensions/acpx/src/runtime.test.ts` are unchanged in this branch's diff vs `origin/main...HEAD`.

## Notes
- Branch includes history rewrites to restore removed non-functional comments and to preserve behavior-neutrality guarantees in `skills.ts` guard paths.

