### PR TITLE
skill-creator: add Determinism Ladder review criterion

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -45,10 +45,12 @@ Think of Codex as exploring a path: a narrow bridge with cliffs needs specific g
 
 ### Determinism Ladder (Review Criterion)
 
+> This is the review-time counterpart of "Set Appropriate Degrees of Freedom" above — the same spectrum, viewed from the perspective of auditing an existing skill.
+
 When creating, reviewing, or auditing a skill, evaluate each instruction against the determinism ladder — prefer more deterministic implementations over prompt-based ones:
 
 1. **Script** (`scripts/`): If the task can be fully automated with a script, write one. Scripts are deterministic, token-efficient, and testable.
-2. **Structured automation** (hooks, templates, config): If the task has a fixed pattern but needs some context, use structured formats over free-text instructions.
+2. **Structured automation** (templates in `assets/`, structured reference files in `references/`): If the task has a fixed pattern but needs some context, use structured formats over free-text instructions.
 3. **Prompt instruction** (SKILL.md body): Only for tasks requiring LLM judgment, contextual reasoning, or creative decisions.
 
 **During review/audit**, flag any SKILL.md instruction that could be a script or structured automation. Ask: "Would a script do this more reliably?" If yes, move it to `scripts/`.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -43,6 +43,16 @@ Match the level of specificity to the task's fragility and variability:
 
 Think of Codex as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
 
+### Determinism Ladder (Review Criterion)
+
+When creating, reviewing, or auditing a skill, evaluate each instruction against the determinism ladder — prefer more deterministic implementations over prompt-based ones:
+
+1. **Script** (`scripts/`): If the task can be fully automated with a script, write one. Scripts are deterministic, token-efficient, and testable.
+2. **Structured automation** (hooks, templates, config): If the task has a fixed pattern but needs some context, use structured formats over free-text instructions.
+3. **Prompt instruction** (SKILL.md body): Only for tasks requiring LLM judgment, contextual reasoning, or creative decisions.
+
+**During review/audit**, flag any SKILL.md instruction that could be a script or structured automation. Ask: "Would a script do this more reliably?" If yes, move it to `scripts/`.
+
 ### Anatomy of a Skill
 
 Every skill consists of a required SKILL.md file and optional bundled resources:


### PR DESCRIPTION
Add a **Determinism Ladder** review criterion to the skill-creator skill, under Core Principles after "Set Appropriate Degrees of Freedom".

This criterion guides skill authors and reviewers to prefer more deterministic implementations:
1. **Scripts** over prompt instructions when tasks can be fully automated
2. **Structured automation** (hooks, templates, config) over free-text when patterns are fixed
3. **Prompt instructions** only for tasks requiring LLM judgment

During review/audit, any SKILL.md instruction that could be a script should be flagged and moved to `scripts/`.

Inspired by the determinism ladder concept from the skill-evolution project.