### PR TITLE
Fix: trim trailing whitespace from final text-chunking chunk (Resolves #64036)

### DIFF
--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -37,4 +37,13 @@ describe("shared/text-chunking", () => {
       "def",
     ]);
   });
+
+  it("trims trailing whitespace from the final chunk emitted after the loop", () => {
+    expect(
+      chunkTextByBreakResolver("  ! ", 2, (window) => window.lastIndexOf(" ") || window.length),
+    ).toEqual(["!"]);
+    expect(
+      chunkTextByBreakResolver("a b ", 2, (window) => window.lastIndexOf(" ") || window.length),
+    ).toEqual(["a", "b"]);
+  });
 });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -28,7 +28,10 @@ export function chunkTextByBreakResolver(
     remaining = remaining.slice(nextStart).trimStart();
   }
   if (remaining.length) {
-    chunks.push(remaining);
+    const finalChunk = remaining.trimEnd();
+    if (finalChunk.length > 0) {
+      chunks.push(finalChunk);
+    }
   }
   return chunks;
 }


### PR DESCRIPTION
Fixes #64036.

## Problem

`chunkTextByBreakResolver` in `src/shared/text-chunking.ts` was inconsistent: chunks emitted inside the loop were trimmed via `trimEnd()`, but the final chunk pushed after the loop preserved trailing whitespace.

```ts
chunkTextByBreakResolver("  ! ", 2, (w) => w.lastIndexOf(" ") || w.length);
// before: ["! "]   ← trailing space
// after:  ["!"]
```

## Fix

Apply `trimEnd()` to the final `remaining` before pushing it, and skip the push entirely when the trimmed result is empty (matches the in-loop branch which already skips empty chunks).

## Test plan

- [x] Added two regression tests covering the counterexamples from the issue (`"  ! "` and `"a b "`).
- [x] `pnpm test src/shared/text-chunking.test.ts` — 6/6 pass.