### PR TITLE
fix: cron text payload silently ignores model override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: preserve model overrides when text cron payloads are promoted to isolated agent turns through nested payload and legacy top-level inputs. Carries forward #64060; refs #28905. Thanks @liaoandi.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -601,6 +601,23 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.to).toBe("123");
   });
 
+  it("promotes text payload to agentTurn on create when model is present", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "daily-sync",
+      schedule: { kind: "cron", expr: "30 17 * * *" },
+      payload: {
+        text: "Run daily sync",
+        model: "anthropic/claude-sonnet-4-6",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.message).toBe("Run daily sync");
+    expect(payload.model).toBe("anthropic/claude-sonnet-4-6");
+    expect(payload).not.toHaveProperty("text");
+  });
+
   it("resolves current sessionTarget to a persistent session when context is available", () => {
     const normalized = normalizeCronJobCreate(
       {
@@ -843,6 +860,22 @@ describe("normalizeCronJobPatch", () => {
 
     expect(normalized.delivery).toBeUndefined();
     expect((normalized.payload as Record<string, unknown>).threadId).toBeUndefined();
+  });
+
+  it("promotes text payload to agentTurn when agentTurn-only fields are present", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        text: "Run daily sync",
+        model: "anthropic/claude-sonnet-4-6",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.message).toBe("Run daily sync");
+    expect(payload.model).toBe("anthropic/claude-sonnet-4-6");
+    expect(payload).not.toHaveProperty("text");
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
   });
 
   it("prunes agentTurn-only payload fields from systemEvent patch payloads", () => {

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -618,6 +618,21 @@ describe("normalizeCronJobCreate", () => {
     expect(payload).not.toHaveProperty("text");
   });
 
+  it("promotes top-level text to agentTurn on create when model is present", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "daily-sync",
+      schedule: { kind: "cron", expr: "30 17 * * *" },
+      text: "Run daily sync",
+      model: "anthropic/claude-sonnet-4-6",
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.message).toBe("Run daily sync");
+    expect(payload.model).toBe("anthropic/claude-sonnet-4-6");
+    expect(payload).not.toHaveProperty("text");
+  });
+
   it("resolves current sessionTarget to a persistent session when context is available", () => {
     const normalized = normalizeCronJobCreate(
       {
@@ -868,6 +883,20 @@ describe("normalizeCronJobPatch", () => {
         text: "Run daily sync",
         model: "anthropic/claude-sonnet-4-6",
       },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.message).toBe("Run daily sync");
+    expect(payload.model).toBe("anthropic/claude-sonnet-4-6");
+    expect(payload).not.toHaveProperty("text");
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
+  it("promotes top-level text to agentTurn on patch when model is present", () => {
+    const normalized = normalizeCronJobPatch({
+      text: "Run daily sync",
+      model: "anthropic/claude-sonnet-4-6",
     }) as unknown as Record<string, unknown>;
 
     const payload = normalized.payload as Record<string, unknown>;

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -616,6 +616,7 @@ describe("normalizeCronJobCreate", () => {
     expect(payload.message).toBe("Run daily sync");
     expect(payload.model).toBe("anthropic/claude-sonnet-4-6");
     expect(payload).not.toHaveProperty("text");
+    expect(validateCronAddParams(normalized)).toBe(true);
   });
 
   it("promotes top-level text to agentTurn on create when model is present", () => {
@@ -631,6 +632,7 @@ describe("normalizeCronJobCreate", () => {
     expect(payload.message).toBe("Run daily sync");
     expect(payload.model).toBe("anthropic/claude-sonnet-4-6");
     expect(payload).not.toHaveProperty("text");
+    expect(validateCronAddParams(normalized)).toBe(true);
   });
 
   it("resolves current sessionTarget to a persistent session when context is available", () => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -315,6 +315,10 @@ function inferTopLevelPayload(next: UnknownRecord) {
   }
 
   const text = normalizeOptionalString(next.text) ?? "";
+  if (text && hasAgentTurnPayloadHint(next)) {
+    // text + agentTurn-only fields (e.g. model) -> promote to agentTurn, text -> message.
+    return { kind: "agentTurn", message: text } satisfies UnknownRecord;
+  }
   if (text) {
     return { kind: "systemEvent", text } satisfies UnknownRecord;
   }

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -311,20 +311,26 @@ function coerceDelivery(delivery: UnknownRecord) {
 function inferTopLevelPayload(next: UnknownRecord) {
   const message = normalizeOptionalString(next.message) ?? "";
   if (message) {
-    return { kind: "agentTurn", message } satisfies UnknownRecord;
+    const payload = { kind: "agentTurn", message } satisfies UnknownRecord;
+    copyTopLevelAgentTurnFields(next, payload);
+    return payload;
   }
 
   const text = normalizeOptionalString(next.text) ?? "";
   if (text && hasAgentTurnPayloadHint(next)) {
     // text + agentTurn-only fields (e.g. model) -> promote to agentTurn, text -> message.
-    return { kind: "agentTurn", message: text } satisfies UnknownRecord;
+    const payload = { kind: "agentTurn", message: text } satisfies UnknownRecord;
+    copyTopLevelAgentTurnFields(next, payload);
+    return payload;
   }
   if (text) {
     return { kind: "systemEvent", text } satisfies UnknownRecord;
   }
 
   if (hasAgentTurnPayloadHint(next)) {
-    return { kind: "agentTurn" } satisfies UnknownRecord;
+    const payload = { kind: "agentTurn" } satisfies UnknownRecord;
+    copyTopLevelAgentTurnFields(next, payload);
+    return payload;
   }
 
   return null;

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -174,6 +174,11 @@ function coercePayload(payload: UnknownRecord) {
     const hasText = Boolean(normalizeOptionalString(next.text));
     if (hasMessage) {
       next.kind = "agentTurn";
+    } else if (hasText && hasAgentTurnPayloadHint(next)) {
+      // text + agentTurn-only fields (e.g. model) → promote to agentTurn, text→message.
+      next.kind = "agentTurn";
+      next.message = next.text;
+      delete next.text;
     } else if (hasText) {
       next.kind = "systemEvent";
     } else if (hasAgentTurnPayloadHint(next)) {


### PR DESCRIPTION
## Bug

`openclaw cron edit --model` has no effect when the cron payload uses the `text` field instead of `message`.

When `kind` is not explicitly set, `coercePayload()` infers `systemEvent` from the presence of `text`, then strips all agentTurn-only fields including `model`. The model override is silently discarded.

This was reported in #28905 (closed as stale) — this PR provides the root-cause fix.

## Fix

In `coercePayload()`, when `text` is present alongside agentTurn-only fields (detected by the existing `hasAgentTurnPayloadHint()`), infer `agentTurn` and promote `text` → `message` instead of inferring `systemEvent`.

### Before

```
payload: { text: "Run sync", model: "anthropic/claude-sonnet-4-6" }
→ kind: "systemEvent" → model deleted → runs on system default (haiku)
```

### After

```
payload: { text: "Run sync", model: "anthropic/claude-sonnet-4-6" }
→ kind: "agentTurn", message: "Run sync", model preserved → runs on sonnet
```

## Test plan

- [x] Added test for `normalizeCronJobCreate` with `text` + `model` → verifies promotion to agentTurn
- [x] Added test for `normalizeCronJobPatch` with `text` + `model` → verifies promotion to agentTurn
- [x] Existing test for explicit `kind: "systemEvent"` + `model` → still prunes model (no behavior change)
- [x] All 53 cron normalize tests pass
- [x] `pnpm check` passes

Closes #28905