### PR TITLE
fix(process): settle Windows supervisor waits from exit state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: preserve announce `threadId` when `sessions.list` fallback rehydrates agent-to-agent announce targets so final announce messages stay in the originating thread/topic. (#63506) Thanks @SnowSky1.
 - Browser/plugin SDK: route browser auth, profile, host-inspection, and doctor readiness helpers through browser plugin public facades so core compatibility helpers stop carrying duplicate runtime implementations. (#63957) Thanks @joshavant.
 - Browser/act: centralize `/act` request normalization and execution dispatch while adding stable machine-readable route-level error codes for invalid requests, selector misuse, evaluate-disabled gating, target mismatch, and existing-session unsupported actions. (#63977) Thanks @joshavant.
+- Windows/exec: settle supervisor waits from child exit state after stdout and stderr drain even when `close` never arrives, so CLI commands stop hanging or dying with forced `SIGKILL` on Windows. (#64072) Thanks @obviyus.
 
 ## 2026.4.9
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -27,32 +27,12 @@ function createStubChild(pid = 1234) {
   Object.defineProperty(child, "killed", { value: false, configurable: true, writable: true });
   Object.defineProperty(child, "exitCode", { value: null, configurable: true, writable: true });
   Object.defineProperty(child, "signalCode", { value: null, configurable: true, writable: true });
-  let emittedClose = false;
-  let emittedExit = false;
-  let closedStreams = 0;
-  const maybeEmitCloseAfterStreamShutdown = () => {
-    if (emittedClose || !emittedExit || closedStreams < 2) {
-      return;
-    }
-    emittedClose = true;
-    child.emit("close", child.exitCode, child.signalCode);
-  };
-  child.stdout.on("close", () => {
-    closedStreams += 1;
-    maybeEmitCloseAfterStreamShutdown();
-  });
-  child.stderr.on("close", () => {
-    closedStreams += 1;
-    maybeEmitCloseAfterStreamShutdown();
-  });
   const killMock = vi.fn(() => true);
   child.kill = killMock as ChildProcess["kill"];
   const emitClose = (code: number | null, signal: NodeJS.Signals | null = null) => {
-    emittedClose = true;
     child.emit("close", code, signal);
   };
   const emitExit = (code: number | null, signal: NodeJS.Signals | null = null) => {
-    emittedExit = true;
     child.exitCode = code;
     child.signalCode = signal;
     child.emit("exit", code, signal);
@@ -197,7 +177,7 @@ describe("createChildAdapter", () => {
     vi.useFakeTimers();
     setPlatform("win32");
 
-    const { adapter, emitExit } = await (async () => {
+    const { adapter, emitExit, child } = await (async () => {
       const stub = createStubChild(8642);
       spawnWithFallbackMock.mockResolvedValue({
         child: stub.child,
@@ -216,6 +196,8 @@ describe("createChildAdapter", () => {
     });
 
     emitExit(0, null);
+    child.stdout?.emit("end");
+    child.stderr?.emit("end");
     await vi.advanceTimersByTimeAsync(300);
 
     expect(settled).toHaveBeenCalledWith({ code: 0, signal: null });

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -25,12 +25,19 @@ function createStubChild(pid = 1234) {
   child.stderr = new PassThrough() as ChildProcess["stderr"];
   Object.defineProperty(child, "pid", { value: pid, configurable: true });
   Object.defineProperty(child, "killed", { value: false, configurable: true, writable: true });
+  Object.defineProperty(child, "exitCode", { value: null, configurable: true, writable: true });
+  Object.defineProperty(child, "signalCode", { value: null, configurable: true, writable: true });
   const killMock = vi.fn(() => true);
   child.kill = killMock as ChildProcess["kill"];
   const emitClose = (code: number | null, signal: NodeJS.Signals | null = null) => {
     child.emit("close", code, signal);
   };
-  return { child, killMock, emitClose };
+  const emitExit = (code: number | null, signal: NodeJS.Signals | null = null) => {
+    child.exitCode = code;
+    child.signalCode = signal;
+    child.emit("exit", code, signal);
+  };
+  return { child, killMock, emitClose, emitExit };
 }
 
 async function createAdapterHarness(params?: {
@@ -53,6 +60,14 @@ async function createAdapterHarness(params?: {
 
 describe("createChildAdapter", () => {
   const originalServiceMarker = process.env.OPENCLAW_SERVICE_MARKER;
+  const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: platform,
+    });
+  };
 
   beforeAll(async () => {
     ({ createChildAdapter } = await import("./child.js"));
@@ -74,6 +89,9 @@ describe("createChildAdapter", () => {
   });
 
   afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
     vi.useRealTimers();
   });
 
@@ -153,6 +171,34 @@ describe("createChildAdapter", () => {
     await vi.advanceTimersByTimeAsync(4_001);
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: "SIGKILL" });
     expect(killMock).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("settles wait from exit state on Windows even when close never arrives", async () => {
+    vi.useFakeTimers();
+    setPlatform("win32");
+
+    const { adapter, emitExit } = await (async () => {
+      const stub = createStubChild(8642);
+      spawnWithFallbackMock.mockResolvedValue({
+        child: stub.child,
+        usedFallback: false,
+      });
+      const adapter = await createChildAdapter({
+        argv: ["openclaw", "version"],
+        stdinMode: "pipe-closed",
+      });
+      return { ...stub, adapter };
+    })();
+
+    const settled = vi.fn();
+    void adapter.wait().then((result) => {
+      settled(result);
+    });
+
+    emitExit(0, null);
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(settled).toHaveBeenCalledWith({ code: 0, signal: null });
   });
 
   it("disables detached mode in service-managed runtime", async () => {

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -27,12 +27,32 @@ function createStubChild(pid = 1234) {
   Object.defineProperty(child, "killed", { value: false, configurable: true, writable: true });
   Object.defineProperty(child, "exitCode", { value: null, configurable: true, writable: true });
   Object.defineProperty(child, "signalCode", { value: null, configurable: true, writable: true });
+  let emittedClose = false;
+  let emittedExit = false;
+  let closedStreams = 0;
+  const maybeEmitCloseAfterStreamShutdown = () => {
+    if (emittedClose || !emittedExit || closedStreams < 2) {
+      return;
+    }
+    emittedClose = true;
+    child.emit("close", child.exitCode, child.signalCode);
+  };
+  child.stdout.on("close", () => {
+    closedStreams += 1;
+    maybeEmitCloseAfterStreamShutdown();
+  });
+  child.stderr.on("close", () => {
+    closedStreams += 1;
+    maybeEmitCloseAfterStreamShutdown();
+  });
   const killMock = vi.fn(() => true);
   child.kill = killMock as ChildProcess["kill"];
   const emitClose = (code: number | null, signal: NodeJS.Signals | null = null) => {
+    emittedClose = true;
     child.emit("close", code, signal);
   };
   const emitExit = (code: number | null, signal: NodeJS.Signals | null = null) => {
+    emittedExit = true;
     child.exitCode = code;
     child.signalCode = signal;
     child.emit("exit", code, signal);

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -6,6 +6,8 @@ import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
 const FORCE_KILL_WAIT_FALLBACK_MS = 4000;
+const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
+const WINDOWS_CLOSE_STATE_POLL_MS = 10;
 
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
@@ -122,6 +124,8 @@ export async function createChildAdapter(params: {
   let rejectWait: ((reason?: unknown) => void) | null = null;
   let waitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | null = null;
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
+  let childExitState: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+  let windowsExitSettleTimer: NodeJS.Timeout | null = null;
 
   const clearForceKillWaitFallback = () => {
     if (!forceKillWaitFallbackTimer) {
@@ -131,11 +135,20 @@ export async function createChildAdapter(params: {
     forceKillWaitFallbackTimer = null;
   };
 
+  const clearWindowsExitSettleTimer = () => {
+    if (!windowsExitSettleTimer) {
+      return;
+    }
+    clearTimeout(windowsExitSettleTimer);
+    windowsExitSettleTimer = null;
+  };
+
   const settleWait = (value: { code: number | null; signal: NodeJS.Signals | null }) => {
     if (waitResult || waitError !== undefined) {
       return;
     }
     clearForceKillWaitFallback();
+    clearWindowsExitSettleTimer();
     waitResult = value;
     if (resolveWait) {
       const resolve = resolveWait;
@@ -150,6 +163,7 @@ export async function createChildAdapter(params: {
       return;
     }
     clearForceKillWaitFallback();
+    clearWindowsExitSettleTimer();
     waitError = error;
     if (rejectWait) {
       const reject = rejectWait;
@@ -168,11 +182,60 @@ export async function createChildAdapter(params: {
     forceKillWaitFallbackTimer.unref?.();
   };
 
+  const resolveObservedExitState = (fallback: {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }) => ({
+    code: childExitState?.code ?? child.exitCode ?? fallback.code,
+    signal: childExitState?.signal ?? child.signalCode ?? fallback.signal,
+  });
+
+  const hasObservedExitState = () =>
+    childExitState != null || child.exitCode != null || child.signalCode != null;
+
+  const scheduleWindowsExitStateSettle = (fallback: {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }) => {
+    if (process.platform !== "win32") {
+      return;
+    }
+    clearWindowsExitSettleTimer();
+    windowsExitSettleTimer = setTimeout(() => {
+      settleWait(resolveObservedExitState(fallback));
+    }, WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS);
+  };
+
   child.once("error", (error) => {
     rejectPendingWait(error);
   });
+  child.once("exit", (code, signal) => {
+    childExitState = { code, signal };
+    scheduleWindowsExitStateSettle({ code, signal });
+  });
   child.once("close", (code, signal) => {
-    settleWait({ code, signal });
+    if (process.platform !== "win32" || hasObservedExitState() || code != null || signal != null) {
+      settleWait(resolveObservedExitState({ code, signal }));
+      return;
+    }
+
+    const startedAt = Date.now();
+    const waitForExitState = () => {
+      if (waitResult || waitError !== undefined) {
+        return;
+      }
+      if (hasObservedExitState()) {
+        settleWait(resolveObservedExitState({ code, signal }));
+        return;
+      }
+      if (Date.now() - startedAt >= WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS) {
+        settleWait({ code, signal });
+        return;
+      }
+      setTimeout(waitForExitState, WINDOWS_CLOSE_STATE_POLL_MS);
+    };
+
+    waitForExitState();
   });
 
   const wait = async () => {
@@ -229,6 +292,7 @@ export async function createChildAdapter(params: {
 
   const dispose = () => {
     clearForceKillWaitFallback();
+    clearWindowsExitSettleTimer();
     child.removeAllListeners();
   };
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -125,6 +125,8 @@ export async function createChildAdapter(params: {
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
   let childExitState: { code: number | null; signal: NodeJS.Signals | null } | null = null;
   let windowsCloseFallbackTimer: NodeJS.Timeout | null = null;
+  let stdoutDrained = child.stdout == null;
+  let stderrDrained = child.stderr == null;
 
   const clearForceKillWaitFallback = () => {
     if (!forceKillWaitFallbackTimer) {
@@ -194,20 +196,45 @@ export async function createChildAdapter(params: {
     };
   };
 
+  const maybeSettleAfterWindowsExit = () => {
+    if (
+      process.platform !== "win32" ||
+      childExitState == null ||
+      !stdoutDrained ||
+      !stderrDrained
+    ) {
+      return;
+    }
+    settleWait(resolveObservedExitState(childExitState));
+  };
+
   const scheduleWindowsCloseFallback = () => {
     if (process.platform !== "win32") {
       return;
     }
     clearWindowsCloseFallbackTimer();
     windowsCloseFallbackTimer = setTimeout(() => {
-      if (waitResult || waitError !== undefined) {
-        return;
-      }
-      child.stdout?.destroy();
-      child.stderr?.destroy();
+      maybeSettleAfterWindowsExit();
     }, WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS);
     windowsCloseFallbackTimer.unref?.();
   };
+
+  child.stdout?.once("end", () => {
+    stdoutDrained = true;
+    maybeSettleAfterWindowsExit();
+  });
+  child.stdout?.once("close", () => {
+    stdoutDrained = true;
+    maybeSettleAfterWindowsExit();
+  });
+  child.stderr?.once("end", () => {
+    stderrDrained = true;
+    maybeSettleAfterWindowsExit();
+  });
+  child.stderr?.once("close", () => {
+    stderrDrained = true;
+    maybeSettleAfterWindowsExit();
+  });
 
   child.once("error", (error) => {
     rejectPendingWait(error);

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -7,7 +7,6 @@ import { toStringEnv } from "./env.js";
 
 const FORCE_KILL_WAIT_FALLBACK_MS = 4000;
 const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
-const WINDOWS_CLOSE_STATE_POLL_MS = 10;
 
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
@@ -125,7 +124,7 @@ export async function createChildAdapter(params: {
   let waitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | null = null;
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
   let childExitState: { code: number | null; signal: NodeJS.Signals | null } | null = null;
-  let windowsExitSettleTimer: NodeJS.Timeout | null = null;
+  let windowsCloseFallbackTimer: NodeJS.Timeout | null = null;
 
   const clearForceKillWaitFallback = () => {
     if (!forceKillWaitFallbackTimer) {
@@ -135,12 +134,12 @@ export async function createChildAdapter(params: {
     forceKillWaitFallbackTimer = null;
   };
 
-  const clearWindowsExitSettleTimer = () => {
-    if (!windowsExitSettleTimer) {
+  const clearWindowsCloseFallbackTimer = () => {
+    if (!windowsCloseFallbackTimer) {
       return;
     }
-    clearTimeout(windowsExitSettleTimer);
-    windowsExitSettleTimer = null;
+    clearTimeout(windowsCloseFallbackTimer);
+    windowsCloseFallbackTimer = null;
   };
 
   const settleWait = (value: { code: number | null; signal: NodeJS.Signals | null }) => {
@@ -148,7 +147,7 @@ export async function createChildAdapter(params: {
       return;
     }
     clearForceKillWaitFallback();
-    clearWindowsExitSettleTimer();
+    clearWindowsCloseFallbackTimer();
     waitResult = value;
     if (resolveWait) {
       const resolve = resolveWait;
@@ -163,7 +162,7 @@ export async function createChildAdapter(params: {
       return;
     }
     clearForceKillWaitFallback();
-    clearWindowsExitSettleTimer();
+    clearWindowsCloseFallbackTimer();
     waitError = error;
     if (rejectWait) {
       const reject = rejectWait;
@@ -185,25 +184,29 @@ export async function createChildAdapter(params: {
   const resolveObservedExitState = (fallback: {
     code: number | null;
     signal: NodeJS.Signals | null;
-  }) => ({
-    code: childExitState?.code ?? child.exitCode ?? fallback.code,
-    signal: childExitState?.signal ?? child.signalCode ?? fallback.signal,
-  });
-
-  const hasObservedExitState = () =>
-    childExitState != null || child.exitCode != null || child.signalCode != null;
-
-  const scheduleWindowsExitStateSettle = (fallback: {
-    code: number | null;
-    signal: NodeJS.Signals | null;
   }) => {
+    if (childExitState != null) {
+      return childExitState;
+    }
+    return {
+      code: child.exitCode ?? fallback.code,
+      signal: child.signalCode ?? fallback.signal,
+    };
+  };
+
+  const scheduleWindowsCloseFallback = () => {
     if (process.platform !== "win32") {
       return;
     }
-    clearWindowsExitSettleTimer();
-    windowsExitSettleTimer = setTimeout(() => {
-      settleWait(resolveObservedExitState(fallback));
+    clearWindowsCloseFallbackTimer();
+    windowsCloseFallbackTimer = setTimeout(() => {
+      if (waitResult || waitError !== undefined) {
+        return;
+      }
+      child.stdout?.destroy();
+      child.stderr?.destroy();
     }, WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS);
+    windowsCloseFallbackTimer.unref?.();
   };
 
   child.once("error", (error) => {
@@ -211,31 +214,10 @@ export async function createChildAdapter(params: {
   });
   child.once("exit", (code, signal) => {
     childExitState = { code, signal };
-    scheduleWindowsExitStateSettle({ code, signal });
+    scheduleWindowsCloseFallback();
   });
   child.once("close", (code, signal) => {
-    if (process.platform !== "win32" || hasObservedExitState() || code != null || signal != null) {
-      settleWait(resolveObservedExitState({ code, signal }));
-      return;
-    }
-
-    const startedAt = Date.now();
-    const waitForExitState = () => {
-      if (waitResult || waitError !== undefined) {
-        return;
-      }
-      if (hasObservedExitState()) {
-        settleWait(resolveObservedExitState({ code, signal }));
-        return;
-      }
-      if (Date.now() - startedAt >= WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS) {
-        settleWait({ code, signal });
-        return;
-      }
-      setTimeout(waitForExitState, WINDOWS_CLOSE_STATE_POLL_MS);
-    };
-
-    waitForExitState();
+    settleWait(resolveObservedExitState({ code, signal }));
   });
 
   const wait = async () => {
@@ -292,7 +274,7 @@ export async function createChildAdapter(params: {
 
   const dispose = () => {
     clearForceKillWaitFallback();
-    clearWindowsExitSettleTimer();
+    clearWindowsCloseFallbackTimer();
     child.removeAllListeners();
   };
 


### PR DESCRIPTION
## Summary
Fix the Windows supervisor child adapter so `wait()` resolves after the process exits even when `close` lags or needs the stdio fallback path.

Fixes #63124

## Why
Windows CLI and exec runs could print output, then never finish because the supervisor kept waiting on `close`. On timeout or cancellation, that surfaced as a later `SIGKILL`.

## Test
- `pnpm test src/process/supervisor/adapters/child.test.ts`
- `pnpm test src/process/supervisor/supervisor.test.ts`
