### PR TITLE
fix: trim trailing whitespace in final text chunk

### DIFF
--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -37,4 +37,13 @@ describe("shared/text-chunking", () => {
       "def",
     ]);
   });
+
+  it("trims trailing whitespace from the final emitted chunk", () => {
+    expect(
+      chunkTextByBreakResolver("  ! ", 2, (window) => window.lastIndexOf(" ") || window.length),
+    ).toEqual(["!"]);
+    expect(
+      chunkTextByBreakResolver("a b ", 2, (window) => window.lastIndexOf(" ") || window.length),
+    ).toEqual(["a", "b"]);
+  });
 });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -28,7 +28,10 @@ export function chunkTextByBreakResolver(
     remaining = remaining.slice(nextStart).trimStart();
   }
   if (remaining.length) {
-    chunks.push(remaining);
+    const finalChunk = remaining.trimEnd();
+    if (finalChunk.length > 0) {
+      chunks.push(finalChunk);
+    }
   }
   return chunks;
 }


### PR DESCRIPTION
## Summary

Trim trailing whitespace from the final chunk emitted by `chunkTextByBreakResolver`, matching the existing behavior for chunks produced inside the main loop.

## Changes

- trim the final `remaining` chunk with `trimEnd()` before pushing it
- skip pushing the final chunk when trimming leaves it empty
- add regression coverage for final-chunk trailing whitespace cases

## Testing

- `pnpm exec vitest run src/shared/text-chunking.test.ts`
- Note: repo-wide pre-commit/tsgo checks in this environment currently fail on unrelated missing optional dependencies/types outside this change

Fixes openclaw/openclaw#64036