### PR TITLE
Slack: unify auto-thread routing for channel top-level messages under replyToMode=all

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -87,8 +87,8 @@ describe("thread-level session keys", () => {
     expect(sessionKey).not.toContain("1770408522.168859");
   });
 
-  it("keeps top-level channel messages on the per-channel session regardless of replyToMode", async () => {
-    for (const mode of ["all", "first", "off"] as const) {
+  it("keeps top-level channel messages on the per-channel session when replyToMode is off or first", async () => {
+    for (const mode of ["first", "off"] as const) {
       const ctx = buildCtx({ replyToMode: mode });
       ctx.resolveUserName = async () => ({ name: "Carol" });
       const account = createSlackTestAccount({ replyToMode: mode });
@@ -113,6 +113,103 @@ describe("thread-level session keys", () => {
       expect(firstKey).toBe(secondKey);
       expect(firstKey).not.toContain(":thread:");
     }
+  });
+
+  it("gives each top-level channel message its own thread session when replyToMode=all", async () => {
+    const ctx = buildCtx({ replyToMode: "all" });
+    ctx.resolveUserName = async () => ({ name: "Carol" });
+    const account = createSlackTestAccount({ replyToMode: "all" });
+
+    const first = await prepareSlackMessage({
+      ctx,
+      account,
+      message: buildChannelMessage({ ts: "1770408530.000000" }),
+      opts: { source: "message" },
+    });
+    const second = await prepareSlackMessage({
+      ctx,
+      account,
+      message: buildChannelMessage({ ts: "1770408531.000000" }),
+      opts: { source: "message" },
+    });
+
+    expect(first).toBeTruthy();
+    expect(second).toBeTruthy();
+    const firstKey = first!.ctxPayload.SessionKey as string;
+    const secondKey = second!.ctxPayload.SessionKey as string;
+    // Each top-level message should get its own thread-scoped session
+    expect(firstKey).not.toBe(secondKey);
+    expect(firstKey).toContain(":thread:1770408530.000000");
+    expect(secondKey).toContain(":thread:1770408531.000000");
+  });
+
+  it("aligns SessionKey and MessageThreadId for top-level channel messages with replyToMode=all", async () => {
+    const ctx = buildCtx({ replyToMode: "all" });
+    ctx.resolveUserName = async () => ({ name: "Carol" });
+    const account = createSlackTestAccount({ replyToMode: "all" });
+
+    const prepared = await prepareSlackMessage({
+      ctx,
+      account,
+      message: buildChannelMessage({ ts: "1770408530.000000" }),
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeTruthy();
+    const sessionKey = prepared!.ctxPayload.SessionKey as string;
+    const messageThreadId = prepared!.ctxPayload.MessageThreadId as string;
+    // Session routing and reply delivery must point to the same conversation
+    expect(sessionKey).toContain(`:thread:${messageThreadId}`);
+  });
+
+  it("routes thread replies into the parent thread session with replyToMode=all", async () => {
+    const ctx = buildCtx({ replyToMode: "all" });
+    ctx.resolveUserName = async () => ({ name: "Carol" });
+    const account = createSlackTestAccount({ replyToMode: "all" });
+
+    const reply = await prepareSlackMessage({
+      ctx,
+      account,
+      message: buildChannelMessage({
+        user: "U2",
+        text: "thread reply",
+        ts: "1770408535.000000",
+        thread_ts: "1770408530.000000",
+      }),
+      opts: { source: "message" },
+    });
+
+    expect(reply).toBeTruthy();
+    const sessionKey = reply!.ctxPayload.SessionKey as string;
+    // Thread reply routes to the parent thread session, not its own ts
+    expect(sessionKey).toContain(":thread:1770408530.000000");
+    expect(sessionKey).not.toContain("1770408535.000000");
+  });
+
+  it("keeps distinct senders on separate sessions in a channel with replyToMode=all", async () => {
+    const ctx = buildCtx({ replyToMode: "all" });
+    ctx.resolveUserName = async () => ({ name: "User" });
+    const account = createSlackTestAccount({ replyToMode: "all" });
+
+    const alice = await prepareSlackMessage({
+      ctx,
+      account,
+      message: buildChannelMessage({ user: "U1", ts: "1770408540.000000" }),
+      opts: { source: "message" },
+    });
+    const bob = await prepareSlackMessage({
+      ctx,
+      account,
+      message: buildChannelMessage({ user: "U2", ts: "1770408541.000000" }),
+      opts: { source: "message" },
+    });
+
+    expect(alice).toBeTruthy();
+    expect(bob).toBeTruthy();
+    const aliceKey = alice!.ctxPayload.SessionKey as string;
+    const bobKey = bob!.ctxPayload.SessionKey as string;
+    // Different senders' top-level messages must not share a session
+    expect(aliceKey).not.toBe(bobKey);
   });
 
   it("does not add thread suffix for DMs when replyToMode=off", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -286,20 +286,25 @@ function resolveSlackRoutingContext(params: {
   const threadContext = resolveSlackThreadContext({ message, replyToMode });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;
-  // Keep true thread replies thread-scoped, but preserve channel-level sessions
-  // for top-level room turns when replyToMode is off.
-  // For DMs, preserve existing auto-thread behavior when replyToMode="all".
+  // Derive a single canonical thread id used for both session routing and reply
+  // delivery so they always point at the same conversation.
+  //
+  // For true thread replies (thread_ts present and differs from message ts),
+  // route into the parent thread session.
+  //
+  // For top-level messages when replyToMode="all", use the message ts as the
+  // thread id. This ensures the session key (`baseKey:thread:<messageTs>`)
+  // matches the `messageThreadId` used for reply delivery, preventing dual
+  // processing through both a parent channel session and a thread session.
+  //
+  // When replyToMode is "off" (or "first" without a thread), top-level channel
+  // messages stay on the shared per-channel session for continuity.
   const autoThreadId =
     !isThreadReply && replyToMode === "all" && threadContext.messageTs
       ? threadContext.messageTs
       : undefined;
-  // Only fork channel/group messages into thread-specific sessions when they are
-  // actual thread replies (thread_ts present, different from message ts).
-  // Top-level channel messages must stay on the per-channel session for continuity.
-  // Before this fix, every channel message used its own ts as threadId, creating
-  // isolated sessions per message (regression from #10686).
-  const roomThreadId = isThreadReply && threadTs ? threadTs : undefined;
-  const canonicalThreadId = isRoomish ? roomThreadId : isThreadReply ? threadTs : autoThreadId;
+  const canonicalThreadId =
+    isThreadReply && threadTs ? threadTs : autoThreadId;
   const threadKeys = resolveThreadSessionKeys({
     baseSessionKey: route.sessionKey,
     threadId: canonicalThreadId,


### PR DESCRIPTION
## Problem

When `replyToMode="all"` is enabled on a Slack channel, each top-level message triggers **two** independent LLM processing paths:

1. A **parent channel session** (via the base session key `agent:...:slack:channel:<channelId>`)
2. A **thread-scoped session** (via `messageThreadId = messageTs` used for reply delivery)

This causes:
- **Duplicate LLM work** — every message processed twice
- **Inflated costs** — observed $18.46 wasted on a single parent session accumulating 82 duplicate responses
- **Cross-sender context bleed** — unrelated senders' conversations mix in the shared parent session
- **Privacy issues** — messages from different users visible in shared context

## Root Cause

In `resolveSlackRoutingContext()`, the `canonicalThreadId` computation has an `isRoomish` branch that discards `autoThreadId` for room/channel messages:

```ts
// Before (buggy):
const roomThreadId = isThreadReply && threadTs ? threadTs : undefined;
const canonicalThreadId = isRoomish ? roomThreadId : isThreadReply ? threadTs : autoThreadId;
```

For top-level channel messages: `isThreadReply` is false, so `roomThreadId` = `undefined`, and the session key falls back to the shared parent channel session. Meanwhile, `messageThreadId` is correctly set to `messageTs` for reply delivery — creating the split-brain routing.

DMs did **not** have this bug because they used the `autoThreadId` path.

## Fix

Remove the room/DM asymmetry. Use `autoThreadId` for all conversation types:

```ts
// After (fixed):
const canonicalThreadId =
  isThreadReply && threadTs ? threadTs : autoThreadId;
```

This ensures the session key (`baseKey:thread:<messageTs>`) matches the `messageThreadId` used for reply delivery, eliminating the dual-processing path.

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| Top-level channel msg, `replyToMode=all` | Parent channel session + thread session (dual) | Thread session only (`:thread:<ts>`) |
| Top-level channel msg, `replyToMode=off` | Parent channel session | Parent channel session (unchanged) |
| Thread reply | Thread session (`:thread:<parent_ts>`) | Thread session (unchanged) |
| DMs | Thread session (`:thread:<ts>`) | Thread session (unchanged) |

## Tests

- Updated existing test: removed `all` from the "keeps top-level on per-channel session" loop (now only `off`/`first`)
- Added 5 new test cases:
  1. Each top-level channel message gets its own thread session with `replyToMode=all`
  2. SessionKey and MessageThreadId are aligned
  3. Thread replies route to parent thread session
  4. Distinct senders get separate sessions
  5. `replyToMode=off/first` behavior preserved

Fixes #64078
