### PR TITLE
Fix proxy fetch propagation for Gemini memory embeddings

### DIFF
--- a/packages/memory-host-sdk/src/host/batch-gemini.ts
+++ b/packages/memory-host-sdk/src/host/batch-gemini.ts
@@ -98,6 +98,7 @@ async function submitGeminiBatch(params: {
   const filePayload = await withRemoteHttpResponse({
     url: uploadUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       method: "POST",
       headers: {
@@ -136,6 +137,7 @@ async function submitGeminiBatch(params: {
   return await withRemoteHttpResponse({
     url: batchEndpoint,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       method: "POST",
       headers: buildBatchHeaders(params.gemini, { json: true }),
@@ -169,6 +171,7 @@ async function fetchGeminiBatchStatus(params: {
   return await withRemoteHttpResponse({
     url: statusUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       headers: buildBatchHeaders(params.gemini, { json: true }),
     },
@@ -193,6 +196,7 @@ async function fetchGeminiFileContent(params: {
   return await withRemoteHttpResponse({
     url: downloadUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       headers: buildBatchHeaders(params.gemini, { json: true }),
     },

--- a/packages/memory-host-sdk/src/host/embeddings-gemini.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-gemini.ts
@@ -20,6 +20,7 @@ export type GeminiEmbeddingClient = {
   baseUrl: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  fetchImpl?: typeof fetch;
   model: string;
   modelPath: string;
   apiKeys: string[];
@@ -333,5 +334,14 @@ export async function resolveGeminiEmbeddingClient(
     embedEndpoint: `${baseUrl}/${modelPath}:embedContent`,
     batchEndpoint: `${baseUrl}/${modelPath}:batchEmbedContents`,
   });
-  return { baseUrl, headers, ssrfPolicy, model, modelPath, apiKeys, outputDimensionality };
+  return {
+    baseUrl,
+    headers,
+    ssrfPolicy,
+    fetchImpl: options.fetchImpl,
+    model,
+    modelPath,
+    apiKeys,
+    outputDimensionality,
+  };
 }

--- a/packages/memory-host-sdk/src/host/embeddings-gemini.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-gemini.ts
@@ -184,6 +184,7 @@ async function fetchGeminiEmbeddingPayload(params: {
       return await withRemoteHttpResponse({
         url: params.endpoint,
         ssrfPolicy: params.client.ssrfPolicy,
+        fetchImpl: params.client.fetchImpl,
         init: {
           method: "POST",
           headers,

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -75,6 +75,7 @@ export type EmbeddingProviderResult = {
 export type EmbeddingProviderOptions = {
   config: OpenClawConfig;
   agentDir?: string;
+  fetchImpl?: typeof fetch;
   provider: EmbeddingProviderRequest;
   remote?: {
     baseUrl?: string;

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -5,6 +5,7 @@ export async function postJson<T>(params: {
   url: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  fetchImpl?: typeof fetch;
   body: unknown;
   errorPrefix: string;
   attachStatus?: boolean;
@@ -13,6 +14,7 @@ export async function postJson<T>(params: {
   return await withRemoteHttpResponse({
     url: params.url,
     ssrfPolicy: params.ssrfPolicy,
+    fetchImpl: params.fetchImpl,
     init: {
       method: "POST",
       headers: params.headers,

--- a/packages/memory-host-sdk/src/host/remote-http.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.ts
@@ -23,11 +23,13 @@ export async function withRemoteHttpResponse<T>(params: {
   url: string;
   init?: RequestInit;
   ssrfPolicy?: SsrFPolicy;
+  fetchImpl?: typeof fetch;
   auditContext?: string;
   onResponse: (response: Response) => Promise<T>;
 }): Promise<T> {
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
+    fetchImpl: params.fetchImpl,
     init: params.init,
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",

--- a/src/memory-host-sdk/host/batch-gemini.ts
+++ b/src/memory-host-sdk/host/batch-gemini.ts
@@ -98,6 +98,7 @@ async function submitGeminiBatch(params: {
   const filePayload = await withRemoteHttpResponse({
     url: uploadUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       method: "POST",
       headers: {
@@ -136,6 +137,7 @@ async function submitGeminiBatch(params: {
   return await withRemoteHttpResponse({
     url: batchEndpoint,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       method: "POST",
       headers: buildBatchHeaders(params.gemini, { json: true }),
@@ -169,6 +171,7 @@ async function fetchGeminiBatchStatus(params: {
   return await withRemoteHttpResponse({
     url: statusUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       headers: buildBatchHeaders(params.gemini, { json: true }),
     },
@@ -193,6 +196,7 @@ async function fetchGeminiFileContent(params: {
   return await withRemoteHttpResponse({
     url: downloadUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
+    fetchImpl: params.gemini.fetchImpl,
     init: {
       headers: buildBatchHeaders(params.gemini, { json: true }),
     },

--- a/src/memory-host-sdk/host/embeddings-gemini.ts
+++ b/src/memory-host-sdk/host/embeddings-gemini.ts
@@ -25,6 +25,7 @@ export type GeminiEmbeddingClient = {
   baseUrl: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
+  fetchImpl?: typeof fetch;
   model: string;
   modelPath: string;
   apiKeys: string[];
@@ -333,5 +334,14 @@ export async function resolveGeminiEmbeddingClient(
     embedEndpoint: `${baseUrl}/${modelPath}:embedContent`,
     batchEndpoint: `${baseUrl}/${modelPath}:batchEmbedContents`,
   });
-  return { baseUrl, headers, ssrfPolicy, model, modelPath, apiKeys, outputDimensionality };
+  return {
+    baseUrl,
+    headers,
+    ssrfPolicy,
+    fetchImpl: options.fetchImpl,
+    model,
+    modelPath,
+    apiKeys,
+    outputDimensionality,
+  };
 }

--- a/src/memory-host-sdk/host/embeddings-gemini.ts
+++ b/src/memory-host-sdk/host/embeddings-gemini.ts
@@ -182,6 +182,7 @@ async function fetchGeminiEmbeddingPayload(params: {
       return await withRemoteHttpResponse({
         url: params.endpoint,
         ssrfPolicy: params.client.ssrfPolicy,
+        fetchImpl: params.client.fetchImpl,
         init: {
           method: "POST",
           headers,

--- a/src/memory-host-sdk/host/embeddings.types.ts
+++ b/src/memory-host-sdk/host/embeddings.types.ts
@@ -35,6 +35,7 @@ export type GeminiTaskType =
 export type EmbeddingProviderOptions = {
   config: OpenClawConfig;
   agentDir?: string;
+  fetchImpl?: typeof fetch;
   provider: EmbeddingProviderRequest;
   remote?: {
     baseUrl?: string;


### PR DESCRIPTION
## Summary
- thread the resolved proxy-aware `fetchImpl` through Gemini memory embedding HTTP calls
- forward `fetchImpl` via `withRemoteHttpResponse()` in the memory host SDK package source
- keep the mirrored `src/memory-host-sdk` Gemini call sites aligned

## Why
In the Gemini memory embedding path, `resolveGeminiEmbeddingClient()` already resolves a proxy-aware `fetchImpl`, but the actual Gemini request call sites were not passing that fetch implementation into `withRemoteHttpResponse(...)`.

That means the client could be configured for env-proxy fetch, while the real HTTP calls still fell back to the default fetch path. In proxy-only / China / corporate-proxy environments this can surface as direct Google connection timeouts in `memory_search` even though other proxy-aware paths work.

This showed up locally as:
- `memory_search` returning `disabled/unavailable`
- `fetch failed | Connect Timeout Error (... 142.250.x.x:443 ...)`
- immediate recovery after patching these call sites in the installed build

## Scope
This PR updates the Gemini memory embedding request path for:
- direct embed requests
- Gemini batch upload
- Gemini batch create
- Gemini batch status polling
- Gemini batch download

## Testing
- Local runtime validation on an installed `2026.4.9` build: patched equivalent dist call sites and confirmed `memory_search` recovered
- Repo test run not completed here because this fresh clone does not have repo dependencies installed yet (`vitest/package.json` missing)

Closes or advances: #52162
