### PR TITLE
fix(speech-core): add discord to OPUS_CHANNELS for native voice-note TTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 - Reply/skills: keep resolved skill and memory secret config stable through embedded reply runs so raw SecretRefs in secondary skill settings no longer crash replies when the gateway already has the live env. (#64249) Thanks @mbelinky.
 - Dreaming/startup: keep plugin-registered startup hooks alive across workspace hook reloads and include dreaming startup owners in the gateway startup plugin scope, so managed Dreaming cron registration comes back reliably after gateway boot. (#62327) Thanks @mbelinky.
 - Plugins: treat duplicate `registerService` calls from the same plugin id as idempotent so snapshot and activation loads no longer emit spurious `service already registered` diagnostics. (#62033, #64128) Thanks @ly85206559.
+- Discord/TTS: route auto voice replies through the native voice-note path so Discord receives Opus voice messages instead of regular audio attachments. (#64096) Thanks @LiuHuaize.
 
 ## 2026.4.9
 

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -1,0 +1,98 @@
+import { rmSync } from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import type {
+  SpeechProviderPlugin,
+  SpeechSynthesisRequest,
+  SpeechSynthesisResult,
+} from "openclaw/plugin-sdk/speech-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const synthesizeMock = vi.hoisted(() =>
+  vi.fn(
+    async (request: SpeechSynthesisRequest): Promise<SpeechSynthesisResult> => ({
+      audioBuffer: Buffer.from("voice"),
+      fileExtension: ".ogg",
+      outputFormat: "ogg",
+      voiceCompatible: request.target === "voice-note",
+    }),
+  ),
+);
+
+const listSpeechProvidersMock = vi.hoisted(() => vi.fn());
+const getSpeechProviderMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/channel-targets", () => ({
+  normalizeChannelId: (channel: string | undefined) => channel?.trim().toLowerCase() ?? null,
+}));
+
+vi.mock("../api.js", async () => {
+  const actual = await vi.importActual<typeof import("../api.js")>("../api.js");
+  const mockProvider: SpeechProviderPlugin = {
+    id: "mock",
+    label: "Mock",
+    autoSelectOrder: 1,
+    isConfigured: () => true,
+    synthesize: synthesizeMock,
+  };
+  listSpeechProvidersMock.mockImplementation(() => [mockProvider]);
+  getSpeechProviderMock.mockImplementation((providerId: string) =>
+    providerId === "mock" ? mockProvider : null,
+  );
+  return {
+    ...actual,
+    canonicalizeSpeechProviderId: (providerId: string | undefined) =>
+      providerId?.trim().toLowerCase() || undefined,
+    normalizeSpeechProviderId: (providerId: string | undefined) =>
+      providerId?.trim().toLowerCase() || undefined,
+    getSpeechProvider: getSpeechProviderMock,
+    listSpeechProviders: listSpeechProvidersMock,
+    scheduleCleanup: vi.fn(),
+  };
+});
+
+const { maybeApplyTtsToPayload } = await import("./tts.js");
+
+describe("speech-core Discord voice-note routing", () => {
+  afterEach(() => {
+    synthesizeMock.mockClear();
+  });
+
+  it("marks Discord auto TTS replies as native voice messages", async () => {
+    const cfg: OpenClawConfig = {
+      messages: {
+        tts: {
+          enabled: true,
+          provider: "mock",
+          prefsPath: "/tmp/openclaw-speech-core-tts-test.json",
+        },
+      },
+    };
+    const payload: ReplyPayload = {
+      text: "This Discord reply should be delivered as a native voice note.",
+    };
+
+    let mediaDir: string | undefined;
+    try {
+      const result = await maybeApplyTtsToPayload({
+        payload,
+        cfg,
+        channel: "discord",
+        kind: "final",
+      });
+
+      expect(synthesizeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ target: "voice-note" }),
+      );
+      expect(result.audioAsVoice).toBe(true);
+      expect(result.mediaUrl).toMatch(/voice-\d+\.ogg$/);
+
+      mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
+    } finally {
+      if (mediaDir) {
+        rmSync(mediaDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -5,13 +5,14 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type {
   SpeechProviderPlugin,
   SpeechSynthesisRequest,
-  SpeechSynthesisResult,
 } from "openclaw/plugin-sdk/speech-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+type MockSpeechSynthesisResult = Awaited<ReturnType<SpeechProviderPlugin["synthesize"]>>;
+
 const synthesizeMock = vi.hoisted(() =>
   vi.fn(
-    async (request: SpeechSynthesisRequest): Promise<SpeechSynthesisResult> => ({
+    async (request: SpeechSynthesisRequest): Promise<MockSpeechSynthesisResult> => ({
       audioBuffer: Buffer.from("voice"),
       fileExtension: ".ogg",
       outputFormat: "ogg",

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -593,7 +593,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
   lastTtsAttempt = entry;
 }
 
-const OPUS_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix"]);
+const OPUS_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix", "discord"]);
 
 function resolveChannelId(channel: string | undefined): ChannelId | null {
   return channel ? normalizeChannelId(channel) : null;


### PR DESCRIPTION
## Summary

- Problem: `extensions/speech-core/src/tts.ts` did not treat Discord as an Opus-capable voice-note channel in the auto-TTS path.
- Why it matters: Discord auto voice replies fell back to regular audio attachments instead of native voice messages.
- What changed: added `discord` to `OPUS_CHANNELS` and added a focused regression test that locks in Discord auto-TTS voice-note routing.
- What did NOT change (scope boundary): no Discord delivery code, provider-specific synthesis logic, or non-Discord channel behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63931
- Related #63950
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the speech-core runtime chose `target: "audio-file"` for Discord because `discord` was missing from `OPUS_CHANNELS`.
- Missing detection / guardrail: there was no regression test asserting that Discord auto-TTS uses the voice-note path.
- Contributing context (if known): #63950 already had the same one-line runtime fix, but that PR was closed for PR-queue reasons rather than because the fix was incorrect.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/speech-core/src/tts.test.ts`
- Scenario the test should lock in: Discord auto TTS should synthesize with `target: "voice-note"` and return `audioAsVoice: true` for a voice-compatible result.
- Why this is the smallest reliable guardrail: it exercises the exact `speech-core` decision point that controls Discord's auto voice-note routing without needing live Discord or provider credentials.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord auto TTS / auto voice replies now route through the native voice-note path instead of falling back to regular audio attachments when the synthesis result is voice-compatible.

## Diagram (if applicable)

```text
Before:
[Discord auto TTS] -> [channel not in OPUS_CHANNELS] -> [target: audio-file] -> [regular audio attachment]

After:
[Discord auto TTS] -> [channel in OPUS_CHANNELS] -> [target: voice-note] -> [native Discord voice message]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin arm64)
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: mocked speech provider in unit test
- Integration/channel (if any): Discord
- Relevant config (redacted): `messages.tts.enabled=true`, `messages.tts.provider=mock`

### Steps

1. Run `pnpm test extensions/speech-core/src/tts.test.ts`.
2. Let the test call `maybeApplyTtsToPayload` for `channel: "discord"` with a mock provider that only marks voice output as compatible when `target === "voice-note"`.
3. Assert the synthesize request uses `target: "voice-note"` and the resulting payload sets `audioAsVoice: true`.

### Expected

- Discord auto TTS uses the voice-note path.
- The returned payload is marked for native voice delivery.

### Actual

- Verified locally after the fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: added and ran `pnpm test extensions/speech-core/src/tts.test.ts` locally; the test passed and asserted both `target: "voice-note"` and `audioAsVoice: true` for Discord.
- Edge cases checked: the mock provider only reports `voiceCompatible` when the request target is the voice-note path, so the test guards both the target selection and the final payload flag.
- What you did **not** verify: live Discord delivery, full repo-wide `pnpm check`, and broader integration suites.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the regression test mocks channel normalization instead of booting the full channel registry.
  - Mitigation: the test intentionally isolates the `speech-core` decision path and asserts the exact voice-note target and payload flag that regressed here.
