### PR TITLE
fix(cli): skip hook-pack fallback after blocked plugin installs

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -252,6 +252,8 @@ vi.mock("./prompt.js", () => ({
 vi.mock("../plugins/install.js", () => ({
   PLUGIN_INSTALL_ERROR_CODE: {
     NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
+    SECURITY_SCAN_BLOCKED: "security_scan_blocked",
+    SECURITY_SCAN_FAILED: "security_scan_failed",
   },
   installPluginFromNpmSpec: ((
     ...args: Parameters<(typeof import("../plugins/install.js"))["installPluginFromNpmSpec"]>

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -205,6 +205,16 @@ function primeHookPackNpmFallback() {
   return { cfg, installedCfg };
 }
 
+function primeBlockedNpmPluginInstall(params: { spec: string; pluginId: string }) {
+  loadConfig.mockReturnValue({} as OpenClawConfig);
+  mockClawHubPackageNotFound(params.spec);
+  installPluginFromNpmSpec.mockResolvedValue({
+    ok: false,
+    error: `Plugin "${params.pluginId}" installation blocked: dangerous code patterns detected: finding details`,
+    code: "security_scan_blocked",
+  });
+}
+
 function primeHookPackPathFallback(params: {
   tmpRoot: string;
   pluginInstallError: string;
@@ -710,6 +720,21 @@ describe("plugins cli install", () => {
     );
     expect(writeConfigFile).toHaveBeenCalledWith(installedCfg);
     expect(runtimeLogs.some((line) => line.includes("Installed hook pack: demo-hooks"))).toBe(true);
+  });
+
+  it("does not try hook-pack fallback after a blocked npm security scan", async () => {
+    primeBlockedNpmPluginInstall({
+      spec: "@acme/unsafe-plugin",
+      pluginId: "unsafe-plugin",
+    });
+
+    await expect(runPluginsCommand(["plugins", "install", "@acme/unsafe-plugin"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain('Plugin "unsafe-plugin" installation blocked');
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
   it("passes force through as overwrite mode for hook-pack npm fallback installs", async () => {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -9,7 +9,12 @@ import { extractErrorCode, formatErrorMessage } from "../infra/errors.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
 import { formatClawHubSpecifier, installPluginFromClawHub } from "../plugins/clawhub.js";
 import type { InstallSafetyOverrides } from "../plugins/install-security-scan.js";
-import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
+import {
+  installPluginFromNpmSpec,
+  installPluginFromPath,
+  PLUGIN_INSTALL_ERROR_CODE,
+  type InstallPluginResult,
+} from "../plugins/install.js";
 import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
 import {
   installPluginFromMarketplace,
@@ -46,6 +51,15 @@ function resolveInstallSafetyOverrides(overrides: InstallSafetyOverrides): Insta
   return {
     dangerouslyForceUnsafeInstall: overrides.dangerouslyForceUnsafeInstall,
   };
+}
+
+function shouldAttemptHookPackFallback(
+  result: Extract<InstallPluginResult, { ok: false }>,
+): boolean {
+  return (
+    result.code !== PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED &&
+    result.code !== PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED
+  );
 }
 
 async function installBundledPluginSource(params: {
@@ -402,6 +416,10 @@ export async function runPluginInstallCommand(params: {
       logger: createPluginInstallLogger(),
     });
     if (!result.ok) {
+      if (!shouldAttemptHookPackFallback(result)) {
+        defaultRuntime.error(result.error);
+        return defaultRuntime.exit(1);
+      }
       const hookFallback = await tryInstallHookPackFromLocalPath({
         config: cfg,
         installMode,
@@ -547,6 +565,10 @@ export async function runPluginInstallCommand(params: {
     logger: createPluginInstallLogger(),
   });
   if (!result.ok) {
+    if (!shouldAttemptHookPackFallback(result)) {
+      defaultRuntime.error(result.error);
+      return defaultRuntime.exit(1);
+    }
     const bundledFallbackPlan = resolveBundledInstallPlanForNpmFailure({
       rawSpec: raw,
       code: result.code,


### PR DESCRIPTION
## Summary

- stop `openclaw plugins install` from retrying a failed plugin install as a hook pack when the plugin install was already blocked by the security scanner
- remove the extra download/extract attempt and the misleading `Also not a valid hook pack` follow-up after a security block
- add a focused CLI regression test for blocked npm plugin installs

## Why

Security-scan failures are terminal for the plugin install path. Falling through to hook-pack detection only adds duplicate work and noisier error output.

## Testing

- `pnpm test src/cli/plugins-cli.install.test.ts`
- the repo pre-commit `pnpm check` path hit unrelated existing `pnpm tsgo` failures outside this CLI scope, so the commit used the repo's documented `FAST_COMMIT=1` path after the focused CLI test passed
