### PR TITLE
feat: per-server MCP tool allow/deny filter

### DIFF
--- a/src/agents/pi-bundle-mcp-filter.test.ts
+++ b/src/agents/pi-bundle-mcp-filter.test.ts
@@ -141,4 +141,50 @@ describe("applyMcpToolFilter", () => {
     });
     expect(infoSpy).not.toHaveBeenCalled();
   });
+
+  it("coerces a non-array allow (e.g. bundle-provided truthy garbage) to undefined and warns", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: true as unknown as [string, ...string[]] },
+    });
+    // allow ignored → tools pass through unchanged
+    expect(result).toBe(tools);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'bundle-mcp: server "srv" tools.allow is not an array — ignoring',
+    );
+  });
+
+  it("coerces a non-array deny (e.g. {}) to undefined and warns", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { deny: {} as unknown as [string, ...string[]] },
+    });
+    expect(result).toBe(tools);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'bundle-mcp: server "srv" tools.deny is not an array — ignoring',
+    );
+  });
+
+  it("applies a valid allow even when deny is a non-array", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta", "gamma");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: {
+        allow: ["alpha", "beta"],
+        deny: "nope" as unknown as [string, ...string[]],
+      },
+    });
+    expect(result.map((tool) => tool.name)).toEqual(["alpha", "beta"]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'bundle-mcp: server "srv" tools.deny is not an array — ignoring',
+    );
+  });
 });

--- a/src/agents/pi-bundle-mcp-filter.test.ts
+++ b/src/agents/pi-bundle-mcp-filter.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as logger from "../logger.js";
+import { applyMcpToolFilter } from "./pi-bundle-mcp-filter.js";
+
+type FakeTool = { name: string };
+
+function makeTools(...names: string[]): FakeTool[] {
+  return names.map((name) => ({ name }));
+}
+
+describe("applyMcpToolFilter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the input unchanged when the filter is undefined", () => {
+    const tools = makeTools("a", "b", "c");
+    const result = applyMcpToolFilter({ serverName: "srv", tools });
+    expect(result).toEqual(tools);
+    expect(result).toBe(tools);
+  });
+
+  it("returns the input unchanged when the filter has neither allow nor deny", () => {
+    const tools = makeTools("a", "b");
+    const result = applyMcpToolFilter({ serverName: "srv", tools, filter: {} });
+    expect(result).toBe(tools);
+  });
+
+  it("keeps only tools listed in allow", () => {
+    const tools = makeTools("alpha", "beta", "gamma");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: ["alpha", "gamma"] },
+    });
+    expect(result.map((tool) => tool.name)).toEqual(["alpha", "gamma"]);
+  });
+
+  it("drops tools listed in deny and keeps the rest", () => {
+    const tools = makeTools("alpha", "beta", "gamma");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { deny: ["beta"] },
+    });
+    expect(result.map((tool) => tool.name)).toEqual(["alpha", "gamma"]);
+  });
+
+  it("applies allow first, then deny carves exceptions", () => {
+    const tools = makeTools("alpha", "beta", "gamma", "delta");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: ["alpha", "beta", "gamma"], deny: ["beta"] },
+    });
+    expect(result.map((tool) => tool.name)).toEqual(["alpha", "gamma"]);
+  });
+
+  it("drops a tool listed in both allow and deny (deny wins on overlap)", () => {
+    const tools = makeTools("alpha", "beta");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: ["alpha", "beta"], deny: ["beta"] },
+    });
+    expect(result.map((tool) => tool.name)).toEqual(["alpha"]);
+  });
+
+  it("dedupes allow entries so a duplicated typo only warns once", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha");
+    applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: ["alpha", "nope", "nope"] },
+    });
+    const notFoundCalls = warnSpy.mock.calls.filter(([message]) =>
+      typeof message === "string" && message.includes('"nope"'),
+    );
+    expect(notFoundCalls).toHaveLength(1);
+  });
+
+  it("matches case-sensitively — mismatched case is filtered out and warns", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("list_work_items");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: ["List_work_items"] },
+    });
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"List_work_items"'),
+    );
+  });
+
+  it("warns on unknown allow entries with the grep-friendly phrasing", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha");
+    applyMcpToolFilter({
+      serverName: "plane",
+      tools,
+      filter: { allow: ["alpha", "nonexistent_tool"] },
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'bundle-mcp: allow-list entry "nonexistent_tool" not found on server "plane" (typo or upstream rename?)',
+    );
+  });
+
+  it("does NOT warn on unknown deny entries (denying a missing tool is idempotent)", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha");
+    applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { deny: ["alpha", "already_gone"] },
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits an info log with the post-filter count when the filter changes the tool list", () => {
+    const infoSpy = vi.spyOn(logger, "logInfo").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta", "gamma");
+    applyMcpToolFilter({
+      serverName: "plane",
+      tools,
+      filter: { allow: ["alpha"] },
+    });
+    expect(infoSpy).toHaveBeenCalledWith(
+      'bundle-mcp: server "plane" filter applied — 1 of 3 tools exposed',
+    );
+  });
+
+  it("does not emit an info log when the filter is a no-op on the tool list", () => {
+    const infoSpy = vi.spyOn(logger, "logInfo").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta");
+    applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: ["alpha", "beta"] },
+    });
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-bundle-mcp-filter.test.ts
+++ b/src/agents/pi-bundle-mcp-filter.test.ts
@@ -187,4 +187,50 @@ describe("applyMcpToolFilter", () => {
       'bundle-mcp: server "srv" tools.deny is not an array — ignoring',
     );
   });
+
+  it("rejects an empty allow (bundle path) and passes tools through unchanged with a warn", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { allow: [] as unknown as [string, ...string[]] },
+    });
+    // allow: [] must not silently hide every tool — bundle configs bypass Zod's .min(1)
+    expect(result).toBe(tools);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'bundle-mcp: server "srv" tools.allow is empty — ignoring (use deny to remove specific tools)',
+    );
+  });
+
+  it("rejects an empty deny (bundle path) and passes tools through unchanged with a warn", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: { deny: [] as unknown as [string, ...string[]] },
+    });
+    expect(result).toBe(tools);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'bundle-mcp: server "srv" tools.deny is empty — ignoring',
+    );
+  });
+
+  it("applies a valid allow even when deny is an empty array", () => {
+    const warnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+    const tools = makeTools("alpha", "beta", "gamma");
+    const result = applyMcpToolFilter({
+      serverName: "srv",
+      tools,
+      filter: {
+        allow: ["alpha", "beta"],
+        deny: [] as unknown as [string, ...string[]],
+      },
+    });
+    expect(result.map((tool) => tool.name)).toEqual(["alpha", "beta"]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'bundle-mcp: server "srv" tools.deny is empty — ignoring',
+    );
+  });
 });

--- a/src/agents/pi-bundle-mcp-filter.ts
+++ b/src/agents/pi-bundle-mcp-filter.ts
@@ -21,9 +21,10 @@ export type McpToolFilter = {
  *   Unknown `deny` entries are silent because denying a non-existent tool is idempotent
  *   and often intentional (defensive config).
  *
- * The filter is a **context-budget mechanism**, not an access-control mechanism. See the
- * note in pi-bundle-mcp-runtime.ts `callTool` for why denying a tool here does NOT prevent
- * direct invocation by name via the runtime.
+ * The filter is a **context-budget mechanism**, not an access-control mechanism.
+ * Denying a tool here prevents models from seeing it in the catalog, but does NOT prevent
+ * direct invocation by name through the runtime's `callTool` path (which bypasses catalog
+ * filtering). Do not rely on this filter as a security boundary.
  *
  * Generic on `T extends { name: string }` so it can be called directly on the SDK
  * `ListedTool` shape without an adapter.
@@ -34,14 +35,43 @@ export function applyMcpToolFilter<T extends { name: string }>(params: {
   filter?: McpToolFilter;
 }): T[] {
   const { serverName, tools, filter } = params;
-  if (!filter || (!filter.allow && !filter.deny)) {
+  if (!filter || (filter.allow === undefined && filter.deny === undefined)) {
+    return tools;
+  }
+
+  // Defensive: bundle-provided MCP configs reach this function via a runtime
+  // cast in pi-bundle-mcp-runtime.ts and are not always zod-validated, so
+  // allow/deny may be arbitrary runtime values (e.g. `true`, `{}`) despite
+  // the TypeScript type. Coerce non-array shapes to undefined and warn the
+  // operator instead of letting `new Set(...)` throw on a non-iterable.
+  let allow: string[] | undefined;
+  if (filter.allow !== undefined) {
+    if (Array.isArray(filter.allow)) {
+      allow = filter.allow;
+    } else {
+      logWarn(
+        `bundle-mcp: server "${serverName}" tools.allow is not an array — ignoring`,
+      );
+    }
+  }
+  let deny: string[] | undefined;
+  if (filter.deny !== undefined) {
+    if (Array.isArray(filter.deny)) {
+      deny = filter.deny;
+    } else {
+      logWarn(
+        `bundle-mcp: server "${serverName}" tools.deny is not an array — ignoring`,
+      );
+    }
+  }
+  if (!allow && !deny) {
     return tools;
   }
 
   let filtered = tools;
 
-  if (filter.allow) {
-    const allowSet = new Set(filter.allow);
+  if (allow) {
+    const allowSet = new Set(allow);
     const seenOnServer = new Set(tools.map((tool) => tool.name));
     for (const entry of allowSet) {
       if (!seenOnServer.has(entry)) {
@@ -53,8 +83,8 @@ export function applyMcpToolFilter<T extends { name: string }>(params: {
     filtered = filtered.filter((tool) => allowSet.has(tool.name));
   }
 
-  if (filter.deny) {
-    const denySet = new Set(filter.deny);
+  if (deny) {
+    const denySet = new Set(deny);
     filtered = filtered.filter((tool) => !denySet.has(tool.name));
   }
 

--- a/src/agents/pi-bundle-mcp-filter.ts
+++ b/src/agents/pi-bundle-mcp-filter.ts
@@ -1,0 +1,68 @@
+import { logInfo, logWarn } from "../logger.js";
+
+export type McpToolFilter = {
+  allow?: string[];
+  deny?: string[];
+};
+
+/**
+ * Apply a per-server allow/deny filter to the tool list discovered from an MCP server.
+ *
+ * Semantics:
+ * - No filter, or filter with neither `allow` nor `deny` set → return tools unchanged.
+ * - `allow` defines the universe of permitted tools; anything not listed is dropped.
+ * - `deny` carves exceptions; anything listed is dropped.
+ * - When both are present, `allow` runs first, then `deny` — so a tool present in both
+ *   lists is dropped (deny wins on overlap).
+ * - Matching is case-sensitive. MCP tool names are case-sensitive per the MCP spec.
+ * - Duplicate entries in `allow`/`deny` are deduped on ingress so warnings fire only once.
+ * - Unknown `allow` entries (names not present on the server) emit a warning — this is
+ *   typically a typo or an upstream rename, both of which the operator should know about.
+ *   Unknown `deny` entries are silent because denying a non-existent tool is idempotent
+ *   and often intentional (defensive config).
+ *
+ * The filter is a **context-budget mechanism**, not an access-control mechanism. See the
+ * note in pi-bundle-mcp-runtime.ts `callTool` for why denying a tool here does NOT prevent
+ * direct invocation by name via the runtime.
+ *
+ * Generic on `T extends { name: string }` so it can be called directly on the SDK
+ * `ListedTool` shape without an adapter.
+ */
+export function applyMcpToolFilter<T extends { name: string }>(params: {
+  serverName: string;
+  tools: T[];
+  filter?: McpToolFilter;
+}): T[] {
+  const { serverName, tools, filter } = params;
+  if (!filter || (!filter.allow && !filter.deny)) {
+    return tools;
+  }
+
+  let filtered = tools;
+
+  if (filter.allow) {
+    const allowSet = new Set(filter.allow);
+    const seenOnServer = new Set(tools.map((tool) => tool.name));
+    for (const entry of allowSet) {
+      if (!seenOnServer.has(entry)) {
+        logWarn(
+          `bundle-mcp: allow-list entry "${entry}" not found on server "${serverName}" (typo or upstream rename?)`,
+        );
+      }
+    }
+    filtered = filtered.filter((tool) => allowSet.has(tool.name));
+  }
+
+  if (filter.deny) {
+    const denySet = new Set(filter.deny);
+    filtered = filtered.filter((tool) => !denySet.has(tool.name));
+  }
+
+  if (filtered.length !== tools.length) {
+    logInfo(
+      `bundle-mcp: server "${serverName}" filter applied — ${filtered.length} of ${tools.length} tools exposed`,
+    );
+  }
+
+  return filtered;
+}

--- a/src/agents/pi-bundle-mcp-filter.ts
+++ b/src/agents/pi-bundle-mcp-filter.ts
@@ -41,27 +41,38 @@ export function applyMcpToolFilter<T extends { name: string }>(params: {
 
   // Defensive: bundle-provided MCP configs reach this function via a runtime
   // cast in pi-bundle-mcp-runtime.ts and are not always zod-validated, so
-  // allow/deny may be arbitrary runtime values (e.g. `true`, `{}`) despite
+  // allow/deny may be arbitrary runtime values (e.g. `true`, `{}`, `[]`) despite
   // the TypeScript type. Coerce non-array shapes to undefined and warn the
   // operator instead of letting `new Set(...)` throw on a non-iterable.
+  // Empty arrays are also rejected — an `allow: []` would silently hide every
+  // tool on the server with only an info log, the exact footgun Zod's `.min(1)`
+  // guards against on the user-config path.
   let allow: string[] | undefined;
   if (filter.allow !== undefined) {
-    if (Array.isArray(filter.allow)) {
-      allow = filter.allow;
-    } else {
+    if (!Array.isArray(filter.allow)) {
       logWarn(
         `bundle-mcp: server "${serverName}" tools.allow is not an array — ignoring`,
       );
+    } else if (filter.allow.length === 0) {
+      logWarn(
+        `bundle-mcp: server "${serverName}" tools.allow is empty — ignoring (use deny to remove specific tools)`,
+      );
+    } else {
+      allow = filter.allow;
     }
   }
   let deny: string[] | undefined;
   if (filter.deny !== undefined) {
-    if (Array.isArray(filter.deny)) {
-      deny = filter.deny;
-    } else {
+    if (!Array.isArray(filter.deny)) {
       logWarn(
         `bundle-mcp: server "${serverName}" tools.deny is not an array — ignoring`,
       );
+    } else if (filter.deny.length === 0) {
+      logWarn(
+        `bundle-mcp: server "${serverName}" tools.deny is empty — ignoring`,
+      );
+    } else {
+      deny = filter.deny;
     }
   }
   if (!allow && !deny) {

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -11,6 +11,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { loadEmbeddedPiMcpConfig } from "./embedded-pi-mcp.js";
 import { isMcpConfigRecord } from "./mcp-config-shared.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
+import { applyMcpToolFilter } from "./pi-bundle-mcp-filter.js";
 import { sanitizeServerName } from "./pi-bundle-mcp-names.js";
 import type {
   McpCatalogTool,
@@ -195,12 +196,25 @@ export function createSessionMcpRuntime(params: {
             failIfDisposed();
             const listedTools = await listAllTools(client);
             failIfDisposed();
+            // rawServer is Record<string, unknown> (from ConfigMcpServers at mcp-config.ts:6)
+            // because the config is validated against a zod schema with .catchall(z.unknown()),
+            // so the `tools` field loses its narrowed type after normalization. The cast below
+            // is the trade-off for keeping the schema permissive — don't "fix" it by removing
+            // it without first re-typing normalizeConfiguredMcpServers. The tools field is
+            // validated at config-load time by McpServerSchema in zod-schema.ts.
+            const toolFilter = (rawServer as { tools?: { allow?: string[]; deny?: string[] } })
+              .tools;
+            const filteredTools = applyMcpToolFilter({
+              serverName,
+              tools: listedTools,
+              filter: toolFilter,
+            });
             servers[serverName] = {
               serverName,
               launchSummary: resolved.description,
-              toolCount: listedTools.length,
+              toolCount: filteredTools.length,
             };
-            for (const tool of listedTools) {
+            for (const tool of filteredTools) {
               const toolName = tool.name.trim();
               if (!toolName) {
                 continue;

--- a/src/agents/pi-bundle-mcp-test-harness.ts
+++ b/src/agents/pi-bundle-mcp-test-harness.ts
@@ -42,17 +42,26 @@ export async function waitForFileText(filePath: string, timeoutMs = 5_000): Prom
 }
 
 export async function startSseProbeServer(
-  probeText = "FROM-SSE",
+  probeTextOrOptions: string | { probeText?: string; extraToolNames?: string[] } = "FROM-SSE",
 ): Promise<{ port: number; close: () => Promise<void> }> {
+  const options =
+    typeof probeTextOrOptions === "string"
+      ? { probeText: probeTextOrOptions, extraToolNames: [] as string[] }
+      : { probeText: probeTextOrOptions.probeText ?? "FROM-SSE", extraToolNames: probeTextOrOptions.extraToolNames ?? [] };
   const { McpServer } = await import(SDK_SERVER_MCP_PATH);
   const { SSEServerTransport } = await import(SDK_SERVER_SSE_PATH);
 
   const mcpServer = new McpServer({ name: "sse-probe", version: "1.0.0" });
   mcpServer.tool("sse_probe", "SSE MCP probe", async () => {
     return {
-      content: [{ type: "text", text: probeText }],
+      content: [{ type: "text", text: options.probeText }],
     };
   });
+  for (const extraToolName of options.extraToolNames) {
+    mcpServer.tool(extraToolName, "SSE MCP extra probe", async () => ({
+      content: [{ type: "text", text: extraToolName }],
+    }));
+  }
 
   let sseTransport:
     | {

--- a/src/agents/pi-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.materialize.test.ts
@@ -169,4 +169,38 @@ describe("createBundleMcpToolRuntime", () => {
       "multi__zeta",
     ]);
   });
+
+  it("applies tools.allow at discovery time so only whitelisted tools reach the catalog", async () => {
+    const sseServer = await startSseProbeServer({
+      extraToolNames: ["extra_tool_a", "extra_tool_b"],
+    });
+
+    try {
+      const workspaceDir = await makeTempDir("openclaw-bundle-mcp-sse-");
+      const runtime = await createBundleMcpToolRuntime({
+        workspaceDir,
+        cfg: {
+          mcp: {
+            servers: {
+              sseProbe: {
+                url: `http://127.0.0.1:${sseServer.port}/sse`,
+                transport: "sse",
+                tools: {
+                  allow: ["sse_probe"],
+                },
+              },
+            },
+          },
+        },
+      });
+
+      try {
+        expect(runtime.tools.map((tool) => tool.name)).toEqual(["sseProbe__sse_probe"]);
+      } finally {
+        await runtime.dispose();
+      }
+    } finally {
+      await sseServer.close();
+    }
+  });
 });

--- a/src/agents/pi-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.materialize.test.ts
@@ -3,6 +3,7 @@ import {
   createBundleMcpToolRuntime,
   materializeBundleMcpToolsForRun,
 } from "./pi-bundle-mcp-materialize.js";
+import { makeTempDir, startSseProbeServer } from "./pi-bundle-mcp-test-harness.js";
 import type { McpCatalogTool } from "./pi-bundle-mcp-types.js";
 import type { SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
 

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -154,4 +154,85 @@ describe("config mcp config", () => {
       });
     });
   });
+
+  it("accepts MCP server configs with tools.allow and tools.deny", async () => {
+    await withTempHomeConfig({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "plane",
+        server: {
+          url: "https://mcp.plane.so/http/api-key/mcp",
+          tools: {
+            allow: ["list_work_items", "retrieve_work_item"],
+            deny: ["delete_project"],
+          },
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      const loaded = await listConfiguredMcpServers();
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) {
+        throw new Error("expected MCP config to load");
+      }
+      expect(loaded.mcpServers.plane).toEqual({
+        url: "https://mcp.plane.so/http/api-key/mcp",
+        tools: {
+          allow: ["list_work_items", "retrieve_work_item"],
+          deny: ["delete_project"],
+        },
+      });
+    });
+  });
+
+  it("rejects tools field when it is not an object", async () => {
+    await withTempHomeConfig({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "plane",
+        server: {
+          url: "https://mcp.plane.so/http/api-key/mcp",
+          tools: "allow",
+        },
+      });
+      expect(setResult.ok).toBe(false);
+    });
+  });
+
+  it("rejects tools.allow with an empty string entry", async () => {
+    await withTempHomeConfig({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "plane",
+        server: {
+          url: "https://mcp.plane.so/http/api-key/mcp",
+          tools: { allow: [""] },
+        },
+      });
+      expect(setResult.ok).toBe(false);
+    });
+  });
+
+  it("rejects tools.allow: [] (load-bearing guard against silent-hide footgun)", async () => {
+    await withTempHomeConfig({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "plane",
+        server: {
+          url: "https://mcp.plane.so/http/api-key/mcp",
+          tools: { allow: [] },
+        },
+      });
+      expect(setResult.ok).toBe(false);
+    });
+  });
+
+  it("rejects tools.deny: [] (symmetric guard with allow)", async () => {
+    await withTempHomeConfig({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "plane",
+        server: {
+          url: "https://mcp.plane.so/http/api-key/mcp",
+          tools: { deny: [] },
+        },
+      });
+      expect(setResult.ok).toBe(false);
+    });
+  });
 });

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -156,7 +156,7 @@ describe("config mcp config", () => {
   });
 
   it("accepts MCP server configs with tools.allow and tools.deny", async () => {
-    await withTempHome(async () => {
+    await withMcpConfigHome({}, async () => {
       const setResult = await setConfiguredMcpServer({
         name: "plane",
         server: {

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -156,7 +156,7 @@ describe("config mcp config", () => {
   });
 
   it("accepts MCP server configs with tools.allow and tools.deny", async () => {
-    await withTempHomeConfig({}, async () => {
+    await withTempHome(async () => {
       const setResult = await setConfiguredMcpServer({
         name: "plane",
         server: {
@@ -185,7 +185,7 @@ describe("config mcp config", () => {
   });
 
   it("rejects tools field when it is not an object", async () => {
-    await withTempHomeConfig({}, async () => {
+    await withTempHome(async () => {
       const setResult = await setConfiguredMcpServer({
         name: "plane",
         server: {
@@ -198,7 +198,7 @@ describe("config mcp config", () => {
   });
 
   it("rejects tools.allow with an empty string entry", async () => {
-    await withTempHomeConfig({}, async () => {
+    await withTempHome(async () => {
       const setResult = await setConfiguredMcpServer({
         name: "plane",
         server: {
@@ -211,7 +211,7 @@ describe("config mcp config", () => {
   });
 
   it("rejects tools.allow: [] (load-bearing guard against silent-hide footgun)", async () => {
-    await withTempHomeConfig({}, async () => {
+    await withTempHome(async () => {
       const setResult = await setConfiguredMcpServer({
         name: "plane",
         server: {
@@ -224,7 +224,7 @@ describe("config mcp config", () => {
   });
 
   it("rejects tools.deny: [] (symmetric guard with allow)", async () => {
-    await withTempHomeConfig({}, async () => {
+    await withTempHome(async () => {
       const setResult = await setConfiguredMcpServer({
         name: "plane",
         server: {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -22317,6 +22317,28 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     ],
                   },
                 },
+                tools: {
+                  type: "object",
+                  properties: {
+                    allow: {
+                      minItems: 1,
+                      type: "array",
+                      items: {
+                        type: "string",
+                        minLength: 1,
+                      },
+                    },
+                    deny: {
+                      minItems: 1,
+                      type: "array",
+                      items: {
+                        type: "string",
+                        minLength: 1,
+                      },
+                    },
+                  },
+                  additionalProperties: false,
+                },
               },
               additionalProperties: {},
             },

--- a/src/config/types.mcp.ts
+++ b/src/config/types.mcp.ts
@@ -19,10 +19,10 @@ export type McpServerConfig = {
   connectionTimeoutMs?: number;
   /** Per-server tool filter applied after MCP discovery, before materialization. */
   tools?: {
-    /** Whitelist of bare tool names to expose. If set, only these tools pass. */
-    allow?: string[];
-    /** Blacklist of bare tool names to hide. Applied after allow (deny wins on overlap). */
-    deny?: string[];
+    /** Whitelist of bare tool names to expose. If set, only these tools pass. Must be non-empty. */
+    allow?: [string, ...string[]];
+    /** Blacklist of bare tool names to hide. Applied after allow (deny wins on overlap). Must be non-empty. */
+    deny?: [string, ...string[]];
   };
   [key: string]: unknown;
 };

--- a/src/config/types.mcp.ts
+++ b/src/config/types.mcp.ts
@@ -17,6 +17,13 @@ export type McpServerConfig = {
   headers?: Record<string, string | number | boolean>;
   /** Optional connection timeout in milliseconds. */
   connectionTimeoutMs?: number;
+  /** Per-server tool filter applied after MCP discovery, before materialization. */
+  tools?: {
+    /** Whitelist of bare tool names to expose. If set, only these tools pass. */
+    allow?: string[];
+    /** Blacklist of bare tool names to hide. Applied after allow (deny wins on overlap). */
+    deny?: string[];
+  };
   [key: string]: unknown;
 };
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -210,6 +210,14 @@ const TalkSchema = z
     }
   });
 
+const McpServerToolFilterSchema = z
+  .object({
+    allow: z.array(z.string().min(1)).min(1).optional(),
+    deny: z.array(z.string().min(1)).min(1).optional(),
+  })
+  .strict()
+  .optional();
+
 const McpServerSchema = z
   .object({
     command: z.string().optional(),
@@ -224,6 +232,7 @@ const McpServerSchema = z
         z.union([z.string().register(sensitive), z.number(), z.boolean()]).register(sensitive),
       )
       .optional(),
+    tools: McpServerToolFilterSchema,
   })
   .catchall(z.unknown());
 


### PR DESCRIPTION
## Summary

Adds `tools.allow` / `tools.deny` filtering to MCP server config, applied at discovery time inside `getCatalog`. Prevents tool-rich servers (Plane: 80+ tools, Linear, GitHub, etc.) from blowing context budgets on small-window models.

Default behavior unchanged: a config with no `tools` field exposes all tools as before. The filter is a **context-budget mechanism, not an access-control boundary** — see commit message for full scope/non-goals.

### Config shape

```json
{
  "mcp": {
    "servers": {
      "plane": {
        "url": "https://mcp.plane.so/http/api-key/mcp",
        "tools": {
          "allow": ["list_work_items", "retrieve_work_item", "update_work_item", "create_work_item"]
        }
      }
    }
  }
}
```

### Semantics

- `allow` present → keep only tools whose name appears in the allow set.
- `deny` present → drop tools whose name appears in the deny set.
- Both present → allow runs first, then deny carves exceptions (deny wins on overlap).
- Neither present → pass all.
- `allow: []` / `deny: []` rejected at Zod parse time (`.min(1)`) — half-written configs fail loud instead of silently hiding every tool.
- Matching is case-sensitive per the MCP spec.
- Duplicates in `allow` / `deny` are Set-deduped at filter ingress so a typo only warns once.
- Unknown `allow` entries emit a grep-friendly warning `bundle-mcp: allow-list entry \"{entry}\" not found on server \"{server}\" (typo or upstream rename?)`, don't fail (upstream renames/drops tools).
- Unknown `deny` entries are silent (denying a missing tool is idempotent).
- When the filter actually reduces the tool count, emits `bundle-mcp: server \"{server}\" filter applied — {n} of {m} tools exposed` at info level as an operator sanity signal.

### Why this was cherry-picked onto a fresh branch

The original PR (#64099) was opened from a fork that had diverged ~5K commits behind upstream/main and hit merge conflicts on config-doc-baseline refactors unrelated to this change. This branch is cherry-picked from that commit directly onto current `upstream/main` with no extraneous churn — the diff is scoped to the CAL-20 surface area.

## Test plan

- [x] Unit tests: `pnpm vitest run src/agents/pi-bundle-mcp-filter.test.ts` — 12 cases covering undefined/empty filter, allow-only, deny-only, allow+deny, overlap (deny wins), dedup, case sensitivity, unknown-allow warn, unknown-deny silent, info log on filter applied, info log suppressed on no-op
- [x] Config tests: `pnpm vitest run src/config/mcp-config.test.ts` — 8 cases including parse-time rejection of `tools: \"allow\"`, `tools.allow: [\"\"]`, `tools.allow: []`, `tools.deny: []`
- [x] Integration test: `pnpm vitest run src/agents/pi-bundle-mcp-tools.materialize.test.ts -t \"applies tools.allow\"` — wires SSE probe with extra tools and asserts the allow-list narrows the materialized catalog to the whitelisted tool only
- [x] `pnpm config:schema:check` — passes (generated base schema regenerated and committed)
- [x] `pnpm config:docs:check` — passes (docs baseline sha256 regenerated and committed)

> Note on local test flake: two unrelated stdio MCP tests are broken on my Windows box due to a pre-existing `ERR_UNSUPPORTED_ESM_URL_SCHEME` issue with `node --input-type=module` + `file:` URL resolution on Windows paths. Those are not touched by this PR and should pass on Linux CI — I intentionally routed the integration test through the SSE probe harness (in-process) to avoid that Windows-specific path.