### PR TITLE
fix(qa-lab): avoid completion-cache install crash

### DIFF
--- a/extensions/qa-lab/src/discovery-eval.test.ts
+++ b/extensions/qa-lab/src/discovery-eval.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   hasDiscoveryLabels,
   reportsDiscoveryScopeLeak,
@@ -97,5 +97,35 @@ Final QA tally update: all mandatory scenarios resolved. QA run complete.
     expect(hasDiscoveryLabels(report)).toBe(true);
     expect(reportsMissingDiscoveryFiles(report)).toBe(false);
     expect(reportsDiscoveryScopeLeak(report)).toBe(true);
+  });
+
+  it("falls back to default discovery refs when the scenario pack is unavailable at import time", async () => {
+    vi.resetModules();
+    vi.doMock("./scenario-catalog.js", () => ({
+      readQaScenarioExecutionConfig: () => {
+        throw new Error("qa scenario pack not found: qa/scenarios/index.md");
+      },
+    }));
+
+    try {
+      const mod = await import("./discovery-eval.js");
+      const report = `
+Worked
+- Read all three requested files: repo/qa/scenarios/index.md, repo/extensions/qa-lab/src/suite.ts, and repo/docs/help/testing.md.
+Failed
+- None.
+Blocked
+- Runtime execution not attempted here.
+Follow-up
+- Run the live suite next.
+`.trim();
+
+      expect(mod.hasDiscoveryLabels(report)).toBe(true);
+      expect(mod.reportsMissingDiscoveryFiles(report)).toBe(false);
+      expect(mod.reportsDiscoveryScopeLeak(report)).toBe(false);
+    } finally {
+      vi.doUnmock("./scenario-catalog.js");
+      vi.resetModules();
+    }
   });
 });

--- a/extensions/qa-lab/src/discovery-eval.test.ts
+++ b/extensions/qa-lab/src/discovery-eval.test.ts
@@ -5,6 +5,11 @@ import {
   reportsMissingDiscoveryFiles,
 } from "./discovery-eval.js";
 
+async function importFreshDiscoveryEval(tag: string) {
+  const modulePath = `./discovery-eval.js?${tag}` as string;
+  return (await import(/* @vite-ignore */ modulePath)) as typeof import("./discovery-eval.js");
+}
+
 describe("qa discovery evaluation", () => {
   it("accepts rich discovery reports that explicitly confirm all required files were read", () => {
     const report = `
@@ -108,7 +113,7 @@ Final QA tally update: all mandatory scenarios resolved. QA run complete.
     }));
 
     try {
-      const mod = await import("./discovery-eval.js");
+      const mod = await importFreshDiscoveryEval("missing-pack");
       const report = `
 Worked
 - Read all three requested files: repo/qa/scenarios/index.md, repo/extensions/qa-lab/src/suite.ts, and repo/docs/help/testing.md.
@@ -123,6 +128,36 @@ Follow-up
       expect(mod.hasDiscoveryLabels(report)).toBe(true);
       expect(mod.reportsMissingDiscoveryFiles(report)).toBe(false);
       expect(mod.reportsDiscoveryScopeLeak(report)).toBe(false);
+    } finally {
+      vi.doUnmock("./scenario-catalog.js");
+      vi.resetModules();
+    }
+  });
+
+  it("rethrows non-missing scenario pack failures when resolving required refs", async () => {
+    vi.resetModules();
+    vi.doMock("./scenario-catalog.js", () => ({
+      readQaScenarioExecutionConfig: () => {
+        throw new Error("qa scenario pack missing ```yaml qa-pack fence in qa/scenarios/index.md");
+      },
+    }));
+
+    try {
+      const mod = await importFreshDiscoveryEval("invalid-pack");
+      const report = `
+Worked
+- Read all three requested files: repo/qa/scenarios/index.md, repo/extensions/qa-lab/src/suite.ts, and repo/docs/help/testing.md.
+Failed
+- None.
+Blocked
+- Runtime execution not attempted here.
+Follow-up
+- Run the live suite next.
+`.trim();
+
+      expect(() => mod.reportsMissingDiscoveryFiles(report)).toThrow(
+        "qa scenario pack missing ```yaml qa-pack fence in qa/scenarios/index.md",
+      );
     } finally {
       vi.doUnmock("./scenario-catalog.js");
       vi.resetModules();

--- a/extensions/qa-lab/src/discovery-eval.ts
+++ b/extensions/qa-lab/src/discovery-eval.ts
@@ -1,22 +1,49 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { readQaScenarioExecutionConfig } from "./scenario-catalog.js";
 
+const DEFAULT_REQUIRED_DISCOVERY_REFS = [
+  "repo/qa/scenarios/index.md",
+  "repo/extensions/qa-lab/src/suite.ts",
+  "repo/docs/help/testing.md",
+] as const;
+
+let cachedRequiredDiscoveryRefs: readonly string[] | null = null;
+let cachedRequiredDiscoveryRefsLower: readonly string[] | null = null;
+
 function readRequiredDiscoveryRefs() {
   const config = readQaScenarioExecutionConfig("source-docs-discovery-report") as
-    | { requiredFiles?: string[] }
+    | { requiredFiles?: unknown }
     | undefined;
-  return (
-    config?.requiredFiles ?? [
-      "repo/qa/scenarios/index.md",
-      "repo/extensions/qa-lab/src/suite.ts",
-      "repo/docs/help/testing.md",
-    ]
-  );
+  const requiredFiles = Array.isArray(config?.requiredFiles)
+    ? config.requiredFiles.filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
+  return requiredFiles.length > 0 ? requiredFiles : DEFAULT_REQUIRED_DISCOVERY_REFS;
 }
 
-const REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();
+function getRequiredDiscoveryRefs() {
+  if (cachedRequiredDiscoveryRefs) {
+    return cachedRequiredDiscoveryRefs;
+  }
+  try {
+    cachedRequiredDiscoveryRefs = readRequiredDiscoveryRefs();
+  } catch {
+    // Global npm installs do not ship the qa/scenarios source pack.
+    cachedRequiredDiscoveryRefs = DEFAULT_REQUIRED_DISCOVERY_REFS;
+  }
+  return cachedRequiredDiscoveryRefs;
+}
 
-const REQUIRED_DISCOVERY_REFS_LOWER = REQUIRED_DISCOVERY_REFS.map(normalizeLowercaseStringOrEmpty);
+function getRequiredDiscoveryRefsLower() {
+  if (cachedRequiredDiscoveryRefsLower) {
+    return cachedRequiredDiscoveryRefsLower;
+  }
+  cachedRequiredDiscoveryRefsLower = getRequiredDiscoveryRefs().map(
+    normalizeLowercaseStringOrEmpty,
+  );
+  return cachedRequiredDiscoveryRefsLower;
+}
 
 const DISCOVERY_SCOPE_LEAK_PHRASES = [
   "all mandatory scenarios",
@@ -29,7 +56,7 @@ const DISCOVERY_SCOPE_LEAK_PHRASES = [
 
 function confirmsDiscoveryFileRead(text: string) {
   const lower = normalizeLowercaseStringOrEmpty(text);
-  const mentionsAllRefs = REQUIRED_DISCOVERY_REFS_LOWER.every((ref) => lower.includes(ref));
+  const mentionsAllRefs = getRequiredDiscoveryRefsLower().every((ref) => lower.includes(ref));
   const mentionsReadVerb = /(?:read|retrieved|inspected|loaded|accessed|digested)/.test(lower);
   const requiredCountPattern = "(?:three|3|four|4)";
   const confirmsRead =

--- a/extensions/qa-lab/src/discovery-eval.ts
+++ b/extensions/qa-lab/src/discovery-eval.ts
@@ -22,13 +22,20 @@ function readRequiredDiscoveryRefs() {
   return requiredFiles.length > 0 ? requiredFiles : DEFAULT_REQUIRED_DISCOVERY_REFS;
 }
 
+function isMissingQaScenarioPackError(error: unknown) {
+  return error instanceof Error && error.message.startsWith("qa scenario pack not found:");
+}
+
 function getRequiredDiscoveryRefs() {
   if (cachedRequiredDiscoveryRefs) {
     return cachedRequiredDiscoveryRefs;
   }
   try {
     cachedRequiredDiscoveryRefs = readRequiredDiscoveryRefs();
-  } catch {
+  } catch (error) {
+    if (!isMissingQaScenarioPackError(error)) {
+      throw error;
+    }
     // Global npm installs do not ship the qa/scenarios source pack.
     cachedRequiredDiscoveryRefs = DEFAULT_REQUIRED_DISCOVERY_REFS;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: importing `extensions/qa-lab/src/discovery-eval.ts` eagerly read the QA scenario pack during command-group registration, which crashes global npm installs because `qa/scenarios/index.md` is not shipped in the published dist.
- Why it matters: completion cache refreshes during flows like `openclaw plugins update` fail with a noisy stack trace even though the plugin operation itself succeeds.
- What changed: `discovery-eval` now resolves `requiredFiles` lazily, caches the result, and falls back to the built-in default refs when the scenario pack is unavailable.
- What did NOT change (scope boundary): this does not ship `qa/scenarios/` in npm, and it does not change `scenario-catalog` behavior for real QA runs that actually require the pack.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63541
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `discovery-eval.ts` called `readRequiredDiscoveryRefs()` at module load, which called `readQaScenarioExecutionConfig()` and ultimately `readQaScenarioPack()` during command registration.
- Missing detection / guardrail: there was no fallback path for published npm installs where `qa/scenarios/index.md` is intentionally absent.
- Contributing context (if known): the completion cache path registers qa-lab command groups even when the user is not invoking any QA command.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qa-lab/src/discovery-eval.test.ts`
- Scenario the test should lock in: importing `discovery-eval` while `readQaScenarioExecutionConfig()` throws `qa scenario pack not found` should still succeed and use the default discovery refs.
- Why this is the smallest reliable guardrail: the crash happens at module import time, so mocking the scenario-catalog import in a unit test covers the exact failing seam without needing a full global-install fixture.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Global npm installs no longer crash completion cache refreshes just because qa-lab's source-only scenario pack is missing from the published dist.

## Diagram (if applicable)

```text
Before:
[completion cache refresh] -> [register qa-lab command group] -> [import discovery-eval] -> [eager scenario-pack read] -> [throw]

After:
[completion cache refresh] -> [register qa-lab command group] -> [import discovery-eval] -> [no eager pack read] -> [success]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Install openclaw globally from npm without the source repo layout.
2. Trigger a completion cache refresh via a command like `openclaw plugins update <plugin>`.
3. Register the qa-lab command group as part of CLI startup.

### Expected

- Completion cache refresh succeeds without requiring `qa/scenarios/index.md`.

### Actual

- Before this change, CLI startup failed with `qa scenario pack not found: qa/scenarios/index.md`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/qa-lab/src/discovery-eval.test.ts`; `pnpm build`.
- Edge cases checked: mocked missing-pack import path falls back to default refs instead of crashing module import.
- What you did **not** verify: I did not reproduce against an actual `npm i -g` install tarball locally.

`pnpm check` still fails on latest `origin/main` due pre-existing TypeScript errors in `extensions/msteams/src/attachments.test.ts:645` and `src/process/supervisor/adapters/child.test.ts:36-37`; this PR does not touch those files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - Fallback could mask unexpected scenario-pack read failures in dev contexts.
- Mitigation:
  - The fallback is limited to discovery-eval's optional metadata path; real QA scenario execution still reads the scenario pack through `scenario-catalog` and still fails loudly if the pack is required.
