### PR TITLE
fix: preserve FormData Content-Type when using runtime fetch with dispatcher

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1070,4 +1070,45 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(lookupFn).toHaveBeenCalledOnce();
     await result.release();
   });
+
+  it("preserves FormData Content-Type when routing through runtime fetch with dispatcher", async () => {
+    const runtimeFetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      const ct = init?.headers instanceof Headers
+        ? init.headers.get("content-type")
+        : undefined;
+      // The Content-Type must include the multipart boundary
+      expect(ct).toBeDefined();
+      expect(ct).toContain("multipart/form-data");
+      expect(ct).toContain("boundary=");
+      return okResponse();
+    });
+
+    const originalGlobalFetch = globalThis.fetch;
+    (globalThis as Record<string, unknown>).fetch = (() => {
+      throw new Error("global fetch should not be called");
+    }) as unknown as typeof fetch;
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: class { constructor(readonly options: unknown) {} },
+      EnvHttpProxyAgent: class { constructor(readonly options: unknown) {} },
+      ProxyAgent: class { constructor(readonly options: unknown) {} },
+      fetch: runtimeFetch,
+    };
+
+    try {
+      const form = new FormData();
+      form.append("file", new Blob(["audio-data"], { type: "audio/ogg" }), "test.ogg");
+      form.append("model", "whisper-large-v3-turbo");
+
+      const result = await fetchWithSsrFGuard({
+        url: "https://api.example.com/audio/transcriptions",
+        init: { method: "POST", body: form },
+        lookupFn: createPublicLookup(),
+      });
+
+      expect(runtimeFetch).toHaveBeenCalledTimes(1);
+      await result.release();
+    } finally {
+      (globalThis as Record<string, unknown>).fetch = originalGlobalFetch;
+    }
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -346,6 +346,23 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       // because the default global fetch path will not honor per-request
       // dispatchers.
       const shouldUseRuntimeFetch = Boolean(dispatcher) && !supportsDispatcherInit;
+
+      // undici's fetch does not auto-set the Content-Type header (including the
+      // multipart boundary) when the request body is FormData and a custom
+      // dispatcher is attached.  Work around by letting a temporary Request
+      // resolve the correct header, then forwarding the serialized blob.
+      if (shouldUseRuntimeFetch && init.body instanceof FormData) {
+        const tmp = new Request("http://localhost", { method: init.method ?? "POST", body: init.body });
+        const ct = tmp.headers.get("content-type");
+        if (ct) {
+          const h = new Headers(init.headers);
+          if (!h.has("content-type")) {
+            h.set("content-type", ct);
+          }
+          init = { ...init, headers: h, body: await tmp.blob() };
+        }
+      }
+
       const response = shouldUseRuntimeFetch
         ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
         : await defaultFetch(parsedUrl.toString(), init);

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -351,6 +351,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       // multipart boundary) when the request body is FormData and a custom
       // dispatcher is attached.  Work around by letting a temporary Request
       // resolve the correct header, then forwarding the serialized blob.
+      let resolvedInit: DispatcherAwareRequestInit = init;
       if (shouldUseRuntimeFetch && init.body instanceof FormData) {
         const tmp = new Request("http://localhost", { method: init.method ?? "POST", body: init.body });
         const ct = tmp.headers.get("content-type");
@@ -359,13 +360,13 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
           if (!h.has("content-type")) {
             h.set("content-type", ct);
           }
-          init = { ...init, headers: h, body: await tmp.blob() };
+          resolvedInit = { ...init, headers: h, body: await tmp.blob() };
         }
       }
 
       const response = shouldUseRuntimeFetch
-        ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
-        : await defaultFetch(parsedUrl.toString(), init);
+        ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), resolvedInit)
+        : await defaultFetch(parsedUrl.toString(), resolvedInit);
 
       if (isRedirectStatus(response.status)) {
         const location = response.headers.get("location");


### PR DESCRIPTION
## Summary

- Fix audio transcription failing with HTTP 400 when `fetchWithSsrFGuard` routes FormData requests through undici's runtime fetch with a pinned DNS dispatcher
- undici 8.x does not auto-set `Content-Type: multipart/form-data; boundary=...` when a custom dispatcher is attached — the fix pre-serializes FormData via a temporary `Request` to resolve the correct header before forwarding

## Problem

All provider-based STT models (Groq Whisper, OpenAI Whisper, Deepgram, etc.) fail with HTTP 400 on containerized/server deployments:

```
Audio transcription failed (HTTP 400):
{"error":{"message":"request Content-Type isn't multipart/form-data"}}
```

The SSRF guard creates a pinned DNS dispatcher for every outbound request. When `shouldUseRuntimeFetch` is true, the request is routed through `fetchWithRuntimeDispatcher()` (undici's fetch). undici's fetch with a dispatcher does not auto-set the `Content-Type` header for `FormData` bodies, so the multipart boundary is lost.

Native `fetch()` without a dispatcher works correctly — this is why local development (macOS) often doesn't reproduce the issue.

## Fix

Before calling `fetchWithRuntimeDispatcher`, detect `FormData` body and pre-serialize it:

```ts
if (shouldUseRuntimeFetch && init.body instanceof FormData) {
  const tmp = new Request("http://localhost", { method: init.method ?? "POST", body: init.body });
  const ct = tmp.headers.get("content-type");
  if (ct) {
    const h = new Headers(init.headers);
    if (!h.has("content-type")) h.set("content-type", ct);
    init = { ...init, headers: h, body: await tmp.blob() };
  }
}
```

SSRF protection (pinned DNS dispatcher) is fully preserved.

## Test plan

- [x] Added test: \`preserves FormData Content-Type when routing through runtime fetch with dispatcher\`
- [ ] Verify Groq/OpenAI \`/audio/transcriptions\` returns 200 on containerized deployment
- [ ] Verify existing SSRF tests pass

Fixes #61937