### PR TITLE
Browser: keep explicit ai snapshots out of efficient role fallback (#62550)

### DIFF
--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -183,13 +183,16 @@ export async function executeSnapshotAction(params: {
   const { input, baseUrl, profile, proxyRequest } = params;
   const snapshotDefaults = browserToolActionDeps.loadConfig().browser?.snapshotDefaults;
   const format: "ai" | "aria" | undefined =
-    input.snapshotFormat === "ai" || input.snapshotFormat === "aria"
-      ? input.snapshotFormat
-      : undefined;
+    input.snapshotFormat === "ai"
+      ? "ai"
+      : input.snapshotFormat === "aria"
+        ? "aria"
+        : undefined;
+  const formatExplicit = format !== undefined;
   const mode: "efficient" | undefined =
     input.mode === "efficient"
       ? "efficient"
-      : format !== "aria" && snapshotDefaults?.mode === "efficient"
+      : !formatExplicit && format !== "aria" && snapshotDefaults?.mode === "efficient"
         ? "efficient"
         : undefined;
   const labels = typeof input.labels === "boolean" ? input.labels : undefined;

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -377,7 +377,8 @@ describe("browser tool snapshot maxChars", () => {
     configMocks.loadConfig.mockReturnValue({
       browser: { snapshotDefaults: { mode: "efficient" } },
     });
-    await runSnapshotToolCall({ snapshotFormat: "ai" });
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "snapshot", target: "host" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalledWith(
       undefined,
@@ -397,6 +398,19 @@ describe("browser tool snapshot maxChars", () => {
       target: "host",
       snapshotFormat: "aria",
     });
+
+    expect(browserClientMocks.browserSnapshot).toHaveBeenCalled();
+    const opts = browserClientMocks.browserSnapshot.mock.calls.at(-1)?.[1] as
+      | { mode?: string }
+      | undefined;
+    expect(opts?.mode).toBeUndefined();
+  });
+
+  it("does not apply config snapshot defaults to explicit ai snapshots", async () => {
+    configMocks.loadConfig.mockReturnValue({
+      browser: { snapshotDefaults: { mode: "efficient" } },
+    });
+    await runSnapshotToolCall({ snapshotFormat: "ai" });
 
     expect(browserClientMocks.browserSnapshot).toHaveBeenCalled();
     const opts = browserClientMocks.browserSnapshot.mock.calls.at(-1)?.[1] as

--- a/extensions/browser/src/browser/pw-ai.e2e.test.ts
+++ b/extensions/browser/src/browser/pw-ai.e2e.test.ts
@@ -118,6 +118,35 @@ describe("pw-ai", () => {
     expect(p1.click).toHaveBeenCalledTimes(1);
   });
 
+  it("returns numeric ai snapshot refs in the public snapshot output", async () => {
+    const snapshot = ['- button "OK" [ref=1]', '- link "Docs" [ref=2]'].join("\n");
+    const p1 = createPage({ targetId: "T1", snapshotFull: snapshot });
+    const browser = createBrowser([p1.page]);
+
+    (chromiumMock.connectOverCDP as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(browser);
+
+    const res = await snapshotAiViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+    });
+
+    expect(res.snapshot).toContain("[ref=1]");
+    expect(res.snapshot).toContain("[ref=2]");
+    expect(res.refs).toMatchObject({
+      1: { role: "button", name: "OK" },
+      2: { role: "link", name: "Docs" },
+    });
+
+    await clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      ref: "1",
+    });
+
+    expect(p1.locator).toHaveBeenCalledWith("aria-ref=1");
+    expect(p1.click).toHaveBeenCalledTimes(1);
+  });
+
   it("truncates oversized snapshots", async () => {
     const longSnapshot = "A".repeat(20);
     const p1 = createPage({ targetId: "T1", snapshotFull: longSnapshot });

--- a/extensions/browser/src/browser/pw-role-snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.test.ts
@@ -64,7 +64,7 @@ describe("pw-role-snapshot", () => {
     expect(parseRoleRef("e12")).toBe("e12");
     expect(parseRoleRef("@e12")).toBe("e12");
     expect(parseRoleRef("ref=e12")).toBe("e12");
-    expect(parseRoleRef("12")).toBeNull();
+    expect(parseRoleRef("12")).toBe("12");
     expect(parseRoleRef("")).toBeNull();
   });
 
@@ -86,5 +86,19 @@ describe("pw-role-snapshot", () => {
     expect(Object.keys(res.refs).toSorted()).toEqual(["e5", "e7"]);
     expect(res.refs.e5).toMatchObject({ role: "link", name: "Home" });
     expect(res.refs.e7).toMatchObject({ role: "button", name: "Save" });
+  });
+
+  it("preserves numeric Playwright AI snapshot refs (#62550)", () => {
+    const ai = [
+      "- navigation [ref=1]:",
+      '  - link "Home" [ref=5]',
+      '  - button "Save" [ref=7] [cursor=pointer]:',
+    ].join("\n");
+
+    const res = buildRoleSnapshotFromAiSnapshot(ai, { interactive: true });
+    expect(res.snapshot).toContain("[ref=5]");
+    expect(Object.keys(res.refs).toSorted()).toEqual(["5", "7"]);
+    expect(res.refs["5"]).toMatchObject({ role: "link", name: "Home" });
+    expect(res.refs["7"]).toMatchObject({ role: "button", name: "Save" });
   });
 });

--- a/extensions/browser/src/browser/pw-role-snapshot.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.ts
@@ -265,7 +265,13 @@ export function parseRoleRef(raw: string): string | null {
     : trimmed.startsWith("ref=")
       ? trimmed.slice(4)
       : trimmed;
-  return /^e\d+$/.test(normalized) ? normalized : null;
+  if (/^e\d+$/i.test(normalized)) {
+    return normalized;
+  }
+  if (/^\d{1,9}$/.test(normalized)) {
+    return normalized;
+  }
+  return null;
 }
 
 export function buildRoleSnapshotFromAriaSnapshot(
@@ -328,8 +334,13 @@ export function buildRoleSnapshotFromAriaSnapshot(
 }
 
 function parseAiSnapshotRef(suffix: string): string | null {
-  const match = suffix.match(/\[ref=(e\d+)\]/i);
-  return match ? match[1] : null;
+  const eMatch = suffix.match(/\[ref=(e\d+)\]/i);
+  if (eMatch) {
+    return eMatch[1];
+  }
+  // Playwright 2026.4.x+ AI snapshots may emit numeric refs (e.g. [ref=42]) instead of e-prefixed ids.
+  const numMatch = suffix.match(/\[ref=(\d{1,9})\]/);
+  return numMatch ? numMatch[1] : null;
 }
 
 /**

--- a/extensions/browser/src/cli/browser-cli-inspect.test.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.test.ts
@@ -97,6 +97,11 @@ describe("browser cli snapshot defaults", () => {
       expectMode: "efficient",
     },
     {
+      label: "does not apply config snapshot defaults to explicit ai snapshots",
+      args: ["--format", "ai"],
+      expectMode: undefined,
+    },
+    {
       label: "does not apply config snapshot defaults to aria snapshots",
       args: ["--format", "aria"],
       expectMode: undefined,
@@ -106,7 +111,7 @@ describe("browser cli snapshot defaults", () => {
       browser: { snapshotDefaults: { mode: "efficient" } },
     });
 
-    if (args.includes("--format")) {
+    if (args.includes("--format") && args.includes("aria")) {
       gatewayMocks.callGatewayFromCli.mockResolvedValueOnce({
         ok: true,
         format: "aria",

--- a/extensions/browser/src/cli/browser-cli-inspect.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.ts
@@ -72,8 +72,12 @@ export function registerBrowserInspectCommands(
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
       const format = opts.format === "aria" ? "aria" : "ai";
+      const formatWasExplicit =
+        typeof cmd.getOptionValueSource === "function" && cmd.getOptionValueSource("format") === "cli";
       const configMode =
-        format === "ai" && loadConfig().browser?.snapshotDefaults?.mode === "efficient"
+        !formatWasExplicit &&
+        format === "ai" &&
+        loadConfig().browser?.snapshotDefaults?.mode === "efficient"
           ? "efficient"
           : undefined;
       const mode = opts.efficient === true || opts.mode === "efficient" ? "efficient" : configMode;


### PR DESCRIPTION
## Summary

- Problem: `browser snapshot --format ai` could still return role-style `e`-prefixed refs when caller defaults injected `mode=efficient`, because the CLI and Browser tool kept applying `browser.snapshotDefaults.mode=efficient` even after the user explicitly requested `format=ai`.
- Why it matters: this made explicit AI snapshot requests look like silent fallbacks to role snapshots, which matches the confusing behavior reported in #62550.
- What changed: explicit `format=ai` now opts out of config-driven `efficient` defaults in both the CLI and Browser tool entrypoints, so callers only get role-style refs when they explicitly ask for efficient/interactive/compact behavior. This branch also keeps the additive numeric AI ref parsing compatibility for Playwright AI snapshots.
- Regression coverage: targeted tests now lock in that explicit AI snapshots do not inherit `efficient` defaults and that numeric AI refs remain visible in the public snapshot output and usable for follow-up actions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62550
- Related #64123
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: config-driven `browser.snapshotDefaults.mode=efficient` was still being applied after callers explicitly requested `format=ai`, and `efficient` intentionally routes through the role snapshot path with `e`-prefixed refs.
- Missing detection / guardrail: tests covered config defaults and numeric ref parsing separately, but did not lock in that an explicit AI format request must override implicit efficient defaults.
- Contributing context (if known): because the response still reported `format: ai`, the fallback looked like an AI snapshot regression instead of a default-mode override.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests/files:
  - `extensions/browser/src/cli/browser-cli-inspect.test.ts`
  - `extensions/browser/src/browser-tool.test.ts`
  - `extensions/browser/src/browser/pw-ai.e2e.test.ts`
- Scenarios locked in:
  - explicit `--format ai` does not inherit config-driven `mode=efficient`
  - explicit Browser tool `snapshotFormat: ai` does not inherit config-driven `mode=efficient`
  - numeric AI refs remain visible in the public snapshot output and still work for follow-up actions
- Why this is the smallest reliable guardrail: the bug lives at the entrypoints that assemble snapshot requests plus the AI snapshot response path, so focused CLI/tool tests plus one Playwright seam test cover the failure without requiring a live browser run.

## User-visible / Behavior Changes

- Explicit AI snapshot requests now stay AI snapshots unless the caller also explicitly asks for efficient/role-style behavior.
- Numeric Playwright AI refs remain accepted and usable for follow-up actions.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: Node 24 repo test entrypoint
- Model/provider: N/A
- Integration/channel (if any): browser plugin / Playwright AI snapshots
- Relevant config (redacted): simulated `browser.snapshotDefaults.mode=efficient`

### Steps

1. Configure `browser.snapshotDefaults.mode=efficient`.
2. Request `openclaw browser snapshot --format ai` (or Browser tool `snapshotFormat: ai`) without an explicit mode.
3. Verify the request/query no longer inherits `mode=efficient`.
4. Feed `snapshotAiViaPlaywright()` a numeric-ref AI snapshot and verify the returned snapshot text and follow-up action path.

### Expected

- Explicit AI snapshot requests do not silently fall back to role snapshots due to config defaults.
- Numeric AI refs remain visible in the returned snapshot text and usable in follow-up actions.

### Actual before fix

- Explicit AI snapshot requests could still inherit `mode=efficient`, producing role-style refs while still reporting `format: ai`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran targeted regression tests for the CLI snapshot defaults, Browser tool snapshot defaults, and Playwright AI snapshot response path.
- Commands run: `pnpm test extensions/browser/src/browser/pw-ai.e2e.test.ts extensions/browser/src/cli/browser-cli-inspect.test.ts extensions/browser/src/browser-tool.test.ts`
- Extra environment note: the PR worktree initially lacked dependencies (`vitest/package.json` missing), so I ran `pnpm install` and retried the exact test command before finishing verification.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: callers that implicitly relied on config default `efficient` even when explicitly asking for `format=ai` will now get true AI snapshots instead of role snapshots.
  - Mitigation: that new behavior matches the explicit caller intent; callers that want role-style snapshots can still request `--efficient`, `--interactive`, `--compact`, `--depth`, or equivalent tool inputs explicitly.