### PR TITLE
Fix: boundary-file-read distinguishes ENOENT from path-escape

### DIFF
--- a/src/channels/plugins/module-loader.ts
+++ b/src/channels/plugins/module-loader.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { openBoundaryFileSync } from "../../infra/boundary-file-read.js";
+import {
+  describePluginBoundaryFileOpenFailure,
+  openBoundaryFileSync,
+} from "../../infra/boundary-file-read.js";
 import {
   getCachedPluginJitiLoader,
   type PluginJitiLoaderCache,
@@ -77,8 +80,12 @@ export function loadChannelPluginModule(params: {
     skipLexicalRootCheck: true,
   });
   if (!opened.ok) {
+    const label = `${params.boundaryLabel ?? "plugin"} module`;
     throw new Error(
-      `${params.boundaryLabel ?? "plugin"} module path escapes plugin root or fails alias checks`,
+      describePluginBoundaryFileOpenFailure(opened, {
+        entryPath: params.modulePath,
+        moduleLabel: label,
+      }),
     );
   }
   const safePath = opened.path;

--- a/src/infra/boundary-file-read.test.ts
+++ b/src/infra/boundary-file-read.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveBoundaryPathSyncMock = vi.hoisted(() => vi.fn());
 const resolveBoundaryPathMock = vi.hoisted(() => vi.fn());
@@ -15,19 +15,24 @@ vi.mock("./safe-open-sync.js", () => ({
 }));
 
 let canUseBoundaryFileOpen: typeof import("./boundary-file-read.js").canUseBoundaryFileOpen;
+let describePluginBoundaryFileOpenFailure: typeof import("./boundary-file-read.js").describePluginBoundaryFileOpenFailure;
 let matchBoundaryFileOpenFailure: typeof import("./boundary-file-read.js").matchBoundaryFileOpenFailure;
 let openBoundaryFile: typeof import("./boundary-file-read.js").openBoundaryFile;
 let openBoundaryFileSync: typeof import("./boundary-file-read.js").openBoundaryFileSync;
 
 describe("boundary-file-read", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
     ({
       canUseBoundaryFileOpen,
+      describePluginBoundaryFileOpenFailure,
       matchBoundaryFileOpenFailure,
       openBoundaryFile,
       openBoundaryFileSync,
     } = await import("./boundary-file-read.js"));
+  });
+
+  beforeEach(() => {
     resolveBoundaryPathSyncMock.mockReset();
     resolveBoundaryPathMock.mockReset();
     openVerifiedFileSyncMock.mockReset();
@@ -236,5 +241,35 @@ describe("boundary-file-read", () => {
     expect(missing).toBe("missing");
     expect(io).toBe("io");
     expect(validation).toBe("validation");
+  });
+
+  it("describePluginBoundaryFileOpenFailure labels missing files vs boundary escape", () => {
+    const missingError = Object.assign(new Error("ENOENT: missing"), { code: "ENOENT" });
+    const loopError = Object.assign(new Error("ELOOP: loop"), { code: "ELOOP" });
+
+    expect(
+      describePluginBoundaryFileOpenFailure(
+        { ok: false, reason: "path", error: missingError },
+        { entryPath: "./src/channel.js" },
+      ),
+    ).toContain("file not found in build output");
+    expect(
+      describePluginBoundaryFileOpenFailure(
+        { ok: false, reason: "path", error: loopError },
+        { entryPath: "./src/channel.js" },
+      ),
+    ).toContain("path could not be opened");
+    expect(
+      describePluginBoundaryFileOpenFailure(
+        { ok: false, reason: "validation", error: new Error("outside") },
+        { entryPath: "/tmp/x" },
+      ),
+    ).toContain("escapes plugin root");
+    expect(
+      describePluginBoundaryFileOpenFailure(
+        { ok: false, reason: "io", error: new Error("EACCES: denied") },
+        { entryPath: "./src/channel.js" },
+      ),
+    ).toContain("read failed");
   });
 });

--- a/src/infra/boundary-file-read.ts
+++ b/src/infra/boundary-file-read.ts
@@ -5,6 +5,7 @@ import {
   resolveBoundaryPathSync,
   type ResolvedBoundaryPath,
 } from "./boundary-path.js";
+import { extractErrorCode, formatErrorMessage } from "./errors.js";
 import type { PathAliasPolicy } from "./path-alias-guards.js";
 import {
   openVerifiedFileSync,
@@ -109,6 +110,39 @@ export function matchBoundaryFileOpenFailure<T>(
       return handlers.io ? handlers.io(failure) : handlers.fallback(failure);
   }
   return handlers.fallback(failure);
+}
+
+/**
+ * User-facing explanation for plugin entry opens that failed boundary checks.
+ * Distinguishes missing build artifacts (ENOENT after a successful boundary resolve)
+ * from real boundary / alias violations (`validation` from {@link resolveBoundaryPathSync})
+ * and other path-level open failures such as ENOTDIR/ELOOP.
+ */
+export function describePluginBoundaryFileOpenFailure(
+  failure: BoundaryFileOpenFailure,
+  params: { entryPath: string; moduleLabel?: string },
+): string {
+  const label = params.moduleLabel ?? "plugin entry";
+  switch (failure.reason) {
+    case "validation":
+      return `${label} path escapes plugin root or fails alias checks`;
+    case "path":
+      if (extractErrorCode(failure.error) === "ENOENT") {
+        return `${label} file not found in build output: ${params.entryPath}`;
+      }
+      return `${label} path could not be opened: ${formatBoundaryFileOpenErrorDetail(failure.error)}`;
+    case "io":
+      return `${label} read failed: ${formatBoundaryFileOpenErrorDetail(failure.error)}`;
+    default:
+      return `${label} open failed`;
+  }
+}
+
+function formatBoundaryFileOpenErrorDetail(error: unknown): string {
+  if (error === undefined) {
+    return "unknown error";
+  }
+  return formatErrorMessage(error);
 }
 
 function openBoundaryFileResolved(params: {

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import {
+  describePluginBoundaryFileOpenFailure,
+  openBoundaryFileSync,
+} from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   withBundledPluginEnablementCompat,
@@ -284,7 +287,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
       recordCapabilityLoadError(
         registry,
         record,
-        "plugin entry path escapes plugin root or fails alias checks",
+        describePluginBoundaryFileOpenFailure(opened, { entryPath: record.source }),
       );
       continue;
     }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -11,7 +11,10 @@ import { isChannelConfigured } from "../config/channel-configured.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
-import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import {
+  describePluginBoundaryFileOpenFailure,
+  openBoundaryFileSync,
+} from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
@@ -2748,7 +2751,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         skipLexicalRootCheck: true,
       });
       if (!opened.ok) {
-        pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+        pushPluginLoadError(
+          describePluginBoundaryFileOpenFailure(opened, { entryPath: loadSource }),
+        );
         continue;
       }
       const safeSource = opened.path;
@@ -3397,7 +3402,9 @@ export async function loadOpenClawPluginCliRegistry(
       skipLexicalRootCheck: true,
     });
     if (!opened.ok) {
-      pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+      pushPluginLoadError(
+        describePluginBoundaryFileOpenFailure(opened, { entryPath: sourceForCliMetadata }),
+      );
       continue;
     }
     const safeSource = opened.path;


### PR DESCRIPTION
## Summary

- Problem: plugin boundary file opens could collapse missing-file (`ENOENT`) failures into the same user-facing path-escape style message, which made missing build artifacts look like a boundary violation.
- Why it matters: when a plugin entry file is missing, maintainers need to know it is a build/output problem rather than an unsafe path or alias escape.
- What changed: `src/infra/boundary-file-read.ts` now provides `describePluginBoundaryFileOpenFailure()` and `matchBoundaryFileOpenFailure()` so callers can distinguish `path`, `validation`, and `io` outcomes cleanly. `src/plugins/loader.ts`, `src/plugins/bundled-capability-runtime.ts`, and `src/channels/plugins/module-loader.ts` now use that split message path, `src/infra/boundary-file-read.test.ts` adds focused coverage, and `CHANGELOG.md` records the fix.
- What did NOT change (scope boundary): this does not change plugin discovery policy, manifest validation rules, or boundary enforcement semantics; it only fixes error classification and messaging at file-open call sites.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61708
- Related #64124
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: plugin entry open failures were not giving callers a stable, user-facing distinction between missing files after a successful boundary resolve and true boundary-validation failures.
- Missing detection / guardrail: the boundary read helpers and their callers lacked focused tests that locked in separate `path`, `validation`, and `io` messaging.
- Contributing context (if known): the same boundary-open path is reused by plugin loader, bundled capability runtime, and channel plugin module loading.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/boundary-file-read.test.ts`
- Scenario the test should lock in: missing plugin entry files produce the build-output/file-not-found message, boundary escape failures keep the escape message, and generic I/O failures keep a separate read-failed message.
- Why this is the smallest reliable guardrail: the classification logic is centralized in the boundary file read helper, so one focused test file locks the contract for all three callers.
- Existing test that already covers this (if any): this PR extends the helper test file; previous coverage did not fully lock the caller-facing distinction.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Missing plugin entry files now surface as build-output/file-not-found errors instead of looking like a plugin-root escape or alias failure.

## Diagram (if applicable)

```text
Before:
[plugin entry missing] -> openBoundaryFileSync() -> generic path/escape-style message

After:
[plugin entry missing] -> openBoundaryFileSync() -> reason=path -> build-output not-found message
[path/alias violation] -> reason=validation -> escape/alias failure message
[other file I/O failure] -> reason=io -> read failed message
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: Node 22+ repo scripts
- Model/provider: N/A
- Integration/channel (if any): plugin loader / bundled capability runtime / channel module loader
- Relevant config (redacted): N/A

### Steps

1. Attempt to open a plugin entry path inside the allowed root where the target file is missing.
2. Attempt a boundary-escape or alias-validation failure through the same helper.
3. Compare the resulting messages from the plugin loader call sites.

### Expected

- Missing file: build-output/file-not-found wording.
- Boundary escape or alias failure: escape/validation wording.
- Other I/O failure: read-failed wording.

### Actual

- Before this fix, missing plugin entry files could reuse the same misleading path-escape style message.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: rebased onto current `main`, reviewed each call site to ensure they now share the centralized helper wording, and added focused helper coverage for missing-file, validation, and `io` message branches.
- Edge cases checked: generic `io` failures keep a separate message path instead of being folded into missing-file or boundary-escape wording.
- What you did **not** verify: I could not complete a local `pnpm test src/infra/boundary-file-read.test.ts` run on this Windows machine because the repo test entrypoint fails before collecting tests with an existing Vitest runner initialization error in `test/non-isolated-runner.ts` (`Class extends value undefined is not a constructor or null`). I also ran `pnpm build` because this touches loader/module-loader surfaces; that failed in this workspace on pre-existing unrelated unresolved-import warnings across optional extension dependencies before a clean build could finish.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: downstream callers could still rely on older message strings instead of the failure reason split.
  - Mitigation: the behavior is centralized through `describePluginBoundaryFileOpenFailure()` / `matchBoundaryFileOpenFailure()` so future callers can stay on the typed reason contract rather than string matching.