### PR TITLE
fix(config): dedupe repeated warning logs on unchanged reloads

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -106,6 +106,7 @@ export { resolveShellEnvExpectedKeys } from "./shell-env-expected-keys.js";
 
 const CONFIG_HEALTH_STATE_FILENAME = "config-health.json";
 const loggedInvalidConfigs = new Set<string>();
+const loggedConfigWarningFingerprints = new Map<string, string>();
 
 type ConfigHealthFingerprint = {
   hash: string;
@@ -866,6 +867,30 @@ function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console
   }
 }
 
+function logConfigWarningsOnce(params: {
+  configPath: string;
+  hash: string;
+  warnings: Array<{ path: string; message: string }>;
+  logger: Pick<typeof console, "warn">;
+}): void {
+  if (params.warnings.length === 0) {
+    loggedConfigWarningFingerprints.delete(params.configPath);
+    return;
+  }
+  const details = params.warnings
+    .map(
+      (warning) =>
+        `- ${sanitizeTerminalText(warning.path || "<root>")}: ${sanitizeTerminalText(warning.message)}`,
+    )
+    .join("\n");
+  const fingerprint = `${params.hash}\n${details}`;
+  if (loggedConfigWarningFingerprints.get(params.configPath) === fingerprint) {
+    return;
+  }
+  loggedConfigWarningFingerprints.set(params.configPath, fingerprint);
+  params.logger.warn(`Config warnings:\n${details}`);
+}
+
 function resolveConfigPathForDeps(deps: Required<ConfigIoDeps>): string {
   if (deps.configPath) {
     return deps.configPath;
@@ -1034,6 +1059,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     try {
       maybeLoadDotEnvForConfig(deps.env);
       if (!deps.fs.existsSync(configPath)) {
+        loggedConfigWarningFingerprints.delete(configPath);
         if (shouldEnableShellEnvFallback(deps.env) && !shouldDeferShellEnvFallback(deps.env)) {
           loadShellEnvFallback({
             enabled: true,
@@ -1070,6 +1096,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       warnOnConfigMiskeys(effectiveConfigRaw, deps.logger);
       if (typeof effectiveConfigRaw !== "object" || effectiveConfigRaw === null) {
+        loggedConfigWarningFingerprints.delete(configPath);
         observeLoadConfigSnapshot({
           ...createConfigFileSnapshot({
             path: configPath,
@@ -1096,6 +1123,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, { env: deps.env });
       if (!validated.ok) {
+        loggedConfigWarningFingerprints.delete(configPath);
         observeLoadConfigSnapshot({
           ...createConfigFileSnapshot({
             path: configPath,
@@ -1118,15 +1146,12 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           loggedConfigPaths: loggedInvalidConfigs,
         });
       }
-      if (validated.warnings.length > 0) {
-        const details = validated.warnings
-          .map(
-            (iss) =>
-              `- ${sanitizeTerminalText(iss.path || "<root>")}: ${sanitizeTerminalText(iss.message)}`,
-          )
-          .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
-      }
+      logConfigWarningsOnce({
+        configPath,
+        hash,
+        warnings: validated.warnings,
+        logger: deps.logger,
+      });
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = materializeRuntimeConfig(validated.config, "load");
       observeLoadConfigSnapshot({

--- a/src/config/io.warning-dedupe.test.ts
+++ b/src/config/io.warning-dedupe.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createConfigIO } from "./io.js";
+
+describe("config io warning logging", () => {
+  let fixtureRoot = "";
+  let homeCaseId = 0;
+
+  async function withSuiteHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+    const home = path.join(fixtureRoot, `case-${homeCaseId++}`);
+    await fs.mkdir(home, { recursive: true });
+    return await fn(home);
+  }
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-warning-dedupe-"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("logs repeated config warnings once per unchanged load and uses real newlines", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            plugins: {
+              allow: ["google-antigravity-auth"],
+              deny: ["google-antigravity-auth"],
+              slots: {
+                memory: "google-antigravity-auth",
+              },
+              entries: {
+                "google-antigravity-auth": {
+                  enabled: true,
+                },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const warn = vi.fn();
+      const io = createConfigIO({
+        env: {
+          HOME: home,
+          OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
+          OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+          OPENCLAW_PLUGIN_MANIFEST_CACHE_MS: "10000",
+          VITEST: "true",
+        } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: {
+          warn,
+          error: vi.fn(),
+        },
+      });
+
+      io.loadConfig();
+      io.loadConfig();
+
+      const warningCalls = warn.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (message): message is string =>
+            typeof message === "string" && message.startsWith("Config warnings:"),
+        );
+
+      expect(warningCalls).toHaveLength(1);
+      expect(warningCalls[0]).toContain(
+        "Config warnings:\n- plugins.entries.google-antigravity-auth:",
+      );
+      expect(warningCalls[0]).toContain("- plugins.allow:");
+      expect(warningCalls[0]).not.toContain("\\n");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- dedupe repeated `Config warnings` logs when the config file hash and warning payload are unchanged
- format the warning output with real newlines instead of the literal `\n` sequence
- add a focused regression test for repeated `loadConfig()` calls

## Notes
- this keeps the fix scoped to warning logging without pulling in the broader restart/logging changes from #38295

## Testing
- `pnpm test src/config/io.compat.test.ts src/config/io.warning-dedupe.test.ts`

Refs #25574