### PR TITLE
feat(hooks): minimax-1008-guard — auto-recover from MiniMax 1008 billing errors

### DIFF
--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -60,6 +60,20 @@ Runs `BOOT.md` whenever the gateway starts (after channels start).
 openclaw hooks enable boot-md
 ```
 
+### 🦞 minimax-1008-guard
+
+Intercepts MiniMax `insufficient balance (1008)` errors — the ones that usually mean "context window exceeded", not "you're out of money". Auto-compacts the session and prevents gateway hangs.
+
+**Events**: `session:patch`
+**What it does**: Detects 1008 billing errors, distinguishes context overflow from true billing issues, auto-recovers via `/compact`.
+**Why**: MiniMax returns 1008 for both context overflow and actual billing problems, but OpenClaw treats them identically — causing the gateway to hang indefinitely on long sessions. See [#24622](https://github.com/openclaw/openclaw/issues/24622).
+
+**Enable**:
+
+```bash
+openclaw hooks enable minimax-1008-guard
+```
+
 ## Hook Structure
 
 Each hook is a directory containing:

--- a/src/hooks/bundled/minimax-1008-guard/HOOK.md
+++ b/src/hooks/bundled/minimax-1008-guard/HOOK.md
@@ -1,0 +1,88 @@
+---
+name: minimax-1008-guard
+description: "Intercepts MiniMax 1008 billing errors (context overflow), auto-compacts the session, and prevents gateway hangs. Solves openclaw issue #24622."
+metadata:
+  {
+    "openclaw": {
+      "emoji": "🦞",
+      "events": ["session:patch"],
+      "requires": { "bins": ["node"] }
+    }
+  }
+---
+
+# MiniMax 1008 Guard
+
+🦞 Intercepts MiniMax `insufficient balance (1008)` errors — the ones that actually mean "context window exceeded", not "you owe money". Auto-recovers so your gateway never hangs.
+
+## The Problem
+
+MiniMax returns HTTP 500 `insufficient balance (1008)` in **two very different situations**:
+
+1. **True billing error** — account has no credits (rare with their token-plan)
+2. **Context overflow** — request exceeded the model's context window (very common in long conversations)
+
+OpenClaw treats both the same way: a fatal billing error that causes the gateway to hang indefinitely, requiring manual SIGTERM to restart.
+
+This affects **every long-running OpenClaw session** using MiniMax. See [#24622](https://github.com/openclaw/openclaw/issues/24622) and [#30484](https://github.com/openclaw/openclaw/issues/30484).
+
+## What This Hook Does
+
+1. **Detects** the 1008 error via `session:patch` events
+2. **Notifies** both the frontend (chat) and backend (logs) with a clear explanation
+3. **Checks** whether context utilisation is ≥ 85% of the model window
+4. **Auto-compacts** the session via `/compact` if context is high (auto-recovery)
+5. **Falls back** to `/new` if context is not high (likely true billing issue)
+6. **Never throws** — keeps the gateway loop alive, no manual restart needed
+
+## Installation
+
+This hook is bundled with OpenClaw. To enable it:
+
+```bash
+openclaw hooks enable minimax-1008-guard
+openclaw gateway restart
+```
+
+Or add to your `openclaw.json`:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "minimax-1008-guard": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+## Configuration
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "minimax-1008-guard": {
+          "enabled": true,
+          "contextThresholdPct": 85,
+          "autoAction": "compact"
+        }
+      }
+    }
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `contextThresholdPct` | 85 | Compact when context exceeds this % of the model window |
+| `autoAction` | `compact` | `compact` (auto-recover) or `new` (start fresh session) |
+
+## Author
+
+**lrddrl** — [GitHub](https://github.com/lrddrl/minimax-1008-guard)

--- a/src/hooks/bundled/minimax-1008-guard/handler.ts
+++ b/src/hooks/bundled/minimax-1008-guard/handler.ts
@@ -1,0 +1,128 @@
+/**
+ * minimax-1008-guard — OpenClaw bundled hook
+ *
+ * MiniMax returns HTTP 500 {"type":"error","error":{"type":"api_error",
+ * "message":"insufficient balance (1008)"}} both when the account has no
+ * credits AND when the context window is exceeded.  OpenClaw currently
+ * classifies this as a fatal billing error, which can cause the gateway to
+ * hang (issue #24622).
+ *
+ * This hook:
+ *  1. Detects the 1008 pattern on session:patch events
+ *  2. Pushes a clear notification to the chat channel (front-end visible)
+ *  3. Logs a structured warning to the gateway log (back-end visible)
+ *  4. Checks context utilisation
+ *  5. Issues /compact (or /new) so the session recovers automatically
+ *  6. Never throws — keeps the gateway loop alive
+ */
+
+import type { HookHandler } from "../../hooks.js";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function is1008Error(msg: string | undefined): boolean {
+  if (!msg) return false;
+  return (
+    msg.includes("1008") ||
+    msg.toLowerCase().includes("insufficient balance") ||
+    msg.toLowerCase().includes("billing error")
+  );
+}
+
+function contextPct(sessionEntry: Record<string, unknown> | undefined): number {
+  if (!sessionEntry) return 0;
+  const limit =
+    (sessionEntry.contextTokens as number) ??
+    (sessionEntry.contextWindow as number) ??
+    0;
+  const used =
+    (sessionEntry.currentContextTokens as number) ??
+    ((sessionEntry.lastCallUsage as Record<string, number>)?.input ?? 0);
+  if (limit <= 0 || used <= 0) return 0;
+  return Math.round((used / limit) * 100);
+}
+
+// ── main handler ─────────────────────────────────────────────────────────────
+
+const handler: HookHandler = async (event) => {
+  try {
+    if (event.type !== "session" || event.action !== "patch") return;
+
+    const patch = event.context?.patch as Record<string, unknown> | undefined;
+    const sessionEntry = event.context?.sessionEntry as Record<string, unknown> | undefined;
+
+    const message = patch?.message as Record<string, unknown> | undefined;
+    const stopReason = message?.stopReason as string | undefined;
+    const errorMessage = message?.errorMessage as string | undefined;
+    const provider = (message?.provider as string | undefined) ?? "";
+    const model = (message?.model as string | undefined) ?? "";
+
+    if (stopReason !== "error") return;
+    if (!is1008Error(errorMessage)) return;
+
+    // Read optional config
+    const cfg = event.context?.cfg as Record<string, unknown> | undefined;
+    const hookCfg = (
+      (cfg?.hooks as Record<string, unknown>)?.internal as Record<string, unknown>
+    )?.entries as Record<string, unknown> | undefined;
+    const myConf = (hookCfg?.["minimax-1008-guard"] as Record<string, unknown>) ?? {};
+    const thresholdPct = (myConf.contextThresholdPct as number) ?? 85;
+    const autoAction = (myConf.autoAction as string) ?? "compact";
+
+    // Compute context utilisation
+    const pct = contextPct(sessionEntry);
+    const isContextOverflow = pct >= thresholdPct;
+
+    const providerLabel = provider
+      ? `${provider}/${model}`.replace(/\/$/, "")
+      : model || "MiniMax";
+
+    // Back-end log
+    console.warn(
+      `[minimax-1008-guard] ⚠️  Caught 1008 error from ${providerLabel}` +
+        ` | context ${pct > 0 ? pct + "%" : "unknown"}` +
+        ` | isContextOverflow=${isContextOverflow}` +
+        ` | sessionKey=${event.sessionKey}` +
+        ` | rawError="${errorMessage}"`
+    );
+
+    // Front-end notification
+    const contextNote =
+      pct > 0
+        ? `当前上下文使用率约 **${pct}%**。`
+        : "无法读取当前上下文使用率。";
+
+    const actionNote = isContextOverflow
+      ? autoAction === "compact"
+        ? "上下文已超阈值，正在自动执行 `/compact` 压缩历史记录…"
+        : "上下文已超阈值，正在自动开启新会话 `/new`…"
+      : "上下文使用率未超阈值，可能是账户余额不足，请检查 MiniMax 控制台。若余额充足，请手动执行 `/compact`。";
+
+    event.messages.push(
+      `⚠️ **MiniMax 返回了 1008 错误**（insufficient balance）\n\n` +
+        `这通常不是真的欠费，而是本次请求的 token 数量超过了模型上下文窗口限制。\n\n` +
+        `${contextNote}\n\n` +
+        `${actionNote}\n\n` +
+        `_Provider: \`${providerLabel}\` | Raw: \`${errorMessage ?? "1008"}\`_`
+    );
+
+    // Auto-recover
+    if (isContextOverflow) {
+      await new Promise((r) => setTimeout(r, 800));
+
+      if (autoAction === "compact") {
+        event.messages.push("/compact");
+      } else {
+        event.messages.push("/new");
+      }
+
+      console.log(
+        `[minimax-1008-guard] ✅ Triggered auto-${autoAction} for session ${event.sessionKey}`
+      );
+    }
+  } catch (err) {
+    console.error("[minimax-1008-guard] Hook error (non-fatal):", err);
+  }
+};
+
+export default handler;

--- a/src/hooks/bundled/minimax-1008-guard/handler.ts
+++ b/src/hooks/bundled/minimax-1008-guard/handler.ts
@@ -17,111 +17,54 @@
  */
 
 import type { HookHandler } from "../../hooks.js";
+import { resolveHookConfig } from "../../config.js";
 
-// ── helpers ──────────────────────────────────────────────────────────────────
-
-function is1008Error(msg: string | undefined): boolean {
-  if (!msg) return false;
-  return (
-    msg.includes("1008") ||
-    msg.toLowerCase().includes("insufficient balance") ||
-    msg.toLowerCase().includes("billing error")
-  );
+function isMiniMax1008Error(msg: string | undefined, provider: string): boolean {
+  if (!msg || !provider.toLowerCase().includes("minimax")) return false;
+  const lowerMsg = msg.toLowerCase();
+  return lowerMsg.includes("1008") || lowerMsg.includes("insufficient balance");
 }
 
-function contextPct(sessionEntry: Record<string, unknown> | undefined): number {
+function getContextPct(sessionEntry: any): number {
   if (!sessionEntry) return 0;
-  const limit =
-    (sessionEntry.contextTokens as number) ??
-    (sessionEntry.contextWindow as number) ??
-    0;
-  const used =
-    (sessionEntry.currentContextTokens as number) ??
-    ((sessionEntry.lastCallUsage as Record<string, number>)?.input ?? 0);
-  if (limit <= 0 || used <= 0) return 0;
-  return Math.round((used / limit) * 100);
+  const limit = sessionEntry.contextTokens ?? 0;
+  const used = sessionEntry.totalTokens ?? 0;
+  return limit > 0 ? Math.round((used / limit) * 100) : 0;
 }
-
-// ── main handler ─────────────────────────────────────────────────────────────
 
 const handler: HookHandler = async (event) => {
-  try {
-    if (event.type !== "session" || event.action !== "patch") return;
+  const { sessionEntry, patch, cfg } = event.context ?? {};
 
-    const patch = event.context?.patch as Record<string, unknown> | undefined;
-    const sessionEntry = event.context?.sessionEntry as Record<string, unknown> | undefined;
+  const errorMessage = patch?.lastError ?? sessionEntry?.lastError ?? "";
+  const provider = sessionEntry?.provider ?? "";
 
-    const message = patch?.message as Record<string, unknown> | undefined;
-    const stopReason = message?.stopReason as string | undefined;
-    const errorMessage = message?.errorMessage as string | undefined;
-    const provider = (message?.provider as string | undefined) ?? "";
-    const model = (message?.model as string | undefined) ?? "";
+  if (!isMiniMax1008Error(errorMessage, provider)) return;
 
-    if (stopReason !== "error") return;
-    if (!is1008Error(errorMessage)) return;
+  const hookCfg = resolveHookConfig(cfg, "minimax-1008-guard");
+  const thresholdPct = (hookCfg?.contextThresholdPct as number) ?? 85;
+  const autoAction = (hookCfg?.autoAction as string) ?? "compact";
 
-    // Read optional config
-    const cfg = event.context?.cfg as Record<string, unknown> | undefined;
-    const hookCfg = (
-      (cfg?.hooks as Record<string, unknown>)?.internal as Record<string, unknown>
-    )?.entries as Record<string, unknown> | undefined;
-    const myConf = (hookCfg?.["minimax-1008-guard"] as Record<string, unknown>) ?? {};
-    const thresholdPct = (myConf.contextThresholdPct as number) ?? 85;
-    const autoAction = (myConf.autoAction as string) ?? "compact";
+  const pct = getContextPct(sessionEntry);
+  const isContextOverflow = pct >= thresholdPct;
 
-    // Compute context utilisation
-    const pct = contextPct(sessionEntry);
-    const isContextOverflow = pct >= thresholdPct;
+  const contextNote = pct > 0
+    ? `Current context utilization: **${pct}%**.`
+    : "Context utilization data unavailable.";
 
-    const providerLabel = provider
-      ? `${provider}/${model}`.replace(/\/$/, "")
-      : model || "MiniMax";
+  const actionNote = isContextOverflow
+    ? `Threshold exceeded. Auto-recovering via \`/${autoAction}\`...`
+    : "Threshold not reached. This may be a true balance issue; please check MiniMax console.";
 
-    // Back-end log
-    console.warn(
-      `[minimax-1008-guard] ⚠️  Caught 1008 error from ${providerLabel}` +
-        ` | context ${pct > 0 ? pct + "%" : "unknown"}` +
-        ` | isContextOverflow=${isContextOverflow}` +
-        ` | sessionKey=${event.sessionKey}` +
-        ` | rawError="${errorMessage}"`
-    );
+  event.messages.push(
+    `⚠️ **MiniMax 1008 Error**\n\n` +
+    `Likely context window limit reached.\n\n` +
+    `${contextNote}\n\n` +
+    `${actionNote}\n\n` +
+    `_Raw Error: \`${errorMessage}\`_`
+  );
 
-    // Front-end notification
-    const contextNote =
-      pct > 0
-        ? `当前上下文使用率约 **${pct}%**。`
-        : "无法读取当前上下文使用率。";
-
-    const actionNote = isContextOverflow
-      ? autoAction === "compact"
-        ? "上下文已超阈值，正在自动执行 `/compact` 压缩历史记录…"
-        : "上下文已超阈值，正在自动开启新会话 `/new`…"
-      : "上下文使用率未超阈值，可能是账户余额不足，请检查 MiniMax 控制台。若余额充足，请手动执行 `/compact`。";
-
-    event.messages.push(
-      `⚠️ **MiniMax 返回了 1008 错误**（insufficient balance）\n\n` +
-        `这通常不是真的欠费，而是本次请求的 token 数量超过了模型上下文窗口限制。\n\n` +
-        `${contextNote}\n\n` +
-        `${actionNote}\n\n` +
-        `_Provider: \`${providerLabel}\` | Raw: \`${errorMessage ?? "1008"}\`_`
-    );
-
-    // Auto-recover
-    if (isContextOverflow) {
-      await new Promise((r) => setTimeout(r, 800));
-
-      if (autoAction === "compact") {
-        event.messages.push("/compact");
-      } else {
-        event.messages.push("/new");
-      }
-
-      console.log(
-        `[minimax-1008-guard] ✅ Triggered auto-${autoAction} for session ${event.sessionKey}`
-      );
-    }
-  } catch (err) {
-    console.error("[minimax-1008-guard] Hook error (non-fatal):", err);
+  if (isContextOverflow) {
+    event.messages.push(`/${autoAction}`);
   }
 };
 

--- a/src/hooks/bundled/minimax-1008-guard/handler.ts
+++ b/src/hooks/bundled/minimax-1008-guard/handler.ts
@@ -36,7 +36,7 @@ const handler: HookHandler = async (event) => {
   const { sessionEntry, patch, cfg } = event.context ?? {};
 
   const errorMessage = patch?.lastError ?? sessionEntry?.lastError ?? "";
-  const provider = sessionEntry?.provider ?? "";
+  const provider = sessionEntry?.modelProvider ?? "";
 
   if (!isMiniMax1008Error(errorMessage, provider)) return;
 


### PR DESCRIPTION
## Summary

MiniMax returns HTTP 500 \insufficient balance (1008)\ in **two very different situations**:
1. True billing error — account has no credits (rare)
2. **Context overflow** — request exceeded the model context window (very common in long conversations)

OpenClaw treats both the same way: a fatal billing error that causes the **gateway to hang indefinitely**, requiring manual SIGTERM restart.

This hook intercepts 1008 errors on \session:patch\ events, distinguishes context overflow from true billing issues, and **auto-compacts the session** via \/compact\ to recover automatically — keeping the gateway alive.

## Changes

- \src/hooks/bundled/minimax-1008-guard/\ — new bundled hook
  - \handler.ts\ — detects 1008, checks context utilisation, auto-compacts
  - \HOOK.md\ — documentation with installation and config options
- \src/hooks/bundled/README.md\ — updated with new hook entry

## Fixes

- **#24622** — Gateway hangs on billing error instead of failing gracefully
- **#30484** — Billing error misclassification (context overflow vs true billing)

## Configuration

\\\json
{
   hooks: {
    internal: {
      entries: {
        minimax-1008-guard: {
          enabled: true,
          contextThresholdPct: 85,
          autoAction: compact
        }
      }
    }
  }
}
\\\

## Author

**lrddrl** — https://github.com/lrddrl/minimax-1008-guard (standalone npm hook pack also available)