### PR TITLE
fix(ollama): register mediaUnderstandingProviders contract for vision models

### DIFF
--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -20,7 +20,8 @@
   ],
   "contracts": {
     "memoryEmbeddingProviders": ["ollama"],
-    "webSearchProviders": ["ollama"]
+    "webSearchProviders": ["ollama"],
+    "mediaUnderstandingProviders": ["ollama"]
   },
   "configSchema": {
     "type": "object",


### PR DESCRIPTION
## Summary

Ollama plugin only registered  and  contracts, missing the  contract. This caused the image tool's provider lookup to fail for Ollama vision models (e.g. gemma4:e4b), even though Ollama's /api/chat natively supports vision.

## Fix

Add  to the plugin contracts in , consistent with all other vision-capable plugins (openai, anthropic, google, etc.).

## Testing

- Verified the plugin manifest schema already supports  (src/plugins/manifest.ts:142)
- No code logic changes required — the provider lookup path already looks for this contract
- Manual verification: after this change,  tool with  should route correctly

Fixes #64111