### PR TITLE
fix: preserve commands.list metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - UI/compaction: keep the compaction indicator in a retry-pending state until the run actually finishes, so the UI does not show `Context compacted` before compaction actually finishes. (#55132) Thanks @mpz4life.
 - Cron/tool schemas: keep cron tool schemas strict-model-friendly while still preserving `failureAlert=false`, nullable `agentId`/`sessionKey`, and flattened add/update recovery for the newly exposed cron job fields. (#55043) Thanks @brunolorente.
 - Git metadata: read commit ids from packed refs as well as loose refs so version and status metadata stay accurate after repository maintenance. (#63943)
+- Gateway: keep `commands.list` skill entries categorized under tools and include provider-aware plugin `nativeName` metadata even when `scope=text`, so remote clients can group skills correctly and map text-surface plugin commands back to native aliases.
 
 ## 2026.4.9
 

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -100,6 +100,9 @@ describe("commands registry", () => {
       { skillCommands },
     );
     expect(commands.find((spec) => spec.nativeName === "demo_skill")).toBeTruthy();
+    expect(commands.find((spec) => spec.nativeName === "demo_skill")).toMatchObject({
+      category: "tools",
+    });
 
     const native = listNativeCommandSpecsForConfig(
       { commands: { config: false, plugins: false, debug: false, native: true } },

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -88,6 +88,7 @@ function buildSkillCommandDefinitions(skillCommands?: SkillCommandSpec[]): ChatC
     acceptsArgs: true,
     argsParsing: "none",
     scope: "both",
+    category: "tools",
   }));
 }
 

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -299,10 +299,33 @@ describe("commands.list handler", () => {
   it("keeps plugin text commands visible for scope=text even without native provider support", () => {
     const { payload } = callHandler({ provider: "whatsapp", scope: "text" });
     const { commands } = payload as {
-      commands: Array<{ name: string; source: string; textAliases?: string[] }>;
+      commands: Array<{
+        name: string;
+        source: string;
+        textAliases?: string[];
+        nativeName?: string;
+      }>;
     };
     expect(commands.find((c) => c.source === "plugin")).toMatchObject({
       name: "tts",
+      textAliases: ["/tts"],
+    });
+    expect(commands.find((c) => c.source === "plugin")?.nativeName).toBeUndefined();
+  });
+
+  it("keeps plugin text names while exposing provider-native aliases for scope=text", () => {
+    const { payload } = callHandler({ provider: "discord", scope: "text" });
+    const { commands } = payload as {
+      commands: Array<{
+        name: string;
+        source: string;
+        textAliases?: string[];
+        nativeName?: string;
+      }>;
+    };
+    expect(commands.find((c) => c.source === "plugin")).toMatchObject({
+      name: "tts",
+      nativeName: "discord_tts",
       textAliases: ["/tts"],
     });
   });

--- a/src/gateway/server-methods/commands.ts
+++ b/src/gateway/server-methods/commands.ts
@@ -120,6 +120,34 @@ function mapCommand(
   };
 }
 
+function buildPluginCommandEntries(params: {
+  provider?: string;
+  nameSurface: CommandNameSurface;
+}): CommandEntry[] {
+  const pluginTextSpecs = listPluginCommands();
+  const pluginNativeSpecs = getPluginCommandSpecs(params.provider);
+  const entries: CommandEntry[] = [];
+
+  for (const [index, textSpec] of pluginTextSpecs.entries()) {
+    const nativeSpec = pluginNativeSpecs[index];
+    const nativeName = nativeSpec?.name;
+    entries.push({
+      name: params.nameSurface === "text" ? textSpec.name : (nativeName ?? textSpec.name),
+      ...(nativeName ? { nativeName } : {}),
+      textAliases: [`/${textSpec.name}`],
+      description: textSpec.description,
+      source: "plugin",
+      scope: "both",
+      acceptsArgs: textSpec.acceptsArgs,
+    });
+  }
+
+  if (params.nameSurface === "native") {
+    return entries.filter((entry) => entry.nativeName);
+  }
+  return entries;
+}
+
 export function buildCommandsListResult(params: {
   cfg: ReturnType<typeof loadConfig>;
   agentId: string;
@@ -153,33 +181,7 @@ export function buildCommandsListResult(params: {
     );
   }
 
-  if (nameSurface === "text") {
-    for (const spec of listPluginCommands()) {
-      commands.push({
-        name: spec.name,
-        textAliases: [`/${spec.name}`],
-        description: spec.description,
-        source: "plugin",
-        scope: "both",
-        acceptsArgs: spec.acceptsArgs,
-      });
-    }
-  } else {
-    const pluginTextSpecs = listPluginCommands();
-    const pluginSpecs = getPluginCommandSpecs(provider);
-    for (const [index, spec] of pluginSpecs.entries()) {
-      const textName = pluginTextSpecs[index]?.name ?? spec.name;
-      commands.push({
-        name: spec.name,
-        nativeName: spec.name,
-        textAliases: [`/${textName}`],
-        description: spec.description,
-        source: "plugin",
-        scope: "both",
-        acceptsArgs: spec.acceptsArgs,
-      });
-    }
-  }
+  commands.push(...buildPluginCommandEntries({ provider, nameSurface }));
 
   return { commands };
 }


### PR DESCRIPTION
## Summary
- keep dynamic skill commands categorized as `tools` in `commands.list`
- include provider-aware plugin `nativeName` metadata even when `scope=text`
- add regression coverage for both paths

## Validation
- `pnpm exec vitest run src/auto-reply/commands-registry.test.ts src/gateway/server-methods/commands.test.ts`
  - passed (`2` files, `42` tests)
- `OPENCLAW_LOCAL_CHECK=0 pnpm tsgo`
  - still fails on existing `origin/main` baseline issues in `src/agents/provider-request-config.ts`, `src/media-understanding/runner.entries.ts`, and unrelated pre-existing test typing lanes

## Context
Follow-up to #62656 after post-merge review comments identified two missing metadata cases.