### PR TITLE
backup: exclude node_modules inside extensions from archive

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatBackupCreateSummary, type BackupCreateResult } from "./backup-create.js";
+import {
+  buildExtensionsNodeModulesFilter,
+  formatBackupCreateSummary,
+  type BackupCreateResult,
+} from "./backup-create.js";
 
 function makeResult(overrides: Partial<BackupCreateResult> = {}): BackupCreateResult {
   return {
@@ -81,5 +85,41 @@ describe("formatBackupCreateSummary", () => {
     },
   ])("$name", ({ result, expected }) => {
     expect(formatBackupCreateSummary(result)).toEqual(expected);
+  });
+});
+
+describe("buildExtensionsNodeModulesFilter", () => {
+  const filter = buildExtensionsNodeModulesFilter("/home/user/.openclaw");
+
+  it("allows non-extension paths through", () => {
+    expect(filter("/home/user/.openclaw/openclaw.json")).toBe(true);
+    expect(filter("/home/user/.openclaw/sessions/abc.jsonl")).toBe(true);
+  });
+
+  it("allows extension files that are not inside node_modules", () => {
+    expect(filter("/home/user/.openclaw/extensions/my-plugin/package.json")).toBe(true);
+    expect(filter("/home/user/.openclaw/extensions/my-plugin/dist/index.js")).toBe(true);
+    expect(filter("/home/user/.openclaw/extensions/my-plugin/openclaw.plugin.json")).toBe(true);
+  });
+
+  it("excludes node_modules inside extensions", () => {
+    expect(filter("/home/user/.openclaw/extensions/my-plugin/node_modules/foo/index.js")).toBe(
+      false,
+    );
+    expect(
+      filter("/home/user/.openclaw/extensions/my-plugin/node_modules/.package-lock.json"),
+    ).toBe(false);
+  });
+
+  it("excludes nested node_modules inside extensions", () => {
+    expect(
+      filter(
+        "/home/user/.openclaw/extensions/my-plugin/node_modules/foo/node_modules/bar/index.js",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not exclude node_modules outside extensions", () => {
+    expect(filter("/home/user/.openclaw/node_modules/something")).toBe(true);
   });
 });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -122,4 +122,12 @@ describe("buildExtensionsNodeModulesFilter", () => {
   it("does not exclude node_modules outside extensions", () => {
     expect(filter("/home/user/.openclaw/node_modules/something")).toBe(true);
   });
+
+  it("handles Windows-style backslash paths", () => {
+    const winFilter = buildExtensionsNodeModulesFilter("C:\\Users\\user\\.openclaw");
+    expect(winFilter("C:\\Users\\user\\.openclaw\\extensions\\my-plugin\\package.json")).toBe(true);
+    expect(
+      winFilter("C:\\Users\\user\\.openclaw\\extensions\\my-plugin\\node_modules\\foo\\index.js"),
+    ).toBe(false);
+  });
 });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -348,6 +348,7 @@ export async function createBackupArchive(
         gzip: true,
         portable: true,
         preservePaths: true,
+        filter: buildExtensionsNodeModulesFilter(plan.stateDir),
         onWriteEntry: (entry) => {
           entry.path = remapArchiveEntryPath({
             entryPath: entry.path,
@@ -365,4 +366,22 @@ export async function createBackupArchive(
   }
 
   return result;
+}
+
+/**
+ * Build a tar filter that excludes `node_modules` directories inside the
+ * `extensions/` subtree of the given state directory. Extension dependencies
+ * can be reinstalled after restore via `npm install --omit=dev`, so backing
+ * them up only inflates the archive without adding restore value.
+ */
+export function buildExtensionsNodeModulesFilter(stateDir: string): (filePath: string) => boolean {
+  const extensionsPrefix = `${path.join(stateDir, "extensions")}/`;
+  return (filePath: string): boolean => {
+    if (!filePath.startsWith(extensionsPrefix)) {
+      return true;
+    }
+    const relative = filePath.slice(extensionsPrefix.length);
+    const segments = relative.split("/");
+    return !segments.includes("node_modules");
+  };
 }

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -375,12 +375,14 @@ export async function createBackupArchive(
  * them up only inflates the archive without adding restore value.
  */
 export function buildExtensionsNodeModulesFilter(stateDir: string): (filePath: string) => boolean {
-  const extensionsPrefix = `${path.join(stateDir, "extensions")}/`;
+  const normalised = stateDir.replaceAll("\\", "/");
+  const extensionsPrefix = `${normalised}/extensions/`;
   return (filePath: string): boolean => {
-    if (!filePath.startsWith(extensionsPrefix)) {
+    const fp = filePath.replaceAll("\\", "/");
+    if (!fp.startsWith(extensionsPrefix)) {
       return true;
     }
-    const relative = filePath.slice(extensionsPrefix.length);
+    const relative = fp.slice(extensionsPrefix.length);
     const segments = relative.split("/");
     return !segments.includes("node_modules");
   };

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -348,7 +348,9 @@ export async function createBackupArchive(
         gzip: true,
         portable: true,
         preservePaths: true,
-        filter: buildExtensionsNodeModulesFilter(plan.stateDir),
+        filter: buildExtensionsNodeModulesFilter(
+          result.assets.find((a) => a.kind === "state")?.sourcePath ?? plan.stateDir,
+        ),
         onWriteEntry: (entry) => {
           entry.path = remapArchiveEntryPath({
             entryPath: entry.path,


### PR DESCRIPTION
## Summary

- Filter out `node_modules` directories inside `extensions/` when creating backup archives
- Extension manifests, config, and plugin source are still included
- Dependencies can be reinstalled after restore via `npm install --omit=dev`

Closes #64144

## Motivation

`openclaw backup create` archives the entire state directory, including `~/.openclaw/extensions/*/node_modules/`. These dependency trees are often hundreds of MB, are trivially reinstallable, and may contain platform-specific native modules that won't work cross-platform anyway.

## Changes

- Added a `filter` callback to `tar.c()` in `src/infra/backup-create.ts` that skips any path containing `node_modules` within the `extensions/` subtree of the state directory
- Extracted the filter as `buildExtensionsNodeModulesFilter()` for testability
- Added unit tests covering: non-extension paths pass through, extension files pass through, node_modules inside extensions are excluded, nested node_modules are excluded, node_modules outside extensions are not affected

## Test plan

- [x] Unit tests for `buildExtensionsNodeModulesFilter` added and passing
- [ ] Manual: run `openclaw backup create` with installed extensions, verify archive does not contain `node_modules` under extensions
- [ ] Manual: restore from the archive, run `npm install --omit=dev` in extension dirs, verify plugins work