### PR TITLE
fix(memory-core): keep dreaming active with external memory owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.
 - Dreaming/narrative: harden request-scoped diary fallback so scheduled dreaming only falls back on the dedicated subagent-runtime error, stop trusting spoofable raw error-code objects, and avoid leaking workspace paths when local fallback writes fail. (#64156) Thanks @mbelinky.
+- Memory/dreaming: keep bundled `memory-core` dreaming active alongside external memory owners, route `/dreaming` through the selected memory slot plugin config, and block reserved slot keys from poisoning dreaming config ownership. (#64155) Thanks @mbelinky.
 
 ## 2026.4.8
 

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -1,11 +1,12 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core";
-import { describe, expect, it } from "vitest";
+import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryFlushPlan,
   buildPromptSection,
   DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
   DEFAULT_MEMORY_FLUSH_PROMPT,
   DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
+  default as memoryCorePlugin,
 } from "./index.js";
 
 describe("buildPromptSection", () => {
@@ -178,5 +179,41 @@ describe("buildMemoryFlushPlan", () => {
     expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("do not overwrite");
     expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("timestamped variant");
     expect(DEFAULT_MEMORY_FLUSH_PROMPT).toContain("YYYY-MM-DD.md");
+  });
+});
+
+describe("memory-core plugin registration", () => {
+  function createRegistrationHarness(config: OpenClawConfig = {}) {
+    const api = {
+      config,
+      registerMemoryEmbeddingProvider: vi.fn(),
+      registerCommand: vi.fn(),
+      registerHook: vi.fn(),
+      on: vi.fn(),
+      registerMemoryCapability: vi.fn(),
+      registerTool: vi.fn(),
+      registerCli: vi.fn(),
+    } as unknown as OpenClawPluginApi;
+
+    memoryCorePlugin.register(api);
+    return api;
+  }
+
+  it("keeps dreaming surfaces but skips exclusive memory registration when another memory plugin owns the slot", () => {
+    const api = createRegistrationHarness({
+      plugins: {
+        slots: {
+          memory: "memory-lancedb",
+        },
+      },
+    });
+
+    expect(api.registerCommand).toHaveBeenCalled();
+    expect(api.registerHook).toHaveBeenCalled();
+    expect(api.on).toHaveBeenCalled();
+    expect(api.registerMemoryEmbeddingProvider).toHaveBeenCalled();
+    expect(api.registerMemoryCapability).not.toHaveBeenCalled();
+    expect(api.registerTool).not.toHaveBeenCalled();
+    expect(api.registerCli).not.toHaveBeenCalled();
   });
 });

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,3 +1,4 @@
+import { resolveMemoryDreamingPluginId } from "openclaw/plugin-sdk/memory-core-host-status";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { registerMemoryCli } from "./src/cli.js";
 import { registerDreamingCommand } from "./src/dreaming-command.js";
@@ -27,9 +28,14 @@ export default definePluginEntry({
   description: "File-backed memory search tools and CLI",
   kind: "memory",
   register(api) {
+    const memoryCoreOwnsSlot = resolveMemoryDreamingPluginId(api.config) === "memory-core";
+
     registerBuiltInMemoryEmbeddingProviders(api);
     registerShortTermPromotionDreaming(api);
     registerDreamingCommand(api);
+    if (!memoryCoreOwnsSlot) {
+      return;
+    }
     api.registerMemoryCapability({
       promptBuilder: buildPromptSection,
       flushPlanResolver: buildMemoryFlushPlan,

--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -13,8 +13,11 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
-function resolveStoredDreaming(config: OpenClawConfig): Record<string, unknown> {
-  const entry = asRecord(config.plugins?.entries?.["memory-core"]);
+function resolveStoredDreaming(
+  config: OpenClawConfig,
+  pluginId = "memory-core",
+): Record<string, unknown> {
+  const entry = asRecord(config.plugins?.entries?.[pluginId]);
   const pluginConfig = asRecord(entry?.config);
   return asRecord(pluginConfig?.dreaming) ?? {};
 }
@@ -119,6 +122,35 @@ describe("memory-core /dreaming command", () => {
     expect(result.text).toContain("Dreaming disabled.");
   });
 
+  it("persists dreaming config under the selected memory slot owner", async () => {
+    const { command, runtime, getRuntimeConfig } = createHarness({
+      plugins: {
+        slots: {
+          memory: "memory-lancedb",
+        },
+        entries: {
+          "memory-lancedb": {
+            config: {
+              dreaming: {
+                frequency: "5 1 * * *",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const result = await command.handler(createCommandContext("on"));
+
+    expect(runtime.config.writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(resolveStoredDreaming(getRuntimeConfig(), "memory-lancedb")).toMatchObject({
+      enabled: true,
+      frequency: "5 1 * * *",
+    });
+    expect(resolveStoredDreaming(getRuntimeConfig(), "memory-core")).toEqual({});
+    expect(result.text).toContain("Dreaming enabled.");
+  });
+
   it("blocks unscoped gateway callers from persisting dreaming config", async () => {
     const { command, runtime } = createHarness();
 
@@ -187,6 +219,41 @@ describe("memory-core /dreaming command", () => {
     expect(result.text).toContain("- enabled: off (America/Los_Angeles)");
     expect(result.text).toContain("- sweep cadence: 15 */8 * * *");
     expect(result.text).toContain("- promotion policy: score>=0.8, recalls>=3, uniqueQueries>=3");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("reads status from the selected memory slot owner", async () => {
+    const { command, runtime } = createHarness({
+      plugins: {
+        slots: {
+          memory: "memory-lancedb",
+        },
+        entries: {
+          "memory-lancedb": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "15 */8 * * *",
+                timezone: "America/Los_Angeles",
+                phases: {
+                  deep: {
+                    minScore: 0.6,
+                    minRecallCount: 2,
+                    minUniqueQueries: 4,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const result = await command.handler(createCommandContext("status"));
+
+    expect(result.text).toContain("- enabled: on (America/Los_Angeles)");
+    expect(result.text).toContain("- sweep cadence: 15 */8 * * *");
+    expect(result.text).toContain("- promotion policy: score>=0.6, recalls>=2, uniqueQueries>=4");
     expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
   });
 

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -1,20 +1,24 @@
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
-import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import {
+  resolveMemoryDreamingConfig,
+  resolveMemoryDreamingPluginConfig,
+  resolveMemoryDreamingPluginId,
+} from "openclaw/plugin-sdk/memory-core-host-status";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
 
 function resolveMemoryCorePluginConfig(cfg: OpenClawConfig): Record<string, unknown> {
-  const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
-  return asRecord(entry?.config) ?? {};
+  return resolveMemoryDreamingPluginConfig(cfg) ?? {};
 }
 
 function updateDreamingEnabledInConfig(cfg: OpenClawConfig, enabled: boolean): OpenClawConfig {
+  const pluginId = resolveMemoryDreamingPluginId(cfg);
   const entries = { ...cfg.plugins?.entries };
-  const existingEntry = asRecord(entries["memory-core"]) ?? {};
+  const existingEntry = asRecord(entries[pluginId]) ?? {};
   const existingConfig = asRecord(existingEntry.config) ?? {};
   const existingSleep = asRecord(existingConfig.dreaming) ?? {};
-  entries["memory-core"] = {
+  entries[pluginId] = {
     ...existingEntry,
     config: {
       ...existingConfig,

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -278,4 +278,39 @@ describe("memory dreaming host helpers", () => {
       },
     });
   });
+
+  it("falls back to memory-core when memory slot uses a blocked object key", () => {
+    expect(
+      resolveMemoryDreamingPluginId({
+        plugins: {
+          slots: {
+            memory: "__proto__",
+          },
+        },
+      } as OpenClawConfig),
+    ).toBe("memory-core");
+
+    expect(
+      resolveMemoryDreamingPluginConfig({
+        plugins: {
+          slots: {
+            memory: "constructor",
+          },
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig),
+    ).toEqual({
+      dreaming: {
+        enabled: true,
+      },
+    });
+  });
 });

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { asNullableRecord } from "../shared/record-coerce.js";
 import {
   lowercasePreservingWhitespace,
@@ -325,7 +326,11 @@ export function resolveMemoryDreamingPluginId(
   const plugins = asNullableRecord(root?.plugins);
   const slots = asNullableRecord(plugins?.slots);
   const configuredSlot = normalizeTrimmedString(slots?.memory);
-  if (configuredSlot && normalizeLowercaseStringOrEmpty(configuredSlot) !== "none") {
+  if (
+    configuredSlot &&
+    normalizeLowercaseStringOrEmpty(configuredSlot) !== "none" &&
+    !isBlockedObjectKey(configuredSlot)
+  ) {
     return configuredSlot;
   }
   return DEFAULT_MEMORY_DREAMING_PLUGIN_ID;

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3094,6 +3094,74 @@ module.exports = {
         },
       },
       {
+        label:
+          "keeps bundled memory-core loaded as an auxiliary sidecar when another memory plugin owns the slot",
+        loadRegistry: () => {
+          const bundledDir = makeTempDir();
+          const memoryCoreDir = path.join(bundledDir, "memory-core");
+          const memoryBDir = path.join(bundledDir, "memory-b");
+          mkdirSafe(memoryCoreDir);
+          mkdirSafe(memoryBDir);
+          writePlugin({
+            id: "memory-core",
+            dir: memoryCoreDir,
+            filename: "index.cjs",
+            body: memoryPluginBody("memory-core"),
+          });
+          writePlugin({
+            id: "memory-b",
+            dir: memoryBDir,
+            filename: "index.cjs",
+            body: memoryPluginBody("memory-b"),
+          });
+          fs.writeFileSync(
+            path.join(memoryCoreDir, "openclaw.plugin.json"),
+            JSON.stringify(
+              {
+                id: "memory-core",
+                kind: "memory",
+                configSchema: EMPTY_PLUGIN_SCHEMA,
+                enabledByDefault: true,
+              },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          fs.writeFileSync(
+            path.join(memoryBDir, "openclaw.plugin.json"),
+            JSON.stringify(
+              {
+                id: "memory-b",
+                kind: "memory",
+                configSchema: EMPTY_PLUGIN_SCHEMA,
+              },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+          return loadOpenClawPlugins({
+            cache: false,
+            config: {
+              plugins: {
+                slots: { memory: "memory-b" },
+              },
+            },
+          });
+        },
+        assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+          const memoryCore = registry.plugins.find((entry) => entry.id === "memory-core");
+          const memoryB = registry.plugins.find((entry) => entry.id === "memory-b");
+          expect(memoryCore?.status).toBe("loaded");
+          expect(memoryCore?.memorySlotSelected).not.toBe(true);
+          expect(memoryB?.status).toBe("loaded");
+          expect(memoryB?.memorySlotSelected).toBe(true);
+        },
+      },
+      {
         label: "disables memory plugins when slot is none",
         loadRegistry: () => {
           process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
@@ -3115,6 +3183,49 @@ module.exports = {
         assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
           const entry = registry.plugins.find((item) => item.id === "memory-off");
           expect(entry?.status).toBe("disabled");
+        },
+      },
+      {
+        label: "does not keep bundled memory-core loaded when the memory slot is none",
+        loadRegistry: () => {
+          const bundledDir = makeTempDir();
+          const memoryCoreDir = path.join(bundledDir, "memory-core");
+          mkdirSafe(memoryCoreDir);
+          writePlugin({
+            id: "memory-core",
+            dir: memoryCoreDir,
+            filename: "index.cjs",
+            body: memoryPluginBody("memory-core"),
+          });
+          fs.writeFileSync(
+            path.join(memoryCoreDir, "openclaw.plugin.json"),
+            JSON.stringify(
+              {
+                id: "memory-core",
+                kind: "memory",
+                configSchema: EMPTY_PLUGIN_SCHEMA,
+                enabledByDefault: true,
+              },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+          return loadOpenClawPlugins({
+            cache: false,
+            config: {
+              plugins: {
+                slots: { memory: "none" },
+              },
+            },
+          });
+        },
+        assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+          const memoryCore = registry.plugins.find((entry) => entry.id === "memory-core");
+          expect(memoryCore?.status).toBe("disabled");
+          expect(String(memoryCore?.error ?? "")).toContain("memory slot disabled");
         },
       },
     ] as const;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -75,7 +75,7 @@ import {
   resolvePluginSdkScopedAliasMap,
   shouldPreferNativeJiti,
 } from "./sdk-alias.js";
-import { hasKind, kindsEqual } from "./slots.js";
+import { hasKind, isBundledMemoryCoreDreamingSidecarCandidate, kindsEqual } from "./slots.js";
 import type {
   OpenClawPluginDefinition,
   OpenClawPluginModule,
@@ -1492,7 +1492,16 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           slot: memorySlot,
           selectedId: selectedMemoryPluginId,
         });
-        if (!earlyMemoryDecision.enabled) {
+        if (
+          !earlyMemoryDecision.enabled &&
+          !isBundledMemoryCoreDreamingSidecarCandidate({
+            id: record.id,
+            kind: manifestRecord.kind,
+            origin: candidate.origin,
+            slot: memorySlot,
+            selectedId: selectedMemoryPluginId,
+          })
+        ) {
           record.enabled = false;
           record.status = "disabled";
           record.error = earlyMemoryDecision.reason;
@@ -1516,7 +1525,16 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           selectedId: selectedMemoryPluginId,
         });
 
-        if (!memoryDecision.enabled) {
+        if (
+          !memoryDecision.enabled &&
+          !isBundledMemoryCoreDreamingSidecarCandidate({
+            id: record.id,
+            kind: record.kind,
+            origin: candidate.origin,
+            slot: memorySlot,
+            selectedId: selectedMemoryPluginId,
+          })
+        ) {
           record.enabled = false;
           record.status = "disabled";
           record.error = memoryDecision.reason;
@@ -1664,7 +1682,16 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           selectedId: selectedMemoryPluginId,
         });
 
-        if (!memoryDecision.enabled) {
+        if (
+          !memoryDecision.enabled &&
+          !isBundledMemoryCoreDreamingSidecarCandidate({
+            id: record.id,
+            kind: record.kind,
+            origin: candidate.origin,
+            slot: memorySlot,
+            selectedId: selectedMemoryPluginId,
+          })
+        ) {
           record.enabled = false;
           record.status = "disabled";
           record.error = memoryDecision.reason;
@@ -2094,7 +2121,16 @@ export async function loadOpenClawPluginCliRegistry(
       slot: memorySlot,
       selectedId: selectedMemoryPluginId,
     });
-    if (!memoryDecision.enabled) {
+    if (
+      !memoryDecision.enabled &&
+      !isBundledMemoryCoreDreamingSidecarCandidate({
+        id: record.id,
+        kind: record.kind,
+        origin: candidate.origin,
+        slot: memorySlot,
+        selectedId: selectedMemoryPluginId,
+      })
+    ) {
       record.enabled = false;
       record.status = "disabled";
       record.error = memoryDecision.reason;

--- a/src/plugins/slots.test.ts
+++ b/src/plugins/slots.test.ts
@@ -127,17 +127,15 @@ describe("applyExclusiveSlotSelection", () => {
 
   it.each([
     {
-      name: "selects the slot and disables other entries for the same kind",
+      name: "switches the slot while keeping memory-core enabled as the dreaming sidecar",
       config: createMemoryConfig({
         slots: { memory: "memory-core" },
         entries: { "memory-core": { enabled: true } },
       }),
-      expectedDisabled: false,
+      expectedDisabled: true,
       warningChecks: {
-        contains: [
-          'Exclusive slot "memory" switched from "memory-core" to "memory".',
-          'Disabled other "memory" slot plugins: memory-core.',
-        ],
+        contains: ['Exclusive slot "memory" switched from "memory-core" to "memory".'],
+        excludes: ['Disabled other "memory" slot plugins: memory-core.'],
       },
     },
     {
@@ -215,7 +213,7 @@ describe("applyExclusiveSlotSelection", () => {
     expect(result.changed).toBe(true);
     expect(result.config.plugins?.slots?.memory).toBe("dual-plugin");
     expect(result.config.plugins?.slots?.contextEngine).toBe("dual-plugin");
-    expect(result.config.plugins?.entries?.["memory-core"]?.enabled).toBe(false);
+    expect(result.config.plugins?.entries?.["memory-core"]?.enabled).toBe(true);
     expect(result.config.plugins?.entries?.legacy?.enabled).toBe(false);
   });
 

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -135,6 +135,10 @@ export function applyExclusiveSlotSelection(params: {
         if (
           isBundledMemoryCoreDreamingSidecarCandidate({
             ...plugin,
+            // During config selection we already know the new memory-slot owner.
+            // Passing it through both fields keeps the sidecar predicate aligned
+            // with loader-time checks, where either "configured owner" or
+            // "selected owner" can prove another plugin owns the slot.
             slot: params.selectedId,
             selectedId: params.selectedId,
           })

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginSlotsConfig } from "../config/types.plugins.js";
-import type { PluginKind } from "./types.js";
+import type { PluginKind, PluginOrigin } from "./types.js";
 
 export type PluginSlotKey = keyof PluginSlotsConfig;
 
@@ -67,6 +67,25 @@ export function defaultSlotIdForKey(slotKey: PluginSlotKey): string {
   return DEFAULT_SLOT_BY_KEY[slotKey];
 }
 
+export function isBundledMemoryCoreDreamingSidecarCandidate(params: {
+  id: string;
+  kind?: PluginKind | PluginKind[];
+  origin?: PluginOrigin;
+  slot?: string | null;
+  selectedId?: string | null;
+}): boolean {
+  const anotherPluginOwnsMemorySlot =
+    (typeof params.slot === "string" && params.slot !== "memory-core") ||
+    Boolean(params.selectedId && params.selectedId !== "memory-core");
+  return (
+    params.id === "memory-core" &&
+    (params.origin === undefined || params.origin === "bundled") &&
+    hasKind(params.kind, "memory") &&
+    params.slot !== null &&
+    anotherPluginOwnsMemorySlot
+  );
+}
+
 export type SlotSelectionResult = {
   config: OpenClawConfig;
   warnings: string[];
@@ -111,6 +130,15 @@ export function applyExclusiveSlotSelection(params: {
           (k) => SLOT_BY_KIND[k] === slotKey,
         );
         if (!kindForSlot || !hasKind(plugin.kind, kindForSlot)) {
+          continue;
+        }
+        if (
+          isBundledMemoryCoreDreamingSidecarCandidate({
+            ...plugin,
+            slot: params.selectedId,
+            selectedId: params.selectedId,
+          })
+        ) {
           continue;
         }
         // Don't disable a plugin that still owns another slot (explicit or default).


### PR DESCRIPTION
## Summary
- Problem: when another plugin owns `plugins.slots.memory`, bundled `memory-core` gets disabled entirely, so dreaming disappears with it.
- Why it matters: users lose `/dreaming`, managed dream cron, `.dreams` output, and `DREAMS.md` even though dreaming is presented as a separate capability.
- What changed:
  - keep bundled `memory-core` loaded as a dreaming sidecar when another memory plugin owns the slot
  - still disable it when memory is explicitly `none`
  - keep exclusive memory registration off in sidecar mode, so the active memory owner stays authoritative
  - route `/dreaming` reads and writes through the selected memory owner config instead of hardcoding `memory-core`

## Change Type
- [x] Bug fix
- [x] Refactor required for the fix

## Scope
- [x] Memory / storage
- [x] API / contracts

## Linked Issues
- Closes #63831
- Closes #63590
- Closes #61936
- Closes #63067

## Root Cause
Dreaming lived inside `memory-core`, but slot resolution and loader policy treated `memory-core` as fully mutually exclusive with any other memory plugin. Even after config ownership fixes, the plugin never loaded, so its dreaming command, hook registration, and cron lifecycle never came up.

## Implementation Notes
This is intentionally split into two commits:
1. keep `memory-core` loaded as a sidecar for dreaming while another memory plugin owns the memory slot
2. make `/dreaming` operate on the selected memory owner's config

## Regression Test Plan
- [x] Unit test
- Target files:
  - `src/plugins/loader.test.ts`
  - `src/plugins/slots.test.ts`
  - `extensions/memory-core/index.test.ts`
  - `extensions/memory-core/src/dreaming-command.test.ts`
- Locked scenarios:
  - bundled `memory-core` stays loaded alongside another memory owner
  - bundled `memory-core` does not stay loaded when memory slot is `none`
  - `memory-core` sidecar keeps dreaming surfaces but skips exclusive memory registration
  - `/dreaming` persists and reads config from the active memory owner

## Verification
Authoritative `mb-server` gates passed:
- `pnpm test -- src/plugins/loader.test.ts -t "enforces memory slot loading rules"`
- `pnpm test -- src/plugins/slots.test.ts extensions/memory-core/index.test.ts extensions/memory-core/src/dreaming-command.test.ts`

## Risks and Mitigations
- Risk: sidecar mode could accidentally keep `memory-core` alive when memory is intentionally disabled.
  - Mitigation: loader exemption only applies when another memory plugin actually owns the slot, not when slot is `none`.
- Risk: sidecar mode could let `memory-core` compete for memory ownership.
  - Mitigation: sidecar mode skips exclusive memory capability/tool/CLI registration.
