### PR TITLE
fix: Provider-supplied OAuth URLs inject Windows cmd.exe via openUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Windows/onboarding: open provider OAuth and sign-in URLs with `explorer.exe` instead of routing them through `cmd /c start`, so quoted provider URLs cannot break out into host command execution. (#64161) Thanks @coygeek and @vincentkoc.
 - OpenAI/Codex OAuth: stop rewriting the upstream authorize URL scopes so new Codex sign-ins do not fail with `invalid_scope` before returning an authorization code. (#64713) Thanks @fuller-stack-dev.
 - Audio transcription: disable pinned DNS only for OpenAI-compatible multipart requests, while still validating hostnames, so OpenAI, Groq, and Mistral transcription works again without weakening other request paths. (#64766) Thanks @GodsBoy.
 - macOS/Talk Mode: after granting microphone permission on first enable, continue starting Talk Mode instead of requiring a second toggle. (#62459) Thanks @ggarber.

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
 });
 
 describe("openUrl", () => {
-  it("quotes URLs on win32 so '&' is not treated as cmd separator", async () => {
+  it("passes OAuth URLs to explorer.exe on win32 without cmd parsing", async () => {
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "");
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
@@ -59,23 +59,20 @@ describe("openUrl", () => {
 
     expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(1);
     const [argv, options] = mocks.runCommandWithTimeout.mock.calls[0] ?? [];
-    expect(argv?.slice(0, 4)).toEqual(["cmd", "/c", "start", '""']);
-    expect(argv?.at(-1)).toBe(`"${url}"`);
-    expect(options).toMatchObject({
-      timeoutMs: 5_000,
-      windowsVerbatimArguments: true,
-    });
+    expect(argv).toEqual(["explorer.exe", url]);
+    expect(options).toMatchObject({ timeoutMs: 5_000 });
+    expect(options?.windowsVerbatimArguments).toBeUndefined();
 
     platformSpy.mockRestore();
   });
 });
 
 describe("resolveBrowserOpenCommand", () => {
-  it("marks win32 commands as quoteUrl=true", async () => {
+  it("uses explorer.exe on win32", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const resolved = await resolveBrowserOpenCommand();
-    expect(resolved.argv).toEqual(["cmd", "/c", "start", ""]);
-    expect(resolved.quoteUrl).toBe(true);
+    expect(resolved.argv).toEqual(["explorer.exe"]);
+    expect(resolved.command).toBe("explorer.exe");
     platformSpy.mockRestore();
   });
 });

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -6,7 +6,6 @@ export type BrowserOpenCommand = {
   argv: string[] | null;
   reason?: string;
   command?: string;
-  quoteUrl?: boolean;
 };
 
 export type BrowserOpenSupport = {
@@ -36,9 +35,8 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
 
   if (platform === "win32") {
     return {
-      argv: ["cmd", "/c", "start", ""],
-      command: "cmd",
-      quoteUrl: true,
+      argv: ["explorer.exe"],
+      command: "explorer.exe",
     };
   }
 
@@ -86,21 +84,10 @@ export async function openUrl(url: string): Promise<boolean> {
   if (!resolved.argv) {
     return false;
   }
-  const quoteUrl = resolved.quoteUrl === true;
   const command = [...resolved.argv];
-  if (quoteUrl) {
-    if (command.at(-1) === "") {
-      command[command.length - 1] = '""';
-    }
-    command.push(`"${url}"`);
-  } else {
-    command.push(url);
-  }
+  command.push(url);
   try {
-    await runCommandWithTimeout(command, {
-      timeoutMs: 5_000,
-      windowsVerbatimArguments: quoteUrl,
-    });
+    await runCommandWithTimeout(command, { timeoutMs: 5_000 });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Fix Summary
On Windows, a malicious or compromised provider response can turn an OAuth or sign-in URL into arbitrary command execution on the gateway host. `openUrl()` wraps the raw URL in quotes for `cmd /c start` but does not escape embedded double quotes, so a provider-supplied payload like `https://example.invalid/" & calc & rem "` breaks out of the quoted URL and runs attacker-controlled commands as the local OpenClaw user.

## Issue Linkage
Fixes #64159

## Security Snapshot
- CVSS v3.1: 8.3 (High)
- CVSS v4.0: 9.0 (Critical)

## Implementation Details
### Files Changed
- `src/commands/onboard-helpers.test.ts` (+7/-10)
- `src/infra/browser-open.ts` (+4/-17)

### Technical Analysis
1. Use a Windows OpenClaw host on release `v2026.4.9` and start an interactive provider auth flow that calls `openUrl()`, such as MiniMax portal OAuth or Ollama Cloud sign-in.
2. Return a crafted provider URL containing an injected closing quote and command separator, for example `https://example.invalid/" & calc & rem "`.
3. MiniMax still reads `verification_uri` from the provider JSON response and calls `await params.openUrl(verificationUrl)` at `extensions/minimax/oauth.ts:193-205`; Ollama still reads `signin_url` from `/api/me` and calls `await params.openUrl(authResult.signinUrl)` at `extensions/ollama/src/setup.ts:84-86,366-370`.
4. On Windows, `openUrl()` still constructs `cmd /c start "" "https://example.invalid/" & calc & rem ""` and launches it with `windowsVerbatimArguments: true`, so `cmd.exe` executes the injected command on the host.

## Validation Evidence
- Command: `pnpm test src/commands/onboard-helpers.test.ts`
- Status: passed (with pre-existing baseline failures)

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: opencode/claude-sonnet-4.6
