### PR TITLE
fix: Control UI stores reusable device-auth secrets in browser...

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -30,10 +30,11 @@ Auth is supplied during the WebSocket handshake via:
 - Tailscale Serve identity headers when `gateway.auth.allowTailscale: true`
 - trusted-proxy identity headers when `gateway.auth.mode: "trusted-proxy"`
 
-The dashboard settings panel keeps a token for the current browser tab session
-and selected gateway URL; passwords are not persisted. Onboarding usually
-generates a gateway token for shared-secret auth on first connect, but password
-auth works too when `gateway.auth.mode` is `"password"`.
+The dashboard settings panel keeps gateway tokens, paired device tokens, and
+browser device identity only for the current browser tab session and selected
+gateway URL; passwords are not persisted. Onboarding usually generates a gateway
+token for shared-secret auth on first connect, but password auth works too when
+`gateway.auth.mode` is `"password"`.
 
 ## Device pairing (first connection)
 

--- a/ui/src/ui/device-auth-session-storage.test.ts
+++ b/ui/src/ui/device-auth-session-storage.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { clearDeviceAuthToken, loadDeviceAuthToken, storeDeviceAuthToken } from "./device-auth.ts";
+import { loadOrCreateDeviceIdentity } from "./device-identity.ts";
+
+describe("device auth browser storage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    vi.stubGlobal("window", {
+      localStorage,
+      sessionStorage,
+      location: { href: "http://127.0.0.1:18789/" },
+    });
+    vi.stubGlobal("crypto", crypto);
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("stores device auth tokens in sessionStorage", () => {
+    storeDeviceAuthToken({
+      deviceId: "device-1",
+      role: "operator",
+      token: "tab-token",
+      scopes: ["operator.read"],
+    });
+
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "operator" })).toMatchObject({
+      token: "tab-token",
+      scopes: ["operator.read"],
+    });
+    expect(sessionStorage.getItem("openclaw.device.auth.v1")).toContain("tab-token");
+    expect(localStorage.getItem("openclaw.device.auth.v1")).toBeNull();
+  });
+
+  it("migrates legacy device auth out of localStorage on read", () => {
+    localStorage.setItem(
+      "openclaw.device.auth.v1",
+      JSON.stringify({
+        version: 1,
+        deviceId: "device-1",
+        tokens: {
+          operator: {
+            token: "legacy-token",
+            role: "operator",
+            scopes: ["operator.read"],
+            updatedAtMs: 1,
+          },
+        },
+      }),
+    );
+
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "operator" })?.token).toBe(
+      "legacy-token",
+    );
+    expect(sessionStorage.getItem("openclaw.device.auth.v1")).toContain("legacy-token");
+    expect(localStorage.getItem("openclaw.device.auth.v1")).toBeNull();
+  });
+
+  it("clears legacy localStorage state when removing a token", () => {
+    localStorage.setItem(
+      "openclaw.device.auth.v1",
+      JSON.stringify({
+        version: 1,
+        deviceId: "device-1",
+        tokens: { operator: { token: "legacy-token", role: "operator", updatedAtMs: 1 } },
+      }),
+    );
+    storeDeviceAuthToken({ deviceId: "device-1", role: "operator", token: "tab-token" });
+
+    clearDeviceAuthToken({ deviceId: "device-1", role: "operator" });
+
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "operator" })).toBeNull();
+    expect(localStorage.getItem("openclaw.device.auth.v1")).toBeNull();
+  });
+
+  it("stores device identity in sessionStorage and scrubs legacy localStorage", async () => {
+    const identity = await loadOrCreateDeviceIdentity();
+
+    expect(identity.deviceId).toBeTruthy();
+    expect(sessionStorage.getItem("openclaw-device-identity-v1")).toContain(identity.deviceId);
+    expect(localStorage.getItem("openclaw-device-identity-v1")).toBeNull();
+  });
+
+  it("migrates legacy device identity out of localStorage", async () => {
+    const legacy = {
+      version: 1,
+      deviceId: "wrong-device-id",
+      publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      privateKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      createdAtMs: 1,
+    };
+    localStorage.setItem("openclaw-device-identity-v1", JSON.stringify(legacy));
+
+    const identity = await loadOrCreateDeviceIdentity();
+
+    expect(identity.publicKey).toBe(legacy.publicKey);
+    expect(identity.privateKey).toBe(legacy.privateKey);
+    expect(sessionStorage.getItem("openclaw-device-identity-v1")).toContain(identity.deviceId);
+    expect(localStorage.getItem("openclaw-device-identity-v1")).toBeNull();
+  });
+});

--- a/ui/src/ui/device-auth.ts
+++ b/ui/src/ui/device-auth.ts
@@ -5,13 +5,13 @@ import {
   storeDeviceAuthTokenInStore,
 } from "../../../src/shared/device-auth-store.js";
 import type { DeviceAuthStore } from "../../../src/shared/device-auth.js";
-import { getSafeLocalStorage } from "../local-storage.ts";
+import { getSafeLocalStorage, getSafeSessionStorage } from "../local-storage.ts";
 
 const STORAGE_KEY = "openclaw.device.auth.v1";
 
-function readStore(): DeviceAuthStore | null {
+function readStoreFrom(storage: Storage | null): DeviceAuthStore | null {
   try {
-    const raw = getSafeLocalStorage()?.getItem(STORAGE_KEY);
+    const raw = storage?.getItem(STORAGE_KEY);
     if (!raw) {
       return null;
     }
@@ -31,9 +31,26 @@ function readStore(): DeviceAuthStore | null {
   }
 }
 
+function readStore(): DeviceAuthStore | null {
+  const sessionStore = readStoreFrom(getSafeSessionStorage());
+  if (sessionStore) {
+    return sessionStore;
+  }
+  const legacyStore = readStoreFrom(getSafeLocalStorage());
+  if (legacyStore) {
+    writeStore(legacyStore);
+    try {
+      getSafeLocalStorage()?.removeItem(STORAGE_KEY);
+    } catch {
+      // best-effort legacy scrub
+    }
+  }
+  return legacyStore;
+}
+
 function writeStore(store: DeviceAuthStore) {
   try {
-    getSafeLocalStorage()?.setItem(STORAGE_KEY, JSON.stringify(store));
+    getSafeSessionStorage()?.setItem(STORAGE_KEY, JSON.stringify(store));
   } catch {
     // best-effort
   }
@@ -71,4 +88,9 @@ export function clearDeviceAuthToken(params: { deviceId: string; role: string })
     deviceId: params.deviceId,
     role: params.role,
   });
+  try {
+    getSafeLocalStorage()?.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort legacy scrub
+  }
 }

--- a/ui/src/ui/device-identity.ts
+++ b/ui/src/ui/device-identity.ts
@@ -1,5 +1,5 @@
 import { getPublicKeyAsync, signAsync, utils } from "@noble/ed25519";
-import { getSafeLocalStorage } from "../local-storage.ts";
+import { getSafeLocalStorage, getSafeSessionStorage } from "../local-storage.ts";
 
 type StoredIdentity = {
   version: 1;
@@ -16,6 +16,14 @@ export type DeviceIdentity = {
 };
 
 const STORAGE_KEY = "openclaw-device-identity-v1";
+
+function scrubLegacyLocalIdentity() {
+  try {
+    getSafeLocalStorage()?.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort legacy scrub
+  }
+}
 
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
@@ -59,7 +67,8 @@ async function generateIdentity(): Promise<DeviceIdentity> {
 }
 
 export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
-  const storage = getSafeLocalStorage();
+  const storage = getSafeSessionStorage();
+  const legacyStorage = getSafeLocalStorage();
   try {
     const raw = storage?.getItem(STORAGE_KEY);
     if (raw) {
@@ -77,6 +86,7 @@ export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
             deviceId: derivedId,
           };
           storage?.setItem(STORAGE_KEY, JSON.stringify(updated));
+          scrubLegacyLocalIdentity();
           return {
             deviceId: derivedId,
             publicKey: parsed.publicKey,
@@ -85,6 +95,34 @@ export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
         }
         return {
           deviceId: parsed.deviceId,
+          publicKey: parsed.publicKey,
+          privateKey: parsed.privateKey,
+        };
+      }
+    }
+  } catch {
+    // fall through to regenerate
+  }
+
+  try {
+    const raw = legacyStorage?.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as StoredIdentity;
+      if (
+        parsed?.version === 1 &&
+        typeof parsed.deviceId === "string" &&
+        typeof parsed.publicKey === "string" &&
+        typeof parsed.privateKey === "string"
+      ) {
+        const derivedId = await fingerprintPublicKey(base64UrlDecode(parsed.publicKey));
+        const migrated: StoredIdentity = {
+          ...parsed,
+          deviceId: derivedId,
+        };
+        storage?.setItem(STORAGE_KEY, JSON.stringify(migrated));
+        scrubLegacyLocalIdentity();
+        return {
+          deviceId: derivedId,
           publicKey: parsed.publicKey,
           privateKey: parsed.privateKey,
         };
@@ -103,6 +141,7 @@ export async function loadOrCreateDeviceIdentity(): Promise<DeviceIdentity> {
     createdAtMs: Date.now(),
   };
   storage?.setItem(STORAGE_KEY, JSON.stringify(stored));
+  scrubLegacyLocalIdentity();
   return identity;
 }
 

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -93,9 +93,11 @@ type ConnectFrame = {
 };
 
 function stubWindowGlobals(storage?: ReturnType<typeof createStorageMock>) {
+  const sessionStorage = createStorageMock();
   vi.stubGlobal("window", {
     location: { href: "http://127.0.0.1:18789/" },
     localStorage: storage,
+    sessionStorage,
     setTimeout: (handler: (...args: unknown[]) => void, timeout?: number, ...args: unknown[]) =>
       globalThis.setTimeout(() => handler(...args), timeout),
     clearTimeout: (timeoutId: number | undefined) => globalThis.clearTimeout(timeoutId),
@@ -182,6 +184,7 @@ async function startRetriedDeviceTokenConnect(params: {
 describe("GatewayBrowserClient", () => {
   beforeEach(() => {
     const storage = createStorageMock();
+    const sessionStorage = createStorageMock();
     wsInstances.length = 0;
     loadOrCreateDeviceIdentityMock.mockReset();
     signDevicePayloadMock.mockClear();
@@ -192,8 +195,10 @@ describe("GatewayBrowserClient", () => {
     });
 
     vi.stubGlobal("localStorage", storage);
+    vi.stubGlobal("sessionStorage", sessionStorage);
     stubWindowGlobals(storage);
     localStorage.clear();
+    sessionStorage.clear();
     vi.stubGlobal("WebSocket", MockWebSocket);
 
     storeDeviceAuthToken({
@@ -294,7 +299,7 @@ describe("GatewayBrowserClient", () => {
   });
 
   it("ignores cached operator device tokens that do not include read access", async () => {
-    localStorage.clear();
+    sessionStorage.clear();
     storeDeviceAuthToken({
       deviceId: "device-1",
       role: "operator",


### PR DESCRIPTION
## Fix Summary
The Control UI persists both its Ed25519 device signing key and its cached operator device token in `localStorage`. Any same-origin JavaScript foothold in that browser origin can extract both values and reuse them to establish a fresh operator WebSocket session with `operator.admin`, `operator.read`, `operator.write`, `operator.approvals`, and `operator.pairing` scopes.

## Issue Linkage
Fixes #64163

## Security Snapshot
- CVSS v3.1: 8.0 (High)
- CVSS v4.0: 8.8 (High)

## Implementation Details
### Files Changed
- `docs/web/control-ui.md` (+5/-4)
- `ui/src/ui/device-auth-session-storage.test.ts` (+106/-0)
- `ui/src/ui/device-auth.ts` (+26/-4)
- `ui/src/ui/device-identity.ts` (+41/-2)
- `ui/src/ui/gateway.node.test.ts` (+6/-1)

### Technical Analysis
1. Open the Control UI over `https://` or `localhost` and complete one successful device-authenticated connection.
2. In the same browser profile, read the stored values with `localStorage.getItem("openclaw-device-identity-v1")` and `localStorage.getItem("openclaw.device.auth.v1")`.
3. Observe that the first entry contains `deviceId`, `publicKey`, and the raw Ed25519 `privateKey`, while the second entry contains the cached operator `deviceToken`, role, and scopes.
4. Open a fresh WebSocket connection to the Gateway endpoint and wait for the `connect.challenge` nonce.
5. Recreate the browser `connect` payload using the Control UI logic in `ui/src/ui/gateway.ts:243-253`: build the device-auth payload for role `operator`, token=`<stolen device token>`, and the full `CONTROL_UI_OPERATOR_SCOPES`, then sign it with `signDevicePayload(privateKey, payload)`.
6. Send a `connect` frame with `auth.token` set to the stolen device token and `device` set to the stolen device id/public key plus the fresh signature.
7. The server accepts the signature via `resolveDeviceSignaturePayloadVersion()`, treats `auth.token` as a device-token fallback in `resolveConnectAuthState()`, accepts that token via `verifyDeviceToken()`, and returns `hello-ok` with operator auth state.

## Validation Evidence
- Command: `pnpm test ui/src/ui/device-auth-session-storage.test.ts ui/src/ui/gateway.node.test.ts`
- Status: passed (with pre-existing baseline failures)

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: opencode/claude-sonnet-4.6
