### PR TITLE
fix: copy SKILL.md as hard file instead of symlink to fix security check failure

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -79,7 +79,8 @@ function shouldCopyRuntimeFile(sourcePath) {
     relativePath.endsWith("/openclaw.plugin.json") ||
     relativePath.endsWith("/.codex-plugin/plugin.json") ||
     relativePath.endsWith("/.claude-plugin/plugin.json") ||
-    relativePath.endsWith("/.cursor-plugin/plugin.json")
+    relativePath.endsWith("/.cursor-plugin/plugin.json") ||
+    relativePath.endsWith("/SKILL.md")
   );
 }
 


### PR DESCRIPTION

Fixes #64138

## Summary

- **Problem:** `stage-bundled-plugin-runtime.mjs` creates symlinks for most files in `dist-runtime/`, including `SKILL.md`. At runtime, `resolveContainedSkillPath` in `workspace.ts` calls `realpathSync()` which resolves the symlink to the `dist/` directory, failing the path containment security check (`assertNoPathAliasEscape`).
- **Why it matters:** All 23 bundled plugin skills (wecom 15, feishu 4, qqbot 3, tavily 1) were silently skipped at load time, making them completely unavailable to users.
- **What changed:** Added `relativePath.endsWith("/SKILL.md")` to the `shouldCopyRuntimeFile` whitelist in `scripts/stage-bundled-plugin-runtime.mjs`, so SKILL.md files are hard-copied instead of symlinked — matching the existing pattern for `package.json`, `openclaw.plugin.json`, and other plugin config files.
- **What did NOT change (scope boundary):** Other symlinked files (e.g. `references/` subdirectories under skills) are not addressed here. They may have a similar issue in non-sandbox mode but are lower priority and tracked separately.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #64138
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `shouldCopyRuntimeFile` only whitelisted `package.json` and `*plugin.json` config files for hard copy. `SKILL.md` was not included, so it was symlinked like all other files. The runtime security check (`realpathSync` + path containment assertion) correctly rejects paths that resolve outside `dist-runtime/`, but this meant all plugin skills were silently dropped.
- **Missing detection / guardrail:** No test or build-time validation exists to verify that skill files are actually loadable after staging. The skip is logged at debug level only, making it easy to miss.
- **Contributing context:** The symlink optimization in the staging script is intentional for saving disk space, but the security boundary check was added later without updating the copy whitelist for skill-critical files.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** A build validation test that runs `find dist-runtime -name SKILL.md -type l` and asserts zero symlinks.
- **Scenario the test should lock in:** After `stage-bundled-plugin-runtime`, all `SKILL.md` files in `dist-runtime/` must be regular files, not symlinks.
- **Why this is the smallest reliable guardrail:** It catches the exact failure mode (symlink → realpathSync escape) at build time before any runtime behavior is affected.
- **If no new test is added, why not:** This is a one-line whitelist addition with straightforward behavior. The fix was verified manually (see Evidence below). A CI check can be added as a follow-up.

## User-visible / Behavior Changes

- Before: `pnpm openclaw skills list` showed 8/73 skills ready. All 23 bundled plugin skills were silently skipped.
- After: `pnpm openclaw skills list` shows 31/73 skills ready. All 23 bundled plugin skills (wecom, feishu, qqbot, tavily) load correctly.

## Diagram (if applicable)

```text
Before:
dist-runtime/extensions/wecom/skills/*/SKILL.md (symlink → ../../dist/extensions/...)
  → realpathSync() resolves to dist/extensions/...
  → assertNoPathAliasEscape fails (outside dist-runtime/)
  → skill skipped

After:
dist-runtime/extensions/wecom/skills/*/SKILL.md (regular file, hard copy)
  → realpathSync() resolves within dist-runtime/
  → security check passes
  → skill loaded successfully
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — skills were always designed to be loaded; this fix restores intended behavior.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (dev container)
- Runtime/container: Node.js via pnpm
- Model/provider: N/A (build script issue)
- Integration/channel: wecom, feishu, qqbot, tavily plugins

### Steps

1. Build openclaw with `pnpm build`
2. Check `dist-runtime/` for SKILL.md files: `find dist-runtime -name SKILL.md -exec file {} \;`
3. Run `pnpm openclaw skills list`

### Expected

- All SKILL.md files are regular files
- Plugin skills (wecom, feishu, qqbot, tavily) appear as "ready"

### Actual (before fix)

- All SKILL.md files were symlinks
- 23 plugin skills skipped, only 8/73 ready

## Evidence

- **Before fix:** `find dist-runtime -name SKILL.md` — all 29 files were symlinks; `skills list` showed 8/73 ready; debug log showed 23 skills skipped with "Skipping skill — resolved path escapes plugin directory"
- **After fix:** `find dist-runtime -name SKILL.md -exec file {} \;` — all 29 files reported as "regular file"; `skills list` showed 31/73 ready (8 base + 23 plugin skills restored)
- **Tavily log confirmation:** Configured tavily plugin separately to confirm its single skill was also affected and recovered after fix.

## Human Verification (required)

- **Verified scenarios:** Full rebuild → `find` confirmed no SKILL.md symlinks remain → `skills list` confirmed 31/73 ready → individual plugin skills (wecom, feishu, qqbot, tavily) all present
- **Edge cases checked:** Tavily (single-skill plugin) verified separately to confirm fix applies universally, not just to multi-skill plugins
- **What I did not verify:** `references/` subdirectory symlinks (tracked as separate follow-up); gateway hot-reload behavior (requires process restart)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** `references/` and other auxiliary files under skill directories remain as symlinks, which may fail path containment checks in non-sandbox mode.
  - **Mitigation:** This is pre-existing behavior unrelated to this change. Tracked for separate follow-up. Sandbox mode (the common case) resolves symlinks via `fsp.cp` and is unaffected.
```
