### PR TITLE
plugins: preserve contextEngine during plugin config normalization

### DIFF
--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -13,6 +13,7 @@ export type NormalizedPluginsConfig = {
   loadPaths: string[];
   slots: {
     memory?: string | null;
+    contextEngine?: string | null;
   };
   entries: Record<
     string,
@@ -135,6 +136,7 @@ export function normalizePluginsConfigWithResolver(
   normalizePluginId: NormalizePluginId = identityNormalizePluginId,
 ): NormalizedPluginsConfig {
   const memorySlot = normalizeSlotValue(config?.slots?.memory);
+  const contextEngineSlot = normalizeSlotValue(config?.slots?.contextEngine);
   return {
     enabled: config?.enabled !== false,
     allow: normalizeList(config?.allow, normalizePluginId),
@@ -142,6 +144,7 @@ export function normalizePluginsConfigWithResolver(
     loadPaths: normalizeList(config?.load?.paths, identityNormalizePluginId),
     slots: {
       memory: memorySlot === undefined ? defaultSlotIdForKey("memory") : memorySlot,
+      ...(contextEngineSlot !== undefined ? { contextEngine: contextEngineSlot } : {}),
     },
     entries: normalizePluginEntries(config?.entries, normalizePluginId),
   };

--- a/src/plugins/config-policy.test.ts
+++ b/src/plugins/config-policy.test.ts
@@ -25,6 +25,20 @@ describe("normalizePluginsConfigWithResolver", () => {
     expect(normalized.deny).toEqual(["BETA"]);
     expect(normalized.entries).toHaveProperty("GAMMA");
   });
+
+  it("preserves the contextEngine slot when configured", () => {
+    const normalized = normalizePluginsConfigWithResolver({
+      slots: {
+        memory: "memory-core",
+        contextEngine: "lossless-claw",
+      },
+    });
+
+    expect(normalized.slots).toEqual({
+      memory: "memory-core",
+      contextEngine: "lossless-claw",
+    });
+  });
 });
 
 describe("hasExplicitPluginConfig", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1023,7 +1023,7 @@ function warnWhenAllowlistIsOpen(params: {
   const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
   openAllowlistWarningCache.add(params.warningCacheKey);
   params.logger.warn(
-    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    `[plugins] effective plugin allowlist is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
   );
 }
 


### PR DESCRIPTION
## Summary
- preserve `plugins.slots.contextEngine` in normalized plugin config
- add a regression test covering the contextEngine slot
- tighten the warning text to say the **effective** allowlist is empty

## Why
Fixes openclaw/openclaw#64170.

Without this, slot-selected context-engine plugins lose explicit-selection credit after normalization, which can produce a false `plugins.allow is empty` warning even when the raw config is fine.

## Testing
- `pnpm exec vitest run src/plugins/config-policy.test.ts src/plugins/slots.test.ts`

## Notes
I also tried the repository's full commit-time checks, but they currently fail in unrelated Discord extension types on a fresh checkout:
- `extensions/discord/src/components-registry.ts(2,38): error TS2305 ...`
- plus related `DiscordModalEntry` / modal type errors

So the focused plugin tests passed, but the full pre-commit check is presently red for unrelated reasons.
