### PR TITLE
fix(discord): raise thread title max tokens for reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Bedrock: let `/btw` side questions use `auth: "aws-sdk"` without a static API key so Bedrock IAM and instance-role sessions stop failing before the side question runs. (#64218) Thanks @SnowSky1.
 - Agents/failover: detect llama.cpp slot context overflows as context-overflow errors so compaction can retry self-hosted OpenAI-compatible runs instead of surfacing the raw upstream 400. (#64196) Thanks @alexander-applyinnovations.
 - Claude CLI/skills: pass eligible OpenClaw skills into CLI runs, including native Claude Code skill resolution via a temporary plugin plus per-run skill env/API key injection. (#62686, #62723) Thanks @zomars.
+- Discord: keep generated auto-thread names working with reasoning models by giving title generation enough output budget for thinking plus visible title text. (#64172) Thanks @hanamizuki.
 - Heartbeat: ignore doc-only Markdown fence markers in the default `HEARTBEAT.md` template so comment-only heartbeat scaffolds skip API calls again. (#63434) Thanks @ravyg.
 - Control UI/BTW: render `/btw` side results as dismissible ephemeral cards in the browser, send `/btw` immediately during active runs, and clear stale BTW cards on reset flows so webchat matches the intended detached side-question behavior. (#64290) Thanks @ngutman.
 - Reply/skills: keep resolved skill and memory secret config stable through embedded reply runs so raw SecretRefs in secondary skill settings no longer crash replies when the gateway already has the live env. (#64249) Thanks @mbelinky.

--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -172,7 +172,7 @@ describe("generateThreadTitle", () => {
     ).toContain("Channel description: Deploy updates and incident notes");
     expect(completeWithPreparedSimpleCompletionModelMock.mock.calls[0]?.[0]?.options).toEqual(
       expect.objectContaining({
-        maxTokens: 24,
+        maxTokens: 512,
       }),
     );
     expect(

--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -23,12 +23,12 @@ beforeEach(() => {
   prepareSimpleCompletionModelForAgentMock.mockResolvedValue({
     selection: {
       provider: "anthropic",
-      modelId: "claude-opus-4-6",
+      modelId: "claude-sonnet-4-6",
       agentDir: "/tmp/openclaw-agent",
     },
     model: {
       provider: "anthropic",
-      id: "claude-opus-4-6",
+      id: "claude-sonnet-4-6",
     },
     auth: {
       apiKey: "sk-test",
@@ -128,7 +128,7 @@ describe("generateThreadTitle", () => {
       error: 'No API key resolved for provider "anthropic" (auth mode: api-key).',
       selection: {
         provider: "anthropic",
-        modelId: "claude-opus-4-6",
+        modelId: "claude-sonnet-4-6",
         agentDir: "/tmp/openclaw-agent",
       },
     } as Awaited<ReturnType<typeof agentRuntimeModule.prepareSimpleCompletionModelForAgent>>);

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -10,7 +10,12 @@ const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 10_000;
 const MAX_THREAD_TITLE_SOURCE_CHARS = 600;
 const MAX_THREAD_TITLE_CHANNEL_NAME_CHARS = 120;
 const MAX_THREAD_TITLE_CHANNEL_DESCRIPTION_CHARS = 320;
-const DISCORD_THREAD_TITLE_MAX_TOKENS = 24;
+// Budget generous enough to cover reasoning-model thinking tokens plus the
+// short text output. Lower values (e.g. 24) starve reasoning models of output
+// capacity: the entire budget is consumed by the thinking block before any
+// text is emitted, so extractAssistantText returns empty and the rename is
+// silently skipped.
+const DISCORD_THREAD_TITLE_MAX_TOKENS = 512;
 const DISCORD_THREAD_TITLE_SYSTEM_PROMPT =
   "Generate a concise Discord thread title (3-6 words). Return only the title. Use channel context when provided and avoid redundant channel-name words unless needed for clarity.";
 


### PR DESCRIPTION
## Summary

- **Problem:** `autoThreadName: "generated"` silently fails to rename auto-created threads when the selected simple-completion model is a reasoning model (e.g. MiniMax M2, Claude thinking models, OpenAI o-series).
- **Why it matters:** The feature introduced in #43366 appears to do nothing for any setup whose default completion model happens to reason — threads stay named after the raw first message with no error or user-visible log.
- **What changed:** `DISCORD_THREAD_TITLE_MAX_TOKENS` raised from `24` to `512` in `extensions/discord/src/monitor/thread-title.ts`, plus the matching expectation in the existing unit test.
- **What did NOT change (scope boundary):** No changes to the rename flow, provider selection, model-ref resolution, prompt text, or the non-reasoning code path.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (Discord)

## Linked Issue/PR

- Related #43366 (original `autoThreadName: "generated"` feature)
- Related 7785dc21e6 (most recent follow-up on the same file — drop temperature)
- [x] This PR fixes a bug or regression

## Root Cause

The simple-completion call in `generateThreadTitle` sets `maxTokens: 24` as a cost/latency guard, assuming the model's entire output budget will go to a 3-6 word title. That assumption holds for instruct-only models but breaks for reasoning models whose API response contains a `thinking` content block before the `text` block:

1. The provider emits `content: [{ type: "thinking", thinking: "..." }, { type: "text", text: "..." }]`.
2. With `maxTokens: 24`, the entire budget is consumed by the thinking block before any text token is produced.
3. `extractAssistantText(response)` walks the content array looking for text blocks, finds none, and returns `""`.
4. `normalizeGeneratedThreadTitle("") → ""` → `generated || null → null` → `maybeRenameDiscordAutoThread` early-returns.
5. The only log emitted on that path is a `logVerbose` — invisible unless the gateway is explicitly in verbose mode — so the failure is silent in normal operation.

Bumping the ceiling to `512` gives enough headroom for a short thinking pass plus the title output. The generous ceiling only costs more tokens when the provider actually reasons; instruct-only models still emit a short title and stop early at natural end-of-sequence.

## Test plan

- [x] `pnpm test:extension discord` — 928/928 tests passing locally (112 files)
- [x] Live end-to-end verification on a running gateway with the default simple-completion model set to a MiniMax M2 reasoning model served through an Anthropic-compatible API endpoint:
  - **Before:** `extractAssistantText` returned `""`; `generateThreadTitle` returned `null`; `maybeRenameDiscordAutoThread` early-returned with no visible log; the thread kept the raw first-message name.
  - **After:** the response included both a `thinking` block and a `text` block (total token usage well under 512); `rawText` was non-empty; a concise title was produced; the Discord `PATCH /channels/{id}` call succeeded; the thread was visibly renamed in the Discord UI.
- [x] Existing unit test `thread-title.generate.test.ts` updated to expect `maxTokens: 512` (it was the only test asserting the constant value).

## AI-Assisted

- [x] Marked as AI-assisted
- Tooling: Claude Code (Claude Opus 4.6, 1M context)
- Degree of testing: fully tested — Discord extension test lane green + live end-to-end validation on a running gateway
- I understand what the code does and why the fix is correct
- Session logs available on request

## Notes

- Unrelated `pnpm tsgo` errors in `extensions/discord/src/components.ts` and siblings (`DiscordModalEntry`, `DiscordComponentModalEntry`, etc.) reproduce on an otherwise-clean `upstream/main` checkout — pre-existing and untouched by this PR.