### PR TITLE
fix(skills): copy staged SKILL.md into dist-runtime

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -77,6 +77,9 @@ function shouldCopyRuntimeFile(sourcePath) {
   return (
     relativePath.endsWith("/package.json") ||
     relativePath.endsWith("/openclaw.plugin.json") ||
+    // Skill definitions must stay physically under dist-runtime so realpath-based
+    // containment checks do not resolve them back into dist/.
+    relativePath.endsWith("/SKILL.md") ||
     relativePath.endsWith("/.codex-plugin/plugin.json") ||
     relativePath.endsWith("/.claude-plugin/plugin.json") ||
     relativePath.endsWith("/.cursor-plugin/plugin.json")

--- a/test/scripts/stage-bundled-plugin-runtime.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime.test.ts
@@ -18,9 +18,44 @@ describe("stageBundledPluginRuntime", () => {
     vi.restoreAllMocks();
   });
 
+  it("copies SKILL.md into dist-runtime while leaving other skill assets linked", async () => {
+    await withTempDir(async (repoRoot) => {
+      const skillDir = path.join(repoRoot, "dist", "extensions", "acpx", "skills", "acp-router");
+      const skillFile = path.join(skillDir, "SKILL.md");
+      const assetFile = path.join(skillDir, "notes.txt");
+      await fs.promises.mkdir(skillDir, { recursive: true });
+      await fs.promises.writeFile(skillFile, "skill-body\n", "utf8");
+      await fs.promises.writeFile(assetFile, "notes\n", "utf8");
+
+      stageBundledPluginRuntime({ repoRoot });
+
+      const runtimeSkillFile = path.join(
+        repoRoot,
+        "dist-runtime",
+        "extensions",
+        "acpx",
+        "skills",
+        "acp-router",
+        "SKILL.md",
+      );
+      const runtimeAssetFile = path.join(
+        repoRoot,
+        "dist-runtime",
+        "extensions",
+        "acpx",
+        "skills",
+        "acp-router",
+        "notes.txt",
+      );
+      expect(await fs.promises.readFile(runtimeSkillFile, "utf8")).toBe("skill-body\n");
+      expect(fs.lstatSync(runtimeSkillFile).isSymbolicLink()).toBe(false);
+      expect(fs.lstatSync(runtimeAssetFile).isSymbolicLink()).toBe(true);
+    });
+  });
+
   it("copies files when Windows rejects runtime overlay symlinks", async () => {
     await withTempDir(async (repoRoot) => {
-      const sourceFile = path.join(
+      const skillFile = path.join(
         repoRoot,
         "dist",
         "extensions",
@@ -29,8 +64,10 @@ describe("stageBundledPluginRuntime", () => {
         "acp-router",
         "SKILL.md",
       );
-      await fs.promises.mkdir(path.dirname(sourceFile), { recursive: true });
-      await fs.promises.writeFile(sourceFile, "skill-body\n", "utf8");
+      const sourceFile = path.join(path.dirname(skillFile), "notes.txt");
+      await fs.promises.mkdir(path.dirname(skillFile), { recursive: true });
+      await fs.promises.writeFile(skillFile, "skill-body\n", "utf8");
+      await fs.promises.writeFile(sourceFile, "notes\n", "utf8");
 
       vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       const symlinkSpy = vi
@@ -56,9 +93,9 @@ describe("stageBundledPluginRuntime", () => {
         "acpx",
         "skills",
         "acp-router",
-        "SKILL.md",
+        "notes.txt",
       );
-      expect(await fs.promises.readFile(runtimeFile, "utf8")).toBe("skill-body\n");
+      expect(await fs.promises.readFile(runtimeFile, "utf8")).toBe("notes\n");
       expect(fs.lstatSync(runtimeFile).isSymbolicLink()).toBe(false);
       expect(symlinkSpy).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- Problem: `scripts/stage-bundled-plugin-runtime.mjs` staged plugin `SKILL.md` files as symlinks inside `dist-runtime`, so `realpath()` resolved them back into `dist/`.
- Why it matters: plugin skills from enabled extensions were skipped by the existing containment check in `src/agents/skills/workspace.ts` and never loaded at runtime.
- What changed: `SKILL.md` is now treated as a copy-only runtime artifact, and the staging test suite now covers both the direct copy regression and the existing Windows symlink-fallback path.
- What did NOT change (scope boundary): this PR does not relax or modify runtime containment/security logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #64138
- Related #64138
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the build overlay created `dist-runtime/extensions/*/skills/*/SKILL.md` as symlinks, but the runtime loader validates skill paths after `realpath()`. That resolved the skill file into `dist/`, so the existing `isPathInside(rootRealPath, candidateRealPath)` check correctly rejected it as outside `dist-runtime`.
- Missing detection / guardrail: the staging tests covered Windows symlink fallback, but not the steady-state requirement that `SKILL.md` must remain physically inside `dist-runtime` for the runtime containment check.
- Contributing context (if known): the issue reproduces for any enabled bundled plugin that declares `skills`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
  - [ ] Unit test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/stage-bundled-plugin-runtime.test.ts`
- Scenario the test should lock in: staging copies `SKILL.md` into `dist-runtime` while leaving unrelated skill assets symlinked.
- Why this is the smallest reliable guardrail: it exercises the exact build overlay behavior that feeds the runtime loader without widening scope into runtime security code.
- Existing test that already covers this (if any): the Windows fallback test in the same file still covers copy-on-symlink-failure for non-skill assets.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Plugin skills from enabled bundled extensions now load again after build/runtime staging because their `SKILL.md` files stay within `dist-runtime`.

## Diagram (if applicable)

```text
Before:
[build stage] -> [dist-runtime/.../SKILL.md symlink] -> [realpath -> dist/.../SKILL.md] -> [containment check rejects skill]

After:
[build stage] -> [dist-runtime/.../SKILL.md copied file] -> [realpath stays under dist-runtime] -> [skill loads]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): bundled plugin skills staging
- Relevant config (redacted): N/A

### Steps

1. Create a staged plugin skill under `dist/extensions/<plugin>/skills/<skill>/SKILL.md`.
2. Run `stageBundledPluginRuntime`.
3. Inspect the corresponding file under `dist-runtime/extensions/<plugin>/skills/<skill>/SKILL.md`.

### Expected

- `SKILL.md` is copied into `dist-runtime`, so `realpath()` remains under the runtime root.

### Actual

- Verified in the new regression test; non-skill assets still symlink as before.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test test/scripts/stage-bundled-plugin-runtime.test.ts`; `pnpm build`
- Edge cases checked: Windows-style symlink failure still falls back to copying regular skill assets.
- What you did **not** verify: I did not broaden this PR into the unrelated `pnpm check` failure currently present on `origin/main` under `extensions/discord/src/components*.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: copying `SKILL.md` slightly increases `dist-runtime` duplication for plugin skills.
  - Mitigation: scope stays minimal to a small markdown file per skill; all other non-skill assets keep the previous symlink behavior.
