### PR TITLE
fix(tts): pass configured voice into tts tool

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -234,7 +234,7 @@ export function createOpenClawTools(
     ...(messageTool ? [messageTool] : []),
     createTtsTool({
       agentChannel: options?.agentChannel,
-      config: options?.config,
+      config: resolvedConfig,
     }),
     ...collectPresentOpenClawTools([imageGenerateTool, musicGenerateTool, videoGenerateTool]),
     createGatewayTool({

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  textToSpeech: vi.fn(async () => ({
+    success: true,
+    audioPath: "/tmp/tts-config-test.opus",
+    provider: "microsoft",
+    voiceCompatible: true,
+  })),
+}));
+
+vi.mock("../tts/tts.js", () => ({
+  textToSpeech: mocks.textToSpeech,
+}));
+
+describe("createOpenClawTools TTS config wiring", () => {
+  beforeEach(() => {
+    mocks.textToSpeech.mockClear();
+  });
+
+  it("passes the resolved shared config into the tts tool", async () => {
+    const injectedConfig = {
+      messages: {
+        tts: {
+          provider: "edge",
+          edge: {
+            voice: "en-US-AvaNeural",
+          },
+          providers: {
+            microsoft: {
+              voice: "en-US-AvaNeural",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const { __testing, createOpenClawTools } = await import("./openclaw-tools.js");
+    __testing.setDepsForTest({ config: injectedConfig });
+
+    try {
+      const tool = createOpenClawTools({
+        disablePluginTools: true,
+        disableMessageTool: true,
+      }).find((candidate) => candidate.name === "tts");
+
+      expect(tool).toBeDefined();
+      if (!tool) {
+        throw new Error("missing tts tool");
+      }
+
+      await tool.execute("call-1", { text: "hello from config" });
+
+      expect(mocks.textToSpeech).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "hello from config",
+          cfg: injectedConfig,
+        }),
+      );
+    } finally {
+      __testing.setDepsForTest();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- pass the resolved shared OpenClaw config into the built-in  tool instead of only forwarding the optional per-call config
- let the tool path honor the existing  provider configuration, including Edge/Microsoft voice settings
- add a focused regression test proving the  tool receives the resolved shared config

Closes #64153

## Testing
- attempted:  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/root/.openclaw/workspace".
- blocked locally in this worktree because / are unavailable ()
- sending to CI for verification