### PR TITLE
fix(slack): propagate file IDs through media pipeline to agent context

### DIFF
--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -153,7 +153,6 @@ export type SlackMediaResult = {
   path: string;
   contentType?: string;
   placeholder: string;
-  /** Original Slack file ID — needed for agent actions like download-file. */
   fileId?: string;
 };
 

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -153,6 +153,8 @@ export type SlackMediaResult = {
   path: string;
   contentType?: string;
   placeholder: string;
+  /** Original Slack file ID — needed for agent actions like download-file. */
+  fileId?: string;
 };
 
 export const MAX_SLACK_MEDIA_FILES = 8;
@@ -268,6 +270,7 @@ export async function resolveSlackMedia(params: {
           path: saved.path,
           ...(contentType ? { contentType } : {}),
           placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
+          fileId: file.id,
         };
       } catch {
         return null;

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -763,6 +763,10 @@ export async function prepareSlackMessage(params: {
       effectiveMedia && effectiveMedia.length > 0
         ? effectiveMedia.map((m) => m.contentType ?? "")
         : undefined,
+    MediaFileIds:
+      effectiveMedia && effectiveMedia.length > 0
+        ? effectiveMedia.map((m) => m.fileId ?? "")
+        : undefined,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -106,6 +106,8 @@ export type MsgContext = {
   MediaPaths?: string[];
   MediaUrls?: string[];
   MediaTypes?: string[];
+  /** Provider-native file IDs for inbound media (e.g. Slack file IDs for download-file). */
+  MediaFileIds?: string[];
   /** Telegram sticker metadata (emoji, set name, file IDs, cached description). */
   Sticker?: StickerContextMetadata;
   /** True when current-turn sticker media is present in MediaPaths (false for cached-description path). */


### PR DESCRIPTION
## Summary

When Slack files are downloaded during message ingestion, the original Slack file ID (e.g. `F0ARV9LMMU2`) is available on the `SlackFile` object but gets dropped when creating `SlackMediaResult`. This means agents receiving inbound media have local file paths but no way to reference the original Slack file ID, causing the `download-file` action to fail with `"fileId required"`.

**Root cause:** `SlackMediaResult` only carried `{ path, contentType, placeholder }` — the `file.id` from the Slack event was never preserved through the pipeline.

**Fix (4 lines of logic across 3 files):**
- Add `fileId?: string` to `SlackMediaResult` type
- Preserve `file.id` in `resolveSlackMedia()` return value  
- Add `MediaFileIds?: string[]` to `MsgContext` (generic, channel-agnostic — could benefit other channels too)
- Populate `MediaFileIds` in `prepareSlackMessage()` from `effectiveMedia`

## Test plan

- [x] All 77 Slack extension test files pass (609 tests) via `pnpm test:extension slack`
- [x] TypeScript type check passes via `pnpm tsgo`
- [ ] Manual test: send a Slack audio clip → agent receives `MediaFileIds` in context → `download-file` action can use the file ID

**Note:** The pre-commit hook lint error on `prepare.ts:575` (`no-redundant-type-constituents` for `AckReactionScope`) is pre-existing on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)