### PR TITLE
Docs: add Feishu session trace relay

### DIFF
--- a/docs/automation/feishu-session-trace.md
+++ b/docs/automation/feishu-session-trace.md
@@ -1,0 +1,130 @@
+---
+summary: "Forward important tool activity from a session JSONL log into a Feishu chat"
+title: "Feishu Session Trace Relay"
+---
+
+# Feishu Session Trace Relay
+
+Use this helper when you want a lightweight mission-control feed that mirrors important tool calls from a running OpenClaw session into a Feishu DM or group.
+
+The script tails an agent `.jsonl` session log, summarizes a small allowlist of tool calls, redacts obvious secrets, and forwards each summary through `openclaw message send`.
+
+## When to use this
+
+- You want real-time visibility into what an agent is doing without watching the terminal
+- You want a shared Feishu thread for risky or high-signal agent activity
+- You want to keep an operator-facing audit trail of reads, edits, shell commands, and web actions
+
+## Requirements
+
+- OpenClaw CLI on PATH
+- Feishu channel access configured for `openclaw message send`
+- Access to the session log file under `~/.openclaw/agents/<agent-id>/sessions/*.jsonl`
+- Node 22+ with `tsx` available through the repo install
+
+## Script location
+
+```text
+scripts/feishu-session-trace.ts
+```
+
+## Usage
+
+```bash
+node --import tsx scripts/feishu-session-trace.ts \
+  --session-file "${HOME}/.openclaw/agents/<agent-id>/sessions/<session-id>.jsonl" \
+  --target "chat:oc_xxx" \
+  --account default \
+  --min-interval-ms 5000 \
+  --max-len 260
+```
+
+### Arguments
+
+| Flag                | Description                                                                 |
+| ------------------- | --------------------------------------------------------------------------- |
+| `--session-file`    | Required. Absolute path to the `.jsonl` session log to follow.              |
+| `--target`          | Required. Feishu target such as `user:ou_xxx` or `chat:oc_xxx`.             |
+| `--account`         | Optional Feishu account id configured in OpenClaw.                          |
+| `--min-interval-ms` | Debounce window between forwarded messages. Default: `5000`.                |
+| `--max-len`         | Maximum forwarded message length. Default: `260`.                           |
+| `--dry-run`         | Print via `openclaw message send --dry-run` instead of delivering for real. |
+
+## What gets forwarded
+
+The helper emits one-line summaries for a short list of tool types:
+
+- `read`
+- `write`, `edit`, `apply_patch`
+- `exec`, `bash`, `shell`
+- `web_search`, `web_fetch`
+- `todo_write`
+
+Everything else is ignored to keep the relay low-noise.
+
+## Finding the session log path
+
+1. Identify the target agent id from the runtime banner, for example `agent=main`
+2. Inspect `~/.openclaw/agents/<agent-id>/sessions/`
+3. Pick the current `.jsonl` file
+4. Pass that path to `--session-file`
+
+## Running in the background
+
+For longer-lived relays, run the helper under your preferred supervisor.
+
+### launchd example (macOS)
+
+Create `~/Library/LaunchAgents/ai.openclaw.session-trace.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.openclaw.session-trace</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>node</string>
+    <string>--import</string>
+    <string>tsx</string>
+    <string>/path/to/openclaw/scripts/feishu-session-trace.ts</string>
+    <string>--session-file</string>
+    <string>/Users/you/.openclaw/agents/main/sessions/<session-id>.jsonl</string>
+    <string>--target</string>
+    <string>chat:oc_xxx</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/feishu-session-trace.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/feishu-session-trace.err</string>
+</dict>
+</plist>
+```
+
+Then load it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/ai.openclaw.session-trace.plist
+```
+
+## Troubleshooting
+
+| Symptom                       | Fix                                                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Missing required args         | Provide both `--session-file` and `--target`.                                                                                |
+| `openclaw message send` fails | Check Feishu auth and target permissions, then try a manual `openclaw message send --channel feishu --target ... --message`. |
+| No events forwarded           | Verify the session file is active and that new assistant tool-call records are appended.                                     |
+| Too many messages             | Raise `--min-interval-ms` or tighten the tool allowlist in the helper.                                                       |
+
+## Related
+
+- [Automation & Tasks](/automation/index)
+- [Hooks](/automation/hooks)
+- [Background Tasks](/automation/tasks)

--- a/docs/automation/feishu-session-trace.md
+++ b/docs/automation/feishu-session-trace.md
@@ -92,7 +92,7 @@ Create `~/Library/LaunchAgents/ai.openclaw.session-trace.plist`:
     <string>tsx</string>
     <string>/path/to/openclaw/scripts/feishu-session-trace.ts</string>
     <string>--session-file</string>
-    <string>/Users/you/.openclaw/agents/main/sessions/<session-id>.jsonl</string>
+    <string>/Users/you/.openclaw/agents/main/sessions/&lt;session-id&gt;.jsonl</string>
     <string>--target</string>
     <string>chat:oc_xxx</string>
   </array>

--- a/docs/automation/feishu-session-trace.md
+++ b/docs/automation/feishu-session-trace.md
@@ -111,7 +111,13 @@ Create `~/Library/LaunchAgents/ai.openclaw.session-trace.plist`:
 Then load it:
 
 ```bash
-launchctl load ~/Library/LaunchAgents/ai.openclaw.session-trace.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.session-trace.plist
+```
+
+To stop it later:
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.session-trace.plist
 ```
 
 ## Troubleshooting

--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -103,6 +103,7 @@ See [Heartbeat](/gateway/heartbeat).
 - **Standing orders** give the agent persistent context and authority boundaries.
 - **Task Flow** coordinates multi-step flows above individual tasks.
 - **Tasks** automatically track all detached work so you can inspect and audit it.
+- **Session trace relays** forward selected session activity into an operator chat when you need lightweight oversight.
 
 ## Related
 
@@ -110,6 +111,7 @@ See [Heartbeat](/gateway/heartbeat).
 - [Background Tasks](/automation/tasks) — task ledger for all detached work
 - [Task Flow](/automation/taskflow) — durable multi-step flow orchestration
 - [Hooks](/automation/hooks) — event-driven lifecycle scripts
+- [Feishu Session Trace Relay](/automation/feishu-session-trace) — forward selected session activity into Feishu
 - [Standing Orders](/automation/standing-orders) — persistent agent instructions
 - [Heartbeat](/gateway/heartbeat) — periodic main-session turns
 - [Configuration Reference](/gateway/configuration-reference) — all config keys

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1156,6 +1156,7 @@
                   "automation/cron-jobs",
                   "automation/tasks",
                   "automation/taskflow",
+                  "automation/feishu-session-trace",
                   "automation/standing-orders",
                   "automation/hooks"
                 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1156,9 +1156,9 @@
                   "automation/cron-jobs",
                   "automation/tasks",
                   "automation/taskflow",
-                  "automation/feishu-session-trace",
                   "automation/standing-orders",
-                  "automation/hooks"
+                  "automation/hooks",
+                  "automation/feishu-session-trace"
                 ]
               },
               {

--- a/scripts/feishu-session-trace.ts
+++ b/scripts/feishu-session-trace.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S node --import tsx
 
 import { spawn } from "node:child_process";
-import readline from "node:readline";
 import {
   clampOneLine,
   extractTraceMessagesFromSessionLine,
+  followAppendedFileLines,
   parseFeishuSessionTraceArgs,
   redactTraceText,
   type FeishuSessionTraceArgs,
@@ -54,24 +54,9 @@ async function sendFeishuMessage(text: string, args: FeishuSessionTraceArgs): Pr
 
 async function main() {
   const args = parseFeishuSessionTraceArgs(process.argv.slice(2));
-  const tail = spawn("tail", ["-n", "0", "-F", args.sessionFile], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  tail.stderr.on("data", (chunk) => {
-    const text = String(chunk).trim();
-    if (text) {
-      console.error(text);
-    }
-  });
-
-  const lines = readline.createInterface({
-    input: tail.stdout,
-    crlfDelay: Infinity,
-  });
 
   let lastSentAt = 0;
-  for await (const line of lines) {
+  for await (const line of followAppendedFileLines(args.sessionFile)) {
     for (const summary of extractTraceMessagesFromSessionLine(line)) {
       const now = Date.now();
       if (now - lastSentAt < args.minIntervalMs) {

--- a/scripts/feishu-session-trace.ts
+++ b/scripts/feishu-session-trace.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env -S node --import tsx
+
+import { spawn } from "node:child_process";
+import readline from "node:readline";
+import {
+  clampOneLine,
+  extractTraceMessagesFromSessionLine,
+  parseFeishuSessionTraceArgs,
+  redactTraceText,
+  type FeishuSessionTraceArgs,
+} from "../src/scripts/feishu-session-trace-shared.js";
+
+async function sendFeishuMessage(text: string, args: FeishuSessionTraceArgs): Promise<void> {
+  const command = [
+    "openclaw",
+    "message",
+    "send",
+    "--channel",
+    "feishu",
+    "--target",
+    args.target,
+    "--message",
+    text,
+  ];
+  if (args.account) {
+    command.push("--account", args.account);
+  }
+  if (args.dryRun) {
+    command.push("--dry-run");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command[0], command.slice(1), {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`openclaw message send failed (exit ${code}): ${stderr || stdout}`));
+    });
+  });
+}
+
+async function main() {
+  const args = parseFeishuSessionTraceArgs(process.argv.slice(2));
+  const tail = spawn("tail", ["-n", "0", "-F", args.sessionFile], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  tail.stderr.on("data", (chunk) => {
+    const text = String(chunk).trim();
+    if (text) {
+      console.error(text);
+    }
+  });
+
+  const lines = readline.createInterface({
+    input: tail.stdout,
+    crlfDelay: Infinity,
+  });
+
+  let lastSentAt = 0;
+  for await (const line of lines) {
+    for (const summary of extractTraceMessagesFromSessionLine(line)) {
+      const now = Date.now();
+      if (now - lastSentAt < args.minIntervalMs) {
+        continue;
+      }
+      const safe = clampOneLine(redactTraceText(summary), args.maxLen);
+      await sendFeishuMessage(safe, args);
+      lastSentAt = now;
+    }
+  }
+}
+
+void main().catch((error) => {
+  console.error(String(error instanceof Error ? (error.stack ?? error.message) : error));
+  process.exitCode = 1;
+});

--- a/src/scripts/feishu-session-trace-shared.test.ts
+++ b/src/scripts/feishu-session-trace-shared.test.ts
@@ -63,6 +63,11 @@ describe("feishu session trace shared helpers", () => {
     expect(summarizeToolCall("unknown_tool", {})).toBeNull();
   });
 
+  it("normalizes tool names before summary matching", () => {
+    expect(summarizeToolCall(" Read ", { path: "/tmp/a.txt" })).toBe("Read file /tmp/a.txt");
+    expect(summarizeToolCall(" BASH ", { cmd: "pnpm test" })).toBe("Run command pnpm test");
+  });
+
   it("extracts summaries from assistant tool-call session lines", () => {
     const line = JSON.stringify({
       type: "message",

--- a/src/scripts/feishu-session-trace-shared.test.ts
+++ b/src/scripts/feishu-session-trace-shared.test.ts
@@ -49,6 +49,7 @@ describe("feishu session trace shared helpers", () => {
   it("redacts obvious secrets", () => {
     expect(redactTraceText("OPENAI_API_KEY=sk-1234567890abcdef")).toBe("OPENAI_API_KEY=***");
     expect(redactTraceText("ghp_1234567890abcdef")).toBe("ghp_***");
+    expect(redactTraceText("Run command curl sk-1234567890abcdef")).toBe("Run command curl sk-***");
   });
 
   it("summarizes supported tool calls", () => {
@@ -85,6 +86,35 @@ describe("feishu session trace shared helpers", () => {
     expect(extractTraceMessagesFromSessionLine(line)).toEqual([
       "Read file /tmp/a.txt",
       "Search web openclaw",
+    ]);
+  });
+
+  it("accepts legacy content block types and top-level tool call payloads", () => {
+    const line = JSON.stringify({
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            name: "edit",
+            input: { path: "/tmp/b.txt" },
+          },
+        ],
+        tool_calls: [
+          {
+            function: {
+              name: "exec",
+              arguments: JSON.stringify({ command: "pnpm test" }),
+            },
+          },
+        ],
+      },
+    });
+
+    expect(extractTraceMessagesFromSessionLine(line)).toEqual([
+      "Edit file /tmp/b.txt",
+      "Run command pnpm test",
     ]);
   });
 });

--- a/src/scripts/feishu-session-trace-shared.test.ts
+++ b/src/scripts/feishu-session-trace-shared.test.ts
@@ -117,4 +117,19 @@ describe("feishu session trace shared helpers", () => {
       "Run command pnpm test",
     ]);
   });
+
+  it("parses stringified arguments on top-level function_call payloads", () => {
+    const line = JSON.stringify({
+      type: "message",
+      message: {
+        role: "assistant",
+        function_call: {
+          name: "exec",
+          arguments: JSON.stringify({ command: "pnpm build" }),
+        },
+      },
+    });
+
+    expect(extractTraceMessagesFromSessionLine(line)).toEqual(["Run command pnpm build"]);
+  });
 });

--- a/src/scripts/feishu-session-trace-shared.test.ts
+++ b/src/scripts/feishu-session-trace-shared.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampOneLine,
+  extractTraceMessagesFromSessionLine,
+  parseFeishuSessionTraceArgs,
+  redactTraceText,
+  summarizeToolCall,
+} from "./feishu-session-trace-shared.js";
+
+describe("feishu session trace shared helpers", () => {
+  it("parses required args and optional flags", () => {
+    expect(
+      parseFeishuSessionTraceArgs([
+        "--session-file",
+        "/tmp/session.jsonl",
+        "--target",
+        "chat:oc_xxx",
+        "--account",
+        "default",
+        "--min-interval-ms",
+        "3000",
+        "--max-len",
+        "180",
+        "--dry-run",
+      ]),
+    ).toEqual({
+      sessionFile: "/tmp/session.jsonl",
+      target: "chat:oc_xxx",
+      account: "default",
+      minIntervalMs: 3000,
+      maxLen: 180,
+      dryRun: true,
+    });
+  });
+
+  it("rejects missing required args", () => {
+    expect(() => parseFeishuSessionTraceArgs(["--target", "chat:oc_xxx"])).toThrow(
+      "Missing --session-file",
+    );
+    expect(() => parseFeishuSessionTraceArgs(["--session-file", "/tmp/x.jsonl"])).toThrow(
+      "Missing --target",
+    );
+  });
+
+  it("clamps multi-line text to one line", () => {
+    expect(clampOneLine("hello\nworld", 40)).toBe("hello world");
+  });
+
+  it("redacts obvious secrets", () => {
+    expect(redactTraceText("OPENAI_API_KEY=sk-1234567890abcdef")).toBe("OPENAI_API_KEY=***");
+    expect(redactTraceText("ghp_1234567890abcdef")).toBe("ghp_***");
+  });
+
+  it("summarizes supported tool calls", () => {
+    expect(summarizeToolCall("read", { path: "/tmp/a.txt" })).toBe("Read file /tmp/a.txt");
+    expect(summarizeToolCall("exec", { command: "pnpm test" })).toBe("Run command pnpm test");
+    expect(summarizeToolCall("todoWrite", {})).toBe("Update todo list");
+    expect(summarizeToolCall("unknown_tool", {})).toBeNull();
+  });
+
+  it("extracts summaries from assistant tool-call session lines", () => {
+    const line = JSON.stringify({
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "read",
+            arguments: { path: "/tmp/a.txt" },
+          },
+          {
+            type: "text",
+            text: "done",
+          },
+          {
+            type: "toolCall",
+            name: "webSearch",
+            arguments: { query: "openclaw" },
+          },
+        ],
+      },
+    });
+
+    expect(extractTraceMessagesFromSessionLine(line)).toEqual([
+      "Read file /tmp/a.txt",
+      "Search web openclaw",
+    ]);
+  });
+});

--- a/src/scripts/feishu-session-trace-shared.test.ts
+++ b/src/scripts/feishu-session-trace-shared.test.ts
@@ -1,7 +1,11 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   clampOneLine,
   extractTraceMessagesFromSessionLine,
+  followAppendedFileLines,
   parseFeishuSessionTraceArgs,
   redactTraceText,
   summarizeToolCall,
@@ -131,5 +135,30 @@ describe("feishu session trace shared helpers", () => {
     });
 
     expect(extractTraceMessagesFromSessionLine(line)).toEqual(["Run command pnpm build"]);
+  });
+
+  it("follows appended lines without relying on tail", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "feishu-trace-"));
+    const file = path.join(dir, "session.jsonl");
+    await fs.writeFile(file, "old\n");
+
+    const controller = new AbortController();
+    const lines = followAppendedFileLines(file, {
+      pollMs: 10,
+      signal: controller.signal,
+    });
+
+    const firstLine = lines.next();
+    await fs.appendFile(file, "new-one\n");
+    await expect(firstLine).resolves.toEqual({ done: false, value: "new-one" });
+
+    const secondLine = lines.next();
+    await fs.appendFile(file, "new");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await fs.appendFile(file, "-two\r\n");
+    await expect(secondLine).resolves.toEqual({ done: false, value: "new-two" });
+
+    controller.abort();
+    await lines.return(undefined);
   });
 });

--- a/src/scripts/feishu-session-trace-shared.ts
+++ b/src/scripts/feishu-session-trace-shared.ts
@@ -240,7 +240,7 @@ function summarizeTraceToolCall(value: unknown): string | null {
 }
 
 export function summarizeToolCall(toolName: unknown, args: unknown): string | null {
-  const name = String(toolName);
+  const name = String(toolName).trim().toLowerCase();
   const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
 
   if (name === "read") {
@@ -249,9 +249,9 @@ export function summarizeToolCall(toolName: unknown, args: unknown): string | nu
   }
 
   if (
-    name === "applyPatch" ||
+    name === "applypatch" ||
     name === "apply_patch" ||
-    name === "editFile" ||
+    name === "editfile" ||
     name === "edit" ||
     name === "write"
   ) {
@@ -269,7 +269,7 @@ export function summarizeToolCall(toolName: unknown, args: unknown): string | nu
     return command ? `Run command ${command}` : "Run command";
   }
 
-  if (name === "webSearch" || name === "web_search") {
+  if (name === "websearch" || name === "web_search") {
     const query =
       typeof record.search_term === "string"
         ? record.search_term
@@ -279,12 +279,12 @@ export function summarizeToolCall(toolName: unknown, args: unknown): string | nu
     return query ? `Search web ${query}` : "Search web";
   }
 
-  if (name === "webFetch" || name === "web_fetch") {
+  if (name === "webfetch" || name === "web_fetch") {
     const url = typeof record.url === "string" ? record.url : undefined;
     return url ? `Fetch web ${url}` : "Fetch web";
   }
 
-  if (name === "todoWrite" || name === "todo_write") {
+  if (name === "todowrite" || name === "todo_write") {
     return "Update todo list";
   }
 

--- a/src/scripts/feishu-session-trace-shared.ts
+++ b/src/scripts/feishu-session-trace-shared.ts
@@ -1,0 +1,183 @@
+export interface FeishuSessionTraceArgs {
+  sessionFile: string;
+  target: string;
+  account?: string;
+  minIntervalMs: number;
+  maxLen: number;
+  dryRun: boolean;
+}
+
+export function parseFeishuSessionTraceArgs(argv: string[]): FeishuSessionTraceArgs {
+  const out: FeishuSessionTraceArgs = {
+    sessionFile: "",
+    target: "",
+    account: undefined,
+    minIntervalMs: 5000,
+    maxLen: 260,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--session-file") {
+      out.sessionFile = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--target") {
+      out.target = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--account") {
+      out.account = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--min-interval-ms") {
+      out.minIntervalMs = Number(argv[i + 1] ?? "5000");
+      i += 1;
+      continue;
+    }
+    if (arg === "--max-len") {
+      out.maxLen = Number(argv[i + 1] ?? "260");
+      i += 1;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      out.dryRun = true;
+    }
+  }
+
+  if (!out.sessionFile) {
+    throw new Error("Missing --session-file");
+  }
+  if (!out.target) {
+    throw new Error("Missing --target");
+  }
+  if (!Number.isFinite(out.minIntervalMs) || out.minIntervalMs < 0) {
+    throw new Error("--min-interval-ms must be >= 0");
+  }
+  if (!Number.isFinite(out.maxLen) || out.maxLen < 80) {
+    throw new Error("--max-len must be >= 80");
+  }
+
+  return out;
+}
+
+export function clampOneLine(text: string, maxLen: number): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= maxLen) {
+    return oneLine;
+  }
+  return `${oneLine.slice(0, Math.max(0, maxLen - 1)).trimEnd()}…`;
+}
+
+export function redactTraceText(text: string): string {
+  return text
+    .replace(/\bsk-[A-Za-z0-9_-]{10,}\b/g, "sk-***")
+    .replace(/\bghp_[A-Za-z0-9]{10,}\b/g, "ghp_***")
+    .replace(/\b(xox[baprs]-[A-Za-z0-9-]{10,})\b/g, "xox***")
+    .replace(/\b(OPENAI_API_KEY|ANTHROPIC_API_KEY|FEISHU_APP_SECRET)\s*=\s*[^ \n]+/g, "$1=***");
+}
+
+export function summarizeToolCall(toolName: unknown, args: unknown): string | null {
+  const name = String(toolName);
+  const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+
+  if (name === "read") {
+    const path = typeof record.path === "string" ? record.path : undefined;
+    return path ? `Read file ${path}` : "Read file";
+  }
+
+  if (
+    name === "applyPatch" ||
+    name === "apply_patch" ||
+    name === "editFile" ||
+    name === "edit" ||
+    name === "write"
+  ) {
+    const path = typeof record.path === "string" ? record.path : undefined;
+    return path ? `Edit file ${path}` : "Edit file";
+  }
+
+  if (name === "shell" || name === "exec" || name === "bash") {
+    const command =
+      typeof record.command === "string"
+        ? record.command
+        : typeof record.cmd === "string"
+          ? record.cmd
+          : undefined;
+    return command ? `Run command ${command}` : "Run command";
+  }
+
+  if (name === "webSearch" || name === "web_search") {
+    const query =
+      typeof record.search_term === "string"
+        ? record.search_term
+        : typeof record.query === "string"
+          ? record.query
+          : undefined;
+    return query ? `Search web ${query}` : "Search web";
+  }
+
+  if (name === "webFetch" || name === "web_fetch") {
+    const url = typeof record.url === "string" ? record.url : undefined;
+    return url ? `Fetch web ${url}` : "Fetch web";
+  }
+
+  if (name === "todoWrite" || name === "todo_write") {
+    return "Update todo list";
+  }
+
+  return null;
+}
+
+export function extractTraceMessagesFromSessionLine(line: string): string[] {
+  if (!line.trim()) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return [];
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return [];
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (record.type !== "message") {
+    return [];
+  }
+
+  const message = record.message;
+  if (!message || typeof message !== "object") {
+    return [];
+  }
+
+  const messageRecord = message as Record<string, unknown>;
+  if (messageRecord.role !== "assistant") {
+    return [];
+  }
+
+  const content = Array.isArray(messageRecord.content) ? messageRecord.content : [];
+  const summaries: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    const partRecord = part as Record<string, unknown>;
+    if (partRecord.type !== "toolCall") {
+      continue;
+    }
+    const summary = summarizeToolCall(partRecord.name, partRecord.arguments);
+    if (summary) {
+      summaries.push(summary);
+    }
+  }
+  return summaries;
+}

--- a/src/scripts/feishu-session-trace-shared.ts
+++ b/src/scripts/feishu-session-trace-shared.ts
@@ -102,6 +102,13 @@ function parseToolCallArgs(value: unknown): unknown {
   if (record.arguments && typeof record.arguments === "object") {
     return record.arguments;
   }
+  if (typeof record.arguments === "string") {
+    try {
+      return JSON.parse(record.arguments);
+    } catch {
+      return undefined;
+    }
+  }
   if (record.input && typeof record.input === "object") {
     return record.input;
   }

--- a/src/scripts/feishu-session-trace-shared.ts
+++ b/src/scripts/feishu-session-trace-shared.ts
@@ -81,6 +81,75 @@ export function redactTraceText(text: string): string {
     .replace(/\b(OPENAI_API_KEY|ANTHROPIC_API_KEY|FEISHU_APP_SECRET)\s*=\s*[^ \n]+/g, "$1=***");
 }
 
+const TOOL_CALL_TYPES = new Set([
+  "toolcall",
+  "tool_call",
+  "tooluse",
+  "tool_use",
+  "functioncall",
+  "function_call",
+]);
+
+function normalizeToolCallType(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function parseToolCallArgs(value: unknown): unknown {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.arguments && typeof record.arguments === "object") {
+    return record.arguments;
+  }
+  if (record.input && typeof record.input === "object") {
+    return record.input;
+  }
+  if (record.args && typeof record.args === "object") {
+    return record.args;
+  }
+  const fn = record.function;
+  if (!fn || typeof fn !== "object") {
+    return undefined;
+  }
+  const fnRecord = fn as Record<string, unknown>;
+  if (fnRecord.arguments && typeof fnRecord.arguments === "object") {
+    return fnRecord.arguments;
+  }
+  if (typeof fnRecord.arguments === "string") {
+    try {
+      return JSON.parse(fnRecord.arguments);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function resolveToolCallName(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.name === "string" && record.name.trim()) {
+    return record.name;
+  }
+  const fn = record.function;
+  if (!fn || typeof fn !== "object") {
+    return undefined;
+  }
+  const fnName = (fn as Record<string, unknown>).name;
+  return typeof fnName === "string" && fnName.trim() ? fnName : undefined;
+}
+
+function summarizeTraceToolCall(value: unknown): string | null {
+  const toolName = resolveToolCallName(value);
+  if (!toolName) {
+    return null;
+  }
+  return summarizeToolCall(toolName, parseToolCallArgs(value));
+}
+
 export function summarizeToolCall(toolName: unknown, args: unknown): string | null {
   const name = String(toolName);
   const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
@@ -164,20 +233,30 @@ export function extractTraceMessagesFromSessionLine(line: string): string[] {
     return [];
   }
 
-  const content = Array.isArray(messageRecord.content) ? messageRecord.content : [];
   const summaries: string[] = [];
+  const content = Array.isArray(messageRecord.content) ? messageRecord.content : [];
   for (const part of content) {
-    if (!part || typeof part !== "object") {
+    if (!TOOL_CALL_TYPES.has(normalizeToolCallType((part as { type?: unknown } | null)?.type))) {
       continue;
     }
-    const partRecord = part as Record<string, unknown>;
-    if (partRecord.type !== "toolCall") {
-      continue;
-    }
-    const summary = summarizeToolCall(partRecord.name, partRecord.arguments);
+    const summary = summarizeTraceToolCall(part);
     if (summary) {
       summaries.push(summary);
     }
   }
+
+  const rawToolCalls =
+    messageRecord.tool_calls ??
+    messageRecord.toolCalls ??
+    messageRecord.function_call ??
+    messageRecord.functionCall;
+  const toolCalls = Array.isArray(rawToolCalls) ? rawToolCalls : rawToolCalls ? [rawToolCalls] : [];
+  for (const call of toolCalls) {
+    const summary = summarizeTraceToolCall(call);
+    if (summary) {
+      summaries.push(summary);
+    }
+  }
+
   return summaries;
 }

--- a/src/scripts/feishu-session-trace-shared.ts
+++ b/src/scripts/feishu-session-trace-shared.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import { setTimeout as sleep } from "node:timers/promises";
+
 export interface FeishuSessionTraceArgs {
   sessionFile: string;
   target: string;
@@ -79,6 +82,85 @@ export function redactTraceText(text: string): string {
     .replace(/\bghp_[A-Za-z0-9]{10,}\b/g, "ghp_***")
     .replace(/\b(xox[baprs]-[A-Za-z0-9-]{10,})\b/g, "xox***")
     .replace(/\b(OPENAI_API_KEY|ANTHROPIC_API_KEY|FEISHU_APP_SECRET)\s*=\s*[^ \n]+/g, "$1=***");
+}
+
+export async function* followAppendedFileLines(
+  filePath: string,
+  opts?: {
+    pollMs?: number;
+    signal?: AbortSignal;
+    startAtEnd?: boolean;
+  },
+): AsyncGenerator<string> {
+  const pollMs = Math.max(10, opts?.pollMs ?? 250);
+  let initialized = false;
+  let offset = 0;
+  let remainder = "";
+  let lastIdentity = "";
+
+  while (!opts?.signal?.aborted) {
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stat = await fs.stat(filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      try {
+        await sleep(pollMs, undefined, { signal: opts?.signal });
+      } catch (sleepError) {
+        if ((sleepError as Error).name === "AbortError") {
+          return;
+        }
+        throw sleepError;
+      }
+      continue;
+    }
+
+    const identity = `${stat.dev}:${stat.ino}`;
+    if (!initialized) {
+      offset = opts?.startAtEnd === false ? 0 : stat.size;
+      initialized = true;
+      lastIdentity = identity;
+    } else if (stat.size < offset || identity !== lastIdentity) {
+      offset = 0;
+      remainder = "";
+      lastIdentity = identity;
+    }
+
+    if (stat.size > offset) {
+      const handle = await fs.open(filePath, "r");
+      try {
+        const bytesToRead = stat.size - offset;
+        const chunk = Buffer.alloc(bytesToRead);
+        const { bytesRead } = await handle.read(chunk, 0, bytesToRead, offset);
+        offset += bytesRead;
+        remainder += chunk.toString("utf8", 0, bytesRead);
+      } finally {
+        await handle.close();
+      }
+
+      while (true) {
+        const newlineIndex = remainder.search(/\r?\n/u);
+        if (newlineIndex < 0) {
+          break;
+        }
+        const newlineLength = remainder[newlineIndex] === "\r" ? 2 : 1;
+        const line = remainder.slice(0, newlineIndex);
+        remainder = remainder.slice(newlineIndex + newlineLength);
+        yield line;
+      }
+    }
+
+    try {
+      await sleep(pollMs, undefined, { signal: opts?.signal });
+    } catch (sleepError) {
+      if ((sleepError as Error).name === "AbortError") {
+        return;
+      }
+      throw sleepError;
+    }
+  }
 }
 
 const TOOL_CALL_TYPES = new Set([


### PR DESCRIPTION
#### Summary

Add a documented Feishu session-trace relay recipe, plus a small helper script and focused tests for the parsing/redaction logic.

This gives operators a lightweight way to forward important tool activity from a live session JSONL file into a Feishu DM or group without opening the terminal UI.

Code word: lobster-biscuit.

#### Behavior Changes

- Add `/automation/feishu-session-trace` documentation
- Add `scripts/feishu-session-trace.ts` as a runnable helper script
- Add shared parsing/redaction helpers under `src/scripts/`
- Add focused tests for argument parsing, secret redaction, supported tool summaries, and JSONL extraction
- Add the new page to the Automation docs navigation

#### Codebase and GitHub Search

- Codebase searches:
  - `rg -n "session.*jsonl|openclaw message send|tail -F" scripts docs src`
  - `rg -n "Automation & Tasks|automation/index" docs/docs.json docs/automation/index.md`
- GitHub issue searches:
  - `gh search issues 'feishu session trace' --repo openclaw/openclaw --limit 5`
  - `gh search issues 'session trace relay' --repo openclaw/openclaw --limit 5`
- I did not find an existing upstream session-trace relay recipe for Feishu.

#### Tests

- `./node_modules/.bin/oxlint scripts/feishu-session-trace.ts src/scripts/feishu-session-trace-shared.ts src/scripts/feishu-session-trace-shared.test.ts`
- `node scripts/run-vitest.mjs run src/scripts/feishu-session-trace-shared.test.ts`
- `./node_modules/.bin/oxfmt --check docs/automation/feishu-session-trace.md docs/automation/index.md`
- `./node_modules/.bin/oxfmt --check docs/docs.json`

#### Manual Testing (omit if N/A)

### Prerequisites

- A Feishu target such as `user:ou_xxx` or `chat:oc_xxx`
- Access to a live session JSONL file
- OpenClaw CLI configured for Feishu delivery

### Steps

1. Start the relay with `node --import tsx scripts/feishu-session-trace.ts --session-file ... --target ... --dry-run`.
2. Trigger a few supported tools in the live session, for example `read`, `exec`, or `web_search`.
3. Confirm the relay emits concise one-line summaries.
4. Confirm obvious secrets are redacted and unsupported tools are ignored.

#### Evidence (omit if N/A)

- Added a dedicated automation doc page and navigation entry.
- Added focused tests for the reusable parsing/redaction helper layer.

**Sign-Off**

- Models used: GPT-5 Codex
- Submitter effort (self-reported): medium
- Agent notes (optional, cite evidence): I intentionally kept the forwarded tool allowlist small so the relay stays useful as operator signal rather than becoming a noisy full transcript mirror.
