### PR TITLE
Fix: sort merged workspace skills alphabetically for deterministic order (Resolves #64167)

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -355,4 +355,45 @@ describe("loadWorkspaceSkillEntries", () => {
       });
     },
   );
+
+  it("returns merged skills in a deterministic alphabetical order regardless of extraDirs order", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const extraDirA = await createTempWorkspaceDir();
+    const extraDirB = await createTempWorkspaceDir();
+
+    await writeSkill({
+      dir: path.join(extraDirA, "charlie"),
+      name: "charlie",
+      description: "Charlie skill",
+    });
+    await writeSkill({
+      dir: path.join(extraDirA, "alpha"),
+      name: "alpha",
+      description: "Alpha skill",
+    });
+    await writeSkill({
+      dir: path.join(extraDirB, "bravo"),
+      name: "bravo",
+      description: "Bravo skill",
+    });
+    await writeSkill({
+      dir: path.join(extraDirB, "delta"),
+      name: "delta",
+      description: "Delta skill",
+    });
+
+    const loadWithExtraDirs = (extraDirs: string[]) =>
+      loadWorkspaceSkillEntries(workspaceDir, {
+        config: { skills: { load: { extraDirs } } },
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      });
+
+    const firstOrder = loadWithExtraDirs([extraDirA, extraDirB]);
+    const swappedOrder = loadWithExtraDirs([extraDirB, extraDirA]);
+
+    const expected = ["alpha", "bravo", "charlie", "delta"];
+    expect(firstOrder.map((entry) => entry.skill.name)).toEqual(expected);
+    expect(swappedOrder.map((entry) => entry.skill.name)).toEqual(expected);
+  });
 });

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -471,7 +471,15 @@ function loadSkillEntries(
     merged.set(skill.name, skill);
   }
 
-  const skillEntries: SkillEntry[] = Array.from(merged.values()).map((skill) => {
+  // Sort merged skills alphabetically by name so the final order is
+  // deterministic regardless of source/extraDirs ordering. Map preserves
+  // insertion order, which would otherwise make the <available_skills> prompt
+  // section depend on which source wrote each skill first and bypass the
+  // LLM prompt cache across instances with different extraDirs orderings.
+  const sortedMergedSkills = Array.from(merged.values()).toSorted((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  const skillEntries: SkillEntry[] = sortedMergedSkills.map((skill) => {
     const frontmatter =
       readSkillFrontmatterSafe({
         rootDir: skill.baseDir,


### PR DESCRIPTION
Fixes #64167.

## Problem

`loadSkillEntries` in `src/agents/skills/workspace.ts` merges skills from multiple sources (bundled, `extraDirs`, managed, personal/project `.agents/skills`, workspace) into a `Map<string, Skill>`. The final array is built from `Array.from(merged.values())`, which preserves **Map insertion order** — i.e. the order in which each skill name was first written.

That means the order of skills in `<available_skills>` depends on which source saw each skill first, and for `extraDirs` specifically on the order of entries in `skills.load.extraDirs`. In multi-instance cloud deployments where instances may list `extraDirs` in different orders, each instance produces a different prompt prefix, bypassing the LLM prompt cache and increasing API cost/latency.

Within a single source `loadSkills()` already sorts `childDirs.slice().sort()`, and the truncation path sorts by skill name — but there is no global sort after the cross-source merge.

## Fix

Sort the merged `Array.from(merged.values())` alphabetically by `skill.name` (via `localeCompare`) before constructing `SkillEntry[]`. Precedence-based overrides from the merge loop are untouched; only the traversal order of the resulting array becomes deterministic.

This satisfies the prompt-cache-stability guidance in `CLAUDE.md`: "Any code that assembles model or tool payloads from maps, sets, registries, plugin lists… must make ordering deterministic before building the request."

## Test plan

- [x] Added `loadWorkspaceSkillEntries` regression test that creates four skills split across two `extraDirs` and asserts identical alphabetical ordering for both `[A, B]` and `[B, A]` extraDirs configurations.
- [x] `pnpm test src/agents/skills.loadworkspaceskillentries.test.ts` — 15/15 pass.
- [x] `pnpm test src/agents/skills.test.ts src/agents/skills.buildworkspaceskillsnapshot.test.ts src/agents/skills.build-workspace-skills-prompt.*.test.ts src/agents/skills.agents-skills-directory.test.ts` — 42/42 pass.