### PR TITLE
fix(agents): detect llama.cpp slot overflow as context overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 - ACP/gateway chat: classify lifecycle errors before forwarding them to ACP clients so refusals use ACP's refusal stop reason while transient backend errors continue to finish as normal turns.
 - Commands/btw: keep tool-less side questions from sending injected empty `tools` arrays on strict OpenAI-compatible providers, so `/btw` continues working after prior tool-call history. (#64219) Thanks @ngutman.
 - Agents/Bedrock: let `/btw` side questions use `auth: "aws-sdk"` without a static API key so Bedrock IAM and instance-role sessions stop failing before the side question runs. (#64218) Thanks @SnowSky1.
+- Agents/failover: detect llama.cpp slot context overflows as context-overflow errors so compaction can retry self-hosted OpenAI-compatible runs instead of surfacing the raw upstream 400. (#64196) Thanks @alexander-applyinnovations.
 
 ## 2026.4.9
 

--- a/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
+++ b/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
@@ -50,6 +50,11 @@ describe("matchesProviderContextOverflow", () => {
     // Cohere
     "total tokens exceeds the model's maximum limit of 4096",
 
+    // llama.cpp HTTP server (slot ctx-size overflow)
+    "400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it",
+    "request (130000 tokens) exceeds available context size (131072 tokens)",
+    "prompt (8500 tokens) exceeds the available context size (8192 tokens), try increasing it",
+
     // Generic
     "input is too long for model gpt-5.4",
   ])("matches provider-specific overflow: %s", (msg) => {
@@ -111,6 +116,15 @@ describe("isContextOverflowError with provider patterns", () => {
 
   it("detects Ollama context overflow", () => {
     expect(isContextOverflowError("ollama error: context length exceeded")).toBe(true);
+  });
+
+  it("detects llama.cpp slot ctx-size overflow", () => {
+    // Native llama.cpp HTTP server overflow surfaced through openai-completions providers.
+    expect(
+      isContextOverflowError(
+        "400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it",
+      ),
+    ).toBe(true);
   });
 
   it("still detects standard context overflow patterns", () => {

--- a/src/agents/pi-embedded-helpers/provider-error-patterns.ts
+++ b/src/agents/pi-embedded-helpers/provider-error-patterns.ts
@@ -35,6 +35,13 @@ export const PROVIDER_CONTEXT_OVERFLOW_PATTERNS: readonly RegExp[] = [
   // Cohere does not currently ship a bundled provider hook.
   /\btotal tokens?.*exceeds? (?:the )?(?:model(?:'s)? )?(?:max|maximum|limit)/i,
 
+  // llama.cpp HTTP server (often used directly or behind an OpenAI-compatible
+  // shim) returns "request (N tokens) exceeds the available context size
+  // (M tokens), try increasing it" when the prompt overshoots a slot's
+  // ctx-size. Wording is from the upstream slot manager and is stable.
+  // Example: "400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it"
+  /\b(?:request|prompt) \(\d[\d,]*\s*tokens?\) exceeds (?:the )?available context size\b/i,
+
   // Generic "input too long" pattern that isn't covered by existing checks
   /\binput (?:is )?too long for (?:the )?model\b/i,
 ];


### PR DESCRIPTION
## Summary

- Adds a llama.cpp-shaped regex to `PROVIDER_CONTEXT_OVERFLOW_PATTERNS` so `isContextOverflowError()` recognises the native overflow message from llama.cpp's slot manager (used directly or behind any `api: "openai-completions"` proxy).
- Adds 4 unit test cases covering the new pattern (3 parameterised messages + 1 end-to-end `isContextOverflowError()` assertion).

Closes #64180

## The Bug

Self-hosted llama.cpp HTTP servers are very common (`ghcr.io/ggml-org/llama.cpp:server-cuda` and similar). When a prompt overshoots a slot's `--ctx-size`, llama.cpp returns:

```
400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it
```

This message slips past every existing detector:

| Check | Why it misses |
|---|---|
| `request_too_large` | wrong wording |
| `context length exceeded` / `maximum context length` | llama.cpp says **"context size"**, not "context length" |
| `prompt is too long` / `prompt too long` | llama.cpp says "request (N tokens) exceeds…" |
| `exceeds model context window` / `context_window_exceeded` | wrong wording |
| `413` + `too large` | llama.cpp returns **400** |
| `\binput token count exceeds the maximum number of input tokens\b` (Bedrock) | wrong wording |
| `\binput is too long for this model\b` (Bedrock/Mistral generic) | wrong wording |
| `\binput exceeds the maximum number of tokens\b` (Vertex) | wrong wording |
| `\bollama error:\s*context length exceeded\b` (Ollama) | no `ollama error:` prefix |
| `\btotal tokens?.*exceeds?` (Cohere) | message has "(N tokens)", not "total tokens" |

The generic candidate pre-check (`PROVIDER_CONTEXT_OVERFLOW_SIGNAL_RE` + `PROVIDER_CONTEXT_OVERFLOW_ACTION_RE`) does pass — the message contains "request"/"tokens"/"context"/"exceeds" — but no concrete pattern matches, so `matchesProviderContextOverflow()` returns `false`. The agent runner sees `isContextOverflowError() === false`, never enters the compaction branch, and the user gets the raw upstream 400 instead of an automatic compact + retry.

Same class of bug as #58839 (Bedrock/Ollama/Cohere), just for a different provider.

## The Fix

One regex added next to the existing provider patterns in `src/agents/pi-embedded-helpers/provider-error-patterns.ts`:

```ts
// llama.cpp HTTP server (often used directly or behind an OpenAI-compatible
// shim) returns "request (N tokens) exceeds the available context size
// (M tokens), try increasing it" when the prompt overshoots a slot's
// ctx-size. Wording is from the upstream slot manager and is stable.
// Example: "400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it"
/\b(?:request|prompt) \(\d[\d,]*\s*tokens?\) exceeds (?:the )?available context size\b/i,
```

The pattern is anchored on the stable slot-manager wording (`(?:request|prompt) (N tokens) exceeds (the )?available context size`) so it can't accidentally swallow unrelated provider errors. The existing candidate pre-check still gates the regex evaluation, keeping cost negligible.

## Tests

- `provider-error-patterns.test.ts` parameterised cases:
  - `"400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it"` (verbatim production payload)
  - `"request (130000 tokens) exceeds available context size (131072 tokens)"` (no `the`, no status prefix)
  - `"prompt (8500 tokens) exceeds the available context size (8192 tokens), try increasing it"` (the `prompt` alternation)
- New end-to-end case under `describe("isContextOverflowError with provider patterns")` asserting that `isContextOverflowError(<verbatim message>) === true`, which is what the agent runner actually calls.

Targeted run:

```
$ pnpm vitest run src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
 Test Files  1 passed (1)
      Tests  26 passed (26)
```

Broader vitest run shows 2 pre-existing failures in `src/channels/plugins/contracts/group-policy.fallback.contract.test.ts` — those are not touched by this PR (the change is scoped to two files in `src/agents/pi-embedded-helpers/`).

## Test plan

- [x] Targeted unit tests pass (26/26 in `provider-error-patterns.test.ts`)
- [x] Pattern only matches llama.cpp's specific wording (verified by the existing "does not match unrelated errors" cases)
- [ ] Manual: verify on a llama.cpp deployment that compaction now triggers when a session overshoots `--ctx-size`

## AI-assisted

- [x] Drafted with Claude Code (Claude Opus 4.6, 1M context)
- [x] Lightly tested (targeted unit tests pass; manual verification still pending in our prod env)
- [x] I understand what the code does — added one regex to an existing fallback list and added matching test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)