### PR TITLE
feat(gateway): add skills.download and skills.remove RPC methods

### DIFF
--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -189,8 +189,12 @@ import {
   type SkillsBinsParams,
   SkillsBinsParamsSchema,
   type SkillsBinsResult,
+  type SkillsDownloadParams,
+  SkillsDownloadParamsSchema,
   type SkillsInstallParams,
   SkillsInstallParamsSchema,
+  type SkillsRemoveParams,
+  SkillsRemoveParamsSchema,
   type SkillsStatusParams,
   SkillsStatusParamsSchema,
   type SkillsUpdateParams,
@@ -327,6 +331,10 @@ export const validateSkillsBinsParams = ajv.compile<SkillsBinsParams>(SkillsBins
 export const validateSkillsInstallParams =
   ajv.compile<SkillsInstallParams>(SkillsInstallParamsSchema);
 export const validateSkillsUpdateParams = ajv.compile<SkillsUpdateParams>(SkillsUpdateParamsSchema);
+export const validateSkillsDownloadParams = ajv.compile<SkillsDownloadParams>(
+  SkillsDownloadParamsSchema,
+);
+export const validateSkillsRemoveParams = ajv.compile<SkillsRemoveParams>(SkillsRemoveParamsSchema);
 export const validateCronListParams = ajv.compile<CronListParams>(CronListParamsSchema);
 export const validateCronStatusParams = ajv.compile<CronStatusParams>(CronStatusParamsSchema);
 export const validateCronAddParams = ajv.compile<CronAddParams>(CronAddParamsSchema);

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -208,6 +208,24 @@ export const SkillsUpdateParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const SkillsDownloadParamsSchema = Type.Object(
+  {
+    slug: NonEmptyString,
+    version: Type.Optional(NonEmptyString),
+    registryUrl: Type.Optional(NonEmptyString),
+    force: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+
+export const SkillsRemoveParamsSchema = Type.Object(
+  {
+    skillKey: NonEmptyString,
+    force: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+
 export const ToolsCatalogParamsSchema = Type.Object(
   {
     agentId: Type.Optional(NonEmptyString),

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -29,7 +29,9 @@ import type {
   ModelsListResultSchema,
   SkillsBinsParamsSchema,
   SkillsBinsResultSchema,
+  SkillsDownloadParamsSchema,
   SkillsInstallParamsSchema,
+  SkillsRemoveParamsSchema,
   SkillsStatusParamsSchema,
   SkillsUpdateParamsSchema,
   ToolCatalogEntrySchema,
@@ -225,7 +227,9 @@ export type ToolCatalogGroup = Static<typeof ToolCatalogGroupSchema>;
 export type ToolsCatalogResult = Static<typeof ToolsCatalogResultSchema>;
 export type SkillsBinsParams = Static<typeof SkillsBinsParamsSchema>;
 export type SkillsBinsResult = Static<typeof SkillsBinsResultSchema>;
+export type SkillsDownloadParams = Static<typeof SkillsDownloadParamsSchema>;
 export type SkillsInstallParams = Static<typeof SkillsInstallParamsSchema>;
+export type SkillsRemoveParams = Static<typeof SkillsRemoveParamsSchema>;
 export type SkillsUpdateParams = Static<typeof SkillsUpdateParamsSchema>;
 export type CronJob = Static<typeof CronJobSchema>;
 export type CronListParams = Static<typeof CronListParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -47,6 +47,8 @@ const BASE_METHODS = [
   "skills.bins",
   "skills.install",
   "skills.update",
+  "skills.download",
+  "skills.remove",
   "update.run",
   "voicewake.get",
   "voicewake.set",

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -236,6 +236,11 @@ export const skillsHandlers: GatewayRequestHandlers = {
     }
     const skillsDir = path.join(CONFIG_DIR, "skills");
     const targetDir = path.join(skillsDir, p.slug);
+    const resolvedTarget = path.resolve(targetDir);
+    if (!resolvedTarget.startsWith(path.resolve(skillsDir) + path.sep)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "path traversal detected"));
+      return;
+    }
     if (fs.existsSync(targetDir) && !p.force) {
       respond(
         false,
@@ -287,7 +292,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
         {
           ok: true,
           slug: p.slug,
-          version: p.version || "latest",
+          version: p.version ?? undefined,
           path: targetDir,
           stdout: result.stdout.trim(),
         },
@@ -341,8 +346,24 @@ export const skillsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    // When force is not set, require the skill to be disabled in config first.
+    if (!p.force) {
+      const cfg = loadConfig();
+      const entry = cfg.skills?.entries?.[p.skillKey];
+      if (entry?.enabled === true) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `skill "${p.skillKey}" is still enabled. Disable it first or use force: true.`,
+          ),
+        );
+        return;
+      }
+    }
     try {
-      fs.rmSync(targetDir, { recursive: true, force: true });
+      fs.rmSync(targetDir, { recursive: true, force: !!p.force });
       // Clean up config entry.
       const cfg = loadConfig();
       const skills = cfg.skills ? { ...cfg.skills } : {};

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
@@ -10,14 +12,18 @@ import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { CONFIG_DIR } from "../../utils.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
   validateSkillsBinsParams,
+  validateSkillsDownloadParams,
   validateSkillsInstallParams,
+  validateSkillsRemoveParams,
   validateSkillsStatusParams,
   validateSkillsUpdateParams,
 } from "../protocol/index.js";
@@ -200,5 +206,162 @@ export const skillsHandlers: GatewayRequestHandlers = {
     };
     await writeConfigFile(nextConfig);
     respond(true, { ok: true, skillKey: p.skillKey, config: current }, undefined);
+  },
+  "skills.download": async ({ params, respond }) => {
+    if (!validateSkillsDownloadParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid skills.download params: ${formatValidationErrors(validateSkillsDownloadParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as {
+      slug: string;
+      version?: string;
+      registryUrl?: string;
+      force?: boolean;
+    };
+    const SAFE_SLUG = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+    if (!SAFE_SLUG.test(p.slug) || p.slug.includes("..")) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `invalid slug: "${p.slug}"`),
+      );
+      return;
+    }
+    const skillsDir = path.join(CONFIG_DIR, "skills");
+    const targetDir = path.join(skillsDir, p.slug);
+    if (fs.existsSync(targetDir) && !p.force) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `skill "${p.slug}" already installed at ${targetDir}. Use force: true to overwrite.`,
+        ),
+      );
+      return;
+    }
+    const argv = ["npx", "clawhub", "install", p.slug, "--no-input"];
+    if (p.version) {
+      argv.push("--version", p.version);
+    }
+    if (p.force) {
+      argv.push("--force");
+    }
+    if (p.registryUrl) {
+      argv.push("--registry", p.registryUrl);
+    }
+    try {
+      const result = await runCommandWithTimeout(argv, {
+        timeoutMs: 60_000,
+        cwd: CONFIG_DIR,
+      });
+      if (result.code !== 0) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.UNAVAILABLE,
+            `clawhub install failed (exit ${result.code}): ${result.stderr.trim() || result.stdout.trim()}`,
+          ),
+        );
+        return;
+      }
+      // Enable the skill in config by default.
+      const cfg = loadConfig();
+      const skills = cfg.skills ? { ...cfg.skills } : {};
+      const entries = skills.entries ? { ...skills.entries } : {};
+      if (!entries[p.slug]) {
+        entries[p.slug] = { enabled: true };
+        skills.entries = entries;
+        await writeConfigFile({ ...cfg, skills });
+      }
+      respond(
+        true,
+        {
+          ok: true,
+          slug: p.slug,
+          version: p.version || "latest",
+          path: targetDir,
+          stdout: result.stdout.trim(),
+        },
+        undefined,
+      );
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          `skills.download failed: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
+  },
+  "skills.remove": async ({ params, respond }) => {
+    if (!validateSkillsRemoveParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid skills.remove params: ${formatValidationErrors(validateSkillsRemoveParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as { skillKey: string; force?: boolean };
+    const SAFE_KEY = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+    if (!SAFE_KEY.test(p.skillKey) || p.skillKey.includes("..")) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `invalid skillKey: "${p.skillKey}"`),
+      );
+      return;
+    }
+    const skillsDir = path.join(CONFIG_DIR, "skills");
+    const targetDir = path.join(skillsDir, p.skillKey);
+    const resolved = path.resolve(targetDir);
+    if (!resolved.startsWith(path.resolve(skillsDir) + path.sep)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "path traversal detected"));
+      return;
+    }
+    if (!fs.existsSync(targetDir)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `skill "${p.skillKey}" not found`),
+      );
+      return;
+    }
+    try {
+      fs.rmSync(targetDir, { recursive: true, force: true });
+      // Clean up config entry.
+      const cfg = loadConfig();
+      const skills = cfg.skills ? { ...cfg.skills } : {};
+      const entries = skills.entries ? { ...skills.entries } : {};
+      if (entries[p.skillKey]) {
+        delete entries[p.skillKey];
+        skills.entries = entries;
+        await writeConfigFile({ ...cfg, skills });
+      }
+      respond(true, { ok: true, skillKey: p.skillKey }, undefined);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          `skills.remove failed: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
   },
 };


### PR DESCRIPTION
## Summary

- Add `skills.download` RPC method: downloads and installs a skill from ClawHub registry into the managed skills directory, delegating to `npx clawhub install`. Automatically enables the skill in config after install.
- Add `skills.remove` RPC method: removes an installed skill by deleting its directory and cleaning up the config entry. Includes path traversal protection.

These two methods complete the skill CRUD lifecycle over the gateway WebSocket protocol, enabling external services (e.g. a BFF / web dashboard) to manage skills on a remote OpenClaw instance without requiring filesystem or SSH access.

### Motivation

Currently, installing and removing skills requires either CLI access (`clawhub install/uninstall`) or direct filesystem manipulation. For deployments where the management UI runs on a separate host from the OpenClaw gateway (e.g. Docker on a cloud server), there is no RPC method to install or remove skills remotely. The existing `skills.install` method only handles binary dependency installation (brew/npm/go), not skill content from the registry.

### Changes

| File | Change |
|------|--------|
| `src/gateway/protocol/schema/agents-models-skills.ts` | Add `SkillsDownloadParamsSchema` and `SkillsRemoveParamsSchema` |
| `src/gateway/protocol/schema/types.ts` | Export new param types |
| `src/gateway/protocol/index.ts` | Add `validateSkillsDownloadParams` and `validateSkillsRemoveParams` |
| `src/gateway/server-methods/skills.ts` | Implement `skills.download` and `skills.remove` handlers |
| `src/gateway/server-methods-list.ts` | Register the two new methods |

## Test plan

- [ ] Call `skills.download` with a valid ClawHub slug → verify skill directory created under `~/.openclaw/skills/` and config entry added
- [ ] Call `skills.download` with an already-installed slug (no force) → verify error response
- [ ] Call `skills.download` with `force: true` on existing skill → verify overwrite
- [ ] Call `skills.remove` with an installed skill → verify directory deleted and config cleaned
- [ ] Call `skills.remove` with path traversal attempt (e.g. `../etc`) → verify rejection
- [ ] Call `skills.remove` with non-existent skill → verify error response
- [ ] Verify hot-reload: after `skills.download`, agent picks up new skill on next turn without restart