### PR TITLE
fix(skills): sort available_skills alphabetically for prompt cache stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Sessions/Codex: skip redundant `delivery-mirror` transcript appends only when the latest assistant message has the same visible text, preventing duplicate visible replies on Codex-backed turns without suppressing repeated answers across turns. (#67185) Thanks @andyylin.
 - Auto-reply/prompt-cache: keep volatile inbound chat IDs out of the stable system prompt so task-scoped adapters can reuse prompt caches across runs, while preserving conversation metadata for the user turn and media-only messages. (#65071) Thanks @MonkeyLeeT.
 - BlueBubbles/inbound: restore inbound image attachment downloads on Node 22+ by stripping incompatible bundled-undici dispatchers from the non-SSRF fetch path, accept `updated-message` webhooks carrying attachments, use event-type-aware dedup keys so attachment follow-ups are not rejected as duplicates, and retry attachment fetch from the BB API when the initial webhook arrives with an empty array. (#64105, #61861, #65430, #67510) Thanks @omarshahine.
+- Agents/skills: sort prompt-facing `available_skills` entries by skill name after merging sources so `skills.load.extraDirs` order no longer changes prompt-cache prefixes. (#64198) Thanks @Bartok9.
 
 ## 2026.4.15-beta.1
 

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -1,8 +1,8 @@
 import { Type } from "@sinclair/typebox";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { withEnv } from "openclaw/plugin-sdk/testing";
 import { describe, expect, it, vi } from "vitest";
-import { withEnv } from "../../../src/test-utils/env.js";
 
 const handleDiscordMessageActionMock = vi.hoisted(() =>
   vi.fn(async () => ({ content: [], details: { ok: true } })),

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { withEnv } from "../../../src/test-utils/env.js";
 
 const handleDiscordMessageActionMock = vi.hoisted(() =>
   vi.fn(async () => ({ content: [], details: { ok: true } })),
@@ -15,20 +16,22 @@ const { discordMessageActions } = await import("./channel-actions.js");
 
 describe("discordMessageActions", () => {
   it("returns no tool actions when no token-sourced Discord accounts are enabled", () => {
-    const discovery = discordMessageActions.describeMessageTool?.({
-      cfg: {
-        channels: {
-          discord: {
-            enabled: true,
+    withEnv({ DISCORD_BOT_TOKEN: undefined }, () => {
+      const discovery = discordMessageActions.describeMessageTool?.({
+        cfg: {
+          channels: {
+            discord: {
+              enabled: true,
+            },
           },
-        },
-      } as OpenClawConfig,
-    });
+        } as OpenClawConfig,
+      });
 
-    expect(discovery).toEqual({
-      actions: [],
-      capabilities: [],
-      schema: null,
+      expect(discovery).toEqual({
+        actions: [],
+        capabilities: [],
+        schema: null,
+      });
     });
   });
 

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -271,6 +271,20 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt).not.toContain(home);
   });
 
+  it("skills are sorted alphabetically regardless of entry insertion order", () => {
+    // Entries provided in reverse alphabetical order should still produce
+    // an alphabetically sorted prompt (fixes #64167).
+    const entries = ["zoo", "apple", "mango", "banana"].map((n) =>
+      makeEntry(makeSkill(n, `${n} skill`)),
+    );
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries,
+      config: { skills: { limits: { maxSkillsPromptChars: 50_000 } } } satisfies OpenClawConfig,
+    });
+    const nameMatches = [...prompt.matchAll(/<name>(\w+)<\/name>/g)].map((m) => m[1]);
+    expect(nameMatches).toEqual(["apple", "banana", "mango", "zoo"]);
+  });
+
   it("resolvedSkills in snapshot keeps canonical paths, not compacted", () => {
     const home = os.homedir();
     const skills = Array.from({ length: 5 }, (_, i) =>

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -500,7 +500,7 @@ function loadSkillEntries(
     if (loadedSkills.length > limits.maxSkillsLoadedPerSource) {
       return loadedSkills
         .slice()
-        .sort((a, b) => a.name.localeCompare(b.name))
+        .sort((a, b) => a.name.localeCompare(b.name, "en"))
         .slice(0, limits.maxSkillsLoadedPerSource);
     }
 
@@ -575,7 +575,7 @@ function loadSkillEntries(
   }
 
   const skillEntries: SkillEntry[] = Array.from(merged.values())
-    .sort((a, b) => a.name.localeCompare(b.name))
+    .sort((a, b) => a.name.localeCompare(b.name, "en"))
     .map((skill) => {
       const frontmatter =
         readSkillFrontmatterSafe({
@@ -764,7 +764,7 @@ function resolveWorkspaceSkillPromptState(
   // resolvedSkills keeps canonical paths for snapshot / runtime consumers.
   const promptSkills = compactSkillPaths(resolvedSkills)
     .slice()
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => a.name.localeCompare(b.name, "en"));
   const { skillsForPrompt, truncated, compact } = applySkillsPromptLimits({
     skills: promptSkills,
     config: opts?.config,

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -574,29 +574,31 @@ function loadSkillEntries(
     merged.set(skill.name, skill);
   }
 
-  const skillEntries: SkillEntry[] = Array.from(merged.values()).map((skill) => {
-    const frontmatter =
-      readSkillFrontmatterSafe({
-        rootDir: skill.baseDir,
-        filePath: skill.filePath,
-        maxBytes: limits.maxSkillFileBytes,
-      }) ?? ({} as ParsedSkillFrontmatter);
-    const invocation = resolveSkillInvocationPolicy(frontmatter);
-    return {
-      skill,
-      frontmatter,
-      metadata: resolveOpenClawMetadata(frontmatter),
-      invocation,
-      exposure: {
-        includeInRuntimeRegistry: true,
-        // Freshly loaded entries preserve the documented disable-model-invocation
-        // contract, while legacy entries without exposure metadata still use the
-        // fallback in isSkillVisibleInAvailableSkillsPrompt().
-        includeInAvailableSkillsPrompt: invocation.disableModelInvocation !== true,
-        userInvocable: invocation.userInvocable !== false,
-      },
-    };
-  });
+  const skillEntries: SkillEntry[] = Array.from(merged.values())
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((skill) => {
+      const frontmatter =
+        readSkillFrontmatterSafe({
+          rootDir: skill.baseDir,
+          filePath: skill.filePath,
+          maxBytes: limits.maxSkillFileBytes,
+        }) ?? ({} as ParsedSkillFrontmatter);
+      const invocation = resolveSkillInvocationPolicy(frontmatter);
+      return {
+        skill,
+        frontmatter,
+        metadata: resolveOpenClawMetadata(frontmatter),
+        invocation,
+        exposure: {
+          includeInRuntimeRegistry: true,
+          // Freshly loaded entries preserve the documented disable-model-invocation
+          // contract, while legacy entries without exposure metadata still use the
+          // fallback in isSkillVisibleInAvailableSkillsPrompt().
+          includeInAvailableSkillsPrompt: invocation.disableModelInvocation !== true,
+          userInvocable: invocation.userInvocable !== false,
+        },
+      };
+    });
   return skillEntries;
 }
 
@@ -760,7 +762,9 @@ function resolveWorkspaceSkillPromptState(
   // Budget checks and final render both use this same representation so the
   // tier decision is based on the exact strings that end up in the prompt.
   // resolvedSkills keeps canonical paths for snapshot / runtime consumers.
-  const promptSkills = compactSkillPaths(resolvedSkills);
+  const promptSkills = compactSkillPaths(resolvedSkills)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
   const { skillsForPrompt, truncated, compact } = applySkillsPromptLimits({
     skills: promptSkills,
     config: opts?.config,

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -372,23 +372,41 @@ describe("gateway-status command", () => {
 
   it("surfaces unresolved SecretRef auth diagnostics when probe fails", async () => {
     const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
-    await withEnvAsync({ MISSING_GATEWAY_TOKEN: undefined }, async () => {
-      mockLocalTokenEnvRefConfig();
-      probeGateway.mockResolvedValueOnce({
-        ok: false,
-        url: "ws://127.0.0.1:18789",
-        connectLatencyMs: null,
-        error: "connection refused",
-        close: null,
-        health: null,
-        status: null,
-        presence: null,
-        configSnapshot: null,
+    const defaultReadBestEffortConfig = readBestEffortConfig.getMockImplementation();
+    const defaultProbeGateway = probeGateway.getMockImplementation();
+    try {
+      await withEnvAsync({ MISSING_GATEWAY_TOKEN: undefined }, async () => {
+        readBestEffortConfig.mockReset();
+        probeGateway.mockReset();
+        mockLocalTokenEnvRefConfig();
+        probeGateway.mockImplementation(async (opts: { url: string }) => {
+          const { url } = opts;
+          return {
+            ok: false,
+            url,
+            connectLatencyMs: null,
+            error: "connection refused",
+            close: null,
+            health: null,
+            status: null,
+            presence: null,
+            configSnapshot: null,
+          };
+        });
+        await expect(runGatewayStatus(runtime, { timeout: "1000", json: true })).rejects.toThrow(
+          "__exit__:1",
+        );
       });
-      await expect(runGatewayStatus(runtime, { timeout: "1000", json: true })).rejects.toThrow(
-        "__exit__:1",
-      );
-    });
+    } finally {
+      readBestEffortConfig.mockReset();
+      if (defaultReadBestEffortConfig) {
+        readBestEffortConfig.mockImplementation(defaultReadBestEffortConfig);
+      }
+      probeGateway.mockReset();
+      if (defaultProbeGateway) {
+        probeGateway.mockImplementation(defaultProbeGateway);
+      }
+    }
 
     expect(runtimeErrors).toHaveLength(0);
     const unresolvedWarning = findUnresolvedSecretRefWarning(runtimeLogs);

--- a/src/plugins/contracts/speech-vitest-registry.ts
+++ b/src/plugins/contracts/speech-vitest-registry.ts
@@ -108,6 +108,21 @@ function loadVitestMusicGenerationFallbackEntries(
   });
 }
 
+function loadVitestSpeechFallbackEntries(
+  pluginIds: readonly string[],
+): SpeechProviderContractEntry[] {
+  return loadVitestCapabilityContractEntries({
+    contract: "speechProviders",
+    pluginSdkResolution: "src",
+    pluginIds,
+    pickEntries: (registry) =>
+      registry.speechProviders.map((entry) => ({
+        pluginId: entry.pluginId,
+        provider: entry.provider,
+      })),
+  });
+}
+
 function hasExplicitVideoGenerationModes(provider: VideoGenerationProviderPlugin): boolean {
   return Boolean(
     provider.capabilities.generate &&
@@ -156,7 +171,7 @@ function loadVitestCapabilityContractEntries<T>(params: {
 }
 
 export function loadVitestSpeechProviderContractRegistry(): SpeechProviderContractEntry[] {
-  return loadVitestCapabilityContractEntries({
+  const entries = loadVitestCapabilityContractEntries({
     contract: "speechProviders",
     pickEntries: (registry) =>
       registry.speechProviders.map((entry) => ({
@@ -164,6 +179,19 @@ export function loadVitestSpeechProviderContractRegistry(): SpeechProviderContra
         provider: entry.provider,
       })),
   });
+  const coveredPluginIds = new Set(entries.map((entry) => entry.pluginId));
+  const missingPluginIds = VITEST_CONTRACT_PLUGIN_IDS.speechProviders.filter(
+    (pluginId) => !coveredPluginIds.has(pluginId),
+  );
+  if (missingPluginIds.length === 0) {
+    return entries;
+  }
+  const replacementEntries = loadVitestSpeechFallbackEntries(missingPluginIds);
+  const replacedPluginIds = new Set(replacementEntries.map((entry) => entry.pluginId));
+  return [
+    ...entries.filter((entry) => !replacedPluginIds.has(entry.pluginId)),
+    ...replacementEntries,
+  ];
 }
 
 export function loadVitestMediaUnderstandingProviderContractRegistry(): MediaUnderstandingProviderContractEntry[] {


### PR DESCRIPTION
## Summary

Sort the merged skill entries by name before rendering into the `<available_skills>` prompt block.

## Problem

The order of skills in `<available_skills>` depended on `Map` insertion order, which varies with the order of directories in `skills.load.extraDirs`. In multi-instance cloud deployments, each instance could produce a different prompt, bypassing LLM prompt caching and increasing API costs.

## Fix

Two alphabetical sort points added:

1. **`loadSkillEntries`** — canonical ordering at the data source, after the precedence-based merge
2. **`resolveWorkspaceSkillPromptState`** — ensures prompt stability even when callers pass pre-built entry arrays directly

Both use `name.localeCompare(name)` for stable, locale-aware ordering.

## Test

Added a test that passes entries in non-alphabetical order (`zoo, apple, mango, banana`) and verifies the prompt output contains them sorted as `apple, banana, mango, zoo`.

All 19 existing tests in `compact-format.test.ts` continue to pass.

Fixes #64167