### PR TITLE
Add cloud-local OpenClaw stability control loop

### DIFF
--- a/.github/workflows/agent-cloud-control.yml
+++ b/.github/workflows/agent-cloud-control.yml
@@ -1,0 +1,58 @@
+name: Agent Cloud Control
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_local_smoke:
+        description: "Run local smoke test on self-hosted Windows runner"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: "*/30 * * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/agent-cloud-control.yml"
+      - "scripts/ci/validate_openclaw_stack.py"
+      - "tools/openclaw-local-guard.ps1"
+      - "tools/openclaw-cdp-proxy.js"
+      - "docs/openclaw-cloud-local-stability.md"
+
+jobs:
+  cloud-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate Cloud/Local Control Files
+        run: python scripts/ci/validate_openclaw_stack.py
+
+  local-smoke:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_local_smoke == 'true' }}
+    runs-on:
+      - self-hosted
+      - windows
+      - openclaw
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Local Smoke
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Path .tmp -Force | Out-Null
+          .\tools\openclaw-local-guard.ps1 -Action smoke -JsonOut ".tmp\openclaw-local-health.json"
+
+      - name: Upload Local Health Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: openclaw-local-health
+          path: .tmp/openclaw-local-health.json

--- a/docs/openclaw-cloud-local-stability.md
+++ b/docs/openclaw-cloud-local-stability.md
@@ -1,0 +1,74 @@
+# OpenClaw Cloud + Local Stability Plan
+
+This setup gives you a stable control loop in two layers:
+
+1. Cloud control plane (GitHub Actions)
+2. Local execution plane (Windows + WSL + OpenClaw + Edge CDP bridge)
+
+## What was added
+
+- `.github/workflows/agent-cloud-control.yml`
+- `scripts/ci/validate_openclaw_stack.py`
+- `tools/openclaw-local-guard.ps1`
+- `tools/openclaw-cdp-proxy.js`
+
+## Layer 1: Cloud control plane
+
+Workflow: `Agent Cloud Control`
+
+- `cloud-validate` job runs on GitHub-hosted Ubuntu
+- validates required control-plane files are present and structurally sane
+- runs every 30 minutes and on manual dispatch
+
+Manual run:
+
+1. Open GitHub Actions
+2. Select `Agent Cloud Control`
+3. Click `Run workflow`
+
+## Layer 2: Local execution plane
+
+Local guard script:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\\tools\\openclaw-local-guard.ps1 -Action status
+powershell -ExecutionPolicy Bypass -File .\\tools\\openclaw-local-guard.ps1 -Action repair
+powershell -ExecutionPolicy Bypass -File .\\tools\\openclaw-local-guard.ps1 -Action smoke
+```
+
+What `repair` does:
+
+- ensures WSL Ollama service is running
+- ensures OpenClaw launch process is running
+- ensures Edge starts with remote debugging (`9333`)
+- ensures CDP proxy starts (`9334 -> 9333`)
+
+What `smoke` verifies:
+
+- `ollama` API reachable in WSL
+- OpenClaw gateway reachable in WSL
+- WSL can reach Windows CDP proxy endpoint
+
+## Optional: GitHub-triggered local smoke
+
+If you add a self-hosted runner on your Windows machine with labels:
+
+- `self-hosted`
+- `windows`
+- `openclaw`
+
+Then `Run workflow` with `run_local_smoke=true` will execute:
+
+```powershell
+.\\tools\\openclaw-local-guard.ps1 -Action smoke -JsonOut ".tmp\\openclaw-local-health.json"
+```
+
+and upload the JSON health artifact to GitHub Actions.
+
+## Why this closes the loop
+
+- Cloud side continuously validates the control-plane definition.
+- Local side can self-repair and output machine-readable health.
+- Both sides use repeatable commands with clear pass/fail signals.
+
+This is the minimum stable baseline before adding higher-level task orchestration.

--- a/scripts/ci/validate_openclaw_stack.py
+++ b/scripts/ci/validate_openclaw_stack.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate cloud/local control-plane files for OpenClaw stack."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_FILES = [
+    ".github/workflows/agent-cloud-control.yml",
+    "scripts/ci/validate_openclaw_stack.py",
+    "tools/openclaw-local-guard.ps1",
+    "tools/openclaw-cdp-proxy.js",
+    "docs/openclaw-cloud-local-stability.md",
+]
+
+REQUIRED_MARKERS = {
+    ".github/workflows/agent-cloud-control.yml": [
+        "cloud-validate",
+        "local-smoke",
+        "runs-on:",
+    ],
+    "tools/openclaw-local-guard.ps1": [
+        "param(",
+        "ValidateSet('status', 'repair', 'smoke')",
+        "Invoke-Wsl",
+    ],
+    "tools/openclaw-cdp-proxy.js": [
+        "net.createServer",
+        "targetPort",
+        "listenPort",
+    ],
+}
+
+
+def main() -> int:
+    missing = []
+    marker_failures = []
+
+    for rel_path in REQUIRED_FILES:
+        file_path = ROOT / rel_path
+        if not file_path.exists():
+            missing.append(rel_path)
+
+    if missing:
+        print(json.dumps({"ok": False, "missing": missing}, ensure_ascii=True, indent=2))
+        return 1
+
+    for rel_path, markers in REQUIRED_MARKERS.items():
+        text = (ROOT / rel_path).read_text(encoding="utf-8", errors="replace")
+        for marker in markers:
+            if marker not in text:
+                marker_failures.append({"file": rel_path, "marker": marker})
+
+    result = {
+        "ok": len(marker_failures) == 0,
+        "missing": missing,
+        "marker_failures": marker_failures,
+    }
+    print(json.dumps(result, ensure_ascii=True, indent=2))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/openclaw-cdp-proxy.js
+++ b/tools/openclaw-cdp-proxy.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+"use strict";
+
+const net = require("net");
+
+const args = process.argv.slice(2);
+
+function readArg(name, fallback) {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx + 1 >= args.length) return fallback;
+  const value = Number(args[idx + 1]);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+const listenPort = readArg("--listen-port", 9334);
+const targetPort = readArg("--target-port", 9333);
+const targetHost = "127.0.0.1";
+
+const server = net.createServer((client) => {
+  const upstream = net.connect({ host: targetHost, port: targetPort });
+
+  client.pipe(upstream);
+  upstream.pipe(client);
+
+  const cleanup = () => {
+    if (!client.destroyed) client.destroy();
+    if (!upstream.destroyed) upstream.destroy();
+  };
+
+  client.on("error", cleanup);
+  upstream.on("error", cleanup);
+  client.on("close", cleanup);
+  upstream.on("close", cleanup);
+});
+
+server.on("error", (err) => {
+  process.stderr.write(`[cdp-proxy] server error: ${err.message}\n`);
+  process.exit(1);
+});
+
+server.listen(listenPort, "0.0.0.0", () => {
+  process.stdout.write(
+    `[cdp-proxy] listening on 0.0.0.0:${listenPort}, forwarding to ${targetHost}:${targetPort}\n`
+  );
+});

--- a/tools/openclaw-local-guard.ps1
+++ b/tools/openclaw-local-guard.ps1
@@ -1,0 +1,313 @@
+[CmdletBinding()]
+param(
+  [ValidateSet('status', 'repair', 'smoke')]
+  [string]$Action = 'status',
+  [string]$WslDistro = 'Ubuntu',
+  [string]$WslUser = 'root',
+  [string]$Model = 'gemma4:e4b',
+  [int]$GatewayPort = 8081,
+  [int]$OllamaPort = 11434,
+  [int]$EdgeDebugPort = 9333,
+  [int]$ProxyPort = 9334,
+  [string]$JsonOut = ''
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Invoke-Wsl {
+  param(
+    [Parameter(Mandatory = $true)][string]$Command,
+    [switch]$AllowFailure
+  )
+
+  $output = & wsl -d $WslDistro -u $WslUser -- bash -lc "$Command" 2>&1
+  $exitCode = $LASTEXITCODE
+  if (-not $AllowFailure -and $exitCode -ne 0) {
+    throw "WSL command failed ($exitCode): $Command`n$($output -join "`n")"
+  }
+  return [pscustomobject]@{
+    ExitCode = $exitCode
+    Output   = @($output)
+  }
+}
+
+function Test-HttpEndpoint {
+  param(
+    [Parameter(Mandatory = $true)][string]$Url,
+    [int]$TimeoutSec = 4
+  )
+
+  try {
+    $invokeParams = @{
+      Uri = $Url
+      TimeoutSec = $TimeoutSec
+    }
+    if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey('UseBasicParsing')) {
+      $invokeParams['UseBasicParsing'] = $true
+    }
+    $resp = Invoke-WebRequest @invokeParams
+    return [pscustomobject]@{
+      Ok     = $true
+      Detail = "HTTP $([int]$resp.StatusCode)"
+    }
+  } catch {
+    return [pscustomobject]@{
+      Ok     = $false
+      Detail = $_.Exception.Message
+    }
+  }
+}
+
+function Get-WslGatewayIp {
+  $result = Invoke-Wsl -Command "ip route | sed -n 's/^default via \\([^ ]*\\).*/\\1/p' | head -n 1" -AllowFailure
+  $ip = ($result.Output | Select-Object -First 1).Trim()
+  if ([string]::IsNullOrWhiteSpace($ip) -or $ip -notmatch '^\d{1,3}(\.\d{1,3}){3}$') {
+    return $null
+  }
+  return $ip
+}
+
+function Get-EdgePath {
+  $candidates = @(
+    "$env:ProgramFiles\Microsoft\Edge\Application\msedge.exe",
+    "${env:ProgramFiles(x86)}\Microsoft\Edge\Application\msedge.exe"
+  )
+  foreach ($path in $candidates) {
+    if ($path -and (Test-Path $path)) {
+      return $path
+    }
+  }
+  return $null
+}
+
+function Ensure-EdgeDebugSession {
+  $edgePath = Get-EdgePath
+  if (-not $edgePath) {
+    return [pscustomobject]@{ Ok = $false; Detail = 'Edge executable not found.' }
+  }
+
+  $existing = Get-CimInstance Win32_Process |
+    Where-Object {
+      $_.Name -eq 'msedge.exe' -and
+      $_.CommandLine -like "*--remote-debugging-port=$EdgeDebugPort*" -and
+      $_.CommandLine -like '*openclaw-edge-cdp*'
+    } |
+    Select-Object -First 1
+
+  if (-not $existing) {
+    $userDataDir = 'C:\openclaw-edge-cdp'
+    New-Item -ItemType Directory -Path $userDataDir -Force | Out-Null
+    Start-Process -FilePath $edgePath -ArgumentList @(
+      "--remote-debugging-port=$EdgeDebugPort",
+      '--remote-debugging-address=127.0.0.1',
+      "--user-data-dir=$userDataDir"
+    ) | Out-Null
+    Start-Sleep -Seconds 2
+  }
+
+  return Test-HttpEndpoint -Url "http://127.0.0.1:$EdgeDebugPort/json/version"
+}
+
+function Ensure-CdpProxy {
+  $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+  if (-not $nodeCmd) {
+    return [pscustomobject]@{ Ok = $false; Detail = 'node command not found.' }
+  }
+
+  $proxyScript = Join-Path $PSScriptRoot 'openclaw-cdp-proxy.js'
+  if (-not (Test-Path $proxyScript)) {
+    return [pscustomobject]@{ Ok = $false; Detail = "Proxy script not found: $proxyScript" }
+  }
+
+  $existing = Get-CimInstance Win32_Process |
+    Where-Object {
+      $_.Name -eq 'node.exe' -and
+      $_.CommandLine -like "*openclaw-cdp-proxy.js*" -and
+      $_.CommandLine -like "*--listen-port $ProxyPort*" -and
+      $_.CommandLine -like "*--target-port $EdgeDebugPort*"
+    } |
+    Select-Object -First 1
+
+  if (-not $existing) {
+    Start-Process -FilePath $nodeCmd.Source -ArgumentList @(
+      $proxyScript,
+      '--listen-port', $ProxyPort,
+      '--target-port', $EdgeDebugPort
+    ) -WindowStyle Hidden | Out-Null
+    Start-Sleep -Seconds 1
+  }
+
+  return Test-HttpEndpoint -Url "http://127.0.0.1:$ProxyPort/json/version"
+}
+
+function Ensure-WslCoreServices {
+  $service = Invoke-Wsl -Command "systemctl is-active ollama || true" -AllowFailure
+  $serviceState = ($service.Output | Select-Object -First 1).Trim()
+  if ($serviceState -ne 'active') {
+    [void](Invoke-Wsl -Command 'systemctl start ollama' -AllowFailure)
+    Start-Sleep -Seconds 2
+  }
+
+  $running = Invoke-Wsl -Command "pgrep -af 'openclaw-gateway|ollama launch openclaw|openclaw launch' || true" -AllowFailure
+  if (-not @($running.Output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }).Count) {
+    [void](Invoke-Wsl -Command "setsid ollama launch openclaw --yes --model $Model >/tmp/openclaw-launch.log 2>&1 < /dev/null &" -AllowFailure)
+    Start-Sleep -Seconds 4
+  }
+}
+
+function Get-OpenClawStatus {
+  $checks = @()
+  $gatewayIp = $null
+  $configCdpUrl = ''
+
+  try {
+    $wslPing = Invoke-Wsl -Command 'echo ok'
+    $checks += [pscustomobject]@{ name = 'wsl_reachable'; ok = ($wslPing.ExitCode -eq 0); detail = (($wslPing.Output | Select-Object -First 1).Trim()) }
+  } catch {
+    $checks += [pscustomobject]@{ name = 'wsl_reachable'; ok = $false; detail = $_.Exception.Message }
+  }
+
+  $gatewayIp = Get-WslGatewayIp
+  $gatewayDetail = 'not resolved'
+  if ($gatewayIp) {
+    $gatewayDetail = $gatewayIp
+  }
+  $checks += [pscustomobject]@{
+      name = 'wsl_gateway_ip'
+      ok = -not [string]::IsNullOrWhiteSpace($gatewayIp)
+      detail = $gatewayDetail
+    }
+
+  $ollamaPortCheck = Invoke-Wsl -Command "ss -ltn '( sport = :$OllamaPort )' | tail -n +2 | wc -l" -AllowFailure
+  $ollamaListening = ((($ollamaPortCheck.Output | Select-Object -First 1).Trim()) -as [int]) -gt 0
+  $checks += [pscustomobject]@{ name = 'ollama_listening'; ok = $ollamaListening; detail = "port $OllamaPort" }
+
+  $gatewayPortCheck = Invoke-Wsl -Command "ss -ltn '( sport = :$GatewayPort )' | tail -n +2 | wc -l" -AllowFailure
+  $gatewayListening = ((($gatewayPortCheck.Output | Select-Object -First 1).Trim()) -as [int]) -gt 0
+  $checks += [pscustomobject]@{ name = 'openclaw_gateway_listening'; ok = $gatewayListening; detail = "port $GatewayPort" }
+
+  $configRaw = Invoke-Wsl -Command 'cat /root/.openclaw/openclaw.json' -AllowFailure
+  if ($configRaw.ExitCode -eq 0) {
+    try {
+      $cfg = ($configRaw.Output -join "`n") | ConvertFrom-Json
+      $allow = @($cfg.plugins.allow)
+      $hasBrowser = $allow -contains 'browser'
+      $hasWebSearch = $allow -contains 'openclaw-web-search'
+      $hasOllama = $allow -contains 'ollama'
+      $checks += [pscustomobject]@{ name = 'plugin_browser_enabled'; ok = $hasBrowser; detail = 'plugins.allow contains browser' }
+      $checks += [pscustomobject]@{ name = 'plugin_web_search_enabled'; ok = $hasWebSearch; detail = 'plugins.allow contains openclaw-web-search' }
+      $checks += [pscustomobject]@{ name = 'plugin_ollama_enabled'; ok = $hasOllama; detail = 'plugins.allow contains ollama' }
+      $configCdpUrl = [string]$cfg.browser.profiles.windows.cdpUrl
+    } catch {
+      $checks += [pscustomobject]@{ name = 'config_parse'; ok = $false; detail = $_.Exception.Message }
+    }
+  } else {
+    $checks += [pscustomobject]@{ name = 'config_exists'; ok = $false; detail = '/root/.openclaw/openclaw.json unreadable' }
+  }
+
+  $edgeStatus = Test-HttpEndpoint -Url "http://127.0.0.1:$EdgeDebugPort/json/version"
+  $checks += [pscustomobject]@{ name = 'edge_debug_ready'; ok = $edgeStatus.Ok; detail = $edgeStatus.Detail }
+
+  $proxyStatus = Test-HttpEndpoint -Url "http://127.0.0.1:$ProxyPort/json/version"
+  $checks += [pscustomobject]@{ name = 'cdp_proxy_ready'; ok = $proxyStatus.Ok; detail = $proxyStatus.Detail }
+
+  if ($gatewayIp) {
+    $wslCdp = Invoke-Wsl -Command "curl -fsS --max-time 4 http://${gatewayIp}:$ProxyPort/json/version >/dev/null 2>&1; echo `$?" -AllowFailure
+    $ok = ((($wslCdp.Output | Select-Object -First 1).Trim()) -eq '0')
+    $checks += [pscustomobject]@{
+        name = 'wsl_to_windows_cdp'
+        ok = $ok
+        detail = "http://${gatewayIp}:$ProxyPort/json/version"
+      }
+  } else {
+    $checks += [pscustomobject]@{ name = 'wsl_to_windows_cdp'; ok = $false; detail = 'gateway ip missing' }
+  }
+
+  $failedChecks = 0
+  foreach ($check in $checks) {
+    if (-not [bool]$check.ok) {
+      $failedChecks++
+    }
+  }
+  $overall = ($failedChecks -eq 0)
+
+  return [pscustomobject]@{
+    ok = $overall
+    action = $Action
+    timestamp = (Get-Date).ToString('s')
+    model = $Model
+    cdpUrlInConfig = $configCdpUrl
+    checks = @($checks)
+  }
+}
+
+function Run-Repair {
+  Ensure-WslCoreServices
+  [void](Ensure-EdgeDebugSession)
+  [void](Ensure-CdpProxy)
+}
+
+function Run-Smoke {
+  $gatewayIp = Get-WslGatewayIp
+  $smoke = @()
+
+  $ollamaApi = Invoke-Wsl -Command "curl -fsS --max-time 4 http://127.0.0.1:$OllamaPort/api/version >/dev/null 2>&1; echo `$?" -AllowFailure
+  $smoke += [pscustomobject]@{
+      name = 'ollama_api'
+      ok = ((($ollamaApi.Output | Select-Object -First 1).Trim()) -eq '0')
+      detail = "http://127.0.0.1:$OllamaPort/api/version"
+    }
+
+  $gatewayApi = Invoke-Wsl -Command "curl -fsS --max-time 4 http://127.0.0.1:$GatewayPort >/dev/null 2>&1; echo `$?" -AllowFailure
+  $smoke += [pscustomobject]@{
+      name = 'openclaw_gateway_api'
+      ok = ((($gatewayApi.Output | Select-Object -First 1).Trim()) -eq '0')
+      detail = "http://127.0.0.1:$GatewayPort"
+    }
+
+  if ($gatewayIp) {
+    $cdp = Invoke-Wsl -Command "curl -fsS --max-time 4 http://${gatewayIp}:$ProxyPort/json/version >/dev/null 2>&1; echo `$?" -AllowFailure
+    $smoke += [pscustomobject]@{
+        name = 'wsl_to_cdp'
+        ok = ((($cdp.Output | Select-Object -First 1).Trim()) -eq '0')
+        detail = "http://${gatewayIp}:$ProxyPort/json/version"
+      }
+  } else {
+    $smoke += [pscustomobject]@{
+        name = 'wsl_to_cdp'
+        ok = $false
+        detail = 'gateway ip missing'
+      }
+  }
+
+  return @($smoke)
+}
+
+if ($Action -eq 'repair' -or $Action -eq 'smoke') {
+  Run-Repair
+}
+
+$status = Get-OpenClawStatus
+if ($Action -eq 'smoke') {
+  $status | Add-Member -NotePropertyName smoke -NotePropertyValue (Run-Smoke)
+  $smokeFailed = 0
+  foreach ($item in $status.smoke) {
+    if (-not [bool]$item.ok) {
+      $smokeFailed++
+    }
+  }
+  $status.ok = ([bool]$status.ok -and ($smokeFailed -eq 0))
+}
+
+$json = $status | ConvertTo-Json -Depth 8
+
+if (-not [string]::IsNullOrWhiteSpace($JsonOut)) {
+  $parentDir = Split-Path -Parent $JsonOut
+  if (-not [string]::IsNullOrWhiteSpace($parentDir) -and -not (Test-Path $parentDir)) {
+    New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+  }
+  $json | Set-Content -Path $JsonOut -Encoding UTF8
+}
+
+$json


### PR DESCRIPTION
## Summary
- add a cloud validation workflow for OpenClaw cloud/local control loop
- add local guard script for `status` / `repair` / `smoke`
- add a lightweight CDP proxy helper for Windows desktop bridge
- add a validation script for control-plane files
- add docs for setup and operations

## Validation performed locally
- `openclaw-local-guard.ps1 -Action repair` -> ok=true
- `openclaw-local-guard.ps1 -Action status` -> ok=true
- `openclaw-local-guard.ps1 -Action smoke` -> ok=true
- `python3 scripts/ci/validate_openclaw_stack.py` -> ok=true

## Notes
- This PR is intentionally additive and does not modify existing business logic.
- Local smoke job requires a self-hosted Windows runner labeled: `self-hosted`, `windows`, `openclaw`.
