### PR TITLE
fix(text): strip Qwen-style XML tool call payloads from visible text (#63999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - Discord/TTS: route auto voice replies through the native voice-note path so Discord receives Opus voice messages instead of regular audio attachments. (#64096) Thanks @LiuHuaize.
 - Config/plugins: use plugin-owned command alias metadata when `plugins.allow` contains runtime command names like `dreaming`, and point users at the owning plugin instead of stale plugin-not-found guidance. (#64242) Thanks @feiskyer.
 - Agents/Gemini: strip orphaned `required` entries from Gemini tool schemas so provider validation no longer rejects tools after schema cleanup or union flattening. (#64284) Thanks @xxxxxmax.
+- Assistant text: strip Qwen-style XML tool call payloads from visible replies so web and channel messages no longer show raw `<tool_call><function=...>` output. (#64214) Thanks @MoerAI.
 
 ## 2026.4.9
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -152,6 +152,27 @@ describe("stripAssistantInternalScaffolding", () => {
       );
     });
 
+    it("strips Qwen-style <tool_call> with nested <function=...> XML", () => {
+      expectVisibleText(
+        "prefix\n<tool_call><function=read><parameter=path>/home/user</parameter></function></tool_call>\nsuffix",
+        "prefix\n\nsuffix",
+      );
+    });
+
+    it("strips Qwen-style <tool_call> with whitespace before nested XML", () => {
+      expectVisibleText(
+        "prefix\n<tool_call>\n<function=search><parameter=query>test</parameter></function>\n</tool_call>\nsuffix",
+        "prefix\n\nsuffix",
+      );
+    });
+
+    it("strips dangling Qwen-style <tool_call> with nested XML to end", () => {
+      expectVisibleText(
+        "prefix\n<tool_call><function=read><parameter=path>/home",
+        "prefix\n",
+      );
+    });
+
     it("does not close early on </tool_call> text inside JSON strings", () => {
       expectVisibleText(
         [

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -25,6 +25,8 @@ const TOOL_CALL_TAG_NAMES = new Set([
 ]);
 const TOOL_CALL_JSON_PAYLOAD_START_RE =
   /^(?:\s+[A-Za-z_:][-A-Za-z0-9_:.]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))*\s*(?:\r?\n\s*)?[[{]/;
+const TOOL_CALL_XML_PAYLOAD_START_RE =
+  /^\s*(?:\r?\n\s*)?<(?:function|invoke|parameters?|arguments?)\b/i;
 
 function endsInsideQuotedString(text: string, start: number, end: number): boolean {
   let quoteChar: "'" | '"' | null = null;
@@ -107,7 +109,11 @@ function findTagCloseIndex(text: string, start: number): number {
 }
 
 function looksLikeToolCallPayloadStart(text: string, start: number): boolean {
-  return TOOL_CALL_JSON_PAYLOAD_START_RE.test(text.slice(start));
+  const rest = text.slice(start);
+  return (
+    TOOL_CALL_JSON_PAYLOAD_START_RE.test(rest) ||
+    TOOL_CALL_XML_PAYLOAD_START_RE.test(rest)
+  );
 }
 
 function parseToolCallTagAt(text: string, start: number): ParsedToolCallTag | null {
@@ -212,9 +218,14 @@ export function stripToolCallXmlTags(text: string): string {
         idx = Math.max(idx, tag.end - 1);
         continue;
       }
+      const payloadStart = tag.isTruncated ? tag.contentStart : tag.end;
+      const hasToolCallPayloadStart =
+        tag.tagName === "tool_call"
+          ? looksLikeToolCallPayloadStart(text, payloadStart)
+          : TOOL_CALL_JSON_PAYLOAD_START_RE.test(text.slice(payloadStart));
       if (
         !tag.isClose &&
-        looksLikeToolCallPayloadStart(text, tag.isTruncated ? tag.contentStart : tag.end)
+        hasToolCallPayloadStart
       ) {
         inToolCallBlock = true;
         toolCallContentStart = tag.end;


### PR DESCRIPTION
## Summary
Qwen models emit tool calls as nested XML (`<tool_call><function=read><parameter=path>...</parameter></function></tool_call>`) instead of JSON. The `stripToolCallXmlTags` sanitizer only recognized JSON payloads after `<tool_call>` tags, so Qwen's XML format leaked into user-visible chat bubbles and channel delivery.

## Root Cause
`looksLikeToolCallPayloadStart` checked `TOOL_CALL_JSON_PAYLOAD_START_RE` which required `[{` after the opening tag. Qwen's nested XML starts with `<function=...>` which doesn't match, causing the sanitizer to preserve the tag content as prose.

## Changes
- `src/shared/text/assistant-visible-text.ts`: Added `TOOL_CALL_XML_PAYLOAD_START_RE` to recognize known inner tool call XML element names (`function`, `invoke`, `parameter(s)`, `argument(s)`) after `<tool_call>` tags. Extended `looksLikeToolCallPayloadStart` to check both JSON and XML patterns, scoped to `tool_call` tags only.
- `src/shared/text/assistant-visible-text.test.ts`: Added regression tests for Qwen XML stripping (inline, whitespace-prefixed, and dangling).

## Test
55 tests passed (`pnpm test src/shared/text/assistant-visible-text.test.ts`). Existing prose-preservation tests unaffected.

Closes #63999