### PR TITLE
fix(skills): sort available_skills alphabetically for deterministic prompt ordering (#64167)

### DIFF
--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import path from "node:path";
 import { formatSkillsForPrompt as upstreamFormatSkillsForPrompt } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -123,6 +124,22 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt).not.toContain("hidden");
   });
 
+  it("sorts available skills alphabetically before formatting the prompt", () => {
+    const prompt = buildPrompt([
+      makeSkill("zebra", "last"),
+      makeSkill("monkey", "middle"),
+      makeSkill("ant", "first"),
+    ]);
+
+    const antIndex = prompt.indexOf("<name>ant</name>");
+    const monkeyIndex = prompt.indexOf("<name>monkey</name>");
+    const zebraIndex = prompt.indexOf("<name>zebra</name>");
+
+    expect(antIndex).toBeGreaterThanOrEqual(0);
+    expect(monkeyIndex).toBeGreaterThan(antIndex);
+    expect(zebraIndex).toBeGreaterThan(monkeyIndex);
+  });
+
   it("tier 1: uses full format when under budget", () => {
     const skills = [makeSkill("weather", "Get weather data")];
     const prompt = buildPrompt(skills, { maxChars: 50_000 });
@@ -230,15 +247,15 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     const home = os.homedir();
     const skills = Array.from({ length: 30 }, (_, i) =>
       makeSkill(
-        `skill-${i}`,
+        `skill-${String(i).padStart(2, "0")}`,
         "A".repeat(200),
-        `${home}/.openclaw/workspace/skills/skill-${i}/SKILL.md`,
+        path.join(home, ".openclaw", "workspace", "skills", `skill-${String(i).padStart(2, "0")}`, "SKILL.md"),
       ),
     );
     // Compute compacted lengths (what the prompt will actually contain)
     const compactedSkills = skills.map((s) => ({
       ...s,
-      filePath: s.filePath.replace(home, "~"),
+      filePath: s.filePath.replace(`${home}${path.sep}`, "~/"),
     }));
     const compactedCompactLen = formatSkillsCompact(compactedSkills).length;
     const canonicalCompactLen = formatSkillsCompact(skills).length;
@@ -249,7 +266,7 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     const budget = Math.floor((compactedCompactLen + canonicalCompactLen) / 2) + 150;
     const prompt = buildPrompt(skills, { maxChars: budget });
     // All 30 skills should be preserved in compact form (tier 2, no dropping)
-    expect(prompt).toContain("skill-0");
+    expect(prompt).toContain("skill-00");
     expect(prompt).toContain("skill-29");
     expect(prompt).not.toContain("included");
     expect(prompt).toContain("compact format");
@@ -261,7 +278,11 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
   it("resolvedSkills in snapshot keeps canonical paths, not compacted", () => {
     const home = os.homedir();
     const skills = Array.from({ length: 5 }, (_, i) =>
-      makeSkill(`skill-${i}`, "A skill", `${home}/.openclaw/workspace/skills/skill-${i}/SKILL.md`),
+      makeSkill(
+        `skill-${i}`,
+        "A skill",
+        path.join(home, ".openclaw", "workspace", "skills", `skill-${i}`, "SKILL.md"),
+      ),
     );
     const snapshot = buildWorkspaceSkillSnapshot("/fake", {
       entries: skills.map(makeEntry),

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -650,7 +650,7 @@ function resolveWorkspaceSkillPromptState(
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries
     .map((entry) => entry.skill)
-    .toSorted((a, b) => a.name.localeCompare(b.name));
+    .toSorted((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.
   // Budget checks and final render both use this same representation so the
   // tier decision is based on the exact strings that end up in the prompt.

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -648,7 +648,9 @@ function resolveWorkspaceSkillPromptState(
   );
   const promptEntries = eligible.filter((entry) => isSkillVisibleInAvailableSkillsPrompt(entry));
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
-  const resolvedSkills = promptEntries.map((entry) => entry.skill);
+  const resolvedSkills = promptEntries
+    .map((entry) => entry.skill)
+    .toSorted((a, b) => a.name.localeCompare(b.name));
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.
   // Budget checks and final render both use this same representation so the
   // tier decision is based on the exact strings that end up in the prompt.


### PR DESCRIPTION
## Summary
The `available_skills` prompt section ordering depended on `extraDirs` config order instead of being deterministic. In multi-instance deployments, each instance could produce different prompts, bypassing LLM prompt cache and increasing API costs.

## Root Cause
`resolveWorkspaceSkillPromptState()` in `src/agents/skills/workspace.ts` assembled skills from a Map that preserved insertion order from the config-ordered directory scan. No sort was applied before formatting into the prompt.

## Changes
- `src/agents/skills/workspace.ts`: Sort `resolvedSkills` alphabetically by `name` before passing to `compactSkillPaths()` and downstream formatting functions.
- `src/agents/skills/compact-format.test.ts`: Added regression test verifying alphabetical ordering in the rendered `<available_skills>` block.

## Test
39 tests passed (`pnpm test src/agents/skills/`). The new regression test feeds reverse-ordered skills and asserts alphabetical output.

Closes #64167