### PR TITLE
fix(btw): allow aws-sdk auth for bedrock side questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/pairing: fail closed for paired device records that have no device tokens, and reject pairing approvals whose requested scopes do not match the requested device roles.
 - ACP/gateway chat: classify lifecycle errors before forwarding them to ACP clients so refusals use ACP's refusal stop reason while transient backend errors continue to finish as normal turns.
 - Commands/btw: keep tool-less side questions from sending injected empty `tools` arrays on strict OpenAI-compatible providers, so `/btw` continues working after prior tool-call history. (#64219) Thanks @ngutman.
+- Agents/Bedrock: let `/btw` side questions use `auth: "aws-sdk"` without a static API key so Bedrock IAM and instance-role sessions stop failing before the side question runs. (#64218) Thanks @SnowSky1.
 
 ## 2026.4.9
 

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -312,6 +312,37 @@ describe("runBtwSideQuestion", () => {
     expect(result).toBeUndefined();
   });
 
+  it("allows Bedrock /btw runs to proceed without a static api key in aws-sdk mode", async () => {
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "amazon-bedrock",
+      id: "us.anthropic.claude-sonnet-4-5-v1:0",
+      api: "anthropic-messages",
+    });
+    getApiKeyForModelMock.mockResolvedValue({
+      apiKey: undefined,
+      mode: "aws-sdk",
+      source: "aws-sdk default chain",
+    });
+    streamSimpleMock.mockReturnValue(makeAsyncEvents([createDoneEvent("Bedrock answer.")]));
+
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: DEFAULT_AGENT_DIR,
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-sonnet-4-5-v1:0",
+      question: DEFAULT_QUESTION,
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: DEFAULT_REASONING_LEVEL,
+      opts: {},
+      isNewSession: false,
+    });
+
+    expect(result).toEqual({ text: "Bedrock answer." });
+    expect(requireApiKeyMock).not.toHaveBeenCalled();
+    const [, , options] = streamSimpleMock.mock.calls.at(-1) ?? [];
+    expect((options as { apiKey?: string } | undefined)?.apiKey).toBeUndefined();
+  });
+
   it("forces provider reasoning off even when the session think level is adaptive", async () => {
     streamSimpleMock.mockImplementation((_model, _input, options?: { reasoning?: unknown }) => {
       return options?.reasoning === undefined

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -256,7 +256,10 @@ export async function runBtwSideQuestion(
     profileId: authProfileId,
     agentDir: params.agentDir,
   });
-  const apiKey = requireApiKey(apiKeyInfo, model.provider);
+  const apiKey =
+    apiKeyInfo.mode === "aws-sdk" && !apiKeyInfo.apiKey
+      ? undefined
+      : requireApiKey(apiKeyInfo, model.provider);
 
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking


### PR DESCRIPTION
## Summary

- allow `/btw` to skip `requireApiKey(...)` when Bedrock resolves `auth: aws-sdk` without a static key
- keep the existing API key guard for auth modes that still require a concrete key
- add a Bedrock regression test that proves `/btw` forwards no `apiKey` in the `aws-sdk` path

## Why

`runBtwSideQuestion()` currently resolves provider auth via `getApiKeyForModel(...)`, then immediately calls `requireApiKey(...)` unconditionally. That breaks Bedrock setups that intentionally use IAM/AWS SDK credential resolution instead of a static API key, even though the main embedded runners already allow `mode === "aws-sdk"` without one.

This revives the good part of #53598 with the smallest possible patch. I kept the fix aligned with the existing runner behavior in `compact.ts` and `run/auth-controller.ts`, and avoided the broken import path introduced in #53730.

## Scope

- Fixes #53592
- Fixes #55571
- Supersedes #53598
- The follow-up Bedrock `toolConfig` problem remains separately tracked in #56558

## Verification

- `pnpm test src/agents/btw.test.ts`
- `pnpm check`
