### PR TITLE
fix(btw): omit empty tools arrays for tool-less side questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - iMessage (imsg): strip an accidental protobuf length-delimited UTF-8 field wrapper from inbound `text` and `reply_to_text` when it fully consumes the field, fixing leading garbage before the real message. (#63868) Thanks @neeravmakwana.
 - Gateway/pairing: fail closed for paired device records that have no device tokens, and reject pairing approvals whose requested scopes do not match the requested device roles.
 - ACP/gateway chat: classify lifecycle errors before forwarding them to ACP clients so refusals use ACP's refusal stop reason while transient backend errors continue to finish as normal turns.
+- Commands/btw: keep tool-less side questions from sending injected empty `tools` arrays on strict OpenAI-compatible providers, so `/btw` continues working after prior tool-call history. (#64219) Thanks @ngutman.
 
 ## 2026.4.9
 

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -297,6 +297,21 @@ describe("runBtwSideQuestion", () => {
     expect(result).toEqual({ text: "Final answer." });
   });
 
+  it("strips injected empty tools arrays from BTW payloads before sending", async () => {
+    mockDoneAnswer("Final answer.");
+
+    await runSideQuestion();
+
+    const [, , options] = streamSimpleMock.mock.calls[0] ?? [];
+    const onPayload = (options as { onPayload?: (payload: unknown) => void })?.onPayload;
+    const payloadWithEmptyTools = { messages: [], tools: [] as unknown[] };
+
+    const result = onPayload?.(payloadWithEmptyTools);
+
+    expect(payloadWithEmptyTools).not.toHaveProperty("tools");
+    expect(result).toBeUndefined();
+  });
+
   it("forces provider reasoning off even when the session think level is adaptive", async () => {
     streamSimpleMock.mockImplementation((_model, _input, options?: { reasoning?: unknown }) => {
       return options?.reasoning === undefined

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -21,6 +21,7 @@ import { ensureOpenClawModelsJson } from "./models-config.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 import { resolveModelWithRegistry } from "./pi-embedded-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./pi-embedded-runner/runs.js";
+import { streamWithPayloadPatch } from "./pi-embedded-runner/stream-payload-utils.js";
 import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
 
@@ -283,7 +284,8 @@ export async function runBtwSideQuestion(
     await blockEmitChain;
   };
 
-  const stream = streamSimple(
+  const stream = await streamWithPayloadPatch(
+    streamSimple,
     model,
     {
       systemPrompt: buildBtwSystemPrompt(),
@@ -307,6 +309,13 @@ export async function runBtwSideQuestion(
       // reasoning off so we reliably receive answer text instead of thinking-only output.
       reasoning: undefined,
       signal: params.opts?.abortSignal,
+    },
+    (payloadObj) => {
+      // BTW is intentionally tool-less. Some OpenAI-compatible providers reject
+      // the empty tools arrays injected for generic tool-history replay.
+      if (Array.isArray(payloadObj.tools) && payloadObj.tools.length === 0) {
+        delete payloadObj.tools;
+      }
     },
   );
 


### PR DESCRIPTION
## Summary

- Problem: `/btw` can fail on strict OpenAI-compatible providers like ModelStudio/GLM because the outgoing request can still include `tools: []`.
- Why it matters: `/btw` is intentionally tool-less, but it reuses session context and can preserve prior assistant tool-call history, which triggers the generic empty-tools replay behavior.
- What changed: `/btw` now patches its outgoing payload to omit an injected empty `tools` array before send, and adds regression coverage for that path.
- What did NOT change (scope boundary): global OpenAI-compatible transport behavior for non-`/btw` runs remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53174
- Related #59669
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `/btw` is tool-less by design, but it still reuses assistant messages from the active session. Prior assistant `toolCall` history causes the OpenAI-compatible transport layer to inject `tools: []` for generic tool-history replay. Strict providers like ModelStudio/GLM reject that empty array.
- Missing detection / guardrail: `/btw` had no payload-level guard ensuring its tool-less requests stay tool-less after downstream transport shaping.
- Contributing context (if known): the generic empty-tools replay behavior is still useful for some Anthropic-via-proxy paths, so this needs to stay localized instead of changing global transport behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/btw.test.ts`
- Scenario the test should lock in: when `/btw` sends a payload and downstream shaping injects `tools: []`, the BTW-specific payload patch removes the field before send.
- Why this is the smallest reliable guardrail: it verifies the exact BTW request seam without changing global transport expectations for other providers.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`/btw` now works on strict OpenAI-compatible providers that reject empty `tools` arrays, while keeping BTW side questions tool-less.

## Diagram (if applicable)

```text
Before:
/btw with prior tool-call history -> transport injects tools: [] -> strict provider rejects request

After:
/btw with prior tool-call history -> BTW payload patch removes empty tools -> strict provider accepts request
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm
- Model/provider: strict OpenAI-compatible providers such as ModelStudio / GLM
- Integration/channel (if any): N/A
- Relevant config (redacted): model provider configured with `api: openai-completions`

### Steps

1. Use a strict OpenAI-compatible provider that rejects empty `tools` arrays.
2. Build session context containing prior assistant tool-call history.
3. Run `/btw <question>`.

### Expected

- `/btw` sends a tool-less request without `tools: []` and returns normally.

### Actual

- Before this change, the request could still include `tools: []` and fail with `400 [] is too short - 'tools'`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added and ran `src/agents/btw.test.ts`; confirmed the BTW payload hook removes an injected empty `tools` array.
- Edge cases checked: kept the fix localized to `/btw`; did not alter global OpenAI-compatible tool-history behavior.
- What you did **not** verify: live ModelStudio/GLM API calls against a real remote account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a future refactor could bypass the BTW-local payload patch.
  - Mitigation: add regression coverage in `src/agents/btw.test.ts` for the exact empty-tools injection path.
