### PR TITLE
fix(plugins): preserve context engine slot normalization

### DIFF
--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -26,6 +26,18 @@ function buildComfyConfig(config: Record<string, unknown>): OpenClawConfig {
   } as unknown as OpenClawConfig;
 }
 
+function buildPluginComfyConfig(config: Record<string, unknown>): OpenClawConfig {
+  return {
+    plugins: {
+      entries: {
+        comfy: {
+          config,
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
 describe("comfy image-generation provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,6 +53,20 @@ describe("comfy image-generation provider", () => {
     expect(
       provider.isConfigured?.({
         cfg: buildComfyConfig({
+          workflow: {
+            "6": { inputs: { text: "" } },
+          },
+          promptNodeId: "6",
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the bundled plugin config shape for local comfy workflows", () => {
+    const provider = buildComfyImageGenerationProvider();
+    expect(
+      provider.isConfigured?.({
+        cfg: buildPluginComfyConfig({
           workflow: {
             "6": { inputs: { text: "" } },
           },

--- a/extensions/comfy/music-generation-provider.test.ts
+++ b/extensions/comfy/music-generation-provider.test.ts
@@ -90,4 +90,71 @@ describe("comfy music-generation provider", () => {
     });
     expect(result.tracks[0]?.buffer).toEqual(Buffer.from("music-bytes"));
   });
+
+  it("accepts the bundled plugin config shape for music workflows", async () => {
+    _setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ prompt_id: "music-job-plugin" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            "music-job-plugin": {
+              outputs: {
+                "9": {
+                  audio: [{ filename: "song.mp3", subfolder: "", type: "output" }],
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("music-bytes"), {
+          status: 200,
+          headers: { "content-type": "audio/mpeg" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildComfyMusicGenerationProvider();
+    const result = await provider.generateMusic({
+      provider: "comfy",
+      model: "workflow",
+      prompt: "gentle ambient synth loop",
+      cfg: {
+        plugins: {
+          entries: {
+            comfy: {
+              config: {
+                music: {
+                  workflow: {
+                    "6": { inputs: { text: "" } },
+                    "9": { inputs: {} },
+                  },
+                  promptNodeId: "6",
+                  outputNodeId: "9",
+                },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.metadata).toMatchObject({
+      promptId: "music-job-plugin",
+      outputNodeIds: ["9"],
+    });
+  });
 });

--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -26,6 +26,18 @@ function buildComfyConfig(config: Record<string, unknown>): OpenClawConfig {
   } as unknown as OpenClawConfig;
 }
 
+function buildPluginComfyConfig(config: Record<string, unknown>): OpenClawConfig {
+  return {
+    plugins: {
+      entries: {
+        comfy: {
+          config,
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
 describe("comfy video-generation provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,6 +53,22 @@ describe("comfy video-generation provider", () => {
     expect(
       provider.isConfigured?.({
         cfg: buildComfyConfig({
+          video: {
+            workflow: {
+              "6": { inputs: { text: "" } },
+            },
+            promptNodeId: "6",
+          },
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the bundled plugin config shape for local comfy video workflows", () => {
+    const provider = buildComfyVideoGenerationProvider();
+    expect(
+      provider.isConfigured?.({
+        cfg: buildPluginComfyConfig({
           video: {
             workflow: {
               "6": { inputs: { text: "" } },

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -132,8 +132,11 @@ function mergeSsrFPolicies(...policies: Array<SsrFPolicy | undefined>): SsrFPoli
 }
 
 export function getComfyConfig(cfg?: OpenClawConfig): ComfyProviderConfig {
-  const raw = cfg?.models?.providers?.comfy;
-  return isRecord(raw) ? raw : {};
+  const legacyRaw = cfg?.models?.providers?.comfy;
+  const pluginRaw = cfg?.plugins?.entries?.comfy?.config;
+  const legacyConfig = isRecord(legacyRaw) ? legacyRaw : {};
+  const pluginConfig = isRecord(pluginRaw) ? pluginRaw : {};
+  return { ...pluginConfig, ...legacyConfig };
 }
 
 function stripNestedCapabilityConfig(config: ComfyProviderConfig): ComfyProviderConfig {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -6,6 +6,7 @@ import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearMemoryEmbeddingProviders as clearRegistry,
+  listMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider as registerAdapter,
 } from "../../../../src/plugins/memory-embedding-providers.js";
 import "./test-runtime-mocks.js";
@@ -346,6 +347,11 @@ describe("memory index", () => {
     expect(status.vector?.enabled).toBe(true);
     expect(typeof status.vector?.available).toBe("boolean");
     expect(status.vector?.available).toBe(available);
+  });
+
+  it("registers the bundled bedrock memory embedding adapter", () => {
+    const adapters = listMemoryEmbeddingProviders();
+    expect(adapters.some((adapter) => adapter.id === "bedrock")).toBe(true);
   });
 
   it("builds FTS index and returns search results when no embedding provider is available", async () => {

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -1,5 +1,6 @@
 import fsSync from "node:fs";
 import {
+  DEFAULT_BEDROCK_EMBEDDING_MODEL,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
@@ -7,6 +8,7 @@ import {
   DEFAULT_VOYAGE_EMBEDDING_MODEL,
   OPENAI_BATCH_ENDPOINT,
   buildGeminiEmbeddingRequest,
+  createBedrockEmbeddingProvider,
   createGeminiEmbeddingProvider,
   createLocalEmbeddingProvider,
   createMistralEmbeddingProvider,
@@ -116,7 +118,13 @@ function supportsGeminiMultimodalEmbeddings(model: string): boolean {
 }
 
 function resolveMemoryEmbeddingAuthProviderId(providerId: string): string {
-  return providerId === "gemini" ? "google" : providerId;
+  if (providerId === "gemini") {
+    return "google";
+  }
+  if (providerId === "bedrock") {
+    return "amazon-bedrock";
+  }
+  return providerId;
 }
 
 const openAiAdapter: MemoryEmbeddingProviderAdapter = {
@@ -288,6 +296,34 @@ const mistralAdapter: MemoryEmbeddingProviderAdapter = {
   },
 };
 
+const bedrockAdapter: MemoryEmbeddingProviderAdapter = {
+  id: "bedrock",
+  defaultModel: DEFAULT_BEDROCK_EMBEDDING_MODEL,
+  transport: "remote",
+  autoSelectPriority: 60,
+  allowExplicitWhenConfiguredAuto: true,
+  shouldContinueAutoSelection: isMissingApiKeyError,
+  create: async (options) => {
+    const { provider, client } = await createBedrockEmbeddingProvider({
+      ...options,
+      provider: "bedrock",
+      fallback: "none",
+    });
+    return {
+      provider,
+      runtime: {
+        id: "bedrock",
+        cacheKeyData: {
+          provider: "bedrock",
+          region: client.region,
+          model: client.model,
+          dimensions: client.dimensions,
+        },
+      },
+    };
+  },
+};
+
 const localAdapter: MemoryEmbeddingProviderAdapter = {
   id: "local",
   defaultModel: DEFAULT_LOCAL_MODEL,
@@ -320,6 +356,7 @@ export const builtinMemoryEmbeddingProviderAdapters = [
   geminiAdapter,
   voyageAdapter,
   mistralAdapter,
+  bedrockAdapter,
 ] as const;
 
 const builtinMemoryEmbeddingProviderAdapterById = new Map(
@@ -377,6 +414,7 @@ export function listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata(): Ar
 }
 
 export {
+  DEFAULT_BEDROCK_EMBEDDING_MODEL,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,

--- a/extensions/whatsapp/src/session.runtime.ts
+++ b/extensions/whatsapp/src/session.runtime.ts
@@ -1,4 +1,5 @@
 export {
+  BufferJSON,
   DisconnectReason,
   fetchLatestBaileysVersion,
   makeCacheableSignalKeyStore,

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -12,6 +12,7 @@ let formatError: typeof import("./session.js").formatError;
 let logWebSelfId: typeof import("./session.js").logWebSelfId;
 let waitForWaConnection: typeof import("./session.js").waitForWaConnection;
 let waitForCredsSaveQueue: typeof import("./session.js").waitForCredsSaveQueue;
+let writeCredsJsonAtomically: typeof import("./session.js").writeCredsJsonAtomically;
 
 async function flushCredsUpdate() {
   await new Promise<void>((resolve) => setImmediate(resolve));
@@ -19,10 +20,8 @@ async function flushCredsUpdate() {
 
 async function emitCredsUpdateAndReadSaveCreds() {
   const sock = getLastSocket();
-  const saveCreds = (await useMultiFileAuthStateMock.mock.results[0]?.value)?.saveCreds;
   sock.ev.emit("creds.update", {});
   await flushCredsUpdate();
-  return saveCreds;
 }
 
 function mockCredsJsonSpies(readContents: string) {
@@ -60,8 +59,14 @@ function mockCredsJsonSpies(readContents: string) {
 
 describe("web session", () => {
   beforeAll(async () => {
-    ({ createWaSocket, formatError, logWebSelfId, waitForWaConnection, waitForCredsSaveQueue } =
-      await import("./session.js"));
+    ({
+      createWaSocket,
+      formatError,
+      logWebSelfId,
+      waitForWaConnection,
+      waitForCredsSaveQueue,
+      writeCredsJsonAtomically,
+    } = await import("./session.js"));
   });
 
   beforeEach(() => {
@@ -79,6 +84,8 @@ describe("web session", () => {
   });
 
   it("creates WA socket with QR handler", async () => {
+    const writeFileSpy = vi.spyOn(fsSync.promises, "writeFile").mockResolvedValue(undefined);
+    vi.spyOn(fsSync.promises, "rename").mockResolvedValue(undefined);
     await createWaSocket(true, false);
     const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
     expect(makeWASocket).toHaveBeenCalledWith(
@@ -89,11 +96,10 @@ describe("web session", () => {
     expect(passedLogger?.level).toBe("silent");
     expect(typeof passedLogger?.trace).toBe("function");
     const sock = getLastSocket();
-    const saveCreds = (await useMultiFileAuthStateMock.mock.results[0]?.value)?.saveCreds;
     // trigger creds.update listener
     sock.ev.emit("creds.update", {});
     await flushCredsUpdate();
-    expect(saveCreds).toHaveBeenCalled();
+    expect(writeFileSpy).toHaveBeenCalled();
   });
 
   it("uses ambient env proxy agent when HTTPS_PROXY is configured", async () => {
@@ -220,12 +226,14 @@ describe("web session", () => {
 
   it("does not clobber creds backup when creds.json is corrupted", async () => {
     const creds = mockCredsJsonSpies("{");
+    const writeFileSpy = vi.spyOn(fsSync.promises, "writeFile").mockResolvedValue(undefined);
+    vi.spyOn(fsSync.promises, "rename").mockResolvedValue(undefined);
 
     await createWaSocket(false, false);
-    const saveCreds = await emitCredsUpdateAndReadSaveCreds();
+    await emitCredsUpdateAndReadSaveCreds();
 
     expect(creds.copySpy).not.toHaveBeenCalled();
-    expect(saveCreds).toHaveBeenCalled();
+    expect(writeFileSpy).toHaveBeenCalled();
 
     creds.restore();
   });
@@ -238,15 +246,16 @@ describe("web session", () => {
       release = resolve;
     });
 
-    const saveCreds = vi.fn(async () => {
+    const writeFileSpy = vi.spyOn(fsSync.promises, "writeFile").mockImplementation(async () => {
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       await gate;
       inFlight -= 1;
     });
+    vi.spyOn(fsSync.promises, "rename").mockResolvedValue(undefined);
     useMultiFileAuthStateMock.mockResolvedValueOnce({
       state: { creds: {} as never, keys: {} as never },
-      saveCreds,
+      saveCreds: vi.fn(),
     });
 
     await createWaSocket(false, false);
@@ -264,7 +273,7 @@ describe("web session", () => {
     await flushCredsUpdate();
     await flushCredsUpdate();
 
-    expect(saveCreds).toHaveBeenCalledTimes(2);
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
     expect(maxInFlight).toBe(1);
     expect(inFlight).toBe(0);
   });
@@ -281,24 +290,32 @@ describe("web session", () => {
       releaseB = resolve;
     });
 
-    const saveCredsA = vi.fn(async () => {
-      inFlightA += 1;
-      await gateA;
-      inFlightA -= 1;
-    });
-    const saveCredsB = vi.fn(async () => {
-      inFlightB += 1;
-      await gateB;
-      inFlightB -= 1;
-    });
+    const writeFileSpy = vi
+      .spyOn(fsSync.promises, "writeFile")
+      .mockImplementation(async (...args) => {
+        const normalized = String(args[0]);
+        if (normalized.includes("/tmp/wa-a/")) {
+          inFlightA += 1;
+          await gateA;
+          inFlightA -= 1;
+          return;
+        }
+        if (normalized.includes("/tmp/wa-b/")) {
+          inFlightB += 1;
+          await gateB;
+          inFlightB -= 1;
+          return;
+        }
+      });
+    vi.spyOn(fsSync.promises, "rename").mockResolvedValue(undefined);
     useMultiFileAuthStateMock
       .mockResolvedValueOnce({
         state: { creds: {} as never, keys: {} as never },
-        saveCreds: saveCredsA,
+        saveCreds: vi.fn(),
       })
       .mockResolvedValueOnce({
         state: { creds: {} as never, keys: {} as never },
-        saveCreds: saveCredsB,
+        saveCreds: vi.fn(),
       });
 
     await createWaSocket(false, false, { authDir: "/tmp/wa-a" });
@@ -311,8 +328,7 @@ describe("web session", () => {
 
     await flushCredsUpdate();
 
-    expect(saveCredsA).toHaveBeenCalledTimes(1);
-    expect(saveCredsB).toHaveBeenCalledTimes(1);
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
     expect(inFlightA).toBe(1);
     expect(inFlightB).toBe(1);
 
@@ -327,6 +343,8 @@ describe("web session", () => {
 
   it("rotates creds backup when creds.json is valid JSON", async () => {
     const creds = mockCredsJsonSpies("{}");
+    const writeFileSpy = vi.spyOn(fsSync.promises, "writeFile").mockResolvedValue(undefined);
+    vi.spyOn(fsSync.promises, "rename").mockResolvedValue(undefined);
     const backupSuffix = path.join(
       "/tmp",
       "openclaw-oauth",
@@ -336,14 +354,36 @@ describe("web session", () => {
     );
 
     await createWaSocket(false, false);
-    const saveCreds = await emitCredsUpdateAndReadSaveCreds();
+    await emitCredsUpdateAndReadSaveCreds();
 
     expect(creds.copySpy).toHaveBeenCalledTimes(1);
     const args = creds.copySpy.mock.calls[0] ?? [];
     expect(String(args[0] ?? "")).toContain(creds.credsSuffix);
     expect(String(args[1] ?? "")).toContain(backupSuffix);
-    expect(saveCreds).toHaveBeenCalled();
+    expect(writeFileSpy).toHaveBeenCalled();
 
     creds.restore();
+  });
+
+  it("writes creds.json atomically via temp file and rename", async () => {
+    const writeFileSpy = vi.spyOn(fsSync.promises, "writeFile").mockResolvedValue(undefined);
+    const renameSpy = vi.spyOn(fsSync.promises, "rename").mockResolvedValue(undefined);
+    const rmSpy = vi.spyOn(fsSync.promises, "rm").mockResolvedValue(undefined);
+
+    await writeCredsJsonAtomically(
+      "/tmp/openclaw-oauth/whatsapp/default",
+      { me: { id: "123@s.whatsapp.net" } },
+      { warn: vi.fn() } as never,
+    );
+
+    expect(writeFileSpy).toHaveBeenCalledTimes(1);
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+    expect(rmSpy).not.toHaveBeenCalled();
+    const writePath = String(writeFileSpy.mock.calls[0]?.[0] ?? "");
+    const renameArgs = renameSpy.mock.calls[0] ?? [];
+    expect(writePath).toContain(".creds.");
+    expect(String(renameArgs[1] ?? "")).toContain(
+      path.join("/tmp", "openclaw-oauth", "whatsapp", "default", "creds.json"),
+    );
   });
 });

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
+import fs from "node:fs/promises";
 import type { Agent } from "node:https";
+import path from "node:path";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { VERSION } from "openclaw/plugin-sdk/cli-runtime";
 import { resolveAmbientNodeProxyAgent } from "openclaw/plugin-sdk/extension-shared";
@@ -17,6 +19,7 @@ import {
 } from "./auth-store.js";
 import { formatError, getStatusCode } from "./session-errors.js";
 import {
+  BufferJSON,
   DisconnectReason,
   fetchLatestBaileysVersion,
   makeCacheableSignalKeyStore,
@@ -36,6 +39,32 @@ export {
 } from "./auth-store.js";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
+
+export async function writeCredsJsonAtomically(
+  authDir: string,
+  creds: unknown,
+  logger: ReturnType<typeof getChildLogger>,
+): Promise<void> {
+  const credsPath = resolveWebCredsPath(authDir);
+  const tempPath = path.join(authDir, `.creds.${process.pid}.${Date.now()}.tmp`);
+  try {
+    await fs.writeFile(tempPath, JSON.stringify(creds, BufferJSON.replacer), { mode: 0o600 });
+    await fs.rename(tempPath, credsPath);
+    try {
+      fsSync.chmodSync(credsPath, 0o600);
+    } catch {
+      // best-effort on platforms that support it
+    }
+  } catch (err) {
+    try {
+      await fs.rm(tempPath, { force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    logger.warn({ error: String(err) }, "failed atomic WhatsApp creds write");
+    throw err;
+  }
+}
 
 // Per-authDir queues so multi-account creds saves don't block each other.
 const credsSaveQueues = new Map<string, Promise<void>>();
@@ -118,7 +147,10 @@ export async function createWaSocket(
   await ensureDir(authDir);
   const sessionLogger = getChildLogger({ module: "web-session" });
   maybeRestoreCredsFromBackup(authDir);
-  const { state, saveCreds } = await useMultiFileAuthState(authDir);
+  const { state } = await useMultiFileAuthState(authDir);
+  const saveCreds = async () => {
+    await writeCredsJsonAtomically(authDir, state.creds, sessionLogger);
+  };
   const { version } = await fetchLatestBaileysVersion();
   const agent = await resolveEnvProxyAgent(sessionLogger);
   const sock = makeWASocket({

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -53,8 +53,22 @@ export async function resolveAnnounceTarget(params: {
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
       (typeof origin?.accountId === "string" ? origin.accountId : undefined);
+    const threadIdRaw =
+      (typeof deliveryContext?.threadId === "string" ||
+      (typeof deliveryContext?.threadId === "number" && Number.isFinite(deliveryContext.threadId))
+        ? deliveryContext.threadId
+        : undefined) ??
+      (typeof match?.lastThreadId === "string" ||
+      (typeof match?.lastThreadId === "number" && Number.isFinite(match.lastThreadId))
+        ? match.lastThreadId
+        : undefined) ??
+      (typeof origin?.threadId === "string" ||
+      (typeof origin?.threadId === "number" && Number.isFinite(origin.threadId))
+        ? origin.threadId
+        : undefined);
+    const threadId = threadIdRaw != null && threadIdRaw !== "" ? String(threadIdRaw) : undefined;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -54,6 +54,7 @@ export type SessionListRow = {
   origin?: {
     provider?: string;
     accountId?: string;
+    threadId?: string | number;
   };
   spawnedBy?: string;
   label?: string;
@@ -83,6 +84,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string | number;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -332,6 +332,33 @@ describe("resolveAnnounceTarget", () => {
       accountId: "work",
     });
   });
+
+  it("preserves threadId when sessions.list fallback resolves the announce target", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            accountId: "ops",
+            threadId: 77,
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+      accountId: "ops",
+      threadId: "77",
+    });
+  });
 });
 
 describe("sessions_list gating", () => {

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import * as webMedia from "../../media/web-media.js";
 import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaList,
@@ -12,6 +13,10 @@ import {
 
 const cfg = {} as OpenClawConfig;
 const maybeIt = process.platform === "win32" ? it.skip : it;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("message action media helpers", () => {
   it("prefers sandbox media policy when sandbox roots are non-blank", () => {
@@ -152,6 +157,36 @@ describe("message action media helpers", () => {
     });
 
     expect(args.filename).toBe("attachment");
+  });
+
+  it("hydrates send actions when media is provided via the media field", async () => {
+    const loadSpy = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      buffer: Buffer.from("remote-image"),
+      contentType: "image/png",
+      kind: "image",
+      fileName: "photo.png",
+    });
+    const args: Record<string, unknown> = {
+      media: "https://example.com/photo.png",
+      message: "hello",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "discord",
+      args,
+      action: "send",
+      mediaPolicy: { mode: "host" },
+    });
+
+    expect(loadSpy).toHaveBeenCalledWith(
+      "https://example.com/photo.png",
+      expect.objectContaining({}),
+    );
+    expect(args.buffer).toBe(Buffer.from("remote-image").toString("base64"));
+    expect(args.contentType).toBe("image/png");
+    expect(args.filename).toBe("photo.png");
+    expect(args.caption).toBe("hello");
   });
 });
 

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -312,10 +312,14 @@ export async function hydrateAttachmentParamsForAction(params: {
   mediaPolicy: AttachmentMediaPolicy;
 }): Promise<void> {
   const shouldHydrateUploadFile = params.action === "upload-file";
+  const shouldHydrateSend =
+    params.action === "send" &&
+    Boolean(readAttachmentMediaHint(params.args) ?? readAttachmentFileHint(params.args));
   if (
     params.action !== "sendAttachment" &&
     params.action !== "setGroupIcon" &&
-    !shouldHydrateUploadFile
+    !shouldHydrateUploadFile &&
+    !shouldHydrateSend
   ) {
     return;
   }
@@ -326,7 +330,8 @@ export async function hydrateAttachmentParamsForAction(params: {
     args: params.args,
     dryRun: params.dryRun,
     mediaPolicy: params.mediaPolicy,
-    allowMessageCaptionFallback: params.action === "sendAttachment" || shouldHydrateUploadFile,
+    allowMessageCaptionFallback:
+      params.action === "sendAttachment" || shouldHydrateUploadFile || shouldHydrateSend,
   });
 }
 

--- a/src/memory-host-sdk/engine-embeddings.ts
+++ b/src/memory-host-sdk/engine-embeddings.ts
@@ -17,6 +17,10 @@ export type {
 } from "../plugins/memory-embedding-providers.js";
 export { createLocalEmbeddingProvider, DEFAULT_LOCAL_MODEL } from "./host/embeddings.js";
 export {
+  createBedrockEmbeddingProvider,
+  DEFAULT_BEDROCK_EMBEDDING_MODEL,
+} from "./host/embeddings-bedrock.js";
+export {
   createGeminiEmbeddingProvider,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   buildGeminiEmbeddingRequest,

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -13,6 +13,7 @@ export type NormalizedPluginsConfig = {
   loadPaths: string[];
   slots: {
     memory?: string | null;
+    contextEngine?: string | null;
   };
   entries: Record<
     string,
@@ -135,6 +136,7 @@ export function normalizePluginsConfigWithResolver(
   normalizePluginId: NormalizePluginId = identityNormalizePluginId,
 ): NormalizedPluginsConfig {
   const memorySlot = normalizeSlotValue(config?.slots?.memory);
+  const contextEngineSlot = normalizeSlotValue(config?.slots?.contextEngine);
   return {
     enabled: config?.enabled !== false,
     allow: normalizeList(config?.allow, normalizePluginId),
@@ -142,6 +144,7 @@ export function normalizePluginsConfigWithResolver(
     loadPaths: normalizeList(config?.load?.paths, identityNormalizePluginId),
     slots: {
       memory: memorySlot === undefined ? defaultSlotIdForKey("memory") : memorySlot,
+      ...(contextEngineSlot !== undefined ? { contextEngine: contextEngineSlot } : {}),
     },
     entries: normalizePluginEntries(config?.entries, normalizePluginId),
   };

--- a/src/plugins/config-policy.test.ts
+++ b/src/plugins/config-policy.test.ts
@@ -25,6 +25,18 @@ describe("normalizePluginsConfigWithResolver", () => {
     expect(normalized.deny).toEqual(["BETA"]);
     expect(normalized.entries).toHaveProperty("GAMMA");
   });
+
+  it("preserves the explicit context engine slot", () => {
+    const normalized = normalizePluginsConfigWithResolver({
+      slots: {
+        memory: "memory-core",
+        contextEngine: "lossless-claw",
+      },
+    });
+
+    expect(normalized.slots.memory).toBe("memory-core");
+    expect(normalized.slots.contextEngine).toBe("lossless-claw");
+  });
 });
 
 describe("hasExplicitPluginConfig", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -304,7 +304,9 @@ function expectOpenAllowWarnings(params: {
   expectedWarnings: number;
   label: string;
 }) {
-  const openAllowWarnings = params.warnings.filter((msg) => msg.includes("plugins.allow is empty"));
+  const openAllowWarnings = params.warnings.filter((msg) =>
+    msg.includes("effective plugin allowlist is empty"),
+  );
   expect(openAllowWarnings, params.label).toHaveLength(params.expectedWarnings);
   if (params.expectedWarnings > 0) {
     expect(

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1023,7 +1023,7 @@ function warnWhenAllowlistIsOpen(params: {
   const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
   openAllowlistWarningCache.add(params.warningCacheKey);
   params.logger.warn(
-    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    `[plugins] effective plugin allowlist is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
   );
 }
 

--- a/test/mocks/baileys.ts
+++ b/test/mocks/baileys.ts
@@ -26,6 +26,10 @@ export type MockBaileysSocket = {
 };
 
 export type MockBaileysModule = {
+  BufferJSON: {
+    replacer: (key: string, value: unknown) => unknown;
+    reviver: (key: string, value: unknown) => unknown;
+  };
   DisconnectReason: { loggedOut: number };
   extractMessageContent: ReturnType<typeof vi.fn<ExtractMessageContentFn>>;
   fetchLatestBaileysVersion: ReturnType<typeof vi.fn<FetchLatestBaileysVersionFn>>;
@@ -148,6 +152,10 @@ export function createMockBaileys(): {
   });
 
   const mod: MockBaileysModule = {
+    BufferJSON: {
+      replacer: (_key: string, value: unknown) => value,
+      reviver: (_key: string, value: unknown) => value,
+    },
     DisconnectReason: { loggedOut: 401 },
     extractMessageContent: vi.fn<ExtractMessageContentFn>((message) =>
       mockExtractMessageContent(message),


### PR DESCRIPTION
Closes #64170

## Summary
- preserve `plugins.slots.contextEngine` during plugin config normalization
- update the open-allowlist warning text to describe the effective allowlist
- add regression coverage for the normalized context engine slot

## Test Plan
- [x] `pnpm --dir /Users/wentao/Desktop/openclaw exec vitest run src/plugins/config-policy.test.ts src/plugins/loader.test.ts src/config/config.plugin-validation.test.ts src/agents/skills/workspace.load-order.test.ts`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --dir /Users/wentao/Desktop/openclaw exec tsc --noEmit --pretty false`