### PR TITLE
fix(btw): strip replayed tool calls from side-question context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Docs: https://docs.openclaw.ai
 - iMessage (imsg): strip an accidental protobuf length-delimited UTF-8 field wrapper from inbound `text` and `reply_to_text` when it fully consumes the field, fixing leading garbage before the real message. (#63868) Thanks @neeravmakwana.
 - Gateway/pairing: fail closed for paired device records that have no device tokens, and reject pairing approvals whose requested scopes do not match the requested device roles.
 - ACP/gateway chat: classify lifecycle errors before forwarding them to ACP clients so refusals use ACP's refusal stop reason while transient backend errors continue to finish as normal turns.
+- Agents/BTW: strip replayed tool blocks, hidden reasoning, and malformed image payloads from `/btw` side-question context so Bedrock no-tools side questions keep working after tool-use turns. (#64225) Thanks @ngutman.
 - Commands/btw: keep tool-less side questions from sending injected empty `tools` arrays on strict OpenAI-compatible providers, so `/btw` continues working after prior tool-call history. (#64219) Thanks @ngutman.
 - Agents/Bedrock: let `/btw` side questions use `auth: "aws-sdk"` without a static API key so Bedrock IAM and instance-role sessions stop failing before the side question runs. (#64218) Thanks @SnowSky1.
 

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -726,6 +726,135 @@ describe("runBtwSideQuestion", () => {
     });
   });
 
+  it("drops assistant thinking blocks from BTW context", async () => {
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: "assistant-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "seed" }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Visible answer" },
+            { type: "thinking", thinking: "Hidden chain of thought" },
+          ],
+          provider: DEFAULT_PROVIDER,
+          api: "anthropic-messages",
+          model: DEFAULT_MODEL,
+          stopReason: "stop",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          timestamp: 2,
+        },
+      ],
+    });
+    mockDoneAnswer(MATH_ANSWER);
+
+    await runMathSideQuestion();
+
+    const [, context] = streamSimpleMock.mock.calls[0] ?? [];
+    expect(context).toMatchObject({
+      messages: [
+        expect.objectContaining({ role: "user" }),
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: "Visible answer" }],
+        }),
+        expect.objectContaining({ role: "user" }),
+      ],
+    });
+    expect(
+      (context as { messages?: Array<{ role?: string; content?: Array<{ type?: string }> }> })
+        .messages,
+    ).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.arrayContaining([expect.objectContaining({ type: "thinking" })]),
+        }),
+      ]),
+    );
+  });
+
+  it("drops thinking-only assistant messages from BTW context", async () => {
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: "assistant-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "seed" }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "Hidden chain of thought" }],
+          provider: DEFAULT_PROVIDER,
+          api: "anthropic-messages",
+          model: DEFAULT_MODEL,
+          stopReason: "stop",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          timestamp: 2,
+        },
+      ],
+    });
+    mockDoneAnswer(MATH_ANSWER);
+
+    await runMathSideQuestion();
+
+    const [, context] = streamSimpleMock.mock.calls[0] ?? [];
+    expect(
+      (context as { messages?: Array<{ role?: string }> }).messages?.filter(
+        (message) => message.role === "assistant",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("drops malformed user image blocks from BTW context", async () => {
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: "assistant-1",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "seed" },
+            { type: "image", mimeType: "image/png" },
+          ],
+          timestamp: 1,
+        },
+      ],
+    });
+    mockDoneAnswer(MATH_ANSWER);
+
+    await runMathSideQuestion();
+
+    const [, context] = streamSimpleMock.mock.calls[0] ?? [];
+    expect(context).toMatchObject({
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          content: [{ type: "text", text: "seed" }],
+        }),
+        expect.objectContaining({ role: "user" }),
+      ],
+    });
+  });
+
   it("normalizes malformed assistant content before stripping tool blocks", async () => {
     getActiveEmbeddedRunSnapshotMock.mockReturnValue({
       transcriptLeafId: "assistant-1",

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -597,6 +597,7 @@ describe("runBtwSideQuestion", () => {
             { type: "text", text: "Let me check." },
             { type: "toolCall", id: "call_1", name: "read", arguments: { path: "README.md" } },
             { type: "toolUse", id: "call_legacy", name: "read", input: { path: "README.md" } },
+            { type: "tool_call", id: "call_snake", name: "read", arguments: { path: "README.md" } },
           ],
           provider: DEFAULT_PROVIDER,
           api: "anthropic-messages",
@@ -636,9 +637,132 @@ describe("runBtwSideQuestion", () => {
       expect.arrayContaining([
         expect.objectContaining({
           role: "assistant",
-          content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+          content: expect.arrayContaining([
+            expect.objectContaining({ type: "toolCall" }),
+            expect.objectContaining({ type: "toolUse" }),
+            expect.objectContaining({ type: "tool_call" }),
+          ]),
         }),
       ]),
     );
+  });
+
+  it("drops assistant messages that contain only tool calls", async () => {
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: "assistant-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "seed" }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+          provider: DEFAULT_PROVIDER,
+          api: "anthropic-messages",
+          model: DEFAULT_MODEL,
+          stopReason: "toolUse",
+          usage: {
+            input: 1,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 1,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          timestamp: 2,
+        },
+      ],
+    });
+    mockDoneAnswer(MATH_ANSWER);
+
+    await runMathSideQuestion();
+
+    const [, context] = streamSimpleMock.mock.calls[0] ?? [];
+    expect(
+      (context as { messages?: Array<{ role?: string }> }).messages?.filter(
+        (message) => message.role === "assistant",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("strips embedded user tool results from BTW context", async () => {
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: "assistant-1",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "seed" },
+            {
+              type: "toolResult",
+              toolUseId: "call_1",
+              content: [{ type: "text", text: "secret" }],
+            },
+            {
+              type: "tool_result",
+              toolUseId: "call_2",
+              content: [{ type: "text", text: "secret-2" }],
+            },
+          ],
+          timestamp: 1,
+        },
+      ],
+    });
+    mockDoneAnswer(MATH_ANSWER);
+
+    await runMathSideQuestion();
+
+    const [, context] = streamSimpleMock.mock.calls[0] ?? [];
+    expect(context).toMatchObject({
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          content: [{ type: "text", text: "seed" }],
+        }),
+        expect.objectContaining({ role: "user" }),
+      ],
+    });
+  });
+
+  it("normalizes malformed assistant content before stripping tool blocks", async () => {
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: "assistant-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "seed" }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+          provider: DEFAULT_PROVIDER,
+          api: "anthropic-messages",
+          model: DEFAULT_MODEL,
+          stopReason: "toolUse",
+          usage: {
+            input: 1,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 1,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          timestamp: 2,
+        },
+      ],
+    });
+    mockDoneAnswer(MATH_ANSWER);
+
+    await runMathSideQuestion();
+
+    const [, context] = streamSimpleMock.mock.calls[0] ?? [];
+    expect(
+      (context as { messages?: Array<{ role?: string }> }).messages?.filter(
+        (message) => message.role === "assistant",
+      ),
+    ).toHaveLength(0);
   });
 });

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -581,4 +581,64 @@ describe("runBtwSideQuestion", () => {
       expect.arrayContaining([expect.objectContaining({ role: "toolResult" })]),
     );
   });
+
+  it("strips assistant tool calls from BTW context so no-tool side questions stay tool-free", async () => {
+    getActiveEmbeddedRunSnapshotMock.mockReturnValue({
+      transcriptLeafId: "assistant-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "seed" }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check." },
+            { type: "toolCall", id: "call_1", name: "read", arguments: { path: "README.md" } },
+            { type: "toolUse", id: "call_legacy", name: "read", input: { path: "README.md" } },
+          ],
+          provider: DEFAULT_PROVIDER,
+          api: "anthropic-messages",
+          model: DEFAULT_MODEL,
+          stopReason: "toolUse",
+          usage: {
+            input: 1,
+            output: 2,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 3,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          timestamp: 2,
+        },
+      ],
+    });
+    mockDoneAnswer(MATH_ANSWER);
+
+    await runMathSideQuestion();
+
+    const [, context] = streamSimpleMock.mock.calls[0] ?? [];
+    expect(context).toMatchObject({
+      messages: [
+        expect.objectContaining({ role: "user" }),
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: "Let me check." }],
+        }),
+        expect.objectContaining({ role: "user" }),
+      ],
+    });
+    expect(
+      (context as { messages?: Array<{ role?: string; content?: Array<{ type?: string }> }> })
+        .messages,
+    ).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.arrayContaining([expect.objectContaining({ type: "toolCall" })]),
+        }),
+      ]),
+    );
+  });
 });

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -2,8 +2,10 @@ import {
   streamSimple,
   type Api,
   type AssistantMessageEvent,
+  type ImageContent,
   type Message,
   type Model,
+  type TextContent,
 } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
@@ -17,6 +19,10 @@ import {
 import { diagnosticLogger as diag } from "../logging/diagnostic.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
+import {
+  resolveImageSanitizationLimits,
+  type ImageSanitizationLimits,
+} from "./image-sanitization.js";
 import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./pi-embedded-block-chunker.js";
@@ -25,6 +31,7 @@ import { getActiveEmbeddedRunSnapshot } from "./pi-embedded-runner/runs.js";
 import { streamWithPayloadPatch } from "./pi-embedded-runner/stream-payload-utils.js";
 import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
+import { sanitizeImageBlocks } from "./tool-images.js";
 
 type SessionManagerLike = {
   getLeafEntry?: () => {
@@ -84,9 +91,6 @@ function buildBtwQuestionPrompt(question: string, inFlightPrompt?: string): stri
   return lines.join("\n");
 }
 
-const BTW_ALLOWED_USER_BLOCK_TYPES = new Set(["text", "image"]);
-const BTW_ALLOWED_ASSISTANT_BLOCK_TYPES = new Set(["text", "thinking"]);
-
 function normalizeBtwContentBlocks(content: unknown): unknown[] | undefined {
   if (Array.isArray(content)) {
     return content;
@@ -97,36 +101,60 @@ function normalizeBtwContentBlocks(content: unknown): unknown[] | undefined {
   return undefined;
 }
 
-function sanitizeBtwContentBlocks(
-  content: unknown,
-  allowedTypes: Set<string>,
-): unknown[] | undefined {
-  const blocks = normalizeBtwContentBlocks(content);
+function isBtwTextBlock(block: unknown): block is TextContent {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const record = block as { type?: unknown; text?: unknown };
+  return normalizeLowercaseStringOrEmpty(record.type) === "text" && typeof record.text === "string";
+}
+
+function isBtwImageBlock(block: unknown): block is ImageContent {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const record = block as { type?: unknown; data?: unknown; mimeType?: unknown };
+  return (
+    normalizeLowercaseStringOrEmpty(record.type) === "image" &&
+    typeof record.data === "string" &&
+    typeof record.mimeType === "string"
+  );
+}
+
+async function sanitizeBtwUserMessage(params: {
+  message: Extract<Message, { role: "user" }>;
+  imageLimits: ImageSanitizationLimits;
+}): Promise<Extract<Message, { role: "user" }> | undefined> {
+  if (typeof params.message.content === "string") {
+    return params.message;
+  }
+  const blocks = normalizeBtwContentBlocks(params.message.content);
   if (!blocks) {
     return undefined;
   }
-  const sanitizedBlocks = blocks.filter((block) => {
-    if (!block || typeof block !== "object") {
-      return false;
-    }
-    return allowedTypes.has(normalizeLowercaseStringOrEmpty((block as { type?: unknown }).type));
-  });
-  return sanitizedBlocks.length > 0 ? sanitizedBlocks : undefined;
-}
 
-function sanitizeBtwUserMessage(
-  message: Extract<Message, { role: "user" }>,
-): Extract<Message, { role: "user" }> | undefined {
-  if (typeof message.content === "string") {
-    return message;
+  const content: Array<TextContent | ImageContent> = [];
+  for (const block of blocks) {
+    if (isBtwTextBlock(block)) {
+      content.push({ type: "text", text: block.text });
+      continue;
+    }
+    if (!isBtwImageBlock(block)) {
+      continue;
+    }
+    const { images } = await sanitizeImageBlocks([block], "btw:context", params.imageLimits);
+    const image = images[0];
+    if (image) {
+      content.push(image);
+    }
   }
-  const content = sanitizeBtwContentBlocks(message.content, BTW_ALLOWED_USER_BLOCK_TYPES);
-  if (!content) {
+
+  if (content.length === 0) {
     return undefined;
   }
   return {
-    ...message,
-    content: content as Extract<Message, { role: "user" }>["content"],
+    ...params.message,
+    content,
   };
 }
 
@@ -135,45 +163,62 @@ function sanitizeBtwAssistantMessage(
 ): Extract<Message, { role: "assistant" }> | undefined {
   const rawContent = (message as { content?: unknown }).content;
   if (typeof rawContent === "string") {
-    return rawContent.trim().length > 0
+    const trimmed = rawContent.trim();
+    return trimmed.length > 0
       ? {
           ...message,
-          content: [{ type: "text", text: rawContent }],
+          content: [{ type: "text", text: trimmed }],
         }
       : undefined;
   }
-  const content = sanitizeBtwContentBlocks(rawContent, BTW_ALLOWED_ASSISTANT_BLOCK_TYPES);
-  if (!content) {
+  const blocks = normalizeBtwContentBlocks(rawContent);
+  if (!blocks) {
+    return undefined;
+  }
+  const content = blocks.flatMap((block): TextContent[] =>
+    isBtwTextBlock(block) ? [{ type: "text", text: block.text }] : [],
+  );
+  if (content.length === 0) {
     return undefined;
   }
   return {
     ...message,
-    content: content as Extract<Message, { role: "assistant" }>["content"],
+    content,
   };
 }
 
-function toSimpleContextMessages(messages: unknown[]): Message[] {
-  const contextMessages = messages.flatMap((message): Message[] => {
+async function toSimpleContextMessages(params: {
+  messages: unknown[];
+  imageLimits: ImageSanitizationLimits;
+}): Promise<Message[]> {
+  const contextMessages: Message[] = [];
+  for (const message of params.messages) {
     if (!message || typeof message !== "object") {
-      return [];
+      continue;
     }
     const role = (message as { role?: unknown }).role;
     if (role === "user") {
-      const sanitizedMessage = sanitizeBtwUserMessage(
-        message as Extract<Message, { role: "user" }>,
-      );
-      return sanitizedMessage ? [sanitizedMessage] : [];
+      const sanitizedMessage = await sanitizeBtwUserMessage({
+        message: message as Extract<Message, { role: "user" }>,
+        imageLimits: params.imageLimits,
+      });
+      if (sanitizedMessage) {
+        contextMessages.push(sanitizedMessage);
+      }
+      continue;
     }
     if (role !== "assistant") {
-      return [];
+      continue;
     }
-    // BTW is a no-tools path, so keep only user/assistant blocks that remain
-    // readable without replaying tool calls or tool results.
+    // BTW is a no-tools path, so keep only user-visible blocks from prior
+    // messages and strip hidden reasoning/tool replay data.
     const sanitizedMessage = sanitizeBtwAssistantMessage(
       message as Extract<Message, { role: "assistant" }>,
     );
-    return sanitizedMessage ? [sanitizedMessage] : [];
-  });
+    if (sanitizedMessage) {
+      contextMessages.push(sanitizedMessage);
+    }
+  }
   return stripToolResultDetails(
     contextMessages as Parameters<typeof stripToolResultDetails>[0],
   ) as Message[];
@@ -283,10 +328,14 @@ export async function runBtwSideQuestion(
 
   const sessionManager = SessionManager.open(sessionFile) as SessionManagerLike;
   const activeRunSnapshot = getActiveEmbeddedRunSnapshot(sessionId);
+  const imageLimits = resolveImageSanitizationLimits(params.cfg);
   let messages: Message[] = [];
   let inFlightPrompt: string | undefined;
   if (Array.isArray(activeRunSnapshot?.messages) && activeRunSnapshot.messages.length > 0) {
-    messages = toSimpleContextMessages(activeRunSnapshot.messages);
+    messages = await toSimpleContextMessages({
+      messages: activeRunSnapshot.messages,
+      imageLimits,
+    });
     inFlightPrompt = activeRunSnapshot.inFlightPrompt;
   } else if (activeRunSnapshot) {
     inFlightPrompt = activeRunSnapshot.inFlightPrompt;
@@ -314,9 +363,10 @@ export async function runBtwSideQuestion(
   }
   if (messages.length === 0) {
     const sessionContext = sessionManager.buildSessionContext();
-    messages = toSimpleContextMessages(
-      Array.isArray(sessionContext.messages) ? sessionContext.messages : [],
-    );
+    messages = await toSimpleContextMessages({
+      messages: Array.isArray(sessionContext.messages) ? sessionContext.messages : [],
+      imageLimits,
+    });
   }
   if (messages.length === 0 && !inFlightPrompt?.trim()) {
     throw new Error("No active session context.");

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -15,6 +15,7 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import { diagnosticLogger as diag } from "../logging/diagnostic.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
@@ -83,27 +84,71 @@ function buildBtwQuestionPrompt(question: string, inFlightPrompt?: string): stri
   return lines.join("\n");
 }
 
-const BTW_TOOL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const BTW_ALLOWED_USER_BLOCK_TYPES = new Set(["text", "image"]);
+const BTW_ALLOWED_ASSISTANT_BLOCK_TYPES = new Set(["text", "thinking"]);
 
-function sanitizeBtwAssistantMessage(
-  message: Extract<Message, { role: "assistant" }>,
-): Extract<Message, { role: "assistant" }> | undefined {
-  const originalContent = Array.isArray(message.content) ? message.content : [];
-  const content = originalContent.filter((block) => {
+function normalizeBtwContentBlocks(content: unknown): unknown[] | undefined {
+  if (Array.isArray(content)) {
+    return content;
+  }
+  if (content && typeof content === "object") {
+    return [content];
+  }
+  return undefined;
+}
+
+function sanitizeBtwContentBlocks(
+  content: unknown,
+  allowedTypes: Set<string>,
+): unknown[] | undefined {
+  const blocks = normalizeBtwContentBlocks(content);
+  if (!blocks) {
+    return undefined;
+  }
+  const sanitizedBlocks = blocks.filter((block) => {
     if (!block || typeof block !== "object") {
-      return true;
+      return false;
     }
-    return !BTW_TOOL_BLOCK_TYPES.has((block as { type?: unknown }).type as string);
+    return allowedTypes.has(normalizeLowercaseStringOrEmpty((block as { type?: unknown }).type));
   });
-  if (content.length === originalContent.length) {
+  return sanitizedBlocks.length > 0 ? sanitizedBlocks : undefined;
+}
+
+function sanitizeBtwUserMessage(
+  message: Extract<Message, { role: "user" }>,
+): Extract<Message, { role: "user" }> | undefined {
+  if (typeof message.content === "string") {
     return message;
   }
-  if (content.length === 0) {
+  const content = sanitizeBtwContentBlocks(message.content, BTW_ALLOWED_USER_BLOCK_TYPES);
+  if (!content) {
     return undefined;
   }
   return {
     ...message,
-    content,
+    content: content as Extract<Message, { role: "user" }>["content"],
+  };
+}
+
+function sanitizeBtwAssistantMessage(
+  message: Extract<Message, { role: "assistant" }>,
+): Extract<Message, { role: "assistant" }> | undefined {
+  const rawContent = (message as { content?: unknown }).content;
+  if (typeof rawContent === "string") {
+    return rawContent.trim().length > 0
+      ? {
+          ...message,
+          content: [{ type: "text", text: rawContent }],
+        }
+      : undefined;
+  }
+  const content = sanitizeBtwContentBlocks(rawContent, BTW_ALLOWED_ASSISTANT_BLOCK_TYPES);
+  if (!content) {
+    return undefined;
+  }
+  return {
+    ...message,
+    content: content as Extract<Message, { role: "assistant" }>["content"],
   };
 }
 
@@ -114,13 +159,16 @@ function toSimpleContextMessages(messages: unknown[]): Message[] {
     }
     const role = (message as { role?: unknown }).role;
     if (role === "user") {
-      return [message as Extract<Message, { role: "user" }>];
+      const sanitizedMessage = sanitizeBtwUserMessage(
+        message as Extract<Message, { role: "user" }>,
+      );
+      return sanitizedMessage ? [sanitizedMessage] : [];
     }
     if (role !== "assistant") {
       return [];
     }
-    // BTW is a no-tools path, so strip replay-only tool calls from assistant
-    // context before handing history to strict providers like Bedrock.
+    // BTW is a no-tools path, so keep only user/assistant blocks that remain
+    // readable without replaying tool calls or tool results.
     const sanitizedMessage = sanitizeBtwAssistantMessage(
       message as Extract<Message, { role: "assistant" }>,
     );

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -83,13 +83,48 @@ function buildBtwQuestionPrompt(question: string, inFlightPrompt?: string): stri
   return lines.join("\n");
 }
 
+const BTW_TOOL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+
+function sanitizeBtwAssistantMessage(
+  message: Extract<Message, { role: "assistant" }>,
+): Extract<Message, { role: "assistant" }> | undefined {
+  const originalContent = Array.isArray(message.content) ? message.content : [];
+  const content = originalContent.filter((block) => {
+    if (!block || typeof block !== "object") {
+      return true;
+    }
+    return !BTW_TOOL_BLOCK_TYPES.has((block as { type?: unknown }).type as string);
+  });
+  if (content.length === originalContent.length) {
+    return message;
+  }
+  if (content.length === 0) {
+    return undefined;
+  }
+  return {
+    ...message,
+    content,
+  };
+}
+
 function toSimpleContextMessages(messages: unknown[]): Message[] {
-  const contextMessages = messages.filter((message): message is Message => {
+  const contextMessages = messages.flatMap((message): Message[] => {
     if (!message || typeof message !== "object") {
-      return false;
+      return [];
     }
     const role = (message as { role?: unknown }).role;
-    return role === "user" || role === "assistant";
+    if (role === "user") {
+      return [message as Extract<Message, { role: "user" }>];
+    }
+    if (role !== "assistant") {
+      return [];
+    }
+    // BTW is a no-tools path, so strip replay-only tool calls from assistant
+    // context before handing history to strict providers like Bedrock.
+    const sanitizedMessage = sanitizeBtwAssistantMessage(
+      message as Extract<Message, { role: "assistant" }>,
+    );
+    return sanitizedMessage ? [sanitizedMessage] : [];
   });
   return stripToolResultDetails(
     contextMessages as Parameters<typeof stripToolResultDetails>[0],


### PR DESCRIPTION
## Summary
- strip replay-only assistant tool-call blocks from `/btw` context before sending side-question history to the model
- keep `/btw` tool-free for strict providers like Bedrock Converse, which require `toolConfig` when `toolUse`/`toolResult` blocks appear in history
- add a regression test covering assistant tool-call blocks in `/btw` context

Fixes #56558.

## Testing
- `pnpm test src/agents/btw.test.ts`
- `pnpm check`
