### PR TITLE
Patch acpx internal error handling for null final replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1472,6 +1472,9 @@
           "strip-ansi": "^7.2.0"
         }
       }
+    },
+    "patchedDependencies": {
+      "acpx@0.5.2": "patches/acpx@0.5.2.patch"
     }
   }
 }

--- a/patches/acpx@0.5.2.patch
+++ b/patches/acpx@0.5.2.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/prompt-turn-CXMtXBl-.js b/dist/prompt-turn-CXMtXBl-.js
+index f400935a798295db77f6676f2f8142d7671c0701..affdca628a8872c481aa6c9067a8cfe01716fea3 100644
+--- a/dist/prompt-turn-CXMtXBl-.js
++++ b/dist/prompt-turn-CXMtXBl-.js
+@@ -3343,6 +3343,19 @@ async function runPromptTurn(params) {
+ 			source: "rpc"
+ 		};
+ 	} catch (error) {
++		const acp = extractAcpError(error);
++		const genericInternalDetails = acp && acp.data && typeof acp.data === "object" ? asRecord$1(acp.data)?.details : void 0;
++		const shouldSuppressNullFinalInternalError = Boolean(params.promptMessageId) && acp?.code === -32603 && /^Internal error(?::|$)/.test(acp.message) && !(typeof genericInternalDetails === "string" && genericInternalDetails.trim().length > 0);
++		if (shouldSuppressNullFinalInternalError) {
++			await params.client.waitForSessionUpdatesIdle?.({
++				idleMs: SESSION_REPLY_IDLE_MS,
++				timeoutMs: SESSION_REPLY_DRAIN_TIMEOUT_MS
++			}).catch(() => {});
++			return {
++				stopReason: "end_turn",
++				source: "session"
++			};
++		}
+ 		if (!(error instanceof TimeoutError) || !params.promptMessageId) throw error;
+ 		await params.client.waitForSessionUpdatesIdle?.({
+ 			idleMs: SESSION_REPLY_IDLE_MS,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
+patchedDependencies:
+  acpx@0.5.2:
+    hash: 9338084c359862351961078d6522581492570f84c764686115e895bb87e71eac
+    path: patches/acpx@0.5.2.patch
+
 importers:
 
   .:
@@ -329,7 +334,7 @@ importers:
     dependencies:
       acpx:
         specifier: 0.5.2
-        version: 0.5.2
+        version: 0.5.2(patch_hash=9338084c359862351961078d6522581492570f84c764686115e895bb87e71eac)
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -10737,7 +10742,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acpx@0.5.2:
+  acpx@0.5.2(patch_hash=9338084c359862351961078d6522581492570f84c764686115e895bb87e71eac):
     dependencies:
       '@agentclientprotocol/sdk': 0.17.1(zod@4.3.6)
       commander: 14.0.3


### PR DESCRIPTION
## Summary
Patch the bundled `acpx@0.5.2` dependency so generic ACP `Internal error` responses without details no longer poison a persistent ACP session into `state:error`.

## Changes
- add a targeted `acpx@0.5.2` patch for `dist/prompt-turn-CXMtXBl-.js`
- suppress generic `-32603 Internal error` failures with no details after waiting for session updates to drain
- keep detailed internal errors on the existing throw path

## Why
In failing ACP turns, Codex could complete the task without a final assistant message and surface a generic `Internal error`. OpenClaw then marked the whole ACP session as errored. This patch narrows that case so the turn ends cleanly instead.

## Validation
- verified the patch only touches `dist/prompt-turn-CXMtXBl-.js`
- installed the patched dependency in the workspace
- confirmed a mocked generic `Internal error` returns `{ stopReason: "end_turn", source: "session" }`
- confirmed a mocked detailed internal error still throws
