### PR TITLE
fix(config): give actionable guidance when command names are used in plugins.allow (#64191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 - Dreaming/startup: keep plugin-registered startup hooks alive across workspace hook reloads and include dreaming startup owners in the gateway startup plugin scope, so managed Dreaming cron registration comes back reliably after gateway boot. (#62327) Thanks @mbelinky.
 - Plugins: treat duplicate `registerService` calls from the same plugin id as idempotent so snapshot and activation loads no longer emit spurious `service already registered` diagnostics. (#62033, #64128) Thanks @ly85206559.
 - Discord/TTS: route auto voice replies through the native voice-note path so Discord receives Opus voice messages instead of regular audio attachments. (#64096) Thanks @LiuHuaize.
+- Config/plugins: use plugin-owned command alias metadata when `plugins.allow` contains runtime command names like `dreaming`, and point users at the owning plugin instead of stale plugin-not-found guidance. (#64242) Thanks @feiskyer.
 
 ## 2026.4.9
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -147,6 +147,7 @@ Those belong in your plugin code and `package.json`.
 | `providers`                         | No       | `string[]`                       | Provider ids owned by this plugin.                                                                                                                                                                           |
 | `modelSupport`                      | No       | `object`                         | Manifest-owned shorthand model-family metadata used to auto-load the plugin before runtime.                                                                                                                  |
 | `cliBackends`                       | No       | `string[]`                       | CLI inference backend ids owned by this plugin. Used for startup auto-activation from explicit config refs.                                                                                                  |
+| `commandAliases`                    | No       | `object[]`                       | Command names owned by this plugin that should produce plugin-aware config and CLI diagnostics before runtime loads.                                                                                         |
 | `providerAuthEnvVars`               | No       | `Record<string, string[]>`       | Cheap provider-auth env metadata that OpenClaw can inspect without loading plugin code.                                                                                                                      |
 | `providerAuthAliases`               | No       | `Record<string, string>`         | Provider ids that should reuse another provider id for auth lookup, for example a coding provider that shares the base provider API key and auth profiles.                                                   |
 | `channelEnvVars`                    | No       | `Record<string, string[]>`       | Cheap channel env metadata that OpenClaw can inspect without loading plugin code. Use this for env-driven channel setup or auth surfaces that generic startup/config helpers should see.                     |
@@ -182,6 +183,30 @@ OpenClaw reads this before provider runtime loads.
 | `cliOption`           | No       | `string`                                        | Full CLI option shape, such as `--openrouter-api-key <key>`.                                             |
 | `cliDescription`      | No       | `string`                                        | Description used in CLI help.                                                                            |
 | `onboardingScopes`    | No       | `Array<"text-inference" \| "image-generation">` | Which onboarding surfaces this choice should appear in. If omitted, it defaults to `["text-inference"]`. |
+
+## commandAliases reference
+
+Use `commandAliases` when a plugin owns a runtime command name that users may
+mistakenly put in `plugins.allow` or try to run as a root CLI command. OpenClaw
+uses this metadata for diagnostics without importing plugin runtime code.
+
+```json
+{
+  "commandAliases": [
+    {
+      "name": "dreaming",
+      "kind": "runtime-slash",
+      "cliCommand": "memory"
+    }
+  ]
+}
+```
+
+| Field        | Required | Type              | What it means                                                           |
+| ------------ | -------- | ----------------- | ----------------------------------------------------------------------- |
+| `name`       | Yes      | `string`          | Command name that belongs to this plugin.                               |
+| `kind`       | No       | `"runtime-slash"` | Marks the alias as a chat slash command rather than a root CLI command. |
+| `cliCommand` | No       | `string`          | Related root CLI command to suggest for CLI operations, if one exists.  |
 
 ## uiHints reference
 

--- a/extensions/device-pair/openclaw.plugin.json
+++ b/extensions/device-pair/openclaw.plugin.json
@@ -3,6 +3,12 @@
   "enabledByDefault": true,
   "name": "Device Pairing",
   "description": "Generate setup codes and approve device pairing requests.",
+  "commandAliases": [
+    {
+      "name": "pair",
+      "kind": "runtime-slash"
+    }
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,6 +1,13 @@
 {
   "id": "memory-core",
   "kind": "memory",
+  "commandAliases": [
+    {
+      "name": "dreaming",
+      "kind": "runtime-slash",
+      "cliCommand": "memory"
+    }
+  ],
   "uiHints": {
     "dreaming.frequency": {
       "label": "Dreaming Frequency",

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -914,13 +914,14 @@ describe("memory cli", () => {
   it("previews rem harness output as json", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const nowMs = Date.now();
+      const isoDay = new Date(nowMs).toISOString().slice(0, 10);
       await recordShortTermRecalls({
         workspaceDir,
         query: "weather plans",
         nowMs,
         results: [
           {
-            path: "memory/2026-04-03.md",
+            path: `memory/${isoDay}.md`,
             startLine: 2,
             endLine: 3,
             score: 0.92,

--- a/extensions/phone-control/openclaw.plugin.json
+++ b/extensions/phone-control/openclaw.plugin.json
@@ -3,6 +3,12 @@
   "enabledByDefault": true,
   "name": "Phone Control",
   "description": "Arm/disarm high-risk phone node commands (camera/screen/writes) with an optional auto-expiry.",
+  "commandAliases": [
+    {
+      "name": "phone",
+      "kind": "runtime-slash"
+    }
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { startQaGatewayRpcClient } from "./gateway-rpc-client.js";
 import { splitQaModelRef } from "./model-selection.js";
@@ -526,11 +527,20 @@ async function waitForGatewayReady(params: {
     }
     for (const healthPath of ["/readyz", "/healthz"]) {
       try {
-        const response = await fetch(`${params.baseUrl}${healthPath}`, {
-          signal: AbortSignal.timeout(2_000),
+        const { response, release } = await fetchWithSsrFGuard({
+          url: `${params.baseUrl}${healthPath}`,
+          init: {
+            signal: AbortSignal.timeout(2_000),
+          },
+          policy: { allowPrivateNetwork: true },
+          auditContext: "qa-lab-gateway-child-health",
         });
-        if (response.ok) {
-          return;
+        try {
+          if (response.ok) {
+            return;
+          }
+        } finally {
+          await release();
         }
       } catch {
         // retry until timeout

--- a/extensions/talk-voice/openclaw.plugin.json
+++ b/extensions/talk-voice/openclaw.plugin.json
@@ -3,6 +3,12 @@
   "enabledByDefault": true,
   "name": "Talk Voice",
   "description": "Manage Talk voice selection (list/set).",
+  "commandAliases": [
+    {
+      "name": "voice",
+      "kind": "runtime-slash"
+    }
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -105,4 +105,22 @@ describe("resolveMissingPluginCommandMessage", () => {
       }),
     ).toBeNull();
   });
+
+  it("explains that dreaming is a runtime slash command, not a CLI command", () => {
+    const message = resolveMissingPluginCommandMessage("dreaming", {});
+    expect(message).toContain("runtime slash command");
+    expect(message).toContain("/dreaming");
+    expect(message).toContain("memory-core");
+    expect(message).toContain("openclaw memory");
+  });
+
+  it("returns the runtime command message even when plugins.allow is set", () => {
+    const message = resolveMissingPluginCommandMessage("dreaming", {
+      plugins: {
+        allow: ["memory-core"],
+      },
+    });
+    expect(message).toContain("runtime slash command");
+    expect(message).not.toContain("plugins.allow");
+  });
 });

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -123,4 +123,29 @@ describe("resolveMissingPluginCommandMessage", () => {
     expect(message).toContain("runtime slash command");
     expect(message).not.toContain("plugins.allow");
   });
+
+  it("points command names in plugins.allow at their parent plugin", () => {
+    const message = resolveMissingPluginCommandMessage("dreaming", {
+      plugins: {
+        allow: ["dreaming"],
+      },
+    });
+    expect(message).toContain('"dreaming" is not a plugin');
+    expect(message).toContain('"memory-core"');
+    expect(message).toContain("plugins.allow");
+  });
+
+  it("explains parent plugin disablement for runtime command aliases", () => {
+    const message = resolveMissingPluginCommandMessage("dreaming", {
+      plugins: {
+        entries: {
+          "memory-core": {
+            enabled: false,
+          },
+        },
+      },
+    });
+    expect(message).toContain("plugins.entries.memory-core.enabled=false");
+    expect(message).not.toContain("runtime slash command");
+  });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -11,6 +11,7 @@ import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { enableConsoleCapture } from "../logging.js";
+import { resolveManifestCommandAliasOwner } from "../plugins/manifest-registry.js";
 import { hasMemoryRuntime } from "../plugins/memory-state.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -63,15 +64,6 @@ export function shouldUseRootHelpFastPath(argv: string[]): boolean {
   return resolveCliArgvInvocation(argv).isRootHelpInvocation;
 }
 
-/**
- * Maps well-known runtime command names to the plugin that provides them.
- * Used to give actionable guidance when users try to run a runtime slash
- * command (e.g. `/dreaming`) as a CLI command (`openclaw dreaming`).
- */
-const RUNTIME_COMMAND_TO_PLUGIN_ID: Record<string, string> = {
-  dreaming: "memory-core",
-};
-
 export function resolveMissingPluginCommandMessage(
   pluginId: string,
   config?: OpenClawConfig,
@@ -80,17 +72,6 @@ export function resolveMissingPluginCommandMessage(
   if (!normalizedPluginId) {
     return null;
   }
-
-  // Check if this is a runtime slash command rather than a CLI command.
-  const parentPluginId = RUNTIME_COMMAND_TO_PLUGIN_ID[normalizedPluginId];
-  if (parentPluginId) {
-    return (
-      `"${normalizedPluginId}" is a runtime slash command (/${normalizedPluginId}), not a CLI command. ` +
-      `It is provided by the "${parentPluginId}" plugin. ` +
-      `Use \`openclaw memory\` for CLI memory operations, or \`/${normalizedPluginId}\` in a chat session.`
-    );
-  }
-
   const allow =
     Array.isArray(config?.plugins?.allow) && config.plugins.allow.length > 0
       ? config.plugins.allow
@@ -98,6 +79,38 @@ export function resolveMissingPluginCommandMessage(
           .map((entry) => normalizeOptionalLowercaseString(entry))
           .filter(Boolean)
       : [];
+  const commandAlias = resolveManifestCommandAliasOwner({
+    command: normalizedPluginId,
+    config,
+  });
+  const parentPluginId = commandAlias?.pluginId;
+  if (parentPluginId) {
+    if (allow.length > 0 && !allow.includes(parentPluginId)) {
+      return (
+        `"${normalizedPluginId}" is not a plugin; it is a command provided by the ` +
+        `"${parentPluginId}" plugin. Add "${parentPluginId}" to \`plugins.allow\` ` +
+        `instead of "${normalizedPluginId}".`
+      );
+    }
+    if (config?.plugins?.entries?.[parentPluginId]?.enabled === false) {
+      return (
+        `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
+        `\`plugins.entries.${parentPluginId}.enabled=false\`. Re-enable that entry if you want ` +
+        "the bundled plugin command surface."
+      );
+    }
+    if (commandAlias.kind === "runtime-slash") {
+      const cliHint = commandAlias.cliCommand
+        ? `Use \`openclaw ${commandAlias.cliCommand}\` for related CLI operations, or `
+        : "Use ";
+      return (
+        `"${normalizedPluginId}" is a runtime slash command (/${normalizedPluginId}), not a CLI command. ` +
+        `It is provided by the "${parentPluginId}" plugin. ` +
+        `${cliHint}\`/${normalizedPluginId}\` in a chat session.`
+      );
+    }
+  }
+
   if (allow.length > 0 && !allow.includes(normalizedPluginId)) {
     return (
       `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -63,6 +63,15 @@ export function shouldUseRootHelpFastPath(argv: string[]): boolean {
   return resolveCliArgvInvocation(argv).isRootHelpInvocation;
 }
 
+/**
+ * Maps well-known runtime command names to the plugin that provides them.
+ * Used to give actionable guidance when users try to run a runtime slash
+ * command (e.g. `/dreaming`) as a CLI command (`openclaw dreaming`).
+ */
+const RUNTIME_COMMAND_TO_PLUGIN_ID: Record<string, string> = {
+  dreaming: "memory-core",
+};
+
 export function resolveMissingPluginCommandMessage(
   pluginId: string,
   config?: OpenClawConfig,
@@ -71,6 +80,17 @@ export function resolveMissingPluginCommandMessage(
   if (!normalizedPluginId) {
     return null;
   }
+
+  // Check if this is a runtime slash command rather than a CLI command.
+  const parentPluginId = RUNTIME_COMMAND_TO_PLUGIN_ID[normalizedPluginId];
+  if (parentPluginId) {
+    return (
+      `"${normalizedPluginId}" is a runtime slash command (/${normalizedPluginId}), not a CLI command. ` +
+      `It is provided by the "${parentPluginId}" plugin. ` +
+      `Use \`openclaw memory\` for CLI memory operations, or \`/${normalizedPluginId}\` in a chat session.`
+    );
+  }
+
   const allow =
     Array.isArray(config?.plugins?.allow) && config.plugins.allow.length > 0
       ? config.plugins.allow

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -278,6 +278,35 @@ describe("config plugin validation", () => {
     }
   });
 
+  it("warns with actionable guidance when a runtime command name is used in plugins.allow", async () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        allow: ["dreaming"],
+        entries: {
+          "memory-core": {
+            config: { dreaming: { enabled: true } },
+          },
+        },
+      },
+    });
+    // Should not produce the generic "plugin not found" warning.
+    expect(
+      res.warnings?.some(
+        (w) => w.path === "plugins.allow" && w.message.includes("plugin not found: dreaming"),
+      ),
+    ).toBe(false);
+    // Should produce a helpful redirect to the parent plugin.
+    expect(
+      res.warnings?.some(
+        (w) =>
+          w.path === "plugins.allow" &&
+          w.message.includes('"dreaming" is not a plugin') &&
+          w.message.includes("memory-core"),
+      ),
+    ).toBe(true);
+  });
+
   it("does not fail validation for the implicit default memory slot when plugins config is explicit", async () => {
     const res = validateConfigObjectWithPlugins(
       {

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -218,6 +218,7 @@ vi.mock("../plugins/manifest-registry.js", () => {
       params?.contract === "webSearchProviders"
         ? mockWebSearchProviders.find((provider) => provider.id === params.value)?.pluginId
         : undefined,
+    resolveManifestCommandAliasOwner: () => undefined,
   };
 });
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -40,6 +40,19 @@ import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
 
+/**
+ * Maps well-known runtime command names to the plugin that provides them.
+ * Used to give actionable guidance when users accidentally put a command name
+ * (e.g. "dreaming") into `plugins.allow` instead of the parent plugin id.
+ */
+const COMMAND_NAME_TO_PLUGIN_ID: Record<string, string> = {
+  dreaming: "memory-core",
+  // "active-memory" omitted: command name equals plugin id, no redirect needed.
+  voice: "talk-voice",
+  phone: "phone-control",
+  pair: "device-pair",
+};
+
 type UnknownIssueRecord = Record<string, unknown>;
 type ConfigPathSegment = string | number;
 type AllowedValuesCollection = {
@@ -1040,7 +1053,17 @@ function validateConfigObjectWithPluginsBase(
       continue;
     }
     if (!knownIds.has(pluginId)) {
-      pushMissingPluginIssue("plugins.allow", pluginId, { warnOnly: true });
+      const parentPluginId = COMMAND_NAME_TO_PLUGIN_ID[pluginId];
+      if (parentPluginId && parentPluginId !== pluginId && knownIds.has(parentPluginId)) {
+        warnings.push({
+          path: "plugins.allow",
+          message:
+            `"${pluginId}" is not a plugin — it is a command provided by the "${parentPluginId}" plugin. ` +
+            `Use "${parentPluginId}" in plugins.allow instead.`,
+        });
+      } else {
+        pushMissingPluginIssue("plugins.allow", pluginId, { warnOnly: true });
+      }
     }
   }
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -13,6 +13,7 @@ import {
 } from "../plugins/doctor-contract-registry.js";
 import {
   loadPluginManifestRegistry,
+  resolveManifestCommandAliasOwner,
   resolveManifestContractPluginIds,
 } from "../plugins/manifest-registry.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
@@ -39,19 +40,6 @@ import { coerceSecretRef } from "./types.secrets.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
-
-/**
- * Maps well-known runtime command names to the plugin that provides them.
- * Used to give actionable guidance when users accidentally put a command name
- * (e.g. "dreaming") into `plugins.allow` instead of the parent plugin id.
- */
-const COMMAND_NAME_TO_PLUGIN_ID: Record<string, string> = {
-  dreaming: "memory-core",
-  // "active-memory" omitted: command name equals plugin id, no redirect needed.
-  voice: "talk-voice",
-  phone: "phone-control",
-  pair: "device-pair",
-};
 
 type UnknownIssueRecord = Record<string, unknown>;
 type ConfigPathSegment = string | number;
@@ -1053,13 +1041,16 @@ function validateConfigObjectWithPluginsBase(
       continue;
     }
     if (!knownIds.has(pluginId)) {
-      const parentPluginId = COMMAND_NAME_TO_PLUGIN_ID[pluginId];
-      if (parentPluginId && parentPluginId !== pluginId && knownIds.has(parentPluginId)) {
+      const commandAlias = resolveManifestCommandAliasOwner({
+        command: pluginId,
+        registry,
+      });
+      if (commandAlias?.pluginId && knownIds.has(commandAlias.pluginId)) {
         warnings.push({
           path: "plugins.allow",
           message:
-            `"${pluginId}" is not a plugin — it is a command provided by the "${parentPluginId}" plugin. ` +
-            `Use "${parentPluginId}" in plugins.allow instead.`,
+            `"${pluginId}" is not a plugin — it is a command provided by the "${commandAlias.pluginId}" plugin. ` +
+            `Use "${commandAlias.pluginId}" in plugins.allow instead.`,
         });
       } else {
         pushMissingPluginIssue("plugins.allow", pluginId, { warnOnly: true });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -17,6 +17,7 @@ import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
 import {
   loadPluginManifest,
   type OpenClawPackageManifest,
+  type PluginManifestCommandAlias,
   type PluginManifestConfigContracts,
   type PluginManifest,
   type PluginManifestChannelConfig,
@@ -78,6 +79,7 @@ export type PluginManifestRecord = {
   providerDiscoverySource?: string;
   modelSupport?: PluginManifestModelSupport;
   cliBackends: string[];
+  commandAliases?: PluginManifestCommandAlias[];
   providerAuthEnvVars?: Record<string, string[]>;
   providerAuthAliases?: Record<string, string>;
   channelEnvVars?: Record<string, string[]>;
@@ -204,6 +206,47 @@ export function resolveManifestContractOwnerPluginId(params: {
   )?.id;
 }
 
+export type PluginManifestCommandAliasRecord = PluginManifestCommandAlias & {
+  pluginId: string;
+};
+
+export function resolveManifestCommandAliasOwner(params: {
+  command: string | undefined;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  registry?: PluginManifestRegistry;
+}): PluginManifestCommandAliasRecord | undefined {
+  const normalizedCommand = normalizeOptionalLowercaseString(params.command);
+  if (!normalizedCommand) {
+    return undefined;
+  }
+  const registry =
+    params.registry ??
+    loadPluginManifestRegistry({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+    });
+
+  const commandIsPluginId = registry.plugins.some(
+    (plugin) => normalizeOptionalLowercaseString(plugin.id) === normalizedCommand,
+  );
+  if (commandIsPluginId) {
+    return undefined;
+  }
+
+  for (const plugin of registry.plugins) {
+    const alias = plugin.commandAliases?.find(
+      (entry) => normalizeOptionalLowercaseString(entry.name) === normalizedCommand,
+    );
+    if (alias) {
+      return { ...alias, pluginId: plugin.id };
+    }
+  }
+  return undefined;
+}
+
 function resolveManifestCacheMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS?.trim();
   if (raw === "" || raw === "0") {
@@ -315,6 +358,7 @@ function buildRecord(params: {
       : undefined,
     modelSupport: params.manifest.modelSupport,
     cliBackends: params.manifest.cliBackends ?? [],
+    commandAliases: params.manifest.commandAliases,
     providerAuthEnvVars: params.manifest.providerAuthEnvVars,
     providerAuthAliases: params.manifest.providerAuthAliases,
     channelEnvVars: params.manifest.channelEnvVars,

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -34,6 +34,17 @@ export type PluginManifestModelSupport = {
   modelPatterns?: string[];
 };
 
+export type PluginManifestCommandAliasKind = "runtime-slash";
+
+export type PluginManifestCommandAlias = {
+  /** Command-like name users may put in plugin config by mistake. */
+  name: string;
+  /** Command family, used for targeted diagnostics. */
+  kind?: PluginManifestCommandAliasKind;
+  /** Optional root CLI command that handles related CLI operations. */
+  cliCommand?: string;
+};
+
 export type PluginManifestConfigLiteral = string | number | boolean | null;
 
 export type PluginManifestDangerousConfigFlag = {
@@ -108,6 +119,11 @@ export type PluginManifest = {
   modelSupport?: PluginManifestModelSupport;
   /** Cheap startup activation lookup for plugin-owned CLI inference backends. */
   cliBackends?: string[];
+  /**
+   * Plugin-owned command aliases that should resolve to this plugin during
+   * config diagnostics before runtime loads.
+   */
+  commandAliases?: PluginManifestCommandAlias[];
   /** Cheap provider-auth env lookup without booting plugin runtime. */
   providerAuthEnvVars?: Record<string, string[]>;
   /** Provider ids that should reuse another provider id for auth lookup. */
@@ -357,6 +373,38 @@ function normalizeManifestModelSupport(value: unknown): PluginManifestModelSuppo
   return Object.keys(modelSupport).length > 0 ? modelSupport : undefined;
 }
 
+function normalizeManifestCommandAliases(value: unknown): PluginManifestCommandAlias[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalized: PluginManifestCommandAlias[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      const name = normalizeOptionalString(entry) ?? "";
+      if (name) {
+        normalized.push({ name });
+      }
+      continue;
+    }
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const name = normalizeOptionalString(entry.name) ?? "";
+    if (!name) {
+      continue;
+    }
+    const kind = entry.kind === "runtime-slash" ? entry.kind : undefined;
+    const cliCommand = normalizeOptionalString(entry.cliCommand) ?? "";
+    normalized.push({
+      name,
+      ...(kind ? { kind } : {}),
+      ...(cliCommand ? { cliCommand } : {}),
+    });
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 function normalizeProviderAuthChoices(
   value: unknown,
 ): PluginManifestProviderAuthChoice[] | undefined {
@@ -539,6 +587,7 @@ export function loadPluginManifest(
   const providerDiscoveryEntry = normalizeOptionalString(raw.providerDiscoveryEntry);
   const modelSupport = normalizeManifestModelSupport(raw.modelSupport);
   const cliBackends = normalizeTrimmedStringList(raw.cliBackends);
+  const commandAliases = normalizeManifestCommandAliases(raw.commandAliases);
   const providerAuthEnvVars = normalizeStringListRecord(raw.providerAuthEnvVars);
   const providerAuthAliases = normalizeStringRecord(raw.providerAuthAliases);
   const channelEnvVars = normalizeStringListRecord(raw.channelEnvVars);
@@ -569,6 +618,7 @@ export function loadPluginManifest(
       providerDiscoveryEntry,
       modelSupport,
       cliBackends,
+      commandAliases,
       providerAuthEnvVars,
       providerAuthAliases,
       channelEnvVars,

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -54,11 +54,14 @@ function loadSetupRegistryRuntime(): SetupRegistryRuntimeModule | null {
 }
 
 export function resolvePluginSetupCliBackendRuntime(params: { backend: string }) {
+  const normalized = normalizeProviderId(params.backend);
   const runtime = loadSetupRegistryRuntime();
   if (runtime) {
-    return runtime.resolvePluginSetupCliBackend(params);
+    const resolved = runtime.resolvePluginSetupCliBackend(params);
+    if (resolved) {
+      return resolved;
+    }
   }
-  const normalized = normalizeProviderId(params.backend);
   return resolveBundledSetupCliBackends().find(
     (entry) => normalizeProviderId(entry.backend.id) === normalized,
   );


### PR DESCRIPTION
## Summary

- **Problem:** Putting `"dreaming"` in `plugins.allow` causes a "plugin not found" warning, and running `openclaw dreaming` from CLI misleadingly tells users to add `"dreaming"` to `plugins.allow` — creating a circular trap where neither path works.
- **Why it matters:** Users cannot discover that `/dreaming` is a runtime slash command from `memory-core`, not a standalone plugin or CLI command. The error messages actively mislead them.
- **What changed:** Added a command-name-to-plugin-id map so both validation and CLI resolution give actionable guidance pointing users to the correct plugin id (`memory-core`) and the correct usage (`/dreaming` in chat or `openclaw memory` on CLI).
- **What did NOT change:** No new features, no behavioral changes to dreaming itself, no changes to how `plugins.allow` enforcement works. Generic "plugin not found" handling for truly unknown ids is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64191
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `dreaming` is a runtime slash command registered by the `memory-core` plugin via `api.registerCommand()`, but both config validation and CLI command resolution treat unrecognized names as plugin ids. Neither path knows that some command names map to parent plugins.
- **Missing detection / guardrail:** No mapping existed between well-known runtime command names and their parent plugin ids.
- **Contributing context:** The `memory-core` plugin registers CLI commands under `memory` (via `api.registerCli()`) but its slash command under `dreaming` (via `api.registerCommand()`). The naming mismatch between the CLI surface (`memory`) and the slash command (`dreaming`) makes this confusing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file:
  - `src/cli/run-main.test.ts` — 2 new tests for `resolveMissingPluginCommandMessage("dreaming")`
  - `src/config/config.plugin-validation.test.ts` — 1 new test for `plugins.allow: ["dreaming"]`
- Scenario the test should lock in:
  - `"dreaming"` in `plugins.allow` produces a redirect warning (not generic "plugin not found")
  - `openclaw dreaming` produces a runtime-command explanation (not a misleading `plugins.allow` suggestion)
  - The runtime-command message takes priority even when `plugins.allow` is set

## Security Impact

1. Does this touch auth, tokens, credentials, or permission checks? **No**
2. Does this change exec, shell, or code-execution paths? **No**
3. Does this affect network, SSRF, or fetch-guard behavior? **No**
4. Does this change how untrusted content is processed? **No**
5. Does this modify config loading, validation, or defaults? **Yes — validation warning messages only, no behavioral changes to enforcement**

## Human Verification (required)

**Verified scenarios:**
- Docker E2E: `plugins.allow: ["dreaming"]` + `openclaw doctor` → shows redirect warning to `memory-core` ✅
- Docker E2E: `openclaw dreaming status` with `plugins.allow: ["memory-core"]` → shows runtime slash command explanation ✅
- Docker E2E: `openclaw dreaming status` without `plugins.allow` → same explanation ✅
- Docker E2E: `openclaw memory --help` → still works normally ✅
- Unit tests: all 3 new tests pass, all existing tests pass ✅
- `pnpm check` passes (types, lint, all checks) ✅

**Edge cases checked:**
- `COMMAND_NAME_TO_PLUGIN_ID` entries where command name equals plugin id (e.g. `active-memory`) are skipped by the `parentPluginId !== pluginId` guard
- Unknown plugin ids not in the map still get the generic "plugin not found" warning

**What I did NOT verify:**
- Gateway runtime behavior of `/dreaming` slash command (not changed by this PR)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** The static `COMMAND_NAME_TO_PLUGIN_ID` map could become stale if plugins rename their commands.
  - **Mitigation:** The map is small, well-documented, and only affects warning messages. If a mapping becomes stale, users fall back to the existing generic "plugin not found" warning — no worse than before.