### PR TITLE
fix(reply): keep resolved secret config stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.
 - Dreaming/narrative: harden request-scoped diary fallback so scheduled dreaming only falls back on the dedicated subagent-runtime error, stop trusting spoofable raw error-code objects, and avoid leaking workspace paths when local fallback writes fail. (#64156) Thanks @mbelinky.
+- Reply/skills: keep resolved skill and memory secret config stable through embedded reply runs so raw SecretRefs in secondary skill settings no longer crash replies when the gateway already has the live env. (#64249) Thanks @mbelinky.
 
 ## 2026.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Docs: https://docs.openclaw.ai
 - Claude CLI/skills: pass eligible OpenClaw skills into CLI runs, including native Claude Code skill resolution via a temporary plugin plus per-run skill env/API key injection. (#62686, #62723) Thanks @zomars.
 - Heartbeat: ignore doc-only Markdown fence markers in the default `HEARTBEAT.md` template so comment-only heartbeat scaffolds skip API calls again. (#63434) Thanks @ravyg.
 - Control UI/BTW: render `/btw` side results as dismissible ephemeral cards in the browser, send `/btw` immediately during active runs, and clear stale BTW cards on reset flows so webchat matches the intended detached side-question behavior. (#64290) Thanks @ngutman.
+- Reply/skills: keep resolved skill and memory secret config stable through embedded reply runs so raw SecretRefs in secondary skill settings no longer crash replies when the gateway already has the live env. (#64249) Thanks @mbelinky.
 
 ## 2026.4.9
 
@@ -146,7 +147,6 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.
 - Dreaming/narrative: harden request-scoped diary fallback so scheduled dreaming only falls back on the dedicated subagent-runtime error, stop trusting spoofable raw error-code objects, and avoid leaking workspace paths when local fallback writes fail. (#64156) Thanks @mbelinky.
-- Reply/skills: keep resolved skill and memory secret config stable through embedded reply runs so raw SecretRefs in secondary skill settings no longer crash replies when the gateway already has the live env. (#64249) Thanks @mbelinky.
 
 ## 2026.4.8
 

--- a/packages/memory-host-sdk/src/host/secret-input.ts
+++ b/packages/memory-host-sdk/src/host/secret-input.ts
@@ -1,6 +1,8 @@
 import {
   hasConfiguredSecretInput,
   normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+  resolveSecretInputRef,
 } from "../../../../src/config/types.secrets.js";
 
 export function hasConfiguredMemorySecretInput(value: unknown): boolean {
@@ -11,6 +13,13 @@ export function resolveMemorySecretInputString(params: {
   value: unknown;
   path: string;
 }): string | undefined {
+  const { ref } = resolveSecretInputRef({ value: params.value });
+  if (ref?.source === "env") {
+    const envValue = normalizeSecretInputString(process.env[ref.id]);
+    if (envValue) {
+      return envValue;
+    }
+  }
   return normalizeResolvedSecretInputString({
     value: params.value,
     path: params.path,

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -97,6 +97,46 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     });
   });
 
+  it("prefers caller config when the active runtime snapshot still contains raw skill SecretRefs", () => {
+    const sourceConfig: OpenClawConfig = {
+      skills: {
+        entries: {
+          diffs: {
+            apiKey: {
+              source: "file",
+              provider: "default",
+              id: "/skills/entries/diffs/apiKey",
+            },
+          },
+        },
+      },
+    };
+    const runtimeConfig: OpenClawConfig = structuredClone(sourceConfig);
+    const callerConfig: OpenClawConfig = {
+      skills: {
+        entries: {
+          diffs: {
+            apiKey: "resolved-key",
+          },
+        },
+      },
+    };
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/tmp/workspace",
+      config: callerConfig,
+      skillsSnapshot: {
+        prompt: "skills prompt",
+        skills: [],
+      },
+    });
+
+    expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/tmp/workspace", {
+      config: callerConfig,
+    });
+  });
+
   it("skips skill entry loading when resolved snapshot skills are present", () => {
     const snapshot: SkillSnapshot = {
       prompt: "skills prompt",

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -470,6 +470,85 @@ describe("applySkillEnvOverrides", () => {
     });
   });
 
+  it("prefers resolved caller skill config when the active runtime snapshot is still raw", async () => {
+    const workspaceDir = await makeWorkspace();
+    await writeEnvSkill(workspaceDir);
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+    const sourceConfig: OpenClawConfig = {
+      skills: {
+        entries: {
+          "env-skill": {
+            apiKey: {
+              source: "file",
+              provider: "default",
+              id: "/skills/entries/env-skill/apiKey",
+            },
+          },
+        },
+      },
+    };
+    const callerConfig: OpenClawConfig = {
+      skills: {
+        entries: {
+          "env-skill": {
+            apiKey: "resolved-key",
+          },
+        },
+      },
+    };
+    setRuntimeConfigSnapshot(sourceConfig, sourceConfig);
+
+    withClearedEnv(["ENV_KEY"], () => {
+      const restore = applySkillEnvOverrides({
+        skills: entries,
+        config: callerConfig,
+      });
+
+      try {
+        expect(process.env.ENV_KEY).toBe("resolved-key");
+      } finally {
+        restore();
+        expect(process.env.ENV_KEY).toBeUndefined();
+      }
+    });
+  });
+
+  it("does not resolve raw skill apiKey refs when the host already provides primaryEnv", async () => {
+    const workspaceDir = await makeWorkspace();
+    await writeEnvSkill(workspaceDir);
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    withClearedEnv(["ENV_KEY"], () => {
+      process.env.ENV_KEY = "host-key";
+      const restore = applySkillEnvOverrides({
+        skills: entries,
+        config: {
+          skills: {
+            entries: {
+              "env-skill": {
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "OPENAI_API_KEY",
+                },
+              },
+            },
+          },
+        },
+      });
+
+      try {
+        expect(process.env.ENV_KEY).toBe("host-key");
+      } finally {
+        restore();
+        expect(process.env.ENV_KEY).toBe("host-key");
+        delete process.env.ENV_KEY;
+      }
+    });
+  });
+
   it("blocks unsafe env overrides but allows declared secrets", async () => {
     const workspaceDir = await makeWorkspace();
     const skillDir = path.join(workspaceDir, "skills", "unsafe-env-skill");

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -172,17 +172,17 @@ function applySkillConfigEnvOverrides(params: {
     }
   }
 
-  const resolvedApiKey =
-    normalizeResolvedSecretInputString({
-      value: skillConfig.apiKey,
-      path: `skills.entries.${skillKey}.apiKey`,
-    }) ?? "";
   const canInjectPrimaryEnv =
     normalizedPrimaryEnv &&
     (process.env[normalizedPrimaryEnv] === undefined ||
       activeSkillEnvEntries.has(normalizedPrimaryEnv));
-  if (canInjectPrimaryEnv && resolvedApiKey) {
-    if (!pendingOverrides[normalizedPrimaryEnv]) {
+  if (canInjectPrimaryEnv && !pendingOverrides[normalizedPrimaryEnv]) {
+    const resolvedApiKey =
+      normalizeResolvedSecretInputString({
+        value: skillConfig.apiKey,
+        path: `skills.entries.${skillKey}.apiKey`,
+      }) ?? "";
+    if (resolvedApiKey) {
       pendingOverrides[normalizedPrimaryEnv] = resolvedApiKey;
     }
   }

--- a/src/agents/skills/runtime-config.ts
+++ b/src/agents/skills/runtime-config.ts
@@ -1,5 +1,34 @@
 import { getRuntimeConfigSnapshot, type OpenClawConfig } from "../../config/config.js";
+import { coerceSecretRef } from "../../config/types.secrets.js";
+
+function hasConfiguredSkillApiKeyRef(config?: OpenClawConfig): boolean {
+  const entries = config?.skills?.entries;
+  if (!entries || typeof entries !== "object") {
+    return false;
+  }
+  for (const skillConfig of Object.values(entries)) {
+    if (!skillConfig || typeof skillConfig !== "object") {
+      continue;
+    }
+    if (coerceSecretRef(skillConfig.apiKey) !== null) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export function resolveSkillRuntimeConfig(config?: OpenClawConfig): OpenClawConfig | undefined {
-  return getRuntimeConfigSnapshot() ?? config;
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  if (!runtimeConfig) {
+    return config;
+  }
+  if (!config) {
+    return runtimeConfig;
+  }
+  const runtimeHasRawSkillSecretRefs = hasConfiguredSkillApiKeyRef(runtimeConfig);
+  const configHasRawSkillSecretRefs = hasConfiguredSkillApiKeyRef(config);
+  if (runtimeHasRawSkillSecretRefs && !configHasRawSkillSecretRefs) {
+    return config;
+  }
+  return runtimeConfig;
 }

--- a/src/memory-host-sdk/host/secret-input.test.ts
+++ b/src/memory-host-sdk/host/secret-input.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveMemorySecretInputString } from "./secret-input.js";
+
+describe("resolveMemorySecretInputString", () => {
+  afterEach(() => {
+    delete process.env.GOOGLE_API_KEY;
+  });
+
+  it("uses the daemon env for env-backed SecretRefs", () => {
+    process.env.GOOGLE_API_KEY = "resolved-key";
+
+    expect(
+      resolveMemorySecretInputString({
+        value: {
+          source: "env",
+          provider: "default",
+          id: "GOOGLE_API_KEY",
+        },
+        path: "agents.main.memorySearch.remote.apiKey",
+      }),
+    ).toBe("resolved-key");
+  });
+
+  it("still throws when an env-backed SecretRef is missing from the daemon env", () => {
+    expect(() =>
+      resolveMemorySecretInputString({
+        value: {
+          source: "env",
+          provider: "default",
+          id: "GOOGLE_API_KEY",
+        },
+        path: "agents.main.memorySearch.remote.apiKey",
+      }),
+    ).toThrow(/unresolved SecretRef/);
+  });
+});

--- a/src/memory-host-sdk/host/secret-input.ts
+++ b/src/memory-host-sdk/host/secret-input.ts
@@ -1,6 +1,8 @@
 import {
   hasConfiguredSecretInput,
   normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+  resolveSecretInputRef,
 } from "../../config/types.secrets.js";
 
 export function hasConfiguredMemorySecretInput(value: unknown): boolean {
@@ -11,6 +13,13 @@ export function resolveMemorySecretInputString(params: {
   value: unknown;
   path: string;
 }): string | undefined {
+  const { ref } = resolveSecretInputRef({ value: params.value });
+  if (ref?.source === "env") {
+    const envValue = normalizeSecretInputString(process.env[ref.id]);
+    if (envValue) {
+      return envValue;
+    }
+  }
   return normalizeResolvedSecretInputString({
     value: params.value,
     path: params.path,


### PR DESCRIPTION
## Summary

- Problem: embedded reply runs could resolve gateway secrets once, then later throw that resolved config away and reread raw SecretRef-backed skill or memory settings.
- Why it matters: a secondary integration like Whisper or memory search could crash the whole reply path even when the gateway already had the live env vars.
- What changed: keep caller-resolved skill config stable, avoid eagerly resolving secondary skill apiKey refs when host env already provides the needed primary env, and let memory secret inputs reuse daemon env for env-backed refs.
- What did NOT change (scope boundary): no doctor/path-state repair in this PR; this is only the runtime failure-path fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #63217
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: reply-time code could start from a resolved config, but deeper skill and memory helpers could overwrite it with the active runtime snapshot or eagerly resolve raw SecretRefs again.
- Missing detection / guardrail: we had tests for individual resolution helpers, but not for keeping already-resolved caller config stable through embedded reply and secondary-service paths.
- Contributing context (if known): the bug surfaced as generic Telegram failures because secondary services were allowed to hard-fail the whole reply before their env was actually needed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/skills.test.ts`, `src/agents/pi-embedded-runner/skills-runtime.test.ts`, `src/memory-host-sdk/host/secret-input.test.ts`
- Scenario the test should lock in: embedded reply code keeps a caller-resolved config instead of reintroducing raw SecretRefs, and env-backed secondary secrets do not crash when the daemon env already provides them.
- Why this is the smallest reliable guardrail: the failure happens in shared runtime helpers below Telegram/channel code, so tight runtime-seam tests are enough to prove the root cause.
- Existing test that already covers this (if any): prior tests covered single helpers but not this end-to-end runtime stability behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Replies no longer crash just because a secondary skill or memory secret setting is stored as an env SecretRef while the gateway already has the resolved env value.
- If a real unresolved SecretRef remains, the earlier PR's concrete error surfacing still applies.

## Diagram (if applicable)

```text
Before:
[reply run] -> [resolved config] -> [deep helper rereads raw SecretRef config] -> [secondary service throws] -> [reply fails]

After:
[reply run] -> [resolved config] -> [deep helper keeps resolved config / uses host env] -> [secondary service can run or stay dormant] -> [reply continues]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: this only changes which already-available secret source wins at runtime. It prefers the gateway/daemon env or already-resolved caller config over re-reading raw SecretRefs, and adds regression coverage for that behavior.

## Repro + Verification

### Environment

- OS: Ubuntu on `mb-server`
- Runtime/container: repo worktree with shared `node_modules`
- Model/provider: N/A
- Integration/channel (if any): reply-runtime path, skill runtime, memory host runtime
- Relevant config (redacted): env-backed SecretRefs for secondary skill/memory settings

### Steps

1. Build an embedded reply/skill runtime config that starts resolved.
2. Keep the active runtime snapshot raw or set a secondary env-backed SecretRef.
3. Run the skill/memory helper.

### Expected

- The helper keeps the resolved caller config or uses daemon env, and does not reintroduce a raw SecretRef failure.

### Actual

- Before this patch, the helper could overwrite the resolved config with raw SecretRefs and fail the reply.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted `mb-server` tests for skill runtime stability, embedded-run skill runtime, and memory secret-input resolution.
- Edge cases checked: raw runtime snapshot still present, host env already providing the primary env, env-backed memory SecretRef missing from env still throws.
- What you did **not** verify: full Telegram end-to-end in CI; this PR stays at the shared runtime seam where the bug actually lives.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: preferring caller config over runtime snapshot could preserve a stale caller config in cases where the caller intentionally wanted the current snapshot.
  - Mitigation: the fallback only prefers caller config when the runtime snapshot still contains raw skill SecretRefs and the caller config does not; otherwise existing snapshot behavior stays intact.
- Risk: delaying `apiKey` SecretRef resolution could skip a needed validation for some skill paths.
  - Mitigation: resolution still happens when the override is actually needed; tests cover both the injected and already-present env cases.
