### PR TITLE
fix(auth): apply copilot runtime auth to /btw

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -14,6 +14,7 @@ const getApiKeyForModelMock = vi.fn();
 const requireApiKeyMock = vi.fn();
 const resolveSessionAuthProfileOverrideMock = vi.fn();
 const getActiveEmbeddedRunSnapshotMock = vi.fn();
+const prepareProviderRuntimeAuthMock = vi.fn();
 const diagDebugMock = vi.fn();
 
 vi.mock("@mariozechner/pi-ai", async () => {
@@ -56,6 +57,10 @@ vi.mock("./model-auth.js", () => ({
 
 vi.mock("./pi-embedded-runner/runs.js", () => ({
   getActiveEmbeddedRunSnapshot: (...args: unknown[]) => getActiveEmbeddedRunSnapshotMock(...args),
+}));
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  prepareProviderRuntimeAuth: (...args: unknown[]) => prepareProviderRuntimeAuthMock(...args),
 }));
 
 vi.mock("./auth-profiles/session-override.js", () => ({
@@ -194,6 +199,7 @@ describe("runBtwSideQuestion", () => {
     requireApiKeyMock.mockReset();
     resolveSessionAuthProfileOverrideMock.mockReset();
     getActiveEmbeddedRunSnapshotMock.mockReset();
+    prepareProviderRuntimeAuthMock.mockReset();
     diagDebugMock.mockReset();
 
     buildSessionContextMock.mockReturnValue({
@@ -209,6 +215,7 @@ describe("runBtwSideQuestion", () => {
     requireApiKeyMock.mockReturnValue("secret");
     resolveSessionAuthProfileOverrideMock.mockResolvedValue("profile-1");
     getActiveEmbeddedRunSnapshotMock.mockReturnValue(undefined);
+    prepareProviderRuntimeAuthMock.mockResolvedValue(undefined);
   });
 
   it("streams blocks without persisting BTW data to disk", async () => {
@@ -295,6 +302,55 @@ describe("runBtwSideQuestion", () => {
     const result = await runSideQuestion();
 
     expect(result).toEqual({ text: "Final answer." });
+  });
+
+  it("applies provider runtime auth before streaming github-copilot BTW questions", async () => {
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "github-copilot",
+      id: "gpt-5.4",
+      api: "openai-responses",
+      baseUrl: "https://api.individual.githubcopilot.com",
+    });
+    getApiKeyForModelMock.mockResolvedValue({
+      apiKey: "github-token",
+      mode: "token",
+      source: "profile",
+      profileId: "github-copilot:github",
+    });
+    requireApiKeyMock.mockReturnValue("github-token");
+    prepareProviderRuntimeAuthMock.mockResolvedValue({
+      apiKey: "copilot-runtime-token",
+      baseUrl: "https://api.enterprise.githubcopilot.com",
+    });
+    mockDoneAnswer("Copilot answer.");
+
+    const result = await runSideQuestion({
+      provider: "github-copilot",
+      model: "gpt-5.4",
+    });
+
+    expect(result).toEqual({ text: "Copilot answer." });
+    expect(prepareProviderRuntimeAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        context: expect.objectContaining({
+          provider: "github-copilot",
+          modelId: "gpt-5.4",
+          apiKey: "github-token",
+          authMode: "token",
+          profileId: "profile-1",
+        }),
+      }),
+    );
+    expect(streamSimpleMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        id: "gpt-5.4",
+        baseUrl: "https://api.enterprise.githubcopilot.com",
+      }),
+      expect.anything(),
+      expect.objectContaining({ apiKey: "copilot-runtime-token" }),
+    );
   });
 
   it("strips injected empty tools arrays from BTW payloads before sending", async () => {

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -14,6 +14,8 @@ const getApiKeyForModelMock = vi.fn();
 const requireApiKeyMock = vi.fn();
 const resolveSessionAuthProfileOverrideMock = vi.fn();
 const getActiveEmbeddedRunSnapshotMock = vi.fn();
+const resolveSessionAgentIdMock = vi.fn();
+const resolveAgentWorkspaceDirMock = vi.fn();
 const prepareProviderRuntimeAuthMock = vi.fn();
 const diagDebugMock = vi.fn();
 
@@ -57,6 +59,11 @@ vi.mock("./model-auth.js", () => ({
 
 vi.mock("./pi-embedded-runner/runs.js", () => ({
   getActiveEmbeddedRunSnapshot: (...args: unknown[]) => getActiveEmbeddedRunSnapshotMock(...args),
+}));
+
+vi.mock("./agent-scope.js", () => ({
+  resolveSessionAgentId: (...args: unknown[]) => resolveSessionAgentIdMock(...args),
+  resolveAgentWorkspaceDir: (...args: unknown[]) => resolveAgentWorkspaceDirMock(...args),
 }));
 
 vi.mock("../plugins/provider-runtime.js", () => ({
@@ -199,6 +206,8 @@ describe("runBtwSideQuestion", () => {
     requireApiKeyMock.mockReset();
     resolveSessionAuthProfileOverrideMock.mockReset();
     getActiveEmbeddedRunSnapshotMock.mockReset();
+    resolveSessionAgentIdMock.mockReset();
+    resolveAgentWorkspaceDirMock.mockReset();
     prepareProviderRuntimeAuthMock.mockReset();
     diagDebugMock.mockReset();
 
@@ -215,6 +224,8 @@ describe("runBtwSideQuestion", () => {
     requireApiKeyMock.mockReturnValue("secret");
     resolveSessionAuthProfileOverrideMock.mockResolvedValue("profile-1");
     getActiveEmbeddedRunSnapshotMock.mockReturnValue(undefined);
+    resolveSessionAgentIdMock.mockReturnValue("main");
+    resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     prepareProviderRuntimeAuthMock.mockResolvedValue(undefined);
   });
 
@@ -333,9 +344,11 @@ describe("runBtwSideQuestion", () => {
     expect(prepareProviderRuntimeAuthMock).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "github-copilot",
+        workspaceDir: "/tmp/workspace",
         context: expect.objectContaining({
           provider: "github-copilot",
           modelId: "gpt-5.4",
+          workspaceDir: "/tmp/workspace",
           apiKey: "github-token",
           authMode: "token",
           profileId: "profile-1",

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -17,7 +17,9 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import { diagnosticLogger as diag } from "../logging/diagnostic.js";
+import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import {
   resolveImageSanitizationLimits,
@@ -389,10 +391,45 @@ export async function runBtwSideQuestion(
     profileId: authProfileId,
     agentDir: params.agentDir,
   });
-  const apiKey =
+  let runtimeModel = model;
+  let apiKey =
     apiKeyInfo.mode === "aws-sdk" && !apiKeyInfo.apiKey
       ? undefined
       : requireApiKey(apiKeyInfo, model.provider);
+  if (apiKey) {
+    const sessionAgentId = resolveSessionAgentId({
+      sessionKey: params.sessionKey,
+      config: params.cfg,
+    });
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, sessionAgentId);
+    const preparedAuth = await prepareProviderRuntimeAuth({
+      provider: model.provider,
+      config: params.cfg,
+      workspaceDir,
+      env: process.env,
+      context: {
+        config: params.cfg,
+        agentDir: params.agentDir,
+        workspaceDir,
+        env: process.env,
+        provider: model.provider,
+        modelId: model.id,
+        model,
+        apiKey,
+        authMode: apiKeyInfo.mode,
+        profileId: authProfileId,
+      },
+    });
+    if (preparedAuth?.baseUrl) {
+      runtimeModel = {
+        ...runtimeModel,
+        baseUrl: preparedAuth.baseUrl,
+      };
+    }
+    if (preparedAuth?.apiKey) {
+      apiKey = preparedAuth.apiKey;
+    }
+  }
 
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking
@@ -422,7 +459,7 @@ export async function runBtwSideQuestion(
 
   const stream = await streamWithPayloadPatch(
     streamSimple,
-    model,
+    runtimeModel,
     {
       systemPrompt: buildBtwSystemPrompt(),
       messages: [


### PR DESCRIPTION
## Summary

- Problem: `/btw` failed with `400 The requested model is not supported` in sessions using `github-copilot/gpt-5.4`, even though normal chat in the same session worked.
- Why it matters: Copilot-backed sessions had an inconsistent command path where normal turns worked but ephemeral side questions broke.
- What changed: `src/agents/btw.ts` now applies provider runtime auth before sending the BTW side-question request, matching the main embedded runner path.
- What did NOT change (scope boundary): no provider catalog changes, no gateway protocol changes, and no unrelated model-routing behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53925
- Related #53925
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the normal embedded runner path applies provider-owned runtime auth exchange in `src/agents/pi-embedded-runner/run/auth-controller.ts`, but `/btw` resolved auth directly in `src/agents/btw.ts` and skipped that step. For GitHub Copilot, that meant BTW used the raw GitHub token instead of exchanging it into the runtime Copilot token and entitlement-specific base URL provided by `extensions/github-copilot/index.ts`.
- Missing detection / guardrail: there was no regression test covering `/btw` with a provider that requires runtime auth exchange.
- Contributing context (if known): Copilot chat worked on the main path, which hid the bug until users exercised `/btw` specifically.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/btw.test.ts`
- Scenario the test should lock in: when `/btw` runs against `github-copilot/gpt-5.4`, it should apply provider runtime auth and stream using the exchanged runtime token/base URL.
- Why this is the smallest reliable guardrail: the bug lives inside the BTW auth-preparation seam, so mocking that seam directly is the narrowest stable test.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `/btw` now works in GitHub Copilot sessions that require runtime auth exchange.

## Diagram (if applicable)

```text
Before:
/btw on github-copilot session -> raw GitHub token used directly -> Copilot rejects request

After:
/btw on github-copilot session -> runtime auth exchange -> Copilot runtime token/base URL -> side question succeeds
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: this change reuses the existing provider-owned runtime auth exchange already used by normal chat runs; it narrows behavior divergence rather than introducing a new credential path.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev gateway
- Model/provider: `github-copilot/gpt-5.4`
- Integration/channel (if any): Gateway `chat.send` on a dashboard session
- Relevant config (redacted): loopback local gateway for verification; existing GitHub Copilot auth profile

### Steps

1. Create or switch to a session using `github-copilot/gpt-5.4`.
2. Send a normal message.
3. Send `/btw ...` in the same session.

### Expected

- Both the normal message and `/btw` succeed.

### Actual

- Before the fix, `/btw` failed while the normal message succeeded.
- After the fix, both succeed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran `pnpm test src/agents/btw.test.ts`
  - Ran `pnpm test src/auto-reply/reply/commands-btw.test.ts`
  - Ran `pnpm build`
  - Started a local loopback gateway, created a fresh session pinned to `github-copilot/gpt-5.4`, confirmed a normal chat reply succeeded, then confirmed `/btw` returned a BTW side-result successfully instead of failing.
- Edge cases checked:
  - Copilot runtime auth test covers exchanged `apiKey` and `baseUrl` use in the BTW path.
- What you did **not** verify:
  - Other runtime-auth-exchange providers beyond GitHub Copilot.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: BTW now depends on provider runtime auth prep succeeding for providers that implement it.
  - Mitigation: this matches the already-working main runner path and is covered by a focused regression test.
