### PR TITLE
fix(msteams): use dynamic tenant ID for sts.windows.net JWT issuer

### DIFF
--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -234,7 +234,7 @@ describe("createBotFrameworkJwtValidator", () => {
 
   it("validates a token with STS Windows issuer", async () => {
     jwtState.decodedPayload = {
-      iss: "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+      iss: `https://sts.windows.net/${creds.tenantId}/`,
     };
 
     const validator = await createBotFrameworkJwtValidator(creds);
@@ -243,7 +243,7 @@ describe("createBotFrameworkJwtValidator", () => {
     expect(jwtState.verifyCalls).toHaveLength(1);
     const opts = jwtState.verifyCalls[0]?.options as Record<string, unknown>;
     expect(opts.issuer as string[]).toContain(
-      "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+      `https://sts.windows.net/${creds.tenantId}/`,
     );
   });
 

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -446,7 +446,7 @@ const BOT_FRAMEWORK_ISSUERS: ReadonlyArray<{
     jwksUri: "https://login.microsoftonline.com/common/discovery/v2.0/keys",
   },
   {
-    issuer: "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+    issuer: (tenantId: string) => `https://sts.windows.net/${tenantId}/`,
     jwksUri: "https://login.microsoftonline.com/common/discovery/v2.0/keys",
   },
 ];


### PR DESCRIPTION
## Summary

- The `sts.windows.net` issuer entry in `BOT_FRAMEWORK_ISSUERS` was hardcoded to a single tenant ID (`d6d49420-f39b-4df7-a1dc-d59a935871db`), causing JWT validation to reject tokens from **all other** SingleTenant bot deployments
- Changed the static string to a dynamic function `(tenantId) => \`https://sts.windows.net/${tenantId}/\`` matching the pattern used by the `login.microsoftonline.com` entry
- Updated the corresponding test to use the test credential's `tenantId` instead of the hardcoded value

## Context

SingleTenant Azure Bot registrations (required since Microsoft deprecated MultiTenant after 2025-07-31) issue tokens with issuer `https://sts.windows.net/{tenantId}/` (Azure AD v1 endpoint). The current code only accepts this issuer for one specific tenant, so every other SingleTenant deployment gets `401 Unauthorized` on all incoming Bot Framework webhooks.

Fixes #64270

## Test plan

- [ ] Existing test "validates a token with STS Windows issuer" now uses dynamic `creds.tenantId` instead of hardcoded UUID
- [ ] Verify `vitest run --config vitest.extension-msteams.config.ts` passes
- [ ] Deploy a SingleTenant bot and confirm incoming Teams messages no longer return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)