### PR TITLE
fix: sanitize required fields in tool schemas for Gemini compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 - Plugins: treat duplicate `registerService` calls from the same plugin id as idempotent so snapshot and activation loads no longer emit spurious `service already registered` diagnostics. (#62033, #64128) Thanks @ly85206559.
 - Discord/TTS: route auto voice replies through the native voice-note path so Discord receives Opus voice messages instead of regular audio attachments. (#64096) Thanks @LiuHuaize.
 - Config/plugins: use plugin-owned command alias metadata when `plugins.allow` contains runtime command names like `dreaming`, and point users at the owning plugin instead of stale plugin-not-found guidance. (#64242) Thanks @feiskyer.
+- Agents/Gemini: strip orphaned `required` entries from Gemini tool schemas so provider validation no longer rejects tools after schema cleanup or union flattening. (#64284) Thanks @xxxxxmax.
 
 ## 2026.4.9
 

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -33,6 +33,16 @@ describe("normalizeToolParameterSchema", () => {
   });
 });
 
+function makeTool(parameters: unknown): AnyAgentTool {
+  return {
+    name: "test_tool",
+    label: "Test Tool",
+    description: "test",
+    parameters,
+    execute: vi.fn(),
+  };
+}
+
 describe("normalizeToolParameters", () => {
   it("normalizes truly empty schemas to type:object with properties:{} (MCP parameter-free tools)", () => {
     const tool: AnyAgentTool = {
@@ -142,5 +152,131 @@ describe("normalizeToolParameters", () => {
     expect(parameters.properties?.count.type).toBe("integer");
     expect(parameters.properties?.query.minLength).toBeUndefined();
     expect(parameters.properties?.query.type).toBe("string");
+  });
+
+  it("filters required to match properties when flattening anyOf for Gemini", () => {
+    const tool = makeTool({
+      type: "object",
+      required: ["action", "amount", "token"],
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            action: { type: "string", enum: ["buy"] },
+            amount: { type: "number" },
+          },
+        },
+        {
+          type: "object",
+          properties: {
+            action: { type: "string", enum: ["sell"] },
+            price: { type: "number" },
+          },
+        },
+      ],
+    });
+
+    const result = normalizeToolParameters(tool, {
+      modelProvider: "google",
+    });
+
+    const params = result.parameters as {
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+
+    expect(params.required).not.toContain("token");
+    expect(params.required).toContain("action");
+    expect(params.properties).toHaveProperty("action");
+    expect(params.properties).toHaveProperty("amount");
+    expect(params.properties).toHaveProperty("price");
+  });
+
+  it("preserves extra required fields for non-Gemini providers", () => {
+    const tool = makeTool({
+      type: "object",
+      required: ["action", "token"],
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            action: { type: "string" },
+          },
+        },
+      ],
+    });
+
+    const result = normalizeToolParameters(tool);
+    const params = result.parameters as { required?: string[] };
+
+    expect(params.required).toEqual(["action", "token"]);
+  });
+
+  it("keeps all required fields when they exist in merged properties", () => {
+    const tool = makeTool({
+      type: "object",
+      required: ["action", "amount"],
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            action: { type: "string" },
+            amount: { type: "number" },
+          },
+        },
+      ],
+    });
+
+    const result = normalizeToolParameters(tool, {
+      modelProvider: "google",
+    });
+
+    const params = result.parameters as { required?: string[] };
+    expect(params.required).toContain("action");
+    expect(params.required).toContain("amount");
+  });
+
+  it("removes required entirely when no fields match merged properties", () => {
+    const tool = makeTool({
+      type: "object",
+      required: ["ghost_a", "ghost_b"],
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            real: { type: "string" },
+          },
+        },
+      ],
+    });
+
+    const result = normalizeToolParameters(tool, {
+      modelProvider: "google",
+    });
+
+    const params = result.parameters as { required?: string[] };
+    expect(params.required).toBeUndefined();
+  });
+
+  it("drops inherited names like toString for Gemini", () => {
+    const tool = makeTool({
+      type: "object",
+      required: ["toString", "name"],
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      ],
+    });
+
+    const result = normalizeToolParameters(tool, {
+      modelProvider: "google",
+    });
+
+    const params = result.parameters as { required?: string[] };
+    expect(params.required).toEqual(["name"]);
   });
 });

--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -30,6 +30,82 @@ describe("cleanSchemaForGemini", () => {
     expect(cleaned.properties).toEqual({});
   });
 
+  it("filters required fields that are not in properties", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        amount: { type: "number" },
+      },
+      required: ["action", "amount", "token"],
+    }) as { required?: string[] };
+
+    expect(cleaned.required).toEqual(["action", "amount"]);
+  });
+
+  it("preserves required when all fields exist in properties", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        amount: { type: "number" },
+      },
+      required: ["action", "amount"],
+    }) as { required?: string[] };
+
+    expect(cleaned.required).toEqual(["action", "amount"]);
+  });
+
+  it("removes required entirely when no fields match properties", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+      },
+      required: ["missing_a", "missing_b"],
+    }) as { required?: string[] };
+
+    expect(cleaned.required).toBeUndefined();
+  });
+
+  it("leaves required as-is when properties is absent", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      required: ["a", "b"],
+    }) as { required?: string[] };
+
+    expect(cleaned.required).toEqual(["a", "b"]);
+  });
+
+  it("filters required in nested object properties", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        config: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+          },
+          required: ["name", "ghost"],
+        },
+      },
+    }) as { properties?: { config?: { required?: string[] } } };
+
+    expect(cleaned.properties?.config?.required).toEqual(["name"]);
+  });
+
+  it("does not treat inherited keys as declared properties", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      required: ["toString", "name"],
+    }) as { required?: string[] };
+
+    expect(cleaned.required).toEqual(["name"]);
+  });
+
   it("coerces nested null properties while preserving valid siblings", () => {
     const cleaned = cleanSchemaForGemini({
       type: "object",

--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -68,9 +68,18 @@ describe("cleanSchemaForGemini", () => {
     expect(cleaned.required).toBeUndefined();
   });
 
-  it("leaves required as-is when properties is absent", () => {
+  it("removes required from object schemas when properties is absent", () => {
     const cleaned = cleanSchemaForGemini({
       type: "object",
+      required: ["a", "b"],
+    }) as { required?: string[] };
+
+    expect(cleaned.required).toBeUndefined();
+  });
+
+  it("leaves required as-is for non-object schemas when properties is absent", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "array",
       required: ["a", "b"],
     }) as { required?: string[] };
 

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -212,6 +212,31 @@ function simplifyUnionVariants(params: { obj: Record<string, unknown>; variants:
   return { variants: stripped ? nonNullVariants : variants };
 }
 
+// Gemini rejects object schemas whose `required` entries do not exist in `properties`.
+function sanitizeRequiredFields(schema: Record<string, unknown>): Record<string, unknown> {
+  if (
+    !Array.isArray(schema.required) ||
+    !schema.properties ||
+    typeof schema.properties !== "object" ||
+    Array.isArray(schema.properties)
+  ) {
+    return schema;
+  }
+
+  const properties = schema.properties as Record<string, unknown>;
+  const required = schema.required.filter(
+    (key): key is string => typeof key === "string" && Object.hasOwn(properties, key),
+  );
+
+  if (required.length > 0) {
+    schema.required = required;
+  } else {
+    delete schema.required;
+  }
+
+  return schema;
+}
+
 function cleanSchemaForGeminiWithDefs(
   schema: unknown,
   defs: SchemaDefs | undefined,
@@ -362,17 +387,17 @@ function cleanSchemaForGeminiWithDefs(
   if (cleaned.anyOf && Array.isArray(cleaned.anyOf)) {
     const flattened = flattenUnionFallback(cleaned, cleaned.anyOf);
     if (flattened) {
-      return flattened;
+      return sanitizeRequiredFields(flattened);
     }
   }
   if (cleaned.oneOf && Array.isArray(cleaned.oneOf)) {
     const flattened = flattenUnionFallback(cleaned, cleaned.oneOf);
     if (flattened) {
-      return flattened;
+      return sanitizeRequiredFields(flattened);
     }
   }
 
-  return cleaned;
+  return sanitizeRequiredFields(cleaned);
 }
 
 /**

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -214,12 +214,18 @@ function simplifyUnionVariants(params: { obj: Record<string, unknown>; variants:
 
 // Gemini rejects object schemas whose `required` entries do not exist in `properties`.
 function sanitizeRequiredFields(schema: Record<string, unknown>): Record<string, unknown> {
+  if (!Array.isArray(schema.required)) {
+    return schema;
+  }
+
   if (
-    !Array.isArray(schema.required) ||
     !schema.properties ||
     typeof schema.properties !== "object" ||
     Array.isArray(schema.properties)
   ) {
+    if (schema.type === "object") {
+      delete schema.required;
+    }
     return schema;
   }
 


### PR DESCRIPTION
## Summary

Gemini-backed providers reject tool schemas when a `required` entry does not correspond to a declared property. In practice this shows up after schema cleanup and union flattening paths leave behind phantom required keys, which can trigger Gemini 400s while other providers tolerate the same payload.

This change keeps the fix scoped to the Gemini cleanup path:

- add `sanitizeRequiredFields()` in `src/agents/schema/clean-for-gemini.ts`
- filter `required` against declared own properties before returning cleaned Gemini schemas
- drop `required` entirely when no valid entries remain
- preserve non-Gemini behavior for flattened tool schemas
- avoid inherited-property false positives like `toString`

## Test plan

- [x] `OPENCLAW_LOCAL_CHECK=0 pnpm test src/agents/pi-tools.schema.test.ts`
- [x] `OPENCLAW_LOCAL_CHECK=0 pnpm test src/agents/schema/clean-for-gemini.test.ts`
