### PR TITLE
fix(telegram): keep tool media after text preview

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -619,6 +619,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.stop).toHaveBeenCalled();
   });
 
+  it("delivers media for final replies that also finalize visible text", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: "Generated audio reply.",
+          mediaUrl: "/tmp/reply.opus",
+          audioAsVoice: true,
+        },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "Generated audio reply.",
+      expect.any(Object),
+    );
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({
+            text: undefined,
+            mediaUrl: "/tmp/reply.opus",
+            audioAsVoice: true,
+          }),
+        ],
+      }),
+    );
+  });
+
   it("emits only the internal message:sent hook when a final answer stays in preview", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -693,6 +693,13 @@ export const dispatchTelegramMessage = async ({
             }
           }
           if (segments.length > 0) {
+            if (reply.hasMedia) {
+              // Text-bearing payloads still need their media delivery after the
+              // lane text path consumes the visible text. Otherwise mixed
+              // tool/media replies such as Telegram TTS outputs can finalize a
+              // text preview but silently drop the actual attachment.
+              await sendPayload({ ...payload, text: undefined });
+            }
             return;
           }
           if (split.suppressedReasoningOnly) {


### PR DESCRIPTION
## Summary
- preserve Telegram tool-generated media delivery even when the reply pipeline already emitted visible text segments
- send the media-bearing payload after the text lane consumes the preview text instead of returning early and silently dropping attachments
- add a regression test covering mixed text + media replies so Telegram TTS-style voice-note outputs still deliver their media

Closes #64272

## Testing
- attempted:  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/root/.openclaw/workspace".
- blocked locally in this worktree because  /  are unavailable ()
- sending to CI for verification

## Notes
- this is intentionally scoped to the Telegram outbound dispatch regression described in #64272
- I did not include a broader STT/inbound refactor because the reproducible root cause fixed here is the outbound mixed text+media early-return path