### PR TITLE
openai-codex: fix auth scope handling and classify provider/runtime failures

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -324,6 +324,16 @@ describe("failover-error", () => {
     ).toEqual({ kind: "context_overflow" });
   });
 
+  it("requires explicit scope signals before classifying openai-codex auth_scope", () => {
+    expect(
+      classifyFailoverSignal({
+        status: 403,
+        provider: "openai-codex",
+        message: "OpenAI Codex returned insufficient permissions for this workspace",
+      }),
+    ).toEqual({ kind: "reason", reason: "auth" });
+  });
+
   it("treats HTTP 422 as format error", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/pi-embedded-error-observation.test.ts
+++ b/src/agents/pi-embedded-error-observation.test.ts
@@ -23,6 +23,7 @@ describe("buildApiErrorObservationFields", () => {
       rawErrorPreview: expect.stringContaining('"request_id":"sha256:'),
       rawErrorHash: expect.stringMatching(/^sha256:/),
       rawErrorFingerprint: expect.stringMatching(/^sha256:/),
+      providerRuntimeFailureKind: "timeout",
       providerErrorType: "overloaded_error",
       providerErrorMessagePreview: "Overloaded",
       requestIdHash: expect.stringMatching(/^sha256:/),
@@ -69,6 +70,7 @@ describe("buildApiErrorObservationFields", () => {
       textPreview: expect.stringContaining('"request_id":"sha256:'),
       textHash: expect.stringMatching(/^sha256:/),
       textFingerprint: expect.stringMatching(/^sha256:/),
+      providerRuntimeFailureKind: "timeout",
       providerErrorType: "overloaded_error",
       providerErrorMessagePreview: "Overloaded",
       requestIdHash: expect.stringMatching(/^sha256:/),
@@ -156,6 +158,7 @@ describe("buildApiErrorObservationFields", () => {
       textHash: undefined,
       textFingerprint: undefined,
       httpCode: undefined,
+      providerRuntimeFailureKind: undefined,
       providerErrorType: undefined,
       providerErrorMessagePreview: undefined,
       requestIdHash: undefined,
@@ -175,6 +178,17 @@ describe("buildApiErrorObservationFields", () => {
 
     expect(observed.rawErrorPreview).not.toContain("custom-secret-abc123");
     expect(observed.rawErrorPreview).toContain("custom");
+  });
+
+  it("records runtime failure kind for missing-scope auth payloads", () => {
+    const observed = buildApiErrorObservationFields(
+      '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+    );
+
+    expect(observed).toMatchObject({
+      httpCode: "401",
+      providerRuntimeFailureKind: "auth_scope",
+    });
   });
 });
 

--- a/src/agents/pi-embedded-error-observation.test.ts
+++ b/src/agents/pi-embedded-error-observation.test.ts
@@ -180,14 +180,14 @@ describe("buildApiErrorObservationFields", () => {
     expect(observed.rawErrorPreview).toContain("custom");
   });
 
-  it("records runtime failure kind for missing-scope auth payloads", () => {
+  it("keeps provider-less missing-scope auth payloads out of the codex-specific scope lane", () => {
     const observed = buildApiErrorObservationFields(
       '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
     );
 
     expect(observed).toMatchObject({
       httpCode: "401",
-      providerRuntimeFailureKind: "auth_scope",
+      providerRuntimeFailureKind: "unknown",
     });
   });
 });

--- a/src/agents/pi-embedded-error-observation.ts
+++ b/src/agents/pi-embedded-error-observation.ts
@@ -104,7 +104,10 @@ function buildObservationFingerprint(params: {
   return getApiErrorPayloadFingerprint(params.raw);
 }
 
-export function buildApiErrorObservationFields(rawError?: string): {
+export function buildApiErrorObservationFields(
+  rawError?: string,
+  opts?: { provider?: string },
+): {
   rawErrorPreview?: string;
   rawErrorHash?: string;
   rawErrorFingerprint?: string;
@@ -146,6 +149,7 @@ export function buildApiErrorObservationFields(rawError?: string): {
       providerRuntimeFailureKind: classifyProviderRuntimeFailureKind({
         status: parsed?.httpCode ? Number(parsed.httpCode) : undefined,
         message: trimmed,
+        provider: opts?.provider,
       }),
       providerErrorType: parsed?.type,
       providerErrorMessagePreview: truncateForObservation(
@@ -159,7 +163,10 @@ export function buildApiErrorObservationFields(rawError?: string): {
   }
 }
 
-export function buildTextObservationFields(text?: string): {
+export function buildTextObservationFields(
+  text?: string,
+  opts?: { provider?: string },
+): {
   textPreview?: string;
   textHash?: string;
   textFingerprint?: string;
@@ -169,7 +176,7 @@ export function buildTextObservationFields(text?: string): {
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
 } {
-  const observed = buildApiErrorObservationFields(text);
+  const observed = buildApiErrorObservationFields(text, opts);
   return {
     textPreview: observed.rawErrorPreview,
     textHash: observed.rawErrorHash,

--- a/src/agents/pi-embedded-error-observation.ts
+++ b/src/agents/pi-embedded-error-observation.ts
@@ -3,7 +3,11 @@ import { redactIdentifier } from "../logging/redact-identifier.js";
 import { getDefaultRedactPatterns, redactSensitiveText } from "../logging/redact.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
-import { getApiErrorPayloadFingerprint, parseApiErrorInfo } from "./pi-embedded-helpers.js";
+import {
+  classifyProviderRuntimeFailureKind,
+  getApiErrorPayloadFingerprint,
+  parseApiErrorInfo,
+} from "./pi-embedded-helpers.js";
 import { stableStringify } from "./stable-stringify.js";
 
 export { sanitizeForConsole } from "./console-sanitize.js";
@@ -105,6 +109,7 @@ export function buildApiErrorObservationFields(rawError?: string): {
   rawErrorHash?: string;
   rawErrorFingerprint?: string;
   httpCode?: string;
+  providerRuntimeFailureKind?: string;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
@@ -138,6 +143,10 @@ export function buildApiErrorObservationFields(rawError?: string): {
         ? redactIdentifier(rawFingerprint, { len: 12 })
         : undefined,
       httpCode: parsed?.httpCode,
+      providerRuntimeFailureKind: classifyProviderRuntimeFailureKind({
+        status: parsed?.httpCode ? Number(parsed.httpCode) : undefined,
+        message: trimmed,
+      }),
       providerErrorType: parsed?.type,
       providerErrorMessagePreview: truncateForObservation(
         redactedProviderMessage,
@@ -155,6 +164,7 @@ export function buildTextObservationFields(text?: string): {
   textHash?: string;
   textFingerprint?: string;
   httpCode?: string;
+  providerRuntimeFailureKind?: string;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
@@ -165,6 +175,7 @@ export function buildTextObservationFields(text?: string): {
     textHash: observed.rawErrorHash,
     textFingerprint: observed.rawErrorFingerprint,
     httpCode: observed.httpCode,
+    providerRuntimeFailureKind: observed.providerRuntimeFailureKind,
     providerErrorType: observed.providerErrorType,
     providerErrorMessagePreview: observed.providerErrorMessagePreview,
     requestIdHash: observed.requestIdHash,

--- a/src/agents/pi-embedded-error-observation.ts
+++ b/src/agents/pi-embedded-error-observation.ts
@@ -7,6 +7,7 @@ import {
   classifyProviderRuntimeFailureKind,
   getApiErrorPayloadFingerprint,
   parseApiErrorInfo,
+  type ProviderRuntimeFailureKind,
 } from "./pi-embedded-helpers.js";
 import { stableStringify } from "./stable-stringify.js";
 
@@ -112,7 +113,7 @@ export function buildApiErrorObservationFields(
   rawErrorHash?: string;
   rawErrorFingerprint?: string;
   httpCode?: string;
-  providerRuntimeFailureKind?: string;
+  providerRuntimeFailureKind?: ProviderRuntimeFailureKind;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
@@ -171,7 +172,7 @@ export function buildTextObservationFields(
   textHash?: string;
   textFingerprint?: string;
   httpCode?: string;
-  providerRuntimeFailureKind?: string;
+  providerRuntimeFailureKind?: ProviderRuntimeFailureKind;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -228,8 +228,17 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError(
       '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"}}',
     );
-    expect(formatAssistantErrorText(msg)).toBe(
+    expect(formatAssistantErrorText(msg, { provider: "openai-codex" })).toBe(
       "Authentication is missing the required OpenAI Codex scopes. Re-run OpenAI/Codex login and try again.",
+    );
+  });
+
+  it("does not misdiagnose non-Codex permission errors as missing-scope failures", () => {
+    const msg = makeAssistantError(
+      '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"}}',
+    );
+    expect(formatAssistantErrorText(msg, { provider: "openai" })).not.toContain(
+      "required OpenAI Codex scopes",
     );
   });
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -215,6 +215,38 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("returns an explicit re-authentication message for OAuth refresh failures", () => {
+    const msg = makeAssistantError(
+      "OAuth token refresh failed for openai-codex: invalid_grant. Please try again or re-authenticate.",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Authentication refresh failed. Re-authenticate this provider and try again.",
+    );
+  });
+
+  it("returns a missing-scope message for OpenAI Codex scope failures", () => {
+    const msg = makeAssistantError(
+      '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"}}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Authentication is missing the required OpenAI Codex scopes. Re-run OpenAI/Codex login and try again.",
+    );
+  });
+
+  it("returns an HTML-403 auth message for HTML provider auth failures", () => {
+    const msg = makeAssistantError("403 <!DOCTYPE html><html><body>Access denied</body></html>");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Authentication failed with an HTML 403 response from the provider. Re-authenticate and verify your provider account access.",
+    );
+  });
+
+  it("returns a proxy-specific message for proxy misroutes", () => {
+    const msg = makeAssistantError("407 Proxy Authentication Required");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM request failed: proxy or tunnel configuration blocked the provider request.",
+    );
+  });
+
   it("sanitizes invalid streaming event order errors", () => {
     const msg = makeAssistantError(
       'Unexpected event order, got message_start before receiving "message_stop"',

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -252,6 +252,15 @@ describe("formatAssistantErrorText", () => {
     expect(formatted).not.toContain("Re-run OpenAI/Codex login");
   });
 
+  it("does not misdiagnose provider-scoped upstream 400s as schema failures", () => {
+    const msg = makeAssistantError("400 Provider returned error");
+    const formatted = formatAssistantErrorText(msg, { provider: "openrouter" });
+
+    expect(formatted).not.toBe(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+    );
+  });
+
   it("returns an HTML-403 auth message for HTML provider auth failures", () => {
     const msg = makeAssistantError("403 <!DOCTYPE html><html><body>Access denied</body></html>");
     expect(formatAssistantErrorText(msg)).toBe(

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -242,6 +242,16 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("does not misdiagnose generic Codex permission denials as missing-scope failures", () => {
+    const msg = makeAssistantError(
+      '403 {"type":"error","error":{"type":"permission_error","message":"You have insufficient permissions for this operation"}}',
+    );
+    const formatted = formatAssistantErrorText(msg, { provider: "openai-codex" });
+
+    expect(formatted).not.toContain("required OpenAI Codex scopes");
+    expect(formatted).not.toContain("Re-run OpenAI/Codex login");
+  });
+
   it("returns an HTML-403 auth message for HTML provider auth failures", () => {
     const msg = makeAssistantError("403 <!DOCTYPE html><html><body>Access denied</body></html>");
     expect(formatAssistantErrorText(msg)).toBe(

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -275,6 +275,13 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("does not misdiagnose provider ids containing proxy as transport failures", () => {
+    const msg = makeAssistantError("Unknown model: custom-proxy/foo");
+    expect(formatAssistantErrorText(msg)).not.toBe(
+      "LLM request failed: proxy or tunnel configuration blocked the provider request.",
+    );
+  });
+
   it("sanitizes invalid streaming event order errors", () => {
     const msg = makeAssistantError(
       'Unexpected event order, got message_start before receiving "message_stop"',

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1106,10 +1106,22 @@ describe("classifyFailoverReason", () => {
 describe("classifyProviderRuntimeFailureKind", () => {
   it("classifies missing scope failures", () => {
     expect(
-      classifyProviderRuntimeFailureKind(
-        '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
-      ),
+      classifyProviderRuntimeFailureKind({
+        provider: "openai-codex",
+        message:
+          '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      }),
     ).toBe("auth_scope");
+  });
+
+  it("does not classify non-Codex permission errors as missing scope failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        provider: "openai",
+        message:
+          '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      }),
+    ).not.toBe("auth_scope");
   });
 
   it("classifies OAuth refresh failures", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyProviderRuntimeFailureKind,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,
   extractObservedOverflowTokenCount,
@@ -1099,5 +1100,48 @@ describe("classifyFailoverReason", () => {
         '{"type":"error","error":{"type":"api_error","message":"permission_error: OAuth authentication is currently not allowed for this organization"}}',
       ),
     ).toBe("auth_permanent");
+  });
+});
+
+describe("classifyProviderRuntimeFailureKind", () => {
+  it("classifies missing scope failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      ),
+    ).toBe("auth_scope");
+  });
+
+  it("classifies OAuth refresh failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "OAuth token refresh failed for openai-codex: invalid_grant. Please try again or re-authenticate.",
+      ),
+    ).toBe("auth_refresh");
+  });
+
+  it("classifies HTML 403 auth failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "403 <!DOCTYPE html><html><body>Access denied</body></html>",
+      ),
+    ).toBe("auth_html_403");
+  });
+
+  it("classifies proxy, dns, timeout, schema, sandbox, and replay failures", () => {
+    expect(classifyProviderRuntimeFailureKind("407 Proxy Authentication Required")).toBe("proxy");
+    expect(
+      classifyProviderRuntimeFailureKind("dial tcp: lookup api.example.com: no such host"),
+    ).toBe("dns");
+    expect(classifyProviderRuntimeFailureKind("socket hang up")).toBe("timeout");
+    expect(
+      classifyProviderRuntimeFailureKind("INVALID_REQUEST_ERROR: string should match pattern"),
+    ).toBe("schema");
+    expect(classifyProviderRuntimeFailureKind("exec denied (allowlist-miss):")).toBe(
+      "sandbox_blocked",
+    );
+    expect(classifyProviderRuntimeFailureKind("tool_use.input: Field required")).toBe(
+      "replay_invalid",
+    );
   });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1124,6 +1124,16 @@ describe("classifyProviderRuntimeFailureKind", () => {
     ).not.toBe("auth_scope");
   });
 
+  it("does not treat generic Codex permission denials as missing scope failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        provider: "openai-codex",
+        message:
+          '403 {"type":"error","error":{"type":"permission_error","message":"You have insufficient permissions for this operation"}}',
+      }),
+    ).not.toBe("auth_scope");
+  });
+
   it("classifies OAuth refresh failures", () => {
     expect(
       classifyProviderRuntimeFailureKind(

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1161,6 +1161,10 @@ describe("classifyProviderRuntimeFailureKind", () => {
 
   it("classifies proxy, dns, timeout, schema, sandbox, and replay failures", () => {
     expect(classifyProviderRuntimeFailureKind("407 Proxy Authentication Required")).toBe("proxy");
+    expect(classifyProviderRuntimeFailureKind("tunnel connection failed")).toBe("proxy");
+    expect(classifyProviderRuntimeFailureKind("Unknown model: custom-proxy/foo")).not.toBe(
+      "proxy",
+    );
     expect(
       classifyProviderRuntimeFailureKind("dial tcp: lookup api.example.com: no such host"),
     ).toBe("dns");

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1134,6 +1134,15 @@ describe("classifyProviderRuntimeFailureKind", () => {
     ).not.toBe("auth_scope");
   });
 
+  it("keeps provider-scoped upstream 400s out of schema classification", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        provider: "openrouter",
+        message: "400 Provider returned error",
+      }),
+    ).toBe("timeout");
+  });
+
   it("classifies OAuth refresh failures", () => {
     expect(
       classifyProviderRuntimeFailureKind(

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -45,6 +45,7 @@ export {
   parseImageDimensionError,
   parseImageSizeError,
 } from "./pi-embedded-helpers/errors.js";
+export type { ProviderRuntimeFailureKind } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 
 export {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -11,6 +11,7 @@ export {
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,
+  classifyProviderRuntimeFailureKind,
   formatBillingErrorMessage,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -465,7 +465,7 @@ const TIMEOUT_ERROR_CODES = new Set([
   "EAI_AGAIN",
 ]);
 const AUTH_SCOPE_HINT_RE =
-  /\b(?:missing|required|requires|insufficient)\s+(?:the\s+following\s+)?scopes?\b|\bmissing\s+scope\b|\binsufficient\s+permissions?\b/i;
+  /\b(?:missing|required|requires|insufficient)\s+(?:the\s+following\s+)?scopes?\b|\bmissing\s+scope\b/i;
 const AUTH_SCOPE_NAME_RE = /\b(?:api\.responses\.write|model\.request)\b/i;
 const HTML_BODY_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -502,8 +502,20 @@ function isHtmlErrorResponse(raw: string, status?: number): boolean {
   return HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
 }
 
-function isAuthScopeErrorMessage(raw: string, status?: number): boolean {
+function isOpenAICodexScopeContext(raw: string, provider?: string): boolean {
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  return (
+    normalizedProvider === "openai-codex" ||
+    /\bopenai\s+codex\b/i.test(raw) ||
+    /\bcodex\b.*\bscopes?\b/i.test(raw)
+  );
+}
+
+function isAuthScopeErrorMessage(raw: string, status?: number, provider?: string): boolean {
   if (!raw) {
+    return false;
+  }
+  if (!isOpenAICodexScopeContext(raw, provider)) {
     return false;
   }
   const inferred =
@@ -916,7 +928,7 @@ export function classifyProviderRuntimeFailureKind(
   if (message && classifyOAuthRefreshFailure(message)) {
     return "auth_refresh";
   }
-  if (message && isAuthScopeErrorMessage(message, status)) {
+  if (message && isAuthScopeErrorMessage(message, status, normalizedSignal.provider)) {
     return "auth_scope";
   }
   if (message && status === 403 && isHtmlErrorResponse(message, status)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -18,6 +18,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   parseApiErrorInfo,
 } from "../../shared/assistant-error-format.js";
+import { classifyOAuthRefreshFailure } from "../auth-profiles/oauth-refresh-failure.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { isModelNotFoundErrorMessage } from "../live-model-errors.js";
@@ -407,6 +408,19 @@ export type FailoverClassification =
       kind: "context_overflow";
     };
 
+export type ProviderRuntimeFailureKind =
+  | "auth_scope"
+  | "auth_refresh"
+  | "auth_html_403"
+  | "proxy"
+  | "rate_limit"
+  | "dns"
+  | "timeout"
+  | "schema"
+  | "sandbox_blocked"
+  | "replay_invalid"
+  | "unknown";
+
 const BILLING_402_HINTS = [
   "insufficient credits",
   "insufficient quota",
@@ -450,6 +464,102 @@ const TIMEOUT_ERROR_CODES = new Set([
   "EPIPE",
   "EAI_AGAIN",
 ]);
+const AUTH_SCOPE_HINT_RE =
+  /\b(?:missing|required|requires|insufficient)\s+(?:the\s+following\s+)?scopes?\b|\bmissing\s+scope\b|\binsufficient\s+permissions?\b/i;
+const AUTH_SCOPE_NAME_RE = /\b(?:api\.responses\.write|model\.request)\b/i;
+const HTML_BODY_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
+const HTML_CLOSE_RE = /<\/html>/i;
+const PROXY_ERROR_RE =
+  /\bproxy\b|\bproxyconnect\b|\bhttps?_proxy\b|\b407\b|\bproxy authentication required\b|\btunnel connection failed\b|\bconnect tunnel\b|\bsocks proxy\b/i;
+const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host\b|\bdns\b/i;
+const INTERRUPTED_NETWORK_ERROR_RE =
+  /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
+const REPLAY_INVALID_RE =
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b/i;
+const SANDBOX_BLOCKED_RE =
+  /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b/i;
+
+function inferSignalStatus(signal: FailoverSignal): number | undefined {
+  if (typeof signal.status === "number" && Number.isFinite(signal.status)) {
+    return signal.status;
+  }
+  return extractLeadingHttpStatus(signal.message?.trim() ?? "")?.code;
+}
+
+function isHtmlErrorResponse(raw: string, status?: number): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const inferred =
+    typeof status === "number" && Number.isFinite(status)
+      ? status
+      : extractLeadingHttpStatus(trimmed)?.code;
+  if (typeof inferred !== "number" || inferred < 400) {
+    return false;
+  }
+  const rest = extractLeadingHttpStatus(trimmed)?.rest ?? trimmed;
+  return HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
+}
+
+function isAuthScopeErrorMessage(raw: string, status?: number): boolean {
+  if (!raw) {
+    return false;
+  }
+  const inferred =
+    typeof status === "number" && Number.isFinite(status)
+      ? status
+      : extractLeadingHttpStatus(raw.trim())?.code;
+  if (inferred !== 401 && inferred !== 403) {
+    return false;
+  }
+  return AUTH_SCOPE_HINT_RE.test(raw) || AUTH_SCOPE_NAME_RE.test(raw);
+}
+
+function isProxyErrorMessage(raw: string, status?: number): boolean {
+  if (!raw) {
+    return false;
+  }
+  if (status === 407) {
+    return true;
+  }
+  return PROXY_ERROR_RE.test(raw);
+}
+
+function isDnsTransportErrorMessage(raw: string): boolean {
+  return DNS_ERROR_RE.test(raw);
+}
+
+function isReplayInvalidErrorMessage(raw: string): boolean {
+  return REPLAY_INVALID_RE.test(raw);
+}
+
+function isSandboxBlockedErrorMessage(raw: string): boolean {
+  return Boolean(formatExecDeniedUserMessage(raw)) || SANDBOX_BLOCKED_RE.test(raw);
+}
+
+function isSchemaErrorMessage(raw: string): boolean {
+  if (!raw || isReplayInvalidErrorMessage(raw) || isContextOverflowError(raw)) {
+    return false;
+  }
+  return classifyFailoverReason(raw) === "format" || matchesFormatErrorPattern(raw);
+}
+
+function isTimeoutTransportErrorMessage(raw: string, status?: number): boolean {
+  if (!raw) {
+    return false;
+  }
+  if (isTimeoutErrorMessage(raw) || INTERRUPTED_NETWORK_ERROR_RE.test(raw)) {
+    return true;
+  }
+  if (
+    typeof status === "number" &&
+    [408, 499, 500, 502, 503, 504, 521, 522, 523, 524, 529].includes(status)
+  ) {
+    return true;
+  }
+  return false;
+}
 
 function includesAnyHint(text: string, hints: readonly string[]): boolean {
   return hints.some((hint) => text.includes(hint));
@@ -774,10 +884,7 @@ function classifyFailoverClassificationFromMessage(
 }
 
 export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassification | null {
-  const inferredStatus =
-    typeof signal.status === "number" && Number.isFinite(signal.status)
-      ? signal.status
-      : extractLeadingHttpStatus(signal.message?.trim() ?? "")?.code;
+  const inferredStatus = inferSignalStatus(signal);
   const messageClassification = signal.message
     ? classifyFailoverClassificationFromMessage(signal.message, signal.provider)
     : null;
@@ -794,6 +901,60 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
     return toReasonClassification(codeReason);
   }
   return messageClassification;
+}
+
+export function classifyProviderRuntimeFailureKind(
+  signal: FailoverSignal | string,
+): ProviderRuntimeFailureKind {
+  const normalizedSignal = typeof signal === "string" ? { message: signal } : signal;
+  const message = normalizedSignal.message?.trim() ?? "";
+  const status = inferSignalStatus(normalizedSignal);
+
+  if (!message && typeof status !== "number") {
+    return "unknown";
+  }
+  if (message && classifyOAuthRefreshFailure(message)) {
+    return "auth_refresh";
+  }
+  if (message && isAuthScopeErrorMessage(message, status)) {
+    return "auth_scope";
+  }
+  if (message && status === 403 && isHtmlErrorResponse(message, status)) {
+    return "auth_html_403";
+  }
+  if (message && isProxyErrorMessage(message, status)) {
+    return "proxy";
+  }
+  const failoverClassification = classifyFailoverSignal({
+    ...normalizedSignal,
+    status,
+    message: message || undefined,
+  });
+  if (failoverClassification?.kind === "reason" && failoverClassification.reason === "rate_limit") {
+    return "rate_limit";
+  }
+  if (message && isDnsTransportErrorMessage(message)) {
+    return "dns";
+  }
+  if (message && isSandboxBlockedErrorMessage(message)) {
+    return "sandbox_blocked";
+  }
+  if (message && isReplayInvalidErrorMessage(message)) {
+    return "replay_invalid";
+  }
+  if (message && isSchemaErrorMessage(message)) {
+    return "schema";
+  }
+  if (
+    failoverClassification?.kind === "reason" &&
+    (failoverClassification.reason === "timeout" || failoverClassification.reason === "overloaded")
+  ) {
+    return "timeout";
+  }
+  if (message && isTimeoutTransportErrorMessage(message, status)) {
+    return "timeout";
+  }
+  return "unknown";
 }
 
 function coerceText(value: unknown): string {
@@ -947,6 +1108,12 @@ export function formatAssistantErrorText(
     return "LLM request failed with an unknown error.";
   }
 
+  const providerRuntimeFailureKind = classifyProviderRuntimeFailureKind({
+    status: extractLeadingHttpStatus(raw)?.code,
+    message: raw,
+    provider: opts?.provider ?? msg.provider,
+  });
+
   const unknownTool =
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
     raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
@@ -964,6 +1131,28 @@ export function formatAssistantErrorText(
   const diskSpaceCopy = formatDiskSpaceErrorCopy(raw);
   if (diskSpaceCopy) {
     return diskSpaceCopy;
+  }
+
+  if (providerRuntimeFailureKind === "auth_refresh") {
+    return "Authentication refresh failed. Re-authenticate this provider and try again.";
+  }
+
+  if (providerRuntimeFailureKind === "auth_scope") {
+    return (
+      "Authentication is missing the required OpenAI Codex scopes. " +
+      "Re-run OpenAI/Codex login and try again."
+    );
+  }
+
+  if (providerRuntimeFailureKind === "auth_html_403") {
+    return (
+      "Authentication failed with an HTML 403 response from the provider. " +
+      "Re-authenticate and verify your provider account access."
+    );
+  }
+
+  if (providerRuntimeFailureKind === "proxy") {
+    return "LLM request failed: proxy or tunnel configuration blocked the provider request.";
   }
 
   if (isContextOverflowError(raw)) {
@@ -1025,6 +1214,17 @@ export function formatAssistantErrorText(
 
   if (isBillingErrorMessage(raw)) {
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
+  }
+
+  if (providerRuntimeFailureKind === "schema") {
+    return "LLM request failed: provider rejected the request schema or tool payload.";
+  }
+
+  if (providerRuntimeFailureKind === "replay_invalid") {
+    return (
+      "Session history or replay state is invalid. " +
+      "Use /new to start a fresh session and try again."
+    );
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -470,7 +470,7 @@ const AUTH_SCOPE_NAME_RE = /\b(?:api\.responses\.write|model\.request)\b/i;
 const HTML_BODY_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;
 const PROXY_ERROR_RE =
-  /\bproxy\b|\bproxyconnect\b|\bhttps?_proxy\b|\b407\b|\bproxy authentication required\b|\btunnel connection failed\b|\bconnect tunnel\b|\bsocks proxy\b/i;
+  /\bproxyconnect\b|\bhttps?_proxy\b|\b407\b|\bproxy authentication required\b|\btunnel connection failed\b|\bconnect tunnel\b|\bsocks proxy\b/i;
 const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host\b|\bdns\b/i;
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -550,11 +550,14 @@ function isSandboxBlockedErrorMessage(raw: string): boolean {
   return Boolean(formatExecDeniedUserMessage(raw)) || SANDBOX_BLOCKED_RE.test(raw);
 }
 
-function isSchemaErrorMessage(raw: string): boolean {
+function isSchemaErrorMessage(raw: string, provider?: string): boolean {
   if (!raw || isReplayInvalidErrorMessage(raw) || isContextOverflowError(raw)) {
     return false;
   }
-  return classifyFailoverReason(raw) === "format" || matchesFormatErrorPattern(raw);
+  return (
+    classifyFailoverReason(raw, provider ? { provider } : undefined) === "format" ||
+    matchesFormatErrorPattern(raw)
+  );
 }
 
 function isTimeoutTransportErrorMessage(raw: string, status?: number): boolean {
@@ -954,7 +957,7 @@ export function classifyProviderRuntimeFailureKind(
   if (message && isReplayInvalidErrorMessage(message)) {
     return "replay_invalid";
   }
-  if (message && isSchemaErrorMessage(message)) {
+  if (message && isSchemaErrorMessage(message, normalizedSignal.provider)) {
     return "schema";
   }
   if (

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -68,6 +68,7 @@ describe("handleAgentEnd", () => {
       event: "embedded_run_agent_end",
       runId: "run-1",
       error: "LLM request failed: connection refused by the provider endpoint.",
+      providerRuntimeFailureKind: "timeout",
       rawErrorPreview: "connection refused",
       consoleMessage:
         "embedded run agent end: runId=run-1 isError=true model=unknown provider=unknown error=LLM request failed: connection refused by the provider endpoint. rawError=connection refused",
@@ -101,6 +102,7 @@ describe("handleAgentEnd", () => {
       runId: "run-1",
       error: "The AI service is temporarily overloaded. Please try again in a moment.",
       failoverReason: "overloaded",
+      providerRuntimeFailureKind: "timeout",
       providerErrorType: "overloaded_error",
       consoleMessage:
         'embedded run agent end: runId=run-1 isError=true model=claude-test provider=anthropic error=The AI service is temporarily overloaded. Please try again in a moment. rawError={"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
@@ -157,6 +159,26 @@ describe("handleAgentEnd", () => {
         phase: "error",
         error: "x-api-key: ***",
       },
+    });
+  });
+
+  it("logs runtime failure kind for missing-scope auth errors", async () => {
+    const ctx = createContext({
+      role: "assistant",
+      stopReason: "error",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      errorMessage:
+        '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      content: [{ type: "text", text: "" }],
+    });
+
+    await handleAgentEnd(ctx);
+
+    expect(vi.mocked(ctx.log.warn).mock.calls[0]?.[1]).toMatchObject({
+      failoverReason: "auth",
+      providerRuntimeFailureKind: "auth_scope",
+      httpCode: "401",
     });
   });
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -5,7 +5,11 @@ import {
   buildTextObservationFields,
   sanitizeForConsole,
 } from "./pi-embedded-error-observation.js";
-import { classifyFailoverReason, formatAssistantErrorText } from "./pi-embedded-helpers.js";
+import {
+  classifyFailoverReason,
+  classifyProviderRuntimeFailureKind,
+  formatAssistantErrorText,
+} from "./pi-embedded-helpers.js";
 import {
   consumePendingToolMediaReply,
   hasAssistantVisibleReply,
@@ -50,6 +54,10 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     const failoverReason = classifyFailoverReason(rawError ?? "", {
       provider: lastAssistant.provider,
     });
+    const providerRuntimeFailureKind = classifyProviderRuntimeFailureKind({
+      message: rawError ?? "",
+      provider: lastAssistant.provider,
+    });
     const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
     const observedError = buildApiErrorObservationFields(rawError);
     const safeErrorText =
@@ -66,6 +74,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       isError: true,
       error: safeErrorText,
       failoverReason,
+      providerRuntimeFailureKind,
       model: lastAssistant.model,
       provider: lastAssistant.provider,
       ...observedError,

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -78,10 +78,10 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       isError: true,
       error: safeErrorText,
       failoverReason,
-      providerRuntimeFailureKind,
       model: lastAssistant.model,
       provider: lastAssistant.provider,
       ...observedError,
+      providerRuntimeFailureKind,
       consoleMessage: `embedded run agent end: runId=${safeRunId} isError=true model=${safeModel} provider=${safeProvider} error=${safeErrorText}${rawErrorConsoleSuffix}`,
     });
     emitAgentEvent({

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -59,9 +59,13 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       provider: lastAssistant.provider,
     });
     const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
-    const observedError = buildApiErrorObservationFields(rawError);
+    const observedError = buildApiErrorObservationFields(rawError, {
+      provider: lastAssistant.provider,
+    });
     const safeErrorText =
-      buildTextObservationFields(errorText).textPreview ?? "LLM request failed.";
+      buildTextObservationFields(errorText, {
+        provider: lastAssistant.provider,
+      }).textPreview ?? "LLM request failed.";
     const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
     const safeModel = sanitizeForConsole(lastAssistant.model) ?? "unknown";
     const safeProvider = sanitizeForConsole(lastAssistant.provider) ?? "unknown";

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -85,7 +85,7 @@ describe("loginOpenAICodexOAuth", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("passes through Pi-provided OAuth authorize URL without mutation", async () => {
+  it("adds required Codex OAuth scopes to Pi-provided authorize URLs", async () => {
     const creds = {
       provider: "openai-codex" as const,
       access: "access-token",
@@ -106,10 +106,35 @@ describe("loginOpenAICodexOAuth", () => {
     const { runtime } = await runCodexOAuth({ isRemote: false, openUrl });
 
     expect(openUrl).toHaveBeenCalledWith(
-      "https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access&state=abc",
+      "https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access+model.request+api.responses.write&state=abc",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Open: https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access&state=abc",
+      "Open: https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access+model.request+api.responses.write&state=abc",
+    );
+  });
+
+  it("adds a scope parameter when the upstream authorize url omitted it", async () => {
+    const creds = {
+      provider: "openai-codex" as const,
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "user@example.com",
+    };
+    mocks.loginOpenAICodex.mockImplementation(
+      async (opts: { onAuth: (event: { url: string }) => Promise<void> }) => {
+        await opts.onAuth({
+          url: "https://auth.openai.com/oauth/authorize?state=abc",
+        });
+        return creds;
+      },
+    );
+
+    const openUrl = vi.fn(async () => {});
+    await runCodexOAuth({ isRemote: false, openUrl });
+
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://auth.openai.com/oauth/authorize?state=abc&scope=openid+profile+email+offline_access+model.request+api.responses.write",
     );
   });
 

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -25,7 +25,7 @@ function normalizeOpenAICodexAuthorizeUrl(rawUrl: string): string {
   }
   try {
     const url = new URL(trimmed);
-    if (!/openai\.com$/i.test(url.hostname) || !/\/oauth\/authorize$/i.test(url.pathname)) {
+    if (!/(?:^|\.)openai\.com$/i.test(url.hostname) || !/\/oauth\/authorize$/i.test(url.pathname)) {
       return rawUrl;
     }
 

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -9,6 +9,41 @@ import {
 } from "./provider-openai-codex-oauth-tls.js";
 
 const manualInputPromptMessage = "Paste the authorization code (or full redirect URL):";
+const OPENAI_CODEX_OAUTH_REQUIRED_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  "model.request",
+  "api.responses.write",
+] as const;
+
+function normalizeOpenAICodexAuthorizeUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return rawUrl;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (!/openai\.com$/i.test(url.hostname) || !/\/oauth\/authorize$/i.test(url.pathname)) {
+      return rawUrl;
+    }
+
+    const existing = new Set(
+      (url.searchParams.get("scope") ?? "")
+        .split(/\s+/)
+        .map((scope) => scope.trim())
+        .filter(Boolean),
+    );
+    for (const scope of OPENAI_CODEX_OAUTH_REQUIRED_SCOPES) {
+      existing.add(scope);
+    }
+    url.searchParams.set("scope", Array.from(existing).join(" "));
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
 
 export async function loginOpenAICodexOAuth(params: {
   prompter: WizardPrompter;
@@ -59,7 +94,11 @@ export async function loginOpenAICodexOAuth(params: {
     });
 
     const creds = await loginOpenAICodex({
-      onAuth: baseOnAuth,
+      onAuth: async (event) =>
+        await baseOnAuth({
+          ...event,
+          url: normalizeOpenAICodexAuthorizeUrl(event.url),
+        }),
       onPrompt,
       onManualCodeInput: isRemote
         ? async () =>


### PR DESCRIPTION
## Summary

This is PR 2 of the GPT-5.4 / Codex agentic runtime parity program tracked in #64227 and scoped by #64229.

It fixes the maintained-source OpenAI Codex OAuth scope gap in OpenClaw's login wrapper and adds a separate provider/runtime failure taxonomy that makes auth-scope, refresh, HTML 403, proxy, DNS, timeout, schema, sandbox-blocked, and replay-invalid failures observable in logs and easier to explain to users.

## What changed

- normalize OpenAI Codex authorize URLs so the required scopes are always present:
  - `openid`
  - `profile`
  - `email`
  - `offline_access`
  - `model.request`
  - `api.responses.write`
- add `classifyProviderRuntimeFailureKind(...)` as a typed provider/runtime failure classifier
- keep the older failover-reason contract intact instead of widening it in this slice
- thread `providerRuntimeFailureKind` through embedded-run observation fields and lifecycle logging
- surface more truthful user-facing copy for:
  - OAuth refresh failures
  - missing OpenAI Codex scopes
  - HTML 403 auth failures
  - proxy/tunnel misroutes
  - replay-invalid failures
- add focused regressions for scope failures, refresh failures, HTML 403, proxy, DNS, timeout, schema, sandbox-blocked, and replay-invalid paths

## Why

GPT-5.4 / Codex failures in OpenClaw are still too easy to misdiagnose as generic model stops. This slice makes the auth/runtime layer tell the truth before we move on to tool-contract and parity-harness work.

## Non-goals

- does not implement tool compatibility work from #64230
- does not implement permission truthfulness work from #64231
- does not implement replay/liveness hardening from #64232
- does not implement the benchmark harness from #64233
- does not widen the generic failover-reason enum for every caller in this slice

## Builds on prior groundwork

- #45176
- #48592
- #53702
- #55206
- #44019

## Validation

Focused checks run:

- `CI=1 pnpm exec vitest run src/commands/openai-codex-oauth.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts src/agents/pi-embedded-error-observation.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`
- repo hook gate during commit:
  - `pnpm check:no-conflict-markers`
  - `pnpm tool-display:check`
  - `pnpm check:host-env-policy:swift`
  - `pnpm tsgo`
  - `node scripts/prepare-extension-package-boundary-artifacts.mjs`
  - `pnpm lint`
  - `pnpm lint:webhook:no-low-level-body-read`
  - `pnpm lint:auth:no-pairing-store-group`
  - `pnpm lint:auth:pairing-account-scope`

## Linked issues

- Closes #64229
- Refs #64227
- Refs #64133
- Refs #64174
- Refs #64092
- Refs #57399
- Refs #62672
