### PR TITLE
fix(ui): support /btw side results in control ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: detect llama.cpp slot context overflows as context-overflow errors so compaction can retry self-hosted OpenAI-compatible runs instead of surfacing the raw upstream 400. (#64196) Thanks @alexander-applyinnovations.
 - Claude CLI/skills: pass eligible OpenClaw skills into CLI runs, including native Claude Code skill resolution via a temporary plugin plus per-run skill env/API key injection. (#62686, #62723) Thanks @zomars.
 - Heartbeat: ignore doc-only Markdown fence markers in the default `HEARTBEAT.md` template so comment-only heartbeat scaffolds skip API calls again. (#63434) Thanks @ravyg.
+- Control UI/BTW: render `/btw` side results as dismissible ephemeral cards in the browser, send `/btw` immediately during active runs, and clear stale BTW cards on reset flows so webchat matches the intended detached side-question behavior. (#64290) Thanks @ngutman.
 
 ## 2026.4.9
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1445,6 +1445,99 @@
   }
 }
 
+.chat-side-result {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: min(100%, 820px);
+  margin: 0 auto 8px;
+  padding: 12px 14px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.08), rgba(59, 130, 246, 0.03));
+  color: var(--text);
+  animation: fade-in 0.2s var(--ease-out);
+}
+
+.chat-side-result--error {
+  border-color: rgba(239, 68, 68, 0.28);
+  background: linear-gradient(180deg, rgba(239, 68, 68, 0.08), rgba(239, 68, 68, 0.03));
+}
+
+.chat-side-result__header,
+.chat-side-result__label-row {
+  display: flex;
+  align-items: center;
+}
+
+.chat-side-result__header {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.chat-side-result__label-row {
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.chat-side-result__label {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--info);
+}
+
+.chat-side-result--error .chat-side-result__label {
+  color: var(--danger);
+}
+
+.chat-side-result__meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.chat-side-result__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: var(--radius-full);
+  color: var(--muted);
+}
+
+.chat-side-result__dismiss:hover {
+  color: var(--foreground);
+}
+
+.chat-side-result__dismiss svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-side-result__question {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.chat-side-result__body {
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.chat-side-result__body > :first-child {
+  margin-top: 0;
+}
+
+.chat-side-result__body > :last-child {
+  margin-bottom: 0;
+}
+
 /* ===========================================
    Code Blocks
    =========================================== */

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -7,7 +7,7 @@ const { setLastActiveSessionKeyMock } = vi.hoisted(() => ({
   setLastActiveSessionKeyMock: vi.fn(),
 }));
 
-vi.mock("./app-settings.ts", () => ({
+vi.mock("./app-last-active-session.ts", () => ({
   setLastActiveSessionKey: (...args: unknown[]) => setLastActiveSessionKeyMock(...args),
 }));
 
@@ -39,6 +39,8 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     basePath: "",
     hello: null,
     chatAvatarUrl: null,
+    chatSideResult: null,
+    chatSideResultTerminalRuns: new Set<string>(),
     chatModelOverrides: {},
     chatModelsLoading: false,
     chatModelCatalog: [],
@@ -304,6 +306,43 @@ describe("handleSendChat", () => {
     expect(host.lastError).toContain("network down");
   });
 
+  it("clears BTW side results when /clear resets chat history", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.reset") {
+        return { ok: true };
+      }
+      if (method === "chat.history") {
+        return { messages: [], thinkingLevel: null };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      chatMessage: "/clear",
+      chatMessages: [{ role: "user", content: "hello", timestamp: 1 }],
+      chatSideResult: {
+        kind: "btw",
+        runId: "btw-run-clear",
+        sessionKey: "main",
+        question: "what changed?",
+        text: "Detached BTW result",
+        isError: false,
+        ts: 1,
+      },
+      chatSideResultTerminalRuns: new Set(["btw-run-clear"]),
+    });
+
+    await handleSendChat(host);
+
+    expect(request).toHaveBeenCalledWith("sessions.reset", { key: "main" });
+    expect(host.chatMessages).toEqual([]);
+    expect(host.chatSideResult).toBeNull();
+    expect(host.chatSideResultTerminalRuns?.size).toBe(0);
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatStream).toBeNull();
+  });
+
   it("shows a visible pending item for /steer on the active run", async () => {
     vi.doMock("./chat/slash-command-executor.ts", async () => {
       const actual = await vi.importActual<typeof import("./chat/slash-command-executor.ts")>(
@@ -364,6 +403,6 @@ describe("handleSendChat", () => {
 });
 
 afterAll(() => {
-  vi.doUnmock("./app-settings.ts");
+  vi.doUnmock("./app-last-active-session.ts");
   vi.resetModules();
 });

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -222,6 +222,88 @@ describe("handleSendChat", () => {
     expect(onSlashAction).toHaveBeenCalledWith("refresh-tools-effective");
   });
 
+  it("sends /btw immediately while a main run is active without queueing it", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return {};
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatRunId: "run-main",
+      chatStream: "Working...",
+      chatMessage: "/btw what changed?",
+    });
+
+    await handleSendChat(host);
+
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        sessionKey: "agent:main",
+        message: "/btw what changed?",
+        deliver: false,
+        idempotencyKey: expect.any(String),
+      }),
+    );
+    expect(host.chatQueue).toEqual([]);
+    expect(host.chatRunId).toBe("run-main");
+    expect(host.chatStream).toBe("Working...");
+    expect(host.chatMessages).toEqual([]);
+    expect(host.chatMessage).toBe("");
+  });
+
+  it("sends /btw without adopting a main chat run when idle", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return {};
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "/btw summarize this",
+    });
+
+    await handleSendChat(host);
+
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        message: "/btw summarize this",
+        deliver: false,
+      }),
+    );
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatMessages).toEqual([]);
+    expect(host.chatMessage).toBe("");
+  });
+
+  it("restores the BTW draft when detached send fails", async () => {
+    const host = makeHost({
+      client: {
+        request: vi.fn(async (method: string) => {
+          if (method === "chat.send") {
+            throw new Error("network down");
+          }
+          throw new Error(`Unexpected request: ${method}`);
+        }),
+      } as unknown as ChatHost["client"],
+      chatRunId: "run-main",
+      chatStream: "Working...",
+      chatMessage: "/btw what changed?",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatQueue).toEqual([]);
+    expect(host.chatRunId).toBe("run-main");
+    expect(host.chatStream).toBe("Working...");
+    expect(host.chatMessage).toBe("/btw what changed?");
+    expect(host.lastError).toContain("network down");
+  });
+
   it("shows a visible pending item for /steer on the active run", async () => {
     vi.doMock("./chat/slash-command-executor.ts", async () => {
       const actual = await vi.importActual<typeof import("./chat/slash-command-executor.ts")>(

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -7,6 +7,7 @@ import {
   abortChatRun,
   loadChatHistory,
   sendChatMessage,
+  sendDetachedChatMessage,
   type ChatState,
 } from "./controllers/chat.ts";
 import { loadModels } from "./controllers/models.ts";
@@ -79,6 +80,10 @@ function isChatResetCommand(text: string) {
     return true;
   }
   return normalized.startsWith("/new ") || normalized.startsWith("/reset ");
+}
+
+function isBtwCommand(text: string) {
+  return /^\/btw(?::|\s|$)/i.test(text.trim());
 }
 
 export async function handleAbortChat(host: ChatHost) {
@@ -177,6 +182,36 @@ async function sendChatMessageNow(
   return ok;
 }
 
+async function sendDetachedBtwMessage(
+  host: ChatHost,
+  message: string,
+  opts?: {
+    previousDraft?: string;
+    attachments?: ChatAttachment[];
+    previousAttachments?: ChatAttachment[];
+  },
+) {
+  const runId = await sendDetachedChatMessage(
+    host as unknown as ChatState,
+    message,
+    opts?.attachments,
+  );
+  const ok = Boolean(runId);
+  if (!ok && opts?.previousDraft != null) {
+    host.chatMessage = opts.previousDraft;
+  }
+  if (!ok && opts?.previousAttachments) {
+    host.chatAttachments = opts.previousAttachments;
+  }
+  if (ok) {
+    setLastActiveSessionKey(
+      host as unknown as Parameters<typeof setLastActiveSessionKey>[0],
+      host.sessionKey,
+    );
+  }
+  return ok;
+}
+
 async function flushChatQueue(host: ChatHost) {
   if (!host.connected || isChatBusy(host)) {
     return;
@@ -240,6 +275,19 @@ export async function handleSendChat(
 
   if (isChatStopCommand(message)) {
     await handleAbortChat(host);
+    return;
+  }
+
+  if (isBtwCommand(message)) {
+    if (messageOverride == null) {
+      host.chatMessage = "";
+      host.chatAttachments = [];
+    }
+    await sendDetachedBtwMessage(host, message, {
+      previousDraft: messageOverride == null ? previousDraft : undefined,
+      attachments: hasAttachments ? attachmentsToSend : undefined,
+      previousAttachments: messageOverride == null ? attachments : undefined,
+    });
     return;
   }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,6 +1,7 @@
 import { setLastActiveSessionKey } from "./app-last-active-session.ts";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
+import type { ChatSideResult } from "./chat/side-result.ts";
 import { executeSlashCommand } from "./chat/slash-command-executor.ts";
 import { parseSlashCommand } from "./chat/slash-commands.ts";
 import {
@@ -36,6 +37,8 @@ export type ChatHost = {
   basePath: string;
   hello: GatewayHelloOk | null;
   chatAvatarUrl: string | null;
+  chatSideResult?: ChatSideResult | null;
+  chatSideResultTerminalRuns?: Set<string>;
   chatModelOverrides: Record<string, ChatModelOverride | null>;
   chatModelsLoading: boolean;
   chatModelCatalog: ModelCatalogEntry[];
@@ -425,6 +428,8 @@ async function clearChatHistory(host: ChatHost) {
   try {
     await host.client.request("sessions.reset", { key: host.sessionKey });
     host.chatMessages = [];
+    host.chatSideResult = null;
+    host.chatSideResultTerminalRuns?.clear();
     host.chatStream = null;
     host.chatRunId = null;
     await loadChatHistory(host as unknown as ChatState);

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -98,7 +98,14 @@ vi.mock("./controllers/chat.ts", async () => {
   };
 });
 
-function createHost() {
+type TestGatewayHost = Parameters<typeof connectGateway>[0] & {
+  chatSideResult: unknown;
+  chatSideResultTerminalRuns: Set<string>;
+  chatStream: string | null;
+  toolStreamOrder: string[];
+};
+
+function createHost(): TestGatewayHost {
   return {
     settings: {
       gatewayUrl: "ws://127.0.0.1:18789",
@@ -155,10 +162,7 @@ function createHost() {
     execApprovalQueue: [],
     execApprovalError: null,
     updateAvailable: null,
-  } as unknown as Parameters<typeof connectGateway>[0] & {
-    chatSideResult: unknown;
-    chatSideResultTerminalRuns: Set<string>;
-  };
+  } as unknown as TestGatewayHost;
 }
 
 function connectHostGateway() {
@@ -594,9 +598,12 @@ describe("connectGateway", () => {
     expect(host.chatSideResultTerminalRuns.has("btw-run-1")).toBe(true);
   });
 
-  it("does not reload chat history for BTW terminal finals, even after tool events", () => {
+  it("ignores tracked BTW terminal finals without tearing down the active run", () => {
     const { host, client } = connectHostGateway();
+    host.chatRunId = "main-run-1";
     emitToolResultEvent(client);
+    host.chatStream = "still streaming";
+    expect(host.toolStreamOrder).toHaveLength(1);
 
     client.emitEvent({
       event: "chat.side_result",
@@ -619,7 +626,76 @@ describe("connectGateway", () => {
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(host.chatRunId).toBe("main-run-1");
+    expect(host.chatStream).toBe("still streaming");
+    expect(host.toolStreamOrder).toHaveLength(1);
     expect(host.chatSideResultTerminalRuns.has("btw-run-2")).toBe(false);
+  });
+
+  it.each(["aborted", "error"] as const)(
+    "cleans up tracked BTW %s events without touching the active run",
+    (terminalState) => {
+      const { host, client } = connectHostGateway();
+      host.chatRunId = "main-run-2";
+      emitToolResultEvent(client);
+      host.chatStream = "stream in progress";
+
+      client.emitEvent({
+        event: "chat.side_result",
+        payload: {
+          kind: "btw",
+          runId: `btw-run-${terminalState}`,
+          sessionKey: "main",
+          question: "what changed?",
+          text: "Detached BTW response",
+          ts: 789,
+        },
+      });
+      client.emitEvent({
+        event: "chat",
+        payload: {
+          runId: `btw-run-${terminalState}`,
+          sessionKey: "main",
+          state: terminalState,
+          errorMessage: terminalState === "error" ? "btw failed" : undefined,
+        },
+      });
+
+      expect(host.chatSideResultTerminalRuns.has(`btw-run-${terminalState}`)).toBe(false);
+      expect(host.chatRunId).toBe("main-run-2");
+      expect(host.chatStream).toBe("stream in progress");
+      expect(host.toolStreamOrder).toHaveLength(1);
+      expect(host.lastError).toBeNull();
+    },
+  );
+
+  it("clears tracked BTW terminal runs after reconnect hello", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const firstClient = gatewayClientInstances[0];
+    expect(firstClient).toBeDefined();
+
+    firstClient.emitEvent({
+      event: "chat.side_result",
+      payload: {
+        kind: "btw",
+        runId: "btw-run-reconnect",
+        sessionKey: "main",
+        question: "what changed?",
+        text: "Temporary BTW state",
+        ts: 987,
+      },
+    });
+    expect(host.chatSideResultTerminalRuns.has("btw-run-reconnect")).toBe(true);
+
+    connectGateway(host);
+    const reconnectClient = gatewayClientInstances[1];
+    expect(reconnectClient).toBeDefined();
+
+    reconnectClient.emitHello();
+
+    expect(host.chatSideResultTerminalRuns.size).toBe(0);
   });
 
   it("ignores BTW side results for other sessions", () => {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -145,15 +145,20 @@ function createHost() {
     chatStream: null,
     chatStreamStartedAt: null,
     chatRunId: null,
+    chatSideResult: null,
     chatSending: false,
     toolStreamById: new Map(),
     toolStreamOrder: [],
     toolStreamSyncTimer: null,
     refreshSessionsAfterChat: new Set<string>(),
+    chatSideResultTerminalRuns: new Set<string>(),
     execApprovalQueue: [],
     execApprovalError: null,
     updateAvailable: null,
-  } as unknown as Parameters<typeof connectGateway>[0];
+  } as unknown as Parameters<typeof connectGateway>[0] & {
+    chatSideResult: unknown;
+    chatSideResultTerminalRuns: Set<string>;
+  };
 }
 
 function connectHostGateway() {
@@ -563,6 +568,77 @@ describe("connectGateway", () => {
     emitToolResultEvent(client);
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("stores BTW side results for the active session", () => {
+    const { host, client } = connectHostGateway();
+
+    client.emitEvent({
+      event: "chat.side_result",
+      payload: {
+        kind: "btw",
+        runId: "btw-run-1",
+        sessionKey: "main",
+        question: "what changed?",
+        text: "Only the UI layer is missing support.",
+        ts: 123,
+      },
+    });
+
+    expect(host.chatSideResult).toMatchObject({
+      kind: "btw",
+      runId: "btw-run-1",
+      question: "what changed?",
+      text: "Only the UI layer is missing support.",
+    });
+    expect(host.chatSideResultTerminalRuns.has("btw-run-1")).toBe(true);
+  });
+
+  it("does not reload chat history for BTW terminal finals, even after tool events", () => {
+    const { host, client } = connectHostGateway();
+    emitToolResultEvent(client);
+
+    client.emitEvent({
+      event: "chat.side_result",
+      payload: {
+        kind: "btw",
+        runId: "btw-run-2",
+        sessionKey: "main",
+        question: "what changed?",
+        text: "A dedicated side-result card now renders in webchat.",
+        ts: 456,
+      },
+    });
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "btw-run-2",
+        sessionKey: "main",
+        state: "final",
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(host.chatSideResultTerminalRuns.has("btw-run-2")).toBe(false);
+  });
+
+  it("ignores BTW side results for other sessions", () => {
+    const { host, client } = connectHostGateway();
+
+    client.emitEvent({
+      event: "chat.side_result",
+      payload: {
+        kind: "btw",
+        runId: "btw-run-3",
+        sessionKey: "other-session",
+        question: "what changed?",
+        text: "Nothing here.",
+        ts: 789,
+      },
+    });
+
+    expect(host.chatSideResult).toBeNull();
+    expect(host.chatSideResultTerminalRuns.size).toBe(0);
   });
 
   it("routes plugin.approval.requested into execApprovalQueue with kind plugin", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -16,6 +16,7 @@ import {
 } from "./app-settings.ts";
 import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
+import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
 import { formatConnectError } from "./connect-error.ts";
 import { loadAgents, type AgentsState } from "./controllers/agents.ts";
 import {
@@ -107,6 +108,11 @@ type SessionDefaultsSnapshot = {
 type GatewayHostWithShutdownMessage = GatewayHost & {
   pendingShutdownMessage?: string | null;
   resumeChatQueueAfterReconnect?: boolean;
+};
+
+type GatewayHostWithSideResults = GatewayHost & {
+  chatSideResult?: ChatSideResult | null;
+  chatSideResultTerminalRuns?: Set<string>;
 };
 
 type ConnectGatewayOptions = {
@@ -322,6 +328,7 @@ function handleTerminalChatEvent(
   host: GatewayHost,
   payload: ChatEventPayload | undefined,
   state: ReturnType<typeof handleChatEvent>,
+  opts?: { skipHistoryReload?: boolean },
 ): boolean {
   if (state !== "final" && state !== "error" && state !== "aborted") {
     return false;
@@ -346,7 +353,7 @@ function handleTerminalChatEvent(
   }
   // Reload history when tools were used so the persisted tool results
   // replace the now-cleared streaming state.
-  if (hadToolEvents && state === "final") {
+  if (hadToolEvents && state === "final" && !opts?.skipHistoryReload) {
     void loadChatHistory(host as unknown as ChatState);
     return true;
   }
@@ -361,8 +368,23 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     );
   }
   const state = handleChatEvent(host as unknown as ChatState, payload);
-  const historyReloaded = handleTerminalChatEvent(host, payload, state);
-  if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {
+  const sideResultHost = host as GatewayHostWithSideResults;
+  const skipHistoryReloadForSideResult =
+    state === "final" &&
+    typeof payload?.runId === "string" &&
+    sideResultHost.chatSideResultTerminalRuns?.has(payload.runId) === true;
+  if (skipHistoryReloadForSideResult && payload?.runId) {
+    sideResultHost.chatSideResultTerminalRuns?.delete(payload.runId);
+  }
+  const historyReloaded = handleTerminalChatEvent(host, payload, state, {
+    skipHistoryReload: skipHistoryReloadForSideResult,
+  });
+  if (
+    state === "final" &&
+    !skipHistoryReloadForSideResult &&
+    !historyReloaded &&
+    shouldReloadHistoryForFinalEvent(payload)
+  ) {
     void loadChatHistory(host as unknown as ChatState);
   }
 }
@@ -389,6 +411,17 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
 
   if (evt.event === "chat") {
     handleChatGatewayEvent(host, evt.payload as ChatEventPayload | undefined);
+    return;
+  }
+
+  if (evt.event === "chat.side_result") {
+    const sideResult = parseChatSideResult(evt.payload);
+    if (!sideResult || sideResult.sessionKey !== host.sessionKey) {
+      return;
+    }
+    const sideResultHost = host as GatewayHostWithSideResults;
+    sideResultHost.chatSideResult = sideResult;
+    sideResultHost.chatSideResultTerminalRuns?.add(sideResult.runId);
     return;
   }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -115,6 +115,12 @@ type GatewayHostWithSideResults = GatewayHost & {
   chatSideResultTerminalRuns?: Set<string>;
 };
 
+function isTerminalChatState(
+  state: ChatEventPayload["state"] | ReturnType<typeof handleChatEvent> | null | undefined,
+): state is "final" | "aborted" | "error" {
+  return state === "final" || state === "aborted" || state === "error";
+}
+
 type ConnectGatewayOptions = {
   reason?: "initial" | "seq-gap";
 };
@@ -251,6 +257,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host.chatRunId = null;
       (host as unknown as { chatStream: string | null }).chatStream = null;
       (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
+      (host as GatewayHostWithSideResults).chatSideResultTerminalRuns?.clear();
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
       if (shutdownHost.resumeChatQueueAfterReconnect) {
         // The interrupted run will never emit its terminal event now that the
@@ -328,7 +335,6 @@ function handleTerminalChatEvent(
   host: GatewayHost,
   payload: ChatEventPayload | undefined,
   state: ReturnType<typeof handleChatEvent>,
-  opts?: { skipHistoryReload?: boolean },
 ): boolean {
   if (state !== "final" && state !== "error" && state !== "aborted") {
     return false;
@@ -353,7 +359,7 @@ function handleTerminalChatEvent(
   }
   // Reload history when tools were used so the persisted tool results
   // replace the now-cleared streaming state.
-  if (hadToolEvents && state === "final" && !opts?.skipHistoryReload) {
+  if (hadToolEvents && state === "final") {
     void loadChatHistory(host as unknown as ChatState);
     return true;
   }
@@ -367,24 +373,18 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
       payload.sessionKey,
     );
   }
-  const state = handleChatEvent(host as unknown as ChatState, payload);
   const sideResultHost = host as GatewayHostWithSideResults;
-  const skipHistoryReloadForSideResult =
-    state === "final" &&
+  const isTrackedSideResultTerminalEvent =
+    isTerminalChatState(payload?.state) &&
     typeof payload?.runId === "string" &&
     sideResultHost.chatSideResultTerminalRuns?.has(payload.runId) === true;
-  if (skipHistoryReloadForSideResult && payload?.runId) {
+  if (isTrackedSideResultTerminalEvent && payload?.runId) {
     sideResultHost.chatSideResultTerminalRuns?.delete(payload.runId);
+    return;
   }
-  const historyReloaded = handleTerminalChatEvent(host, payload, state, {
-    skipHistoryReload: skipHistoryReloadForSideResult,
-  });
-  if (
-    state === "final" &&
-    !skipHistoryReloadForSideResult &&
-    !historyReloaded &&
-    shouldReloadHistoryForFinalEvent(payload)
-  ) {
+  const state = handleChatEvent(host as unknown as ChatState, payload);
+  const historyReloaded = handleTerminalChatEvent(host, payload, state);
+  if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {
     void loadChatHistory(host as unknown as ChatState);
   }
 }

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -336,12 +336,22 @@ describe("switchChatSession", () => {
       chatStreamSegments: [{ text: "segment", ts: 1 }],
       chatThinkingLevel: "high",
       chatStream: "stream",
+      chatSideResult: {
+        kind: "btw",
+        runId: "btw-run-1",
+        sessionKey: "main",
+        question: "what changed?",
+        text: "draft answer",
+        isError: false,
+        ts: 1,
+      },
       lastError: "oops",
       compactionStatus: { phase: "active" },
       fallbackStatus: { phase: "active" },
       chatAvatarUrl: "/avatar/old",
       chatQueue: [{ id: "queued" }],
       chatRunId: "run-1",
+      chatSideResultTerminalRuns: new Set(["btw-run-1"]),
       chatStreamStartedAt: 1,
       settings,
       applySettings(next: typeof settings) {
@@ -359,6 +369,8 @@ describe("switchChatSession", () => {
     switchChatSession(state, "agent:main:test-b");
     await Promise.resolve();
 
+    expect(state.chatSideResult).toBeNull();
+    expect(state.chatSideResultTerminalRuns.size).toBe(0);
     expect(refreshChatAvatarMock).toHaveBeenCalledWith(state);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
     expect(loadSessionsMock).toHaveBeenCalledWith(state, {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -31,6 +31,7 @@ type SessionDefaultsSnapshot = {
 
 type SessionSwitchHost = AppViewState & {
   chatStreamStartedAt: number | null;
+  chatSideResultTerminalRuns: Set<string>;
   resetToolStream(): void;
   resetChatScroll(): void;
 };
@@ -68,6 +69,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.chatStreamSegments = [];
   state.chatThinkingLevel = null;
   state.chatStream = null;
+  state.chatSideResult = null;
   state.lastError = null;
   state.compactionStatus = null;
   state.fallbackStatus = null;
@@ -75,6 +77,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.chatQueue = [];
   host.chatStreamStartedAt = null;
   state.chatRunId = null;
+  host.chatSideResultTerminalRuns.clear();
   host.resetToolStream();
   host.resetChatScroll();
   state.applySettings({

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1770,23 +1770,7 @@ export function renderApp(state: AppViewState) {
           ? renderChat({
               sessionKey: state.sessionKey,
               onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.chatAttachments = [];
-                state.chatStream = null;
-                state.chatStreamStartedAt = null;
-                state.chatRunId = null;
-                state.chatQueue = [];
-                state.resetToolStream();
-                state.resetChatScroll();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-                void state.loadAssistantIdentity();
-                void loadChatHistory(state);
-                void refreshChatAvatar(state);
+                switchChatSession(state, next);
               },
               thinkingLevel: state.chatThinkingLevel,
               showThinking,
@@ -1797,6 +1781,7 @@ export function renderApp(state: AppViewState) {
               fallbackStatus: state.fallbackStatus,
               assistantAvatarUrl: chatAvatarUrl,
               messages: state.chatMessages,
+              sideResult: state.chatSideResult,
               toolMessages: state.chatToolMessages,
               streamSegments: state.chatStreamSegments,
               stream: state.chatStream,
@@ -1810,6 +1795,7 @@ export function renderApp(state: AppViewState) {
               sessions: state.sessionsResult,
               focusMode: chatFocus,
               onRefresh: () => {
+                state.chatSideResult = null;
                 state.resetToolStream();
                 return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
               },
@@ -1832,6 +1818,9 @@ export function renderApp(state: AppViewState) {
               canAbort: Boolean(state.chatRunId),
               onAbort: () => void state.handleAbortChat(),
               onQueueRemove: (id) => state.removeQueuedMessage(id),
+              onDismissSideResult: () => {
+                state.chatSideResult = null;
+              },
               onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
               onClearHistory: async () => {
                 if (!state.client || !state.connected) {
@@ -1840,6 +1829,7 @@ export function renderApp(state: AppViewState) {
                 try {
                   await state.client.request("sessions.reset", { key: state.sessionKey });
                   state.chatMessages = [];
+                  state.chatSideResult = null;
                   state.chatStream = null;
                   state.chatRunId = null;
                   await loadChatHistory(state);
@@ -1850,17 +1840,7 @@ export function renderApp(state: AppViewState) {
               agentsList: state.agentsList,
               currentAgentId: resolvedAgentId ?? "main",
               onAgentChange: (agentId: string) => {
-                state.sessionKey = buildAgentMainSessionKey({ agentId });
-                state.chatMessages = [];
-                state.chatStream = null;
-                state.chatRunId = null;
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: state.sessionKey,
-                  lastActiveSessionKey: state.sessionKey,
-                });
-                void loadChatHistory(state);
-                void state.loadAssistantIdentity();
+                switchChatSession(state, buildAgentMainSessionKey({ agentId }));
               },
               onNavigateToAgent: () => {
                 state.agentsSelectedId = resolvedAgentId;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,5 +1,6 @@
 import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
+import type { ChatSideResult } from "./chat/side-result.ts";
 import type { CronModelSuggestionsState, CronState } from "./controllers/cron.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
@@ -72,6 +73,8 @@ export type AppViewState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
+  chatSideResult: ChatSideResult | null;
+  chatSideResultTerminalRuns: Set<string>;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
   chatAvatarUrl: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -54,6 +54,7 @@ import {
 import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
 import { exportChatMarkdown } from "./chat/export.ts";
+import type { ChatSideResult } from "./chat/side-result.ts";
 import {
   loadToolsEffective as loadToolsEffectiveInternal,
   refreshVisibleToolsEffectiveForCurrentSession as refreshVisibleToolsEffectiveForCurrentSessionInternal,
@@ -166,6 +167,7 @@ export class OpenClawApp extends LitElement {
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
+  @state() chatSideResult: ChatSideResult | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
@@ -486,6 +488,7 @@ export class OpenClawApp extends LitElement {
   private toolStreamById = new Map<string, ToolStreamEntry>();
   private toolStreamOrder: string[] = [];
   refreshSessionsAfterChat = new Set<string>();
+  chatSideResultTerminalRuns = new Set<string>();
   basePath = "";
   private popStateHandler = () =>
     onPopStateInternal(this as unknown as Parameters<typeof onPopStateInternal>[0]);

--- a/ui/src/ui/chat/side-result.ts
+++ b/ui/src/ui/chat/side-result.ts
@@ -1,0 +1,38 @@
+import { normalizeOptionalString } from "../string-coerce.ts";
+
+export type ChatSideResult = {
+  kind: "btw";
+  runId: string;
+  sessionKey: string;
+  question: string;
+  text: string;
+  isError: boolean;
+  ts: number;
+};
+
+export function parseChatSideResult(payload: unknown): ChatSideResult | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const candidate = payload as Record<string, unknown>;
+  if (candidate.kind !== "btw") {
+    return null;
+  }
+  const runId = normalizeOptionalString(candidate.runId);
+  const sessionKey = normalizeOptionalString(candidate.sessionKey);
+  const question = normalizeOptionalString(candidate.question);
+  const text = normalizeOptionalString(candidate.text);
+  if (!(runId && sessionKey && question && text)) {
+    return null;
+  }
+  return {
+    kind: "btw",
+    runId,
+    sessionKey,
+    question,
+    text,
+    isError: candidate.isError === true,
+    ts:
+      typeof candidate.ts === "number" && Number.isFinite(candidate.ts) ? candidate.ts : Date.now(),
+  };
+}

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -142,6 +142,38 @@ function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string }
   return { mimeType: match[1], content: match[2] };
 }
 
+function buildApiAttachments(attachments?: ChatAttachment[]) {
+  const hasAttachments = attachments && attachments.length > 0;
+  return hasAttachments
+    ? attachments
+        .map((att) => {
+          const parsed = dataUrlToBase64(att.dataUrl);
+          if (!parsed) {
+            return null;
+          }
+          return {
+            type: "image",
+            mimeType: parsed.mimeType,
+            content: parsed.content,
+          };
+        })
+        .filter((a): a is NonNullable<typeof a> => a !== null)
+    : undefined;
+}
+
+async function requestChatSend(
+  state: ChatState,
+  params: { message: string; attachments?: ChatAttachment[]; runId: string },
+) {
+  await state.client!.request("chat.send", {
+    sessionKey: state.sessionKey,
+    message: params.message,
+    deliver: false,
+    idempotencyKey: params.runId,
+    attachments: buildApiAttachments(params.attachments),
+  });
+}
+
 type AssistantMessageNormalizationOptions = {
   roleRequirement: "required" | "optional";
   roleCaseSensitive?: boolean;
@@ -238,31 +270,8 @@ export async function sendChatMessage(
   state.chatStream = "";
   state.chatStreamStartedAt = now;
 
-  // Convert attachments to API format
-  const apiAttachments = hasAttachments
-    ? attachments
-        .map((att) => {
-          const parsed = dataUrlToBase64(att.dataUrl);
-          if (!parsed) {
-            return null;
-          }
-          return {
-            type: "image",
-            mimeType: parsed.mimeType,
-            content: parsed.content,
-          };
-        })
-        .filter((a): a is NonNullable<typeof a> => a !== null)
-    : undefined;
-
   try {
-    await state.client.request("chat.send", {
-      sessionKey: state.sessionKey,
-      message: msg,
-      deliver: false,
-      idempotencyKey: runId,
-      attachments: apiAttachments,
-    });
+    await requestChatSend(state, { message: msg, attachments, runId });
     return runId;
   } catch (err) {
     const error = formatConnectError(err);
@@ -281,6 +290,30 @@ export async function sendChatMessage(
     return null;
   } finally {
     state.chatSending = false;
+  }
+}
+
+export async function sendDetachedChatMessage(
+  state: ChatState,
+  message: string,
+  attachments?: ChatAttachment[],
+): Promise<string | null> {
+  if (!state.client || !state.connected) {
+    return null;
+  }
+  const msg = message.trim();
+  const hasAttachments = attachments && attachments.length > 0;
+  if (!msg && !hasAttachments) {
+    return null;
+  }
+  state.lastError = null;
+  const runId = generateUUID();
+  try {
+    await requestChatSend(state, { message: msg, attachments, runId });
+    return runId;
+  } catch (err) {
+    state.lastError = formatConnectError(err);
+    return null;
   }
 }
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -209,6 +209,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     compactionStatus: null,
     fallbackStatus: null,
     messages: [],
+    sideResult: null,
     toolMessages: [],
     streamSegments: [],
     stream: null,
@@ -229,6 +230,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onDraftChange: () => undefined,
     onSend: () => undefined,
     onQueueRemove: () => undefined,
+    onDismissSideResult: () => undefined,
     onNewSession: () => undefined,
     agentsList: null,
     currentAgentId: "",
@@ -291,6 +293,89 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
 }
 
 describe("chat view", () => {
+  it("renders BTW side results outside transcript history", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Saved transcript message" }],
+              timestamp: 1,
+            },
+          ],
+          sideResult: {
+            kind: "btw",
+            runId: "btw-run-1",
+            sessionKey: "main",
+            question: "what changed?",
+            text: "The web UI now renders **BTW** separately.",
+            isError: false,
+            ts: 2,
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-side-result")).not.toBeNull();
+    expect(container.textContent).toContain("BTW");
+    expect(container.textContent).toContain("what changed?");
+    expect(container.textContent).toContain("Not saved to chat history");
+    expect(container.textContent).toContain("Saved transcript message");
+    expect(container.querySelectorAll(".chat-side-result")).toHaveLength(1);
+  });
+
+  it("dismisses BTW side results from the dismiss button", () => {
+    const container = document.createElement("div");
+    const onDismissSideResult = vi.fn();
+    render(
+      renderChat(
+        createProps({
+          sideResult: {
+            kind: "btw",
+            runId: "btw-run-2",
+            sessionKey: "main",
+            question: "what changed?",
+            text: "Dismiss me",
+            isError: false,
+            ts: 3,
+          },
+          onDismissSideResult,
+        }),
+      ),
+      container,
+    );
+
+    const button = container.querySelector<HTMLButtonElement>(".chat-side-result__dismiss");
+    expect(button).not.toBeNull();
+    button?.click();
+    expect(onDismissSideResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders BTW errors with the error variant", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sideResult: {
+            kind: "btw",
+            runId: "btw-run-3",
+            sessionKey: "main",
+            question: "what failed?",
+            text: "The side question could not be answered.",
+            isError: true,
+            ts: 4,
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-side-result--error")).not.toBeNull();
+  });
+
   it("hides the context notice when only cumulative inputTokens exceed the limit", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type {
   CompactionStatus as CompactionIndicatorStatus,
   FallbackStatus as FallbackIndicatorStatus,
@@ -22,6 +23,7 @@ import { PinnedMessages } from "../chat/pinned-messages.ts";
 import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
 import { messageMatchesSearchQuery } from "../chat/search-match.ts";
 import { getOrCreateSessionCacheValue } from "../chat/session-cache.ts";
+import type { ChatSideResult } from "../chat/side-result.ts";
 import {
   CATEGORY_LABELS,
   SLASH_COMMANDS,
@@ -31,6 +33,7 @@ import {
 } from "../chat/slash-commands.ts";
 import { isSttSupported, startStt, stopStt } from "../chat/speech.ts";
 import { icons } from "../icons.ts";
+import { toSanitizedMarkdownHtml } from "../markdown.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
@@ -52,6 +55,7 @@ export type ChatProps = {
   compactionStatus?: CompactionIndicatorStatus | null;
   fallbackStatus?: FallbackIndicatorStatus | null;
   messages: unknown[];
+  sideResult?: ChatSideResult | null;
   toolMessages: unknown[];
   streamSegments: Array<{ text: string; ts: number }>;
   stream: string | null;
@@ -83,6 +87,7 @@ export type ChatProps = {
   onSend: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
+  onDismissSideResult?: () => void;
   onNewSession: () => void;
   onClearHistory?: () => void;
   agentsList: {
@@ -252,6 +257,43 @@ function renderFallbackIndicator(status: FallbackIndicatorStatus | null | undefi
     <div class=${className} role="status" aria-live="polite" title=${details}>
       ${icon} ${message}
     </div>
+  `;
+}
+
+function renderSideResult(
+  sideResult: ChatSideResult | null | undefined,
+  onDismiss?: () => void,
+): TemplateResult | typeof nothing {
+  if (!sideResult) {
+    return nothing;
+  }
+  return html`
+    <section
+      class=${`chat-side-result ${sideResult.isError ? "chat-side-result--error" : ""}`}
+      role="status"
+      aria-live="polite"
+      aria-label="BTW side result"
+    >
+      <div class="chat-side-result__header">
+        <div class="chat-side-result__label-row">
+          <span class="chat-side-result__label">BTW</span>
+          <span class="chat-side-result__meta">Not saved to chat history</span>
+        </div>
+        <button
+          class="btn chat-side-result__dismiss"
+          type="button"
+          aria-label="Dismiss BTW result"
+          title="Dismiss"
+          @click=${() => onDismiss?.()}
+        >
+          ${icons.x}
+        </button>
+      </div>
+      <div class="chat-side-result__question">${sideResult.question}</div>
+      <div class="chat-side-result__body" dir=${detectTextDirection(sideResult.text)}>
+        ${unsafeHTML(toSanitizedMarkdownHtml(sideResult.text))}
+      </div>
+    </section>
   `;
 }
 
@@ -1101,6 +1143,12 @@ export function renderChat(props: ChatProps) {
       }
     }
 
+    if (e.key === "Escape" && props.sideResult && !vs.searchOpen) {
+      e.preventDefault();
+      props.onDismissSideResult?.();
+      return;
+    }
+
     // Input history (only when input is empty)
     if (!props.draft.trim()) {
       if (e.key === "ArrowUp") {
@@ -1237,6 +1285,7 @@ export function renderChat(props: ChatProps) {
             </div>
           `
         : nothing}
+      ${renderSideResult(props.sideResult, props.onDismissSideResult)}
       ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
       ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null)}


### PR DESCRIPTION
## Summary

- Problem: Control UI did not consume `chat.side_result`, so `/btw` replies were missing from the browser, and `/btw` also got queued behind active runs in the dashboard.
- Why it matters: BTW is meant to be an ephemeral side-question flow that stays out of transcript history and should remain usable while the main run is busy.
- What changed: Added a typed `chat.side_result` consumer + ephemeral BTW card in Control UI, suppressed the empty BTW terminal-final history reload, and routed `/btw` through a detached send path so it sends immediately during active runs.
- What did NOT change (scope boundary): Gateway-side BTW semantics, transcript persistence, and TUI/external-channel BTW behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53333
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The Control UI only handled `chat` and `agent` events, not `chat.side_result`, and its busy-send path treated `/btw` like a normal outbound message so it was queued behind the active run.
- Missing detection / guardrail: There was no Control UI coverage for `chat.side_result` consumption or for `/btw` behavior while a run was already active.
- Contributing context (if known): BTW already worked in TUI because TUI has a dedicated BTW event path and renderer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/ui/app-gateway.node.test.ts`
  - `ui/src/ui/views/chat.test.ts`
  - `ui/src/ui/app-render.helpers.node.test.ts`
  - `ui/src/ui/app-chat.test.ts`
- Scenario the test should lock in: Control UI consumes `chat.side_result`, does not reload history for BTW terminal finals, clears ephemeral BTW state on session switch, and sends `/btw` immediately instead of queueing it behind the active run.
- Why this is the smallest reliable guardrail: The bug lives entirely in Control UI state/event/send handling, so focused UI-layer tests catch it without requiring gateway or channel E2E.
- Existing test that already covers this (if any): Gateway already had BTW protocol coverage in `src/gateway/server.chat.gateway-server-chat.test.ts`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `/btw` now renders as a dedicated dismissible side-result card in Control UI.
- BTW stays out of transcript history and disappears on reload/session switch.
- `/btw` now sends immediately in the dashboard even while a normal run is active, instead of waiting in the queue.

## Diagram (if applicable)

```text
Before:
[/btw while run active] -> [normal busy send path] -> [queued] -> [later send]
[/btw result event] -> [no web consumer] -> [no proper browser BTW UI]

After:
[/btw while run active] -> [detached send path] -> [immediate send]
[chat.side_result] -> [ephemeral BTW UI state] -> [dismissible card]
[terminal empty final for BTW] -> [skip history reload] -> [no transcript pollution]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev gateway
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): Control UI / webchat
- Relevant config (redacted): local loopback gateway with `agents.defaults.model.primary = openai-codex/gpt-5.4`

### Steps

1. Start the local gateway and open the Control UI dashboard.
2. Start a normal long-running chat request.
3. While that run is active, send `/btw what changed?` from the dashboard.

### Expected

- BTW sends immediately.
- A dedicated BTW card appears in the browser.
- The BTW result is not added to transcript history.

### Actual

- Before this PR, `/btw` was queued behind the active run and the browser had no dedicated BTW rendering.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Opened the local dashboard against a dev gateway.
  - Confirmed `/btw` renders as an ephemeral card in Control UI.
  - Confirmed `/btw` sends immediately during an active run instead of landing in the queue.
- Edge cases checked:
  - BTW final event does not trigger a useless history reload.
  - BTW state clears on session switch and on reload.
  - BTW error variant renders distinctly.
- What you did **not** verify:
  - Remote gateway deployment behavior.
  - Non-browser channels and TUI (unchanged by this PR).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Ephemeral BTW state could accidentally interfere with normal chat final-event reload behavior.
  - Mitigation: Track BTW terminal run ids separately and cover both side-result handling and final-event behavior with focused tests.
- Risk: Detached `/btw` sends could accidentally adopt main-run state or create transcript artifacts.
  - Mitigation: Use a separate detached send path and test that active `chatRunId`, stream state, queue state, and optimistic transcript messages remain untouched.
