### PR TITLE
test: add Telegram QA E2E lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/dreaming: simplify the Scene and Diary surfaces, preserve unknown phase state for partial status payloads, and stabilize waiting-entry recency ordering so Dreaming status and review lists stay clear and deterministic. (#64035) Thanks @davemorin.
 - Gateway: split startup and runtime seams so gateway lifecycle sequencing, reload state, and shutdown behavior stay easier to maintain without changing observed behavior. (#63975) Thanks @gumadeiras.
 - Matrix/partial streaming: add MSC4357 live markers to draft preview sends and edits so supporting Matrix clients can render a live/typewriter animation and stop it when the final edit lands. (#63513) Thanks @TigerInYourDream.
+- QA/Telegram: add a live `openclaw qa telegram` lane for private-group bot-to-bot checks, harden its artifact handling, and preserve native Telegram command reply threading for QA verification. (#64303) Thanks @obviyus.
 
 ### Fixes
 

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -6,6 +6,7 @@ const {
   runQaSuiteFromRuntime,
   runQaCharacterEval,
   runQaMultipass,
+  runTelegramQaLive,
   startQaLabServer,
   writeQaDockerHarnessFiles,
   buildQaDockerHarnessImage,
@@ -15,6 +16,7 @@ const {
   runQaSuiteFromRuntime: vi.fn(),
   runQaCharacterEval: vi.fn(),
   runQaMultipass: vi.fn(),
+  runTelegramQaLive: vi.fn(),
   startQaLabServer: vi.fn(),
   writeQaDockerHarnessFiles: vi.fn(),
   buildQaDockerHarnessImage: vi.fn(),
@@ -35,6 +37,10 @@ vi.mock("./character-eval.js", () => ({
 
 vi.mock("./multipass.runtime.js", () => ({
   runQaMultipass,
+}));
+
+vi.mock("./telegram-live.runtime.js", () => ({
+  runTelegramQaLive,
 }));
 
 vi.mock("./lab-server.js", () => ({
@@ -58,6 +64,7 @@ import {
   runQaCharacterEvalCommand,
   runQaManualLaneCommand,
   runQaSuiteCommand,
+  runQaTelegramCommand,
 } from "./cli.runtime.js";
 
 describe("qa cli runtime", () => {
@@ -69,6 +76,7 @@ describe("qa cli runtime", () => {
     runQaCharacterEval.mockReset();
     runQaManualLane.mockReset();
     runQaMultipass.mockReset();
+    runTelegramQaLive.mockReset();
     startQaLabServer.mockReset();
     writeQaDockerHarnessFiles.mockReset();
     buildQaDockerHarnessImage.mockReset();
@@ -97,6 +105,13 @@ describe("qa cli runtime", () => {
       guestScriptPath: "/tmp/multipass/multipass-guest-run.sh",
       vmName: "openclaw-qa-test",
       scenarioIds: ["channel-chat-baseline"],
+    });
+    runTelegramQaLive.mockResolvedValue({
+      outputDir: "/tmp/telegram",
+      reportPath: "/tmp/telegram/report.md",
+      summaryPath: "/tmp/telegram/summary.json",
+      observedMessagesPath: "/tmp/telegram/observed.json",
+      scenarios: [],
     });
     startQaLabServer.mockResolvedValue({
       baseUrl: "http://127.0.0.1:58000",
@@ -143,6 +158,30 @@ describe("qa cli runtime", () => {
       alternateModel: "anthropic/claude-sonnet-4-6",
       fastMode: true,
       scenarioIds: ["approval-turn-tool-followthrough"],
+    });
+  });
+
+  it("resolves telegram qa repo-root-relative paths before dispatching", async () => {
+    await runQaTelegramCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      outputDir: ".artifacts/qa/telegram",
+      providerMode: "live-frontier",
+      primaryModel: "openai/gpt-5.4",
+      alternateModel: "openai/gpt-5.4",
+      fastMode: true,
+      scenarioIds: ["telegram-help-command"],
+      sutAccountId: "sut-live",
+    });
+
+    expect(runTelegramQaLive).toHaveBeenCalledWith({
+      repoRoot: path.resolve("/tmp/openclaw-repo"),
+      outputDir: path.resolve("/tmp/openclaw-repo", ".artifacts/qa/telegram"),
+      providerMode: "live-frontier",
+      primaryModel: "openai/gpt-5.4",
+      alternateModel: "openai/gpt-5.4",
+      fastMode: true,
+      scenarioIds: ["telegram-help-command"],
+      sutAccountId: "sut-live",
     });
   });
 

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -185,6 +185,20 @@ describe("qa cli runtime", () => {
     });
   });
 
+  it("defaults telegram qa runs onto the live provider lane", async () => {
+    await runQaTelegramCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      scenarioIds: ["telegram-help-command"],
+    });
+
+    expect(runTelegramQaLive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoRoot: path.resolve("/tmp/openclaw-repo"),
+        providerMode: "live-frontier",
+      }),
+    );
+  });
+
   it("normalizes legacy live-openai suite runs onto the frontier provider mode", async () => {
     await runQaSuiteCommand({
       repoRoot: "/tmp/openclaw-repo",

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -57,6 +57,7 @@ vi.mock("./docker-up.runtime.js", () => ({
 }));
 
 import {
+  __testing,
   runQaLabSelfCheckCommand,
   runQaDockerBuildImageCommand,
   runQaDockerScaffoldCommand,
@@ -183,6 +184,15 @@ describe("qa cli runtime", () => {
       scenarioIds: ["telegram-help-command"],
       sutAccountId: "sut-live",
     });
+  });
+
+  it("rejects output dirs that escape the repo root", () => {
+    expect(() =>
+      __testing.resolveRepoRelativeOutputDir("/tmp/openclaw-repo", "../outside"),
+    ).toThrow("--output-dir must stay within the repo root.");
+    expect(() =>
+      __testing.resolveRepoRelativeOutputDir("/tmp/openclaw-repo", "/tmp/outside"),
+    ).toThrow("--output-dir must be a relative path inside the repo root.");
   });
 
   it("defaults telegram qa runs onto the live provider lane", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -15,6 +15,7 @@ import {
   type QaProviderModeInput,
 } from "./run-config.js";
 import { runQaSuiteFromRuntime } from "./suite-launch.runtime.js";
+import { runTelegramQaLive } from "./telegram-live.runtime.js";
 
 type InterruptibleServer = {
   baseUrl: string;
@@ -278,6 +279,32 @@ export async function runQaSuiteCommand(opts: {
   process.stdout.write(`QA suite watch: ${result.watchUrl}\n`);
   process.stdout.write(`QA suite report: ${result.reportPath}\n`);
   process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
+}
+
+export async function runQaTelegramCommand(opts: {
+  repoRoot?: string;
+  outputDir?: string;
+  providerMode?: QaProviderModeInput;
+  primaryModel?: string;
+  alternateModel?: string;
+  fastMode?: boolean;
+  scenarioIds?: string[];
+  sutAccountId?: string;
+}) {
+  const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const result = await runTelegramQaLive({
+    repoRoot,
+    outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
+    providerMode: opts.providerMode,
+    primaryModel: opts.primaryModel,
+    alternateModel: opts.alternateModel,
+    fastMode: opts.fastMode,
+    scenarioIds: opts.scenarioIds,
+    sutAccountId: opts.sutAccountId,
+  });
+  process.stdout.write(`Telegram QA report: ${result.reportPath}\n`);
+  process.stdout.write(`Telegram QA summary: ${result.summaryPath}\n`);
+  process.stdout.write(`Telegram QA observed messages: ${result.observedMessagesPath}\n`);
 }
 
 export async function runQaCharacterEvalCommand(opts: {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -292,10 +292,12 @@ export async function runQaTelegramCommand(opts: {
   sutAccountId?: string;
 }) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const providerMode: QaProviderMode =
+    opts.providerMode === undefined ? "live-frontier" : normalizeQaProviderMode(opts.providerMode);
   const result = await runTelegramQaLive({
     repoRoot,
     outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
-    providerMode: opts.providerMode,
+    providerMode,
     primaryModel: opts.primaryModel,
     alternateModel: opts.alternateModel,
     fastMode: opts.fastMode,

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -22,6 +22,21 @@ type InterruptibleServer = {
   stop(): Promise<void>;
 };
 
+function resolveRepoRelativeOutputDir(repoRoot: string, outputDir?: string) {
+  if (!outputDir) {
+    return undefined;
+  }
+  if (path.isAbsolute(outputDir)) {
+    throw new Error("--output-dir must be a relative path inside the repo root.");
+  }
+  const resolved = path.resolve(repoRoot, outputDir);
+  const relative = path.relative(repoRoot, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("--output-dir must stay within the repo root.");
+  }
+  return resolved;
+}
+
 function resolveQaManualLaneModels(opts: {
   providerMode: QaProviderMode;
   primaryModel?: string;
@@ -242,7 +257,7 @@ export async function runQaSuiteCommand(opts: {
   if (runner === "multipass") {
     const result = await runQaMultipass({
       repoRoot,
-      outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
+      outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
       providerMode,
       primaryModel: opts.primaryModel,
       alternateModel: opts.alternateModel,
@@ -265,7 +280,7 @@ export async function runQaSuiteCommand(opts: {
   }
   const result = await runQaSuiteFromRuntime({
     repoRoot,
-    outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
+    outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
     providerMode,
     primaryModel: opts.primaryModel,
     alternateModel: opts.alternateModel,
@@ -296,7 +311,7 @@ export async function runQaTelegramCommand(opts: {
     opts.providerMode === undefined ? "live-frontier" : normalizeQaProviderMode(opts.providerMode);
   const result = await runTelegramQaLive({
     repoRoot,
-    outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
+    outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
     providerMode,
     primaryModel: opts.primaryModel,
     alternateModel: opts.alternateModel,
@@ -328,7 +343,7 @@ export async function runQaCharacterEvalCommand(opts: {
   const judges = parseQaModelSpecs("--judge-model", opts.judgeModel);
   const result = await runQaCharacterEval({
     repoRoot,
-    outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
+    outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
     models: candidates.models,
     scenarioId: opts.scenario,
     candidateFastMode: opts.fast,
@@ -420,7 +435,10 @@ export async function runQaDockerScaffoldCommand(opts: {
   bindUiDist?: boolean;
 }) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
-  const outputDir = path.resolve(repoRoot, opts.outputDir);
+  const outputDir = resolveRepoRelativeOutputDir(repoRoot, opts.outputDir);
+  if (!outputDir) {
+    throw new Error("--output-dir is required.");
+  }
   const result = await writeQaDockerHarnessFiles({
     outputDir,
     repoRoot,
@@ -457,7 +475,7 @@ export async function runQaDockerUpCommand(opts: {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const result = await runQaDockerUp({
     repoRoot,
-    outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
+    outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
     gatewayPort: Number.isFinite(opts.gatewayPort) ? opts.gatewayPort : undefined,
     qaLabPort: Number.isFinite(opts.qaLabPort) ? opts.qaLabPort : undefined,
     providerBaseUrl: opts.providerBaseUrl,
@@ -479,3 +497,7 @@ export async function runQaMockOpenAiCommand(opts: { host?: string; port?: numbe
   });
   await runInterruptibleServer("QA mock OpenAI", server);
 }
+
+export const __testing = {
+  resolveRepoRelativeOutputDir,
+};

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -163,7 +163,7 @@ export function registerQaLabCli(program: Command) {
     .option(
       "--provider-mode <mode>",
       "Provider mode: mock-openai or live-frontier (legacy live-openai still works)",
-      "live-frontier",
+      "mock-openai",
     )
     .option("--model <ref>", "Primary provider/model ref")
     .option("--alt-model <ref>", "Alternate provider/model ref")
@@ -223,7 +223,7 @@ export function registerQaLabCli(program: Command) {
     .option(
       "--provider-mode <mode>",
       "Provider mode: mock-openai or live-frontier (legacy live-openai still works)",
-      "mock-openai",
+      "live-frontier",
     )
     .option("--model <ref>", "Primary provider/model ref")
     .option("--alt-model <ref>", "Alternate provider/model ref")

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -35,6 +35,20 @@ async function runQaSuite(opts: {
   await runtime.runQaSuiteCommand(opts);
 }
 
+async function runQaTelegram(opts: {
+  repoRoot?: string;
+  outputDir?: string;
+  providerMode?: QaProviderModeInput;
+  primaryModel?: string;
+  alternateModel?: string;
+  fastMode?: boolean;
+  scenarioIds?: string[];
+  sutAccountId?: string;
+}) {
+  const runtime = await loadQaLabCliRuntime();
+  await runtime.runQaTelegramCommand(opts);
+}
+
 async function runQaCharacterEval(opts: {
   repoRoot?: string;
   outputDir?: string;
@@ -198,6 +212,53 @@ export function registerQaLabCli(program: Command) {
           cpus: opts.cpus,
           memory: opts.memory,
           disk: opts.disk,
+        });
+      },
+    );
+
+  qa.command("telegram")
+    .description("Run the manual Telegram live QA lane against a private bot-to-bot group harness")
+    .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
+    .option("--output-dir <path>", "Telegram QA artifact directory")
+    .option(
+      "--provider-mode <mode>",
+      "Provider mode: mock-openai or live-frontier (legacy live-openai still works)",
+      "mock-openai",
+    )
+    .option("--model <ref>", "Primary provider/model ref")
+    .option("--alt-model <ref>", "Alternate provider/model ref")
+    .option(
+      "--scenario <id>",
+      "Run only the named Telegram QA scenario (repeatable)",
+      collectString,
+      [],
+    )
+    .option("--fast", "Enable provider fast mode where supported", false)
+    .option(
+      "--sut-account <id>",
+      "Temporary Telegram account id inside the QA gateway config",
+      "sut",
+    )
+    .action(
+      async (opts: {
+        repoRoot?: string;
+        outputDir?: string;
+        providerMode?: QaProviderModeInput;
+        model?: string;
+        altModel?: string;
+        scenario?: string[];
+        fast?: boolean;
+        sutAccount?: string;
+      }) => {
+        await runQaTelegram({
+          repoRoot: opts.repoRoot,
+          outputDir: opts.outputDir,
+          providerMode: opts.providerMode,
+          primaryModel: opts.model,
+          alternateModel: opts.altModel,
+          fastMode: opts.fast,
+          scenarioIds: opts.scenario,
+          sutAccountId: opts.sutAccount,
         });
       },
     );

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -163,7 +163,7 @@ export function registerQaLabCli(program: Command) {
     .option(
       "--provider-mode <mode>",
       "Provider mode: mock-openai or live-frontier (legacy live-openai still works)",
-      "mock-openai",
+      "live-frontier",
     )
     .option("--model <ref>", "Primary provider/model ref")
     .option("--alt-model <ref>", "Alternate provider/model ref")

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -678,7 +678,10 @@ export async function startQaGatewayChild(params: {
     controlUiEnabled: params.controlUiEnabled,
   });
   const cfg = params.mutateConfig ? params.mutateConfig(baseCfg) : baseCfg;
-  await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+  await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
   const allowedPluginIds = [...(cfg.plugins?.allow ?? []), "openai"].filter(
     (pluginId, index, array): pluginId is string => {
       return (

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -6,6 +6,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -609,6 +610,7 @@ export async function startQaGatewayChild(params: {
   thinkingDefault?: QaThinkingLevel;
   claudeCliAuthMode?: QaCliBackendAuthMode;
   controlUiEnabled?: boolean;
+  mutateConfig?: (cfg: OpenClawConfig) => OpenClawConfig;
 }) {
   const tempRoot = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-qa-suite-"),
@@ -654,7 +656,7 @@ export async function startQaGatewayChild(params: {
           providerConfigs: liveProviderConfigs,
         })
       : undefined;
-  const cfg = buildQaGatewayConfig({
+  const baseCfg = buildQaGatewayConfig({
     bind: "loopback",
     gatewayPort,
     gatewayToken,
@@ -675,6 +677,7 @@ export async function startQaGatewayChild(params: {
     thinkingDefault: params.thinkingDefault,
     controlUiEnabled: params.controlUiEnabled,
   });
+  const cfg = params.mutateConfig ? params.mutateConfig(baseCfg) : baseCfg;
   await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
   const allowedPluginIds = [...(cfg.plugins?.allow ?? []), "openai"].filter(
     (pluginId, index, array): pluginId is string => {

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -166,6 +166,29 @@ describe("telegram live qa runtime", () => {
     ).toBe("match");
   });
 
+  it("classifies threaded blank sut replies as matches", () => {
+    expect(
+      __testing.classifyCanaryReply({
+        groupId: "-100123",
+        sutBotId: 88,
+        driverMessageId: 55,
+        message: {
+          updateId: 3,
+          messageId: 11,
+          chatId: -100123,
+          senderId: 88,
+          senderIsBot: true,
+          senderUsername: "sut_bot",
+          text: "",
+          replyToMessageId: 55,
+          timestamp: 1_700_000_002_000,
+          inlineButtons: [],
+          mediaKinds: ["photo"],
+        },
+      }),
+    ).toBe("match");
+  });
+
   it("redacts observed message content by default in artifacts", () => {
     expect(
       __testing.buildObservedMessagesArtifact({

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -73,6 +73,7 @@ describe("telegram live qa runtime", () => {
           enabled: true,
           botToken: "sut-token",
           dmPolicy: "disabled",
+          replyToMode: "first",
           groups: {
             "-100123": {
               groupPolicy: "allowlist",

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -166,6 +166,43 @@ describe("telegram live qa runtime", () => {
     ).toBe("match");
   });
 
+  it("redacts observed message content by default in artifacts", () => {
+    expect(
+      __testing.buildObservedMessagesArtifact({
+        includeContent: false,
+        observedMessages: [
+          {
+            updateId: 1,
+            messageId: 9,
+            chatId: -100123,
+            senderId: 42,
+            senderIsBot: true,
+            senderUsername: "driver_bot",
+            text: "secret text",
+            caption: "secret caption",
+            replyToMessageId: 8,
+            timestamp: 1_700_000_000_000,
+            inlineButtons: ["Approve"],
+            mediaKinds: ["photo"],
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        updateId: 1,
+        messageId: 9,
+        chatId: -100123,
+        senderId: 42,
+        senderIsBot: true,
+        senderUsername: "driver_bot",
+        replyToMessageId: 8,
+        timestamp: 1_700_000_000_000,
+        inlineButtons: ["Approve"],
+        mediaKinds: ["photo"],
+      },
+    ]);
+  });
+
   it("formats phase-specific canary diagnostics with context", () => {
     const error = new Error(
       "SUT bot did not send any group reply after the canary command within 30s.",

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -123,6 +123,49 @@ describe("telegram live qa runtime", () => {
     });
   });
 
+  it("ignores unrelated sut replies when matching the canary response", () => {
+    expect(
+      __testing.classifyCanaryReply({
+        groupId: "-100123",
+        sutBotId: 88,
+        driverMessageId: 55,
+        message: {
+          updateId: 1,
+          messageId: 9,
+          chatId: -100123,
+          senderId: 88,
+          senderIsBot: true,
+          senderUsername: "sut_bot",
+          text: "other reply",
+          replyToMessageId: 999,
+          timestamp: 1_700_000_000_000,
+          inlineButtons: [],
+          mediaKinds: [],
+        },
+      }),
+    ).toBe("unthreaded");
+    expect(
+      __testing.classifyCanaryReply({
+        groupId: "-100123",
+        sutBotId: 88,
+        driverMessageId: 55,
+        message: {
+          updateId: 2,
+          messageId: 10,
+          chatId: -100123,
+          senderId: 88,
+          senderIsBot: true,
+          senderUsername: "sut_bot",
+          text: "canary reply",
+          replyToMessageId: 55,
+          timestamp: 1_700_000_001_000,
+          inlineButtons: [],
+          mediaKinds: [],
+        },
+      }),
+    ).toBe("match");
+  });
+
   it("formats phase-specific canary diagnostics with context", () => {
     const error = new Error(
       "SUT bot did not send any group reply after the canary command within 30s.",

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -151,4 +151,25 @@ describe("telegram live qa runtime", () => {
       "Confirm the SUT bot is present in the target private group and can receive /help@BotUsername commands there.",
     );
   });
+
+  it("treats null canary context as a non-canary error", () => {
+    const error = new Error("boom");
+    error.name = "TelegramQaCanaryError";
+    Object.assign(error, {
+      phase: "sut_reply_timeout",
+      context: null,
+    });
+
+    const message = __testing.canaryFailureMessage({
+      error,
+      groupId: "-100123",
+      driverBotId: 42,
+      driverUsername: "driver_bot",
+      sutBotId: 88,
+      sutUsername: "sut_bot",
+    });
+
+    expect(message).toContain("Phase: unknown");
+    expect(message).toContain("boom");
+  });
 });

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -135,25 +135,19 @@ describe("telegram live qa runtime", () => {
       },
     });
 
-    expect(
-      __testing.canaryFailureMessage({
-        error,
-        groupId: "-100123",
-        driverBotId: 42,
-        driverUsername: "driver_bot",
-        sutBotId: 88,
-        sutUsername: "sut_bot",
-      }),
-    ).toContain("Phase: sut_reply_timeout");
-    expect(
-      __testing.canaryFailureMessage({
-        error,
-        groupId: "-100123",
-        driverBotId: 42,
-        driverUsername: "driver_bot",
-        sutBotId: 88,
-        sutUsername: "sut_bot",
-      }),
-    ).toContain("- driverMessageId: 55");
+    const message = __testing.canaryFailureMessage({
+      error,
+      groupId: "-100123",
+      driverBotId: 42,
+      driverUsername: "driver_bot",
+      sutBotId: 88,
+      sutUsername: "sut_bot",
+    });
+    expect(message).toContain("Phase: sut_reply_timeout");
+    expect(message).toContain("- driverMessageId: 55");
+    expect(message).not.toContain("- sutBotId: 88\n- sutBotId: 88");
+    expect(message).toContain(
+      "Confirm the SUT bot is present in the target private group and can receive /help@BotUsername commands there.",
+    );
   });
 });

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -121,4 +121,39 @@ describe("telegram live qa runtime", () => {
       mediaKinds: ["photo"],
     });
   });
+
+  it("formats phase-specific canary diagnostics with context", () => {
+    const error = new Error(
+      "SUT bot did not send any group reply after the canary command within 30s.",
+    );
+    error.name = "TelegramQaCanaryError";
+    Object.assign(error, {
+      phase: "sut_reply_timeout",
+      context: {
+        driverMessageId: 55,
+        sutBotId: 88,
+      },
+    });
+
+    expect(
+      __testing.canaryFailureMessage({
+        error,
+        groupId: "-100123",
+        driverBotId: 42,
+        driverUsername: "driver_bot",
+        sutBotId: 88,
+        sutUsername: "sut_bot",
+      }),
+    ).toContain("Phase: sut_reply_timeout");
+    expect(
+      __testing.canaryFailureMessage({
+        error,
+        groupId: "-100123",
+        driverBotId: 42,
+        driverUsername: "driver_bot",
+        sutBotId: 88,
+        sutUsername: "sut_bot",
+      }),
+    ).toContain("- driverMessageId: 55");
+  });
 });

--- a/extensions/qa-lab/src/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.test.ts
@@ -1,0 +1,124 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it } from "vitest";
+import { __testing } from "./telegram-live.runtime.js";
+
+describe("telegram live qa runtime", () => {
+  it("resolves required Telegram QA env vars", () => {
+    expect(
+      __testing.resolveTelegramQaRuntimeEnv({
+        OPENCLAW_QA_TELEGRAM_GROUP_ID: "-100123",
+        OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN: "driver",
+        OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN: "sut",
+      }),
+    ).toEqual({
+      groupId: "-100123",
+      driverToken: "driver",
+      sutToken: "sut",
+    });
+  });
+
+  it("fails when a required Telegram QA env var is missing", () => {
+    expect(() =>
+      __testing.resolveTelegramQaRuntimeEnv({
+        OPENCLAW_QA_TELEGRAM_GROUP_ID: "-100123",
+        OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN: "driver",
+      }),
+    ).toThrow("OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN");
+  });
+
+  it("fails when the Telegram group id is not numeric", () => {
+    expect(() =>
+      __testing.resolveTelegramQaRuntimeEnv({
+        OPENCLAW_QA_TELEGRAM_GROUP_ID: "qa-group",
+        OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN: "driver",
+        OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN: "sut",
+      }),
+    ).toThrow("OPENCLAW_QA_TELEGRAM_GROUP_ID must be a numeric Telegram chat id.");
+  });
+
+  it("injects a temporary Telegram account into the QA gateway config", () => {
+    const baseCfg: OpenClawConfig = {
+      plugins: {
+        allow: ["memory-core", "qa-channel"],
+        entries: {
+          "memory-core": { enabled: true },
+          "qa-channel": { enabled: true },
+        },
+      },
+      channels: {
+        "qa-channel": {
+          enabled: true,
+          baseUrl: "http://127.0.0.1:43123",
+          botUserId: "openclaw",
+          botDisplayName: "OpenClaw QA",
+          allowFrom: ["*"],
+        },
+      },
+    };
+
+    const next = __testing.buildTelegramQaConfig(baseCfg, {
+      groupId: "-100123",
+      sutToken: "sut-token",
+      driverBotId: 42,
+      sutAccountId: "sut",
+    });
+
+    expect(next.plugins?.allow).toContain("telegram");
+    expect(next.plugins?.entries?.telegram).toEqual({ enabled: true });
+    expect(next.channels?.telegram).toEqual({
+      enabled: true,
+      defaultAccount: "sut",
+      accounts: {
+        sut: {
+          enabled: true,
+          botToken: "sut-token",
+          dmPolicy: "disabled",
+          groups: {
+            "-100123": {
+              groupPolicy: "allowlist",
+              allowFrom: ["42"],
+              requireMention: true,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("normalizes observed Telegram messages", () => {
+    expect(
+      __testing.normalizeTelegramObservedMessage({
+        update_id: 7,
+        message: {
+          message_id: 9,
+          date: 1_700_000_000,
+          text: "hello",
+          chat: { id: -100123 },
+          from: {
+            id: 42,
+            is_bot: true,
+            username: "driver_bot",
+          },
+          reply_to_message: { message_id: 8 },
+          reply_markup: {
+            inline_keyboard: [[{ text: "Approve" }, { text: "Deny" }]],
+          },
+          photo: [{}],
+        },
+      }),
+    ).toEqual({
+      updateId: 7,
+      messageId: 9,
+      chatId: -100123,
+      senderId: 42,
+      senderIsBot: true,
+      senderUsername: "driver_bot",
+      text: "hello",
+      caption: undefined,
+      replyToMessageId: 8,
+      timestamp: 1_700_000_000_000,
+      inlineButtons: ["Approve", "Deny"],
+      mediaKinds: ["photo"],
+    });
+  });
+});

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -325,7 +325,7 @@ async function flushTelegramUpdates(token: string) {
     }
     offset = (updates.at(-1)?.update_id ?? offset) + 1;
   }
-  return offset;
+  throw new Error("timed out after 15000ms draining Telegram updates");
 }
 
 async function sendGroupMessage(token: string, groupId: string, text: string) {
@@ -471,8 +471,7 @@ function classifyCanaryReply(params: {
 }) {
   if (
     params.message.chatId !== Number(params.groupId) ||
-    params.message.senderId !== params.sutBotId ||
-    !params.message.text.trim()
+    params.message.senderId !== params.sutBotId
   ) {
     return "ignore" as const;
   }

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -44,6 +44,11 @@ type TelegramObservedMessage = {
   mediaKinds: string[];
 };
 
+type TelegramObservedMessageArtifact = Omit<TelegramObservedMessage, "text" | "caption"> & {
+  text?: string;
+  caption?: string;
+};
+
 type TelegramQaScenarioResult = {
   id: string;
   title: string;
@@ -425,6 +430,28 @@ function renderTelegramQaMarkdown(params: {
   return lines.join("\n");
 }
 
+function buildObservedMessagesArtifact(params: {
+  observedMessages: TelegramObservedMessage[];
+  includeContent: boolean;
+}) {
+  return params.observedMessages.map<TelegramObservedMessageArtifact>((message) =>
+    params.includeContent
+      ? { ...message }
+      : {
+          updateId: message.updateId,
+          messageId: message.messageId,
+          chatId: message.chatId,
+          senderId: message.senderId,
+          senderIsBot: message.senderIsBot,
+          senderUsername: message.senderUsername,
+          replyToMessageId: message.replyToMessageId,
+          timestamp: message.timestamp,
+          inlineButtons: message.inlineButtons,
+          mediaKinds: message.mediaKinds,
+        },
+  );
+}
+
 function findScenario(ids?: string[]) {
   if (!ids || ids.length === 0) {
     return [...TELEGRAM_QA_SCENARIOS];
@@ -628,6 +655,7 @@ export async function runTelegramQaLive(params: {
   const sutAccountId = params.sutAccountId?.trim() || "sut";
   const scenarios = findScenario(params.scenarioIds);
   const observedMessages: TelegramObservedMessage[] = [];
+  const includeObservedMessageContent = process.env.OPENCLAW_QA_TELEGRAM_CAPTURE_CONTENT === "1";
   const startedAt = new Date().toISOString();
 
   const driverIdentity = await getBotIdentity(runtimeEnv.driverToken);
@@ -755,13 +783,23 @@ export async function runTelegramQaLive(params: {
       finishedAt,
       scenarios: scenarioResults,
     })}\n`,
-    "utf8",
+    { encoding: "utf8", mode: 0o600 },
   );
-  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
   await fs.writeFile(
     observedMessagesPath,
-    `${JSON.stringify(observedMessages, null, 2)}\n`,
-    "utf8",
+    `${JSON.stringify(
+      buildObservedMessagesArtifact({
+        observedMessages,
+        includeContent: includeObservedMessageContent,
+      }),
+      null,
+      2,
+    )}\n`,
+    { encoding: "utf8", mode: 0o600 },
   );
   if (canaryFailure) {
     throw new Error(
@@ -781,6 +819,7 @@ export async function runTelegramQaLive(params: {
 export const __testing = {
   TELEGRAM_QA_SCENARIOS,
   buildTelegramQaConfig,
+  buildObservedMessagesArtifact,
   canaryFailureMessage,
   classifyCanaryReply,
   normalizeTelegramObservedMessage,

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -265,6 +265,7 @@ function buildTelegramQaConfig(
             enabled: true,
             botToken: params.sutToken,
             dmPolicy: "disabled",
+            replyToMode: "first",
             groups: {
               [params.groupId]: {
                 groupPolicy: "allowlist",

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -51,6 +51,12 @@ type TelegramQaScenarioResult = {
   details: string;
 };
 
+type TelegramQaCanaryPhase =
+  | "driver_observation_timeout"
+  | "sut_reply_timeout"
+  | "sut_reply_not_threaded"
+  | "sut_reply_empty";
+
 export type TelegramQaRunResult = {
   outputDir: string;
   reportPath: string;
@@ -70,6 +76,32 @@ type TelegramQaSummary = {
   };
   scenarios: TelegramQaScenarioResult[];
 };
+
+class TelegramQaCanaryError extends Error {
+  phase: TelegramQaCanaryPhase;
+  context: Record<string, string | number | undefined>;
+
+  constructor(
+    phase: TelegramQaCanaryPhase,
+    message: string,
+    context: Record<string, string | number | undefined>,
+  ) {
+    super(message);
+    this.name = "TelegramQaCanaryError";
+    this.phase = phase;
+    this.context = context;
+  }
+}
+
+function isTelegramQaCanaryError(error: unknown): error is TelegramQaCanaryError {
+  return (
+    error instanceof TelegramQaCanaryError ||
+    (typeof error === "object" &&
+      error !== null &&
+      typeof (error as { phase?: unknown }).phase === "string" &&
+      typeof (error as { context?: unknown }).context === "object")
+  );
+}
 
 type TelegramApiEnvelope<T> = {
   ok: boolean;
@@ -418,35 +450,107 @@ async function runCanary(params: {
     params.groupId,
     `/help@${params.sutUsername}`,
   );
-  const driverObserved = await waitForObservedMessage({
-    token: params.driverToken,
-    initialOffset: offset,
-    timeoutMs: 20_000,
-    observedMessages: params.observedMessages,
-    predicate: (message) =>
-      message.chatId === Number(params.groupId) &&
-      message.senderId === params.driverBotId &&
-      message.messageId === driverMessage.message_id,
-  });
+  let driverObserved: Awaited<ReturnType<typeof waitForObservedMessage>>;
+  try {
+    driverObserved = await waitForObservedMessage({
+      token: params.driverToken,
+      initialOffset: offset,
+      timeoutMs: 20_000,
+      observedMessages: params.observedMessages,
+      predicate: (message) =>
+        message.chatId === Number(params.groupId) &&
+        message.senderId === params.driverBotId &&
+        message.messageId === driverMessage.message_id,
+    });
+  } catch (error) {
+    throw new TelegramQaCanaryError(
+      "driver_observation_timeout",
+      "Driver bot did not observe its own canary group message within 20s.",
+      {
+        groupId: params.groupId,
+        driverBotId: params.driverBotId,
+        driverMessageId: driverMessage.message_id,
+        cause: formatErrorMessage(error),
+      },
+    );
+  }
   offset = driverObserved.nextOffset;
-  await waitForObservedMessage({
-    token: params.driverToken,
-    initialOffset: offset,
-    timeoutMs: 30_000,
-    observedMessages: params.observedMessages,
-    predicate: (message) =>
-      message.chatId === Number(params.groupId) &&
-      message.senderId === params.sutBotId &&
-      message.replyToMessageId === driverMessage.message_id &&
-      message.text.trim().length > 0,
-  });
+  let sutObserved: Awaited<ReturnType<typeof waitForObservedMessage>>;
+  try {
+    sutObserved = await waitForObservedMessage({
+      token: params.driverToken,
+      initialOffset: offset,
+      timeoutMs: 30_000,
+      observedMessages: params.observedMessages,
+      predicate: (message) =>
+        message.chatId === Number(params.groupId) && message.senderId === params.sutBotId,
+    });
+  } catch (error) {
+    throw new TelegramQaCanaryError(
+      "sut_reply_timeout",
+      "SUT bot did not send any group reply after the canary command within 30s.",
+      {
+        groupId: params.groupId,
+        sutBotId: params.sutBotId,
+        driverMessageId: driverMessage.message_id,
+        cause: formatErrorMessage(error),
+      },
+    );
+  }
+  if (sutObserved.message.replyToMessageId !== driverMessage.message_id) {
+    throw new TelegramQaCanaryError(
+      "sut_reply_not_threaded",
+      "SUT bot replied, but not as a reply to the canary driver message.",
+      {
+        groupId: params.groupId,
+        sutBotId: params.sutBotId,
+        driverMessageId: driverMessage.message_id,
+        sutMessageId: sutObserved.message.messageId,
+        sutReplyToMessageId: sutObserved.message.replyToMessageId,
+      },
+    );
+  }
+  if (!sutObserved.message.text.trim()) {
+    throw new TelegramQaCanaryError(
+      "sut_reply_empty",
+      "SUT bot replied to the canary message but the reply text was empty.",
+      {
+        groupId: params.groupId,
+        sutBotId: params.sutBotId,
+        driverMessageId: driverMessage.message_id,
+        sutMessageId: sutObserved.message.messageId,
+      },
+    );
+  }
 }
 
-function canaryFailureMessage(error: unknown) {
+function canaryFailureMessage(params: {
+  error: unknown;
+  groupId: string;
+  driverBotId: number;
+  driverUsername?: string;
+  sutBotId: number;
+  sutUsername: string;
+}) {
+  const error = params.error;
   const details = formatErrorMessage(error);
+  const phase = isTelegramQaCanaryError(error) ? error.phase : "unknown";
+  const context = isTelegramQaCanaryError(error)
+    ? Object.entries(error.context)
+        .filter(([, value]) => value !== undefined && value !== "")
+        .map(([key, value]) => `- ${key}: ${String(value)}`)
+    : [];
   return [
     "Telegram QA canary failed.",
+    `Phase: ${phase}`,
     details,
+    "Context:",
+    `- groupId: ${params.groupId}`,
+    `- driverBotId: ${params.driverBotId}`,
+    `- driverUsername: ${params.driverUsername ?? "<none>"}`,
+    `- sutBotId: ${params.sutBotId}`,
+    `- sutUsername: ${params.sutUsername}`,
+    ...context,
     "Remediation:",
     "1. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
     "2. Ensure the driver bot can observe bot traffic in the private group by making it admin or disabling privacy mode, then re-add it.",
@@ -514,6 +618,7 @@ export async function runTelegramQaLive(params: {
   });
 
   const scenarioResults: TelegramQaScenarioResult[] = [];
+  let canaryFailure: string | null = null;
   try {
     await waitForTelegramChannelRunning(gateway, sutAccountId);
     try {
@@ -526,42 +631,56 @@ export async function runTelegramQaLive(params: {
         observedMessages,
       });
     } catch (error) {
-      throw new Error(canaryFailureMessage(error), { cause: error });
+      canaryFailure = canaryFailureMessage({
+        error,
+        groupId: runtimeEnv.groupId,
+        driverBotId: driverIdentity.id,
+        driverUsername: driverIdentity.username,
+        sutBotId: sutIdentity.id,
+        sutUsername,
+      });
+      scenarioResults.push({
+        id: "telegram-canary",
+        title: "Telegram canary",
+        status: "fail",
+        details: canaryFailure,
+      });
     }
-
-    let driverOffset = await flushTelegramUpdates(runtimeEnv.driverToken);
-    for (const scenario of scenarios) {
-      try {
-        const sent = await sendGroupMessage(
-          runtimeEnv.driverToken,
-          runtimeEnv.groupId,
-          scenario.buildInput(sutUsername),
-        );
-        const matched = await waitForObservedMessage({
-          token: runtimeEnv.driverToken,
-          initialOffset: driverOffset,
-          timeoutMs: scenario.timeoutMs,
-          observedMessages,
-          predicate: (message) =>
-            message.chatId === Number(runtimeEnv.groupId) &&
-            message.senderId === sutIdentity.id &&
-            message.replyToMessageId === sent.message_id &&
-            message.text.trim().length > 0,
-        });
-        driverOffset = matched.nextOffset;
-        scenarioResults.push({
-          id: scenario.id,
-          title: scenario.title,
-          status: "pass",
-          details: `reply message ${matched.message.messageId} matched`,
-        });
-      } catch (error) {
-        scenarioResults.push({
-          id: scenario.id,
-          title: scenario.title,
-          status: "fail",
-          details: formatErrorMessage(error),
-        });
+    if (!canaryFailure) {
+      let driverOffset = await flushTelegramUpdates(runtimeEnv.driverToken);
+      for (const scenario of scenarios) {
+        try {
+          const sent = await sendGroupMessage(
+            runtimeEnv.driverToken,
+            runtimeEnv.groupId,
+            scenario.buildInput(sutUsername),
+          );
+          const matched = await waitForObservedMessage({
+            token: runtimeEnv.driverToken,
+            initialOffset: driverOffset,
+            timeoutMs: scenario.timeoutMs,
+            observedMessages,
+            predicate: (message) =>
+              message.chatId === Number(runtimeEnv.groupId) &&
+              message.senderId === sutIdentity.id &&
+              message.replyToMessageId === sent.message_id &&
+              message.text.trim().length > 0,
+          });
+          driverOffset = matched.nextOffset;
+          scenarioResults.push({
+            id: scenario.id,
+            title: scenario.title,
+            status: "pass",
+            details: `reply message ${matched.message.messageId} matched`,
+          });
+        } catch (error) {
+          scenarioResults.push({
+            id: scenario.id,
+            title: scenario.title,
+            status: "fail",
+            details: formatErrorMessage(error),
+          });
+        }
       }
     }
   } finally {
@@ -599,6 +718,11 @@ export async function runTelegramQaLive(params: {
     `${JSON.stringify(observedMessages, null, 2)}\n`,
     "utf8",
   );
+  if (canaryFailure) {
+    throw new Error(
+      `${canaryFailure}\nArtifacts:\n- report: ${reportPath}\n- summary: ${summaryPath}\n- observedMessages: ${observedMessagesPath}`,
+    );
+  }
 
   return {
     outputDir,
@@ -612,6 +736,7 @@ export async function runTelegramQaLive(params: {
 export const __testing = {
   TELEGRAM_QA_SCENARIOS,
   buildTelegramQaConfig,
+  canaryFailureMessage,
   normalizeTelegramObservedMessage,
   resolveTelegramQaRuntimeEnv,
 };

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -535,11 +535,53 @@ function canaryFailureMessage(params: {
   const error = params.error;
   const details = formatErrorMessage(error);
   const phase = isTelegramQaCanaryError(error) ? error.phase : "unknown";
+  const canonicalContext = new Set([
+    "groupId",
+    "driverBotId",
+    "driverUsername",
+    "sutBotId",
+    "sutUsername",
+  ]);
   const context = isTelegramQaCanaryError(error)
     ? Object.entries(error.context)
-        .filter(([, value]) => value !== undefined && value !== "")
+        .filter(([key, value]) => value !== undefined && value !== "" && !canonicalContext.has(key))
         .map(([key, value]) => `- ${key}: ${String(value)}`)
     : [];
+  const remediation = (() => {
+    switch (phase) {
+      case "driver_observation_timeout":
+        return [
+          "1. Ensure the driver bot can observe group traffic by making it admin or disabling privacy mode, then re-add it.",
+          "2. Confirm the driver bot is still a member of the target private group.",
+          "3. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
+        ];
+      case "sut_reply_timeout":
+        return [
+          "1. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
+          "2. Confirm the SUT bot is present in the target private group and can receive /help@BotUsername commands there.",
+          "3. Confirm the QA child gateway started the SUT Telegram account with the expected token.",
+        ];
+      case "sut_reply_not_threaded":
+        return [
+          "1. Check whether the SUT bot is replying in the group without threading to the driver message.",
+          "2. Confirm the Telegram native command path preserves reply-to behavior for group commands.",
+          "3. Inspect the observed messages artifact for the mismatched SUT message id and reply target.",
+        ];
+      case "sut_reply_empty":
+        return [
+          "1. Inspect the observed messages artifact to confirm whether the SUT sent media-only or blank text.",
+          "2. Check whether the Telegram native command response path produced an empty or suppressed reply.",
+          "3. Confirm the SUT command completed successfully in gateway logs.",
+        ];
+      default:
+        return [
+          "1. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
+          "2. Ensure the driver bot can observe bot traffic in the private group by making it admin or disabling privacy mode, then re-add it.",
+          "3. Ensure both bots are members of the same private group.",
+          "4. Confirm the SUT bot is allowed to receive /help@BotUsername commands in that group.",
+        ];
+    }
+  })();
   return [
     "Telegram QA canary failed.",
     `Phase: ${phase}`,
@@ -552,10 +594,7 @@ function canaryFailureMessage(params: {
     `- sutUsername: ${params.sutUsername}`,
     ...context,
     "Remediation:",
-    "1. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
-    "2. Ensure the driver bot can observe bot traffic in the private group by making it admin or disabling privacy mode, then re-add it.",
-    "3. Ensure both bots are members of the same private group.",
-    "4. Confirm the SUT bot is allowed to receive /help@BotUsername commands in that group.",
+    ...remediation,
   ].join("\n");
 }
 

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -51,11 +51,7 @@ type TelegramQaScenarioResult = {
   details: string;
 };
 
-type TelegramQaCanaryPhase =
-  | "driver_observation_timeout"
-  | "sut_reply_timeout"
-  | "sut_reply_not_threaded"
-  | "sut_reply_empty";
+type TelegramQaCanaryPhase = "sut_reply_timeout" | "sut_reply_not_threaded" | "sut_reply_empty";
 
 export type TelegramQaRunResult = {
   outputDir: string;
@@ -440,41 +436,15 @@ async function runCanary(params: {
   driverToken: string;
   groupId: string;
   sutUsername: string;
-  driverBotId: number;
   sutBotId: number;
   observedMessages: TelegramObservedMessage[];
 }) {
-  let offset = await flushTelegramUpdates(params.driverToken);
+  const offset = await flushTelegramUpdates(params.driverToken);
   const driverMessage = await sendGroupMessage(
     params.driverToken,
     params.groupId,
     `/help@${params.sutUsername}`,
   );
-  let driverObserved: Awaited<ReturnType<typeof waitForObservedMessage>>;
-  try {
-    driverObserved = await waitForObservedMessage({
-      token: params.driverToken,
-      initialOffset: offset,
-      timeoutMs: 20_000,
-      observedMessages: params.observedMessages,
-      predicate: (message) =>
-        message.chatId === Number(params.groupId) &&
-        message.senderId === params.driverBotId &&
-        message.messageId === driverMessage.message_id,
-    });
-  } catch (error) {
-    throw new TelegramQaCanaryError(
-      "driver_observation_timeout",
-      "Driver bot did not observe its own canary group message within 20s.",
-      {
-        groupId: params.groupId,
-        driverBotId: params.driverBotId,
-        driverMessageId: driverMessage.message_id,
-        cause: formatErrorMessage(error),
-      },
-    );
-  }
-  offset = driverObserved.nextOffset;
   let sutObserved: Awaited<ReturnType<typeof waitForObservedMessage>>;
   try {
     sutObserved = await waitForObservedMessage({
@@ -549,12 +519,6 @@ function canaryFailureMessage(params: {
     : [];
   const remediation = (() => {
     switch (phase) {
-      case "driver_observation_timeout":
-        return [
-          "1. Ensure the driver bot can observe group traffic by making it admin or disabling privacy mode, then re-add it.",
-          "2. Confirm the driver bot is still a member of the target private group.",
-          "3. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
-        ];
       case "sut_reply_timeout":
         return [
           "1. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
@@ -665,7 +629,6 @@ export async function runTelegramQaLive(params: {
         driverToken: runtimeEnv.driverToken,
         groupId: runtimeEnv.groupId,
         sutUsername,
-        driverBotId: driverIdentity.id,
         sutBotId: sutIdentity.id,
         observedMessages,
       });

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -1,0 +1,617 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { startQaGatewayChild } from "./gateway-child.js";
+import {
+  defaultQaModelForMode,
+  normalizeQaProviderMode,
+  type QaProviderModeInput,
+} from "./run-config.js";
+
+type TelegramQaRuntimeEnv = {
+  groupId: string;
+  driverToken: string;
+  sutToken: string;
+};
+
+type TelegramBotIdentity = {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  username?: string;
+};
+
+type TelegramQaScenarioDefinition = {
+  id: "telegram-help-command";
+  title: string;
+  timeoutMs: number;
+  buildInput: (sutUsername: string) => string;
+};
+
+type TelegramObservedMessage = {
+  updateId: number;
+  messageId: number;
+  chatId: number;
+  senderId: number;
+  senderIsBot: boolean;
+  senderUsername?: string;
+  text: string;
+  caption?: string;
+  replyToMessageId?: number;
+  timestamp: number;
+  inlineButtons: string[];
+  mediaKinds: string[];
+};
+
+type TelegramQaScenarioResult = {
+  id: string;
+  title: string;
+  status: "pass" | "fail";
+  details: string;
+};
+
+export type TelegramQaRunResult = {
+  outputDir: string;
+  reportPath: string;
+  summaryPath: string;
+  observedMessagesPath: string;
+  scenarios: TelegramQaScenarioResult[];
+};
+
+type TelegramQaSummary = {
+  groupId: string;
+  startedAt: string;
+  finishedAt: string;
+  counts: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+  scenarios: TelegramQaScenarioResult[];
+};
+
+type TelegramApiEnvelope<T> = {
+  ok: boolean;
+  result?: T;
+  description?: string;
+};
+
+type TelegramReplyMarkup = {
+  inline_keyboard?: Array<Array<{ text?: string }>>;
+};
+
+type TelegramMessage = {
+  message_id: number;
+  date: number;
+  text?: string;
+  caption?: string;
+  reply_markup?: TelegramReplyMarkup;
+  reply_to_message?: { message_id?: number };
+  from?: {
+    id?: number;
+    is_bot?: boolean;
+    username?: string;
+  };
+  chat: {
+    id: number;
+  };
+  photo?: unknown[];
+  document?: unknown;
+  audio?: unknown;
+  video?: unknown;
+  voice?: unknown;
+  sticker?: unknown;
+};
+
+type TelegramUpdate = {
+  update_id: number;
+  message?: TelegramMessage;
+};
+
+type TelegramSendMessageResult = {
+  message_id: number;
+  chat: {
+    id: number;
+  };
+};
+
+const TELEGRAM_QA_SCENARIOS: TelegramQaScenarioDefinition[] = [
+  {
+    id: "telegram-help-command",
+    title: "Telegram help command reply",
+    timeoutMs: 45_000,
+    buildInput: (sutUsername) => `/help@${sutUsername}`,
+  },
+];
+
+const TELEGRAM_QA_ENV_KEYS = [
+  "OPENCLAW_QA_TELEGRAM_GROUP_ID",
+  "OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN",
+  "OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN",
+] as const;
+
+function resolveEnvValue(env: NodeJS.ProcessEnv, key: (typeof TELEGRAM_QA_ENV_KEYS)[number]) {
+  const value = env[key]?.trim();
+  if (!value) {
+    throw new Error(`Missing ${key}.`);
+  }
+  return value;
+}
+
+export function resolveTelegramQaRuntimeEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): TelegramQaRuntimeEnv {
+  const groupId = resolveEnvValue(env, "OPENCLAW_QA_TELEGRAM_GROUP_ID");
+  if (!/^-?\d+$/u.test(groupId)) {
+    throw new Error("OPENCLAW_QA_TELEGRAM_GROUP_ID must be a numeric Telegram chat id.");
+  }
+  return {
+    groupId,
+    driverToken: resolveEnvValue(env, "OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN"),
+    sutToken: resolveEnvValue(env, "OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN"),
+  };
+}
+
+function flattenInlineButtons(replyMarkup?: TelegramReplyMarkup) {
+  return (replyMarkup?.inline_keyboard ?? [])
+    .flat()
+    .map((button) => button.text?.trim())
+    .filter((text): text is string => Boolean(text));
+}
+
+function detectMediaKinds(message: TelegramMessage) {
+  const kinds: string[] = [];
+  if (Array.isArray(message.photo) && message.photo.length > 0) {
+    kinds.push("photo");
+  }
+  if (message.document) {
+    kinds.push("document");
+  }
+  if (message.audio) {
+    kinds.push("audio");
+  }
+  if (message.video) {
+    kinds.push("video");
+  }
+  if (message.voice) {
+    kinds.push("voice");
+  }
+  if (message.sticker) {
+    kinds.push("sticker");
+  }
+  return kinds;
+}
+
+export function normalizeTelegramObservedMessage(
+  update: TelegramUpdate,
+): TelegramObservedMessage | null {
+  const message = update.message;
+  if (!message?.from?.id) {
+    return null;
+  }
+  return {
+    updateId: update.update_id,
+    messageId: message.message_id,
+    chatId: message.chat.id,
+    senderId: message.from.id,
+    senderIsBot: message.from.is_bot === true,
+    senderUsername: message.from.username,
+    text: message.text ?? message.caption ?? "",
+    caption: message.caption,
+    replyToMessageId: message.reply_to_message?.message_id,
+    timestamp: message.date * 1000,
+    inlineButtons: flattenInlineButtons(message.reply_markup),
+    mediaKinds: detectMediaKinds(message),
+  };
+}
+
+function buildTelegramQaConfig(
+  baseCfg: OpenClawConfig,
+  params: {
+    groupId: string;
+    sutToken: string;
+    driverBotId: number;
+    sutAccountId: string;
+  },
+): OpenClawConfig {
+  const pluginAllow = [...new Set([...(baseCfg.plugins?.allow ?? []), "telegram"])];
+  const pluginEntries = {
+    ...baseCfg.plugins?.entries,
+    telegram: { enabled: true },
+  };
+  return {
+    ...baseCfg,
+    plugins: {
+      ...baseCfg.plugins,
+      allow: pluginAllow,
+      entries: pluginEntries,
+    },
+    channels: {
+      ...baseCfg.channels,
+      telegram: {
+        enabled: true,
+        defaultAccount: params.sutAccountId,
+        accounts: {
+          [params.sutAccountId]: {
+            enabled: true,
+            botToken: params.sutToken,
+            dmPolicy: "disabled",
+            groups: {
+              [params.groupId]: {
+                groupPolicy: "allowlist",
+                allowFrom: [String(params.driverBotId)],
+                requireMention: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+async function callTelegramApi<T>(
+  token: string,
+  method: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body ?? {}),
+  });
+  const payload = (await response.json()) as TelegramApiEnvelope<T>;
+  if (!response.ok || !payload.ok || payload.result === undefined) {
+    throw new Error(
+      payload.description?.trim() || `${method} failed with status ${response.status}`,
+    );
+  }
+  return payload.result;
+}
+
+async function getBotIdentity(token: string) {
+  return await callTelegramApi<TelegramBotIdentity>(token, "getMe");
+}
+
+async function flushTelegramUpdates(token: string) {
+  let offset = 0;
+  while (true) {
+    const updates = await callTelegramApi<TelegramUpdate[]>(token, "getUpdates", {
+      offset,
+      timeout: 0,
+      allowed_updates: ["message"],
+    });
+    if (updates.length === 0) {
+      return offset;
+    }
+    offset = (updates.at(-1)?.update_id ?? offset) + 1;
+  }
+}
+
+async function sendGroupMessage(token: string, groupId: string, text: string) {
+  return await callTelegramApi<TelegramSendMessageResult>(token, "sendMessage", {
+    chat_id: groupId,
+    text,
+    disable_notification: true,
+  });
+}
+
+async function waitForObservedMessage(params: {
+  token: string;
+  initialOffset: number;
+  timeoutMs: number;
+  predicate: (message: TelegramObservedMessage) => boolean;
+  observedMessages: TelegramObservedMessage[];
+}) {
+  const startedAt = Date.now();
+  let offset = params.initialOffset;
+  while (Date.now() - startedAt < params.timeoutMs) {
+    const remainingMs = Math.max(
+      1_000,
+      Math.min(10_000, params.timeoutMs - (Date.now() - startedAt)),
+    );
+    const timeoutSeconds = Math.max(1, Math.min(10, Math.floor(remainingMs / 1000)));
+    const updates = await callTelegramApi<TelegramUpdate[]>(params.token, "getUpdates", {
+      offset,
+      timeout: timeoutSeconds,
+      allowed_updates: ["message"],
+    });
+    if (updates.length === 0) {
+      continue;
+    }
+    offset = (updates.at(-1)?.update_id ?? offset) + 1;
+    for (const update of updates) {
+      const normalized = normalizeTelegramObservedMessage(update);
+      if (!normalized) {
+        continue;
+      }
+      params.observedMessages.push(normalized);
+      if (params.predicate(normalized)) {
+        return { message: normalized, nextOffset: offset };
+      }
+    }
+  }
+  throw new Error(`timed out after ${params.timeoutMs}ms waiting for Telegram message`);
+}
+
+async function waitForTelegramChannelRunning(
+  gateway: Awaited<ReturnType<typeof startQaGatewayChild>>,
+  accountId: string,
+) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 45_000) {
+    try {
+      const payload = (await gateway.call(
+        "channels.status",
+        { probe: false, timeoutMs: 2_000 },
+        { timeoutMs: 5_000 },
+      )) as {
+        channelAccounts?: Record<
+          string,
+          Array<{ accountId?: string; running?: boolean; restartPending?: boolean }>
+        >;
+      };
+      const accounts = payload.channelAccounts?.telegram ?? [];
+      const match = accounts.find((entry) => entry.accountId === accountId);
+      if (match?.running && match.restartPending !== true) {
+        return;
+      }
+    } catch {
+      // retry
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`telegram account "${accountId}" did not become ready`);
+}
+
+function renderTelegramQaMarkdown(params: {
+  groupId: string;
+  startedAt: string;
+  finishedAt: string;
+  scenarios: TelegramQaScenarioResult[];
+}) {
+  const lines = [
+    "# Telegram QA Report",
+    "",
+    `- Group: \`${params.groupId}\``,
+    `- Started: ${params.startedAt}`,
+    `- Finished: ${params.finishedAt}`,
+    "",
+    "## Scenarios",
+    "",
+  ];
+  for (const scenario of params.scenarios) {
+    lines.push(`### ${scenario.title}`);
+    lines.push("");
+    lines.push(`- Status: ${scenario.status}`);
+    lines.push(`- Details: ${scenario.details}`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function findScenario(ids?: string[]) {
+  if (!ids || ids.length === 0) {
+    return [...TELEGRAM_QA_SCENARIOS];
+  }
+  const selected = TELEGRAM_QA_SCENARIOS.filter((scenario) => ids.includes(scenario.id));
+  if (selected.length === 0) {
+    throw new Error(`No Telegram QA scenarios matched: ${ids.join(", ")}`);
+  }
+  return selected;
+}
+
+async function runCanary(params: {
+  driverToken: string;
+  groupId: string;
+  sutUsername: string;
+  driverBotId: number;
+  sutBotId: number;
+  observedMessages: TelegramObservedMessage[];
+}) {
+  let offset = await flushTelegramUpdates(params.driverToken);
+  const driverMessage = await sendGroupMessage(
+    params.driverToken,
+    params.groupId,
+    `/help@${params.sutUsername}`,
+  );
+  const driverObserved = await waitForObservedMessage({
+    token: params.driverToken,
+    initialOffset: offset,
+    timeoutMs: 20_000,
+    observedMessages: params.observedMessages,
+    predicate: (message) =>
+      message.chatId === Number(params.groupId) &&
+      message.senderId === params.driverBotId &&
+      message.messageId === driverMessage.message_id,
+  });
+  offset = driverObserved.nextOffset;
+  await waitForObservedMessage({
+    token: params.driverToken,
+    initialOffset: offset,
+    timeoutMs: 30_000,
+    observedMessages: params.observedMessages,
+    predicate: (message) =>
+      message.chatId === Number(params.groupId) &&
+      message.senderId === params.sutBotId &&
+      message.replyToMessageId === driverMessage.message_id &&
+      message.text.trim().length > 0,
+  });
+}
+
+function canaryFailureMessage(error: unknown) {
+  const details = formatErrorMessage(error);
+  return [
+    "Telegram QA canary failed.",
+    details,
+    "Remediation:",
+    "1. Enable Bot-to-Bot Communication Mode for both the driver and SUT bots in @BotFather.",
+    "2. Ensure the driver bot can observe bot traffic in the private group by making it admin or disabling privacy mode, then re-add it.",
+    "3. Ensure both bots are members of the same private group.",
+    "4. Confirm the SUT bot is allowed to receive /help@BotUsername commands in that group.",
+  ].join("\n");
+}
+
+export async function runTelegramQaLive(params: {
+  repoRoot?: string;
+  outputDir?: string;
+  providerMode?: QaProviderModeInput;
+  primaryModel?: string;
+  alternateModel?: string;
+  fastMode?: boolean;
+  scenarioIds?: string[];
+  sutAccountId?: string;
+}): Promise<TelegramQaRunResult> {
+  const repoRoot = path.resolve(params.repoRoot ?? process.cwd());
+  const outputDir =
+    params.outputDir ??
+    path.join(repoRoot, ".artifacts", "qa-e2e", `telegram-${Date.now().toString(36)}`);
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const runtimeEnv = resolveTelegramQaRuntimeEnv();
+  const providerMode = normalizeQaProviderMode(params.providerMode ?? "mock-openai");
+  const primaryModel = params.primaryModel?.trim() || defaultQaModelForMode(providerMode);
+  const alternateModel = params.alternateModel?.trim() || defaultQaModelForMode(providerMode, true);
+  const sutAccountId = params.sutAccountId?.trim() || "sut";
+  const scenarios = findScenario(params.scenarioIds);
+  const observedMessages: TelegramObservedMessage[] = [];
+  const startedAt = new Date().toISOString();
+
+  const driverIdentity = await getBotIdentity(runtimeEnv.driverToken);
+  const sutIdentity = await getBotIdentity(runtimeEnv.sutToken);
+  const sutUsername = sutIdentity.username?.trim();
+  const uniqueIds = new Set([driverIdentity.id, sutIdentity.id]);
+  if (uniqueIds.size !== 2) {
+    throw new Error("Telegram QA requires two distinct bots for driver and SUT.");
+  }
+  if (!sutUsername) {
+    throw new Error("Telegram QA requires the SUT bot to have a Telegram username.");
+  }
+
+  await Promise.all([
+    flushTelegramUpdates(runtimeEnv.driverToken),
+    flushTelegramUpdates(runtimeEnv.sutToken),
+  ]);
+
+  const gateway = await startQaGatewayChild({
+    repoRoot,
+    qaBusBaseUrl: "http://127.0.0.1:43123",
+    providerMode,
+    primaryModel,
+    alternateModel,
+    fastMode: params.fastMode,
+    controlUiEnabled: false,
+    mutateConfig: (cfg) =>
+      buildTelegramQaConfig(cfg, {
+        groupId: runtimeEnv.groupId,
+        sutToken: runtimeEnv.sutToken,
+        driverBotId: driverIdentity.id,
+        sutAccountId,
+      }),
+  });
+
+  const scenarioResults: TelegramQaScenarioResult[] = [];
+  try {
+    await waitForTelegramChannelRunning(gateway, sutAccountId);
+    try {
+      await runCanary({
+        driverToken: runtimeEnv.driverToken,
+        groupId: runtimeEnv.groupId,
+        sutUsername,
+        driverBotId: driverIdentity.id,
+        sutBotId: sutIdentity.id,
+        observedMessages,
+      });
+    } catch (error) {
+      throw new Error(canaryFailureMessage(error), { cause: error });
+    }
+
+    let driverOffset = await flushTelegramUpdates(runtimeEnv.driverToken);
+    for (const scenario of scenarios) {
+      try {
+        const sent = await sendGroupMessage(
+          runtimeEnv.driverToken,
+          runtimeEnv.groupId,
+          scenario.buildInput(sutUsername),
+        );
+        const matched = await waitForObservedMessage({
+          token: runtimeEnv.driverToken,
+          initialOffset: driverOffset,
+          timeoutMs: scenario.timeoutMs,
+          observedMessages,
+          predicate: (message) =>
+            message.chatId === Number(runtimeEnv.groupId) &&
+            message.senderId === sutIdentity.id &&
+            message.replyToMessageId === sent.message_id &&
+            message.text.trim().length > 0,
+        });
+        driverOffset = matched.nextOffset;
+        scenarioResults.push({
+          id: scenario.id,
+          title: scenario.title,
+          status: "pass",
+          details: `reply message ${matched.message.messageId} matched`,
+        });
+      } catch (error) {
+        scenarioResults.push({
+          id: scenario.id,
+          title: scenario.title,
+          status: "fail",
+          details: formatErrorMessage(error),
+        });
+      }
+    }
+  } finally {
+    await gateway.stop();
+  }
+
+  const finishedAt = new Date().toISOString();
+  const summary: TelegramQaSummary = {
+    groupId: runtimeEnv.groupId,
+    startedAt,
+    finishedAt,
+    counts: {
+      total: scenarioResults.length,
+      passed: scenarioResults.filter((entry) => entry.status === "pass").length,
+      failed: scenarioResults.filter((entry) => entry.status === "fail").length,
+    },
+    scenarios: scenarioResults,
+  };
+  const reportPath = path.join(outputDir, "telegram-qa-report.md");
+  const summaryPath = path.join(outputDir, "telegram-qa-summary.json");
+  const observedMessagesPath = path.join(outputDir, "telegram-qa-observed-messages.json");
+  await fs.writeFile(
+    reportPath,
+    `${renderTelegramQaMarkdown({
+      groupId: runtimeEnv.groupId,
+      startedAt,
+      finishedAt,
+      scenarios: scenarioResults,
+    })}\n`,
+    "utf8",
+  );
+  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  await fs.writeFile(
+    observedMessagesPath,
+    `${JSON.stringify(observedMessages, null, 2)}\n`,
+    "utf8",
+  );
+
+  return {
+    outputDir,
+    reportPath,
+    summaryPath,
+    observedMessagesPath,
+    scenarios: scenarioResults,
+  };
+}
+
+export const __testing = {
+  TELEGRAM_QA_SCENARIOS,
+  buildTelegramQaConfig,
+  normalizeTelegramObservedMessage,
+  resolveTelegramQaRuntimeEnv,
+};

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -95,7 +95,8 @@ function isTelegramQaCanaryError(error: unknown): error is TelegramQaCanaryError
     (typeof error === "object" &&
       error !== null &&
       typeof (error as { phase?: unknown }).phase === "string" &&
-      typeof (error as { context?: unknown }).context === "object")
+      typeof (error as { context?: unknown }).context === "object" &&
+      (error as { context?: unknown }).context !== null)
   );
 }
 
@@ -306,8 +307,9 @@ async function getBotIdentity(token: string) {
 }
 
 async function flushTelegramUpdates(token: string) {
+  const startedAt = Date.now();
   let offset = 0;
-  while (true) {
+  while (Date.now() - startedAt < 15_000) {
     const updates = await callTelegramApi<TelegramUpdate[]>(token, "getUpdates", {
       offset,
       timeout: 0,
@@ -318,6 +320,7 @@ async function flushTelegramUpdates(token: string) {
     }
     offset = (updates.at(-1)?.update_id ?? offset) + 1;
   }
+  return offset;
 }
 
 async function sendGroupMessage(token: string, groupId: string, text: string) {
@@ -580,7 +583,7 @@ export async function runTelegramQaLive(params: {
   await fs.mkdir(outputDir, { recursive: true });
 
   const runtimeEnv = resolveTelegramQaRuntimeEnv();
-  const providerMode = normalizeQaProviderMode(params.providerMode ?? "mock-openai");
+  const providerMode = normalizeQaProviderMode(params.providerMode ?? "live-frontier");
   const primaryModel = params.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   const alternateModel = params.alternateModel?.trim() || defaultQaModelForMode(providerMode, true);
   const sutAccountId = params.sutAccountId?.trim() || "sut";

--- a/extensions/qa-lab/src/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/telegram-live.runtime.ts
@@ -436,6 +436,24 @@ function findScenario(ids?: string[]) {
   return selected;
 }
 
+function classifyCanaryReply(params: {
+  message: TelegramObservedMessage;
+  groupId: string;
+  sutBotId: number;
+  driverMessageId: number;
+}) {
+  if (
+    params.message.chatId !== Number(params.groupId) ||
+    params.message.senderId !== params.sutBotId ||
+    !params.message.text.trim()
+  ) {
+    return "ignore" as const;
+  }
+  return params.message.replyToMessageId === params.driverMessageId
+    ? ("match" as const)
+    : ("unthreaded" as const);
+}
+
 async function runCanary(params: {
   driverToken: string;
   groupId: string;
@@ -449,6 +467,9 @@ async function runCanary(params: {
     params.groupId,
     `/help@${params.sutUsername}`,
   );
+  let firstUnthreadedReply:
+    | Pick<TelegramObservedMessage, "messageId" | "replyToMessageId" | "text">
+    | undefined;
   let sutObserved: Awaited<ReturnType<typeof waitForObservedMessage>>;
   try {
     sutObserved = await waitForObservedMessage({
@@ -456,10 +477,41 @@ async function runCanary(params: {
       initialOffset: offset,
       timeoutMs: 30_000,
       observedMessages: params.observedMessages,
-      predicate: (message) =>
-        message.chatId === Number(params.groupId) && message.senderId === params.sutBotId,
+      predicate: (message) => {
+        const classification = classifyCanaryReply({
+          message,
+          groupId: params.groupId,
+          sutBotId: params.sutBotId,
+          driverMessageId: driverMessage.message_id,
+        });
+        if (classification === "ignore") {
+          return false;
+        }
+        if (classification === "unthreaded") {
+          firstUnthreadedReply ??= {
+            messageId: message.messageId,
+            replyToMessageId: message.replyToMessageId,
+            text: message.text,
+          };
+          return false;
+        }
+        return classification === "match";
+      },
     });
   } catch (error) {
+    if (firstUnthreadedReply) {
+      throw new TelegramQaCanaryError(
+        "sut_reply_not_threaded",
+        "SUT bot replied, but not as a reply to the canary driver message.",
+        {
+          groupId: params.groupId,
+          sutBotId: params.sutBotId,
+          driverMessageId: driverMessage.message_id,
+          sutMessageId: firstUnthreadedReply.messageId,
+          sutReplyToMessageId: firstUnthreadedReply.replyToMessageId,
+        },
+      );
+    }
     throw new TelegramQaCanaryError(
       "sut_reply_timeout",
       "SUT bot did not send any group reply after the canary command within 30s.",
@@ -468,19 +520,6 @@ async function runCanary(params: {
         sutBotId: params.sutBotId,
         driverMessageId: driverMessage.message_id,
         cause: formatErrorMessage(error),
-      },
-    );
-  }
-  if (sutObserved.message.replyToMessageId !== driverMessage.message_id) {
-    throw new TelegramQaCanaryError(
-      "sut_reply_not_threaded",
-      "SUT bot replied, but not as a reply to the canary driver message.",
-      {
-        groupId: params.groupId,
-        sutBotId: params.sutBotId,
-        driverMessageId: driverMessage.message_id,
-        sutMessageId: sutObserved.message.messageId,
-        sutReplyToMessageId: sutObserved.message.replyToMessageId,
       },
     );
   }
@@ -743,6 +782,7 @@ export const __testing = {
   TELEGRAM_QA_SCENARIOS,
   buildTelegramQaConfig,
   canaryFailureMessage,
+  classifyCanaryReply,
   normalizeTelegramObservedMessage,
   resolveTelegramQaRuntimeEnv,
 };

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -941,7 +941,14 @@ export const registerTelegramNativeCommands = ({
                 return;
               }
               const result = await deliverReplies({
-                replies: [payload],
+                replies: [
+                  payload.replyToId
+                    ? payload
+                    : {
+                        ...payload,
+                        replyToId: String(msg.message_id),
+                      },
+                ],
                 ...deliveryBaseOptions,
                 silent: runtimeTelegramCfg.silentErrorReplies === true && payload.isError === true,
               });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2388,6 +2388,7 @@ describe("createTelegramBot", () => {
   });
   it("threads native command replies inside topics", async () => {
     commandSpy.mockClear();
+    sendMessageSpy.mockClear();
     replySpy.mockResolvedValue({ text: "response" });
 
     loadConfig.mockReturnValue({
@@ -2396,6 +2397,7 @@ describe("createTelegramBot", () => {
         telegram: {
           dmPolicy: "open",
           allowFrom: ["*"],
+          replyToMode: "first",
           groups: { "*": { requireMention: false } },
         },
       },
@@ -2413,7 +2415,7 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).toHaveBeenCalledWith(
       "-1001234567890",
       expect.any(String),
-      expect.objectContaining({ message_thread_id: 99 }),
+      expect.objectContaining({ message_thread_id: 99, reply_to_message_id: 42 }),
     );
   });
   it("reloads native command routing bindings between invocations without recreating the bot", async () => {


### PR DESCRIPTION
Adds a live Telegram QA lane for private group E2E checks.

Also fixes native Telegram command reply threading so QA can verify reply chains reliably.

Couple of things before the tests can run:
- the `DRIVER` and `SUT` bot must be in the same group
- Privacy mode MUST be disabled
- Bot to Bot Communication MUST be enabled

Example of the first basic test suite:
<img width="512" height="453" alt="image" src="https://github.com/user-attachments/assets/356cd4cd-fbab-481a-8359-0a0e6dbef7d0" />

Verified QA run:
```bash
OPENCLAW_QA_TELEGRAM_GROUP_ID='-12345678' \
OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN='abc' \
OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN='xyz' \
pnpm openclaw qa telegram --scenario telegram-help-command

> openclaw@2026.4.10 openclaw ~/clawdbot
> node scripts/run-node.mjs qa telegram --scenario telegram-help-command

[openclaw] Building TypeScript (dist is stale: dirty_watched_tree - dirty watched source tree).

🦞 OpenClaw 2026.4.10 (ef73f6d) — I've read more man pages than any human should—so you don't have to.

18:06:26+05:30 [agents] synced openai-codex credentials from external cli
Telegram QA report: ~/clawdbot/.artifacts/qa-e2e/telegram-mnsw3vl4/telegram-qa-report.md
Telegram QA summary: ~/clawdbot/.artifacts/qa-e2e/telegram-mnsw3vl4/telegram-qa-summary.json
Telegram QA observed messages: ~/clawdbot/.artifacts/qa-e2e/telegram-mnsw3vl4/telegram-qa-observed-messages.json
```