### PR TITLE
README: add Feishu quick-start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,31 @@ Details: [Security guide](https://docs.openclaw.ai/gateway/security) · [Docker 
 }
 ```
 
+### [Feishu](https://docs.openclaw.ai/channels/feishu)
+
+- Run `openclaw channels add` and choose **Feishu**, or set `FEISHU_APP_ID` + `FEISHU_APP_SECRET`.
+- Feishu uses the platform's WebSocket event subscription, so you can start without exposing a public webhook URL.
+- For Lark (global) tenants, set `channels.feishu.domain: "lark"` or the per-account `domain` field.
+
+```json5
+{
+  channels: {
+    feishu: {
+      enabled: true,
+      dmPolicy: "pairing",
+      accounts: {
+        main: {
+          appId: "cli_xxx",
+          appSecret: "xxx",
+        },
+      },
+    },
+  },
+}
+```
+
+- Full app setup, permissions, and event subscription steps: [Feishu docs](https://docs.openclaw.ai/channels/feishu)
+
 ### [Signal](https://docs.openclaw.ai/channels/signal)
 
 - Requires `signal-cli` and a `channels.signal` config section.

--- a/README.md
+++ b/README.md
@@ -436,8 +436,6 @@ Details: [Security guide](https://docs.openclaw.ai/gateway/security) · [Docker 
 {
   channels: {
     feishu: {
-      enabled: true,
-      dmPolicy: "pairing",
       accounts: {
         main: {
           appId: "cli_xxx",


### PR DESCRIPTION
## Why

README already lists Feishu as a supported channel and links the full Feishu docs, but the quick-start channel section only walks through WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Teams, WeChat, and WebChat. This leaves a gap for readers who want the same lightweight setup entry point for Feishu/Lark before jumping into the full platform docs.

## What changed

- added a dedicated `Feishu` quick-start subsection to `README.md`
- included the shortest useful setup path: `openclaw channels add`, `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, and a minimal `channels.feishu.accounts.main` config example
- called out the `domain: "lark"` setting for global Lark tenants
- linked back to the full Feishu docs for app creation, permissions, and event subscription details

## Testing

- inspected the rendered README diff locally
- verified all linked docs URLs already exist in the repo/docs site

## Out of scope

- duplicating the full Feishu setup guide in README
- adding screenshots, permission dumps, or event-subscription walkthroughs
