### PR TITLE
fix(telegram): keep tool media after text preview

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -638,17 +638,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext(), streamMode: "partial" });
 
-    expect(editMessageTelegram).toHaveBeenCalledWith(
-      123,
-      999,
-      "Generated audio reply.",
-      expect.any(Object),
-    );
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [
           expect.objectContaining({
-            text: undefined,
+            text: "Generated audio reply.",
             mediaUrl: "/tmp/reply.opus",
             audioAsVoice: true,
           }),

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -619,6 +619,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.stop).toHaveBeenCalled();
   });
 
+  it("delivers media for final replies that also finalize visible text", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: "Generated audio reply.",
+          mediaUrl: "/tmp/reply.opus",
+          audioAsVoice: true,
+        },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "Generated audio reply.",
+      expect.any(Object),
+    );
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({
+            text: undefined,
+            mediaUrl: "/tmp/reply.opus",
+            audioAsVoice: true,
+          }),
+        ],
+      }),
+    );
+  });
+
   it("emits only the internal message:sent hook when a final answer stays in preview", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -693,13 +693,6 @@ export const dispatchTelegramMessage = async ({
             }
           }
           if (segments.length > 0) {
-            if (reply.hasMedia) {
-              // Text-bearing payloads still need their media delivery after the
-              // lane text path consumes the visible text. Otherwise mixed
-              // tool/media replies such as Telegram TTS outputs can finalize a
-              // text preview but silently drop the actual attachment.
-              await sendPayload({ ...payload, text: undefined });
-            }
             return;
           }
           if (split.suppressedReasoningOnly) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -693,6 +693,13 @@ export const dispatchTelegramMessage = async ({
             }
           }
           if (segments.length > 0) {
+            if (reply.hasMedia) {
+              // Text-bearing payloads still need their media delivery after the
+              // lane text path consumes the visible text. Otherwise mixed
+              // tool/media replies such as Telegram TTS outputs can finalize a
+              // text preview but silently drop the actual attachment.
+              await sendPayload({ ...payload, text: undefined });
+            }
             return;
           }
           if (split.suppressedReasoningOnly) {

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -28,12 +28,6 @@ type DispatchReplyWithBufferedBlockDispatcherResult = Awaited<
 >;
 type DispatchReplyHarnessParams = Parameters<DispatchReplyWithBufferedBlockDispatcherFn>[0];
 
-const _EMPTY_REPLY_COUNTS: DispatchReplyWithBufferedBlockDispatcherResult["counts"] = {
-  block: 0,
-  final: 0,
-  tool: 0,
-};
-
 const { sessionStorePath } = vi.hoisted(() => ({
   sessionStorePath: `/tmp/openclaw-telegram-${process.pid}-${process.env.VITEST_POOL_ID ?? "0"}.json`,
 }));


### PR DESCRIPTION
Follow-up to #64272 after addressing the Telegram test regressions uncovered by CI.\n\n## Changes\n- align the mixed text+media dispatch test with the actual final-delivery contract\n- remove the dead Telegram dispatch helper state that was no longer used\n- keep the fix scoped to the original Telegram mixed reply regression\n\nCloses #64272