### PR TITLE
fix(feishu): route /btw through out-of-band lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Agents/BTW: strip replayed tool blocks, hidden reasoning, and malformed image payloads from `/btw` side-question context so Bedrock no-tools side questions keep working after tool-use turns. (#64225) Thanks @ngutman.
 - Commands/btw: keep tool-less side questions from sending injected empty `tools` arrays on strict OpenAI-compatible providers, so `/btw` continues working after prior tool-call history. (#64219) Thanks @ngutman.
 - Agents/Bedrock: let `/btw` side questions use `auth: "aws-sdk"` without a static API key so Bedrock IAM and instance-role sessions stop failing before the side question runs. (#64218) Thanks @SnowSky1.
+- Feishu: route `/btw` side questions and `/stop` onto bounded out-of-band lanes so BTW no longer waits behind a busy normal chat turn while ordinary same-chat traffic stays FIFO. (#64324) Thanks @ngutman.
 - Agents/failover: detect llama.cpp slot context overflows as context-overflow errors so compaction can retry self-hosted OpenAI-compatible runs instead of surfacing the raw upstream 400. (#64196) Thanks @alexander-applyinnovations.
 - Claude CLI/skills: pass eligible OpenClaw skills into CLI runs, including native Claude Code skill resolution via a temporary plugin plus per-run skill env/API key injection. (#62686, #62723) Thanks @zomars.
 - Discord: keep generated auto-thread names working with reasoning models by giving title generation enough output budget for thinking plus visible title text. (#64172) Thanks @hanamizuki.

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -29,6 +29,8 @@ import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
+import { getFeishuSequentialKey } from "./sequential-key.js";
+import { createSequentialQueue } from "./sequential-queue.js";
 import { createFeishuThreadBindingManager } from "./thread-bindings.js";
 import type { FeishuChatType, ResolvedFeishuAccount } from "./types.js";
 
@@ -290,25 +292,6 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   };
 }
 
-/**
- * Per-chat serial queue that ensures messages from the same chat are processed
- * in arrival order while allowing different chats to run concurrently.
- */
-function createChatQueue() {
-  const queues = new Map<string, Promise<void>>();
-  return (chatId: string, task: () => Promise<void>): Promise<void> => {
-    const prev = queues.get(chatId) ?? Promise.resolve();
-    const next = prev.then(task, task);
-    queues.set(chatId, next);
-    void next.finally(() => {
-      if (queues.get(chatId) === next) {
-        queues.delete(chatId);
-      }
-    });
-    return next;
-  };
-}
-
 function mergeFeishuDebounceMentions(
   entries: FeishuMessageEvent[],
 ): FeishuMessageEvent["message"]["mentions"] | undefined {
@@ -395,7 +378,9 @@ function registerEventHandlers(
   });
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
-  const enqueue = createChatQueue();
+  // Keep normal Feishu traffic FIFO per chat while allowing explicit out-of-band
+  // commands like /btw and /stop to bypass the busy main-chat lane.
+  const enqueue = createSequentialQueue();
   const runFeishuHandler = async (params: { task: () => Promise<void>; errorMessage: string }) => {
     if (fireAndForget) {
       void params.task().catch((err) => {
@@ -410,7 +395,12 @@ function registerEventHandlers(
     }
   };
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
-    const chatId = event.message.chat_id?.trim() || "unknown";
+    const sequentialKey = getFeishuSequentialKey({
+      accountId,
+      event,
+      botOpenId: botOpenIds.get(accountId),
+      botName: botNames.get(accountId),
+    });
     const task = () =>
       handleFeishuMessage({
         cfg,
@@ -422,7 +412,7 @@ function registerEventHandlers(
         accountId,
         processingClaimHeld: true,
       });
-    await enqueue(chatId, task);
+    await enqueue(sequentialKey, task);
   };
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
     const senderId =

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -30,7 +30,7 @@ describe("getFeishuSequentialKey", () => {
     [createTextEvent({ text: "hello" }), "feishu:default:oc_dm_chat"],
     [createTextEvent({ text: "/status" }), "feishu:default:oc_dm_chat"],
     [createTextEvent({ text: "/stop" }), "feishu:default:oc_dm_chat:control"],
-    [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw:om_message_1"],
+    [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw"],
   ])("resolves sequential key %#", (event, expected) => {
     expect(
       getFeishuSequentialKey({
@@ -38,6 +38,24 @@ describe("getFeishuSequentialKey", () => {
         event,
       }),
     ).toBe(expected);
+  });
+
+  it("keeps /btw on a stable per-chat lane across different message ids", () => {
+    const first = createTextEvent({ text: "/btw one", messageId: "om_message_1" });
+    const second = createTextEvent({ text: "/btw two", messageId: "om_message_2" });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: first,
+      }),
+    ).toBe("feishu:default:oc_dm_chat:btw");
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: second,
+      }),
+    ).toBe("feishu:default:oc_dm_chat:btw");
   });
 
   it("falls back to a stable btw lane when the message id is unavailable", () => {

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { FeishuMessageEvent } from "./bot.js";
+import { getFeishuSequentialKey } from "./sequential-key.js";
+
+function createTextEvent(params: {
+  text: string;
+  messageId?: string;
+  chatId?: string;
+}): FeishuMessageEvent {
+  return {
+    sender: {
+      sender_id: {
+        open_id: "ou_sender_1",
+        user_id: "ou_user_1",
+      },
+      sender_type: "user",
+    },
+    message: {
+      message_id: params.messageId ?? "om_message_1",
+      chat_id: params.chatId ?? "oc_dm_chat",
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text: params.text }),
+    },
+  } as FeishuMessageEvent;
+}
+
+describe("getFeishuSequentialKey", () => {
+  it.each([
+    [createTextEvent({ text: "hello" }), "feishu:default:oc_dm_chat"],
+    [createTextEvent({ text: "/status" }), "feishu:default:oc_dm_chat"],
+    [createTextEvent({ text: "/stop" }), "feishu:default:oc_dm_chat:control"],
+    [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw:om_message_1"],
+  ])("resolves sequential key %#", (event, expected) => {
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+      }),
+    ).toBe(expected);
+  });
+
+  it("falls back to a stable btw lane when the message id is unavailable", () => {
+    const event = createTextEvent({ text: "/btw what changed?" });
+    delete (event.message as { message_id?: string }).message_id;
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+      }),
+    ).toBe("feishu:default:oc_dm_chat:btw");
+  });
+});

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -1,0 +1,26 @@
+import { isAbortRequestText, isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
+import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+
+export function getFeishuSequentialKey(params: {
+  accountId: string;
+  event: FeishuMessageEvent;
+  botOpenId?: string;
+  botName?: string;
+}): string {
+  const { accountId, event, botOpenId, botName } = params;
+  const chatId = event.message.chat_id?.trim() || "unknown";
+  const baseKey = `feishu:${accountId}:${chatId}`;
+  const parsed = parseFeishuMessageEvent(event, botOpenId, botName);
+  const text = parsed.content.trim();
+
+  if (isAbortRequestText(text)) {
+    return `${baseKey}:control`;
+  }
+
+  if (isBtwRequestText(text)) {
+    const messageId = event.message.message_id?.trim();
+    return messageId ? `${baseKey}:btw:${messageId}` : `${baseKey}:btw`;
+  }
+
+  return baseKey;
+}

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -18,8 +18,7 @@ export function getFeishuSequentialKey(params: {
   }
 
   if (isBtwRequestText(text)) {
-    const messageId = event.message.message_id?.trim();
-    return messageId ? `${baseKey}:btw:${messageId}` : `${baseKey}:btw`;
+    return `${baseKey}:btw`;
   }
 
   return baseKey;

--- a/extensions/feishu/src/sequential-queue.test.ts
+++ b/extensions/feishu/src/sequential-queue.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createSequentialQueue } from "./sequential-queue.js";
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("createSequentialQueue", () => {
+  it("serializes tasks for the same key", async () => {
+    const enqueue = createSequentialQueue();
+    const gate = createDeferred();
+    const order: string[] = [];
+
+    const first = enqueue("feishu:default:chat-1", async () => {
+      order.push("first:start");
+      await gate.promise;
+      order.push("first:end");
+    });
+    const second = enqueue("feishu:default:chat-1", async () => {
+      order.push("second:start");
+      order.push("second:end");
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+
+    gate.resolve();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["first:start", "first:end", "second:start", "second:end"]);
+  });
+
+  it("allows different keys to run concurrently", async () => {
+    const enqueue = createSequentialQueue();
+    const gateA = createDeferred();
+    const gateB = createDeferred();
+    const order: string[] = [];
+
+    const first = enqueue("feishu:default:chat-1", async () => {
+      order.push("chat-1:start");
+      await gateA.promise;
+      order.push("chat-1:end");
+    });
+    const second = enqueue("feishu:default:chat-1:btw:om_2", async () => {
+      order.push("btw:start");
+      await gateB.promise;
+      order.push("btw:end");
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["chat-1:start", "btw:start"]);
+
+    gateA.resolve();
+    gateB.resolve();
+    await Promise.all([first, second]);
+
+    expect(order).toContain("chat-1:end");
+    expect(order).toContain("btw:end");
+  });
+});

--- a/extensions/feishu/src/sequential-queue.ts
+++ b/extensions/feishu/src/sequential-queue.ts
@@ -1,0 +1,15 @@
+export function createSequentialQueue() {
+  const queues = new Map<string, Promise<void>>();
+
+  return (key: string, task: () => Promise<void>): Promise<void> => {
+    const previous = queues.get(key) ?? Promise.resolve();
+    const next = previous.then(task, task);
+    queues.set(key, next);
+    void next.finally(() => {
+      if (queues.get(key) === next) {
+        queues.delete(key);
+      }
+    });
+    return next;
+  };
+}


### PR DESCRIPTION
## Summary

- Problem: Feishu serializes all same-chat inbound work through a single per-chat queue, so `/btw` waits behind an active normal reply instead of behaving like an out-of-band side question.
- Why it matters: the BTW UX contract is that side questions should return immediately without waiting for the busy main session to finish.
- What changed: replaced Feishu's chat-only serializer with a sequential-key serializer and routed `/btw` plus abort-style requests onto dedicated out-of-band keys.
- What did NOT change (scope boundary): core BTW execution, session routing, and normal Feishu same-chat FIFO behavior all stay intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60843
- Related #31807
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Feishu keyed all inbound work for a chat onto one serializer lane in `extensions/feishu/src/monitor.account.ts`, so `/btw` never reached the existing fast inline-command path until the prior message finished.
- Missing detection / guardrail: Feishu had no explicit out-of-band sequencing policy for `/btw` or `/stop`, unlike channels that already special-case those commands.
- Contributing context (if known): the existing Feishu FIFO was intentionally added to prevent dropped same-chat messages, so the fix needs to preserve normal ordering while carving out only the truly out-of-band command lanes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/sequential-key.test.ts`, `extensions/feishu/src/sequential-queue.test.ts`
- Scenario the test should lock in: normal Feishu traffic still serializes on one key, while `/btw` and `/stop` resolve to separate keys that can run concurrently with the busy main chat lane.
- Why this is the smallest reliable guardrail: the regression lives in the Feishu ingress scheduler, so key classification plus per-key queue behavior is the narrowest layer that proves the intended bypass without re-testing core BTW logic.
- Existing test that already covers this (if any): `src/gateway/server.chat.gateway-server-chat.test.ts` already covers core `/btw` side-result behavior outside Feishu.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- In Feishu, `/btw ...` no longer waits behind a busy normal message in the same chat.
- In Feishu, `/stop` also bypasses the normal same-chat lane instead of waiting behind ordinary traffic.
- Normal Feishu same-chat message ordering remains FIFO.

## Diagram (if applicable)

```text
Before:
normal message -> Feishu per-chat lane
/btw arrives   -> same Feishu per-chat lane -> waits for normal reply -> delayed side answer

After:
normal message -> Feishu base chat lane
/btw arrives   -> Feishu btw lane -> runs immediately -> side answer
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm repo workflow
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): default local test config

### Steps

1. Send a normal Feishu message that starts a long-running reply.
2. Send `/btw <question>` in the same Feishu chat while the first reply is still running.
3. Observe whether the side question shares the busy normal chat lane or runs on its own out-of-band lane.

### Expected

- `/btw` runs immediately without waiting behind the normal chat lane.

### Actual

- Before this fix, Feishu queued `/btw` behind the active normal chat task.
- After this fix, Feishu resolves `/btw` to a dedicated sequential key and no longer blocks it behind ordinary traffic.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test extensions/feishu/src/sequential-key.test.ts extensions/feishu/src/sequential-queue.test.ts`; `pnpm build`
- Edge cases checked: `/btw` missing-message-id fallback key; `/stop` stays out-of-band; ordinary slash commands like `/status` remain on the normal chat lane.
- What you did **not** verify: live Feishu end-to-end behavior against a real account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: widening the bypass too far could accidentally let stateful slash commands skip intended same-chat ordering.
  - Mitigation: only `/btw` and abort-style requests get dedicated out-of-band keys; normal messages and ordinary control commands keep the base chat key.
