### PR TITLE
fix(googlechat): fallback to top-level message on INVALID_ARGUMENT thread error

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -164,11 +164,26 @@ export async function sendGoogleChatMessage(params: {
     urlObj.searchParams.set("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
   }
   const url = urlObj.toString();
-  const result = await fetchJson<{ name?: string }>(account, url, {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
-  return result ? { messageName: result.name } : null;
+  try {
+    const result = await fetchJson<{ name?: string }>(account, url, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    return result ? { messageName: result.name } : null;
+  } catch (err) {
+    // If the thread resource name is invalid, retry without threading
+    // to avoid infinite retry loops (see #64313).
+    if (thread && String(err).includes("INVALID_ARGUMENT")) {
+      delete body.thread;
+      const fallbackUrl = new URL(`${CHAT_API_BASE}/${space}/messages`).toString();
+      const result = await fetchJson<{ name?: string }>(account, fallbackUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      return result ? { messageName: result.name } : null;
+    }
+    throw err;
+  }
 }
 
 export async function updateGoogleChatMessage(params: {

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -173,7 +173,9 @@ export async function sendGoogleChatMessage(params: {
   } catch (err) {
     // If the thread resource name is invalid, retry without threading
     // to avoid infinite retry loops (see #64313).
-    if (thread && String(err).includes("INVALID_ARGUMENT")) {
+    // Narrow the match to thread-related INVALID_ARGUMENT errors to avoid
+    // masking unrelated failures (e.g. bad text or attachment token).
+    if (thread && String(err).includes("INVALID_ARGUMENT") && String(err).toLowerCase().includes("thread")) {
       delete body.thread;
       const fallbackUrl = new URL(`${CHAT_API_BASE}/${space}/messages`).toString();
       const result = await fetchJson<{ name?: string }>(account, fallbackUrl, {


### PR DESCRIPTION
## Summary

Fixes #64313 — GChat infinite thread reply retry loop on `INVALID_ARGUMENT` thread resource name.

## Problem

When a user replies to a bot message in Google Chat, the gateway attempts to reply in the same thread using `payload.replyToId`. If the thread resource name is invalid or malformed, the Google Chat API returns `400 INVALID_ARGUMENT`. The existing error handler only logs the error, and the caller retries indefinitely — flooding logs and blocking the conversation.

## Fix

In `sendGoogleChatMessage()`, catch `INVALID_ARGUMENT` errors when a `thread` parameter is present, then retry the same message **without** the thread — gracefully degrading to a new top-level message in the space.

This is consistent with Google's own `REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` semantics, but handles the case where the thread name itself is rejected before the API can apply that fallback.

## Changes

- `extensions/googlechat/src/api.ts`: Wrap the `fetchJson` call in a try/catch. On `INVALID_ARGUMENT` with a thread param, strip `body.thread` and retry to the base messages endpoint.

## Testing

- Manual: Confirmed that non-thread errors are still re-thrown (not swallowed).
- The fix is narrowly scoped to `INVALID_ARGUMENT` + thread presence, so existing thread reply behavior is unchanged for valid threads.