### PR TITLE
fix(qqbot): set MediaType 'audio' for voice attachments to enable TTS…

### DIFF
--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -773,6 +773,22 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
           }
         }
 
+        // Include voice attachment type in MediaTypes so the framework's
+        // isInboundAudioContext() can detect audio input and TTS auto "inbound" mode works.
+        // Do NOT add voice paths to MediaPaths — the framework's applyMediaUnderstanding
+        // would run extractFileBlocks on them, injecting audio binary into context.
+        const hasVoiceAttachments = uniqueVoicePaths.length > 0 || uniqueVoiceUrls.length > 0;
+
+        // Merge all MIME types from images (local + remote) and voice into a single array.
+        // MediaType is the primary type (first image wins); "audio" is appended to MediaTypes
+        // so isInboundAudioContext() can detect it without reclassifying image entries.
+        const allMediaTypes = [...localMediaTypes, ...remoteMediaTypes];
+        if (hasVoiceAttachments) {
+          allMediaTypes.push("audio");
+        }
+        const resolvedMediaType = localMediaTypes[0] ?? remoteMediaTypes[0] ?? (hasVoiceAttachments ? "audio" : undefined);
+        const resolvedMediaTypes = allMediaTypes.length > 0 ? allMediaTypes : undefined;
+
         const ctxPayload = pluginRuntime.channel.reply.finalizeInboundContext({
           Body: body,
           BodyForAgent: agentBody,
@@ -805,8 +821,6 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
             ? {
                 MediaPaths: localMediaPaths,
                 MediaPath: localMediaPaths[0],
-                MediaTypes: localMediaTypes,
-                MediaType: localMediaTypes[0],
               }
             : {}),
           ...(remoteMediaUrls.length > 0
@@ -815,6 +829,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                 MediaUrl: remoteMediaUrls[0],
               }
             : {}),
+          ...(resolvedMediaType ? { MediaType: resolvedMediaType } : {}),
+          ...(resolvedMediaTypes ? { MediaTypes: resolvedMediaTypes } : {}),
           ...(replyToId
             ? {
                 ReplyToId: replyToId,


### PR DESCRIPTION
… inbound mode

When users send voice messages, the framework's isInboundAudioContext() checks ctx.MediaType/MediaTypes for 'audio' to determine if inbound audio was received. The qqbot plugin only populated these fields from image attachments, causing TTS auto 'inbound' mode to always skip.

This fix sets MediaType/MediaTypes to 'audio' when voice attachments are present, without adding voice paths to MediaPaths (which would trigger extractFileBlocks injecting audio binary into model context).

## Summary

- **Problem:** QQ Bot plugin never sets `MediaType: "audio"` when a voice message arrives, so the framework's `isInboundAudioContext()` always returns `false` — TTS auto `"inbound"` mode is completely broken on QQ Bot.
- **Why it matters:** Users who configure `messages.tts.auto: "inbound"` expect voice replies when they send voice messages. On QQ Bot this silently fails; deepseek-style models also leave `[[tts:...]]` tags in plaintext because the framework skips TTS processing entirely.
- **What changed:** When voice attachments exist, `MediaType`/`MediaTypes` now include `"audio"` in the finalized inbound context, enabling `isInboundAudioContext()` to detect audio input.
- **What did NOT change (scope boundary):** Voice attachment paths are **not** added to `MediaPaths` — doing so would trigger the framework's `extractFileBlocks`, injecting audio binary into model context (documented in `stt.ts`). `inbound-attachments.ts`, `stt.ts`, and all outbound/streaming code are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: User report on TTS `inbound` mode not working with QQ Bot voice messages
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `gateway.ts` builds `localMediaPaths`/`localMediaTypes` by iterating only over `imageUrls`. Voice attachments are processed into `voiceAttachmentPaths`/`voiceAttachmentUrls` but never contribute to `MediaType`/`MediaTypes` in the context payload.
- **Missing detection / guardrail:** No test asserts that a voice-only inbound message produces `MediaType: "audio"` in the finalized context.
- **Contributing context:** The framework's `isInboundAudioContext()` has three detection paths (MediaType check, `^<media:audio>` body prefix, `^\[Audio\b` body prefix). QQ Bot's envelope-wrapped body format defeats the last two, making the MediaType path the only viable one.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/qqbot/src/gateway.test.ts` (if it exists) or a new seam test
- **Scenario the test should lock in:** When `processAttachments` returns non-empty `voiceAttachmentPaths`, the finalized `ctxPayload` must have `MediaType === "audio"` (or `MediaTypes` containing `"audio"`)
- **Why this is the smallest reliable guardrail:** Directly tests the mapping from voice attachments to context payload without requiring a live QQ connection
- **If no new test is added, why not:** The upstream qqbot extension currently lacks a gateway unit test harness; verified manually against live QQ Bot instance

## User-visible / Behavior Changes

- TTS auto `"inbound"` mode now works on QQ Bot: when a user sends a voice message, the AI reply will include TTS audio (previously it was always skipped).
- No config changes required — existing `messages.tts.auto: "inbound"` configurations will start working.

## Diagram (if applicable)

```text
Before:
[user sends voice] -> gateway builds ctxPayload (MediaType: undefined)
                   -> isInboundAudioContext() = false
                   -> TTS inbound check: skip
                   -> text-only reply (tags may leak)

After:
[user sends voice] -> gateway builds ctxPayload (MediaType: "audio")
                   -> isInboundAudioContext() = true
                   -> TTS inbound check: pass
                   -> TTS audio generated + tags cleaned
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (remote), macOS (dev)
- Runtime/container: Node.js, OpenClaw 2026.3.28
- Model/provider: deepseek/deepseek-chat, MiniMax-M2.7
- Integration/channel: QQ Bot (openclaw-qqbot)
- Relevant config: `messages.tts.auto: "inbound"`, `messages.tts.provider: "microsoft"`

### Steps

1. Configure `messages.tts.auto: "inbound"` in `openclaw.json`
2. Send a voice message to the QQ Bot in private chat
3. Observe AI reply

### Expected

- AI reply includes TTS-generated voice audio
- No `[[tts:...]]` tags leaked in text

### Actual (before fix)

- AI reply is text-only, no voice audio
- deepseek model leaks `[[/tts:text]]` closing tags in visible text

## Evidence

- [x] Trace/log snippets

Framework log confirms `inboundAudio = false` before fix, `inboundAudio = true` after fix. Detailed analysis in the linked user report covering the full `maybeApplyTtsToPayload` judgment chain.

## Human Verification (required)

- **Verified scenarios:** Voice-only message (pure voice, no image) produces `MediaType: "audio"` in context; image+voice mixed message includes `"audio"` in `MediaTypes` array while preserving image as `MediaType`
- **Edge cases checked:** No voice attachments → no change to existing behavior; `MediaPaths` does not include voice paths (avoiding `extractFileBlocks` binary injection)
- **What you did not verify:** Group chat voice messages (only tested C2C private chat); `"tagged"` mode tag cleanup (framework-side concern, not plugin)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Setting `MediaType: "audio"` without `MediaPaths` is unconventional — if future framework code assumes `MediaType` always has a corresponding `MediaPaths` entry, it could error.
  - **Mitigation:** `isInboundAudioContext()` only reads `MediaType`/`MediaTypes` values and never dereferences paths. The separation is intentional to avoid `extractFileBlocks` processing audio binary (same rationale documented in `stt.ts` header comment).