### PR TITLE
fix: avoid false telegram polling stall restarts

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -417,6 +417,49 @@ describe("TelegramPollingSession", () => {
     expect(createTelegramTransport).toHaveBeenCalledTimes(1);
   });
 
+  it("does not trigger stall restart shortly after a getUpdates error", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    const runnerStop = vi.fn(async () => undefined);
+    const getApiMiddleware = mockBotCapturingApiMiddleware(botStop);
+    const resolveFirstTask = mockLongRunningPollingCycle(runnerStop);
+
+    const watchdogHarness = installPollingStallWatchdogHarness([0, 0, 1, 30_000], 119_999);
+
+    const log = vi.fn();
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      const watchdog = await watchdogHarness.waitForWatchdog();
+
+      const apiMiddleware = getApiMiddleware();
+      if (apiMiddleware) {
+        const failedGetUpdates = vi.fn(async () => {
+          throw new Error("Network request for 'getUpdates' failed!");
+        });
+        await expect(apiMiddleware(failedGetUpdates, "getUpdates", { offset: 1 })).rejects.toThrow(
+          "Network request for 'getUpdates' failed!",
+        );
+      }
+
+      watchdog?.();
+
+      expect(runnerStop).not.toHaveBeenCalled();
+      expect(botStop).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
+
+      abort.abort();
+      resolveFirstTask();
+      await runPromise;
+    } finally {
+      watchdogHarness.restore();
+    }
+  });
+
   it("does not trigger stall restart when non-getUpdates API calls are active", async () => {
     const abort = new AbortController();
     const botStop = vi.fn(async () => undefined);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -265,6 +265,7 @@ export class TelegramPollingSession {
         lastGetUpdatesFinishedAt = finishedAt;
         lastGetUpdatesDurationMs = finishedAt - startedAt;
         lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
+        lastApiActivityAt = finishedAt;
         return result;
       } catch (err) {
         const finishedAt = Date.now();
@@ -272,6 +273,7 @@ export class TelegramPollingSession {
         lastGetUpdatesDurationMs = finishedAt - startedAt;
         lastGetUpdatesOutcome = "error";
         lastGetUpdatesError = formatErrorMessage(err);
+        lastApiActivityAt = finishedAt;
         throw err;
       } finally {
         inFlightGetUpdates = Math.max(0, inFlightGetUpdates - 1);


### PR DESCRIPTION
## Summary
- count completed `getUpdates` calls, including recoverable errors, as API liveness for the polling stall watchdog
- avoid forcing a polling restart while Telegram is still actively retrying after a recent `getUpdates` failure
- add regression coverage for the post-error watchdog window

## Testing
- pnpm test -- extensions/telegram/src/polling-session.test.ts

Fixes #64288
