### PR TITLE
fix(feishu): add docx:document.block:convert scope to batch import JSON

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -109,6 +109,8 @@ On **Permissions**, click **Batch import** and paste:
       "application:bot.menu:write",
       "cardkit:card:read",
       "cardkit:card:write",
+      "docx:document",
+      "docx:document.block:convert",
       "contact:user.employee_id:readonly",
       "corehr:file:download",
       "event:ip_list",


### PR DESCRIPTION
## Summary

Adds the missing `docx:document.block:convert` scope to the Feishu batch import JSON in the documentation. This scope is required for the `document.convert` API that powers the `feishu_doc` tool's `write` and `append` actions.

Without this scope, the `write` and `append` actions return `400 Bad Request` even with valid markdown content.

## Changes

- Added `docx:document` to tenant scopes (for basic docx read/write)
- Added `docx:document.block:convert` to tenant scopes (for markdown-to-block conversion)

## Context

- Issue: openclaw/openclaw#64299
- The `docx:document.block:convert` API is required for markdown-to-block conversion used by `write`/`append` actions