### PR TITLE
docs(start): use model-agnostic example in getting started guide

### DIFF
--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -117,7 +117,7 @@ Example:
 {
   logging: { level: "info" },
   agent: {
-    model: "anthropic/claude-opus-4-6",
+    model: "openai/gpt-5.4",  // or any provider/model you prefer
     workspace: "~/.openclaw/workspace",
     thinkingDefault: "high",
     timeoutSeconds: 1800,


### PR DESCRIPTION
## Summary

Fixes #62529 — The getting-started config example hardcoded `anthropic/claude-opus-4-6`, directing new users to a specific provider.

## Change

Replaced with `openai/gpt-5.4` and added a comment: `// or any provider/model you prefer` to make it clear the choice is up to the user.

This aligns with the project's model-agnostic philosophy.

## Note

Other docs files (fly.md, token-use.md, prompt-caching.md, etc.) also reference anthropic models, but those are in provider-specific examples where it makes sense contextually. The getting-started guide is the one that shapes first impressions.