### PR TITLE
docs(plugins): fix broken configuration reference link

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -455,7 +455,7 @@ hook instead.
 - If plugin config exists but the plugin is **disabled**, the config is kept and
   a **warning** is surfaced in Doctor + logs.
 
-See [Configuration reference](/gateway/configuration) for the full `plugins.*` schema.
+See [Configuration reference](/gateway/configuration-reference) for the full `plugins.*` schema.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Partial fix for #50828 — fixes broken internal link in `docs/plugins/manifest.md`.

## Change

- `/gateway/configuration` → `/gateway/configuration-reference` (the correct page path)

Most other broken links from the original issue appear to have been fixed in subsequent updates.