### PR TITLE
fix(hooks): preserve plugin-registered internal hooks when refreshing file hooks

### DIFF
--- a/src/hooks/bundled/boot-md/handler.gateway-startup.integration.test.ts
+++ b/src/hooks/bundled/boot-md/handler.gateway-startup.integration.test.ts
@@ -19,17 +19,21 @@ vi.mock("../../../logging/subsystem.js", () => ({
 }));
 
 const { default: runBootChecklist } = await import("./handler.js");
-const { clearInternalHooks, createInternalHookEvent, registerInternalHook, triggerInternalHook } =
-  await import("../../internal-hooks.js");
+const {
+  clearAllInternalHooks,
+  createInternalHookEvent,
+  registerInternalHook,
+  triggerInternalHook,
+} = await import("../../internal-hooks.js");
 
 describe("boot-md startup hook integration", () => {
   beforeEach(() => {
     runBootOnce.mockClear();
-    clearInternalHooks();
+    clearAllInternalHooks();
   });
 
   afterEach(() => {
-    clearInternalHooks();
+    clearAllInternalHooks();
   });
 
   it("dispatches gateway:startup through internal hooks and runs BOOT for each configured agent scope", async () => {

--- a/src/hooks/hooks-install.test.ts
+++ b/src/hooks/hooks-install.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { installHooksFromPath } from "./install.js";
 import {
-  clearInternalHooks,
+  clearAllInternalHooks,
   createInternalHookEvent,
   triggerInternalHook,
 } from "./internal-hooks.js";
@@ -85,7 +85,7 @@ describe("hooks install (e2e)", () => {
       return;
     }
 
-    clearInternalHooks();
+    clearAllInternalHooks();
     const bundledHooksDir = path.join(baseDir, "bundled-none");
     await fs.mkdir(bundledHooksDir, { recursive: true });
     const loaded = await loadInternalHooks(

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
+  clearAllInternalHooks,
   clearInternalHooks,
+  clearPluginInternalHooks,
   createInternalHookEvent,
   getRegisteredEventKeys,
   isAgentBootstrapEvent,
@@ -21,11 +23,11 @@ const INTERNAL_HOOK_HANDLERS_KEY = Symbol.for("openclaw.internalHookHandlers");
 
 describe("hooks", () => {
   beforeEach(() => {
-    clearInternalHooks();
+    clearAllInternalHooks();
   });
 
   afterEach(() => {
-    clearInternalHooks();
+    clearAllInternalHooks();
   });
 
   describe("registerInternalHook", () => {
@@ -450,7 +452,20 @@ describe("hooks", () => {
   });
 
   describe("clearInternalHooks", () => {
-    it("should remove all registered handlers", () => {
+    it("should remove all file-based handlers but preserve plugin handlers", () => {
+      registerInternalHook("command:new", vi.fn());
+      registerInternalHook("command:stop", vi.fn());
+      registerInternalHook("session:start", vi.fn(), { source: "plugin" });
+
+      clearInternalHooks();
+
+      const keys = getRegisteredEventKeys();
+      expect(keys).toEqual(["session:start"]);
+      expect(keys).not.toContain("command:new");
+      expect(keys).not.toContain("command:stop");
+    });
+
+    it("should remove all registered file handlers", () => {
       registerInternalHook("command:new", vi.fn());
       registerInternalHook("command:stop", vi.fn());
 
@@ -458,6 +473,72 @@ describe("hooks", () => {
 
       const keys = getRegisteredEventKeys();
       expect(keys).toEqual([]);
+    });
+  });
+
+  describe("clearPluginInternalHooks", () => {
+    it("should remove all plugin handlers but preserve file handlers", () => {
+      registerInternalHook("command:new", vi.fn());
+      registerInternalHook("command:stop", vi.fn(), { source: "plugin" });
+
+      clearPluginInternalHooks();
+
+      const keys = getRegisteredEventKeys();
+      expect(keys).toEqual(["command:new"]);
+      expect(keys).not.toContain("command:stop");
+    });
+  });
+
+  describe("clearAllInternalHooks", () => {
+    it("should remove both file and plugin handlers", () => {
+      registerInternalHook("command:new", vi.fn());
+      registerInternalHook("command:stop", vi.fn(), { source: "plugin" });
+
+      clearAllInternalHooks();
+
+      const keys = getRegisteredEventKeys();
+      expect(keys).toEqual([]);
+    });
+  });
+
+  describe("plugin hooks", () => {
+    it("should register handlers with plugin source", () => {
+      const handler = vi.fn();
+      registerInternalHook("gateway:startup", handler, { source: "plugin" });
+
+      const keys = getRegisteredEventKeys();
+      expect(keys).toContain("gateway:startup");
+    });
+
+    it("should trigger plugin handlers alongside file handlers", async () => {
+      const fileHandler = vi.fn();
+      const pluginHandler = vi.fn();
+
+      registerInternalHook("gateway:startup", fileHandler);
+      registerInternalHook("gateway:startup", pluginHandler, { source: "plugin" });
+
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg: {},
+      });
+      await triggerInternalHook(event);
+
+      expect(fileHandler).toHaveBeenCalledWith(event);
+      expect(pluginHandler).toHaveBeenCalledWith(event);
+    });
+
+    it("should survive clearInternalHooks when registered as plugin", () => {
+      const handler = vi.fn();
+      registerInternalHook("gateway:startup", handler, { source: "plugin" });
+
+      clearInternalHooks();
+
+      const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg: {},
+      });
+      void triggerInternalHook(event);
+
+      const keys = getRegisteredEventKeys();
+      expect(keys).toContain("gateway:startup");
     });
   });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -189,6 +189,8 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
+export type InternalHookSource = "file" | "plugin";
+
 /**
  * Registry of hook handlers by event key.
  *
@@ -198,12 +200,28 @@ export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | 
  * splitting). Without the singleton, handlers registered in one chunk
  * are invisible to triggerInternalHook in another chunk, causing hooks
  * to silently fire with zero handlers.
+ *
+ * We maintain two separate registries:
+ * - `handlers`: for file-based hooks (loaded from ~/.openclaw/hooks/)
+ * - `pluginHandlers`: for plugin-registered hooks (registered during plugin init)
+ *
+ * This separation ensures that `clearInternalHooks()` (which refreshes file hooks)
+ * does not accidentally clear plugin hooks that are registered at a different
+ * point in the startup lifecycle.
  */
 const INTERNAL_HOOK_HANDLERS_KEY = Symbol.for("openclaw.internalHookHandlers");
+const INTERNAL_PLUGIN_HOOK_HANDLERS_KEY = Symbol.for("openclaw.internalPluginHookHandlers");
+
 const handlers = resolveGlobalSingleton<Map<string, InternalHookHandler[]>>(
   INTERNAL_HOOK_HANDLERS_KEY,
   () => new Map<string, InternalHookHandler[]>(),
 );
+
+const pluginHandlers = resolveGlobalSingleton<Map<string, InternalHookHandler[]>>(
+  INTERNAL_PLUGIN_HOOK_HANDLERS_KEY,
+  () => new Map<string, InternalHookHandler[]>(),
+);
+
 const log = createSubsystemLogger("internal-hooks");
 
 /**
@@ -211,25 +229,31 @@ const log = createSubsystemLogger("internal-hooks");
  *
  * @param eventKey - Event type (e.g., 'command') or specific action (e.g., 'command:new')
  * @param handler - Function to call when the event is triggered
+ * @param opts - Optional settings including source ('file' or 'plugin')
  *
  * @example
  * ```ts
- * // Listen to all command events
+ * // Listen to all command events (file hook, default)
  * registerInternalHook('command', async (event) => {
  *   console.log('Command:', event.action);
  * });
  *
- * // Listen only to /new commands
+ * // Listen only to /new commands (plugin hook)
  * registerInternalHook('command:new', async (event) => {
  *   await saveSessionToMemory(event);
- * });
+ * }, { source: 'plugin' });
  * ```
  */
-export function registerInternalHook(eventKey: string, handler: InternalHookHandler): void {
-  if (!handlers.has(eventKey)) {
-    handlers.set(eventKey, []);
+export function registerInternalHook(
+  eventKey: string,
+  handler: InternalHookHandler,
+  opts?: { source?: InternalHookSource },
+): void {
+  const targetHandlers = opts?.source === "plugin" ? pluginHandlers : handlers;
+  if (!targetHandlers.has(eventKey)) {
+    targetHandlers.set(eventKey, []);
   }
-  handlers.get(eventKey)!.push(handler);
+  targetHandlers.get(eventKey)!.push(handler);
 }
 
 /**
@@ -237,9 +261,15 @@ export function registerInternalHook(eventKey: string, handler: InternalHookHand
  *
  * @param eventKey - Event key the handler was registered for
  * @param handler - The handler function to remove
+ * @param opts - Optional settings including source ('file' or 'plugin')
  */
-export function unregisterInternalHook(eventKey: string, handler: InternalHookHandler): void {
-  const eventHandlers = handlers.get(eventKey);
+export function unregisterInternalHook(
+  eventKey: string,
+  handler: InternalHookHandler,
+  opts?: { source?: InternalHookSource },
+): void {
+  const targetHandlers = opts?.source === "plugin" ? pluginHandlers : handlers;
+  const eventHandlers = targetHandlers.get(eventKey);
   if (!eventHandlers) {
     return;
   }
@@ -251,28 +281,50 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
 
   // Clean up empty handler arrays
   if (eventHandlers.length === 0) {
-    handlers.delete(eventKey);
+    targetHandlers.delete(eventKey);
   }
 }
 
 /**
- * Clear all registered hooks (useful for testing)
+ * Clear file-based hooks only (loaded from ~/.openclaw/hooks/).
+ * Plugin hooks are preserved since they have a different lifecycle.
  */
 export function clearInternalHooks(): void {
   handlers.clear();
 }
 
 /**
- * Get all registered event keys (useful for debugging)
+ * Clear all hooks including both file-based and plugin hooks.
+ * Use this only in tests or when completely resetting the hook system.
+ */
+export function clearAllInternalHooks(): void {
+  handlers.clear();
+  pluginHandlers.clear();
+}
+
+/**
+ * Clear plugin hooks only.
+ * Use this when unloading plugins.
+ */
+export function clearPluginInternalHooks(): void {
+  pluginHandlers.clear();
+}
+
+/**
+ * Get all registered event keys from both file and plugin hooks (useful for debugging)
  */
 export function getRegisteredEventKeys(): string[] {
-  return Array.from(handlers.keys());
+  const keys = new Set([...handlers.keys(), ...pluginHandlers.keys()]);
+  return Array.from(keys);
 }
 
 export function hasInternalHookListeners(type: InternalHookEventType, action: string): boolean {
-  return (
-    (handlers.get(type)?.length ?? 0) > 0 || (handlers.get(`${type}:${action}`)?.length ?? 0) > 0
-  );
+  const hasFileListeners =
+    (handlers.get(type)?.length ?? 0) > 0 || (handlers.get(`${type}:${action}`)?.length ?? 0) > 0;
+  const hasPluginListeners =
+    (pluginHandlers.get(type)?.length ?? 0) > 0 ||
+    (pluginHandlers.get(`${type}:${action}`)?.length ?? 0) > 0;
+  return hasFileListeners || hasPluginListeners;
 }
 
 /**
@@ -282,6 +334,7 @@ export function hasInternalHookListeners(type: InternalHookEventType, action: st
  * 1. The general event type (e.g., 'command')
  * 2. The specific event:action combination (e.g., 'command:new')
  *
+ * Handlers from both file hooks and plugin hooks are invoked.
  * Handlers are called in registration order. Errors are caught and logged
  * but don't prevent other handlers from running.
  *
@@ -292,9 +345,17 @@ export async function triggerInternalHook(event: InternalHookEvent): Promise<voi
     return;
   }
 
-  const typeHandlers = handlers.get(event.type) ?? [];
-  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
-  const allHandlers = [...typeHandlers, ...specificHandlers];
+  const fileTypeHandlers = handlers.get(event.type) ?? [];
+  const fileSpecificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const pluginTypeHandlers = pluginHandlers.get(event.type) ?? [];
+  const pluginSpecificHandlers = pluginHandlers.get(`${event.type}:${event.action}`) ?? [];
+
+  const allHandlers = [
+    ...fileTypeHandlers,
+    ...fileSpecificHandlers,
+    ...pluginTypeHandlers,
+    ...pluginSpecificHandlers,
+  ];
 
   for (const handler of allHandlers) {
     try {

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -8,7 +8,7 @@ import { loggingState } from "../logging/state.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { captureEnv } from "../test-utils/env.js";
 import {
-  clearInternalHooks,
+  clearAllInternalHooks,
   getRegisteredEventKeys,
   triggerInternalHook,
   createInternalHookEvent,
@@ -26,7 +26,7 @@ describe("loader", () => {
   });
 
   beforeEach(async () => {
-    clearInternalHooks();
+    clearAllInternalHooks();
     // Create a temp directory for test modules
     tmpDir = path.join(fixtureRoot, `case-${caseId++}`);
     await fs.mkdir(tmpDir, { recursive: true });
@@ -115,7 +115,7 @@ describe("loader", () => {
   }
 
   afterEach(async () => {
-    clearInternalHooks();
+    clearAllInternalHooks();
     loggingState.rawConsole = null;
     setLoggerOverride(null);
     envSnapshot.restore();

--- a/src/hooks/message-hooks.test.ts
+++ b/src/hooks/message-hooks.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearInternalHooks,
+  clearAllInternalHooks,
   createInternalHookEvent,
   registerInternalHook,
   triggerInternalHook,
@@ -108,11 +108,11 @@ const actionCases: ActionCase[] = [
 
 describe("message hooks", () => {
   beforeEach(() => {
-    clearInternalHooks();
+    clearAllInternalHooks();
   });
 
   afterEach(() => {
-    clearInternalHooks();
+    clearAllInternalHooks();
   });
 
   describe("action handlers", () => {

--- a/src/hooks/plugin-hooks.test.ts
+++ b/src/hooks/plugin-hooks.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  clearInternalHooks,
+  clearAllInternalHooks,
   createInternalHookEvent,
   triggerInternalHook,
 } from "./internal-hooks.js";
@@ -23,7 +23,7 @@ describe("bundle plugin hooks", () => {
   });
 
   beforeEach(async () => {
-    clearInternalHooks();
+    clearAllInternalHooks();
     workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
     await fsp.mkdir(workspaceDir, { recursive: true });
     previousBundledHooksDir = process.env.OPENCLAW_BUNDLED_HOOKS_DIR;
@@ -31,7 +31,7 @@ describe("bundle plugin hooks", () => {
   });
 
   afterEach(() => {
-    clearInternalHooks();
+    clearAllInternalHooks();
     if (previousBundledHooksDir === undefined) {
       delete process.env.OPENCLAW_BUNDLED_HOOKS_DIR;
     } else {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -277,7 +277,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     for (const event of normalizedEvents) {
-      registerInternalHook(event, handler);
+      registerInternalHook(event, handler, { source: "plugin" });
     }
   };
 


### PR DESCRIPTION
## Summary

Fix a bug where `clearInternalHooks()` wiped plugin-registered internal hooks during startup.

This caused plugin hooks like memory-core's `gateway:startup` handler to disappear before the startup event fired, which prevented managed dreaming cron reconciliation from running automatically.

## Changes

- separate file-hook and plugin-hook registries
- make `clearInternalHooks()` clear only file hooks
- trigger both file and plugin hook handlers
- add `clearAllInternalHooks()` for tests
- add tests covering plugin hook survival across file-hook refresh

## Why this fixes dreaming

memory-core registers its dreaming startup reconcile hook through the plugin hook path.
Previously that hook could be cleared during startup before `gateway:startup` was triggered, so `Memory Dreaming Promotion` was never auto-reconciled.
With this change, plugin hooks survive file-hook refresh and the startup reconcile can run correctly.
