### PR TITLE
fix(matrix): preserve ACP thread binding targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Docs: https://docs.openclaw.ai
 - Browser/tabs: route `/tabs/action` close/select through the same browser endpoint reachability and policy checks as list/new (including Playwright-backed remote tab operations), reject CDP HTTP redirects on probe requests, and sanitize blocked-endpoint error responses so tab list/focus/close flows fail closed without echoing raw policy details back to callers. (#63332)
 - Gateway/OpenAI compat: return real `usage` for non-stream `/v1/chat/completions` responses, emit the final usage chunk when `stream_options.include_usage=true`, and bound usage-gated stream finalization after lifecycle end. (#62986) Thanks @Lellansin.
 - Matrix/migration: keep packaged warning-only crypto migrations from being misclassified as actionable when only helper chunks are present, so startup and doctor stay on the warning-only path instead of creating unnecessary migration snapshots. (#64373) Thanks @gumadeiras.
+- Matrix/ACP thread bindings: preserve canonical room casing and parent conversation routing during ACP session spawn so mixed-case room ids bind correctly from top-level rooms and existing Matrix threads. (#64343) Thanks @gumadeiras.
 
 ## 2026.4.9
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -689,7 +689,7 @@ describe("spawnAcpDirect", () => {
     expectAgentGatewayCall({
       deliver: true,
       channel: "matrix",
-      to: "room:!Room:Example.org",
+      to: "channel:!Room:Example.org",
       threadId: "child-thread",
     });
   });
@@ -751,7 +751,7 @@ describe("spawnAcpDirect", () => {
     expectAgentGatewayCall({
       deliver: true,
       channel: "matrix",
-      to: "room:!Room:Example.org",
+      to: "channel:!Room:Example.org",
       threadId: "child-thread",
     });
   });

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -322,6 +322,29 @@ function enableLineCurrentConversationBindings(): void {
   });
 }
 
+function enableTelegramCurrentConversationBindings(): void {
+  replaceSpawnConfig({
+    ...hoisted.state.cfg,
+    channels: {
+      ...hoisted.state.cfg.channels,
+      telegram: {
+        threadBindings: {
+          enabled: true,
+        },
+      },
+    },
+  });
+  registerSessionBindingAdapter({
+    channel: "telegram",
+    accountId: "default",
+    capabilities: createSessionBindingCapabilities(),
+    bind: async (input) => await hoisted.sessionBindingBindMock(input),
+    listBySession: (targetSessionKey) => hoisted.sessionBindingListBySessionMock(targetSessionKey),
+    resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
+    unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
+  });
+}
+
 describe("spawnAcpDirect", () => {
   beforeEach(() => {
     replaceSpawnConfig(createDefaultSpawnConfig());
@@ -607,6 +630,128 @@ describe("spawnAcpDirect", () => {
       deliver: true,
       channel: "matrix",
       to: "channel:!room:example",
+      threadId: "child-thread",
+    });
+  });
+
+  it("keeps canonical Matrix room casing for ACP thread bindings", async () => {
+    enableMatrixAcpThreadBindings();
+    hoisted.sessionBindingBindMock.mockImplementationOnce(
+      async (input: {
+        targetSessionKey: string;
+        conversation: { accountId: string; conversationId: string; parentConversationId?: string };
+        metadata?: Record<string, unknown>;
+      }) =>
+        createSessionBinding({
+          targetSessionKey: input.targetSessionKey,
+          conversation: {
+            channel: "matrix",
+            accountId: input.conversation.accountId,
+            conversationId: "child-thread",
+            parentConversationId: input.conversation.parentConversationId ?? "!Room:Example.org",
+          },
+          metadata: {
+            boundBy:
+              typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+            agentId: "codex",
+            webhookId: "wh-1",
+          },
+        }),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:matrix:channel:!room:example.org",
+        agentChannel: "matrix",
+        agentAccountId: "default",
+        agentTo: "room:!Room:Example.org",
+        agentGroupId: "!room:example.org",
+      },
+    );
+
+    expect(result.status, JSON.stringify(result)).toBe("accepted");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "child",
+        conversation: expect.objectContaining({
+          channel: "matrix",
+          accountId: "default",
+          conversationId: "!Room:Example.org",
+        }),
+      }),
+    );
+    expectAgentGatewayCall({
+      deliver: true,
+      channel: "matrix",
+      to: "room:!Room:Example.org",
+      threadId: "child-thread",
+    });
+  });
+
+  it("preserves Matrix parent room casing when binding from an existing thread", async () => {
+    enableMatrixAcpThreadBindings();
+    hoisted.sessionBindingBindMock.mockImplementationOnce(
+      async (input: {
+        targetSessionKey: string;
+        conversation: { accountId: string; conversationId: string; parentConversationId?: string };
+        metadata?: Record<string, unknown>;
+      }) =>
+        createSessionBinding({
+          targetSessionKey: input.targetSessionKey,
+          conversation: {
+            channel: "matrix",
+            accountId: input.conversation.accountId,
+            conversationId: "child-thread",
+            parentConversationId: input.conversation.parentConversationId ?? "!Room:Example.org",
+          },
+          metadata: {
+            boundBy:
+              typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+            agentId: "codex",
+            webhookId: "wh-1",
+          },
+        }),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:matrix:channel:!room:example.org:thread:$thread-root",
+        agentChannel: "matrix",
+        agentAccountId: "default",
+        agentTo: "room:!Room:Example.org",
+        agentThreadId: "$thread-root",
+        agentGroupId: "!room:example.org",
+      },
+    );
+
+    expect(result.status, JSON.stringify(result)).toBe("accepted");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "child",
+        conversation: expect.objectContaining({
+          channel: "matrix",
+          accountId: "default",
+          conversationId: "$thread-root",
+          parentConversationId: "!Room:Example.org",
+        }),
+      }),
+    );
+    expectAgentGatewayCall({
+      deliver: true,
+      channel: "matrix",
+      to: "room:!Room:Example.org",
       threadId: "child-thread",
     });
   });
@@ -932,6 +1077,58 @@ describe("spawnAcpDirect", () => {
       );
     },
   );
+
+  it("preserves LINE fallback conversation precedence when groupId is present", async () => {
+    enableLineCurrentConversationBindings();
+    hoisted.sessionBindingBindMock.mockImplementationOnce(
+      async (input: {
+        targetSessionKey: string;
+        conversation: { accountId: string; conversationId: string };
+        metadata?: Record<string, unknown>;
+      }) =>
+        createSessionBinding({
+          targetSessionKey: input.targetSessionKey,
+          conversation: {
+            channel: "line",
+            accountId: input.conversation.accountId,
+            conversationId: input.conversation.conversationId,
+          },
+          metadata: {
+            boundBy:
+              typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+            agentId: "codex",
+          },
+        }),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:line:direct:R1234567890abcdef1234567890abcdef",
+        agentChannel: "line",
+        agentAccountId: "default",
+        agentTo: "line:user:U1234567890abcdef1234567890abcdef",
+        agentGroupId: "line:room:R1234567890abcdef1234567890abcdef",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "current",
+        conversation: expect.objectContaining({
+          channel: "line",
+          accountId: "default",
+          conversationId: "R1234567890abcdef1234567890abcdef",
+        }),
+      }),
+    );
+  });
 
   it.each([
     {
@@ -1522,27 +1719,7 @@ describe("spawnAcpDirect", () => {
   });
 
   it("binds Telegram forum-topic ACP sessions to the current topic", async () => {
-    replaceSpawnConfig({
-      ...hoisted.state.cfg,
-      channels: {
-        ...hoisted.state.cfg.channels,
-        telegram: {
-          threadBindings: {
-            enabled: true,
-          },
-        },
-      },
-    });
-    registerSessionBindingAdapter({
-      channel: "telegram",
-      accountId: "default",
-      capabilities: createSessionBindingCapabilities(),
-      bind: async (input) => await hoisted.sessionBindingBindMock(input),
-      listBySession: (targetSessionKey) =>
-        hoisted.sessionBindingListBySessionMock(targetSessionKey),
-      resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
-      unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
-    });
+    enableTelegramCurrentConversationBindings();
 
     const result = await spawnAcpDirect(
       {
@@ -1581,27 +1758,7 @@ describe("spawnAcpDirect", () => {
   });
 
   it("preserves topic-qualified Telegram targets without a separate threadId", async () => {
-    replaceSpawnConfig({
-      ...hoisted.state.cfg,
-      channels: {
-        ...hoisted.state.cfg.channels,
-        telegram: {
-          threadBindings: {
-            enabled: true,
-          },
-        },
-      },
-    });
-    registerSessionBindingAdapter({
-      channel: "telegram",
-      accountId: "default",
-      capabilities: createSessionBindingCapabilities(),
-      bind: async (input) => await hoisted.sessionBindingBindMock(input),
-      listBySession: (targetSessionKey) =>
-        hoisted.sessionBindingListBySessionMock(targetSessionKey),
-      resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
-      unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
-    });
+    enableTelegramCurrentConversationBindings();
 
     const result = await spawnAcpDirect(
       {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1757,6 +1757,42 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.channel).toBe("telegram");
   });
 
+  it("drops self-parent Telegram current-conversation refs before binding", async () => {
+    enableTelegramCurrentConversationBindings();
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:telegram:direct:6098642967",
+        agentChannel: "telegram",
+        agentAccountId: "default",
+        agentTo: "telegram:6098642967",
+      },
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.mode).toBe("session");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "current",
+        conversation: expect.objectContaining({
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "6098642967",
+        }),
+      }),
+    );
+    const bindCall = hoisted.sessionBindingBindMock.mock.calls.at(-1)?.[0] as
+      | { conversation?: { parentConversationId?: string } }
+      | undefined;
+    expect(bindCall?.conversation?.parentConversationId).toBeUndefined();
+  });
+
   it("preserves topic-qualified Telegram targets without a separate threadId", async () => {
     enableTelegramCurrentConversationBindings();
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -34,6 +34,7 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import { callGateway } from "../gateway/call.js";
 import { areHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
+import { normalizeConversationTargetRef } from "../infra/outbound/session-binding-normalization.js";
 import {
   getSessionBindingService,
   isSessionBindingError,
@@ -289,13 +290,10 @@ function resolvePluginConversationRefForThreadBinding(params: {
   if (!conversationId) {
     return null;
   }
-  const parentConversationId = normalizeOptionalString(resolvedConversation?.parentConversationId);
-  return {
+  return normalizeConversationTargetRef({
     conversationId,
-    ...(parentConversationId && parentConversationId !== conversationId
-      ? { parentConversationId }
-      : {}),
-  };
+    parentConversationId: resolvedConversation?.parentConversationId,
+  });
 }
 
 function resolveSpawnMode(params: {
@@ -552,7 +550,7 @@ function resolveConversationRefForThreadBinding(params: {
         ](params)
       : undefined;
   if (compatibilityConversationId) {
-    return { conversationId: compatibilityConversationId };
+    return normalizeConversationTargetRef({ conversationId: compatibilityConversationId });
   }
   const parentConversationId = resolveConversationIdFromTargets({
     targets: [params.to],
@@ -562,14 +560,10 @@ function resolveConversationRefForThreadBinding(params: {
     targets: [params.to],
   });
   if (genericConversationId) {
-    return {
+    return normalizeConversationTargetRef({
       conversationId: genericConversationId,
-      ...(params.threadId != null &&
-      parentConversationId &&
-      parentConversationId !== genericConversationId
-        ? { parentConversationId }
-        : {}),
-    };
+      parentConversationId: params.threadId != null ? parentConversationId : undefined,
+    });
   }
   return null;
 }

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -171,6 +171,7 @@ type PreparedAcpThreadBinding = {
   accountId: string;
   placement: "current" | "child";
   conversationId: string;
+  parentConversationId?: string;
 };
 
 type AcpSpawnInitializedSession = Awaited<
@@ -268,6 +269,34 @@ const threadBindingFallbackConversationResolvers = {
   telegram: (params: { to?: string; threadId?: string | number; groupId?: string }) =>
     normalizeTelegramConversationIdFallback(params),
 } as const;
+
+function resolvePluginConversationRefForThreadBinding(params: {
+  channelId: string;
+  to?: string;
+  threadId?: string | number;
+  groupId?: string;
+}): { conversationId: string; parentConversationId?: string } | null {
+  const resolvedConversation = getChannelPlugin(
+    params.channelId,
+  )?.messaging?.resolveInboundConversation?.({
+    // Keep the live delivery target authoritative; conversationId is only a fallback hint.
+    to: params.to,
+    conversationId: params.groupId ?? params.to,
+    threadId: params.threadId,
+    isGroup: true,
+  });
+  const conversationId = normalizeOptionalString(resolvedConversation?.conversationId);
+  if (!conversationId) {
+    return null;
+  }
+  const parentConversationId = normalizeOptionalString(resolvedConversation?.parentConversationId);
+  return {
+    conversationId,
+    ...(parentConversationId && parentConversationId !== conversationId
+      ? { parentConversationId }
+      : {}),
+  };
+}
 
 function resolveSpawnMode(params: {
   requestedMode?: SpawnAcpMode;
@@ -496,25 +525,25 @@ async function persistAcpSpawnSessionFileBestEffort(params: {
   }
 }
 
-function resolveConversationIdForThreadBinding(params: {
+function resolveConversationRefForThreadBinding(params: {
   channel?: string;
   to?: string;
   threadId?: string | number;
   groupId?: string;
-}): string | undefined {
+}): { conversationId: string; parentConversationId?: string } | null {
   const channel = normalizeOptionalLowercaseString(params.channel);
   const normalizedChannelId = channel ? normalizeChannelId(channel) : null;
   const channelKey = normalizedChannelId ?? channel ?? null;
-  const pluginResolvedConversationId = normalizedChannelId
-    ? getChannelPlugin(normalizedChannelId)?.messaging?.resolveInboundConversation?.({
-        to: params.groupId ?? params.to,
-        conversationId: params.groupId ?? params.to,
+  const pluginResolvedConversation = normalizedChannelId
+    ? resolvePluginConversationRefForThreadBinding({
+        channelId: normalizedChannelId,
+        to: params.to,
         threadId: params.threadId,
-        isGroup: true,
-      })?.conversationId
+        groupId: params.groupId,
+      })
     : null;
-  if (normalizeOptionalString(pluginResolvedConversationId)) {
-    return normalizeOptionalString(pluginResolvedConversationId);
+  if (pluginResolvedConversation) {
+    return pluginResolvedConversation;
   }
   const compatibilityConversationId =
     channelKey && Object.hasOwn(threadBindingFallbackConversationResolvers, channelKey)
@@ -523,16 +552,26 @@ function resolveConversationIdForThreadBinding(params: {
         ](params)
       : undefined;
   if (compatibilityConversationId) {
-    return compatibilityConversationId;
+    return { conversationId: compatibilityConversationId };
   }
+  const parentConversationId = resolveConversationIdFromTargets({
+    targets: [params.to],
+  });
   const genericConversationId = resolveConversationIdFromTargets({
     threadId: params.threadId,
     targets: [params.to],
   });
   if (genericConversationId) {
-    return genericConversationId;
+    return {
+      conversationId: genericConversationId,
+      ...(params.threadId != null &&
+      parentConversationId &&
+      parentConversationId !== genericConversationId
+        ? { parentConversationId }
+        : {}),
+    };
   }
-  return undefined;
+  return null;
 }
 
 function resolveAcpSpawnChannelAccountId(params: {
@@ -625,13 +664,13 @@ function prepareAcpThreadBinding(params: {
       error: `Thread bindings do not support ${placementToUse} placement for ${policy.channel}.`,
     };
   }
-  const conversationIdRaw = resolveConversationIdForThreadBinding({
+  const conversationRef = resolveConversationRefForThreadBinding({
     channel: policy.channel,
     to: params.to,
     threadId: params.threadId,
     groupId: params.groupId,
   });
-  if (!conversationIdRaw) {
+  if (!conversationRef?.conversationId) {
     return {
       ok: false,
       error: `Could not resolve a ${policy.channel} conversation for ACP thread spawn.`,
@@ -644,7 +683,10 @@ function prepareAcpThreadBinding(params: {
       channel: policy.channel,
       accountId: policy.accountId,
       placement: placementToUse,
-      conversationId: conversationIdRaw,
+      conversationId: conversationRef.conversationId,
+      ...(conversationRef.parentConversationId
+        ? { parentConversationId: conversationRef.parentConversationId }
+        : {}),
     },
   };
 }
@@ -790,6 +832,9 @@ async function bindPreparedAcpThread(params: {
       channel: params.preparedBinding.channel,
       accountId: params.preparedBinding.accountId,
       conversationId: params.preparedBinding.conversationId,
+      ...(params.preparedBinding.parentConversationId
+        ? { parentConversationId: params.preparedBinding.parentConversationId }
+        : {}),
     },
     placement: params.preparedBinding.placement,
     metadata: {
@@ -867,7 +912,7 @@ function resolveAcpSpawnBootstrapDeliveryPlan(params: {
   const fallbackThreadId =
     fallbackThreadIdRaw != null ? normalizeOptionalString(String(fallbackThreadIdRaw)) : undefined;
   const deliveryThreadId = boundThreadId ?? fallbackThreadId;
-  const requesterConversationId = resolveConversationIdForThreadBinding({
+  const requesterConversationRef = resolveConversationRefForThreadBinding({
     channel: params.requester.origin?.channel,
     threadId: fallbackThreadId,
     to: params.requester.origin?.to,
@@ -881,8 +926,10 @@ function resolveAcpSpawnBootstrapDeliveryPlan(params: {
     params.requester.origin?.channel &&
     params.binding?.conversation.channel === params.requester.origin.channel &&
     params.binding?.conversation.accountId === requesterAccountId &&
-    requesterConversationId &&
-    params.binding?.conversation.conversationId === requesterConversationId,
+    requesterConversationRef?.conversationId &&
+    params.binding?.conversation.conversationId === requesterConversationRef.conversationId &&
+    (params.binding?.conversation.parentConversationId ?? undefined) ===
+      (requesterConversationRef.parentConversationId ?? undefined),
   );
   const boundDeliveryTarget = resolveConversationDeliveryTarget({
     channel: params.requester.origin?.channel ?? params.binding?.conversation.channel,

--- a/src/auto-reply/reply/commands-acp/context.ts
+++ b/src/auto-reply/reply/commands-acp/context.ts
@@ -1,4 +1,5 @@
 import { normalizeConversationText } from "../../../acp/conversation-id.js";
+import { normalizeConversationTargetRef } from "../../../infra/outbound/session-binding-normalization.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
 import type { HandleCommandsParams } from "../commands-types.js";
 import {
@@ -33,12 +34,10 @@ function resolveAcpCommandConversationRef(params: HandleCommandsParams): {
   if (!resolved) {
     return null;
   }
-  return {
+  return normalizeConversationTargetRef({
     conversationId: resolved.conversationId,
-    ...(resolved.parentConversationId && resolved.parentConversationId !== resolved.conversationId
-      ? { parentConversationId: resolved.parentConversationId }
-      : {}),
-  };
+    parentConversationId: resolved.parentConversationId,
+  });
 }
 
 export function resolveAcpCommandConversationId(params: HandleCommandsParams): string | undefined {

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -34,6 +34,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { updateSessionStore } from "../../../config/sessions.js";
 import type { SessionAcpMeta } from "../../../config/sessions/types.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
+import { normalizeConversationRef } from "../../../infra/outbound/session-binding-normalization.js";
 import {
   getSessionBindingService,
   type ConversationRef,
@@ -250,15 +251,12 @@ async function bindSpawnedAcpSessionToCurrentConversation(params: {
   }
 
   const senderId = normalizeOptionalString(params.commandParams.command.senderId) ?? "";
-  const parentConversationId = normalizeOptionalString(bindingContext.parentConversationId);
-  const conversationRef = {
+  const conversationRef = normalizeConversationRef({
     channel: bindingPolicy.channel,
     accountId: bindingPolicy.accountId,
     conversationId: currentConversationId,
-    ...(parentConversationId && parentConversationId !== currentConversationId
-      ? { parentConversationId }
-      : {}),
-  };
+    parentConversationId: bindingContext.parentConversationId,
+  });
   const existingBinding = bindingService.resolveByConversation(conversationRef);
   const boundBy = normalizeOptionalString(existingBinding?.metadata?.boundBy) ?? "";
   if (existingBinding && boundBy && boundBy !== "system" && senderId && senderId !== boundBy) {
@@ -393,15 +391,12 @@ async function bindSpawnedAcpSessionToThread(params: {
   }
 
   const senderId = normalizeOptionalString(commandParams.command.senderId) ?? "";
-  const parentConversationId = normalizeOptionalString(bindingContext.parentConversationId);
-  const conversationRef = {
+  const conversationRef = normalizeConversationRef({
     channel: spawnPolicy.channel,
     accountId: spawnPolicy.accountId,
     conversationId: currentConversationId,
-    ...(parentConversationId && parentConversationId !== currentConversationId
-      ? { parentConversationId }
-      : {}),
-  };
+    parentConversationId: bindingContext.parentConversationId,
+  });
   if (placement === "current") {
     const existingBinding = bindingService.resolveByConversation(conversationRef);
     const boundBy = normalizeOptionalString(existingBinding?.metadata?.boundBy) ?? "";

--- a/src/auto-reply/reply/commands-subagents-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-focus.test.ts
@@ -549,4 +549,37 @@ describe("focus actions", () => {
       reason: "manual",
     });
   });
+
+  it("drops self-parent refs before resolving /unfocus bindings", async () => {
+    hoisted.resolveConversationBindingContextMock.mockReturnValue({
+      channel: THREAD_CHANNEL,
+      accountId: "default",
+      conversationId: "dm-1",
+      parentConversationId: "dm-1",
+    });
+    hoisted.sessionBindingResolveByConversationMock.mockReturnValue(
+      createSessionBindingRecord({
+        bindingId: "default:dm-1",
+        conversation: {
+          channel: THREAD_CHANNEL,
+          accountId: "default",
+          conversationId: "dm-1",
+        },
+        metadata: { boundBy: "user-1" },
+      }),
+    );
+
+    const result = await handleSubagentsUnfocusAction(buildUnfocusContext());
+
+    expect(result.reply?.text).toContain("Conversation unfocused");
+    expect(hoisted.sessionBindingResolveByConversationMock).toHaveBeenCalledWith({
+      channel: THREAD_CHANNEL,
+      accountId: "default",
+      conversationId: "dm-1",
+    });
+    expect(hoisted.sessionBindingUnbindMock).toHaveBeenCalledWith({
+      bindingId: "default:dm-1",
+      reason: "manual",
+    });
+  });
 });

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -16,6 +16,7 @@ import {
   resolveThreadBindingPlacementForCurrentContext,
   resolveThreadBindingSpawnPolicy,
 } from "../../../channels/thread-bindings-policy.js";
+import { normalizeConversationRef } from "../../../infra/outbound/session-binding-normalization.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import type { CommandHandlerResult } from "../commands-types.js";
@@ -38,12 +39,18 @@ function resolveFocusBindingContext(
     return null;
   }
   const chatType = normalizeChatType(params.ctx.ChatType);
-  return {
+  const conversation = normalizeConversationRef({
     channel: bindingContext.channel,
     accountId: bindingContext.accountId,
     conversationId: bindingContext.conversationId,
-    ...(bindingContext.parentConversationId
-      ? { parentConversationId: bindingContext.parentConversationId }
+    parentConversationId: bindingContext.parentConversationId,
+  });
+  return {
+    channel: conversation.channel,
+    accountId: conversation.accountId,
+    conversationId: conversation.conversationId,
+    ...(conversation.parentConversationId
+      ? { parentConversationId: conversation.parentConversationId }
       : {}),
     placement:
       chatType === "direct"
@@ -111,15 +118,13 @@ export async function handleSubagentsFocusAction(
   }
 
   const senderId = normalizeOptionalString(params.command.senderId) ?? "";
-  const existingBinding = bindingService.resolveByConversation({
+  const conversationRef = normalizeConversationRef({
     channel: bindingContext.channel,
     accountId: bindingContext.accountId,
     conversationId: bindingContext.conversationId,
-    ...(bindingContext.parentConversationId &&
-    bindingContext.parentConversationId !== bindingContext.conversationId
-      ? { parentConversationId: bindingContext.parentConversationId }
-      : {}),
+    parentConversationId: bindingContext.parentConversationId,
   });
+  const existingBinding = bindingService.resolveByConversation(conversationRef);
   const boundBy =
     typeof existingBinding?.metadata?.boundBy === "string"
       ? existingBinding.metadata.boundBy.trim()
@@ -146,15 +151,12 @@ export async function handleSubagentsFocusAction(
     binding = await bindingService.bind({
       targetSessionKey: focusTarget.targetSessionKey,
       targetKind: focusTarget.targetKind === "acp" ? "session" : "subagent",
-      conversation: {
+      conversation: normalizeConversationRef({
         channel: bindingContext.channel,
         accountId: bindingContext.accountId,
         conversationId: bindingContext.conversationId,
-        ...(bindingContext.parentConversationId &&
-        bindingContext.parentConversationId !== bindingContext.conversationId
-          ? { parentConversationId: bindingContext.parentConversationId }
-          : {}),
-      },
+        parentConversationId: bindingContext.parentConversationId,
+      }),
       placement: bindingContext.placement,
       metadata: {
         threadName: resolveThreadBindingThreadName({

--- a/src/auto-reply/reply/commands-subagents/action-unfocus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-unfocus.ts
@@ -1,3 +1,4 @@
+import { normalizeConversationRef } from "../../../infra/outbound/session-binding-normalization.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import type { CommandHandlerResult } from "../commands-types.js";
@@ -14,15 +15,14 @@ export async function handleSubagentsUnfocusAction(
     return stopWithText("⚠️ /unfocus must be run inside a focused conversation.");
   }
 
-  const binding = bindingService.resolveByConversation({
-    channel: bindingContext.channel,
-    accountId: bindingContext.accountId,
-    conversationId: bindingContext.conversationId,
-    ...(bindingContext.parentConversationId &&
-    bindingContext.parentConversationId !== bindingContext.conversationId
-      ? { parentConversationId: bindingContext.parentConversationId }
-      : {}),
-  });
+  const binding = bindingService.resolveByConversation(
+    normalizeConversationRef({
+      channel: bindingContext.channel,
+      accountId: bindingContext.accountId,
+      conversationId: bindingContext.conversationId,
+      parentConversationId: bindingContext.parentConversationId,
+    }),
+  );
   if (!binding) {
     return stopWithText("ℹ️ This conversation is not currently focused.");
   }

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -123,6 +123,39 @@ describe("generic current-conversation bindings", () => {
     });
   });
 
+  it("drops self-parent conversation refs when storing generic current bindings", async () => {
+    const bound = await bindGenericCurrentConversation({
+      targetSessionKey: "agent:codex:acp:telegram-dm",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "6098642967",
+        parentConversationId: "6098642967",
+      },
+    });
+
+    expect(bound).toMatchObject({
+      bindingId: "generic:telegram\u241fdefault\u241f\u241f6098642967",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "6098642967",
+      },
+    });
+    expect(bound?.conversation.parentConversationId).toBeUndefined();
+    expect(
+      resolveGenericCurrentConversationBinding({
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "6098642967",
+      }),
+    ).toMatchObject({
+      bindingId: "generic:telegram\u241fdefault\u241f\u241f6098642967",
+      targetSessionKey: "agent:codex:acp:telegram-dm",
+    });
+  });
+
   it("removes persisted bindings on unbind", async () => {
     await bindGenericCurrentConversation({
       targetSessionKey: "agent:codex:acp:googlechat-room",

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -156,6 +156,72 @@ describe("generic current-conversation bindings", () => {
     });
   });
 
+  it("migrates persisted legacy self-parent binding ids on load", async () => {
+    const filePath = __testing.resolveBindingsFilePath();
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        bindings: [
+          {
+            bindingId: "generic:telegram\u241fdefault\u241f6098642967\u241f6098642967",
+            targetSessionKey: "agent:codex:acp:telegram-dm",
+            targetKind: "session",
+            conversation: {
+              channel: "telegram",
+              accountId: "default",
+              conversationId: "6098642967",
+              parentConversationId: "6098642967",
+            },
+            status: "active",
+            boundAt: 1234,
+            metadata: {
+              label: "telegram-dm",
+            },
+          },
+        ],
+      }),
+    );
+
+    const resolved = resolveGenericCurrentConversationBinding({
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "6098642967",
+    });
+
+    expect(resolved).toMatchObject({
+      bindingId: "generic:telegram\u241fdefault\u241f\u241f6098642967",
+      targetSessionKey: "agent:codex:acp:telegram-dm",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "6098642967",
+      },
+    });
+    expect(resolved?.conversation.parentConversationId).toBeUndefined();
+
+    await expect(
+      unbindGenericCurrentConversationBindings({
+        bindingId: resolved?.bindingId,
+        reason: "test cleanup",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        bindingId: "generic:telegram\u241fdefault\u241f\u241f6098642967",
+      }),
+    ]);
+
+    __testing.resetCurrentConversationBindingsForTests();
+    expect(
+      resolveGenericCurrentConversationBinding({
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "6098642967",
+      }),
+    ).toBeNull();
+  });
+
   it("removes persisted bindings on unbind", async () => {
     await bindGenericCurrentConversation({
       targetSessionKey: "agent:codex:acp:googlechat-room",

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -76,9 +76,11 @@ function loadBindingsIntoMemory(): void {
     if (!record?.bindingId || !record?.conversation?.conversationId || isBindingExpired(record)) {
       continue;
     }
-    bindingsByConversationKey.set(buildConversationKey(record.conversation), {
+    const conversation = normalizeConversationRef(record.conversation);
+    bindingsByConversationKey.set(buildConversationKey(conversation), {
       ...record,
-      conversation: normalizeConversationRef(record.conversation),
+      bindingId: buildBindingId(conversation),
+      conversation,
     });
   }
 }

--- a/src/infra/outbound/session-binding-normalization.ts
+++ b/src/infra/outbound/session-binding-normalization.ts
@@ -11,13 +11,30 @@ export type ConversationRefShape = {
   parentConversationId?: string;
 };
 
-export function normalizeConversationRef<T extends ConversationRefShape>(ref: T): T {
+type ConversationTargetRefShape = {
+  conversationId: string;
+  parentConversationId?: string | null;
+};
+
+export function normalizeConversationTargetRef<T extends ConversationTargetRefShape>(ref: T): T {
+  const conversationId = normalizeOptionalString(ref.conversationId) ?? "";
+  const parentConversationId = normalizeOptionalString(ref.parentConversationId);
+  const { parentConversationId: _ignoredParentConversationId, ...rest } = ref;
   return {
-    ...ref,
+    ...rest,
+    conversationId,
+    ...(parentConversationId && parentConversationId !== conversationId
+      ? { parentConversationId }
+      : {}),
+  } as T;
+}
+
+export function normalizeConversationRef<T extends ConversationRefShape>(ref: T): T {
+  const normalizedTarget = normalizeConversationTargetRef(ref);
+  return {
+    ...normalizedTarget,
     channel: normalizeLowercaseStringOrEmpty(ref.channel),
     accountId: normalizeAccountId(ref.accountId),
-    conversationId: normalizeOptionalString(ref.conversationId) ?? "",
-    parentConversationId: normalizeOptionalString(ref.parentConversationId),
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: ACP thread-bound session spawn reused a lossy `groupId` as the transport target, which lowercased mixed-case Matrix room ids and dropped parent conversation context for thread binds.
- Why it matters: Matrix ACP binds could fail from top-level rooms or existing threads, while other channels rely on the same core seam.
- What changed: `src/agents/acp-spawn.ts` now resolves full conversation refs through the plugin seam, keeps canonical `to` authoritative, preserves `parentConversationId` for thread binds, and keeps channel-specific fallback behavior intact.
- What did NOT change (scope boundary): session/group metadata normalization and broader `groupId` semantics across policy/config code were not redesigned here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63828
- Related #63828
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: ACP thread spawn collapsed canonical `to` and fallback `groupId` into the same value before calling `resolveInboundConversation()`, so case-sensitive Matrix room ids were lowercased and parent conversation refs for thread binds were lost.
- Missing detection / guardrail: ACP spawn lacked a seam test that exercised mixed-case Matrix room ids and existing-thread binds through the generic plugin contract.
- Contributing context (if known): `groupId` is still overloaded in core for policy/session metadata, so the ACP seam needed to prefer canonical routing data without changing broader `groupId` behavior for other channels.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/acp-spawn.test.ts`
- Scenario the test should lock in: ACP `thread=true` preserves canonical Matrix room casing from both top-level rooms and existing Matrix threads while leaving LINE and Telegram behavior unchanged.
- Why this is the smallest reliable guardrail: the regression lives at the generic ACP spawn-to-plugin seam, not inside Matrix-only binding code.
- Existing test that already covers this (if any): existing Discord/Telegram ACP spawn tests cover neighboring thread-binding behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Matrix ACP thread-bound session spawns now bind correctly when the room id casing differs from persisted `groupId`, including spawns launched from existing Matrix threads.

## Diagram (if applicable)

```text
Before:
[sessions_spawn thread=true] -> [ACP spawn uses lowercased groupId for to + conversationId]
-> [Matrix resolves wrong parent room] -> [bind/send can fail]

After:
[sessions_spawn thread=true] -> [ACP spawn passes canonical to + fallback conversationId]
-> [plugin resolves full conversation ref] -> [bind/send uses correct room + thread context]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo dev environment
- Model/provider: N/A
- Integration/channel (if any): Matrix ACP thread bindings
- Relevant config (redacted): `channels.matrix.threadBindings.enabled=true`

### Steps

1. Start from a Matrix room with a mixed-case room id and persisted lowercased `groupId`.
2. Trigger `sessions_spawn({ runtime: "acp", thread: true })` from the room or from an existing Matrix thread.
3. Observe the created ACP binding target.

### Expected

- ACP spawn binds using the canonical Matrix room id, preserving parent conversation context for thread binds.

### Actual

- Before this fix, ACP spawn could bind/send using the lowercased room id or lose the parent room when launched from an existing thread.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- `pnpm test src/agents/acp-spawn.test.ts`
- `pnpm check`
