### PR TITLE
fix(package): include qa/scenarios in npm published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
     "skills/",
+    "qa/",
     "scripts/npm-runner.mjs",
     "scripts/postinstall-bundled-plugins.mjs",
     "scripts/windows-cmd-helpers.mjs"


### PR DESCRIPTION
## Summary

Fixes #64348 — `openclaw@2026.4.9` is missing `qa/scenarios/*` files in the npm tarball, causing CLI crashes:

```
Error: qa scenario pack not found: qa/scenarios/index.md
```

## Fix

Add `qa/` to `package.json` `files` array so it's included in the npm package.

## Verification

`npm pack --dry-run` now includes `qa/scenarios/*.md` files.