### PR TITLE
fix(media): decode URI-encoded filenames from URLs for Feishu

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -232,7 +232,13 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     try {
       const parsed = new URL(finalUrl);
       const base = path.basename(parsed.pathname);
-      fileNameFromUrl = base || undefined;
+      // Decode URI-encoded filenames (e.g. Chinese characters: %E4%B9%A6 → 书)
+      // so downstream consumers see the original human-readable name.
+      try {
+        fileNameFromUrl = base ? decodeURIComponent(base) : undefined;
+      } catch {
+        fileNameFromUrl = base || undefined;
+      }
     } catch {
       // ignore parse errors; leave undefined
     }


### PR DESCRIPTION
## Summary

Fixes #40770 — 飞书发送中文文件名文件时，文件名被 URL 编码（如 `%E4%B9%A6%E8%AE%B0...` 而非 `书记...`）。

## Root Cause

In `src/media/fetch.ts`, `fetchRemoteMedia` extracts the filename from the URL pathname via `path.basename(parsed.pathname)`. When the URL contains percent-encoded non-ASCII characters (common for Chinese filenames), the extracted name retains the encoding. This encoded name propagates to Feishu's `file_name` parameter on upload, causing garbled display.

## Fix

Apply `decodeURIComponent()` to the extracted basename, with a try/catch fallback to the raw value for malformed percent sequences.

## Before → After

| Before | After |
|--------|-------|
| `%E4%B9%A6%E8%AE%B0%E5%8F%82%E8%A7%82...docx` | `书记参观接待演示方案.docx` |

## Changes

- `src/media/fetch.ts`: decode URL-extracted filename with `decodeURIComponent`