### PR TITLE
[Feat] Add Campfire channel integration (37signals self-hosted chat) #7880

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,11 @@
       - any-glob-to-any-file:
           - "extensions/bluebubbles/**"
           - "docs/channels/bluebubbles.md"
+"channel: campfire":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/campfire/**"
+          - "docs/channels/campfire.md"
 "channel: discord":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/channels/campfire.md
+++ b/docs/channels/campfire.md
@@ -39,8 +39,8 @@ Details: [Plugins](/tools/plugin)
 3. Point Campfire webhook delivery to your OpenClaw gateway path:
    - Default: `/channels/campfire/webhook/default`
    - Per-account default: `/channels/campfire/webhook/<account-id>`
-4. If you set `webhookSecret`, include it as a query parameter in the webhook URL:
-   - `?secret=<webhookSecret>`
+4. If you set `webhookSecret`, prefer sending it in the `X-Webhook-Secret` request header.
+   - If Campfire cannot set custom headers directly, keep `?secret=<webhookSecret>` only as a backward-compatible fallback, ideally behind a reverse proxy that adds the header.
 5. Restart gateway and send a message in a configured Campfire room.
 
 Minimal config:
@@ -65,7 +65,7 @@ Minimal config:
 
 - `allowFrom` is a Campfire user-id allowlist for inbound webhook events.
 - Empty `allowFrom` means allow all senders.
-- `webhookSecret` protects inbound requests and must match the `secret` query parameter.
+- `webhookSecret` protects inbound requests and is checked against `X-Webhook-Secret` first, with `?secret=` accepted as a legacy fallback.
 
 ## Outbound delivery
 
@@ -114,7 +114,7 @@ Full configuration: [Configuration](/gateway/configuration)
 - `channels.campfire.enabled`: enable/disable startup.
 - `channels.campfire.baseUrl`: Campfire base URL for the workspace.
 - `channels.campfire.botKey`: Campfire bot API key.
-- `channels.campfire.webhookSecret`: optional shared secret checked from `?secret=`.
+- `channels.campfire.webhookSecret`: optional shared secret checked from `X-Webhook-Secret`, with `?secret=` accepted as a backward-compatible fallback.
 - `channels.campfire.allowFrom`: inbound allowlist of Campfire user IDs (as strings).
 - `channels.campfire.webhookPath`: inbound webhook route path.
 - `channels.campfire.textChunkLimit`: outbound chunk size in characters.

--- a/docs/channels/campfire.md
+++ b/docs/channels/campfire.md
@@ -1,0 +1,122 @@
+---
+summary: "Campfire webhook setup and OpenClaw config"
+read_when:
+  - Setting up Campfire with OpenClaw
+  - Debugging Campfire webhook delivery
+title: "Campfire"
+---
+
+# Campfire (plugin)
+
+Status: supported via plugin as a room channel using Campfire webhooks.
+OpenClaw accepts inbound Campfire webhook events and posts plain-text replies to the room message URL.
+
+## Plugin required
+
+Campfire is plugin-based and is not bundled with the default core channel install.
+
+Install via CLI (npm registry):
+
+```bash
+openclaw plugins install @openclaw/campfire
+```
+
+Local checkout (when running from a git repo):
+
+```bash
+openclaw plugins install ./extensions/campfire
+```
+
+Details: [Plugins](/tools/plugin)
+
+## Quick setup
+
+1. Install and enable the Campfire plugin.
+2. Configure your Campfire account in OpenClaw with:
+   - `baseUrl` (for example `https://3.basecamp.com/1234567`)
+   - `botKey`
+   - Optional `webhookSecret`
+3. Point Campfire webhook delivery to your OpenClaw gateway path:
+   - Default: `/channels/campfire/webhook/default`
+   - Per-account default: `/channels/campfire/webhook/<account-id>`
+4. If you set `webhookSecret`, include it as a query parameter in the webhook URL:
+   - `?secret=<webhookSecret>`
+5. Restart gateway and send a message in a configured Campfire room.
+
+Minimal config:
+
+```json5
+{
+  channels: {
+    campfire: {
+      enabled: true,
+      baseUrl: "https://3.basecamp.com/1234567",
+      botKey: "campfire-bot-key",
+      webhookSecret: "shared-secret",
+      allowFrom: ["42"],
+      webhookPath: "/channels/campfire/webhook/default",
+      textChunkLimit: 4000,
+    },
+  },
+}
+```
+
+## Access control
+
+- `allowFrom` is a Campfire user-id allowlist for inbound webhook events.
+- Empty `allowFrom` means allow all senders.
+- `webhookSecret` protects inbound requests and must match the `secret` query parameter.
+
+## Outbound delivery
+
+- Replies are sent as `text/plain`.
+- Long replies are split sequentially by `textChunkLimit`.
+- Manual sends support room message URLs as targets:
+
+```bash
+openclaw message send --channel campfire --target "https://3.basecamp.com/1234567/buckets/999/chats/111/messages/222" --text "Hello from OpenClaw"
+```
+
+- Target URLs must match `channels.campfire.baseUrl` origin.
+
+## Multi-account
+
+Use `channels.campfire.accounts` for multiple Campfire workspaces or bot identities.
+Each account can override base URL, bot key, webhook path, allowlist, and chunking.
+
+```json5
+{
+  channels: {
+    campfire: {
+      defaultAccount: "default",
+      accounts: {
+        default: {
+          baseUrl: "https://3.basecamp.com/1234567",
+          botKey: "campfire-key-a",
+          webhookPath: "/channels/campfire/webhook/default",
+        },
+        support: {
+          baseUrl: "https://3.basecamp.com/7654321",
+          botKey: "campfire-key-b",
+          webhookPath: "/channels/campfire/webhook/support",
+          allowFrom: ["99", "100"],
+        },
+      },
+    },
+  },
+}
+```
+
+## Configuration reference (Campfire)
+
+Full configuration: [Configuration](/gateway/configuration)
+
+- `channels.campfire.enabled`: enable/disable startup.
+- `channels.campfire.baseUrl`: Campfire base URL for the workspace.
+- `channels.campfire.botKey`: Campfire bot API key.
+- `channels.campfire.webhookSecret`: optional shared secret checked from `?secret=`.
+- `channels.campfire.allowFrom`: inbound allowlist of Campfire user IDs (as strings).
+- `channels.campfire.webhookPath`: inbound webhook route path.
+- `channels.campfire.textChunkLimit`: outbound chunk size in characters.
+- `channels.campfire.defaultAccount`: default account id for sends.
+- `channels.campfire.accounts`: per-account overrides.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -14,6 +14,7 @@ Text is supported everywhere; media and reactions vary by channel.
 ## Supported channels
 
 - [BlueBubbles](/channels/bluebubbles) — **Recommended for iMessage**; uses the BlueBubbles macOS server REST API with full feature support (bundled plugin; edit, unsend, effects, reactions, group management — edit currently broken on macOS 26 Tahoe).
+- [Campfire](/channels/campfire) — 37signals Campfire webhook integration (plugin, installed separately).
 - [Discord](/channels/discord) — Discord Bot API + Gateway; supports servers, channels, and DMs.
 - [Feishu](/channels/feishu) — Feishu/Lark bot via WebSocket (bundled plugin).
 - [Google Chat](/channels/googlechat) — Google Chat API app via HTTP webhook.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1005,6 +1005,7 @@
                 "group": "Messaging platforms",
                 "pages": [
                   "channels/bluebubbles",
+                  "channels/campfire",
                   "channels/discord",
                   "channels/feishu",
                   "channels/googlechat",

--- a/extensions/campfire/index.ts
+++ b/extensions/campfire/index.ts
@@ -1,0 +1,14 @@
+import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
+import { campfirePlugin } from "./src/channel.js";
+import { setCampfireRuntime } from "./src/runtime.js";
+
+export { campfirePlugin } from "./src/channel.js";
+export { setCampfireRuntime } from "./src/runtime.js";
+
+export default defineChannelPluginEntry({
+  id: "campfire",
+  name: "Campfire",
+  description: "Campfire channel plugin",
+  plugin: campfirePlugin,
+  setRuntime: setCampfireRuntime,
+});

--- a/extensions/campfire/openclaw.plugin.json
+++ b/extensions/campfire/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "campfire",
+  "channels": ["campfire"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/campfire/package.json
+++ b/extensions/campfire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/campfire",
-  "version": "2026.3.14",
+  "version": "2026.4.10",
   "description": "OpenClaw Campfire channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/campfire/package.json
+++ b/extensions/campfire/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openclaw/campfire",
+  "version": "2026.3.14",
+  "description": "OpenClaw Campfire channel plugin",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "setupEntry": "./setup-entry.ts",
+    "channel": {
+      "id": "campfire",
+      "label": "Campfire",
+      "selectionLabel": "Campfire (Webhook)",
+      "detailLabel": "Campfire",
+      "docsPath": "/channels/campfire",
+      "docsLabel": "campfire",
+      "blurb": "Self-hosted Campfire bot webhook integration.",
+      "order": 65
+    },
+    "install": {
+      "npmSpec": "@openclaw/campfire",
+      "localPath": "extensions/campfire",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/campfire/package.json
+++ b/extensions/campfire/package.json
@@ -25,6 +25,9 @@
       "npmSpec": "@openclaw/campfire",
       "localPath": "extensions/campfire",
       "defaultChoice": "npm"
+    },
+    "release": {
+      "publishToNpm": true
     }
   }
 }

--- a/extensions/campfire/package.json
+++ b/extensions/campfire/package.json
@@ -24,7 +24,8 @@
     "install": {
       "npmSpec": "@openclaw/campfire",
       "localPath": "extensions/campfire",
-      "defaultChoice": "npm"
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.4.10"
     },
     "release": {
       "publishToNpm": true

--- a/extensions/campfire/setup-entry.ts
+++ b/extensions/campfire/setup-entry.ts
@@ -1,0 +1,4 @@
+import { defineSetupPluginEntry } from "openclaw/plugin-sdk/core";
+import { campfirePlugin } from "./src/channel.js";
+
+export default defineSetupPluginEntry(campfirePlugin);

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -63,4 +63,27 @@ describe("campfire channel plugin", () => {
     ).rejects.toThrow("must match channels.campfire.baseUrl");
     expect(sendText).not.toHaveBeenCalled();
   });
+
+  it("rejects outbound targets outside the configured workspace path", async () => {
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const plugin = createCampfirePlugin({ sendText });
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://3.basecamp.com/1234567",
+          botKey: "42-AbCdEf",
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      plugin.outbound?.sendText?.({
+        cfg,
+        to: "https://3.basecamp.com/7654321/buckets/7/chats/88/messages/99",
+        text: "Hello world",
+        accountId: "default",
+      }),
+    ).rejects.toThrow("must match channels.campfire.baseUrl");
+    expect(sendText).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -1,0 +1,66 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createCampfirePlugin } from "./channel.js";
+
+describe("campfire channel plugin", () => {
+  it("sends outbound text using account chunk settings", async () => {
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const plugin = createCampfirePlugin({
+      sendText,
+      now: () => 123,
+    });
+
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "42-AbCdEf",
+          textChunkLimit: 2500,
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await plugin.outbound?.sendText?.({
+      cfg,
+      to: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+      text: "Hello world",
+      accountId: "default",
+    });
+
+    expect(sendText).toHaveBeenCalledWith(
+      "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+      "Hello world",
+      2500,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        channel: "campfire",
+        chatId: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+        messageId: "campfire-123",
+      }),
+    );
+  });
+
+  it("rejects outbound targets outside the configured base URL", async () => {
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const plugin = createCampfirePlugin({ sendText });
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "42-AbCdEf",
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      plugin.outbound?.sendText?.({
+        cfg,
+        to: "https://attacker.example.net/rooms/7/key/messages",
+        text: "Hello world",
+        accountId: "default",
+      }),
+    ).rejects.toThrow("must match channels.campfire.baseUrl");
+    expect(sendText).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -30,6 +30,7 @@ describe("campfire channel plugin", () => {
     expect(sendText).toHaveBeenCalledWith(
       "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
       "Hello world",
+      "42-AbCdEf",
       2500,
     );
     expect(result).toEqual(

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -110,6 +110,26 @@ describe("campfire channel plugin", () => {
     expect(route?.sessionKey).not.toContain("https://campfire.example.com");
   });
 
+  it("uses Basecamp bucket id for outbound session routing", async () => {
+    const plugin = createCampfirePlugin();
+
+    const route = await plugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {},
+      agentId: "main",
+      accountId: "default",
+      target: "https://3.basecamp.com/1234567/buckets/7/chats/88/messages/99",
+    });
+
+    expect(route).toEqual(
+      expect.objectContaining({
+        peer: { kind: "group", id: "7" },
+        from: "campfire:room:7",
+        to: "campfire:room:7",
+      }),
+    );
+    expect(route?.sessionKey).toContain(":group:7");
+  });
+
   it("exposes setup applyAccountConfig for channel add", () => {
     const plugin = createCampfirePlugin();
 

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -110,7 +110,7 @@ describe("campfire channel plugin", () => {
     expect(route?.sessionKey).not.toContain("https://campfire.example.com");
   });
 
-  it("uses Basecamp bucket id for outbound session routing", async () => {
+  it("uses Basecamp chat id for outbound session routing", async () => {
     const plugin = createCampfirePlugin();
 
     const route = await plugin.messaging?.resolveOutboundSessionRoute?.({
@@ -122,12 +122,12 @@ describe("campfire channel plugin", () => {
 
     expect(route).toEqual(
       expect.objectContaining({
-        peer: { kind: "group", id: "7" },
-        from: "campfire:room:7",
-        to: "campfire:room:7",
+        peer: { kind: "group", id: "88" },
+        from: "campfire:room:88",
+        to: "campfire:room:88",
       }),
     );
-    expect(route?.sessionKey).toContain(":group:7");
+    expect(route?.sessionKey).toContain(":group:88");
   });
 
   it("exposes setup applyAccountConfig for channel add", () => {

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -119,6 +119,7 @@ describe("campfire channel plugin", () => {
       input: {
         httpUrl: "https://3.basecamp.com/1234567/",
         botToken: "42-AbCdEf",
+        webhookSecret: "shared-secret",
       },
     } as never);
 
@@ -127,12 +128,14 @@ describe("campfire channel plugin", () => {
           enabled?: boolean;
           baseUrl?: string;
           botKey?: string;
+          webhookSecret?: string;
         }
       | undefined;
     expect(section).toBeTruthy();
     expect(section?.enabled).toBe(true);
     expect(section?.baseUrl).toBe("https://3.basecamp.com/1234567");
     expect(section?.botKey).toBe("42-AbCdEf");
+    expect(section?.webhookSecret).toBe("shared-secret");
   });
 
   it("writes named-account setup values under channels.campfire.accounts", () => {
@@ -145,6 +148,7 @@ describe("campfire channel plugin", () => {
         url: "https://3.basecamp.com/7654321",
         token: "99-ZyXwVu",
         webhookPath: "/channels/campfire/webhook/support",
+        webhookSecret: "support-secret",
       },
     } as never);
 
@@ -158,6 +162,7 @@ describe("campfire channel plugin", () => {
               baseUrl?: string;
               botKey?: string;
               webhookPath?: string;
+              webhookSecret?: string;
             }
           >;
         }
@@ -167,5 +172,32 @@ describe("campfire channel plugin", () => {
     expect(section?.accounts?.support?.baseUrl).toBe("https://3.basecamp.com/7654321");
     expect(section?.accounts?.support?.botKey).toBe("99-ZyXwVu");
     expect(section?.accounts?.support?.webhookPath).toBe("/channels/campfire/webhook/support");
+    expect(section?.accounts?.support?.webhookSecret).toBe("support-secret");
+  });
+
+  it("preserves existing webhookSecret when setup input omits it", () => {
+    const plugin = createCampfirePlugin();
+
+    const next = plugin.setup?.applyAccountConfig({
+      cfg: {
+        channels: {
+          campfire: {
+            webhookSecret: "keep-me",
+          },
+        },
+      },
+      accountId: "default",
+      input: {
+        httpUrl: "https://3.basecamp.com/1234567",
+        botToken: "42-AbCdEf",
+      },
+    } as never);
+
+    const section = next?.channels?.campfire as
+      | {
+          webhookSecret?: string;
+        }
+      | undefined;
+    expect(section?.webhookSecret).toBe("keep-me");
   });
 });

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -87,4 +87,26 @@ describe("campfire channel plugin", () => {
     ).rejects.toThrow("must match channels.campfire.baseUrl");
     expect(sendText).not.toHaveBeenCalled();
   });
+
+  it("resolves outbound session routing to stable room identity", async () => {
+    const plugin = createCampfirePlugin();
+
+    const route = await plugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {},
+      agentId: "main",
+      accountId: "default",
+      target: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+    });
+
+    expect(route).toEqual(
+      expect.objectContaining({
+        peer: { kind: "group", id: "7" },
+        chatType: "group",
+        from: "campfire:room:7",
+        to: "campfire:room:7",
+      }),
+    );
+    expect(route?.sessionKey).toContain(":group:7");
+    expect(route?.sessionKey).not.toContain("https://campfire.example.com");
+  });
 });

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -36,7 +36,7 @@ describe("campfire channel plugin", () => {
     expect(result).toEqual(
       expect.objectContaining({
         channel: "campfire",
-        chatId: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+        chatId: "campfire:room:7",
         messageId: "campfire-123",
       }),
     );

--- a/extensions/campfire/src/channel.test.ts
+++ b/extensions/campfire/src/channel.test.ts
@@ -109,4 +109,63 @@ describe("campfire channel plugin", () => {
     expect(route?.sessionKey).toContain(":group:7");
     expect(route?.sessionKey).not.toContain("https://campfire.example.com");
   });
+
+  it("exposes setup applyAccountConfig for channel add", () => {
+    const plugin = createCampfirePlugin();
+
+    const next = plugin.setup?.applyAccountConfig({
+      cfg: {},
+      accountId: "default",
+      input: {
+        httpUrl: "https://3.basecamp.com/1234567/",
+        botToken: "42-AbCdEf",
+      },
+    } as never);
+
+    const section = next?.channels?.campfire as
+      | {
+          enabled?: boolean;
+          baseUrl?: string;
+          botKey?: string;
+        }
+      | undefined;
+    expect(section).toBeTruthy();
+    expect(section?.enabled).toBe(true);
+    expect(section?.baseUrl).toBe("https://3.basecamp.com/1234567");
+    expect(section?.botKey).toBe("42-AbCdEf");
+  });
+
+  it("writes named-account setup values under channels.campfire.accounts", () => {
+    const plugin = createCampfirePlugin();
+
+    const next = plugin.setup?.applyAccountConfig({
+      cfg: {},
+      accountId: "support",
+      input: {
+        url: "https://3.basecamp.com/7654321",
+        token: "99-ZyXwVu",
+        webhookPath: "/channels/campfire/webhook/support",
+      },
+    } as never);
+
+    const section = next?.channels?.campfire as
+      | {
+          enabled?: boolean;
+          accounts?: Record<
+            string,
+            {
+              enabled?: boolean;
+              baseUrl?: string;
+              botKey?: string;
+              webhookPath?: string;
+            }
+          >;
+        }
+      | undefined;
+    expect(section?.enabled).toBe(true);
+    expect(section?.accounts?.support?.enabled).toBe(true);
+    expect(section?.accounts?.support?.baseUrl).toBe("https://3.basecamp.com/7654321");
+    expect(section?.accounts?.support?.botKey).toBe("99-ZyXwVu");
+    expect(section?.accounts?.support?.webhookPath).toBe("/channels/campfire/webhook/support");
+  });
 });

--- a/extensions/campfire/src/channel.ts
+++ b/extensions/campfire/src/channel.ts
@@ -1,0 +1,109 @@
+import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import {
+  campfireChannelConfigSchema,
+  campfireConfigAdapter,
+  resolveCampfireAccount,
+} from "./config.js";
+import { campfireGateway } from "./monitor/provider.js";
+import { sendCampfireText } from "./send.js";
+import type { ResolvedCampfireAccount } from "./types.js";
+
+function resolveOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function assertCampfireOutboundTarget(target: string, account: ResolvedCampfireAccount): string {
+  const normalizedTarget = target.trim();
+  if (!normalizedTarget) {
+    throw new Error("Campfire target URL is required");
+  }
+
+  const targetOrigin = resolveOrigin(normalizedTarget);
+  if (!targetOrigin) {
+    throw new Error("Campfire target must be a valid URL");
+  }
+
+  const accountOrigin = resolveOrigin(account.baseUrl);
+  if (accountOrigin && targetOrigin !== accountOrigin) {
+    throw new Error("Campfire target must match channels.campfire.baseUrl");
+  }
+
+  return normalizedTarget;
+}
+
+export function createCampfirePlugin(params?: {
+  sendText?: typeof sendCampfireText;
+  now?: () => number;
+  gateway?: typeof campfireGateway;
+}): ChannelPlugin<ResolvedCampfireAccount> {
+  const sendText = params?.sendText ?? sendCampfireText;
+  const now = params?.now ?? Date.now;
+  const gateway = params?.gateway ?? campfireGateway;
+
+  return {
+    id: "campfire",
+    meta: {
+      id: "campfire",
+      label: "Campfire",
+      selectionLabel: "Campfire (Webhook)",
+      detailLabel: "Campfire",
+      docsPath: "/channels/campfire",
+      docsLabel: "campfire",
+      blurb: "Self-hosted 37signals Campfire webhook integration.",
+      order: 65,
+    },
+    capabilities: {
+      chatTypes: ["group"],
+      media: false,
+      threads: false,
+      reactions: false,
+      nativeCommands: false,
+      blockStreaming: true,
+    },
+    reload: {
+      configPrefixes: ["channels.campfire"],
+    },
+    configSchema: campfireChannelConfigSchema,
+    config: {
+      ...campfireConfigAdapter,
+      isConfigured: (account) => account.configured,
+      describeAccount: (account) => ({
+        accountId: account.accountId,
+        name: account.name,
+        enabled: account.enabled,
+        configured: account.configured,
+        baseUrl: account.baseUrl ? "[set]" : "[missing]",
+      }),
+    },
+    messaging: {
+      normalizeTarget: (target) => target.trim() || undefined,
+      targetResolver: {
+        looksLikeId: (id) => Boolean(resolveOrigin(id.trim())),
+        hint: "<campfire room webhook URL>",
+      },
+    },
+    outbound: {
+      deliveryMode: "direct",
+      textChunkLimit: 4000,
+      sendText: async ({ cfg, to, text, accountId }) => {
+        const account = resolveCampfireAccount(cfg as OpenClawConfig, accountId);
+        const target = assertCampfireOutboundTarget(to, account);
+
+        await sendText(target, text, account.textChunkLimit);
+        return attachChannelToResult("campfire", {
+          chatId: target,
+          messageId: `campfire-${now()}`,
+        });
+      },
+    },
+    gateway,
+  };
+}
+
+export const campfirePlugin = createCampfirePlugin();

--- a/extensions/campfire/src/channel.ts
+++ b/extensions/campfire/src/channel.ts
@@ -1,5 +1,4 @@
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import {
   campfireChannelConfigSchema,
@@ -90,7 +89,7 @@ export function createCampfirePlugin(params?: {
       deliveryMode: "direct",
       textChunkLimit: 4000,
       sendText: async ({ cfg, to, text, accountId }) => {
-        const account = resolveCampfireAccount(cfg as OpenClawConfig, accountId);
+        const account = resolveCampfireAccount(cfg, accountId);
         const target = assertCampfireOutboundTarget(to, account);
         const roomId = resolveCampfireRoomIdFromTarget(target);
 

--- a/extensions/campfire/src/channel.ts
+++ b/extensions/campfire/src/channel.ts
@@ -9,14 +9,7 @@ import {
 import { campfireGateway } from "./monitor/provider.js";
 import { sendCampfireText } from "./send.js";
 import type { ResolvedCampfireAccount } from "./types.js";
-
-function resolveOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin;
-  } catch {
-    return null;
-  }
-}
+import { isCampfireUrlInWorkspaceScope, isValidCampfireUrl } from "./workspace-url.js";
 
 function assertCampfireOutboundTarget(target: string, account: ResolvedCampfireAccount): string {
   const normalizedTarget = target.trim();
@@ -24,13 +17,11 @@ function assertCampfireOutboundTarget(target: string, account: ResolvedCampfireA
     throw new Error("Campfire target URL is required");
   }
 
-  const targetOrigin = resolveOrigin(normalizedTarget);
-  if (!targetOrigin) {
+  if (!isValidCampfireUrl(normalizedTarget)) {
     throw new Error("Campfire target must be a valid URL");
   }
 
-  const accountOrigin = resolveOrigin(account.baseUrl);
-  if (accountOrigin && targetOrigin !== accountOrigin) {
+  if (!isCampfireUrlInWorkspaceScope(normalizedTarget, account.baseUrl)) {
     throw new Error("Campfire target must match channels.campfire.baseUrl");
   }
 
@@ -84,7 +75,7 @@ export function createCampfirePlugin(params?: {
     messaging: {
       normalizeTarget: (target) => target.trim() || undefined,
       targetResolver: {
-        looksLikeId: (id) => Boolean(resolveOrigin(id.trim())),
+        looksLikeId: (id) => isValidCampfireUrl(id.trim()),
         hint: "<campfire room webhook URL>",
       },
     },

--- a/extensions/campfire/src/channel.ts
+++ b/extensions/campfire/src/channel.ts
@@ -86,7 +86,7 @@ export function createCampfirePlugin(params?: {
         const account = resolveCampfireAccount(cfg as OpenClawConfig, accountId);
         const target = assertCampfireOutboundTarget(to, account);
 
-        await sendText(target, text, account.textChunkLimit);
+        await sendText(target, text, account.botKey, account.textChunkLimit);
         return attachChannelToResult("campfire", {
           chatId: target,
           messageId: `campfire-${now()}`,

--- a/extensions/campfire/src/channel.ts
+++ b/extensions/campfire/src/channel.ts
@@ -8,6 +8,7 @@ import {
 } from "./config.js";
 import { campfireGateway } from "./monitor/provider.js";
 import { sendCampfireText } from "./send.js";
+import { resolveCampfireOutboundSessionRoute } from "./session-route.js";
 import type { ResolvedCampfireAccount } from "./types.js";
 import { isCampfireUrlInWorkspaceScope, isValidCampfireUrl } from "./workspace-url.js";
 
@@ -74,6 +75,7 @@ export function createCampfirePlugin(params?: {
     },
     messaging: {
       normalizeTarget: (target) => target.trim() || undefined,
+      resolveOutboundSessionRoute: (params) => resolveCampfireOutboundSessionRoute(params),
       targetResolver: {
         looksLikeId: (id) => isValidCampfireUrl(id.trim()),
         hint: "<campfire room webhook URL>",

--- a/extensions/campfire/src/channel.ts
+++ b/extensions/campfire/src/channel.ts
@@ -9,6 +9,7 @@ import {
 import { campfireGateway } from "./monitor/provider.js";
 import { sendCampfireText } from "./send.js";
 import { resolveCampfireOutboundSessionRoute } from "./session-route.js";
+import { campfireSetupAdapter } from "./setup-core.js";
 import type { ResolvedCampfireAccount } from "./types.js";
 import { isCampfireUrlInWorkspaceScope, isValidCampfireUrl } from "./workspace-url.js";
 
@@ -73,6 +74,7 @@ export function createCampfirePlugin(params?: {
         baseUrl: account.baseUrl ? "[set]" : "[missing]",
       }),
     },
+    setup: campfireSetupAdapter,
     messaging: {
       normalizeTarget: (target) => target.trim() || undefined,
       resolveOutboundSessionRoute: (params) => resolveCampfireOutboundSessionRoute(params),

--- a/extensions/campfire/src/channel.ts
+++ b/extensions/campfire/src/channel.ts
@@ -8,7 +8,10 @@ import {
 } from "./config.js";
 import { campfireGateway } from "./monitor/provider.js";
 import { sendCampfireText } from "./send.js";
-import { resolveCampfireOutboundSessionRoute } from "./session-route.js";
+import {
+  resolveCampfireOutboundSessionRoute,
+  resolveCampfireRoomIdFromTarget,
+} from "./session-route.js";
 import { campfireSetupAdapter } from "./setup-core.js";
 import type { ResolvedCampfireAccount } from "./types.js";
 import { isCampfireUrlInWorkspaceScope, isValidCampfireUrl } from "./workspace-url.js";
@@ -89,10 +92,11 @@ export function createCampfirePlugin(params?: {
       sendText: async ({ cfg, to, text, accountId }) => {
         const account = resolveCampfireAccount(cfg as OpenClawConfig, accountId);
         const target = assertCampfireOutboundTarget(to, account);
+        const roomId = resolveCampfireRoomIdFromTarget(target);
 
         await sendText(target, text, account.botKey, account.textChunkLimit);
         return attachChannelToResult("campfire", {
-          chatId: target,
+          ...(roomId ? { chatId: `campfire:room:${roomId}` } : {}),
           messageId: `campfire-${now()}`,
         });
       },

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -145,6 +145,29 @@ describe("campfire config resolution", () => {
     expect(account.textChunkLimit).toBe(4000);
   });
 
+  it("does not inherit top-level webhookPath into named accounts", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "42-AbCdEf",
+          webhookPath: "/channels/campfire/webhook/shared",
+          accounts: {
+            support: {
+              botKey: "support-key",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const defaultAccount = resolveCampfireAccount(cfg, "default");
+    const supportAccount = resolveCampfireAccount(cfg, "support");
+
+    expect(defaultAccount.webhookPath).toBe("/channels/campfire/webhook/shared");
+    expect(supportAccount.webhookPath).toBe("/channels/campfire/webhook/support");
+  });
+
   it("lists multiple account IDs", () => {
     const cfg = {
       channels: {

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -250,4 +250,22 @@ describe("campfire config resolution", () => {
     expect(topLevelResult.success).toBe(false);
     expect(accountResult.success).toBe(false);
   });
+
+  it("rejects non-http(s) baseUrl protocols in schema", () => {
+    const topLevelResult = campfireConfigSchema.safeParse({
+      baseUrl: "ftp://campfire.example.com/1234567",
+      botKey: "42-AbCdEf",
+    });
+    const accountResult = campfireConfigSchema.safeParse({
+      accounts: {
+        support: {
+          baseUrl: "file:///tmp/campfire-room",
+          botKey: "99-ZyXwVu",
+        },
+      },
+    });
+
+    expect(topLevelResult.success).toBe(false);
+    expect(accountResult.success).toBe(false);
+  });
 });

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -159,6 +159,6 @@ describe("campfire config resolution", () => {
 
     const ids = listCampfireAccountIds(cfg);
 
-    expect(ids).toEqual(["alerts", "default", "support"]);
+    expect(ids).toEqual(["alerts", "support"]);
   });
 });

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -65,4 +65,100 @@ describe("campfire config resolution", () => {
     expect(account.allowFrom).toEqual(["Bob"]);
     expect(account.webhookPath).toBe("/channels/campfire/webhook/custom-alerts");
   });
+
+  it("marks account as unconfigured when baseUrl is missing", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          botKey: "42-AbCdEf",
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveCampfireAccount(cfg);
+
+    expect(account.configured).toBe(false);
+    expect(account.baseUrl).toBe("");
+  });
+
+  it("marks account as unconfigured when botKey is missing", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveCampfireAccount(cfg);
+
+    expect(account.configured).toBe(false);
+    expect(account.botKey).toBe("");
+  });
+
+  it("resolves disabled account", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "42-AbCdEf",
+          enabled: false,
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveCampfireAccount(cfg);
+
+    expect(account.enabled).toBe(false);
+    expect(account.configured).toBe(true);
+  });
+
+  it("resolves custom textChunkLimit", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "42-AbCdEf",
+          textChunkLimit: 2500,
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveCampfireAccount(cfg);
+
+    expect(account.textChunkLimit).toBe(2500);
+  });
+
+  it("falls back to default textChunkLimit for non-positive values", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "42-AbCdEf",
+          textChunkLimit: 0,
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveCampfireAccount(cfg);
+
+    expect(account.textChunkLimit).toBe(4000);
+  });
+
+  it("lists multiple account IDs", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          accounts: {
+            support: { botKey: "1-abc" },
+            alerts: { botKey: "2-def" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const ids = listCampfireAccountIds(cfg);
+
+    expect(ids).toEqual(["alerts", "default", "support"]);
+  });
 });

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -1,0 +1,68 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  listCampfireAccountIds,
+  resolveCampfireAccount,
+  resolveDefaultCampfireAccountId,
+} from "./config.js";
+
+describe("campfire config resolution", () => {
+  it("returns default when no account config exists", () => {
+    const cfg = {} as OpenClawConfig;
+
+    expect(listCampfireAccountIds(cfg)).toEqual(["default"]);
+    expect(resolveDefaultCampfireAccountId(cfg)).toBe("default");
+  });
+
+  it("resolves top-level account values", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com/",
+          botKey: "42-AbCdEf",
+          webhookSecret: " shared-secret ",
+          allowFrom: [" 42 ", "Alice"],
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveCampfireAccount(cfg);
+
+    expect(account.accountId).toBe("default");
+    expect(account.baseUrl).toBe("https://campfire.example.com");
+    expect(account.botKey).toBe("42-AbCdEf");
+    expect(account.webhookSecret).toBe("shared-secret");
+    expect(account.allowFrom).toEqual(["42", "Alice"]);
+    expect(account.configured).toBe(true);
+    expect(account.webhookPath).toBe("/channels/campfire/webhook/default");
+  });
+
+  it("resolves named account overrides with defaultAccount", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          defaultAccount: "alerts",
+          baseUrl: "https://campfire.example.com",
+          botKey: "top-level-key",
+          accounts: {
+            alerts: {
+              botKey: "alerts-key",
+              webhookPath: "/channels/campfire/webhook/custom-alerts",
+              allowFrom: ["Bob"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveDefaultCampfireAccountId(cfg)).toBe("alerts");
+
+    const account = resolveCampfireAccount(cfg);
+
+    expect(account.accountId).toBe("alerts");
+    expect(account.baseUrl).toBe("https://campfire.example.com");
+    expect(account.botKey).toBe("alerts-key");
+    expect(account.allowFrom).toEqual(["Bob"]);
+    expect(account.webhookPath).toBe("/channels/campfire/webhook/custom-alerts");
+  });
+});

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -66,6 +66,25 @@ describe("campfire config resolution", () => {
     expect(account.webhookPath).toBe("/channels/campfire/webhook/custom-alerts");
   });
 
+  it("matches defaultAccount case-insensitively", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          defaultAccount: "support",
+          accounts: {
+            Support: {
+              baseUrl: "https://campfire.example.com",
+              botKey: "support-key",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveDefaultCampfireAccountId(cfg)).toBe("Support");
+    expect(resolveCampfireAccount(cfg).botKey).toBe("support-key");
+  });
+
   it("marks account as unconfigured when baseUrl is missing", () => {
     const cfg = {
       channels: {
@@ -166,6 +185,28 @@ describe("campfire config resolution", () => {
 
     expect(defaultAccount.webhookPath).toBe("/channels/campfire/webhook/shared");
     expect(supportAccount.webhookPath).toBe("/channels/campfire/webhook/support");
+  });
+
+  it("resolves named accounts case-insensitively", () => {
+    const cfg = {
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "top-level-key",
+          accounts: {
+            Support: {
+              botKey: "support-key",
+              webhookPath: "/channels/campfire/webhook/support-room",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveCampfireAccount(cfg, "support");
+
+    expect(account.botKey).toBe("support-key");
+    expect(account.webhookPath).toBe("/channels/campfire/webhook/support-room");
   });
 
   it("lists multiple account IDs", () => {

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { describe, expect, it } from "vitest";
 import {
+  campfireChannelConfigSchema,
   listCampfireAccountIds,
   resolveCampfireAccount,
   resolveDefaultCampfireAccountId,
@@ -224,5 +225,10 @@ describe("campfire config resolution", () => {
     const ids = listCampfireAccountIds(cfg);
 
     expect(ids).toEqual(["alerts", "support"]);
+  });
+
+  it("marks botKey fields as sensitive in config schema ui hints", () => {
+    expect(campfireChannelConfigSchema.uiHints?.botKey?.sensitive).toBe(true);
+    expect(campfireChannelConfigSchema.uiHints?.["accounts.*.botKey"]?.sensitive).toBe(true);
   });
 });

--- a/extensions/campfire/src/config.test.ts
+++ b/extensions/campfire/src/config.test.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { describe, expect, it } from "vitest";
 import {
   campfireChannelConfigSchema,
+  campfireConfigSchema,
   listCampfireAccountIds,
   resolveCampfireAccount,
   resolveDefaultCampfireAccountId,
@@ -230,5 +231,23 @@ describe("campfire config resolution", () => {
   it("marks botKey fields as sensitive in config schema ui hints", () => {
     expect(campfireChannelConfigSchema.uiHints?.botKey?.sensitive).toBe(true);
     expect(campfireChannelConfigSchema.uiHints?.["accounts.*.botKey"]?.sensitive).toBe(true);
+  });
+
+  it("rejects bare Basecamp shard URLs in schema", () => {
+    const topLevelResult = campfireConfigSchema.safeParse({
+      baseUrl: "https://3.basecamp.com",
+      botKey: "42-AbCdEf",
+    });
+    const accountResult = campfireConfigSchema.safeParse({
+      accounts: {
+        support: {
+          baseUrl: "https://3.basecamp.com",
+          botKey: "99-ZyXwVu",
+        },
+      },
+    });
+
+    expect(topLevelResult.success).toBe(false);
+    expect(accountResult.success).toBe(false);
   });
 });

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -68,7 +68,7 @@ function resolveCampfireConfigSection(cfg: OpenClawConfig): CampfireChannelConfi
   if (!section || typeof section !== "object" || Array.isArray(section)) {
     return {};
   }
-  return section as CampfireChannelConfig;
+  return section;
 }
 
 function hasTopLevelAccountFields(section: CampfireChannelConfig): boolean {

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -28,9 +28,21 @@ function isBareBasecampHostUrl(value: string): boolean {
   }
 }
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 const campfireBaseUrlSchema = z
   .string()
   .url()
+  .refine((value) => isHttpUrl(value), {
+    message: "Campfire baseUrl must be a valid http(s) URL.",
+  })
   .refine((value) => !isBareBasecampHostUrl(value), {
     message:
       "Campfire baseUrl must include a Basecamp workspace path (for example https://3.basecamp.com/1234567).",

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -109,11 +109,7 @@ export function resolveCampfireAccount(
 ): ResolvedCampfireAccount {
   const section = resolveCampfireConfigSection(cfg);
   const resolvedAccountId = trimOptionalString(accountId) ?? resolveDefaultCampfireAccountId(cfg);
-  const {
-    accounts: _accounts,
-    defaultAccount: _defaultAccount,
-    ...base
-  } = section as CampfireChannelConfig;
+  const { accounts: _accounts, defaultAccount: _defaultAccount, ...base } = section;
   const override = resolveCampfireAccountOverride(section, resolvedAccountId);
   const merged: CampfireAccountConfig = {
     ...base,
@@ -173,7 +169,13 @@ export const campfireChannelConfigSchema = {
     botKey: {
       sensitive: true,
     },
+    webhookSecret: {
+      sensitive: true,
+    },
     "accounts.*.botKey": {
+      sensitive: true,
+    },
+    "accounts.*.webhookSecret": {
       sensitive: true,
     },
   },

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -107,8 +107,12 @@ export function resolveCampfireAccount(
 
   const baseUrl = (trimOptionalString(merged.baseUrl) ?? "").replace(/\/+$/, "");
   const botKey = trimOptionalString(merged.botKey) ?? "";
+  const topLevelWebhookPath = trimOptionalString(base.webhookPath);
+  const accountWebhookPath = trimOptionalString(override.webhookPath);
   const webhookPath =
-    trimOptionalString(merged.webhookPath) ?? `/channels/campfire/webhook/${resolvedAccountId}`;
+    accountWebhookPath ??
+    (resolvedAccountId === DEFAULT_ACCOUNT_ID ? topLevelWebhookPath : undefined) ??
+    `/channels/campfire/webhook/${resolvedAccountId}`;
   const textChunkLimit =
     typeof merged.textChunkLimit === "number" &&
     Number.isFinite(merged.textChunkLimit) &&

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -167,7 +167,17 @@ export const campfireConfigSchema: z.ZodType<CampfireChannelConfig> = campfireAc
   accounts: z.record(z.string(), campfireAccountSchema.optional()).optional(),
 });
 
-export const campfireChannelConfigSchema = buildChannelConfigSchema(campfireConfigSchema);
+export const campfireChannelConfigSchema = {
+  ...buildChannelConfigSchema(campfireConfigSchema),
+  uiHints: {
+    botKey: {
+      sensitive: true,
+    },
+    "accounts.*.botKey": {
+      sensitive: true,
+    },
+  },
+};
 
 export const campfireConfigAdapter = createHybridChannelConfigAdapter<ResolvedCampfireAccount>({
   sectionKey: "campfire",

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -1,0 +1,172 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { createHybridChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { z } from "zod";
+import type {
+  CampfireAccountConfig,
+  CampfireChannelConfig,
+  ResolvedCampfireAccount,
+} from "./types.js";
+
+const DEFAULT_TEXT_CHUNK_LIMIT = 4000;
+
+function trimOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeAllowFrom(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((entry) => String(entry).trim()).filter((entry) => entry.length > 0);
+}
+
+function resolveCampfireConfigSection(cfg: OpenClawConfig): CampfireChannelConfig {
+  const section = cfg.channels?.campfire;
+  if (!section || typeof section !== "object" || Array.isArray(section)) {
+    return {};
+  }
+  return section as CampfireChannelConfig;
+}
+
+function hasTopLevelAccountFields(section: CampfireChannelConfig): boolean {
+  return (
+    section.baseUrl !== undefined ||
+    section.botKey !== undefined ||
+    section.webhookSecret !== undefined ||
+    section.allowFrom !== undefined ||
+    section.webhookPath !== undefined ||
+    section.textChunkLimit !== undefined ||
+    section.enabled !== undefined ||
+    section.name !== undefined
+  );
+}
+
+export function listCampfireAccountIds(cfg: OpenClawConfig): string[] {
+  const section = resolveCampfireConfigSection(cfg);
+  const fromAccounts =
+    section.accounts && typeof section.accounts === "object"
+      ? Object.keys(section.accounts).filter(Boolean)
+      : [];
+  const ids = new Set(fromAccounts);
+  if (fromAccounts.length === 0 || hasTopLevelAccountFields(section)) {
+    ids.add(DEFAULT_ACCOUNT_ID);
+  }
+  return [...ids].toSorted((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultCampfireAccountId(cfg: OpenClawConfig): string {
+  const section = resolveCampfireConfigSection(cfg);
+  const ids = listCampfireAccountIds(cfg);
+  const preferred = trimOptionalString(section.defaultAccount);
+  if (preferred && ids.includes(preferred)) {
+    return preferred;
+  }
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveCampfireAccountOverride(
+  section: CampfireChannelConfig,
+  accountId: string,
+): CampfireAccountConfig {
+  const accounts = section.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return {};
+  }
+  const override = accounts[accountId];
+  if (!override || typeof override !== "object" || Array.isArray(override)) {
+    return {};
+  }
+  return override;
+}
+
+export function resolveCampfireAccount(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+): ResolvedCampfireAccount {
+  const section = resolveCampfireConfigSection(cfg);
+  const resolvedAccountId = trimOptionalString(accountId) ?? resolveDefaultCampfireAccountId(cfg);
+  const {
+    accounts: _accounts,
+    defaultAccount: _defaultAccount,
+    ...base
+  } = section as CampfireChannelConfig;
+  const override = resolveCampfireAccountOverride(section, resolvedAccountId);
+  const merged: CampfireAccountConfig = {
+    ...base,
+    ...override,
+  };
+
+  const baseUrl = (trimOptionalString(merged.baseUrl) ?? "").replace(/\/+$/, "");
+  const botKey = trimOptionalString(merged.botKey) ?? "";
+  const webhookPath =
+    trimOptionalString(merged.webhookPath) ?? `/channels/campfire/webhook/${resolvedAccountId}`;
+  const textChunkLimit =
+    typeof merged.textChunkLimit === "number" &&
+    Number.isFinite(merged.textChunkLimit) &&
+    merged.textChunkLimit > 0
+      ? Math.floor(merged.textChunkLimit)
+      : DEFAULT_TEXT_CHUNK_LIMIT;
+
+  return {
+    accountId: resolvedAccountId,
+    name: trimOptionalString(merged.name),
+    enabled: merged.enabled !== false,
+    baseUrl,
+    botKey,
+    webhookSecret: trimOptionalString(merged.webhookSecret),
+    allowFrom: normalizeAllowFrom(merged.allowFrom),
+    webhookPath,
+    textChunkLimit,
+    configured: Boolean(baseUrl && botKey),
+  };
+}
+
+export const campfireAccountSchema = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    baseUrl: z.string().url().optional(),
+    botKey: z.string().min(1).optional(),
+    webhookSecret: z.string().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    webhookPath: z.string().optional(),
+    textChunkLimit: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const campfireConfigSchema: z.ZodType<CampfireChannelConfig> = campfireAccountSchema.extend({
+  defaultAccount: z.string().optional(),
+  accounts: z.record(z.string(), campfireAccountSchema.optional()).optional(),
+});
+
+export const campfireChannelConfigSchema = buildChannelConfigSchema(campfireConfigSchema);
+
+export const campfireConfigAdapter = createHybridChannelConfigAdapter<ResolvedCampfireAccount>({
+  sectionKey: "campfire",
+  listAccountIds: (cfg) => listCampfireAccountIds(cfg),
+  resolveAccount: (cfg, accountId) => resolveCampfireAccount(cfg, accountId),
+  defaultAccountId: (cfg) => resolveDefaultCampfireAccountId(cfg),
+  clearBaseFields: [
+    "name",
+    "enabled",
+    "baseUrl",
+    "botKey",
+    "webhookSecret",
+    "allowFrom",
+    "webhookPath",
+    "textChunkLimit",
+  ],
+  preserveSectionOnDefaultDelete: true,
+  resolveAllowFrom: (account) => account.allowFrom,
+  formatAllowFrom: (allowFrom) =>
+    allowFrom.map((entry) => String(entry).trim()).filter((entry) => entry.length > 0),
+});

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -11,6 +11,31 @@ import type {
 
 const DEFAULT_TEXT_CHUNK_LIMIT = 4000;
 
+function normalizeUrlPath(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/u, "");
+  return trimmed ? trimmed : "/";
+}
+
+function isBareBasecampHostUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    if (!/(^|\.)basecamp\.com$/u.test(parsed.hostname)) {
+      return false;
+    }
+    return normalizeUrlPath(parsed.pathname) === "/";
+  } catch {
+    return false;
+  }
+}
+
+const campfireBaseUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => !isBareBasecampHostUrl(value), {
+    message:
+      "Campfire baseUrl must include a Basecamp workspace path (for example https://3.basecamp.com/1234567).",
+  });
+
 function trimOptionalString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -149,7 +174,7 @@ export const campfireAccountSchema = z
   .object({
     name: z.string().optional(),
     enabled: z.boolean().optional(),
-    baseUrl: z.string().url().optional(),
+    baseUrl: campfireBaseUrlSchema.optional(),
     botKey: z.string().min(1).optional(),
     webhookSecret: z.string().optional(),
     allowFrom: z.array(z.string()).optional(),

--- a/extensions/campfire/src/config.ts
+++ b/extensions/campfire/src/config.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { createHybridChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
 import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
@@ -64,8 +64,14 @@ export function resolveDefaultCampfireAccountId(cfg: OpenClawConfig): string {
   const section = resolveCampfireConfigSection(cfg);
   const ids = listCampfireAccountIds(cfg);
   const preferred = trimOptionalString(section.defaultAccount);
-  if (preferred && ids.includes(preferred)) {
-    return preferred;
+  if (preferred) {
+    const normalizedPreferred = normalizeAccountId(preferred);
+    const matchedPreferred = ids.find(
+      (accountId) => normalizeAccountId(accountId) === normalizedPreferred,
+    );
+    if (matchedPreferred) {
+      return matchedPreferred;
+    }
   }
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
@@ -81,7 +87,16 @@ function resolveCampfireAccountOverride(
   if (!accounts || typeof accounts !== "object") {
     return {};
   }
-  const override = accounts[accountId];
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const accountKey = Object.prototype.hasOwnProperty.call(accounts, accountId)
+    ? accountId
+    : Object.keys(accounts).find(
+        (candidate) => normalizeAccountId(candidate) === normalizedAccountId,
+      );
+  if (!accountKey) {
+    return {};
+  }
+  const override = accounts[accountKey];
   if (!override || typeof override !== "object" || Array.isArray(override)) {
     return {};
   }

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMockServerResponse } from "../../../../test/helpers/extensions/mock-http-response.js";
-import { createCampfireWebhookHandler } from "./index.js";
+import { __testing, createCampfireWebhookHandler, registerCampfireWebhookRoute } from "./index.js";
 
 function createJsonRequest(params: {
   method?: string;
@@ -68,6 +68,10 @@ const validPayload = {
 };
 
 describe("createCampfireWebhookHandler", () => {
+  afterEach(() => {
+    __testing.resetCampfireWebhookPathReservations();
+  });
+
   it("rejects non-POST requests", async () => {
     const handler = createCampfireWebhookHandler({ onInbound: vi.fn() });
     const req = createJsonRequest({ method: "GET" });
@@ -119,5 +123,49 @@ describe("createCampfireWebhookHandler", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(onInbound).toHaveBeenCalledWith(validPayload);
+  });
+
+  it("rejects duplicate webhook paths across different accounts", () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+
+    const unregister = registerCampfireWebhookRoute({
+      accountId: "default",
+      path: "/channels/campfire/webhook/shared",
+      onInbound: vi.fn(),
+      registerRoute,
+    } as never);
+
+    expect(() =>
+      registerCampfireWebhookRoute({
+        accountId: "support",
+        path: "/channels/campfire/webhook/shared/",
+        onInbound: vi.fn(),
+        registerRoute,
+      } as never),
+    ).toThrow(/already assigned to account "default"/);
+
+    unregister();
+  });
+
+  it("allows reusing the same webhook path for one account", () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+
+    const unregisterFirst = registerCampfireWebhookRoute({
+      accountId: "default",
+      path: "/channels/campfire/webhook/shared",
+      onInbound: vi.fn(),
+      registerRoute,
+    } as never);
+    const unregisterSecond = registerCampfireWebhookRoute({
+      accountId: "default",
+      path: "/channels/campfire/webhook/shared/",
+      onInbound: vi.fn(),
+      registerRoute,
+    } as never);
+
+    expect(registerRoute).toHaveBeenCalledTimes(2);
+
+    unregisterSecond();
+    unregisterFirst();
   });
 });

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -1,0 +1,123 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { createMockServerResponse } from "../../../../test/helpers/extensions/mock-http-response.js";
+import { createCampfireWebhookHandler } from "./index.js";
+
+function createJsonRequest(params: {
+  method?: string;
+  url?: string;
+  body?: unknown;
+  rawBody?: string;
+  headers?: Record<string, string>;
+}): IncomingMessage {
+  const req = new EventEmitter() as IncomingMessage & {
+    destroyed?: boolean;
+    destroy: (error?: Error) => IncomingMessage;
+    on: (event: string, listener: (...args: unknown[]) => void) => IncomingMessage;
+  };
+  req.method = params.method ?? "POST";
+  req.url = params.url ?? "/channels/campfire/webhook/default";
+  req.headers = {
+    "content-type": "application/json",
+    ...(params.headers ?? {}),
+  };
+  req.destroyed = false;
+  (req as unknown as { socket: { remoteAddress: string } }).socket = {
+    remoteAddress: "127.0.0.1",
+  };
+  req.destroy = () => {
+    req.destroyed = true;
+    return req;
+  };
+
+  const encodedBody = params.rawBody ?? JSON.stringify(params.body ?? {});
+  const originalOn = req.on.bind(req);
+  let bodyScheduled = false;
+  req.on = ((event: string, listener: (...args: unknown[]) => void) => {
+    const result = originalOn(event, listener);
+    if (!bodyScheduled && (event === "data" || event === "end")) {
+      bodyScheduled = true;
+      void Promise.resolve().then(() => {
+        if (encodedBody.length > 0) {
+          req.emit("data", Buffer.from(encodedBody, "utf-8"));
+        }
+        if (!req.destroyed) {
+          req.emit("end");
+        }
+      });
+    }
+    return result;
+  }) as IncomingMessage["on"];
+
+  return req;
+}
+
+const validPayload = {
+  user: { id: 42, name: "Alice" },
+  room: {
+    id: 7,
+    name: "General",
+    path: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+  },
+  message: {
+    id: 99,
+    body: { plain: "Hey help me" },
+    path: "https://campfire.example.com/rooms/7/@99",
+  },
+};
+
+describe("createCampfireWebhookHandler", () => {
+  it("rejects non-POST requests", async () => {
+    const handler = createCampfireWebhookHandler({ onInbound: vi.fn() });
+    const req = createJsonRequest({ method: "GET" });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.getHeader("allow")).toBe("POST");
+  });
+
+  it("rejects webhook requests with a mismatched secret", async () => {
+    const handler = createCampfireWebhookHandler({
+      webhookSecret: "expected",
+      onInbound: vi.fn(),
+    });
+    const req = createJsonRequest({
+      url: "/channels/campfire/webhook/default?secret=wrong",
+      body: validPayload,
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects malformed payloads", async () => {
+    const handler = createCampfireWebhookHandler({ onInbound: vi.fn() });
+    const req = createJsonRequest({ body: { user: { id: 42 } } });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 and dispatches inbound asynchronously", async () => {
+    const onInbound = vi.fn();
+    const handler = createCampfireWebhookHandler({ onInbound });
+    const req = createJsonRequest({ body: validPayload });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(onInbound).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onInbound).toHaveBeenCalledWith(validPayload);
+  });
+});

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -67,6 +67,18 @@ const validPayload = {
   },
 };
 
+function createOversizedValidPayload(charCount = 70 * 1024) {
+  return {
+    ...validPayload,
+    message: {
+      ...validPayload.message,
+      body: {
+        plain: "x".repeat(charCount),
+      },
+    },
+  };
+}
+
 describe("createCampfireWebhookHandler", () => {
   afterEach(() => {
     __testing.resetCampfireWebhookPathReservations();
@@ -213,6 +225,39 @@ describe("createCampfireWebhookHandler", () => {
     expect(res.statusCode).toBe(200);
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onInbound).toHaveBeenCalledWith(validPayload);
+  });
+
+  it("uses post-auth body limits after a matching webhook secret", async () => {
+    const onInbound = vi.fn();
+    const handler = createCampfireWebhookHandler({
+      webhookSecret: "expected",
+      onInbound,
+    });
+    const req = createJsonRequest({
+      body: createOversizedValidPayload(),
+      headers: { "x-webhook-secret": "expected" },
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onInbound).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps no-secret webhook requests on pre-auth body limits", async () => {
+    const onInbound = vi.fn();
+    const handler = createCampfireWebhookHandler({ onInbound });
+    const req = createJsonRequest({
+      body: createOversizedValidPayload(),
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(413);
+    expect(onInbound).not.toHaveBeenCalled();
   });
 
   it("rejects when no secret is provided but one is configured", async () => {

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -99,7 +99,7 @@ describe("createCampfireWebhookHandler", () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it("rejects requests when webhook secret is not configured", async () => {
+  it("accepts requests when webhook secret is not configured", async () => {
     const onInbound = vi.fn();
     const handler = createCampfireWebhookHandler({ onInbound });
     const req = createJsonRequest({
@@ -110,8 +110,12 @@ describe("createCampfireWebhookHandler", () => {
 
     await handler(req, res);
 
-    expect(res.statusCode).toBe(401);
+    expect(res.statusCode).toBe(200);
     expect(onInbound).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onInbound).toHaveBeenCalledWith(validPayload);
   });
 
   it("rejects malformed payloads", async () => {

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createMockServerResponse } from "../../../../test/helpers/extensions/mock-http-response.js";
+import { createMockServerResponse } from "../../../../test/helpers/plugins/mock-http-response.js";
 import { __testing, createCampfireWebhookHandler, registerCampfireWebhookRoute } from "./index.js";
 
 function createJsonRequest(params: {
@@ -20,7 +20,7 @@ function createJsonRequest(params: {
   req.url = params.url ?? "/channels/campfire/webhook/default";
   req.headers = {
     "content-type": "application/json",
-    ...(params.headers ?? {}),
+    ...params.headers,
   };
   req.destroyed = false;
   (req as unknown as { socket: { remoteAddress: string } }).socket = {
@@ -148,6 +148,84 @@ describe("createCampfireWebhookHandler", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(onInbound).toHaveBeenCalledWith(validPayload);
+  });
+
+  it("accepts webhook secret from X-Webhook-Secret header", async () => {
+    const onInbound = vi.fn();
+    const handler = createCampfireWebhookHandler({ webhookSecret: "header-secret", onInbound });
+    const req = createJsonRequest({
+      body: validPayload,
+      headers: { "x-webhook-secret": "header-secret" },
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onInbound).toHaveBeenCalledWith(validPayload);
+  });
+
+  it("rejects webhook request with wrong X-Webhook-Secret header", async () => {
+    const handler = createCampfireWebhookHandler({
+      webhookSecret: "correct",
+      onInbound: vi.fn(),
+    });
+    const req = createJsonRequest({
+      body: validPayload,
+      headers: { "x-webhook-secret": "wrong" },
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("prefers X-Webhook-Secret header over query param", async () => {
+    const onInbound = vi.fn();
+    const handler = createCampfireWebhookHandler({ webhookSecret: "from-header", onInbound });
+    const req = createJsonRequest({
+      url: "/channels/campfire/webhook/default?secret=wrong-param",
+      body: validPayload,
+      headers: { "x-webhook-secret": "from-header" },
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onInbound).toHaveBeenCalledWith(validPayload);
+  });
+
+  it("falls back to query param secret when header is absent", async () => {
+    const onInbound = vi.fn();
+    const handler = createCampfireWebhookHandler({ webhookSecret: "fallback-secret", onInbound });
+    const req = createJsonRequest({
+      url: "/channels/campfire/webhook/default?secret=fallback-secret",
+      body: validPayload,
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onInbound).toHaveBeenCalledWith(validPayload);
+  });
+
+  it("rejects when no secret is provided but one is configured", async () => {
+    const handler = createCampfireWebhookHandler({
+      webhookSecret: "required",
+      onInbound: vi.fn(),
+    });
+    const req = createJsonRequest({ body: validPayload });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(401);
   });
 
   it("rejects duplicate webhook paths across different accounts", () => {

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -99,8 +99,9 @@ describe("createCampfireWebhookHandler", () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it("rejects requests when webhook secret is not configured", async () => {
-    const handler = createCampfireWebhookHandler({ onInbound: vi.fn() });
+  it("accepts requests when webhook secret is not configured", async () => {
+    const onInbound = vi.fn();
+    const handler = createCampfireWebhookHandler({ onInbound });
     const req = createJsonRequest({
       url: "/channels/campfire/webhook/default?secret=anything",
       body: validPayload,
@@ -109,7 +110,12 @@ describe("createCampfireWebhookHandler", () => {
 
     await handler(req, res);
 
-    expect(res.statusCode).toBe(401);
+    expect(res.statusCode).toBe(200);
+    expect(onInbound).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onInbound).toHaveBeenCalledWith(validPayload);
   });
 
   it("rejects malformed payloads", async () => {

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -99,9 +99,25 @@ describe("createCampfireWebhookHandler", () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it("rejects malformed payloads", async () => {
+  it("rejects requests when webhook secret is not configured", async () => {
     const handler = createCampfireWebhookHandler({ onInbound: vi.fn() });
-    const req = createJsonRequest({ body: { user: { id: 42 } } });
+    const req = createJsonRequest({
+      url: "/channels/campfire/webhook/default?secret=anything",
+      body: validPayload,
+    });
+    const res = createMockServerResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects malformed payloads", async () => {
+    const handler = createCampfireWebhookHandler({ webhookSecret: "expected", onInbound: vi.fn() });
+    const req = createJsonRequest({
+      url: "/channels/campfire/webhook/default?secret=expected",
+      body: { user: { id: 42 } },
+    });
     const res = createMockServerResponse();
 
     await handler(req, res);
@@ -111,8 +127,11 @@ describe("createCampfireWebhookHandler", () => {
 
   it("returns 200 and dispatches inbound asynchronously", async () => {
     const onInbound = vi.fn();
-    const handler = createCampfireWebhookHandler({ onInbound });
-    const req = createJsonRequest({ body: validPayload });
+    const handler = createCampfireWebhookHandler({ webhookSecret: "expected", onInbound });
+    const req = createJsonRequest({
+      url: "/channels/campfire/webhook/default?secret=expected",
+      body: validPayload,
+    });
     const res = createMockServerResponse();
 
     await handler(req, res);
@@ -131,6 +150,7 @@ describe("createCampfireWebhookHandler", () => {
     const unregister = registerCampfireWebhookRoute({
       accountId: "default",
       path: "/channels/campfire/webhook/shared",
+      webhookSecret: "secret",
       onInbound: vi.fn(),
       registerRoute,
     } as never);
@@ -139,6 +159,7 @@ describe("createCampfireWebhookHandler", () => {
       registerCampfireWebhookRoute({
         accountId: "support",
         path: "/channels/campfire/webhook/shared/",
+        webhookSecret: "secret",
         onInbound: vi.fn(),
         registerRoute,
       } as never),
@@ -153,12 +174,14 @@ describe("createCampfireWebhookHandler", () => {
     const unregisterFirst = registerCampfireWebhookRoute({
       accountId: "default",
       path: "/channels/campfire/webhook/shared",
+      webhookSecret: "secret",
       onInbound: vi.fn(),
       registerRoute,
     } as never);
     const unregisterSecond = registerCampfireWebhookRoute({
       accountId: "default",
       path: "/channels/campfire/webhook/shared/",
+      webhookSecret: "secret",
       onInbound: vi.fn(),
       registerRoute,
     } as never);
@@ -167,5 +190,42 @@ describe("createCampfireWebhookHandler", () => {
 
     unregisterSecond();
     unregisterFirst();
+  });
+
+  it("releases reserved paths when route registration fails", () => {
+    const registerRoute = vi
+      .fn<
+        (
+          params: Parameters<typeof registerCampfireWebhookRoute>[0] & {
+            log?: (message: string) => void;
+          },
+        ) => () => void
+      >()
+      .mockImplementationOnce((params) => {
+        params.log?.("plugin: route conflict at /channels/campfire/webhook/shared (exact)");
+        return () => {};
+      })
+      .mockImplementationOnce(() => () => {});
+
+    expect(() =>
+      registerCampfireWebhookRoute({
+        accountId: "default",
+        path: "/channels/campfire/webhook/shared",
+        webhookSecret: "secret",
+        onInbound: vi.fn(),
+        registerRoute: registerRoute as never,
+      }),
+    ).toThrow(/route conflict/i);
+
+    const unregister = registerCampfireWebhookRoute({
+      accountId: "support",
+      path: "/channels/campfire/webhook/shared",
+      webhookSecret: "secret",
+      onInbound: vi.fn(),
+      registerRoute: registerRoute as never,
+    });
+
+    expect(registerRoute).toHaveBeenCalledTimes(2);
+    unregister();
   });
 });

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -89,8 +89,8 @@ describe("createCampfireWebhookHandler", () => {
       onInbound: vi.fn(),
     });
     const req = createJsonRequest({
-      url: "/channels/campfire/webhook/default?secret=wrong",
       body: validPayload,
+      headers: { "x-webhook-secret": "wrong" },
     });
     const res = createMockServerResponse();
 
@@ -121,8 +121,8 @@ describe("createCampfireWebhookHandler", () => {
   it("rejects malformed payloads", async () => {
     const handler = createCampfireWebhookHandler({ webhookSecret: "expected", onInbound: vi.fn() });
     const req = createJsonRequest({
-      url: "/channels/campfire/webhook/default?secret=expected",
       body: { user: { id: 42 } },
+      headers: { "x-webhook-secret": "expected" },
     });
     const res = createMockServerResponse();
 
@@ -135,8 +135,8 @@ describe("createCampfireWebhookHandler", () => {
     const onInbound = vi.fn();
     const handler = createCampfireWebhookHandler({ webhookSecret: "expected", onInbound });
     const req = createJsonRequest({
-      url: "/channels/campfire/webhook/default?secret=expected",
       body: validPayload,
+      headers: { "x-webhook-secret": "expected" },
     });
     const res = createMockServerResponse();
 

--- a/extensions/campfire/src/http/index.test.ts
+++ b/extensions/campfire/src/http/index.test.ts
@@ -99,7 +99,7 @@ describe("createCampfireWebhookHandler", () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it("accepts requests when webhook secret is not configured", async () => {
+  it("rejects requests when webhook secret is not configured", async () => {
     const onInbound = vi.fn();
     const handler = createCampfireWebhookHandler({ onInbound });
     const req = createJsonRequest({
@@ -110,12 +110,8 @@ describe("createCampfireWebhookHandler", () => {
 
     await handler(req, res);
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(401);
     expect(onInbound).not.toHaveBeenCalled();
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(onInbound).toHaveBeenCalledWith(validPayload);
   });
 
   it("rejects malformed payloads", async () => {

--- a/extensions/campfire/src/http/index.ts
+++ b/extensions/campfire/src/http/index.ts
@@ -99,6 +99,7 @@ export function createCampfireWebhookHandler(params: {
     }
 
     const configuredWebhookSecret = params.webhookSecret?.trim();
+    const bodyReadProfile = configuredWebhookSecret ? "post-auth" : "pre-auth";
     if (configuredWebhookSecret) {
       const secret = resolveRequestSecret(req);
       if (!secret || !secretsMatch(secret, configuredWebhookSecret)) {
@@ -111,7 +112,7 @@ export function createCampfireWebhookHandler(params: {
     const parsedBody = await readJsonWebhookBodyOrReject({
       req,
       res,
-      profile: "pre-auth",
+      profile: bodyReadProfile,
       invalidJsonMessage: "Bad Request",
     });
     if (!parsedBody.ok) {

--- a/extensions/campfire/src/http/index.ts
+++ b/extensions/campfire/src/http/index.ts
@@ -1,0 +1,98 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  readJsonWebhookBodyOrReject,
+  registerPluginHttpRoute,
+} from "openclaw/plugin-sdk/webhook-ingress";
+import type { CampfireWebhookPayload } from "../types.js";
+import { parseCampfirePayload } from "./payload.js";
+
+type CampfireWebhookLog = {
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+export type CampfireInboundHandler = (payload: CampfireWebhookPayload) => Promise<void> | void;
+
+function resolveRequestSecret(req: IncomingMessage): string | null {
+  try {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    return url.searchParams.get("secret");
+  } catch {
+    return null;
+  }
+}
+
+export function createCampfireWebhookHandler(params: {
+  webhookSecret?: string;
+  onInbound: CampfireInboundHandler;
+  log?: CampfireWebhookLog;
+}) {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "POST");
+      res.end("Method Not Allowed");
+      return;
+    }
+
+    if (params.webhookSecret) {
+      const secret = resolveRequestSecret(req);
+      if (secret !== params.webhookSecret) {
+        res.statusCode = 401;
+        res.end("Unauthorized");
+        return;
+      }
+    }
+
+    const parsedBody = await readJsonWebhookBodyOrReject({
+      req,
+      res,
+      profile: "pre-auth",
+      invalidJsonMessage: "Bad Request",
+    });
+    if (!parsedBody.ok) {
+      return;
+    }
+
+    const payload = parseCampfirePayload(parsedBody.value);
+    if (!payload) {
+      res.statusCode = 400;
+      res.end("Bad Request");
+      return;
+    }
+
+    res.statusCode = 200;
+    res.end("OK");
+
+    setImmediate(() => {
+      void Promise.resolve(params.onInbound(payload)).catch((err) => {
+        params.log?.error?.(`Campfire inbound dispatch failed: ${String(err)}`);
+      });
+    });
+  };
+}
+
+export function registerCampfireWebhookRoute(params: {
+  accountId: string;
+  path?: string;
+  webhookSecret?: string;
+  onInbound: CampfireInboundHandler;
+  log?: CampfireWebhookLog;
+}): () => void {
+  return registerPluginHttpRoute({
+    path: params.path ?? `/channels/campfire/webhook/${params.accountId}`,
+    auth: "plugin",
+    match: "exact",
+    replaceExisting: true,
+    pluginId: "campfire",
+    accountId: params.accountId,
+    source: "campfire-webhook",
+    log: (message) => params.log?.info?.(message),
+    handler: createCampfireWebhookHandler({
+      webhookSecret: params.webhookSecret,
+      onInbound: params.onInbound,
+      log: params.log,
+    }),
+  });
+}

--- a/extensions/campfire/src/http/index.ts
+++ b/extensions/campfire/src/http/index.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  normalizeWebhookPath,
   readJsonWebhookBodyOrReject,
   registerPluginHttpRoute,
 } from "openclaw/plugin-sdk/webhook-ingress";
@@ -13,6 +14,43 @@ type CampfireWebhookLog = {
 };
 
 export type CampfireInboundHandler = (payload: CampfireWebhookPayload) => Promise<void> | void;
+
+const activeCampfireWebhookPathReservations = new Map<
+  string,
+  {
+    accountId: string;
+    tokens: Set<symbol>;
+  }
+>();
+
+function reserveCampfireWebhookPath(params: { accountId: string; path: string }): () => void {
+  const reservationPath = normalizeWebhookPath(params.path);
+  const existing = activeCampfireWebhookPathReservations.get(reservationPath);
+  if (existing && existing.accountId !== params.accountId) {
+    throw new Error(
+      `Campfire webhook path "${reservationPath}" is already assigned to account "${existing.accountId}"`,
+    );
+  }
+
+  const token = Symbol(params.accountId);
+  const reservation = existing ?? {
+    accountId: params.accountId,
+    tokens: new Set<symbol>(),
+  };
+  reservation.tokens.add(token);
+  activeCampfireWebhookPathReservations.set(reservationPath, reservation);
+
+  return () => {
+    const current = activeCampfireWebhookPathReservations.get(reservationPath);
+    if (!current || current.accountId !== params.accountId) {
+      return;
+    }
+    current.tokens.delete(token);
+    if (current.tokens.size === 0) {
+      activeCampfireWebhookPathReservations.delete(reservationPath);
+    }
+  };
+}
 
 function resolveRequestSecret(req: IncomingMessage): string | null {
   try {
@@ -79,20 +117,47 @@ export function registerCampfireWebhookRoute(params: {
   webhookSecret?: string;
   onInbound: CampfireInboundHandler;
   log?: CampfireWebhookLog;
+  registerRoute?: typeof registerPluginHttpRoute;
 }): () => void {
-  return registerPluginHttpRoute({
-    path: params.path ?? `/channels/campfire/webhook/${params.accountId}`,
-    auth: "plugin",
-    match: "exact",
-    replaceExisting: true,
-    pluginId: "campfire",
+  const path = normalizeWebhookPath(
+    params.path ?? `/channels/campfire/webhook/${params.accountId}`,
+  );
+  const releaseReservation = reserveCampfireWebhookPath({
     accountId: params.accountId,
-    source: "campfire-webhook",
-    log: (message) => params.log?.info?.(message),
-    handler: createCampfireWebhookHandler({
-      webhookSecret: params.webhookSecret,
-      onInbound: params.onInbound,
-      log: params.log,
-    }),
+    path,
   });
+  const registerRoute = params.registerRoute ?? registerPluginHttpRoute;
+
+  let unregister: (() => void) | undefined;
+  try {
+    unregister = registerRoute({
+      path,
+      auth: "plugin",
+      match: "exact",
+      replaceExisting: true,
+      pluginId: "campfire",
+      accountId: params.accountId,
+      source: "campfire-webhook",
+      log: (message) => params.log?.info?.(message),
+      handler: createCampfireWebhookHandler({
+        webhookSecret: params.webhookSecret,
+        onInbound: params.onInbound,
+        log: params.log,
+      }),
+    });
+  } catch (err) {
+    releaseReservation();
+    throw err;
+  }
+
+  return () => {
+    unregister?.();
+    releaseReservation();
+  };
 }
+
+export const __testing = {
+  resetCampfireWebhookPathReservations: () => {
+    activeCampfireWebhookPathReservations.clear();
+  },
+};

--- a/extensions/campfire/src/http/index.ts
+++ b/extensions/campfire/src/http/index.ts
@@ -52,6 +52,16 @@ function reserveCampfireWebhookPath(params: { accountId: string; path: string })
   };
 }
 
+function isCampfireRouteRegistrationFailureLog(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("webhook path missing") ||
+    normalized.includes("route overlap denied") ||
+    normalized.includes("route conflict") ||
+    normalized.includes("route replacement denied")
+  );
+}
+
 function resolveRequestSecret(req: IncomingMessage): string | null {
   try {
     const url = new URL(req.url ?? "/", "http://localhost");
@@ -74,9 +84,16 @@ export function createCampfireWebhookHandler(params: {
       return;
     }
 
-    if (params.webhookSecret) {
+    const configuredWebhookSecret = params.webhookSecret?.trim();
+    if (!configuredWebhookSecret) {
+      res.statusCode = 401;
+      res.end("Unauthorized");
+      return;
+    }
+
+    if (configuredWebhookSecret) {
       const secret = resolveRequestSecret(req);
-      if (secret !== params.webhookSecret) {
+      if (secret !== configuredWebhookSecret) {
         res.statusCode = 401;
         res.end("Unauthorized");
         return;
@@ -127,6 +144,13 @@ export function registerCampfireWebhookRoute(params: {
     path,
   });
   const registerRoute = params.registerRoute ?? registerPluginHttpRoute;
+  let registrationErrorMessage: string | null = null;
+  const routeLog = (message: string) => {
+    if (!registrationErrorMessage && isCampfireRouteRegistrationFailureLog(message)) {
+      registrationErrorMessage = message;
+    }
+    params.log?.info?.(message);
+  };
 
   let unregister: (() => void) | undefined;
   try {
@@ -138,13 +162,18 @@ export function registerCampfireWebhookRoute(params: {
       pluginId: "campfire",
       accountId: params.accountId,
       source: "campfire-webhook",
-      log: (message) => params.log?.info?.(message),
+      log: routeLog,
       handler: createCampfireWebhookHandler({
         webhookSecret: params.webhookSecret,
         onInbound: params.onInbound,
         log: params.log,
       }),
     });
+    if (registrationErrorMessage) {
+      unregister?.();
+      releaseReservation();
+      throw new Error(registrationErrorMessage);
+    }
   } catch (err) {
     releaseReservation();
     throw err;

--- a/extensions/campfire/src/http/index.ts
+++ b/extensions/campfire/src/http/index.ts
@@ -85,12 +85,6 @@ export function createCampfireWebhookHandler(params: {
     }
 
     const configuredWebhookSecret = params.webhookSecret?.trim();
-    if (!configuredWebhookSecret) {
-      res.statusCode = 401;
-      res.end("Unauthorized");
-      return;
-    }
-
     if (configuredWebhookSecret) {
       const secret = resolveRequestSecret(req);
       if (secret !== configuredWebhookSecret) {

--- a/extensions/campfire/src/http/index.ts
+++ b/extensions/campfire/src/http/index.ts
@@ -85,6 +85,12 @@ export function createCampfireWebhookHandler(params: {
     }
 
     const configuredWebhookSecret = params.webhookSecret?.trim();
+    if (!configuredWebhookSecret) {
+      res.statusCode = 401;
+      res.end("Unauthorized");
+      return;
+    }
+
     if (configuredWebhookSecret) {
       const secret = resolveRequestSecret(req);
       if (secret !== configuredWebhookSecret) {

--- a/extensions/campfire/src/http/index.ts
+++ b/extensions/campfire/src/http/index.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   normalizeWebhookPath,
@@ -63,12 +64,25 @@ function isCampfireRouteRegistrationFailureLog(message: string): boolean {
 }
 
 function resolveRequestSecret(req: IncomingMessage): string | null {
+  const headerValue = req.headers["x-webhook-secret"];
+  if (typeof headerValue === "string") {
+    return headerValue;
+  }
   try {
     const url = new URL(req.url ?? "/", "http://localhost");
     return url.searchParams.get("secret");
   } catch {
     return null;
   }
+}
+
+function secretsMatch(provided: string, expected: string): boolean {
+  const providedBuf = Buffer.from(provided, "utf-8");
+  const expectedBuf = Buffer.from(expected, "utf-8");
+  if (providedBuf.length !== expectedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(providedBuf, expectedBuf);
 }
 
 export function createCampfireWebhookHandler(params: {
@@ -87,7 +101,7 @@ export function createCampfireWebhookHandler(params: {
     const configuredWebhookSecret = params.webhookSecret?.trim();
     if (configuredWebhookSecret) {
       const secret = resolveRequestSecret(req);
-      if (secret !== configuredWebhookSecret) {
+      if (!secret || !secretsMatch(secret, configuredWebhookSecret)) {
         res.statusCode = 401;
         res.end("Unauthorized");
         return;

--- a/extensions/campfire/src/http/payload.test.ts
+++ b/extensions/campfire/src/http/payload.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseCampfirePayload } from "./payload.js";
+
+describe("parseCampfirePayload", () => {
+  const validPayload = {
+    user: { id: 42, name: "Alice" },
+    room: {
+      id: 7,
+      name: "General",
+      path: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+    },
+    message: {
+      id: 99,
+      body: {
+        html: "<p>Hey @Bot help me</p>",
+        plain: "Hey help me",
+      },
+      path: "https://campfire.example.com/rooms/7/@99",
+    },
+  };
+
+  it("returns typed payload for valid input", () => {
+    const parsed = parseCampfirePayload(validPayload);
+
+    expect(parsed).toEqual(validPayload);
+  });
+
+  it("returns null when required fields are missing", () => {
+    const parsed = parseCampfirePayload({
+      user: { id: 42, name: "Alice" },
+      room: { id: 7, name: "General" },
+      message: { id: 99, body: { plain: "Hey" } },
+    });
+
+    expect(parsed).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseCampfirePayload(null)).toBeNull();
+    expect(parseCampfirePayload("not-json")).toBeNull();
+    expect(parseCampfirePayload(123)).toBeNull();
+  });
+});

--- a/extensions/campfire/src/http/payload.test.ts
+++ b/extensions/campfire/src/http/payload.test.ts
@@ -35,9 +35,52 @@ describe("parseCampfirePayload", () => {
     expect(parsed).toBeNull();
   });
 
+  it("accepts payload without optional html field", () => {
+    const payload = {
+      user: { id: 42, name: "Alice" },
+      room: {
+        id: 7,
+        name: "General",
+        path: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+      },
+      message: {
+        id: 99,
+        body: { plain: "Hey help me" },
+        path: "https://campfire.example.com/rooms/7/@99",
+      },
+    };
+
+    const parsed = parseCampfirePayload(payload);
+    expect(parsed).toBeTruthy();
+    expect(parsed!.message.body.html).toBeUndefined();
+    expect(parsed!.message.body.plain).toBe("Hey help me");
+  });
+
+  it("returns null when html is present but not a string", () => {
+    const parsed = parseCampfirePayload({
+      user: { id: 42, name: "Alice" },
+      room: {
+        id: 7,
+        name: "General",
+        path: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+      },
+      message: {
+        id: 99,
+        body: { plain: "Hey", html: 123 },
+        path: "https://campfire.example.com/rooms/7/@99",
+      },
+    });
+
+    expect(parsed).toBeNull();
+  });
+
   it("returns null for malformed input", () => {
     expect(parseCampfirePayload(null)).toBeNull();
     expect(parseCampfirePayload("not-json")).toBeNull();
     expect(parseCampfirePayload(123)).toBeNull();
+  });
+
+  it("returns null for array input", () => {
+    expect(parseCampfirePayload([1, 2, 3])).toBeNull();
   });
 });

--- a/extensions/campfire/src/http/payload.ts
+++ b/extensions/campfire/src/http/payload.ts
@@ -1,0 +1,61 @@
+import type { CampfireWebhookPayload } from "../types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseCampfirePayload(value: unknown): CampfireWebhookPayload | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const user = value.user;
+  const room = value.room;
+  const message = value.message;
+
+  if (!isRecord(user) || !isRecord(room) || !isRecord(message)) {
+    return null;
+  }
+
+  const body = message.body;
+  if (!isRecord(body)) {
+    return null;
+  }
+
+  if (
+    typeof user.id !== "number" ||
+    typeof user.name !== "string" ||
+    typeof room.id !== "number" ||
+    typeof room.name !== "string" ||
+    typeof room.path !== "string" ||
+    typeof message.id !== "number" ||
+    typeof message.path !== "string" ||
+    typeof body.plain !== "string"
+  ) {
+    return null;
+  }
+
+  if (body.html !== undefined && typeof body.html !== "string") {
+    return null;
+  }
+
+  return {
+    user: {
+      id: user.id,
+      name: user.name,
+    },
+    room: {
+      id: room.id,
+      name: room.name,
+      path: room.path,
+    },
+    message: {
+      id: message.id,
+      body: {
+        plain: body.plain,
+        ...(body.html !== undefined ? { html: body.html } : {}),
+      },
+      path: message.path,
+    },
+  };
+}

--- a/extensions/campfire/src/monitor/context.test.ts
+++ b/extensions/campfire/src/monitor/context.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { CampfireWebhookPayload } from "../types.js";
+import { buildCampfireInboundContext } from "./context.js";
+
+function createPayload(overrides?: Partial<CampfireWebhookPayload>): CampfireWebhookPayload {
+  return {
+    user: { id: 42, name: "Alice" },
+    room: {
+      id: 7,
+      name: "General",
+      path: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+    },
+    message: {
+      id: 99,
+      body: {
+        html: "<p>Hey @Bot help me</p>",
+        plain: "Hey help me",
+      },
+      path: "https://campfire.example.com/rooms/7/@99",
+    },
+    ...overrides,
+  };
+}
+
+describe("buildCampfireInboundContext", () => {
+  it("blocks users outside allowFrom", () => {
+    const context = buildCampfireInboundContext({
+      payload: createPayload(),
+      allowFrom: ["77", "Bob"],
+      baseUrl: "https://campfire.example.com",
+    });
+
+    expect(context.isAllowed).toBe(false);
+  });
+
+  it("allows all users when allowFrom is empty", () => {
+    const context = buildCampfireInboundContext({
+      payload: createPayload(),
+      allowFrom: [],
+      baseUrl: "https://campfire.example.com",
+    });
+
+    expect(context.isAllowed).toBe(true);
+    expect(context.sender).toEqual({ id: "42", name: "Alice" });
+    expect(context.replyUrl).toBe("https://campfire.example.com/rooms/7/42-AbCdEf/messages");
+  });
+
+  it("uses a stable thread key for the same room", () => {
+    const first = buildCampfireInboundContext({
+      payload: createPayload(),
+      allowFrom: [],
+      baseUrl: "https://campfire.example.com",
+    });
+    const second = buildCampfireInboundContext({
+      payload: createPayload({ message: { id: 100, body: { plain: "follow up" }, path: "x" } }),
+      allowFrom: [],
+      baseUrl: "https://campfire.example.com",
+    });
+
+    expect(first.threadKey).toBe("campfire:room:7");
+    expect(second.threadKey).toBe("campfire:room:7");
+  });
+});

--- a/extensions/campfire/src/monitor/context.test.ts
+++ b/extensions/campfire/src/monitor/context.test.ts
@@ -60,4 +60,20 @@ describe("buildCampfireInboundContext", () => {
     expect(first.threadKey).toBe("campfire:room:7");
     expect(second.threadKey).toBe("campfire:room:7");
   });
+
+  it("blocks reply URLs outside the configured workspace path", () => {
+    const context = buildCampfireInboundContext({
+      payload: createPayload({
+        room: {
+          id: 7,
+          name: "General",
+          path: "https://3.basecamp.com/7654321/buckets/7/chats/88/messages/99",
+        },
+      }),
+      allowFrom: [],
+      baseUrl: "https://3.basecamp.com/1234567",
+    });
+
+    expect(context.isAllowed).toBe(false);
+  });
 });

--- a/extensions/campfire/src/monitor/context.test.ts
+++ b/extensions/campfire/src/monitor/context.test.ts
@@ -45,6 +45,16 @@ describe("buildCampfireInboundContext", () => {
     expect(context.replyUrl).toBe("https://campfire.example.com/rooms/7/42-AbCdEf/messages");
   });
 
+  it("allows all users when allowFrom contains wildcard", () => {
+    const context = buildCampfireInboundContext({
+      payload: createPayload(),
+      allowFrom: ["*"],
+      baseUrl: "https://campfire.example.com",
+    });
+
+    expect(context.isAllowed).toBe(true);
+  });
+
   it("treats allowFrom entries as sender IDs only", () => {
     const context = buildCampfireInboundContext({
       payload: createPayload(),

--- a/extensions/campfire/src/monitor/context.test.ts
+++ b/extensions/campfire/src/monitor/context.test.ts
@@ -45,6 +45,16 @@ describe("buildCampfireInboundContext", () => {
     expect(context.replyUrl).toBe("https://campfire.example.com/rooms/7/42-AbCdEf/messages");
   });
 
+  it("treats allowFrom entries as sender IDs only", () => {
+    const context = buildCampfireInboundContext({
+      payload: createPayload(),
+      allowFrom: ["Alice"],
+      baseUrl: "https://campfire.example.com",
+    });
+
+    expect(context.isAllowed).toBe(false);
+  });
+
   it("uses a stable thread key for the same room", () => {
     const first = buildCampfireInboundContext({
       payload: createPayload(),

--- a/extensions/campfire/src/monitor/context.test.ts
+++ b/extensions/campfire/src/monitor/context.test.ts
@@ -81,6 +81,23 @@ describe("buildCampfireInboundContext", () => {
     expect(second.threadKey).toBe("campfire:room:7");
   });
 
+  it("uses Basecamp chat ids for inbound room routing", () => {
+    const context = buildCampfireInboundContext({
+      payload: createPayload({
+        room: {
+          id: 7,
+          name: "General",
+          path: "https://3.basecamp.com/1234567/buckets/7/chats/88/messages/99",
+        },
+      }),
+      allowFrom: [],
+      baseUrl: "https://3.basecamp.com/1234567",
+    });
+
+    expect(context.roomId).toBe("88");
+    expect(context.threadKey).toBe("campfire:room:88");
+  });
+
   it("blocks reply URLs outside the configured workspace path", () => {
     const context = buildCampfireInboundContext({
       payload: createPayload({

--- a/extensions/campfire/src/monitor/context.ts
+++ b/extensions/campfire/src/monitor/context.ts
@@ -15,7 +15,10 @@ export function buildCampfireInboundContext(params: {
   const senderName = payload.user.name;
 
   const normalizedAllowFrom = (allowFrom ?? []).map((entry) => entry.trim()).filter(Boolean);
-  const senderAllowed = normalizedAllowFrom.length === 0 || normalizedAllowFrom.includes(senderId);
+  const senderAllowed =
+    normalizedAllowFrom.length === 0 ||
+    normalizedAllowFrom.includes("*") ||
+    normalizedAllowFrom.includes(senderId);
 
   const replyUrlAllowed = isAllowedReplyUrl(payload.room.path, baseUrl);
 

--- a/extensions/campfire/src/monitor/context.ts
+++ b/extensions/campfire/src/monitor/context.ts
@@ -1,0 +1,50 @@
+import type { CampfireWebhookPayload } from "../types.js";
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isAllowedReplyUrl(replyUrl: string, baseUrl: string): boolean {
+  const replyOrigin = normalizeOrigin(replyUrl);
+  const expectedOrigin = normalizeOrigin(baseUrl);
+  if (!replyOrigin || !expectedOrigin) {
+    return false;
+  }
+  return replyOrigin === expectedOrigin;
+}
+
+export function buildCampfireInboundContext(params: {
+  payload: CampfireWebhookPayload;
+  allowFrom?: string[];
+  baseUrl: string;
+}) {
+  const { payload, allowFrom, baseUrl } = params;
+  const senderId = String(payload.user.id);
+  const senderName = payload.user.name;
+
+  const normalizedAllowFrom = (allowFrom ?? []).map((entry) => entry.trim()).filter(Boolean);
+  const senderAllowed =
+    normalizedAllowFrom.length === 0 ||
+    normalizedAllowFrom.includes(senderId) ||
+    normalizedAllowFrom.includes(senderName);
+
+  const replyUrlAllowed = isAllowedReplyUrl(payload.room.path, baseUrl);
+
+  return {
+    isAllowed: senderAllowed && replyUrlAllowed,
+    sender: {
+      id: senderId,
+      name: senderName,
+    },
+    roomId: String(payload.room.id),
+    roomName: payload.room.name,
+    replyUrl: payload.room.path,
+    messageId: String(payload.message.id),
+    text: payload.message.body.plain,
+    threadKey: `campfire:room:${payload.room.id}`,
+  };
+}

--- a/extensions/campfire/src/monitor/context.ts
+++ b/extensions/campfire/src/monitor/context.ts
@@ -1,20 +1,8 @@
 import type { CampfireWebhookPayload } from "../types.js";
-
-function normalizeOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin;
-  } catch {
-    return null;
-  }
-}
+import { isCampfireUrlInWorkspaceScope } from "../workspace-url.js";
 
 function isAllowedReplyUrl(replyUrl: string, baseUrl: string): boolean {
-  const replyOrigin = normalizeOrigin(replyUrl);
-  const expectedOrigin = normalizeOrigin(baseUrl);
-  if (!replyOrigin || !expectedOrigin) {
-    return false;
-  }
-  return replyOrigin === expectedOrigin;
+  return isCampfireUrlInWorkspaceScope(replyUrl, baseUrl);
 }
 
 export function buildCampfireInboundContext(params: {

--- a/extensions/campfire/src/monitor/context.ts
+++ b/extensions/campfire/src/monitor/context.ts
@@ -15,10 +15,7 @@ export function buildCampfireInboundContext(params: {
   const senderName = payload.user.name;
 
   const normalizedAllowFrom = (allowFrom ?? []).map((entry) => entry.trim()).filter(Boolean);
-  const senderAllowed =
-    normalizedAllowFrom.length === 0 ||
-    normalizedAllowFrom.includes(senderId) ||
-    normalizedAllowFrom.includes(senderName);
+  const senderAllowed = normalizedAllowFrom.length === 0 || normalizedAllowFrom.includes(senderId);
 
   const replyUrlAllowed = isAllowedReplyUrl(payload.room.path, baseUrl);
 

--- a/extensions/campfire/src/monitor/context.ts
+++ b/extensions/campfire/src/monitor/context.ts
@@ -5,12 +5,46 @@ function isAllowedReplyUrl(replyUrl: string, baseUrl: string): boolean {
   return isCampfireUrlInWorkspaceScope(replyUrl, baseUrl);
 }
 
+function findSegmentAfter(pathname: string, marker: string): string | null {
+  const segments = pathname
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  const markerIndex = segments.findIndex((segment) => segment.toLowerCase() === marker);
+  if (markerIndex < 0) {
+    return null;
+  }
+  const nextSegment = segments[markerIndex + 1]?.trim();
+  return nextSegment ? nextSegment : null;
+}
+
+function resolveInboundRoomId(payload: CampfireWebhookPayload): string {
+  const fallbackRoomId = String(payload.room.id);
+  const normalizedPath = payload.room.path.trim();
+  if (!normalizedPath) {
+    return fallbackRoomId;
+  }
+
+  try {
+    const url = new URL(normalizedPath);
+    return (
+      findSegmentAfter(url.pathname, "rooms") ??
+      findSegmentAfter(url.pathname, "chats") ??
+      findSegmentAfter(url.pathname, "buckets") ??
+      fallbackRoomId
+    );
+  } catch {
+    return fallbackRoomId;
+  }
+}
+
 export function buildCampfireInboundContext(params: {
   payload: CampfireWebhookPayload;
   allowFrom?: string[];
   baseUrl: string;
 }) {
   const { payload, allowFrom, baseUrl } = params;
+  const routeRoomId = resolveInboundRoomId(payload);
   const senderId = String(payload.user.id);
   const senderName = payload.user.name;
 
@@ -28,11 +62,11 @@ export function buildCampfireInboundContext(params: {
       id: senderId,
       name: senderName,
     },
-    roomId: String(payload.room.id),
+    roomId: routeRoomId,
     roomName: payload.room.name,
     replyUrl: payload.room.path,
     messageId: String(payload.message.id),
     text: payload.message.body.plain,
-    threadKey: `campfire:room:${payload.room.id}`,
+    threadKey: `campfire:room:${routeRoomId}`,
   };
 }

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -82,6 +82,11 @@ describe("campfire gateway", () => {
     await registered.onInbound(validPayload);
 
     expect(finalizeInboundContext).toHaveBeenCalled();
+    const finalizedCtx = finalizeInboundContext.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(finalizedCtx?.SessionKey).toMatch(/^agent:/);
+    expect(finalizedCtx?.SessionKey).toContain(":account:default");
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
     expect(sendText).toHaveBeenCalledWith(
       "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
@@ -264,6 +269,59 @@ describe("campfire gateway", () => {
     });
 
     expect(finalizedCtx?.CommandAuthorized).toBe(true);
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("reloads config before computing command authorization", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const loadConfig = vi.fn(() => ({ commands: { useAccessGroups: true } }));
+    let finalizedCtx: Record<string, unknown> | undefined;
+
+    const gateway = createCampfireGateway({ registerRoute, sendText, loadConfig } as never);
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {
+        commands: {
+          useAccessGroups: false,
+        },
+      },
+      accountId: "default",
+      account: createAccount({ allowFrom: [] }),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => {
+            finalizedCtx = ctx;
+            return ctx;
+          }),
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound({
+      ...validPayload,
+      message: {
+        ...validPayload.message,
+        body: {
+          plain: "!status",
+        },
+      },
+    });
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(finalizedCtx?.CommandAuthorized).toBe(false);
 
     abort.abort();
     await startPromise;

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -229,6 +229,53 @@ describe("campfire gateway", () => {
     await startPromise;
   });
 
+  it("authorizes command messages when allowFrom includes wildcard", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    let finalizedCtx: Record<string, unknown> | undefined;
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount({ allowFrom: ["*"] }),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => {
+            finalizedCtx = ctx;
+            return ctx;
+          }),
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound({
+      ...validPayload,
+      message: {
+        ...validPayload.message,
+        body: {
+          plain: "!status",
+        },
+      },
+    });
+
+    expect(finalizedCtx?.CommandAuthorized).toBe(true);
+
+    abort.abort();
+    await startPromise;
+  });
+
   it("honors commands.useAccessGroups=false for command authorization", async () => {
     const registerRoute = vi.fn().mockReturnValue(() => {});
     const sendText = vi.fn().mockResolvedValue(undefined);

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -86,6 +86,7 @@ describe("campfire gateway", () => {
     expect(sendText).toHaveBeenCalledWith(
       "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
       "Hello back",
+      "42-AbCdEf",
       4000,
     );
 

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -380,6 +380,83 @@ describe("campfire gateway", () => {
     await startPromise;
   });
 
+  it("reloads account-scoped settings before inbound authorization and reply delivery", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const loadConfig = vi.fn(() => ({
+      channels: {
+        campfire: {
+          baseUrl: "https://3.basecamp.com/1234567",
+          botKey: "200-NewBotKey",
+          allowFrom: ["42"],
+          textChunkLimit: 1234,
+        },
+      },
+    }));
+
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(
+      async ({
+        dispatcherOptions,
+      }: {
+        dispatcherOptions: {
+          deliver: (payload: { text?: string; body?: string }) => Promise<void>;
+        };
+      }) => {
+        await dispatcherOptions.deliver({ text: "Hello back" });
+      },
+    );
+
+    const gateway = createCampfireGateway({ registerRoute, sendText, loadConfig });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {
+        channels: {
+          campfire: {
+            baseUrl: "https://3.basecamp.com/9999999",
+            botKey: "100-OldBotKey",
+            allowFrom: ["77"],
+            textChunkLimit: 4000,
+          },
+        },
+      },
+      accountId: "default",
+      account: createAccount({
+        baseUrl: "https://3.basecamp.com/9999999",
+        botKey: "100-OldBotKey",
+        allowFrom: ["77"],
+        textChunkLimit: 4000,
+      }),
+      abortSignal: abort.signal,
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound({
+      ...validPayload,
+      room: {
+        ...validPayload.room,
+        path: "https://3.basecamp.com/1234567/buckets/7/chats/88/messages/99",
+      },
+    });
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledWith(
+      "https://3.basecamp.com/1234567/buckets/7/chats/88/messages/99",
+      "Hello back",
+      "200-NewBotKey",
+      1234,
+    );
+
+    abort.abort();
+    await startPromise;
+  });
+
   it("skips webhook registration for disabled accounts", async () => {
     const registerRoute = vi.fn().mockReturnValue(() => {});
     const gateway = createCampfireGateway({ registerRoute });

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CampfireWebhookPayload, ResolvedCampfireAccount } from "../types.js";
+import { createCampfireGateway } from "./provider.js";
+
+const validPayload: CampfireWebhookPayload = {
+  user: { id: 42, name: "Alice" },
+  room: {
+    id: 7,
+    name: "General",
+    path: "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+  },
+  message: {
+    id: 99,
+    body: { plain: "Hey help me" },
+    path: "https://campfire.example.com/rooms/7/@99",
+  },
+};
+
+function createAccount(overrides?: Partial<ResolvedCampfireAccount>): ResolvedCampfireAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    baseUrl: "https://campfire.example.com",
+    botKey: "42-AbCdEf",
+    allowFrom: [],
+    webhookPath: "/channels/campfire/webhook/default",
+    textChunkLimit: 4000,
+    ...overrides,
+  };
+}
+
+describe("campfire gateway", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers webhook ingress and forwards replies", async () => {
+    const unregister = vi.fn();
+    const registerRoute = vi.fn().mockReturnValue(unregister);
+    const sendText = vi.fn().mockResolvedValue(undefined);
+
+    const finalizeInboundContext = vi.fn((ctx: Record<string, unknown>) => ctx);
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(
+      async ({
+        dispatcherOptions,
+      }: {
+        dispatcherOptions: {
+          deliver: (payload: { text?: string; body?: string }) => Promise<void>;
+        };
+      }) => {
+        await dispatcherOptions.deliver({ text: "Hello back" });
+      },
+    );
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount(),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    expect(registered).toBeTruthy();
+    expect(registered.path).toBe("/channels/campfire/webhook/default");
+
+    await registered.onInbound(validPayload);
+
+    expect(finalizeInboundContext).toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledWith(
+      "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+      "Hello back",
+      4000,
+    );
+
+    abort.abort();
+    await startPromise;
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops inbound messages from blocked users", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount({ allowFrom: ["77"] }),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound(validPayload);
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(sendText).not.toHaveBeenCalled();
+
+    abort.abort();
+    await startPromise;
+  });
+});

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -132,4 +132,102 @@ describe("campfire gateway", () => {
     abort.abort();
     await startPromise;
   });
+
+  it("marks command messages unauthorized when no allowFrom is configured", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    let finalizedCtx: Record<string, unknown> | undefined;
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount({ allowFrom: [] }),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => {
+            finalizedCtx = ctx;
+            return ctx;
+          }),
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound({
+      ...validPayload,
+      message: {
+        ...validPayload.message,
+        body: {
+          plain: "!status",
+        },
+      },
+    });
+
+    expect(finalizedCtx?.CommandAuthorized).toBe(false);
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("honors commands.useAccessGroups=false for command authorization", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    let finalizedCtx: Record<string, unknown> | undefined;
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {
+        commands: {
+          useAccessGroups: false,
+        },
+      },
+      accountId: "default",
+      account: createAccount({ allowFrom: [] }),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => {
+            finalizedCtx = ctx;
+            return ctx;
+          }),
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound({
+      ...validPayload,
+      message: {
+        ...validPayload.message,
+        body: {
+          plain: "!status",
+        },
+      },
+    });
+
+    expect(finalizedCtx?.CommandAuthorized).toBe(true);
+
+    abort.abort();
+    await startPromise;
+  });
 });

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -333,6 +333,184 @@ describe("campfire gateway", () => {
     await startPromise;
   });
 
+  it("skips webhook registration for disabled accounts", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const gateway = createCampfireGateway({ registerRoute });
+    const abort = new AbortController();
+
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount({ enabled: false }),
+      abortSignal: abort.signal,
+    });
+
+    expect(registerRoute).not.toHaveBeenCalled();
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("skips webhook registration for unconfigured accounts", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const gateway = createCampfireGateway({ registerRoute });
+    const abort = new AbortController();
+
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount({ configured: false }),
+      abortSignal: abort.signal,
+    });
+
+    expect(registerRoute).not.toHaveBeenCalled();
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("warns and waits when channelRuntime is missing", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const warnSpy = vi.fn();
+    const gateway = createCampfireGateway({ registerRoute });
+    const abort = new AbortController();
+
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount(),
+      abortSignal: abort.signal,
+      log: { warn: warnSpy },
+    });
+
+    expect(registerRoute).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("channelRuntime is unavailable"));
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("falls back to ctx.cfg when config reload fails", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const loadConfig = vi.fn().mockRejectedValue(new Error("config gone"));
+    let finalizedCtx: Record<string, unknown> | undefined;
+
+    const gateway = createCampfireGateway({ registerRoute, sendText, loadConfig });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {
+        commands: { useAccessGroups: false },
+      },
+      accountId: "default",
+      account: createAccount(),
+      abortSignal: abort.signal,
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => {
+            finalizedCtx = ctx;
+            return ctx;
+          }),
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound({
+      ...validPayload,
+      message: { ...validPayload.message, body: { plain: "!status" } },
+    });
+
+    expect(loadConfig).toHaveBeenCalled();
+    // Falls back to ctx.cfg which has useAccessGroups: false → commands authorized
+    expect(finalizedCtx?.CommandAuthorized).toBe(true);
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("delivers body field when text field is absent", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount(),
+      abortSignal: abort.signal,
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockImplementation(
+            async ({
+              dispatcherOptions,
+            }: {
+              dispatcherOptions: {
+                deliver: (p: { text?: string; body?: string }) => Promise<void>;
+              };
+            }) => {
+              await dispatcherOptions.deliver({ body: "fallback body" });
+            },
+          ),
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound(validPayload);
+
+    expect(sendText).toHaveBeenCalledWith(
+      "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
+      "fallback body",
+      "100-AbCdEf",
+      4000,
+    );
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("skips delivery when reply payload has no text or body", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount(),
+      abortSignal: abort.signal,
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockImplementation(
+            async ({
+              dispatcherOptions,
+            }: {
+              dispatcherOptions: {
+                deliver: (p: { text?: string; body?: string }) => Promise<void>;
+              };
+            }) => {
+              await dispatcherOptions.deliver({});
+            },
+          ),
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound(validPayload);
+
+    expect(sendText).not.toHaveBeenCalled();
+
+    abort.abort();
+    await startPromise;
+  });
+
   it("drops inbound messages authored by the configured bot", async () => {
     const registerRoute = vi.fn().mockReturnValue(() => {});
     const sendText = vi.fn().mockResolvedValue(undefined);

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -1,3 +1,4 @@
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CampfireWebhookPayload, ResolvedCampfireAccount } from "../types.js";
 import { createCampfireGateway } from "./provider.js";
@@ -85,8 +86,13 @@ describe("campfire gateway", () => {
     const finalizedCtx = finalizeInboundContext.mock.calls[0]?.[0] as
       | Record<string, unknown>
       | undefined;
-    expect(finalizedCtx?.SessionKey).toMatch(/^agent:/);
-    expect(finalizedCtx?.SessionKey).toContain(":account:default");
+    const expectedRoute = resolveAgentRoute({
+      cfg: {},
+      channel: "campfire",
+      accountId: "default",
+      peer: { kind: "group", id: "7" },
+    });
+    expect(finalizedCtx?.SessionKey).toBe(expectedRoute.sessionKey);
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
     expect(sendText).toHaveBeenCalledWith(
       "https://campfire.example.com/rooms/7/42-AbCdEf/messages",

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -133,6 +133,44 @@ describe("campfire gateway", () => {
     await startPromise;
   });
 
+  it("does not allow sender-name matches in allowFrom", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount({ allowFrom: ["Alice"] }),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound(validPayload);
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(sendText).not.toHaveBeenCalled();
+
+    abort.abort();
+    await startPromise;
+  });
+
   it("marks command messages unauthorized when no allowFrom is configured", async () => {
     const registerRoute = vi.fn().mockReturnValue(() => {});
     const sendText = vi.fn().mockResolvedValue(undefined);

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -280,7 +280,7 @@ describe("campfire gateway", () => {
     const loadConfig = vi.fn(() => ({ commands: { useAccessGroups: true } }));
     let finalizedCtx: Record<string, unknown> | undefined;
 
-    const gateway = createCampfireGateway({ registerRoute, sendText, loadConfig } as never);
+    const gateway = createCampfireGateway({ registerRoute, sendText, loadConfig });
     const abort = new AbortController();
     const startPromise = gateway.startAccount({
       cfg: {

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -330,7 +330,17 @@ describe("campfire gateway", () => {
   it("reloads config before computing command authorization", async () => {
     const registerRoute = vi.fn().mockReturnValue(() => {});
     const sendText = vi.fn().mockResolvedValue(undefined);
-    const loadConfig = vi.fn(() => ({ commands: { useAccessGroups: true } }));
+    const loadConfig = vi.fn(() => ({
+      commands: { useAccessGroups: true },
+      channels: {
+        campfire: {
+          baseUrl: "https://campfire.example.com",
+          botKey: "100-AbCdEf",
+          allowFrom: [],
+          textChunkLimit: 4000,
+        },
+      },
+    }));
     let finalizedCtx: Record<string, unknown> | undefined;
 
     const gateway = createCampfireGateway({ registerRoute, sendText, loadConfig });
@@ -375,6 +385,48 @@ describe("campfire gateway", () => {
 
     expect(loadConfig).toHaveBeenCalledTimes(1);
     expect(finalizedCtx?.CommandAuthorized).toBe(false);
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("stops inbound processing when reloaded config removes campfire section", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+    const loadConfig = vi.fn(() => ({}));
+
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
+
+    const gateway = createCampfireGateway({ registerRoute, sendText, loadConfig });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {
+        channels: {
+          campfire: {
+            baseUrl: "https://campfire.example.com",
+            botKey: "100-AbCdEf",
+            allowFrom: [],
+            textChunkLimit: 4000,
+          },
+        },
+      },
+      accountId: "default",
+      account: createAccount(),
+      abortSignal: abort.signal,
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound(validPayload);
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(sendText).not.toHaveBeenCalled();
 
     abort.abort();
     await startPromise;

--- a/extensions/campfire/src/monitor/provider.test.ts
+++ b/extensions/campfire/src/monitor/provider.test.ts
@@ -23,7 +23,7 @@ function createAccount(overrides?: Partial<ResolvedCampfireAccount>): ResolvedCa
     enabled: true,
     configured: true,
     baseUrl: "https://campfire.example.com",
-    botKey: "42-AbCdEf",
+    botKey: "100-AbCdEf",
     allowFrom: [],
     webhookPath: "/channels/campfire/webhook/default",
     textChunkLimit: 4000,
@@ -97,7 +97,7 @@ describe("campfire gateway", () => {
     expect(sendText).toHaveBeenCalledWith(
       "https://campfire.example.com/rooms/7/42-AbCdEf/messages",
       "Hello back",
-      "42-AbCdEf",
+      "100-AbCdEf",
       4000,
     );
 
@@ -328,6 +328,44 @@ describe("campfire gateway", () => {
 
     expect(loadConfig).toHaveBeenCalledTimes(1);
     expect(finalizedCtx?.CommandAuthorized).toBe(false);
+
+    abort.abort();
+    await startPromise;
+  });
+
+  it("drops inbound messages authored by the configured bot", async () => {
+    const registerRoute = vi.fn().mockReturnValue(() => {});
+    const sendText = vi.fn().mockResolvedValue(undefined);
+
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
+
+    const gateway = createCampfireGateway({ registerRoute, sendText });
+    const abort = new AbortController();
+    const startPromise = gateway.startAccount({
+      cfg: {},
+      accountId: "default",
+      account: createAccount({ botKey: "42-AbCdEf" }),
+      runtime: {
+        log: () => {},
+        error: () => {},
+        exit: () => {},
+      },
+      abortSignal: abort.signal,
+      getStatus: () => ({ accountId: "default" }),
+      setStatus: () => {},
+      channelRuntime: {
+        reply: {
+          finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const registered = registerRoute.mock.calls[0]?.[0];
+    await registered.onInbound(validPayload);
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(sendText).not.toHaveBeenCalled();
 
     abort.abort();
     await startPromise;

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -121,7 +121,12 @@ export function createCampfireGateway(params?: {
               if (!text) {
                 return;
               }
-              await sendText(inbound.replyUrl, text, ctx.account.textChunkLimit);
+              await sendText(
+                inbound.replyUrl,
+                text,
+                ctx.account.botKey,
+                ctx.account.textChunkLimit,
+              );
             },
             onError: (err: unknown, info: { kind: string }) => {
               ctx.log?.error?.(

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveCampfireAccount } from "../config.js";
 import { registerCampfireWebhookRoute, type CampfireInboundHandler } from "../http/index.js";
 import { getCampfireRuntime } from "../runtime.js";
 import { sendCampfireText } from "../send.js";
@@ -116,6 +117,11 @@ async function resolveCampfireInboundConfig(params: {
   }
 }
 
+function hasCampfireChannelSection(cfg: OpenClawConfig): boolean {
+  const section = cfg.channels?.campfire;
+  return Boolean(section && typeof section === "object" && !Array.isArray(section));
+}
+
 export function createCampfireGateway(params?: {
   registerRoute?: typeof registerCampfireWebhookRoute;
   sendText?: typeof sendCampfireText;
@@ -145,13 +151,32 @@ export function createCampfireGateway(params?: {
           return;
         }
 
+        const currentCfg = await resolveCampfireInboundConfig({
+          fallback: ctx.cfg,
+          loadConfigOverride: loadConfig,
+          log: ctx.log,
+        });
+        const resolvedCurrentAccount = resolveCampfireAccount(currentCfg, ctx.account.accountId);
+        const currentAccount =
+          !resolvedCurrentAccount.configured &&
+          ctx.account.configured &&
+          !hasCampfireChannelSection(currentCfg)
+            ? ctx.account
+            : resolvedCurrentAccount;
+        if (!currentAccount.enabled || !currentAccount.configured) {
+          return;
+        }
+
         const inbound = buildCampfireInboundContext({
           payload,
-          allowFrom: ctx.account.allowFrom,
-          baseUrl: ctx.account.baseUrl,
+          allowFrom: currentAccount.allowFrom,
+          baseUrl: currentAccount.baseUrl,
         });
         if (
-          isCampfireSelfAuthoredInbound({ senderId: inbound.sender.id, botKey: ctx.account.botKey })
+          isCampfireSelfAuthoredInbound({
+            senderId: inbound.sender.id,
+            botKey: currentAccount.botKey,
+          })
         ) {
           return;
         }
@@ -159,16 +184,10 @@ export function createCampfireGateway(params?: {
           return;
         }
 
-        const currentCfg = await resolveCampfireInboundConfig({
-          fallback: ctx.cfg,
-          loadConfigOverride: loadConfig,
-          log: ctx.log,
-        });
-
         const route = resolveAgentRoute({
           cfg: currentCfg,
           channel: "campfire",
-          accountId: ctx.account.accountId,
+          accountId: currentAccount.accountId,
           peer: {
             kind: "group",
             id: inbound.roomId,
@@ -178,7 +197,7 @@ export function createCampfireGateway(params?: {
         const commandAuthorized = resolveCampfireCommandAuthorized({
           cfg: currentCfg,
           rawBody: inbound.text,
-          allowFrom: ctx.account.allowFrom,
+          allowFrom: currentAccount.allowFrom,
           senderId: inbound.sender.id,
         });
 
@@ -223,13 +242,13 @@ export function createCampfireGateway(params?: {
               await sendText(
                 inbound.replyUrl,
                 text,
-                ctx.account.botKey,
-                ctx.account.textChunkLimit,
+                currentAccount.botKey,
+                currentAccount.textChunkLimit,
               );
             },
             onError: (err: unknown, info: { kind: string }) => {
               ctx.log?.error?.(
-                `[${ctx.account.accountId}] campfire ${info.kind} reply failed: ${String(err)}`,
+                `[${currentAccount.accountId}] campfire ${info.kind} reply failed: ${String(err)}`,
               );
             },
           },

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -75,19 +75,7 @@ type CampfireGatewayContext = {
     warn?: (message: string) => void;
     error?: (message: string) => void;
   };
-  channelRuntime?: {
-    reply: {
-      finalizeInboundContext: (ctx: Record<string, unknown>) => Record<string, unknown>;
-      dispatchReplyWithBufferedBlockDispatcher: (params: {
-        ctx: Record<string, unknown>;
-        cfg: OpenClawConfig;
-        dispatcherOptions: {
-          deliver: (replyPayload: { text?: string; body?: string }) => Promise<void>;
-          onError?: (err: unknown, info: { kind: string }) => void;
-        };
-      }) => Promise<unknown>;
-    };
-  };
+  channelRuntime?: unknown;
 };
 
 type CampfireGatewayAdapter = {
@@ -95,6 +83,38 @@ type CampfireGatewayAdapter = {
 };
 
 type CampfireConfigLoader = () => OpenClawConfig | Promise<OpenClawConfig>;
+
+type CampfireReplyRuntime = {
+  finalizeInboundContext: (ctx: Record<string, unknown>) => Record<string, unknown>;
+  dispatchReplyWithBufferedBlockDispatcher: (params: {
+    ctx: Record<string, unknown>;
+    cfg: OpenClawConfig;
+    dispatcherOptions: {
+      deliver: (replyPayload: { text?: string; body?: string }) => Promise<void>;
+      onError?: (err: unknown, info: { kind: string }) => void;
+    };
+  }) => Promise<unknown>;
+};
+
+function resolveCampfireReplyRuntime(channelRuntime: unknown): CampfireReplyRuntime | null {
+  if (!channelRuntime || typeof channelRuntime !== "object") {
+    return null;
+  }
+  const reply = (channelRuntime as { reply?: unknown }).reply;
+  if (!reply || typeof reply !== "object") {
+    return null;
+  }
+
+  const replyRecord = reply as Record<string, unknown>;
+  if (
+    typeof replyRecord.finalizeInboundContext !== "function" ||
+    typeof replyRecord.dispatchReplyWithBufferedBlockDispatcher !== "function"
+  ) {
+    return null;
+  }
+
+  return reply as CampfireReplyRuntime;
+}
 
 async function resolveCampfireInboundConfig(params: {
   fallback: OpenClawConfig;
@@ -138,8 +158,8 @@ export function createCampfireGateway(params?: {
         await waitUntilAbort(ctx.abortSignal);
         return;
       }
-      const channelRuntime = ctx.channelRuntime;
-      if (!channelRuntime) {
+      const replyRuntime = resolveCampfireReplyRuntime(ctx.channelRuntime);
+      if (!replyRuntime) {
         ctx.log?.warn?.(
           `[${ctx.account.accountId}] campfire channelRuntime is unavailable; inbound disabled`,
         );
@@ -203,7 +223,7 @@ export function createCampfireGateway(params?: {
           senderId: inbound.sender.id,
         });
 
-        const msgCtx = channelRuntime.reply.finalizeInboundContext({
+        const msgCtx = replyRuntime.finalizeInboundContext({
           Body: inbound.text,
           BodyForAgent: inbound.text,
           RawBody: inbound.text,
@@ -227,7 +247,7 @@ export function createCampfireGateway(params?: {
           CommandAuthorized: commandAuthorized,
         });
 
-        await channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher({
+        await replyRuntime.dispatchReplyWithBufferedBlockDispatcher({
           ctx: msgCtx,
           cfg: currentCfg,
           dispatcherOptions: {

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -33,7 +33,7 @@ function resolveCampfireCommandAuthorized(params: {
   }
 
   const allowFrom = params.allowFrom.map((entry) => entry.trim()).filter(Boolean);
-  const senderAllowedForCommands = allowFrom.includes(params.senderId);
+  const senderAllowedForCommands = allowFrom.includes("*") || allowFrom.includes(params.senderId);
 
   return resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups: params.cfg.commands?.useAccessGroups !== false,

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -4,7 +4,9 @@ import {
   shouldComputeCommandAuthorized,
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { registerCampfireWebhookRoute, type CampfireInboundHandler } from "../http/index.js";
+import { getCampfireRuntime } from "../runtime.js";
 import { sendCampfireText } from "../send.js";
 import type { ResolvedCampfireAccount } from "../types.js";
 import { buildCampfireInboundContext } from "./context.js";
@@ -76,12 +78,37 @@ type CampfireGatewayAdapter = {
   startAccount: (ctx: CampfireGatewayContext) => Promise<void>;
 };
 
+type CampfireConfigLoader = () => OpenClawConfig | Promise<OpenClawConfig>;
+
+async function resolveCampfireInboundConfig(params: {
+  fallback: OpenClawConfig;
+  loadConfigOverride?: CampfireConfigLoader;
+  log?: {
+    warn?: (message: string) => void;
+  };
+}): Promise<OpenClawConfig> {
+  const loadConfig =
+    params.loadConfigOverride ??
+    (() => {
+      return getCampfireRuntime().config.loadConfig();
+    });
+
+  try {
+    return await Promise.resolve(loadConfig());
+  } catch (err) {
+    params.log?.warn?.(`campfire: failed to reload config for inbound webhook: ${String(err)}`);
+    return params.fallback;
+  }
+}
+
 export function createCampfireGateway(params?: {
   registerRoute?: typeof registerCampfireWebhookRoute;
   sendText?: typeof sendCampfireText;
+  loadConfig?: CampfireConfigLoader;
 }): CampfireGatewayAdapter {
   const registerRoute = params?.registerRoute ?? registerCampfireWebhookRoute;
   const sendText = params?.sendText ?? sendCampfireText;
+  const loadConfig = params?.loadConfig;
 
   return {
     startAccount: async (ctx) => {
@@ -112,8 +139,25 @@ export function createCampfireGateway(params?: {
           return;
         }
 
+        const currentCfg = await resolveCampfireInboundConfig({
+          fallback: ctx.cfg,
+          loadConfigOverride: loadConfig,
+          log: ctx.log,
+        });
+
+        const route = resolveAgentRoute({
+          cfg: currentCfg,
+          channel: "campfire",
+          accountId: ctx.account.accountId,
+          peer: {
+            kind: "group",
+            id: inbound.roomId,
+          },
+        });
+        const sessionKey = `${route.sessionKey}:account:${route.accountId}`;
+
         const commandAuthorized = resolveCampfireCommandAuthorized({
-          cfg: ctx.cfg,
+          cfg: currentCfg,
           rawBody: inbound.text,
           allowFrom: ctx.account.allowFrom,
           senderId: inbound.sender.id,
@@ -126,8 +170,8 @@ export function createCampfireGateway(params?: {
           CommandBody: inbound.text,
           From: `campfire:${inbound.sender.id}`,
           To: `campfire:room:${inbound.roomId}`,
-          SessionKey: inbound.threadKey,
-          AccountId: ctx.account.accountId,
+          SessionKey: sessionKey,
+          AccountId: route.accountId,
           ChatType: "group",
           ConversationLabel: inbound.roomName,
           SenderId: inbound.sender.id,
@@ -145,7 +189,7 @@ export function createCampfireGateway(params?: {
 
         await channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher({
           ctx: msgCtx,
-          cfg: ctx.cfg,
+          cfg: currentCfg,
           dispatcherOptions: {
             deliver: async (replyPayload: { text?: string; body?: string }) => {
               const text =

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -1,3 +1,4 @@
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { registerCampfireWebhookRoute, type CampfireInboundHandler } from "../http/index.js";
 import { sendCampfireText } from "../send.js";
@@ -20,8 +21,8 @@ type CampfireGatewayContext = {
   account: ResolvedCampfireAccount;
   abortSignal: AbortSignal;
   runtime?: unknown;
-  getStatus?: () => Record<string, unknown>;
-  setStatus?: (next: Record<string, unknown>) => void;
+  getStatus?: () => ChannelAccountSnapshot;
+  setStatus?: (next: ChannelAccountSnapshot) => void;
   log?: {
     info?: (message: string) => void;
     warn?: (message: string) => void;

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -102,7 +102,7 @@ async function resolveCampfireInboundConfig(params: {
   log?: {
     warn?: (message: string) => void;
   };
-}): Promise<OpenClawConfig> {
+}): Promise<{ cfg: OpenClawConfig; usedFallback: boolean }> {
   const loadConfig =
     params.loadConfigOverride ??
     (() => {
@@ -110,16 +110,17 @@ async function resolveCampfireInboundConfig(params: {
     });
 
   try {
-    return await Promise.resolve(loadConfig());
+    return {
+      cfg: await Promise.resolve(loadConfig()),
+      usedFallback: false,
+    };
   } catch (err) {
     params.log?.warn?.(`campfire: failed to reload config for inbound webhook: ${String(err)}`);
-    return params.fallback;
+    return {
+      cfg: params.fallback,
+      usedFallback: true,
+    };
   }
-}
-
-function hasCampfireChannelSection(cfg: OpenClawConfig): boolean {
-  const section = cfg.channels?.campfire;
-  return Boolean(section && typeof section === "object" && !Array.isArray(section));
 }
 
 export function createCampfireGateway(params?: {
@@ -151,16 +152,17 @@ export function createCampfireGateway(params?: {
           return;
         }
 
-        const currentCfg = await resolveCampfireInboundConfig({
+        const resolvedInboundConfig = await resolveCampfireInboundConfig({
           fallback: ctx.cfg,
           loadConfigOverride: loadConfig,
           log: ctx.log,
         });
+        const currentCfg = resolvedInboundConfig.cfg;
         const resolvedCurrentAccount = resolveCampfireAccount(currentCfg, ctx.account.accountId);
         const currentAccount =
+          resolvedInboundConfig.usedFallback &&
           !resolvedCurrentAccount.configured &&
-          ctx.account.configured &&
-          !hasCampfireChannelSection(currentCfg)
+          ctx.account.configured
             ? ctx.account
             : resolvedCurrentAccount;
         if (!currentAccount.enabled || !currentAccount.configured) {

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -46,6 +46,21 @@ function resolveCampfireCommandAuthorized(params: {
   });
 }
 
+function resolveCampfireBotUserId(botKey: string): string | null {
+  const normalized = botKey.trim();
+  if (!normalized) {
+    return null;
+  }
+  const [prefix] = normalized.split("-", 1);
+  const botUserId = prefix?.trim();
+  return botUserId ? botUserId : null;
+}
+
+function isCampfireSelfAuthoredInbound(params: { senderId: string; botKey: string }): boolean {
+  const botUserId = resolveCampfireBotUserId(params.botKey);
+  return Boolean(botUserId && params.senderId === botUserId);
+}
+
 type CampfireGatewayContext = {
   cfg: OpenClawConfig;
   accountId: string;
@@ -135,6 +150,11 @@ export function createCampfireGateway(params?: {
           allowFrom: ctx.account.allowFrom,
           baseUrl: ctx.account.baseUrl,
         });
+        if (
+          isCampfireSelfAuthoredInbound({ senderId: inbound.sender.id, botKey: ctx.account.botKey })
+        ) {
+          return;
+        }
         if (!inbound.isAllowed) {
           return;
         }

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -154,7 +154,6 @@ export function createCampfireGateway(params?: {
             id: inbound.roomId,
           },
         });
-        const sessionKey = `${route.sessionKey}:account:${route.accountId}`;
 
         const commandAuthorized = resolveCampfireCommandAuthorized({
           cfg: currentCfg,
@@ -170,7 +169,7 @@ export function createCampfireGateway(params?: {
           CommandBody: inbound.text,
           From: `campfire:${inbound.sender.id}`,
           To: `campfire:room:${inbound.roomId}`,
-          SessionKey: sessionKey,
+          SessionKey: route.sessionKey,
           AccountId: route.accountId,
           ChatType: "group",
           ConversationLabel: inbound.roomName,

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -1,4 +1,8 @@
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
+import {
+  resolveCommandAuthorizedFromAuthorizers,
+  shouldComputeCommandAuthorized,
+} from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { registerCampfireWebhookRoute, type CampfireInboundHandler } from "../http/index.js";
 import { sendCampfireText } from "../send.js";
@@ -12,6 +16,33 @@ function waitUntilAbort(signal: AbortSignal): Promise<void> {
       return;
     }
     signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+function resolveCampfireCommandAuthorized(params: {
+  cfg: OpenClawConfig;
+  rawBody: string;
+  allowFrom: string[];
+  senderId: string;
+  senderName: string;
+}): boolean | undefined {
+  const shouldComputeAuth = shouldComputeCommandAuthorized(params.rawBody, params.cfg);
+  if (!shouldComputeAuth) {
+    return undefined;
+  }
+
+  const allowFrom = params.allowFrom.map((entry) => entry.trim()).filter(Boolean);
+  const senderAllowedForCommands =
+    allowFrom.includes(params.senderId) || allowFrom.includes(params.senderName);
+
+  return resolveCommandAuthorizedFromAuthorizers({
+    useAccessGroups: params.cfg.commands?.useAccessGroups !== false,
+    authorizers: [
+      {
+        configured: allowFrom.length > 0,
+        allowed: senderAllowedForCommands,
+      },
+    ],
   });
 }
 
@@ -83,6 +114,14 @@ export function createCampfireGateway(params?: {
           return;
         }
 
+        const commandAuthorized = resolveCampfireCommandAuthorized({
+          cfg: ctx.cfg,
+          rawBody: inbound.text,
+          allowFrom: ctx.account.allowFrom,
+          senderId: inbound.sender.id,
+          senderName: inbound.sender.name,
+        });
+
         const msgCtx = channelRuntime.reply.finalizeInboundContext({
           Body: inbound.text,
           BodyForAgent: inbound.text,
@@ -104,7 +143,7 @@ export function createCampfireGateway(params?: {
           MessageSidFull: inbound.messageId,
           GroupSpace: inbound.roomName,
           Timestamp: Date.now(),
-          CommandAuthorized: true,
+          CommandAuthorized: commandAuthorized,
         });
 
         await channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher({

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -24,7 +24,6 @@ function resolveCampfireCommandAuthorized(params: {
   rawBody: string;
   allowFrom: string[];
   senderId: string;
-  senderName: string;
 }): boolean | undefined {
   const shouldComputeAuth = shouldComputeCommandAuthorized(params.rawBody, params.cfg);
   if (!shouldComputeAuth) {
@@ -32,8 +31,7 @@ function resolveCampfireCommandAuthorized(params: {
   }
 
   const allowFrom = params.allowFrom.map((entry) => entry.trim()).filter(Boolean);
-  const senderAllowedForCommands =
-    allowFrom.includes(params.senderId) || allowFrom.includes(params.senderName);
+  const senderAllowedForCommands = allowFrom.includes(params.senderId);
 
   return resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups: params.cfg.commands?.useAccessGroups !== false,
@@ -119,7 +117,6 @@ export function createCampfireGateway(params?: {
           rawBody: inbound.text,
           allowFrom: ctx.account.allowFrom,
           senderId: inbound.sender.id,
-          senderName: inbound.sender.name,
         });
 
         const msgCtx = channelRuntime.reply.finalizeInboundContext({

--- a/extensions/campfire/src/monitor/provider.ts
+++ b/extensions/campfire/src/monitor/provider.ts
@@ -1,0 +1,151 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { registerCampfireWebhookRoute, type CampfireInboundHandler } from "../http/index.js";
+import { sendCampfireText } from "../send.js";
+import type { ResolvedCampfireAccount } from "../types.js";
+import { buildCampfireInboundContext } from "./context.js";
+
+function waitUntilAbort(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+type CampfireGatewayContext = {
+  cfg: OpenClawConfig;
+  accountId: string;
+  account: ResolvedCampfireAccount;
+  abortSignal: AbortSignal;
+  runtime?: unknown;
+  getStatus?: () => Record<string, unknown>;
+  setStatus?: (next: Record<string, unknown>) => void;
+  log?: {
+    info?: (message: string) => void;
+    warn?: (message: string) => void;
+    error?: (message: string) => void;
+  };
+  channelRuntime?: {
+    reply: {
+      finalizeInboundContext: (ctx: Record<string, unknown>) => Record<string, unknown>;
+      dispatchReplyWithBufferedBlockDispatcher: (params: {
+        ctx: Record<string, unknown>;
+        cfg: OpenClawConfig;
+        dispatcherOptions: {
+          deliver: (replyPayload: { text?: string; body?: string }) => Promise<void>;
+          onError?: (err: unknown, info: { kind: string }) => void;
+        };
+      }) => Promise<unknown>;
+    };
+  };
+};
+
+type CampfireGatewayAdapter = {
+  startAccount: (ctx: CampfireGatewayContext) => Promise<void>;
+};
+
+export function createCampfireGateway(params?: {
+  registerRoute?: typeof registerCampfireWebhookRoute;
+  sendText?: typeof sendCampfireText;
+}): CampfireGatewayAdapter {
+  const registerRoute = params?.registerRoute ?? registerCampfireWebhookRoute;
+  const sendText = params?.sendText ?? sendCampfireText;
+
+  return {
+    startAccount: async (ctx) => {
+      if (!ctx.account.enabled || !ctx.account.configured) {
+        await waitUntilAbort(ctx.abortSignal);
+        return;
+      }
+      const channelRuntime = ctx.channelRuntime;
+      if (!channelRuntime) {
+        ctx.log?.warn?.(
+          `[${ctx.account.accountId}] campfire channelRuntime is unavailable; inbound disabled`,
+        );
+        await waitUntilAbort(ctx.abortSignal);
+        return;
+      }
+
+      const onInbound: CampfireInboundHandler = async (payload) => {
+        if (ctx.abortSignal.aborted) {
+          return;
+        }
+
+        const inbound = buildCampfireInboundContext({
+          payload,
+          allowFrom: ctx.account.allowFrom,
+          baseUrl: ctx.account.baseUrl,
+        });
+        if (!inbound.isAllowed) {
+          return;
+        }
+
+        const msgCtx = channelRuntime.reply.finalizeInboundContext({
+          Body: inbound.text,
+          BodyForAgent: inbound.text,
+          RawBody: inbound.text,
+          CommandBody: inbound.text,
+          From: `campfire:${inbound.sender.id}`,
+          To: `campfire:room:${inbound.roomId}`,
+          SessionKey: inbound.threadKey,
+          AccountId: ctx.account.accountId,
+          ChatType: "group",
+          ConversationLabel: inbound.roomName,
+          SenderId: inbound.sender.id,
+          SenderName: inbound.sender.name,
+          Provider: "campfire",
+          Surface: "campfire",
+          OriginatingChannel: "campfire",
+          OriginatingTo: `campfire:room:${inbound.roomId}`,
+          MessageSid: inbound.messageId,
+          MessageSidFull: inbound.messageId,
+          GroupSpace: inbound.roomName,
+          Timestamp: Date.now(),
+          CommandAuthorized: true,
+        });
+
+        await channelRuntime.reply.dispatchReplyWithBufferedBlockDispatcher({
+          ctx: msgCtx,
+          cfg: ctx.cfg,
+          dispatcherOptions: {
+            deliver: async (replyPayload: { text?: string; body?: string }) => {
+              const text =
+                typeof replyPayload.text === "string"
+                  ? replyPayload.text
+                  : typeof replyPayload.body === "string"
+                    ? replyPayload.body
+                    : "";
+              if (!text) {
+                return;
+              }
+              await sendText(inbound.replyUrl, text, ctx.account.textChunkLimit);
+            },
+            onError: (err: unknown, info: { kind: string }) => {
+              ctx.log?.error?.(
+                `[${ctx.account.accountId}] campfire ${info.kind} reply failed: ${String(err)}`,
+              );
+            },
+          },
+        });
+      };
+
+      const unregister = registerRoute({
+        accountId: ctx.account.accountId,
+        path: ctx.account.webhookPath,
+        webhookSecret: ctx.account.webhookSecret,
+        onInbound,
+        log: ctx.log,
+      });
+
+      try {
+        await waitUntilAbort(ctx.abortSignal);
+      } finally {
+        unregister();
+      }
+    },
+  };
+}
+
+export const campfireGateway = createCampfireGateway();

--- a/extensions/campfire/src/runtime.ts
+++ b/extensions/campfire/src/runtime.ts
@@ -1,0 +1,7 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+
+const { setRuntime: setCampfireRuntime, getRuntime: getCampfireRuntime } =
+  createPluginRuntimeStore<PluginRuntime>("Campfire runtime not initialized");
+
+export { getCampfireRuntime, setCampfireRuntime };

--- a/extensions/campfire/src/send.test.ts
+++ b/extensions/campfire/src/send.test.ts
@@ -6,7 +6,7 @@ describe("sendCampfireReply", () => {
     vi.unstubAllGlobals();
   });
 
-  it("sends a plain text POST request", async () => {
+  it("sends a plain text POST request with bot authorization", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(null, {
         status: 200,
@@ -14,13 +14,18 @@ describe("sendCampfireReply", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await sendCampfireReply("https://campfire.example.com/rooms/7/key/messages", "Hello world");
+    await sendCampfireReply(
+      "https://campfire.example.com/rooms/7/key/messages",
+      "Hello world",
+      "42-AbCdEf",
+    );
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://campfire.example.com/rooms/7/key/messages",
       expect.objectContaining({
         method: "POST",
         headers: {
+          Authorization: "Bearer 42-AbCdEf",
           "Content-Type": "text/plain; charset=utf-8",
         },
         body: "Hello world",
@@ -56,7 +61,12 @@ describe("sendCampfireText", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await sendCampfireText("https://campfire.example.com/rooms/7/key/messages", "abcdefghij", 4);
+    await sendCampfireText(
+      "https://campfire.example.com/rooms/7/key/messages",
+      "abcdefghij",
+      "42-AbCdEf",
+      4,
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock.mock.calls[0]?.[1]).toEqual(

--- a/extensions/campfire/src/send.test.ts
+++ b/extensions/campfire/src/send.test.ts
@@ -1,18 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { chunkCampfireText, sendCampfireReply, sendCampfireText } from "./send.js";
+import {
+  _setFetchGuardForTesting,
+  chunkCampfireText,
+  sendCampfireReply,
+  sendCampfireText,
+} from "./send.js";
 
 describe("sendCampfireReply", () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
+    _setFetchGuardForTesting(null);
   });
 
   it("sends a plain text POST request with bot authorization", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(null, {
+    const release = vi.fn().mockResolvedValue(undefined);
+    const fetchGuardMock = vi.fn().mockResolvedValue({
+      response: new Response(null, {
         status: 200,
       }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
+      finalUrl: "https://campfire.example.com/rooms/7/key/messages",
+      release,
+    });
+    _setFetchGuardForTesting(fetchGuardMock);
 
     await sendCampfireReply(
       "https://campfire.example.com/rooms/7/key/messages",
@@ -20,42 +28,57 @@ describe("sendCampfireReply", () => {
       "42-AbCdEf",
     );
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://campfire.example.com/rooms/7/key/messages",
+    expect(fetchGuardMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "POST",
-        headers: {
-          Authorization: "Bearer 42-AbCdEf",
-          "Content-Type": "text/plain; charset=utf-8",
-        },
-        body: "Hello world",
+        url: "https://campfire.example.com/rooms/7/key/messages",
+        timeoutMs: 10_000,
+        policy: { allowPrivateNetwork: true },
+        auditContext: "campfire-reply",
+        init: expect.objectContaining({
+          method: "POST",
+          headers: {
+            Authorization: "Bearer 42-AbCdEf",
+            "Content-Type": "text/plain; charset=utf-8",
+          },
+          body: "Hello world",
+        }),
       }),
     );
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("omits Authorization header when botKey is empty", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
+    const fetchGuardMock = vi.fn().mockResolvedValue({
+      response: new Response(null, { status: 200 }),
+      finalUrl: "https://campfire.example.com/rooms/7/key/messages",
+      release: vi.fn().mockResolvedValue(undefined),
+    });
+    _setFetchGuardForTesting(fetchGuardMock);
 
     await sendCampfireReply("https://campfire.example.com/rooms/7/key/messages", "Hello world");
 
-    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    const headers = fetchGuardMock.mock.calls[0]?.[0]?.init?.headers as Record<string, string>;
     expect(headers.Authorization).toBeUndefined();
     expect(headers["Content-Type"]).toBe("text/plain; charset=utf-8");
   });
 
   it("throws when Campfire rejects the message", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response("no", {
+    const release = vi.fn().mockResolvedValue(undefined);
+    const fetchGuardMock = vi.fn().mockResolvedValue({
+      response: new Response("no", {
         status: 403,
         statusText: "Forbidden",
       }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
+      finalUrl: "https://campfire.example.com/rooms/7/key/messages",
+      release,
+    });
+    _setFetchGuardForTesting(fetchGuardMock);
 
     await expect(
       sendCampfireReply("https://campfire.example.com/rooms/7/key/messages", "Hello world"),
     ).rejects.toThrow("Campfire reply failed: 403 Forbidden");
+
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -85,16 +108,18 @@ describe("chunkCampfireText", () => {
 
 describe("sendCampfireText", () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
+    _setFetchGuardForTesting(null);
   });
 
   it("sends long replies in deterministic chunks", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(null, {
+    const fetchGuardMock = vi.fn().mockResolvedValue({
+      response: new Response(null, {
         status: 200,
       }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
+      finalUrl: "https://campfire.example.com/rooms/7/key/messages",
+      release: vi.fn().mockResolvedValue(undefined),
+    });
+    _setFetchGuardForTesting(fetchGuardMock);
 
     await sendCampfireText(
       "https://campfire.example.com/rooms/7/key/messages",
@@ -103,18 +128,18 @@ describe("sendCampfireText", () => {
       4,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+    expect(fetchGuardMock).toHaveBeenCalledTimes(3);
+    expect(fetchGuardMock.mock.calls[0]?.[0]?.init).toEqual(
       expect.objectContaining({
         body: "abcd",
       }),
     );
-    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+    expect(fetchGuardMock.mock.calls[1]?.[0]?.init).toEqual(
       expect.objectContaining({
         body: "efgh",
       }),
     );
-    expect(fetchMock.mock.calls[2]?.[1]).toEqual(
+    expect(fetchGuardMock.mock.calls[2]?.[0]?.init).toEqual(
       expect.objectContaining({
         body: "ij",
       }),

--- a/extensions/campfire/src/send.test.ts
+++ b/extensions/campfire/src/send.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { sendCampfireReply, sendCampfireText } from "./send.js";
+import { chunkCampfireText, sendCampfireReply, sendCampfireText } from "./send.js";
 
 describe("sendCampfireReply", () => {
   afterEach(() => {
@@ -33,6 +33,17 @@ describe("sendCampfireReply", () => {
     );
   });
 
+  it("omits Authorization header when botKey is empty", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendCampfireReply("https://campfire.example.com/rooms/7/key/messages", "Hello world");
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers["Content-Type"]).toBe("text/plain; charset=utf-8");
+  });
+
   it("throws when Campfire rejects the message", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response("no", {
@@ -45,6 +56,30 @@ describe("sendCampfireReply", () => {
     await expect(
       sendCampfireReply("https://campfire.example.com/rooms/7/key/messages", "Hello world"),
     ).rejects.toThrow("Campfire reply failed: 403 Forbidden");
+  });
+});
+
+describe("chunkCampfireText", () => {
+  it("returns a single chunk for text within the limit", () => {
+    expect(chunkCampfireText("hello", 10)).toEqual(["hello"]);
+  });
+
+  it("returns an empty-string chunk for empty input", () => {
+    expect(chunkCampfireText("")).toEqual([""]);
+  });
+
+  it("falls back to chunk size 1 for non-positive limits", () => {
+    expect(chunkCampfireText("abc", 0)).toEqual(["a", "b", "c"]);
+    expect(chunkCampfireText("ab", -5)).toEqual(["a", "b"]);
+  });
+
+  it("falls back to chunk size 1 for non-finite limits", () => {
+    expect(chunkCampfireText("ab", Number.NaN)).toEqual(["a", "b"]);
+    expect(chunkCampfireText("ab", Number.POSITIVE_INFINITY)).toEqual(["a", "b"]);
+  });
+
+  it("floors fractional chunk limits", () => {
+    expect(chunkCampfireText("abcde", 2.9)).toEqual(["ab", "cd", "e"]);
   });
 });
 

--- a/extensions/campfire/src/send.test.ts
+++ b/extensions/campfire/src/send.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sendCampfireReply, sendCampfireText } from "./send.js";
+
+describe("sendCampfireReply", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends a plain text POST request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendCampfireReply("https://campfire.example.com/rooms/7/key/messages", "Hello world");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://campfire.example.com/rooms/7/key/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+        },
+        body: "Hello world",
+      }),
+    );
+  });
+
+  it("throws when Campfire rejects the message", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("no", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      sendCampfireReply("https://campfire.example.com/rooms/7/key/messages", "Hello world"),
+    ).rejects.toThrow("Campfire reply failed: 403 Forbidden");
+  });
+});
+
+describe("sendCampfireText", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends long replies in deterministic chunks", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendCampfireText("https://campfire.example.com/rooms/7/key/messages", "abcdefghij", 4);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        body: "abcd",
+      }),
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        body: "efgh",
+      }),
+    );
+    expect(fetchMock.mock.calls[2]?.[1]).toEqual(
+      expect.objectContaining({
+        body: "ij",
+      }),
+    );
+  });
+});

--- a/extensions/campfire/src/send.ts
+++ b/extensions/campfire/src/send.ts
@@ -12,12 +12,25 @@ export function chunkCampfireText(text: string, chunkLimit = DEFAULT_TEXT_CHUNK_
   return chunks.length > 0 ? chunks : [""];
 }
 
-export async function sendCampfireReply(replyUrl: string, text: string): Promise<void> {
+function buildCampfireHeaders(botKey: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "text/plain; charset=utf-8",
+  };
+  const normalizedBotKey = botKey.trim();
+  if (normalizedBotKey) {
+    headers.Authorization = `Bearer ${normalizedBotKey}`;
+  }
+  return headers;
+}
+
+export async function sendCampfireReply(
+  replyUrl: string,
+  text: string,
+  botKey = "",
+): Promise<void> {
   const response = await fetch(replyUrl, {
     method: "POST",
-    headers: {
-      "Content-Type": "text/plain; charset=utf-8",
-    },
+    headers: buildCampfireHeaders(botKey),
     body: text,
   });
 
@@ -29,10 +42,11 @@ export async function sendCampfireReply(replyUrl: string, text: string): Promise
 export async function sendCampfireText(
   replyUrl: string,
   text: string,
+  botKey: string,
   chunkLimit = DEFAULT_TEXT_CHUNK_LIMIT,
 ): Promise<void> {
   const chunks = chunkCampfireText(text, chunkLimit);
   for (const chunk of chunks) {
-    await sendCampfireReply(replyUrl, chunk);
+    await sendCampfireReply(replyUrl, chunk, botKey);
   }
 }

--- a/extensions/campfire/src/send.ts
+++ b/extensions/campfire/src/send.ts
@@ -1,4 +1,13 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+
 const DEFAULT_TEXT_CHUNK_LIMIT = 4000;
+const DEFAULT_REPLY_TIMEOUT_MS = 10_000;
+
+let fetchGuard = fetchWithSsrFGuard;
+
+export function _setFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | null): void {
+  fetchGuard = impl ?? fetchWithSsrFGuard;
+}
 
 export function chunkCampfireText(text: string, chunkLimit = DEFAULT_TEXT_CHUNK_LIMIT): string[] {
   const normalizedLimit =
@@ -28,14 +37,25 @@ export async function sendCampfireReply(
   text: string,
   botKey = "",
 ): Promise<void> {
-  const response = await fetch(replyUrl, {
-    method: "POST",
-    headers: buildCampfireHeaders(botKey),
-    body: text,
+  const { response, release } = await fetchGuard({
+    url: replyUrl,
+    init: {
+      method: "POST",
+      headers: buildCampfireHeaders(botKey),
+      body: text,
+    },
+    timeoutMs: DEFAULT_REPLY_TIMEOUT_MS,
+    // Call sites already constrain reply URLs to the configured Campfire workspace.
+    policy: { allowPrivateNetwork: true },
+    auditContext: "campfire-reply",
   });
 
-  if (!response.ok) {
-    throw new Error(`Campfire reply failed: ${response.status} ${response.statusText}`);
+  try {
+    if (!response.ok) {
+      throw new Error(`Campfire reply failed: ${response.status} ${response.statusText}`);
+    }
+  } finally {
+    await release();
   }
 }
 

--- a/extensions/campfire/src/send.ts
+++ b/extensions/campfire/src/send.ts
@@ -1,0 +1,38 @@
+const DEFAULT_TEXT_CHUNK_LIMIT = 4000;
+
+export function chunkCampfireText(text: string, chunkLimit = DEFAULT_TEXT_CHUNK_LIMIT): string[] {
+  const normalizedLimit =
+    Number.isFinite(chunkLimit) && chunkLimit > 0 ? Math.floor(chunkLimit) : 1;
+  const chunks: string[] = [];
+
+  for (let start = 0; start < text.length; start += normalizedLimit) {
+    chunks.push(text.slice(start, start + normalizedLimit));
+  }
+
+  return chunks.length > 0 ? chunks : [""];
+}
+
+export async function sendCampfireReply(replyUrl: string, text: string): Promise<void> {
+  const response = await fetch(replyUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+    body: text,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Campfire reply failed: ${response.status} ${response.statusText}`);
+  }
+}
+
+export async function sendCampfireText(
+  replyUrl: string,
+  text: string,
+  chunkLimit = DEFAULT_TEXT_CHUNK_LIMIT,
+): Promise<void> {
+  const chunks = chunkCampfireText(text, chunkLimit);
+  for (const chunk of chunks) {
+    await sendCampfireReply(replyUrl, chunk);
+  }
+}

--- a/extensions/campfire/src/session-route.ts
+++ b/extensions/campfire/src/session-route.ts
@@ -24,7 +24,11 @@ export function resolveCampfireRoomIdFromTarget(target: string): string | null {
 
   try {
     const url = new URL(normalizedTarget);
-    return findSegmentAfter(url.pathname, "rooms") ?? findSegmentAfter(url.pathname, "chats");
+    return (
+      findSegmentAfter(url.pathname, "rooms") ??
+      findSegmentAfter(url.pathname, "buckets") ??
+      findSegmentAfter(url.pathname, "chats")
+    );
   } catch {
     return null;
   }

--- a/extensions/campfire/src/session-route.ts
+++ b/extensions/campfire/src/session-route.ts
@@ -26,8 +26,8 @@ export function resolveCampfireRoomIdFromTarget(target: string): string | null {
     const url = new URL(normalizedTarget);
     return (
       findSegmentAfter(url.pathname, "rooms") ??
-      findSegmentAfter(url.pathname, "buckets") ??
-      findSegmentAfter(url.pathname, "chats")
+      findSegmentAfter(url.pathname, "chats") ??
+      findSegmentAfter(url.pathname, "buckets")
     );
   } catch {
     return null;

--- a/extensions/campfire/src/session-route.ts
+++ b/extensions/campfire/src/session-route.ts
@@ -1,0 +1,52 @@
+import {
+  buildChannelOutboundSessionRoute,
+  type ChannelOutboundSessionRouteParams,
+} from "openclaw/plugin-sdk/core";
+
+function findSegmentAfter(pathname: string, marker: string): string | null {
+  const segments = pathname
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  const markerIndex = segments.findIndex((segment) => segment.toLowerCase() === marker);
+  if (markerIndex < 0) {
+    return null;
+  }
+  const nextSegment = segments[markerIndex + 1]?.trim();
+  return nextSegment ? nextSegment : null;
+}
+
+export function resolveCampfireRoomIdFromTarget(target: string): string | null {
+  const normalizedTarget = target.trim();
+  if (!normalizedTarget) {
+    return null;
+  }
+
+  try {
+    const url = new URL(normalizedTarget);
+    return findSegmentAfter(url.pathname, "rooms") ?? findSegmentAfter(url.pathname, "chats");
+  } catch {
+    return null;
+  }
+}
+
+export function resolveCampfireOutboundSessionRoute(params: ChannelOutboundSessionRouteParams) {
+  const roomId = resolveCampfireRoomIdFromTarget(params.target);
+  if (!roomId) {
+    return null;
+  }
+
+  return buildChannelOutboundSessionRoute({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: "campfire",
+    accountId: params.accountId,
+    peer: {
+      kind: "group",
+      id: roomId,
+    },
+    chatType: "group",
+    from: `campfire:room:${roomId}`,
+    to: `campfire:room:${roomId}`,
+  });
+}

--- a/extensions/campfire/src/setup-core.ts
+++ b/extensions/campfire/src/setup-core.ts
@@ -1,0 +1,55 @@
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
+import { createPatchedAccountSetupAdapter } from "openclaw/plugin-sdk/setup";
+
+const channel = "campfire" as const;
+
+function trimOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeCampfireBaseUrl(value: string | undefined): string {
+  return (trimOptionalString(value) ?? "").replace(/\/+$/u, "");
+}
+
+function resolveCampfireBaseUrl(input: ChannelSetupInput): string {
+  return normalizeCampfireBaseUrl(input.httpUrl ?? input.url);
+}
+
+function resolveCampfireBotKey(input: ChannelSetupInput): string {
+  return trimOptionalString(input.botToken ?? input.token) ?? "";
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export const campfireSetupAdapter = createPatchedAccountSetupAdapter({
+  channelKey: channel,
+  validateInput: ({ input }) => {
+    const baseUrl = resolveCampfireBaseUrl(input);
+    const botKey = resolveCampfireBotKey(input);
+    if (!baseUrl || !botKey) {
+      return "Campfire requires --http-url (or --url) and --bot-token (or --token).";
+    }
+    if (!isHttpUrl(baseUrl)) {
+      return "Campfire --http-url/--url must be a valid http(s) URL.";
+    }
+    return null;
+  },
+  buildPatch: (input) => {
+    const baseUrl = resolveCampfireBaseUrl(input);
+    const botKey = resolveCampfireBotKey(input);
+    const webhookPath = trimOptionalString(input.webhookPath);
+    return {
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(botKey ? { botKey } : {}),
+      ...(webhookPath ? { webhookPath } : {}),
+    };
+  },
+});

--- a/extensions/campfire/src/setup-core.ts
+++ b/extensions/campfire/src/setup-core.ts
@@ -1,52 +1,21 @@
-import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import { createPatchedAccountSetupAdapter } from "openclaw/plugin-sdk/setup";
+import {
+  resolveCampfireBaseUrl,
+  resolveCampfireBotKey,
+  resolveOptionalCampfireSetupString,
+  validateCampfireSetupInput,
+} from "./setup-validation.js";
 
 const channel = "campfire" as const;
 
-function trimOptionalString(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function normalizeCampfireBaseUrl(value: string | undefined): string {
-  return (trimOptionalString(value) ?? "").replace(/\/+$/u, "");
-}
-
-function resolveCampfireBaseUrl(input: ChannelSetupInput): string {
-  return normalizeCampfireBaseUrl(input.httpUrl ?? input.url);
-}
-
-function resolveCampfireBotKey(input: ChannelSetupInput): string {
-  return trimOptionalString(input.botToken ?? input.token) ?? "";
-}
-
-function isHttpUrl(value: string): boolean {
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
 export const campfireSetupAdapter = createPatchedAccountSetupAdapter({
   channelKey: channel,
-  validateInput: ({ input }) => {
-    const baseUrl = resolveCampfireBaseUrl(input);
-    const botKey = resolveCampfireBotKey(input);
-    if (!baseUrl || !botKey) {
-      return "Campfire requires --http-url (or --url) and --bot-token (or --token).";
-    }
-    if (!isHttpUrl(baseUrl)) {
-      return "Campfire --http-url/--url must be a valid http(s) URL.";
-    }
-    return null;
-  },
+  validateInput: ({ input }) => validateCampfireSetupInput(input),
   buildPatch: (input) => {
     const baseUrl = resolveCampfireBaseUrl(input);
     const botKey = resolveCampfireBotKey(input);
-    const webhookPath = trimOptionalString(input.webhookPath);
-    const webhookSecret = trimOptionalString(input.webhookSecret);
+    const webhookPath = resolveOptionalCampfireSetupString(input.webhookPath);
+    const webhookSecret = resolveOptionalCampfireSetupString(input.webhookSecret);
     return {
       ...(baseUrl ? { baseUrl } : {}),
       ...(botKey ? { botKey } : {}),

--- a/extensions/campfire/src/setup-core.ts
+++ b/extensions/campfire/src/setup-core.ts
@@ -46,10 +46,12 @@ export const campfireSetupAdapter = createPatchedAccountSetupAdapter({
     const baseUrl = resolveCampfireBaseUrl(input);
     const botKey = resolveCampfireBotKey(input);
     const webhookPath = trimOptionalString(input.webhookPath);
+    const webhookSecret = trimOptionalString(input.webhookSecret);
     return {
       ...(baseUrl ? { baseUrl } : {}),
       ...(botKey ? { botKey } : {}),
       ...(webhookPath ? { webhookPath } : {}),
+      ...(webhookSecret ? { webhookSecret } : {}),
     };
   },
 });

--- a/extensions/campfire/src/setup-validation.test.ts
+++ b/extensions/campfire/src/setup-validation.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { validateCampfireSetupInput } from "./setup-validation.js";
+
+describe("validateCampfireSetupInput", () => {
+  it("rejects bare Basecamp hosts", () => {
+    const error = validateCampfireSetupInput({
+      httpUrl: "https://3.basecamp.com",
+      botToken: "42-AbCdEf",
+    });
+
+    expect(error).toContain("workspace");
+  });
+});

--- a/extensions/campfire/src/setup-validation.ts
+++ b/extensions/campfire/src/setup-validation.ts
@@ -1,0 +1,63 @@
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
+
+function trimOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function normalizeCampfireBaseUrl(value: string | undefined): string {
+  return (trimOptionalString(value) ?? "").replace(/\/+$/u, "");
+}
+
+export function resolveCampfireBaseUrl(input: ChannelSetupInput): string {
+  return normalizeCampfireBaseUrl(input.httpUrl ?? input.url);
+}
+
+export function resolveCampfireBotKey(input: ChannelSetupInput): string {
+  return trimOptionalString(input.botToken ?? input.token) ?? "";
+}
+
+export function resolveOptionalCampfireSetupString(value: string | undefined): string | undefined {
+  return trimOptionalString(value);
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeUrlPath(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/u, "");
+  return trimmed ? trimmed : "/";
+}
+
+function isBareBasecampHost(baseUrl: string): boolean {
+  try {
+    const parsed = new URL(baseUrl);
+    if (!/(^|\.)basecamp\.com$/u.test(parsed.hostname)) {
+      return false;
+    }
+    return normalizeUrlPath(parsed.pathname) === "/";
+  } catch {
+    return false;
+  }
+}
+
+export function validateCampfireSetupInput(input: ChannelSetupInput): string | null {
+  const baseUrl = resolveCampfireBaseUrl(input);
+  const botKey = resolveCampfireBotKey(input);
+  if (!baseUrl || !botKey) {
+    return "Campfire requires --http-url (or --url) and --bot-token (or --token).";
+  }
+  if (!isHttpUrl(baseUrl)) {
+    return "Campfire --http-url/--url must be a valid http(s) URL.";
+  }
+  if (isBareBasecampHost(baseUrl)) {
+    return "Campfire --http-url/--url must include a Basecamp workspace path (for example https://3.basecamp.com/1234567).";
+  }
+  return null;
+}

--- a/extensions/campfire/src/types.ts
+++ b/extensions/campfire/src/types.ts
@@ -1,0 +1,19 @@
+export type CampfireWebhookPayload = {
+  user: {
+    id: number;
+    name: string;
+  };
+  room: {
+    id: number;
+    name: string;
+    path: string;
+  };
+  message: {
+    id: number;
+    body: {
+      html?: string;
+      plain: string;
+    };
+    path: string;
+  };
+};

--- a/extensions/campfire/src/types.ts
+++ b/extensions/campfire/src/types.ts
@@ -17,3 +17,32 @@ export type CampfireWebhookPayload = {
     path: string;
   };
 };
+
+export type CampfireAccountConfig = {
+  name?: string;
+  enabled?: boolean;
+  baseUrl?: string;
+  botKey?: string;
+  webhookSecret?: string;
+  allowFrom?: string[];
+  webhookPath?: string;
+  textChunkLimit?: number;
+};
+
+export type CampfireChannelConfig = CampfireAccountConfig & {
+  defaultAccount?: string;
+  accounts?: Record<string, CampfireAccountConfig | undefined>;
+};
+
+export type ResolvedCampfireAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  baseUrl: string;
+  botKey: string;
+  webhookSecret?: string;
+  allowFrom: string[];
+  webhookPath: string;
+  textChunkLimit: number;
+  configured: boolean;
+};

--- a/extensions/campfire/src/workspace-url.test.ts
+++ b/extensions/campfire/src/workspace-url.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { isCampfireUrlInWorkspaceScope, isValidCampfireUrl } from "./workspace-url.js";
+
+describe("isValidCampfireUrl", () => {
+  it("accepts valid absolute URLs", () => {
+    expect(isValidCampfireUrl("https://campfire.example.com/rooms/7/key/messages")).toBe(true);
+    expect(isValidCampfireUrl("http://localhost:3000/rooms/1/key/messages")).toBe(true);
+  });
+
+  it("rejects relative paths", () => {
+    expect(isValidCampfireUrl("/rooms/7/key/messages")).toBe(false);
+  });
+
+  it("rejects non-URL strings", () => {
+    expect(isValidCampfireUrl("not-a-url")).toBe(false);
+    expect(isValidCampfireUrl("")).toBe(false);
+  });
+});
+
+describe("isCampfireUrlInWorkspaceScope", () => {
+  it("allows target under the same origin", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://campfire.example.com/rooms/7/key/messages",
+        "https://campfire.example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows target under a workspace path prefix", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://3.basecamp.com/1234567/buckets/7/chats/88/messages/99",
+        "https://3.basecamp.com/1234567",
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks targets under a different workspace path", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://3.basecamp.com/7654321/buckets/7/chats/88/messages/99",
+        "https://3.basecamp.com/1234567",
+      ),
+    ).toBe(false);
+  });
+
+  it("blocks targets on a different origin", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://attacker.example.net/rooms/7/key/messages",
+        "https://campfire.example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when either URL is invalid", () => {
+    expect(isCampfireUrlInWorkspaceScope("not-a-url", "https://campfire.example.com")).toBe(false);
+    expect(isCampfireUrlInWorkspaceScope("https://campfire.example.com/rooms/7", "not-a-url")).toBe(
+      false,
+    );
+  });
+
+  it("handles trailing slashes in base URL", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://campfire.example.com/rooms/7/key/messages",
+        "https://campfire.example.com/",
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks path prefix collisions", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://3.basecamp.com/12345678/buckets/7/chats/88",
+        "https://3.basecamp.com/1234567",
+      ),
+    ).toBe(false);
+  });
+});

--- a/extensions/campfire/src/workspace-url.test.ts
+++ b/extensions/campfire/src/workspace-url.test.ts
@@ -54,6 +54,24 @@ describe("isCampfireUrlInWorkspaceScope", () => {
     ).toBe(false);
   });
 
+  it("blocks same-workspace URLs that are not Campfire message endpoints", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://campfire.example.com/admin",
+        "https://campfire.example.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("blocks same-basecamp-workspace URLs outside message endpoints", () => {
+    expect(
+      isCampfireUrlInWorkspaceScope(
+        "https://3.basecamp.com/1234567/admin",
+        "https://3.basecamp.com/1234567",
+      ),
+    ).toBe(false);
+  });
+
   it("returns false when either URL is invalid", () => {
     expect(isCampfireUrlInWorkspaceScope("not-a-url", "https://campfire.example.com")).toBe(false);
     expect(isCampfireUrlInWorkspaceScope("https://campfire.example.com/rooms/7", "not-a-url")).toBe(

--- a/extensions/campfire/src/workspace-url.ts
+++ b/extensions/campfire/src/workspace-url.ts
@@ -1,0 +1,36 @@
+function parseAbsoluteUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function normalizePath(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/u, "");
+  return trimmed.length > 0 ? trimmed : "/";
+}
+
+export function isValidCampfireUrl(value: string): boolean {
+  return parseAbsoluteUrl(value) !== null;
+}
+
+export function isCampfireUrlInWorkspaceScope(targetUrl: string, baseUrl: string): boolean {
+  const target = parseAbsoluteUrl(targetUrl);
+  const base = parseAbsoluteUrl(baseUrl);
+  if (!target || !base) {
+    return false;
+  }
+
+  if (target.origin !== base.origin) {
+    return false;
+  }
+
+  const basePath = normalizePath(base.pathname);
+  if (basePath === "/") {
+    return true;
+  }
+
+  const targetPath = normalizePath(target.pathname);
+  return targetPath === basePath || targetPath.startsWith(`${basePath}/`);
+}

--- a/extensions/campfire/src/workspace-url.ts
+++ b/extensions/campfire/src/workspace-url.ts
@@ -11,6 +11,49 @@ function normalizePath(pathname: string): string {
   return trimmed.length > 0 ? trimmed : "/";
 }
 
+function hasValue(segment: string | undefined): segment is string {
+  return Boolean(segment && segment.trim().length > 0);
+}
+
+function hasCampfireClassicMessagesPath(pathname: string): boolean {
+  const segments = normalizePath(pathname).split("/").filter(Boolean);
+  const roomIndex = segments.findIndex((segment) => segment.toLowerCase() === "rooms");
+  if (roomIndex < 0) {
+    return false;
+  }
+  if (
+    !hasValue(segments[roomIndex + 1]) ||
+    !hasValue(segments[roomIndex + 2]) ||
+    segments[roomIndex + 3]?.toLowerCase() !== "messages"
+  ) {
+    return false;
+  }
+  const remaining = segments.length - (roomIndex + 4);
+  return remaining === 0 || (remaining === 1 && hasValue(segments[roomIndex + 4]));
+}
+
+function hasBasecampChatMessagesPath(pathname: string): boolean {
+  const segments = normalizePath(pathname).split("/").filter(Boolean);
+  const bucketIndex = segments.findIndex((segment) => segment.toLowerCase() === "buckets");
+  if (bucketIndex < 0) {
+    return false;
+  }
+  if (
+    !hasValue(segments[bucketIndex + 1]) ||
+    segments[bucketIndex + 2]?.toLowerCase() !== "chats" ||
+    !hasValue(segments[bucketIndex + 3]) ||
+    segments[bucketIndex + 4]?.toLowerCase() !== "messages"
+  ) {
+    return false;
+  }
+  const remaining = segments.length - (bucketIndex + 5);
+  return remaining === 0 || (remaining === 1 && hasValue(segments[bucketIndex + 5]));
+}
+
+function hasCampfireMessageEndpointPath(pathname: string): boolean {
+  return hasCampfireClassicMessagesPath(pathname) || hasBasecampChatMessagesPath(pathname);
+}
+
 export function isValidCampfireUrl(value: string): boolean {
   return parseAbsoluteUrl(value) !== null;
 }
@@ -27,10 +70,12 @@ export function isCampfireUrlInWorkspaceScope(targetUrl: string, baseUrl: string
   }
 
   const basePath = normalizePath(base.pathname);
-  if (basePath === "/") {
-    return true;
+  const targetPath = normalizePath(target.pathname);
+  const inScopeByPath =
+    basePath === "/" ? true : targetPath === basePath || targetPath.startsWith(`${basePath}/`);
+  if (!inScopeByPath) {
+    return false;
   }
 
-  const targetPath = normalizePath(target.pathname);
-  return targetPath === basePath || targetPath.startsWith(`${basePath}/`);
+  return hasCampfireMessageEndpointPath(targetPath);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/campfire:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
   extensions/chutes:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -86,6 +86,7 @@ export type ChannelSetupInput = {
   httpHost?: string;
   httpPort?: string;
   webhookPath?: string;
+  webhookSecret?: string;
   webhookUrl?: string;
   audienceType?: string;
   audience?: string;

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -28,6 +28,7 @@ const optionNamesAdd = [
   "httpHost",
   "httpPort",
   "webhookPath",
+  "webhookSecret",
   "webhookUrl",
   "audienceType",
   "audience",
@@ -180,6 +181,7 @@ export function registerChannelsCli(program: Command) {
     .option("--http-host <host>", "Signal HTTP host")
     .option("--http-port <port>", "Signal HTTP port")
     .option("--webhook-path <path>", "Webhook path (Google Chat/BlueBubbles)")
+    .option("--webhook-secret <secret>", "Webhook shared secret")
     .option("--webhook-url <url>", "Google Chat webhook URL")
     .option("--audience-type <type>", "Google Chat audience type (app-url|project-number)")
     .option("--audience <value>", "Google Chat audience value (app URL or project number)")

--- a/src/commands/agent-runtime-config.test-support.ts
+++ b/src/commands/agent-runtime-config.test-support.ts
@@ -53,7 +53,7 @@ export async function withSharedAgentCommandTempHome<T>(
 }
 
 export function mockSharedAgentCommandConfig(
-  configSpy: typeof configModule.loadConfig,
+  configSpy: Parameters<typeof mockAgentCommandConfig>[0],
   home: string,
   storePath: string,
   agentOverrides?: Parameters<typeof mockAgentCommandConfig>[3],

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -298,6 +298,7 @@ export async function channelsAddCommand(
     httpHost: opts.httpHost,
     httpPort: opts.httpPort,
     webhookPath: opts.webhookPath,
+    webhookSecret: opts.webhookSecret,
     webhookUrl: opts.webhookUrl,
     audienceType: opts.audienceType,
     audience: opts.audience,

--- a/src/infra/net/runtime-fetch.test.ts
+++ b/src/infra/net/runtime-fetch.test.ts
@@ -54,11 +54,23 @@ describe("fetchWithRuntimeDispatcher", () => {
       return new Response("ok", { status: 200 });
     });
 
+    function MockAgent() {
+      return;
+    }
+
+    function MockEnvHttpProxyAgent() {
+      return;
+    }
+
+    function MockProxyAgent() {
+      return;
+    }
+
     (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
-      Agent: class MockAgent {},
-      EnvHttpProxyAgent: class MockEnvHttpProxyAgent {},
+      Agent: MockAgent,
+      EnvHttpProxyAgent: MockEnvHttpProxyAgent,
       FormData: RuntimeFormData,
-      ProxyAgent: class MockProxyAgent {},
+      ProxyAgent: MockProxyAgent,
       fetch: runtimeFetch,
     };
 

--- a/src/plugins/contracts/package-manifest.contract.test.ts
+++ b/src/plugins/contracts/package-manifest.contract.test.ts
@@ -4,6 +4,7 @@ type PackageManifestContractParams = Parameters<typeof describePackageManifestCo
 
 const packageManifestContractTests: PackageManifestContractParams[] = [
   { pluginId: "bluebubbles", minHostVersionBaseline: "2026.3.22" },
+  { pluginId: "campfire", minHostVersionBaseline: "2026.3.22" },
   {
     pluginId: "discord",
     mirroredRootRuntimeDeps: [


### PR DESCRIPTION
## Summary

Add campfire chat integration.

- Problem: I can't use my self-hosted chat server.
- Why it matters: extra control over my messages. ( I know we're sending them to the inference providers) 
- What changed: Added campfire integration and tests. Updated documentation in the existing style.
- What did NOT change (scope boundary): Anything outside the integration and documentation.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
https://github.com/openclaw/openclaw/issues/7880
- Closes #7880
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

Users can now configure campfire as a messaging server.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
Campfire Webhook Secret & Token Handling — Security Summary

  Secrets inventory

  ┌───────────────┬──────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────┐
  │    Secret     │                                   Storage                                    │                            Usage                            │
  ├───────────────┼──────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ botKey        │ channels.campfire.botKey / channels.campfire.accounts.*.botKey               │ Authorization: Bearer header on outbound Campfire API calls │
  ├───────────────┼──────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ webhookSecret │ channels.campfire.webhookSecret / channels.campfire.accounts.*.webhookSecret │ Authenticates inbound webhook requests                      │
  └───────────────┴──────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────┘

  ---
  Risks and mitigations

  1. Webhook secret transmission (fixed)

  Previously, webhookSecret was read from the ?secret= query parameter — visible in proxy access logs, CDN edges, and potentially Referer headers. The comparison used ===, which is vulnerable to timing side-channels.

  Fix: resolveRequestSecret now reads X-Webhook-Secret header first, falling back to query-param for backward compat (extensions/campfire/src/http/index.ts:67-76). Comparison uses crypto.timingSafeEqual via secretsMatch
  (extensions/campfire/src/http/index.ts:78-84).

  2. botKey over non-TLS connections — partially mitigated

  extensions/campfire/src/send.ts:15-24 sends the botKey as a Bearer token via fetch(). The config schema enforces http(s) scheme and rejects non-HTTP protocols (extensions/campfire/src/config.ts:40-48), but plain http:// is still
  accepted — an operator who configures an http:// baseUrl sends the token in cleartext.

  3. SSRF via crafted inbound reply URL — well mitigated

  An attacker-crafted webhook payload could try to redirect the bot's reply (carrying botKey) to an arbitrary server. extensions/campfire/src/monitor/context.ts:4-5,57 validates the reply URL via isCampfireUrlInWorkspaceScope, which
   enforces same origin, path-prefix match, and known Campfire/Basecamp endpoint structure (extensions/campfire/src/workspace-url.ts:61-81). Disallowed payloads are silently dropped (extensions/campfire/src/monitor/provider.ts:185).

  4. Secret leakage in config UI / status output — well mitigated

  extensions/campfire/src/config.ts:205-218 marks botKey and webhookSecret (including nested accounts.* variants) as sensitive: true in uiHints. describeAccount (extensions/campfire/src/channel.ts:72-78) omits secrets entirely and
  redacts baseUrl to "[set]" / "[missing]".

  5. Open-by-default allowFrom — design tradeoff

  When allowFrom is empty, all room members can trigger the bot (extensions/campfire/src/monitor/context.ts:51-55). This is intentional for ease of onboarding; operators restrict access by populating allowFrom.

  6. Basecamp workspace scope enforcement — well mitigated

  Both config schema (extensions/campfire/src/config.ts:46-49) and setup validation (extensions/campfire/src/setup-validation.ts:59-61) reject bare Basecamp hosts (e.g. https://3.basecamp.com/), requiring a workspace path to prevent
   overly broad URL scoping.

  7. Self-message loop prevention — adequate

  extensions/campfire/src/monitor/provider.ts:50-58 derives the bot's user ID from the botKey prefix. If the key format doesn't match, detection returns null and the bot processes the message rather than looping — fail-safe, not
  fail-open.

Network calls

  ┌───────────┬────────────────────────────────────────────────────────────────────┬───────────────────────┐
  │ Direction │                                Call                                │       Location        │
  ├───────────┼────────────────────────────────────────────────────────────────────┼───────────────────────┤
  │ Outbound  │ POST to Campfire room webhook URL (text/plain, Bearer auth)        │ src/send.ts:31        │
  ├───────────┼────────────────────────────────────────────────────────────────────┼───────────────────────┤
  │ Inbound   │ HTTP POST listener registered on the gateway for Campfire webhooks │ src/http/index.ts:139 │
  └───────────┴────────────────────────────────────────────────────────────────────┴───────────────────────┘

  Two network touchpoints total — one outbound fetch per reply chunk, one inbound webhook route per account.

  Risks

  1. SSRF via reply URL — inbound payload contains room.path used as the reply target. A crafted payload could direct the gateway to POST to an arbitrary internal endpoint.
  2. Webhook forgery — if the endpoint is discovered, an attacker could inject fake inbound messages.
  3. Credential leakage — botKey is sent as a Bearer token on every outbound POST.
  4. Unauthorized command execution — unvetted senders could trigger bot commands.

  Mitigations

  ┌───────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────┐
  │       Risk        │                                                                           Mitigation                                                                           │                   Where                    │
  ├───────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ SSRF              │ Workspace-scoped URL gating — reply URL must match configured baseUrl origin + path prefix, and conform to known Campfire/Basecamp message endpoint patterns   │ workspace-url.ts:61, context.ts:4          │
  │                   │ (/rooms/*/…/messages or /buckets/*/chats/*/messages). Checked before any outbound fetch.                                                                       │                                            │
  ├───────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ Webhook forgery   │ X-Webhook-Secret with timingSafeEqual — when webhookSecret is configured, the header (or ?secret= fallback) is compared in constant time; mismatch → 401.      │ http/index.ts:79-85                        │
  ├───────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ Credential        │ botKey and webhookSecret marked sensitive: true in UI hints; Bearer token only sent to workspace-validated URLs.                                               │ config.ts:206-218                          │
  │ leakage           │                                                                                                                                                                │                                            │
  ├───────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ Unauthorized      │ allowFrom sender allowlist + resolveCampfireCommandAuthorized access-group check; self-loop prevention via bot-user-id extraction from botKey.                 │ monitor/provider.ts:26-48, 60-63           │
  │ commands          │                                                                                                                                                                │                                            │
  ├───────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ Input integrity   │ Strict baseUrl zod schema (http(s) only, rejects bare basecamp.com); typed payload parsing rejects malformed JSON; POST-only on webhook route (405 otherwise); │ config.ts:40-49, http/payload.ts,          │
  │                   │  per-account webhook-path reservation prevents cross-account collision.                                                                                        │ http/index.ts:27-54                        │
  └───────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────┘

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`no`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
