### PR TITLE
Add Discord VC model override support

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1081,6 +1081,7 @@ Auto-join example:
 Notes:
 
 - `voice.tts` overrides `messages.tts` for voice playback only.
+- `voice.model` can be set to override the LLM model used for VC responses (e.g. `openai-codex/gpt-5.4`). Leave unset to inherit the route's default model.
 - Voice transcript turns derive owner status from Discord `allowFrom` (or `dm.allowFrom`); non-owner speakers cannot access owner-only tools (for example `gateway` and `cron`).
 - Voice is enabled by default; set `channels.discord.voice.enabled=false` to disable it.
 - `voice.daveEncryption` and `voice.decryptionFailureTolerance` pass through to `@discordjs/voice` join options.

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -504,6 +504,35 @@ describe("DiscordVoiceManager", () => {
     expect(commandArgs?.senderIsOwner).toBe(false);
   });
 
+  it("passes configured model override to agent command in voice flow", async () => {
+    const client = createClient();
+    client.fetchMember.mockResolvedValue({
+      nickname: "Guest Nick",
+      user: {
+        id: "u-guest",
+        username: "guest",
+        globalName: "Guest",
+        discriminator: "4321",
+      },
+    });
+    const manager = createManager(
+      {
+        voice: {
+          model: "openai-codex/gpt-5.4",
+        },
+      },
+      client,
+    );
+    await processVoiceSegment(manager, "u-guest");
+
+    const commandArgs = agentCommandMock.mock.calls.at(-1)?.[0] as
+      | { allowModelOverride?: boolean; model?: string }
+      | undefined;
+
+    expect(commandArgs?.allowModelOverride).toBe(true);
+    expect(commandArgs?.model).toBe("openai-codex/gpt-5.4");
+  });
+
   it("reuses speaker context cache for repeated segments from the same speaker", async () => {
     const client = createClient();
     client.fetchMember.mockResolvedValue({

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -773,6 +773,8 @@ export class DiscordVoiceManager {
 
     const prompt = formatVoiceIngressPrompt(transcript, speaker.label);
 
+    const modelOverride = normalizeOptionalString(this.params.discordConfig.voice?.model);
+
     const result = await agentCommandFromIngress(
       {
         message: prompt,
@@ -780,7 +782,8 @@ export class DiscordVoiceManager {
         agentId: entry.route.agentId,
         messageChannel: "discord",
         senderIsOwner: speaker.senderIsOwner,
-        allowModelOverride: false,
+        allowModelOverride: Boolean(modelOverride),
+        model: modelOverride,
         deliver: false,
       },
       this.params.runtime,

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -3055,6 +3055,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         label: "Discord Voice Enabled",
         help: "Enable Discord voice channel conversations (default: true). Omit channels.discord.voice to keep voice support disabled for the account.",
       },
+      "voice.model": {
+        label: "Discord Voice LLM Model",
+        help: "Optional override for the LLM model used by voice sessions (for example openai-codex/gpt-5.4). Leave unset to inherit the route/session default model.",
+      },
       "voice.autoJoin": {
         label: "Discord Voice Auto-Join",
         help: "Voice channels to auto-join on startup (list of guildId/channelId entries).",

--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -96,6 +96,23 @@ describe("config discord", () => {
     }
   });
 
+  it("accepts discord voice model override field", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          voice: {
+            model: "openai-codex/gpt-5.4",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.channels?.discord?.voice?.model).toBe("openai-codex/gpt-5.4");
+    }
+  });
+
   it("rejects numeric discord IDs that are not valid non-negative safe integers", () => {
     const cases = [106232522769186816, -1, 123.45];
     for (const id of cases) {

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -128,6 +128,8 @@ export type DiscordVoiceAutoJoinConfig = {
 export type DiscordVoiceConfig = {
   /** Enable Discord voice channel conversations (default: true). */
   enabled?: boolean;
+  /** Model used by the LLM for Discord voice sessions (default: main agent model). */
+  model?: string;
   /** Voice channels to auto-join on startup. */
   autoJoin?: DiscordVoiceAutoJoinConfig[];
   /** Enable/disable DAVE end-to-end encryption (default: true; Discord may require this). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -494,6 +494,7 @@ const DiscordVoiceAutoJoinSchema = z
 const DiscordVoiceSchema = z
   .object({
     enabled: z.boolean().optional(),
+    model: z.string().min(1).optional(),
     autoJoin: z.array(DiscordVoiceAutoJoinSchema).optional(),
     daveEncryption: z.boolean().optional(),
     decryptionFailureTolerance: z.number().int().min(0).optional(),


### PR DESCRIPTION
## What changed
- Add optional `channels.discord.voice.model`.
- Validate and type `channels.discord.voice.model` in Discord config schemas.
- Wire voice ingress to pass the configured model override to `agentCommandFromIngress`.
- Add coverage: config validation + VC model override passthrough unit test.
- Document `voice.model` and add bundled-channel config metadata entry.

## Why
This allows operators to pin a dedicated LLM model for Discord voice sessions while keeping normal route default model behavior when unset.

## Notes
- Could not run unit/e2e tests in this environment due missing local dev dependencies (`vitest`, `tsx`) in node_modules.
