### PR TITLE
fix(net): preserve multipart fields in runtime guarded fetch

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -983,6 +983,66 @@ describe("fetchWithSsrFGuard hardening", () => {
     });
   });
 
+  it("normalizes multipart FormData before runtime dispatcher fetch preserves text fields", async () => {
+    class MockRuntimeFormData {
+      private readonly values: Array<[string, unknown, string | undefined]> = [];
+
+      append(name: string, value: unknown, filename?: string): void {
+        this.values.push([name, value, filename]);
+      }
+
+      entries(): IterableIterator<[string, unknown]> {
+        return this.values
+          .map(([name, value]) => [name, value] as [string, unknown])[Symbol.iterator]();
+      }
+
+      getAll(name: string): unknown[] {
+        return this.values.filter(([key]) => key === name).map(([, value]) => value);
+      }
+    }
+
+    const runtimeFetch = vi.fn(async () => okResponse());
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      FormData: MockRuntimeFormData,
+      fetch: runtimeFetch,
+    };
+
+    const form = new FormData();
+    form.append("model", "gpt-4o-transcribe");
+    form.append("language", "cs");
+    form.append("file", new File([new Uint8Array([1, 2, 3])], "voice.ogg", { type: "audio/ogg" }));
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.openai.com/v1/audio/transcriptions",
+      init: {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-key",
+          "content-type": "multipart/form-data; boundary=stale",
+          "content-length": "999",
+        },
+        body: form,
+      },
+      lookupFn: createPublicLookup(),
+      dispatcherPolicy: { mode: "direct" },
+    });
+
+    const [, init] = runtimeFetch.mock.calls[0] as [string, RequestInit];
+    const runtimeBody = init.body as unknown as MockRuntimeFormData;
+    expect(runtimeBody).toBeInstanceOf(MockRuntimeFormData);
+    expect(runtimeBody.getAll("model")).toEqual(["gpt-4o-transcribe"]);
+    expect(runtimeBody.getAll("language")).toEqual(["cs"]);
+    const headers = new Headers(init.headers);
+    expect(headers.get("authorization")).toBe("Bearer test-key");
+    expect(headers.has("content-type")).toBe(false);
+    expect(headers.has("content-length")).toBe(false);
+
+    await result.release();
+  });
+
   it("allows explicit proxy on localhost when allowPrivateProxy is true even with restrictive hostnameAllowlist", async () => {
     // Reproduces #61906: Telegram media downloads fail because the SSRF guard
     // checks the proxy hostname (localhost) against a target-scoped allowlist

--- a/src/infra/net/runtime-fetch.test.ts
+++ b/src/infra/net/runtime-fetch.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithRuntimeDispatcher } from "./runtime-fetch.js";
+import { TEST_UNDICI_RUNTIME_DEPS_KEY } from "./undici-runtime.js";
+
+class MockRuntimeFormData {
+  private readonly values: Array<[string, unknown, string | undefined]> = [];
+
+  append(name: string, value: unknown, filename?: string): void {
+    this.values.push([name, value, filename]);
+  }
+
+  entries(): IterableIterator<[string, unknown]> {
+    return this.values.map(([name, value]) => [name, value] as [string, unknown])[Symbol.iterator]();
+  }
+
+  getAll(name: string): unknown[] {
+    return this.values.filter(([key]) => key === name).map(([, value]) => value);
+  }
+
+  getFileName(name: string): string | undefined {
+    return this.values.find(([key]) => key === name)?.[2];
+  }
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis as object, TEST_UNDICI_RUNTIME_DEPS_KEY);
+});
+
+describe("fetchWithRuntimeDispatcher", () => {
+  it("rebuilds global FormData with runtime FormData and drops stale multipart headers", async () => {
+    const runtimeFetch = vi.fn(async () => new Response("ok"));
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: class {},
+      EnvHttpProxyAgent: class {},
+      ProxyAgent: class {},
+      FormData: MockRuntimeFormData,
+      fetch: runtimeFetch,
+    };
+
+    const form = new FormData();
+    const file = new File([new Uint8Array([1, 2, 3])], "voice.ogg", { type: "audio/ogg" });
+    form.append("file", file);
+    form.append("model", "gpt-4o-transcribe");
+    form.append("language", "cs");
+
+    await fetchWithRuntimeDispatcher("https://api.openai.com/v1/audio/transcriptions", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-key",
+        "content-type": "multipart/form-data; boundary=stale",
+        "content-length": "123",
+      },
+      body: form,
+    });
+
+    const [, init] = runtimeFetch.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBeInstanceOf(MockRuntimeFormData);
+    const runtimeBody = init.body as unknown as MockRuntimeFormData;
+    expect(runtimeBody.getAll("model")).toEqual(["gpt-4o-transcribe"]);
+    expect(runtimeBody.getAll("language")).toEqual(["cs"]);
+    expect(runtimeBody.getFileName("file")).toBe("voice.ogg");
+
+    const headers = new Headers(init.headers);
+    expect(headers.get("authorization")).toBe("Bearer test-key");
+    expect(headers.has("content-type")).toBe(false);
+    expect(headers.has("content-length")).toBe(false);
+  });
+});

--- a/src/infra/net/runtime-fetch.ts
+++ b/src/infra/net/runtime-fetch.ts
@@ -5,6 +5,46 @@ export type DispatcherAwareRequestInit = RequestInit & { dispatcher?: Dispatcher
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
+function isFormDataBody(body: BodyInit | null | undefined): body is FormData {
+  return typeof FormData !== "undefined" && body instanceof FormData;
+}
+
+function normalizeRuntimeMultipartInit(
+  init: DispatcherAwareRequestInit | undefined,
+): DispatcherAwareRequestInit | undefined {
+  if (!init || !isFormDataBody(init.body)) {
+    return init;
+  }
+
+  const { FormData: RuntimeFormData } = loadUndiciRuntimeDeps();
+  if (typeof RuntimeFormData !== "function") {
+    return init;
+  }
+  const runtimeForm = new RuntimeFormData();
+  for (const [key, value] of init.body.entries()) {
+    if (typeof value === "string") {
+      runtimeForm.append(key, value);
+      continue;
+    }
+    const filename = typeof File !== "undefined" && value instanceof File ? value.name : undefined;
+    if (filename) {
+      runtimeForm.append(key, value, filename);
+    } else {
+      runtimeForm.append(key, value);
+    }
+  }
+
+  const headers = new Headers(init.headers);
+  headers.delete("content-type");
+  headers.delete("content-length");
+
+  return {
+    ...init,
+    headers,
+    body: runtimeForm,
+  };
+}
+
 export function isMockedFetch(fetchImpl: FetchLike | undefined): boolean {
   if (typeof fetchImpl !== "function") {
     return false;
@@ -20,5 +60,5 @@ export async function fetchWithRuntimeDispatcher(
     input: RequestInfo | URL,
     init?: DispatcherAwareRequestInit,
   ) => Promise<unknown>;
-  return (await runtimeFetch(input, init)) as Response;
+  return (await runtimeFetch(input, normalizeRuntimeMultipartInit(init))) as Response;
 }

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -6,6 +6,7 @@ export type UndiciRuntimeDeps = {
   Agent: typeof import("undici").Agent;
   EnvHttpProxyAgent: typeof import("undici").EnvHttpProxyAgent;
   ProxyAgent: typeof import("undici").ProxyAgent;
+  FormData?: typeof import("undici").FormData;
   fetch: typeof import("undici").fetch;
 };
 
@@ -29,6 +30,8 @@ function isUndiciRuntimeDeps(value: unknown): value is UndiciRuntimeDeps {
     typeof (value as UndiciRuntimeDeps).Agent === "function" &&
     typeof (value as UndiciRuntimeDeps).EnvHttpProxyAgent === "function" &&
     typeof (value as UndiciRuntimeDeps).ProxyAgent === "function" &&
+    (((value as UndiciRuntimeDeps).FormData === undefined ||
+      typeof (value as UndiciRuntimeDeps).FormData === "function")) &&
     typeof (value as UndiciRuntimeDeps).fetch === "function"
   );
 }
@@ -45,6 +48,7 @@ export function loadUndiciRuntimeDeps(): UndiciRuntimeDeps {
     Agent: undici.Agent,
     EnvHttpProxyAgent: undici.EnvHttpProxyAgent,
     ProxyAgent: undici.ProxyAgent,
+    FormData: undici.FormData,
     fetch: undici.fetch,
   };
 }


### PR DESCRIPTION
## Summary
- normalize global FormData bodies before guarded runtime undici fetch uses a dispatcher
- preserve multipart text fields like `model` and `language` while clearing stale multipart headers so undici regenerates the boundary
- add regression coverage for both the runtime fetch helper and the SSRF-guarded multipart path

## Root cause
`fetchWithSsrFGuard()` falls back to runtime undici fetch whenever a dispatcher is attached.
For audio transcription, the request body is built with the global `FormData` implementation, but the runtime path serializes through undici's fetch.
That realm mismatch can drop multipart text fields, so OpenAI receives the file but misses fields like `model`, returning `you must provide a model parameter`.

## Testing
- `node scripts/run-vitest.mjs run src/infra/net/runtime-fetch.test.ts src/infra/net/fetch-guard.ssrf.test.ts src/media-understanding/openai-compatible-audio.test.ts`
