### PR TITLE
feat(tools): support Claude Code flat edit params via prepareArguments hook

### DIFF
--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -84,6 +84,66 @@ export const REQUIRED_PARAM_GROUPS = {
   ],
 } as const;
 
+// ========== FORK PATCH: Claude Code alias mapping via prepareArguments ==========
+// 3rd party models (GPT-5 via unleashed, Qwen via litellm) are trained on Claude Code
+// conventions and emit {file_path, old_string, new_string} instead of pi-coding-agent's
+// {path, oldText, newText}. We chain into the tool's prepareArguments hook (which runs
+// BEFORE schema validation in pi-agent-core) to map aliases before upstream's own
+// normalization (prepareEditArguments: flat → edits[] array).
+
+const CLAUDE_CODE_ALIASES: readonly { original: string; alias: string }[] = [
+  { original: "path", alias: "file_path" },
+  { original: "path", alias: "filePath" },
+  { original: "path", alias: "file" },
+  { original: "oldText", alias: "old_string" },
+  { original: "oldText", alias: "old_text" },
+  { original: "oldText", alias: "oldString" },
+  { original: "newText", alias: "new_string" },
+  { original: "newText", alias: "new_text" },
+  { original: "newText", alias: "newString" },
+];
+
+function mapClaudeCodeAliases(args: unknown): unknown {
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return args;
+  }
+  const record = args as Record<string, unknown>;
+  let changed = false;
+  const result: Record<string, unknown> = { ...record };
+  for (const { original, alias } of CLAUDE_CODE_ALIASES) {
+    if (alias in result) {
+      if (!(original in result)) {
+        result[original] = result[alias];
+      }
+      delete result[alias];
+      changed = true;
+    }
+  }
+  return changed ? result : args;
+}
+
+/**
+ * Wrap a tool's prepareArguments hook to map Claude Code aliases
+ * (file_path/old_string/new_string) to pi-coding-agent conventions
+ * (path/oldText/newText) BEFORE the upstream prepareArguments runs.
+ *
+ * pi-coding-agent's edit tool already has prepareEditArguments that wraps
+ * flat {oldText, newText} into {edits: [{oldText, newText}]}. After our
+ * alias mapping, that upstream logic handles the rest.
+ */
+export function wrapToolWithClaudeCodeAliases(tool: AnyAgentTool): AnyAgentTool {
+  const upstreamPrepare = tool.prepareArguments;
+  return {
+    ...tool,
+    prepareArguments: (args: unknown) => {
+      const aliased = mapClaudeCodeAliases(args);
+      return upstreamPrepare ? upstreamPrepare(aliased) : aliased;
+    },
+  } as AnyAgentTool;
+}
+
+// ========== END FORK PATCH ==========
+
 export function getToolParamsRecord(params: unknown): Record<string, unknown> | undefined {
   return params && typeof params === "object" ? (params as Record<string, unknown>) : undefined;
 }

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -20,6 +20,7 @@ import {
   assertRequiredParams,
   getToolParamsRecord,
   wrapToolParamValidation,
+  wrapToolWithClaudeCodeAliases,
 } from "./pi-tools.params.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -604,7 +605,8 @@ export function createSandboxedWriteTool(params: SandboxToolParams) {
   const base = createWriteTool(params.root, {
     operations: createSandboxWriteOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  // Fork patch: map Claude Code aliases (file_path → path) via prepareArguments hook.
+  return wrapToolParamValidation(wrapToolWithClaudeCodeAliases(base), REQUIRED_PARAM_GROUPS.write);
 }
 
 export function createSandboxedEditTool(params: SandboxToolParams) {
@@ -616,14 +618,20 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
     readFile: async (absolutePath: string) =>
       (await params.bridge.readFile({ filePath: absolutePath, cwd: params.root })).toString("utf8"),
   });
-  return wrapToolParamValidation(withRecovery, REQUIRED_PARAM_GROUPS.edit);
+  // Fork patch: map Claude Code aliases (file_path/old_string/new_string) before upstream
+  // prepareEditArguments handles flat → edits[] conversion.
+  return wrapToolParamValidation(
+    wrapToolWithClaudeCodeAliases(withRecovery),
+    REQUIRED_PARAM_GROUPS.edit,
+  );
 }
 
 export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  // Fork patch: map Claude Code aliases (file_path → path) via prepareArguments hook.
+  return wrapToolParamValidation(wrapToolWithClaudeCodeAliases(base), REQUIRED_PARAM_GROUPS.write);
 }
 
 export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {
@@ -634,15 +642,22 @@ export function createHostWorkspaceEditTool(root: string, options?: { workspaceO
     root,
     readFile: (absolutePath: string) => fs.readFile(absolutePath, "utf-8"),
   });
-  return wrapToolParamValidation(withRecovery, REQUIRED_PARAM_GROUPS.edit);
+  // Fork patch: map Claude Code aliases (file_path/old_string/new_string) before upstream
+  // prepareEditArguments handles flat → edits[] conversion.
+  return wrapToolParamValidation(
+    wrapToolWithClaudeCodeAliases(withRecovery),
+    REQUIRED_PARAM_GROUPS.edit,
+  );
 }
 
 export function createOpenClawReadTool(
   base: AnyAgentTool,
   options?: OpenClawReadToolOptions,
 ): AnyAgentTool {
+  // Fork patch: map Claude Code aliases (file_path → path) via prepareArguments hook.
+  const aliased = wrapToolWithClaudeCodeAliases(base);
   return {
-    ...base,
+    ...aliased,
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
       assertRequiredParams(record, REQUIRED_PARAM_GROUPS.read, base.name);


### PR DESCRIPTION
## Problem

Third-party models trained on Claude Code conventions (e.g., GPT-5 via OpenAI-compat endpoints, Qwen distilled from Claude) emit flat edit params instead of the pi-coding-agent schema:

```json
// What these models emit:
{ "file_path": "/tmp/x.ts", "old_string": "foo", "new_string": "bar" }

// What the schema expects:
{ "path": "/tmp/x.ts", "edits": [{ "oldText": "foo", "newText": "bar" }] }
```

AJV validation in `pi-agent-core`'s `agent-loop.js` rejects these calls before `tool.execute()` runs. The agent loops on the broken tool call indefinitely because the model cannot self-correct when it has memorized the wrong format during training.

This affects users who:
- Use OpenAI-compat providers (unleashed, litellm proxies, local Ollama) with Claude-distilled or Claude-Code-trained models
- Route through gateways that expose GPT-5, Qwen, or similar as "Claude-compatible"
- Cannot switch to real Anthropic API for cost/licensing reasons

OpenClaw explicitly advertises multi-provider support (openai, google, ollama, local, etc.), so this is not an "Anthropic-only" concern.

## Solution

Chain a Claude Code alias mapper into `tool.prepareArguments` — the hook that runs **before** `validateToolArguments` in `pi-agent-core`'s tool call flow:

```javascript
// pi-agent-core/dist/agent-loop.js
const preparedToolCall = prepareToolCallArguments(tool, toolCall);  // ← our hook runs here
const validatedArgs = validateToolArguments(tool, preparedToolCall);
// ...
```

`pi-coding-agent`'s edit tool already uses `prepareArguments` (`prepareEditArguments`) to wrap flat `{oldText, newText}` into `{edits: [{oldText, newText}]}`. This PR extends the chain by mapping Claude Code aliases first, then delegating to any existing `prepareArguments`:

```typescript
// Claude Code → pi-coding-agent:
//   { file_path, old_string, new_string }
//     ↓ (our alias mapper)
//   { path, oldText, newText }
//     ↓ (upstream prepareEditArguments)
//   { path, edits: [{ oldText, newText }] }
//     ↓ (AJV validates against schema)
//   { path, edits: [...] }  ← tool.execute receives this
```

## Changes

- **`src/agents/pi-tools.params.ts`** (+60 LOC): adds ` wrapToolWithClaudeCodeAliases()` plus the alias table (9 mappings covering `file_path`/`filePath`/`file` → `path`, `old_string`/`old_text`/`oldString` → `oldText`, `new_string`/`new_text`/`newString` → `newText`).

- **`src/agents/pi-tools.read.ts`** (+25 LOC): applies the wrapper at 5 tool factories:
  - `createSandboxedWriteTool`
  - `createSandboxedEditTool`
  - `createHostWorkspaceWriteTool`
  - `createHostWorkspaceEditTool`
  - `createOpenClawReadTool`

## Properties

- **No-op** when the tool call already matches the pi-coding-agent schema (alias keys absent → wrapper returns args unchanged → real Anthropic / spec-compliant clients unaffected).
- **No schema changes** — the tool's declared JSON schema is untouched.
- **No AJV bypass** — validation still runs with full strictness, just on the normalized args.
- **No new dependencies.**
- **Provider-agnostic** — works regardless of provider id, unlike a per-provider `normalizeToolSchemas` plugin hook.

## Alternatives considered

1. **Plugin via `normalizeToolSchemas`** — rejected: hook is per-provider (`matchesProviderId`, no wildcard), would require enumerating every OpenAI-compat/local provider alias and updating the plugin whenever a new provider is added. Total LOC is higher (~80 + manifest + package.json).

2. **Plugin via `before_tool_call` hook** — rejected: runs AFTER `validateToolArguments` in pi-agent-core, so AJV has already rejected the flat args by the time the hook sees them.

3. **Schema relaxation** (`additionalProperties: false` drop + alias properties) — rejected: couples tool schema to Claude Code conventions, harder to reason about, larger diff (~210 LOC instead of 80).

## Testing

- Build passes (`pnpm build`)
- Running on a production fork (`thebtf/openclaw`) with this patch since 2026-04-10
- Verified with GPT-5.4 (via OpenAI-compat proxy) and Qwen 3.5 (via litellm): edit/write/read tools work with both flat Claude Code format and proper pi-coding-agent format

## Opt-in

The wrapper is unconditionally applied. If upstream prefers opt-in, a config flag (e.g., `tools.claudeCodeAliases: boolean`) can be added — happy to adjust the PR based on maintainer preference.