### PR TITLE
fix: include image param in sandbox media normalization [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Docs: https://docs.openclaw.ai
 - Cron/isolated agent: run scheduled agent turns as non-owner senders so owner-only tools stay unavailable during cron execution. (#63878)
 - Voice Call/realtime: reject oversized realtime WebSocket frames before bridge setup so large pre-start payloads cannot crash the gateway. (#63890) Thanks @mmaps.
 
+- Discord/sandbox: include `image` in sandbox media param normalization so Discord event cover images cannot bypass sandbox path rewriting. (#64377) Thanks @mmaps.
 ## 2026.4.9
 
 ### Changes

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -81,6 +81,29 @@ describe("message action media helpers", () => {
     }
   });
 
+  maybeIt("normalizes Discord event image sandbox media params", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-image-"));
+    try {
+      const args: Record<string, unknown> = {
+        image: " file:///workspace/assets/event-cover.png ",
+      };
+
+      await normalizeSandboxMediaParams({
+        args,
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot: ` ${sandboxRoot} `,
+        },
+      });
+
+      expect(args).toMatchObject({
+        image: path.join(sandboxRoot, "assets", "event-cover.png"),
+      });
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
   maybeIt(
     "keeps remote HTTP mediaUrl and fileUrl aliases unchanged under sandbox normalization",
     async () => {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -16,7 +16,14 @@ import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boo
 
 export const readBooleanParam = readBooleanParamShared;
 
-const SANDBOX_MEDIA_PARAM_KEYS = ["media", "path", "filePath", "mediaUrl", "fileUrl"] as const;
+const SANDBOX_MEDIA_PARAM_KEYS = [
+  "media",
+  "path",
+  "filePath",
+  "mediaUrl",
+  "fileUrl",
+  "image",
+] as const;
 
 function readMediaParam(
   args: Record<string, unknown>,


### PR DESCRIPTION
## Summary

- **Problem:** The `image` parameter (used for Discord event cover images) was omitted from `SANDBOX_MEDIA_PARAM_KEYS`, so sandbox path rewriting never applied to it.
- **Why it matters:** In sandboxed deployments, a caller could supply a host-local `file://` or absolute path as `image`; it would pass through normalization unchanged and be consumed by the Discord event cover image loader against host media roots — a sandbox boundary bypass.
- **What changed:** Added `"image"` to `SANDBOX_MEDIA_PARAM_KEYS` in `src/infra/outbound/message-action-params.ts` so `normalizeSandboxMediaParams` rewrites it into sandbox-local paths before action execution. Added a regression test covering the new key.
- **What did NOT change:** `readAttachmentMediaHint`/`readAttachmentFileHint` are unchanged; `image` is not routed through the buffer-loading hydration pipeline.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Integrations

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `SANDBOX_MEDIA_PARAM_KEYS` was not updated when the `image` parameter was introduced for Discord event cover images.
- Missing detection / guardrail: No test covered sandbox normalization for the `image` key.
- Contributing context (if known): The generic normalization call in `message-action-runner.ts` guards all actions, but only for explicitly listed keys.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/infra/outbound/message-action-params.test.ts`
- Scenario the test should lock in: `normalizeSandboxMediaParams` rewrites a `file://`-prefixed `image` value into its sandbox-relative path.
- Why this is the smallest reliable guardrail: Directly exercises the key-list lookup and path rewriting without requiring Discord credentials or a running gateway.
- Existing test that already covers this (if any): None prior to this PR.

## User-visible / Behavior Changes

None for legitimate sandboxed usage. In sandboxed deployments, `image` paths that previously bypassed rewriting are now correctly resolved to sandbox-local paths.

## Diagram (if applicable)

```text
Before:
[eventCreate image=file:///host/secret.png] -> normalizeSandboxMediaParams (skips image) -> Discord loader reads host file

After:
[eventCreate image=file:///host/secret.png] -> normalizeSandboxMediaParams (rewrites image) -> sandbox-local path -> Discord loader reads sandbox file
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — sandbox media normalization now applies to `image`, restricting file access to sandbox-local paths as intended.
- Explanation: This closes the gap where `image` could reach host-local media roots in sandboxed deployments. The change tightens access scope to match existing behavior for `media`, `path`, `filePath`, `mediaUrl`, and `fileUrl`.

## Repro + Verification

### Environment

- OS: Linux (ubuntu)
- Runtime/container: Node 22 / Bun
- Integration/channel: Discord

### Steps

1. Run the new regression test: `pnpm test src/infra/outbound/message-action-params.test.ts`
2. Confirm the `normalizes Discord event image sandbox media params` case passes.

### Expected

- `image` value is rewritten to a sandbox-local path after `normalizeSandboxMediaParams`.

### Actual

- Test passes; `image` is correctly rewritten.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: New test added and passes; existing tests continue to pass.
- Edge cases checked: Whitespace trimming in both the `image` value and `sandboxRoot`; `file://` URL input.
- What you did **not** verify: Live Discord event creation with a real cover image.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: An existing caller that relies on `image` bypassing sandbox normalization (e.g., passing a host path intentionally).
  - Mitigation: No such caller exists in this repo. Host-mode policies are unaffected (normalization is a no-op when `mode !== "sandbox"`).