### PR TITLE
fix(cli): strip null bytes from system prompt before spawn

### DIFF
--- a/src/agents/system-prompt-cache-boundary.test.ts
+++ b/src/agents/system-prompt-cache-boundary.test.ts
@@ -31,6 +31,18 @@ describe("system prompt cache boundary helpers", () => {
     ).toBe(`Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Per-turn lab context\n\nDynamic suffix`);
   });
 
+  it("strips null bytes from prompt text", () => {
+    expect(stripSystemPromptCacheBoundary("Hello\0World\0")).toBe("HelloWorld");
+  });
+
+  it("strips null bytes alongside cache boundary markers", () => {
+    expect(
+      stripSystemPromptCacheBoundary(
+        `Stable\0 prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic\0 suffix`,
+      ),
+    ).toBe("Stable prefix\nDynamic suffix");
+  });
+
   it("normalizes structured additions and dynamic suffix whitespace", () => {
     expect(
       prependSystemPromptAdditionAfterCacheBoundary({

--- a/src/agents/system-prompt-cache-boundary.ts
+++ b/src/agents/system-prompt-cache-boundary.ts
@@ -3,7 +3,10 @@ import { normalizeStructuredPromptSection } from "./prompt-cache-stability.js";
 export const SYSTEM_PROMPT_CACHE_BOUNDARY = "\n<!-- OPENCLAW_CACHE_BOUNDARY -->\n";
 
 export function stripSystemPromptCacheBoundary(text: string): string {
-  return text.replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n");
+  // Strip cache boundary markers and null bytes. Null bytes in system prompts
+  // (e.g. from conversation metadata in channel messages) cause Node.js
+  // child_process.spawn to throw ERR_INVALID_ARG_VALUE.
+  return text.replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n").replaceAll("\0", "");
 }
 
 export function splitSystemPromptCacheBoundary(


### PR DESCRIPTION
## Summary

CLI backend system prompts containing null bytes crash `child_process.spawn` with `ERR_INVALID_ARG_VALUE`.

## Problem

When using `claude-cli` backend with channel messages (e.g. iMessage), conversation metadata embedded in the system prompt can contain null bytes (`\0`). Node.js rejects these in spawn args:

```
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'args[11]' must be a string without null bytes.
```

The agent returns "Something went wrong" with no useful diagnostic.

## Fix

Strip null bytes in `stripSystemPromptCacheBoundary()`, which is already applied to system prompts at both the spawn-arg path (`helpers.ts:383`) and the temp-file path (`helpers.ts:300`). This is the minimal change that covers all CLI backend system prompt flows.

## Test plan

- [x] All 6 system-prompt-cache-boundary tests pass (4 existing + 2 new)
- [x] 17/18 CLI runner helpers tests pass (1 pre-existing Windows path separator failure)
- New tests verify null byte stripping both standalone and alongside cache boundary markers

Closes #61055