### PR TITLE
fix(exec): honor user's tools.exec.security config setting

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -201,7 +201,11 @@ export function resolveExecHostApprovalContext(params: {
   });
   // Session/config tool policy is the caller's requested contract. The host file
   // may tighten that contract, but it must not silently broaden it.
-  const hostSecurity = minSecurity(params.security, approvals.agent.security);
+  const effectiveRequestedSecurity =
+    params.security === "full"
+      ? "full"
+      : minSecurity(params.security, approvals.agent.security);
+  const hostSecurity = effectiveRequestedSecurity;
   const hostAsk = maxAsk(params.ask, approvals.agent.ask);
   const askFallback = minSecurity(hostSecurity, approvals.agent.askFallback);
   if (hostSecurity === "deny") {


### PR DESCRIPTION
Thank you for the detailed review. You raise valid concerns.

To answer your question about ~/.openclaw/exec-approvals.json - I don't have access to the reporter's config file, as this issue was reported by someone else.

However, your analysis is compelling:
1. The safety invariant (host can always tighten, never broaden) should be preserved
2. If approvals.agent.security resolves to "deny", that's likely a misconfiguration rather than a code bug
3. My fix bypasses minSecurity entirely, which is too aggressive

I'll close this PR and investigate the actual root cause - which may be in how the default approval config is generated, or the reporter may have a stale exec-approvals.json file.

Thank you for the thorough review.