### PR TITLE
fix(plugins): prefer CLI metadata for lazy primary commands

### DIFF
--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -47,16 +47,130 @@ function resolvePluginCliLogger(logger?: PluginLogger): PluginLogger {
   return logger ?? createPluginCliLogger();
 }
 
-function buildPluginCliLoaderParams(
+function isIgnoredAsyncRegisterDiagnosticMessage(message: string): boolean {
+  if (message === "plugin register returned a promise; async registration is ignored") {
+    return true;
+  }
+  // Current loader: `runPluginRegisterSync` throws `plugin register must be synchronous`, then
+  // `recordPluginError` prefixes with `plugin failed during register: `.
+  if (message.includes("plugin register must be synchronous")) {
+    return true;
+  }
+  return false;
+}
+
+function hasIgnoredAsyncPluginRegistration(registry: PluginRegistry): boolean {
+  return (registry.diagnostics ?? []).some((entry) =>
+    isIgnoredAsyncRegisterDiagnosticMessage(entry.message),
+  );
+}
+
+function mergeCliRegistrars(params: {
+  runtimeRegistry: PluginRegistry;
+  metadataRegistry: PluginRegistry;
+}): PluginRegistry["cliRegistrars"] {
+  const runtimeCommands = new Set(
+    params.runtimeRegistry.cliRegistrars.flatMap((entry) => entry.commands),
+  );
+  return [
+    ...params.runtimeRegistry.cliRegistrars,
+    ...params.metadataRegistry.cliRegistrars.filter(
+      (entry) => !entry.commands.some((command) => runtimeCommands.has(command)),
+    ),
+  ];
+}
+
+function sameCommandRoots(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const leftSorted = [...left].toSorted();
+  const rightSorted = [...right].toSorted();
+  return leftSorted.every((command, index) => command === rightSorted[index]);
+}
+
+function canPreferMetadataCliRegistrar(entry: PluginRegistry["cliRegistrars"][number]): boolean {
+  // `registerCli` can record command-only CLIs: `commands` from opts with no descriptor
+  // rows, but a real non-stub `register` body. The placeholder pattern for “roots only”
+  // is still `() => {}` (zero-arity), which we must not swap in for the lazy primary.
+  // (A no-op `(_ctx) => {}` cannot be distinguished; zero-ary stubs are the common case
+  // called out in plugin metadata.)
+  if (entry.register.length === 0) {
+    return false;
+  }
+  return true;
+}
+
+function preferMetadataCliRegistrarsForCommands(params: {
+  cliRegistrars: PluginRegistry["cliRegistrars"];
+  metadataRegistry: PluginRegistry;
+  preferredCommands: readonly string[];
+}): PluginRegistry["cliRegistrars"] | null {
+  const preferredCommands = new Set(params.preferredCommands);
+  if (preferredCommands.size === 0) {
+    return null;
+  }
+
+  let replacedAny = false;
+  const nextCliRegistrars = params.cliRegistrars.map((entry) => {
+    if (!entry.commands.some((command) => preferredCommands.has(command))) {
+      return entry;
+    }
+
+    const metadataEntry = params.metadataRegistry.cliRegistrars.find(
+      (candidate) =>
+        candidate.pluginId === entry.pluginId &&
+        sameCommandRoots(candidate.commands, entry.commands),
+    );
+    if (!metadataEntry || !canPreferMetadataCliRegistrar(metadataEntry)) {
+      return entry;
+    }
+
+    replacedAny = true;
+    return metadataEntry;
+  });
+
+  return replacedAny ? nextCliRegistrars : null;
+}
+
+function canPreferScopedMetadataRegistry(params: {
+  runtimeRegistry: PluginRegistry;
+  scopedPluginIds: readonly string[];
+}): boolean {
+  if (params.scopedPluginIds.length === 0) {
+    return false;
+  }
+
+  // Duplicate plugin ids append disabled "overridden by …" records after the winner.
+  // Prefer the first registry row per id so we do not misread the trailing duplicate.
+  const winningOriginsById = new Map<string, PluginRegistry["plugins"][number]["origin"]>();
+  for (const plugin of params.runtimeRegistry.plugins) {
+    if (!winningOriginsById.has(plugin.id)) {
+      winningOriginsById.set(plugin.id, plugin.origin);
+    }
+  }
+  return params.scopedPluginIds.every((pluginId) => winningOriginsById.get(pluginId) === "bundled");
+}
+
+function resolvePluginCliLoaderParams(
   context: PluginCliLoadContext,
   params?: { primaryCommand?: string },
   loaderOptions?: PluginCliLoaderOptions,
-) {
+  /** e.g. lazy primary CLI: avoid activation + global registry cache in `loadOpenClawPlugins`. */
+  extraRuntimeOptions?: { activate: boolean; cache: boolean },
+): {
+  scopedPluginIds: string[];
+  loadOptions: ReturnType<typeof buildPluginRuntimeLoadOptions>;
+} {
   const onlyPluginIds = resolvePrimaryCommandPluginIds(context, params?.primaryCommand);
-  return buildPluginRuntimeLoadOptions(context, {
-    ...loaderOptions,
-    ...(onlyPluginIds.length > 0 ? { onlyPluginIds } : {}),
-  });
+  return {
+    scopedPluginIds: onlyPluginIds,
+    loadOptions: buildPluginRuntimeLoadOptions(context, {
+      ...loaderOptions,
+      ...(onlyPluginIds.length > 0 ? { onlyPluginIds } : {}),
+      ...(extraRuntimeOptions ?? {}),
+    }),
+  };
 }
 
 function resolvePrimaryCommandPluginIds(
@@ -95,11 +209,10 @@ export async function loadPluginCliMetadataRegistryWithContext(
   params?: { primaryCommand?: string },
   loaderOptions?: PluginCliLoaderOptions,
 ): Promise<PluginCliRegistryLoadResult> {
+  const { loadOptions } = resolvePluginCliLoaderParams(context, params, loaderOptions);
   return {
     ...context,
-    registry: await loadOpenClawPluginCliRegistry(
-      buildPluginCliLoaderParams(context, params, loaderOptions),
-    ),
+    registry: await loadOpenClawPluginCliRegistry(loadOptions),
   };
 }
 
@@ -107,19 +220,69 @@ export async function loadPluginCliCommandRegistryWithContext(params: {
   context: PluginCliLoadContext;
   primaryCommand?: string;
   loaderOptions?: PluginCliLoaderOptions;
+  onMetadataFallbackError: (error: unknown) => void;
+  preferMetadataCommands?: readonly string[];
 }): Promise<PluginCliRegistryLoadResult> {
-  const onlyPluginIds = resolvePrimaryCommandPluginIds(params.context, params.primaryCommand);
-  return {
-    ...params.context,
-    registry: loadOpenClawPlugins(
-      buildPluginRuntimeLoadOptions(params.context, {
-        ...params.loaderOptions,
-        ...(onlyPluginIds.length > 0 ? { onlyPluginIds } : {}),
-        activate: false,
-        cache: false,
-      }),
-    ),
-  };
+  const runtimeLoad = resolvePluginCliLoaderParams(
+    params.context,
+    { primaryCommand: params.primaryCommand },
+    params.loaderOptions,
+    { activate: false, cache: false },
+  );
+  // Full runtime load must precede the optional cli-metadata merge: we need runtime
+  // diagnostics for `hasIgnoredAsyncPluginRegistration`, and we need runtime CLI command
+  // roots so `preferMetadataCliRegistrarsForCommands` can keep richer runtime registrars
+  // when metadata only covers a subset of those roots (see cli.test.ts partial-coverage case).
+  const runtimeRegistry = loadOpenClawPlugins(runtimeLoad.loadOptions);
+  const shouldPreferScopedMetadata =
+    (params.preferMetadataCommands?.length ?? 0) > 0 &&
+    canPreferScopedMetadataRegistry({
+      runtimeRegistry,
+      scopedPluginIds: runtimeLoad.scopedPluginIds,
+    });
+
+  const shouldTryMetadataRegistry =
+    hasIgnoredAsyncPluginRegistration(runtimeRegistry) || shouldPreferScopedMetadata;
+
+  if (!shouldTryMetadataRegistry) {
+    return {
+      ...params.context,
+      registry: runtimeRegistry,
+    };
+  }
+
+  try {
+    const metadataRegistry = await loadOpenClawPluginCliRegistry(runtimeLoad.loadOptions);
+    const mergedRegistry = hasIgnoredAsyncPluginRegistration(runtimeRegistry)
+      ? {
+          ...runtimeRegistry,
+          cliRegistrars: mergeCliRegistrars({
+            runtimeRegistry,
+            metadataRegistry,
+          }),
+        }
+      : runtimeRegistry;
+    const preferredCliRegistrars = preferMetadataCliRegistrarsForCommands({
+      cliRegistrars: mergedRegistry.cliRegistrars,
+      metadataRegistry,
+      preferredCommands: params.preferMetadataCommands ?? [],
+    });
+    return {
+      ...params.context,
+      registry: preferredCliRegistrars
+        ? {
+            ...mergedRegistry,
+            cliRegistrars: preferredCliRegistrars,
+          }
+        : mergedRegistry,
+    };
+  } catch (error) {
+    params.onMetadataFallbackError(error);
+    return {
+      ...params.context,
+      registry: runtimeRegistry,
+    };
+  }
 }
 
 function buildPluginCliCommandGroupEntries(params: {
@@ -141,6 +304,10 @@ function buildPluginCliCommandGroupEntries(params: {
       });
     },
   }));
+}
+
+function logPluginCliMetadataFallbackError(logger: PluginLogger, error: unknown) {
+  logger.warn(`plugin CLI metadata fallback failed: ${String(error)}`);
 }
 
 export async function loadPluginCliDescriptors(
@@ -172,6 +339,8 @@ export async function loadPluginCliRegistrationEntries(params: {
   loaderOptions?: PluginCliLoaderOptions;
   logger?: PluginLogger;
   primaryCommand?: string;
+  onMetadataFallbackError: (error: unknown) => void;
+  preferMetadataCommands?: readonly string[];
 }): Promise<PluginCliCommandGroupEntry[]> {
   const resolvedLogger = resolvePluginCliLogger(params.logger);
   const context = resolvePluginCliLoadContext({
@@ -183,6 +352,8 @@ export async function loadPluginCliRegistrationEntries(params: {
     context,
     primaryCommand: params.primaryCommand,
     loaderOptions: params.loaderOptions,
+    onMetadataFallbackError: params.onMetadataFallbackError,
+    preferMetadataCommands: params.preferMetadataCommands,
   });
   return buildPluginCliCommandGroupEntries({
     registry,
@@ -193,11 +364,14 @@ export async function loadPluginCliRegistrationEntries(params: {
 }
 
 export async function loadPluginCliRegistrationEntriesWithDefaults(
-  params: PluginCliPublicLoadParams,
+  params: PluginCliPublicLoadParams & { preferMetadataCommands?: readonly string[] },
 ): Promise<PluginCliCommandGroupEntry[]> {
   const logger = resolvePluginCliLogger(params.logger);
   return loadPluginCliRegistrationEntries({
     ...params,
     logger,
+    onMetadataFallbackError: (error) => {
+      logPluginCliMetadataFallbackError(logger, error);
+    },
   });
 }

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -49,6 +49,7 @@ function createProgram(existingCommandName?: string) {
 
 function createCliRegistry(params?: {
   memoryCommands?: string[];
+  memoryOrigin?: "bundled" | "global" | "workspace" | "config";
   memoryDescriptors?: Array<{
     name: string;
     description: string;
@@ -76,6 +77,16 @@ function createCliRegistry(params?: {
         commands: ["other"],
         descriptors: [],
         source: "bundled",
+      },
+    ],
+    plugins: [
+      {
+        id: "memory-core",
+        origin: params?.memoryOrigin ?? "bundled",
+      },
+      {
+        id: "other",
+        origin: "bundled",
       },
     ],
   };
@@ -179,6 +190,24 @@ describe("registerPluginCliCommands", () => {
         env,
       }),
     );
+  });
+
+  it("probes cli-metadata when the loader reports an async register rejected as non-synchronous", async () => {
+    mocks.loadOpenClawPlugins.mockReturnValue({
+      ...createCliRegistry(),
+      diagnostics: [
+        {
+          level: "error" as const,
+          pluginId: "memory-core",
+          source: "bundled" as const,
+          message: "plugin failed during register: Error: plugin register must be synchronous",
+        },
+      ],
+    });
+
+    await registerPluginCliCommands(createProgram(), {} as OpenClawConfig);
+
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalled();
   });
 
   it("loads plugin CLI commands from the auto-enabled config snapshot", async () => {
@@ -371,6 +400,164 @@ describe("registerPluginCliCommands", () => {
     expect(mocks.memoryListAction).toHaveBeenCalledTimes(1);
   });
 
+  it("prefers cli-metadata registration for a selected lazy primary", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-core"]);
+    const metadataRegister = vi.fn(async ({ program }: { program: Command }) => {
+      const memory = program.command("memory").description("Memory commands");
+      memory.command("list").action(mocks.memoryListAction);
+    });
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
+      cliRegistrars: [
+        {
+          pluginId: "memory-core",
+          register: metadataRegister,
+          commands: ["memory"],
+          descriptors: [
+            {
+              name: "memory",
+              description: "Memory commands",
+              hasSubcommands: true,
+            },
+          ],
+          source: "bundled",
+        },
+      ],
+      diagnostics: [],
+    });
+    const program = createProgram();
+    program.exitOverride();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      mode: "lazy",
+      primary: "memory",
+    });
+
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledTimes(1);
+    expect(metadataRegister).toHaveBeenCalledTimes(1);
+    expect(mocks.memoryRegister).not.toHaveBeenCalled();
+
+    await program.parseAsync(["memory", "list"], { from: "user" });
+
+    expect(metadataRegister).toHaveBeenCalledTimes(1);
+    expect(mocks.memoryListAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers cli-metadata for a selected lazy primary when metadata is command-only (no descriptor rows)", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-core"]);
+    const metadataRegister = vi.fn(async ({ program }: { program: Command }) => {
+      const memory = program.command("memory").description("Memory");
+      memory.command("list").action(mocks.memoryListAction);
+    });
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
+      cliRegistrars: [
+        {
+          pluginId: "memory-core",
+          register: metadataRegister,
+          commands: ["memory"],
+          descriptors: [],
+          source: "bundled",
+        },
+      ],
+      diagnostics: [],
+    });
+    const program = createProgram();
+    program.exitOverride();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      mode: "lazy",
+      primary: "memory",
+    });
+
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledTimes(1);
+    expect(metadataRegister).toHaveBeenCalledTimes(1);
+    expect(mocks.memoryRegister).not.toHaveBeenCalled();
+
+    await program.parseAsync(["memory", "list"], { from: "user" });
+    expect(mocks.memoryListAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps runtime registration when metadata only provides a command stub", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-core"]);
+    const metadataRegister = vi.fn();
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
+      cliRegistrars: [
+        {
+          pluginId: "memory-core",
+          register: metadataRegister,
+          commands: ["memory"],
+          descriptors: [],
+          source: "bundled",
+        },
+      ],
+      diagnostics: [],
+    });
+    const program = createProgram();
+    program.exitOverride();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      mode: "lazy",
+      primary: "memory",
+    });
+
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.memoryRegister).toHaveBeenCalledTimes(1);
+    expect(metadataRegister).not.toHaveBeenCalled();
+  });
+
+  it("keeps runtime registration when metadata only covers part of the command roots", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-core"]);
+    const metadataRegister = vi.fn(async ({ program }: { program: Command }) => {
+      const memory = program.command("memory").description("Memory commands");
+      memory.command("list").action(mocks.memoryListAction);
+    });
+    mocks.loadOpenClawPlugins.mockReturnValue(
+      createCliRegistry({
+        memoryCommands: ["memory", "memory-admin"],
+        memoryDescriptors: [
+          {
+            name: "memory",
+            description: "Memory commands",
+            hasSubcommands: true,
+          },
+        ],
+      }),
+    );
+    mocks.memoryRegister.mockImplementation(({ program }: { program: Command }) => {
+      const memory = program.command("memory").description("Memory commands");
+      memory.command("list").action(mocks.memoryListAction);
+      program.command("memory-admin").description("Memory admin");
+    });
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
+      cliRegistrars: [
+        {
+          pluginId: "memory-core",
+          register: metadataRegister,
+          commands: ["memory"],
+          descriptors: [
+            {
+              name: "memory",
+              description: "Memory commands",
+              hasSubcommands: true,
+            },
+          ],
+          source: "bundled",
+        },
+      ],
+      diagnostics: [],
+    });
+    const program = createProgram();
+    program.exitOverride();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      mode: "lazy",
+      primary: "memory",
+    });
+
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.memoryRegister).toHaveBeenCalledTimes(1);
+    expect(metadataRegister).not.toHaveBeenCalled();
+  });
+
   it("keeps full CLI loading when primary command planning finds no plugin match", async () => {
     const program = createProgram();
     program.exitOverride();
@@ -385,6 +572,50 @@ describe("registerPluginCliCommands", () => {
         onlyPluginIds: expect.anything(),
       }),
     );
+    expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
+  });
+
+  it("keeps runtime registration for scoped non-bundled primaries", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-core"]);
+    mocks.loadOpenClawPlugins.mockReturnValue({
+      ...createCliRegistry({
+        memoryOrigin: "workspace",
+      }),
+      diagnostics: [],
+    });
+    const program = createProgram();
+    program.exitOverride();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      mode: "lazy",
+      primary: "memory",
+    });
+
+    expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
+    expect(mocks.memoryRegister).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the first registry row for duplicate plugin ids when gating metadata", async () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-core"]);
+    mocks.loadOpenClawPlugins.mockReturnValue({
+      ...createCliRegistry(),
+      plugins: [
+        { id: "memory-core", origin: "config" },
+        { id: "memory-core", origin: "bundled" },
+        { id: "other", origin: "bundled" },
+      ],
+      diagnostics: [],
+    });
+    const program = createProgram();
+    program.exitOverride();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      mode: "lazy",
+      primary: "memory",
+    });
+
+    expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
+    expect(mocks.memoryRegister).toHaveBeenCalledTimes(1);
   });
 
   it("returns null for validated plugin CLI config when the snapshot is invalid", async () => {

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -53,6 +53,7 @@ export async function registerPluginCliCommands(
       env,
       loaderOptions,
       primaryCommand: primary,
+      preferMetadataCommands: mode === "lazy" && primary ? [primary] : undefined,
     }),
     {
       mode,


### PR DESCRIPTION
## Summary

- Problem: lazy startup eagerly registers the selected plugin primary through the full runtime registrar, which can pull in heavy plugin runtime work for commands like `memory`.
- Why it matters: commands such as `openclaw memory --help` should return immediately instead of blocking on unnecessary runtime activation.
- What changed: thread `preferMetadataCommands` into the lazy plugin CLI loader, prefer the non-activating metadata registrar only when the metadata/runtime command roots match exactly, and keep runtime registration when metadata is only a command stub.
- What did NOT change (scope boundary): no change to eager mode, no cross-plugin conflict policy change, and no metadata fallback when the command-root coverage is incomplete or the metadata registrar cannot actually materialize the command.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Memory / storage
- [x] UI / DX
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64354
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the selected lazy primary path eagerly registers the matching plugin command group, but the loader always preferred the full runtime registrar even when a metadata registrar could register the same command roots without activating the heavy runtime path.
- Missing detection / guardrail: there was no regression coverage for "selected lazy primary prefers metadata when safe, falls back to runtime when metadata only partially covers the command roots, and falls back when metadata is only a command stub".
- Contributing context (if known): the affected report was `openclaw memory --help` hanging on Linux in #64354.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/cli.test.ts`
- Scenario the test should lock in: selected lazy primaries use the metadata registrar when it fully covers the command roots, stay on the runtime registrar when metadata only partially covers them, and also stay on the runtime registrar when metadata only advertises a command stub.
- Why this is the smallest reliable guardrail: the regression is in loader/registration selection logic, and the unit test can assert the exact registrar chosen without needing a full plugin runtime.
- Existing test that already covers this (if any): `lazy-registers descriptor-backed plugin commands on first invocation`
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw memory --help` and other selected lazy-primary memory CLI entrypoints avoid the heavy runtime registration path when metadata can safely materialize the same command surface. No config or default changes.

## Diagram (if applicable)

```text
Before:
[selected lazy primary] -> [force runtime registrar] -> [heavy runtime path]

After:
[selected lazy primary] -> [prefer safe metadata registrar when roots match and registrar can materialize commands]
[selected lazy primary] -> [fallback to runtime registrar when metadata coverage is incomplete or only a command stub]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows 10 (local verification); issue repro in #64354 was Debian 13
- Runtime/container: Node `v24.7.0` locally
- Model/provider: N/A
- Integration/channel (if any): CLI / plugin loader
- Relevant config (redacted): default local config

### Steps

1. Run `pnpm test src/plugins/cli.test.ts`
2. Run `pnpm test extensions/memory-core/src/cli.test.ts`
3. Run `pnpm build`
4. Run `pnpm check`

### Expected

- The targeted CLI regression tests pass.
- The memory-core CLI test reaches execution normally.
- Build/check results reflect the current repo state rather than the older local failures originally noted on this PR.

### Actual

- `pnpm test src/plugins/cli.test.ts` passed (`15/15`).
- `pnpm test extensions/memory-core/src/cli.test.ts` passed (`47/47`).
- `pnpm build` still fails locally, but now in unrelated `runtime-postbuild` dependency staging for `amazon-bedrock`.
- `pnpm check` still fails locally on unrelated `tsgo` errors in `extensions/tlon/src/monitor/index.ts` and `ui/src/ui/app-settings.ts`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reran the targeted plugin CLI regression test and the previously blocked `extensions/memory-core` CLI test locally; both passed.
- Edge cases checked: partial command-root coverage still falls back to the runtime registrar, and command-stub metadata registrars do not replace the runtime registrar for the selected lazy primary.
- What you did **not** verify: I did not reproduce the original Debian issue on a Linux install, and repo-wide `build` / `check` are still blocked locally by unrelated failures outside this PR.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Risks and Mitigations

- Risk: lazy-primary selection could still choose a metadata registrar that advertises the right command roots but does not accept a registration context.
  - Mitigation: record whether a registrar accepts CLI context and keep the runtime registrar when metadata only provides a zero-arg command stub.
