### PR TITLE
fix(ci): update cdp.helpers.ts allowlist line in no-raw-channel-fetch guard

### DIFF
--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -16,7 +16,7 @@ const sourceRoots = ["src/channels", "src/routing", "src/line", "extensions"];
 const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("bluebubbles", "src/test-harness.ts", 128),
   bundledPluginCallsite("bluebubbles", "src/types.ts", 181),
-  bundledPluginCallsite("browser", "src/browser/cdp.helpers.ts", 235),
+  bundledPluginCallsite("browser", "src/browser/cdp.helpers.ts", 253),
   bundledPluginCallsite("browser", "src/browser/client-fetch.ts", 192),
   bundledPluginCallsite("browser", "src/browser/test-fetch.ts", 24),
   bundledPluginCallsite("browser", "src/browser/test-fetch.ts", 27),


### PR DESCRIPTION
## Summary

- The raw `fetch()` callsite in `extensions/browser/src/browser/cdp.helpers.ts` shifted from line 235 to line 253 after recent changes
- The allowlist in `scripts/check-no-raw-channel-fetch.mjs` was not updated
- This causes `check-additional` to fail on every PR since the line drift

### One-line fix

Update the line number in the allowlist: `235` → `253`.

### Evidence

`check-additional` has been failing on every PR merged after #64290:
- #64303 — fail
- #64343 — fail
- #64373 — fail
- #64391 — fail

All with the same error:
```
Found raw fetch() usage in channel/plugin runtime sources outside allowlist:
- extensions/browser/src/browser/cdp.helpers.ts:253
```

### AI-assisted

- [x] AI-assisted (Claude Code / Opus 4.6)
- [x] I understand what the code does

## Test plan

- [ ] `check-additional` CI job passes