### PR TITLE
fix: include memory plugins in gateway startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Security/nodes: keep `nodes` tool output paths inside the workspace boundary so model-driven node writes cannot escape the intended workspace. (#63551) Thanks @pgondhi987.
 - Security/QQBot: enforce media storage boundaries for all outbound local file paths and route image-size probes through SSRF-guarded media fetching instead of raw `fetch()`. (#63271, #63495) Thanks @pgondhi987.
 - Channel setup: ignore workspace plugin shadows when resolving trusted channel setup catalog entries so onboarding and setup flows keep using the bundled, trusted setup contract.
+- Gateway/memory startup: load the explicitly selected memory-slot plugin during gateway startup, while keeping restrictive allowlists and implicit default memory slots from auto-starting unrelated memory plugins. (#64423) Thanks @EronFan.
 - Config/plugins: let config writes keep disabled plugin entries without forcing required plugin config schemas or crashing raw plugin validation, and avoid re-activating plugin registry state during schema checks. (#54971, #63296) Thanks @fuller-stack-dev.
 - Config validation: surface the actual offending field for strict-schema union failures in bindings, including top-level unexpected keys on the matching ACP branch. (#40841) Thanks @Hollychou924.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -67,6 +67,15 @@ function createManifestRegistryFixture() {
         cliBackends: [],
       },
       {
+        id: "memory-lancedb",
+        kind: "memory",
+        channels: [],
+        origin: "bundled",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "demo-global-sidecar",
         channels: [],
         origin: "global",
@@ -112,6 +121,7 @@ function createStartupConfig(params: {
   channelIds?: string[];
   allowPluginIds?: string[];
   noConfiguredChannels?: boolean;
+  memorySlot?: string;
 }) {
   return {
     ...(params.noConfiguredChannels
@@ -129,6 +139,7 @@ function createStartupConfig(params: {
       ? {
           plugins: {
             ...(params.allowPluginIds?.length ? { allow: params.allowPluginIds } : {}),
+            ...(params.memorySlot ? { slots: { memory: params.memorySlot } } : {}),
             entries: Object.fromEntries(
               params.enabledPluginIds.map((pluginId) => [pluginId, { enabled: true }]),
             ),
@@ -140,6 +151,14 @@ function createStartupConfig(params: {
               allow: params.allowPluginIds,
             },
           }
+        : params.memorySlot
+          ? {
+              plugins: {
+                slots: {
+                  memory: params.memorySlot,
+                },
+              },
+            }
         : {}),
     ...(params.providerIds?.length
       ? {
@@ -206,9 +225,9 @@ describe("resolveGatewayStartupPluginIds", () => {
     [
       "includes explicitly enabled non-channel sidecars in startup scope",
       createStartupConfig({
-        enabledPluginIds: ["demo-global-sidecar", "voice-call", "memory-core"],
+        enabledPluginIds: ["demo-global-sidecar", "voice-call"],
       }),
-      ["demo-channel", "browser", "voice-call", "memory-core", "demo-global-sidecar"],
+      ["demo-channel", "browser", "voice-call", "demo-global-sidecar"],
     ],
     [
       "keeps default-enabled startup sidecars when a restrictive allowlist permits them",
@@ -255,12 +274,32 @@ describe("resolveGatewayStartupPluginIds", () => {
     });
   });
 
-  it("includes explicitly enabled memory plugins in startup scope", () => {
+  it("includes the explicitly selected memory slot plugin in startup scope", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        enabledPluginIds: ["memory-lancedb"],
+        memorySlot: "memory-lancedb",
+      }),
+      expected: ["demo-channel", "browser", "memory-lancedb"],
+    });
+  });
+
+  it("normalizes the raw memory slot id before startup filtering", () => {
     expectStartupPluginIdsCase({
       config: createStartupConfig({
         enabledPluginIds: ["memory-core"],
+        memorySlot: "Memory-Core",
       }),
       expected: ["demo-channel", "browser", "memory-core"],
+    });
+  });
+
+  it("does not include non-selected memory plugins only because they are enabled", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        enabledPluginIds: ["memory-lancedb"],
+      }),
+      expected: ["demo-channel", "browser"],
     });
   });
 });

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -50,25 +50,16 @@ function createManifestRegistryFixture() {
         cliBackends: ["demo-cli"],
       },
       {
+        id: "voice-call",
+        channels: [],
+        origin: "bundled",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "memory-core",
         kind: "memory",
-        channels: [],
-        origin: "bundled",
-        enabledByDefault: undefined,
-        providers: [],
-        cliBackends: [],
-      },
-      {
-        id: "memory-lancedb",
-        kind: "memory",
-        channels: [],
-        origin: "bundled",
-        enabledByDefault: undefined,
-        providers: [],
-        cliBackends: [],
-      },
-      {
-        id: "voice-call",
         channels: [],
         origin: "bundled",
         enabledByDefault: undefined,
@@ -215,9 +206,9 @@ describe("resolveGatewayStartupPluginIds", () => {
     [
       "includes explicitly enabled non-channel sidecars in startup scope",
       createStartupConfig({
-        enabledPluginIds: ["demo-global-sidecar", "voice-call"],
+        enabledPluginIds: ["demo-global-sidecar", "voice-call", "memory-core"],
       }),
-      ["demo-channel", "browser", "voice-call", "demo-global-sidecar"],
+      ["demo-channel", "browser", "voice-call", "memory-core", "demo-global-sidecar"],
     ],
     [
       "keeps default-enabled startup sidecars when a restrictive allowlist permits them",
@@ -250,6 +241,9 @@ describe("resolveGatewayStartupPluginIds", () => {
           "voice-call": {
             enabled: true,
           },
+          "memory-core": {
+            enabled: true,
+          },
         },
       },
     } as OpenClawConfig;
@@ -261,74 +255,12 @@ describe("resolveGatewayStartupPluginIds", () => {
     });
   });
 
-  it("includes memory-core at startup when dreaming is enabled", () => {
+  it("includes explicitly enabled memory plugins in startup scope", () => {
     expectStartupPluginIdsCase({
-      config: {
-        channels: {},
-        plugins: {
-          entries: {
-            "memory-core": {
-              enabled: true,
-              config: {
-                dreaming: {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        },
-      } as OpenClawConfig,
-      expected: ["browser", "memory-core"],
-    });
-  });
-
-  it("includes the selected memory-slot plugin and memory-core when dreaming is enabled", () => {
-    expectStartupPluginIdsCase({
-      config: {
-        plugins: {
-          slots: {
-            memory: "memory-lancedb",
-          },
-          entries: {
-            "memory-core": {
-              enabled: true,
-            },
-            "memory-lancedb": {
-              enabled: true,
-              config: {
-                dreaming: {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        },
-      } as OpenClawConfig,
-      expected: ["demo-channel", "browser", "memory-core", "memory-lancedb"],
-    });
-  });
-
-  it("does not bypass activation policy for dreaming startup owners", () => {
-    expectStartupPluginIdsCase({
-      config: {
-        channels: {},
-        plugins: {
-          slots: {
-            memory: "memory-lancedb",
-          },
-          entries: {
-            "memory-lancedb": {
-              enabled: false,
-              config: {
-                dreaming: {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        },
-      } as OpenClawConfig,
-      expected: ["browser"],
+      config: createStartupConfig({
+        enabledPluginIds: ["memory-core"],
+      }),
+      expected: ["demo-channel", "browser", "memory-core"],
     });
   });
 });

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -1,11 +1,6 @@
 import { listPotentialConfiguredChannelIds } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  resolveMemoryDreamingConfig,
-  resolveMemoryDreamingPluginConfig,
-  resolveMemoryDreamingPluginId,
-} from "../memory-host-sdk/dreaming.js";
-import {
   createPluginActivationSource,
   normalizePluginsConfig,
   resolveEffectivePluginActivationState,
@@ -29,19 +24,16 @@ function hasRuntimeContractSurface(plugin: PluginManifestRecord): boolean {
   );
 }
 
+function isGatewayStartupMemoryPlugin(plugin: PluginManifestRecord): boolean {
+  return hasKind(plugin.kind, "memory");
+}
+
 function isGatewayStartupSidecar(plugin: PluginManifestRecord): boolean {
   return plugin.channels.length === 0 && !hasRuntimeContractSurface(plugin);
 }
 
-function resolveGatewayStartupDreamingPluginIds(config: OpenClawConfig): Set<string> {
-  const dreamingConfig = resolveMemoryDreamingConfig({
-    pluginConfig: resolveMemoryDreamingPluginConfig(config),
-    cfg: config,
-  });
-  if (!dreamingConfig.enabled) {
-    return new Set();
-  }
-  return new Set(["memory-core", resolveMemoryDreamingPluginId(config)]);
+function shouldConsiderForGatewayStartup(plugin: PluginManifestRecord): boolean {
+  return isGatewayStartupSidecar(plugin) || isGatewayStartupMemoryPlugin(plugin);
 }
 
 export function resolveChannelPluginIds(params: {
@@ -112,7 +104,6 @@ export function resolveGatewayStartupPluginIds(params: {
   const activationSource = createPluginActivationSource({
     config: params.activationSourceConfig ?? params.config,
   });
-  const startupDreamingPluginIds = resolveGatewayStartupDreamingPluginIds(params.config);
   return loadPluginManifestRegistry({
     config: params.config,
     workspaceDir: params.workspaceDir,
@@ -122,6 +113,9 @@ export function resolveGatewayStartupPluginIds(params: {
       if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
         return true;
       }
+      if (!shouldConsiderForGatewayStartup(plugin)) {
+        return false;
+      }
       const activationState = resolveEffectivePluginActivationState({
         id: plugin.id,
         origin: plugin.origin,
@@ -130,22 +124,13 @@ export function resolveGatewayStartupPluginIds(params: {
         enabledByDefault: plugin.enabledByDefault,
         activationSource,
       });
-      const isAllowedStartupActivation = (): boolean => {
-        if (!activationState.enabled) {
-          return false;
-        }
-        if (plugin.origin !== "bundled") {
-          return activationState.explicitlyEnabled;
-        }
-        return activationState.source === "explicit" || activationState.source === "default";
-      };
-      if (startupDreamingPluginIds.has(plugin.id)) {
-        return isAllowedStartupActivation();
-      }
-      if (!isGatewayStartupSidecar(plugin)) {
+      if (!activationState.enabled) {
         return false;
       }
-      return isAllowedStartupActivation();
+      if (plugin.origin !== "bundled") {
+        return activationState.explicitlyEnabled;
+      }
+      return activationState.source === "explicit" || activationState.source === "default";
     })
     .map((plugin) => plugin.id);
 }

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -1,7 +1,13 @@
 import { listPotentialConfiguredChannelIds } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  resolveMemoryDreamingConfig,
+  resolveMemoryDreamingPluginConfig,
+  resolveMemoryDreamingPluginId,
+} from "../memory-host-sdk/dreaming.js";
+import {
   createPluginActivationSource,
+  normalizePluginId,
   normalizePluginsConfig,
   resolveEffectivePluginActivationState,
 } from "./config-state.js";
@@ -32,8 +38,42 @@ function isGatewayStartupSidecar(plugin: PluginManifestRecord): boolean {
   return plugin.channels.length === 0 && !hasRuntimeContractSurface(plugin);
 }
 
-function shouldConsiderForGatewayStartup(plugin: PluginManifestRecord): boolean {
-  return isGatewayStartupSidecar(plugin) || isGatewayStartupMemoryPlugin(plugin);
+function resolveGatewayStartupDreamingPluginIds(config: OpenClawConfig): Set<string> {
+  const dreamingConfig = resolveMemoryDreamingConfig({
+    pluginConfig: resolveMemoryDreamingPluginConfig(config),
+    cfg: config,
+  });
+  if (!dreamingConfig.enabled) {
+    return new Set();
+  }
+  return new Set(["memory-core", resolveMemoryDreamingPluginId(config)]);
+}
+
+function resolveExplicitMemorySlotStartupPluginId(
+  config: OpenClawConfig,
+): string | undefined {
+  const configuredSlot = config.plugins?.slots?.memory?.trim();
+  if (!configuredSlot || configuredSlot.toLowerCase() === "none") {
+    return undefined;
+  }
+  return normalizePluginId(configuredSlot);
+}
+
+function shouldConsiderForGatewayStartup(params: {
+  plugin: PluginManifestRecord;
+  startupDreamingPluginIds: ReadonlySet<string>;
+  explicitMemorySlotStartupPluginId?: string;
+}): boolean {
+  if (isGatewayStartupSidecar(params.plugin)) {
+    return true;
+  }
+  if (!isGatewayStartupMemoryPlugin(params.plugin)) {
+    return false;
+  }
+  if (params.startupDreamingPluginIds.has(params.plugin.id)) {
+    return true;
+  }
+  return params.explicitMemorySlotStartupPluginId === params.plugin.id;
 }
 
 export function resolveChannelPluginIds(params: {
@@ -104,6 +144,10 @@ export function resolveGatewayStartupPluginIds(params: {
   const activationSource = createPluginActivationSource({
     config: params.activationSourceConfig ?? params.config,
   });
+  const startupDreamingPluginIds = resolveGatewayStartupDreamingPluginIds(params.config);
+  const explicitMemorySlotStartupPluginId = resolveExplicitMemorySlotStartupPluginId(
+    params.activationSourceConfig ?? params.config,
+  );
   return loadPluginManifestRegistry({
     config: params.config,
     workspaceDir: params.workspaceDir,
@@ -113,7 +157,13 @@ export function resolveGatewayStartupPluginIds(params: {
       if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
         return true;
       }
-      if (!shouldConsiderForGatewayStartup(plugin)) {
+      if (
+        !shouldConsiderForGatewayStartup({
+          plugin,
+          startupDreamingPluginIds,
+          explicitMemorySlotStartupPluginId,
+        })
+      ) {
         return false;
       }
       const activationState = resolveEffectivePluginActivationState({


### PR DESCRIPTION
## Summary
- include enabled `kind: "memory"` plugins in `resolveGatewayStartupPluginIds`
- keep existing activation-state gating so allowlists still control startup loading
- add regression coverage for explicitly enabled memory plugins

## Testing
- `pnpm vitest run src/plugins/channel-plugin-ids.test.ts --maxWorkers=1 --no-file-parallelism` *(in this workspace the process was SIGKILLed twice by host resource pressure before completion, so I verified the targeted diff and test coverage statically)*

Fixes #64381