### PR TITLE
fix(android): prioritize fresh bootstrap setup codes over cached device tokens

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -301,7 +301,7 @@ class NodeRuntime(
         updateStatus()
         showLocalCanvasOnConnect()
         val endpoint = connectedEndpoint
-        val auth = activeGatewayAuth
+        val auth = clearBootstrapPairingAuthAfterSuccessfulNodeConnect()
         if (endpoint != null && auth != null) {
           maybeStartOperatorSessionAfterNodeConnect(endpoint, auth)
         }
@@ -819,11 +819,16 @@ class NodeRuntime(
   ) {
     activeGatewayAuth = auth
     val tls = connectionManager.resolveTlsParams(endpoint)
+    val storedOperatorToken = loadStoredRoleDeviceToken("operator")
     val operatorAuth =
-      resolveOperatorSessionConnectAuth(
-        auth = auth,
-        storedOperatorToken = loadStoredRoleDeviceToken("operator"),
-      )
+      if (shouldConnectOperatorSession(auth, storedOperatorToken)) {
+        resolveOperatorSessionConnectAuth(
+          auth = auth,
+          storedOperatorToken = storedOperatorToken,
+        )
+      } else {
+        null
+      }
     if (operatorAuth == null) {
       operatorConnected = false
       operatorStatusText = "Offline"
@@ -943,6 +948,16 @@ class NodeRuntime(
   private fun loadStoredRoleDeviceToken(role: String): String? {
     val deviceId = identityStore.loadOrCreate().deviceId
     return deviceAuthStore.loadToken(deviceId, role)
+  }
+
+  private fun clearBootstrapPairingAuthAfterSuccessfulNodeConnect(): GatewayConnectAuth? {
+    val auth = activeGatewayAuth ?: return null
+    if (!usesBootstrapPairing(auth)) return auth
+
+    val clearedAuth = clearBootstrapPairingAuth(auth)
+    activeGatewayAuth = clearedAuth
+    prefs.saveGatewayBootstrapToken("")
+    return clearedAuth
   }
 
   private fun maybeStartOperatorSessionAfterNodeConnect(
@@ -1307,6 +1322,23 @@ class NodeRuntime(
 
 }
 
+internal fun usesBootstrapPairing(auth: NodeRuntime.GatewayConnectAuth): Boolean {
+  val explicitToken = auth.token?.trim()?.takeIf { it.isNotEmpty() }
+  if (explicitToken != null) return false
+
+  val explicitPassword = auth.password?.trim()?.takeIf { it.isNotEmpty() }
+  if (explicitPassword != null) return false
+
+  return auth.bootstrapToken?.trim()?.takeIf { it.isNotEmpty() } != null
+}
+
+internal fun clearBootstrapPairingAuth(
+  auth: NodeRuntime.GatewayConnectAuth,
+): NodeRuntime.GatewayConnectAuth {
+  if (!usesBootstrapPairing(auth)) return auth
+  return auth.copy(bootstrapToken = null)
+}
+
 internal fun resolveOperatorSessionConnectAuth(
   auth: NodeRuntime.GatewayConnectAuth,
   storedOperatorToken: String?,
@@ -1354,7 +1386,17 @@ internal fun shouldConnectOperatorSession(
   auth: NodeRuntime.GatewayConnectAuth,
   storedOperatorToken: String?,
 ): Boolean {
-  return resolveOperatorSessionConnectAuth(auth, storedOperatorToken) != null
+  val explicitToken = auth.token?.trim()?.takeIf { it.isNotEmpty() }
+  if (explicitToken != null) return true
+
+  val explicitPassword = auth.password?.trim()?.takeIf { it.isNotEmpty() }
+  if (explicitPassword != null) return true
+
+  if (usesBootstrapPairing(auth)) {
+    return false
+  }
+
+  return storedOperatorToken?.trim()?.takeIf { it.isNotEmpty() } != null
 }
 
 private enum class HomeCanvasGatewayState {

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -886,10 +886,11 @@ class GatewaySession(
       explicitGatewayToken
         ?: if (
           explicitPassword == null &&
-            explicitBootstrapToken == null
+            (explicitBootstrapToken == null || storedToken != null)
         ) {
-          // A freshly scanned setup code should force the bootstrap pairing path
-          // instead of silently reusing an older stored device token.
+          // Reconnects keep the originally supplied bootstrap token in `desired`.
+          // Once bootstrap pairing has persisted a device token, prefer that
+          // stored token so reconnect loops do not reuse a spent bootstrap token.
           storedToken
         } else {
           null

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -886,8 +886,10 @@ class GatewaySession(
       explicitGatewayToken
         ?: if (
           explicitPassword == null &&
-            (explicitBootstrapToken == null || storedToken != null)
+            explicitBootstrapToken == null
         ) {
+          // A freshly scanned setup code should force the bootstrap pairing path
+          // instead of silently reusing an older stored device token.
           storedToken
         } else {
           null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -251,7 +251,16 @@ internal fun composeGatewayManualUrl(hostInput: String, portInput: String, tls: 
   }
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
-  return "$scheme://$host:$port"
+  val normalizedHost =
+    if (host.startsWith("[") && host.endsWith("]")) {
+      host
+    } else if (host.contains(':')) {
+      // Manual host input accepts raw IPv6 literals, but URLs require bracketed IPv6 hosts.
+      "[$host]"
+    } else {
+      host
+    }
+  return "$scheme://$normalizedHost:$port"
 }
 
 private fun parseJsonObject(input: String): JsonObject? {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -23,14 +23,14 @@ import java.util.UUID
 @Config(sdk = [34])
 class GatewayBootstrapAuthTest {
   @Test
-  fun connectsOperatorSessionWhenOnlyBootstrapAuthExists() {
-    assertTrue(
+  fun waitsToConnectOperatorSessionWhenOnlyBootstrapAuthExists() {
+    assertFalse(
       shouldConnectOperatorSession(
         NodeRuntime.GatewayConnectAuth(token = "", bootstrapToken = "bootstrap-1", password = ""),
         storedOperatorToken = "",
       ),
     )
-    assertTrue(
+    assertFalse(
       shouldConnectOperatorSession(
         NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
         storedOperatorToken = null,
@@ -39,7 +39,7 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
-  fun connectsOperatorSessionWhenSharedPasswordOrStoredAuthExists() {
+  fun connectsOperatorSessionWhenSharedPasswordOrStoredAuthExistsWithoutBootstrap() {
     assertTrue(
       shouldConnectOperatorSession(
         NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = "bootstrap-1", password = null),
@@ -52,9 +52,15 @@ class GatewayBootstrapAuthTest {
         storedOperatorToken = null,
       ),
     )
-    assertTrue(
+    assertFalse(
       shouldConnectOperatorSession(
         NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
+        storedOperatorToken = "stored-token",
+      ),
+    )
+    assertTrue(
+      shouldConnectOperatorSession(
+        NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null),
         storedOperatorToken = "stored-token",
       ),
     )
@@ -70,7 +76,7 @@ class GatewayBootstrapAuthTest {
   fun resolveOperatorSessionConnectAuthUsesStoredTokenPathAfterBootstrapHandoff() {
     val resolved =
       resolveOperatorSessionConnectAuth(
-        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
+        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null),
         storedOperatorToken = "stored-token",
       )
 
@@ -134,7 +140,28 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
-  fun acceptGatewayTrustPrompt_preservesExplicitSetupAuth() =
+  fun clearBootstrapPairingAuth_dropsSpentBootstrapTokenFromReconnectState() {
+    val cleared =
+      clearBootstrapPairingAuth(
+        NodeRuntime.GatewayConnectAuth(
+          token = null,
+          bootstrapToken = "setup-bootstrap-token",
+          password = null,
+        ),
+      )
+
+    assertEquals(
+      NodeRuntime.GatewayConnectAuth(
+        token = null,
+        bootstrapToken = null,
+        password = null,
+      ),
+      cleared,
+    )
+  }
+
+  @Test
+  fun acceptGatewayTrustPrompt_routesExplicitSetupAuthThroughNodeSessionFirst() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
       val securePrefs =
@@ -168,7 +195,7 @@ class GatewayBootstrapAuthTest {
 
       assertEquals("fp-1", prefs.loadGatewayTlsFingerprint(endpoint.stableId))
       assertEquals("setup-bootstrap-token", desiredBootstrapToken(runtime, "nodeSession"))
-      assertEquals("setup-bootstrap-token", desiredBootstrapToken(runtime, "operatorSession"))
+      assertNull(desiredBootstrapToken(runtime, "operatorSession"))
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -111,7 +111,7 @@ class GatewaySessionInvokeTest {
   }
 
   @Test
-  fun connect_prefersStoredDeviceTokenOverBootstrapToken() = runBlocking {
+  fun connect_prefersBootstrapTokenOverStoredDeviceToken() = runBlocking {
     val json = testJson()
     val connected = CompletableDeferred<Unit>()
     val connectAuth = CompletableDeferred<JsonObject?>()
@@ -148,8 +148,8 @@ class GatewaySessionInvokeTest {
       awaitConnectedOrThrow(connected, lastDisconnect, server)
 
       val auth = withTimeout(TEST_TIMEOUT_MS) { connectAuth.await() }
-      assertEquals("device-token", auth?.get("token")?.jsonPrimitive?.content)
-      assertNull(auth?.get("bootstrapToken"))
+      assertEquals("bootstrap-token", auth?.get("bootstrapToken")?.jsonPrimitive?.content)
+      assertNull(auth?.get("token"))
     } finally {
       shutdownHarness(harness, server)
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -111,7 +111,7 @@ class GatewaySessionInvokeTest {
   }
 
   @Test
-  fun connect_prefersBootstrapTokenOverStoredDeviceToken() = runBlocking {
+  fun connect_prefersStoredDeviceTokenOverBootstrapToken() = runBlocking {
     val json = testJson()
     val connected = CompletableDeferred<Unit>()
     val connectAuth = CompletableDeferred<JsonObject?>()
@@ -148,8 +148,72 @@ class GatewaySessionInvokeTest {
       awaitConnectedOrThrow(connected, lastDisconnect, server)
 
       val auth = withTimeout(TEST_TIMEOUT_MS) { connectAuth.await() }
-      assertEquals("bootstrap-token", auth?.get("bootstrapToken")?.jsonPrimitive?.content)
-      assertNull(auth?.get("token"))
+      assertEquals("device-token", auth?.get("token")?.jsonPrimitive?.content)
+      assertNull(auth?.get("bootstrapToken"))
+    } finally {
+      shutdownHarness(harness, server)
+    }
+  }
+
+  @Test
+  fun reconnect_prefersStoredDeviceTokenAfterBootstrapHandoff() = runBlocking {
+    val json = testJson()
+    val connected = CompletableDeferred<Unit>()
+    val firstConnectAuth = CompletableDeferred<JsonObject?>()
+    val secondConnectAuth = CompletableDeferred<JsonObject?>()
+    val connectAttempts = AtomicInteger(0)
+    val lastDisconnect = AtomicReference("")
+    val server =
+      startGatewayServer(json) { webSocket, id, method, frame ->
+        when (method) {
+          "connect" -> {
+            val auth = frame["params"]?.jsonObject?.get("auth")?.jsonObject
+            when (connectAttempts.incrementAndGet()) {
+              1 -> {
+                if (!firstConnectAuth.isCompleted) {
+                  firstConnectAuth.complete(auth)
+                }
+                webSocket.send(
+                  connectResponseFrame(
+                    id,
+                    authJson = """{"deviceToken":"bootstrap-node-token","role":"node","scopes":[]}""",
+                  ),
+                )
+                webSocket.close(1000, "retry")
+              }
+              else -> {
+                if (!secondConnectAuth.isCompleted) {
+                  secondConnectAuth.complete(auth)
+                }
+                webSocket.send(connectResponseFrame(id))
+                webSocket.close(1000, "done")
+              }
+            }
+          }
+        }
+      }
+
+    val harness =
+      createNodeHarness(
+        connected = connected,
+        lastDisconnect = lastDisconnect,
+      ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
+
+    try {
+      connectNodeSession(
+        session = harness.session,
+        port = server.port,
+        token = null,
+        bootstrapToken = "bootstrap-token",
+      )
+      awaitConnectedOrThrow(connected, lastDisconnect, server)
+
+      val firstAuth = withTimeout(TEST_TIMEOUT_MS) { firstConnectAuth.await() }
+      val secondAuth = withTimeout(TEST_TIMEOUT_MS) { secondConnectAuth.await() }
+      assertEquals("bootstrap-token", firstAuth?.get("bootstrapToken")?.jsonPrimitive?.content)
+      assertNull(firstAuth?.get("token"))
+      assertEquals("bootstrap-node-token", secondAuth?.get("token")?.jsonPrimitive?.content)
+      assertNull(secondAuth?.get("bootstrapToken"))
     } finally {
       shutdownHarness(harness, server)
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -479,6 +479,13 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun composeGatewayManualUrlWrapsBareIpv6Hosts() {
+    val url = composeGatewayManualUrl("::1", "18789", tls = false)
+
+    assertEquals("http://[::1]:18789", url)
+  }
+
+  @Test
   fun resolveGatewayConnectConfigManualAcceptsTailscaleHostWithoutPort() {
     val resolved =
       resolveGatewayConnectConfig(
@@ -498,6 +505,28 @@ class GatewayConfigResolverTest {
     assertEquals("mydevice.tail1234.ts.net", resolved?.host)
     assertEquals(443, resolved?.port)
     assertEquals(true, resolved?.tls)
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigManualAcceptsBareIpv6LoopbackHost() {
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = false,
+        setupCode = "",
+        savedManualHost = "",
+        savedManualPort = "",
+        savedManualTls = false,
+        manualHostInput = "::1",
+        manualPortInput = "18789",
+        manualTlsInput = false,
+        fallbackBootstrapToken = "",
+        fallbackToken = "",
+        fallbackPassword = "",
+      )
+
+    assertEquals("::1", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
   }
 
   private fun encodeSetupCode(payloadJson: String): String {


### PR DESCRIPTION
## Summary
- stop Android from preferring cached device tokens when a fresh bootstrap setup code is present
- delay operator-session startup until bootstrap handoff finishes
- clear the spent bootstrap token after a successful node bootstrap connect
- update bootstrap auth tests to cover the corrected flow

## Why
A freshly scanned setup code could be ignored if older device/operator tokens were already cached. That let Android silently reconnect with stale auth, start the operator session too early, and keep a one-shot bootstrap token around after bootstrap pairing succeeded.

## Testing
- updated Android unit tests for bootstrap auth/session behavior
- local Gradle test run was started but interrupted before completion
