### PR TITLE
fix: strip ANSI codes from Control UI logs

### DIFF
--- a/ui/src/ui/ansi.ts
+++ b/ui/src/ui/ansi.ts
@@ -1,0 +1,9 @@
+const ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
+const OSC8_PATTERN = "\\x1b\\]8;;.*?\\x1b\\\\|\\x1b\\]8;;\\x1b\\\\";
+
+const ANSI_CSI_REGEX = new RegExp(ANSI_CSI_PATTERN, "g");
+const OSC8_REGEX = new RegExp(OSC8_PATTERN, "g");
+
+export function stripAnsi(input: string): string {
+  return input.replace(OSC8_REGEX, "").replace(ANSI_CSI_REGEX, "");
+}

--- a/ui/src/ui/controllers/logs.test.ts
+++ b/ui/src/ui/controllers/logs.test.ts
@@ -2,6 +2,31 @@ import { describe, expect, it } from "vitest";
 import { parseLogLine } from "./logs.ts";
 
 describe("parseLogLine", () => {
+  it("strips ANSI escape codes from rendered message text", () => {
+    const line = JSON.stringify({
+      0: '{"subsystem":"gateway/ws\u001b[36m"}',
+      2: "\u001b[31mclosed before connect\u001b[0m",
+      _meta: {
+        logLevelName: "WARN",
+      },
+    });
+
+    expect(parseLogLine(line)).toEqual(
+      expect.objectContaining({
+        level: "warn",
+        subsystem: "gateway/ws",
+        message: "closed before connect",
+      }),
+    );
+  });
+
+  it("strips ANSI escape codes from plain text log lines", () => {
+    expect(parseLogLine("\u001b[31mhello\u001b[0m")).toEqual({
+      raw: "\u001b[31mhello\u001b[0m",
+      message: "hello",
+    });
+  });
+
   it("prefers the human-readable message field when structured data is stored in slot 1", () => {
     const line = JSON.stringify({
       0: '{"subsystem":"gateway/ws"}',

--- a/ui/src/ui/controllers/logs.ts
+++ b/ui/src/ui/controllers/logs.ts
@@ -1,4 +1,5 @@
 import type { GatewayBrowserClient } from "../gateway.ts";
+import { stripAnsi } from "../ansi.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type { LogEntry, LogLevel } from "../types.ts";
 import {
@@ -48,8 +49,9 @@ function normalizeLevel(value: unknown): LogLevel | null {
 }
 
 export function parseLogLine(line: string): LogEntry {
+  const sanitizedLine = stripAnsi(line);
   if (!line.trim()) {
-    return { raw: line, message: line };
+    return { raw: line, message: sanitizedLine };
   }
   try {
     const obj = JSON.parse(line) as Record<string, unknown>;
@@ -63,15 +65,16 @@ export function parseLogLine(line: string): LogEntry {
 
     const contextCandidate =
       typeof obj["0"] === "string" ? obj["0"] : typeof meta?.name === "string" ? meta?.name : null;
-    const contextObj = parseMaybeJsonString(contextCandidate);
+    const sanitizedContextCandidate = contextCandidate ? stripAnsi(contextCandidate) : contextCandidate;
+    const contextObj = parseMaybeJsonString(sanitizedContextCandidate);
     let subsystem =
       typeof contextObj?.subsystem === "string"
         ? contextObj.subsystem
         : typeof contextObj?.module === "string"
           ? contextObj.module
           : null;
-    if (!subsystem && contextCandidate && contextCandidate.length < 120) {
-      subsystem = contextCandidate;
+    if (!subsystem && sanitizedContextCandidate && sanitizedContextCandidate.length < 120) {
+      subsystem = sanitizedContextCandidate;
     }
 
     const message =
@@ -89,12 +92,12 @@ export function parseLogLine(line: string): LogEntry {
       raw: line,
       time,
       level,
-      subsystem,
-      message,
+      subsystem: subsystem ? stripAnsi(subsystem) : subsystem,
+      message: stripAnsi(message),
       meta: meta ?? undefined,
     };
   } catch {
-    return { raw: line, message: line };
+    return { raw: line, message: sanitizedLine };
   }
 }
 

--- a/ui/src/ui/views/overview-log-tail.ts
+++ b/ui/src/ui/views/overview-log-tail.ts
@@ -1,12 +1,7 @@
 import { html, nothing } from "lit";
 import { t } from "../../i18n/index.ts";
+import { stripAnsi } from "../ansi.ts";
 import { icons } from "../icons.ts";
-
-/** Strip ANSI escape codes (SGR, OSC-8) for readable log display. */
-function stripAnsi(text: string): string {
-  /* eslint-disable no-control-regex -- stripping ANSI escape sequences requires matching ESC */
-  return text.replace(/\x1b\]8;;.*?\x1b\\|\x1b\]8;;\x1b\\/g, "").replace(/\x1b\[[0-9;]*m/g, "");
-}
 
 export type OverviewLogTailProps = {
   lines: string[];


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences before Control UI log lines are rendered
- sanitize subsystem strings before JSON context parsing so embedded ANSI does not break extraction
- reuse the same ANSI stripping helper in the overview log tail and add regression coverage

## Testing
- pnpm exec vitest run --config vitest.config.ts --project unit src/ui/controllers/logs.test.ts --maxWorkers=1

Closes #64399