### PR TITLE
openai-codex: classify runtime failures and make full access truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat: stop top-level `interval:` and `prompt:` fields outside the `tasks:` block from bleeding into the last parsed heartbeat task. (#64488) Thanks @Rahulkumar070.
 - Agents/OpenAI replay: preserve malformed function-call arguments in stored assistant history, avoid double-encoding preserved raw strings on replay, and coerce replayed string args back to objects at Anthropic and Google provider boundaries. (#61956) Thanks @100yenadmin.
 - Heartbeat/config: accept and honor `agents.defaults.heartbeat.timeoutSeconds` and per-agent heartbeat timeout overrides for heartbeat agent turns. (#64491) Thanks @cedillarack.
+- OpenAI/Codex: add required Codex OAuth scopes, classify provider/runtime failures more clearly, and stop suggesting `/elevated full` when auto-approved host exec is unavailable. (#64439) Thanks @100yenadmin.
 
 ## 2026.4.9
 

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
@@ -29,6 +29,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
 describe("telegram live qa runtime", () => {
   afterEach(() => {
     fetchWithSsrFGuardMock.mockClear();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -235,6 +236,8 @@ describe("telegram live qa runtime", () => {
   });
 
   it("adds an abort deadline to Telegram API requests", async () => {
+    const controller = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
     let signal: AbortSignal | undefined;
     vi.stubGlobal(
       "fetch",
@@ -252,9 +255,10 @@ describe("telegram live qa runtime", () => {
     await expect(__testing.callTelegramApi("token", "getMe", undefined, 25)).resolves.toEqual({
       id: 42,
     });
-    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(timeoutSpy).toHaveBeenCalledWith(25);
+    expect(signal).toBe(controller.signal);
     expect(signal?.aborted).toBe(false);
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    controller.abort();
     expect(signal?.aborted).toBe(true);
   });
 

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -2,6 +2,7 @@ import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import type { ExecAsk, ExecHost, ExecSecurity, ExecTarget } from "../infra/exec-approvals.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import type { EmbeddedFullAccessBlockedReason } from "./pi-embedded-runner/types.js";
 
 export type ExecToolDefaults = {
   hasCronTool?: boolean;
@@ -37,6 +38,8 @@ export type ExecElevatedDefaults = {
   enabled: boolean;
   allowed: boolean;
   defaultLevel: "on" | "off" | "ask" | "full";
+  fullAccessAvailable?: boolean;
+  fullAccessBlockedReason?: EmbeddedFullAccessBlockedReason;
 };
 
 export type ExecToolDetails =

--- a/src/agents/pi-embedded-error-observation.test.ts
+++ b/src/agents/pi-embedded-error-observation.test.ts
@@ -23,6 +23,7 @@ describe("buildApiErrorObservationFields", () => {
       rawErrorPreview: expect.stringContaining('"request_id":"sha256:'),
       rawErrorHash: expect.stringMatching(/^sha256:/),
       rawErrorFingerprint: expect.stringMatching(/^sha256:/),
+      providerRuntimeFailureKind: "timeout",
       providerErrorType: "overloaded_error",
       providerErrorMessagePreview: "Overloaded",
       requestIdHash: expect.stringMatching(/^sha256:/),
@@ -69,6 +70,7 @@ describe("buildApiErrorObservationFields", () => {
       textPreview: expect.stringContaining('"request_id":"sha256:'),
       textHash: expect.stringMatching(/^sha256:/),
       textFingerprint: expect.stringMatching(/^sha256:/),
+      providerRuntimeFailureKind: "timeout",
       providerErrorType: "overloaded_error",
       providerErrorMessagePreview: "Overloaded",
       requestIdHash: expect.stringMatching(/^sha256:/),
@@ -156,6 +158,7 @@ describe("buildApiErrorObservationFields", () => {
       textHash: undefined,
       textFingerprint: undefined,
       httpCode: undefined,
+      providerRuntimeFailureKind: undefined,
       providerErrorType: undefined,
       providerErrorMessagePreview: undefined,
       requestIdHash: undefined,
@@ -175,6 +178,17 @@ describe("buildApiErrorObservationFields", () => {
 
     expect(observed.rawErrorPreview).not.toContain("custom-secret-abc123");
     expect(observed.rawErrorPreview).toContain("custom");
+  });
+
+  it("records runtime failure kind for missing-scope auth payloads", () => {
+    const observed = buildApiErrorObservationFields(
+      '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+    );
+
+    expect(observed).toMatchObject({
+      httpCode: "401",
+      providerRuntimeFailureKind: "auth_scope",
+    });
   });
 });
 

--- a/src/agents/pi-embedded-error-observation.test.ts
+++ b/src/agents/pi-embedded-error-observation.test.ts
@@ -180,14 +180,14 @@ describe("buildApiErrorObservationFields", () => {
     expect(observed.rawErrorPreview).toContain("custom");
   });
 
-  it("records runtime failure kind for missing-scope auth payloads", () => {
+  it("keeps provider-less missing-scope auth payloads out of the codex-specific scope lane", () => {
     const observed = buildApiErrorObservationFields(
       '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
     );
 
     expect(observed).toMatchObject({
       httpCode: "401",
-      providerRuntimeFailureKind: "auth_scope",
+      providerRuntimeFailureKind: "unknown",
     });
   });
 });

--- a/src/agents/pi-embedded-error-observation.ts
+++ b/src/agents/pi-embedded-error-observation.ts
@@ -104,7 +104,10 @@ function buildObservationFingerprint(params: {
   return getApiErrorPayloadFingerprint(params.raw);
 }
 
-export function buildApiErrorObservationFields(rawError?: string): {
+export function buildApiErrorObservationFields(
+  rawError?: string,
+  opts?: { provider?: string },
+): {
   rawErrorPreview?: string;
   rawErrorHash?: string;
   rawErrorFingerprint?: string;
@@ -146,6 +149,7 @@ export function buildApiErrorObservationFields(rawError?: string): {
       providerRuntimeFailureKind: classifyProviderRuntimeFailureKind({
         status: parsed?.httpCode ? Number(parsed.httpCode) : undefined,
         message: trimmed,
+        provider: opts?.provider,
       }),
       providerErrorType: parsed?.type,
       providerErrorMessagePreview: truncateForObservation(
@@ -159,7 +163,10 @@ export function buildApiErrorObservationFields(rawError?: string): {
   }
 }
 
-export function buildTextObservationFields(text?: string): {
+export function buildTextObservationFields(
+  text?: string,
+  opts?: { provider?: string },
+): {
   textPreview?: string;
   textHash?: string;
   textFingerprint?: string;
@@ -169,7 +176,7 @@ export function buildTextObservationFields(text?: string): {
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
 } {
-  const observed = buildApiErrorObservationFields(text);
+  const observed = buildApiErrorObservationFields(text, opts);
   return {
     textPreview: observed.rawErrorPreview,
     textHash: observed.rawErrorHash,

--- a/src/agents/pi-embedded-error-observation.ts
+++ b/src/agents/pi-embedded-error-observation.ts
@@ -3,7 +3,11 @@ import { redactIdentifier } from "../logging/redact-identifier.js";
 import { getDefaultRedactPatterns, redactSensitiveText } from "../logging/redact.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
-import { getApiErrorPayloadFingerprint, parseApiErrorInfo } from "./pi-embedded-helpers.js";
+import {
+  classifyProviderRuntimeFailureKind,
+  getApiErrorPayloadFingerprint,
+  parseApiErrorInfo,
+} from "./pi-embedded-helpers.js";
 import { stableStringify } from "./stable-stringify.js";
 
 export { sanitizeForConsole } from "./console-sanitize.js";
@@ -105,6 +109,7 @@ export function buildApiErrorObservationFields(rawError?: string): {
   rawErrorHash?: string;
   rawErrorFingerprint?: string;
   httpCode?: string;
+  providerRuntimeFailureKind?: string;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
@@ -138,6 +143,10 @@ export function buildApiErrorObservationFields(rawError?: string): {
         ? redactIdentifier(rawFingerprint, { len: 12 })
         : undefined,
       httpCode: parsed?.httpCode,
+      providerRuntimeFailureKind: classifyProviderRuntimeFailureKind({
+        status: parsed?.httpCode ? Number(parsed.httpCode) : undefined,
+        message: trimmed,
+      }),
       providerErrorType: parsed?.type,
       providerErrorMessagePreview: truncateForObservation(
         redactedProviderMessage,
@@ -155,6 +164,7 @@ export function buildTextObservationFields(text?: string): {
   textHash?: string;
   textFingerprint?: string;
   httpCode?: string;
+  providerRuntimeFailureKind?: string;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
@@ -165,6 +175,7 @@ export function buildTextObservationFields(text?: string): {
     textHash: observed.rawErrorHash,
     textFingerprint: observed.rawErrorFingerprint,
     httpCode: observed.httpCode,
+    providerRuntimeFailureKind: observed.providerRuntimeFailureKind,
     providerErrorType: observed.providerErrorType,
     providerErrorMessagePreview: observed.providerErrorMessagePreview,
     requestIdHash: observed.requestIdHash,

--- a/src/agents/pi-embedded-error-observation.ts
+++ b/src/agents/pi-embedded-error-observation.ts
@@ -7,6 +7,7 @@ import {
   classifyProviderRuntimeFailureKind,
   getApiErrorPayloadFingerprint,
   parseApiErrorInfo,
+  type ProviderRuntimeFailureKind,
 } from "./pi-embedded-helpers.js";
 import { stableStringify } from "./stable-stringify.js";
 
@@ -112,7 +113,7 @@ export function buildApiErrorObservationFields(
   rawErrorHash?: string;
   rawErrorFingerprint?: string;
   httpCode?: string;
-  providerRuntimeFailureKind?: string;
+  providerRuntimeFailureKind?: ProviderRuntimeFailureKind;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;
@@ -171,7 +172,7 @@ export function buildTextObservationFields(
   textHash?: string;
   textFingerprint?: string;
   httpCode?: string;
-  providerRuntimeFailureKind?: string;
+  providerRuntimeFailureKind?: ProviderRuntimeFailureKind;
   providerErrorType?: string;
   providerErrorMessagePreview?: string;
   requestIdHash?: string;

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -233,6 +233,15 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("returns a missing-scope message for raw OpenAI Codex scope payloads without an HTTP prefix", () => {
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"},"code":401}',
+    );
+    expect(formatAssistantErrorText(msg, { provider: "openai-codex" })).toBe(
+      "Authentication is missing the required OpenAI Codex scopes. Re-run OpenAI/Codex login and try again.",
+    );
+  });
+
   it("does not misdiagnose non-Codex permission errors as missing-scope failures", () => {
     const msg = makeAssistantError(
       '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"}}',

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -228,8 +228,17 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError(
       '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"}}',
     );
-    expect(formatAssistantErrorText(msg)).toBe(
+    expect(formatAssistantErrorText(msg, { provider: "openai-codex" })).toBe(
       "Authentication is missing the required OpenAI Codex scopes. Re-run OpenAI/Codex login and try again.",
+    );
+  });
+
+  it("does not misdiagnose non-Codex permission errors as missing-scope failures", () => {
+    const msg = makeAssistantError(
+      '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"}}',
+    );
+    expect(formatAssistantErrorText(msg, { provider: "openai" })).not.toContain(
+      "required OpenAI Codex scopes",
     );
   });
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -215,6 +215,38 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("returns an explicit re-authentication message for OAuth refresh failures", () => {
+    const msg = makeAssistantError(
+      "OAuth token refresh failed for openai-codex: invalid_grant. Please try again or re-authenticate.",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Authentication refresh failed. Re-authenticate this provider and try again.",
+    );
+  });
+
+  it("returns a missing-scope message for OpenAI Codex scope failures", () => {
+    const msg = makeAssistantError(
+      '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write model.request"}}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Authentication is missing the required OpenAI Codex scopes. Re-run OpenAI/Codex login and try again.",
+    );
+  });
+
+  it("returns an HTML-403 auth message for HTML provider auth failures", () => {
+    const msg = makeAssistantError("403 <!DOCTYPE html><html><body>Access denied</body></html>");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Authentication failed with an HTML 403 response from the provider. Re-authenticate and verify your provider account access.",
+    );
+  });
+
+  it("returns a proxy-specific message for proxy misroutes", () => {
+    const msg = makeAssistantError("407 Proxy Authentication Required");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM request failed: proxy or tunnel configuration blocked the provider request.",
+    );
+  });
+
   it("sanitizes invalid streaming event order errors", () => {
     const msg = makeAssistantError(
       'Unexpected event order, got message_start before receiving "message_stop"',

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -265,6 +265,18 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("keeps non-transport config errors that mention proxy settings actionable", () => {
+    const msg = makeAssistantError(
+      'Model-provider request.proxy/request.tls is not yet supported for api "ollama"',
+    );
+    expect(formatAssistantErrorText(msg)).toContain(
+      'Model-provider request.proxy/request.tls is not yet supported for api "ollama"',
+    );
+    expect(formatAssistantErrorText(msg)).not.toBe(
+      "LLM request failed: proxy or tunnel configuration blocked the provider request.",
+    );
+  });
+
   it("sanitizes invalid streaming event order errors", () => {
     const msg = makeAssistantError(
       'Unexpected event order, got message_start before receiving "message_stop"',

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -242,6 +242,15 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("does not misdiagnose generic Codex permission failures as missing-scope failures", () => {
+    const msg = makeAssistantError(
+      '403 {"type":"error","error":{"type":"permission_error","message":"Insufficient permissions for this organization"}}',
+    );
+    expect(formatAssistantErrorText(msg, { provider: "openai-codex" })).not.toContain(
+      "required OpenAI Codex scopes",
+    );
+  });
+
   it("returns an HTML-403 auth message for HTML provider auth failures", () => {
     const msg = makeAssistantError("403 <!DOCTYPE html><html><body>Access denied</body></html>");
     expect(formatAssistantErrorText(msg)).toBe(

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1106,10 +1106,22 @@ describe("classifyFailoverReason", () => {
 describe("classifyProviderRuntimeFailureKind", () => {
   it("classifies missing scope failures", () => {
     expect(
-      classifyProviderRuntimeFailureKind(
-        '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
-      ),
+      classifyProviderRuntimeFailureKind({
+        provider: "openai-codex",
+        message:
+          '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      }),
     ).toBe("auth_scope");
+  });
+
+  it("does not classify non-Codex permission errors as missing scope failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        provider: "openai",
+        message:
+          '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      }),
+    ).not.toBe("auth_scope");
   });
 
   it("classifies OAuth refresh failures", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1114,6 +1114,16 @@ describe("classifyProviderRuntimeFailureKind", () => {
     ).toBe("auth_scope");
   });
 
+  it("classifies raw missing scope payloads without an HTTP prefix", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        provider: "openai-codex",
+        message:
+          '{"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"},"code":401}',
+      }),
+    ).toBe("auth_scope");
+  });
+
   it("does not classify non-Codex permission errors as missing scope failures", () => {
     expect(
       classifyProviderRuntimeFailureKind({

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1166,4 +1166,12 @@ describe("classifyProviderRuntimeFailureKind", () => {
       "replay_invalid",
     );
   });
+
+  it("does not classify generic config errors that mention proxy settings as proxy failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        'Model-provider request.proxy/request.tls is not yet supported for api "ollama"',
+      ),
+    ).not.toBe("proxy");
+  });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1124,6 +1124,16 @@ describe("classifyProviderRuntimeFailureKind", () => {
     ).not.toBe("auth_scope");
   });
 
+  it("does not treat generic Codex permission failures as missing scope failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        provider: "openai-codex",
+        message:
+          '403 {"type":"error","error":{"type":"permission_error","message":"Insufficient permissions for this organization"}}',
+      }),
+    ).not.toBe("auth_scope");
+  });
+
   it("classifies OAuth refresh failures", () => {
     expect(
       classifyProviderRuntimeFailureKind(

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyProviderRuntimeFailureKind,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,
   extractObservedOverflowTokenCount,
@@ -1099,5 +1100,48 @@ describe("classifyFailoverReason", () => {
         '{"type":"error","error":{"type":"api_error","message":"permission_error: OAuth authentication is currently not allowed for this organization"}}',
       ),
     ).toBe("auth_permanent");
+  });
+});
+
+describe("classifyProviderRuntimeFailureKind", () => {
+  it("classifies missing scope failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      ),
+    ).toBe("auth_scope");
+  });
+
+  it("classifies OAuth refresh failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "OAuth token refresh failed for openai-codex: invalid_grant. Please try again or re-authenticate.",
+      ),
+    ).toBe("auth_refresh");
+  });
+
+  it("classifies HTML 403 auth failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "403 <!DOCTYPE html><html><body>Access denied</body></html>",
+      ),
+    ).toBe("auth_html_403");
+  });
+
+  it("classifies proxy, dns, timeout, schema, sandbox, and replay failures", () => {
+    expect(classifyProviderRuntimeFailureKind("407 Proxy Authentication Required")).toBe("proxy");
+    expect(
+      classifyProviderRuntimeFailureKind("dial tcp: lookup api.example.com: no such host"),
+    ).toBe("dns");
+    expect(classifyProviderRuntimeFailureKind("socket hang up")).toBe("timeout");
+    expect(
+      classifyProviderRuntimeFailureKind("INVALID_REQUEST_ERROR: string should match pattern"),
+    ).toBe("schema");
+    expect(classifyProviderRuntimeFailureKind("exec denied (allowlist-miss):")).toBe(
+      "sandbox_blocked",
+    );
+    expect(classifyProviderRuntimeFailureKind("tool_use.input: Field required")).toBe(
+      "replay_invalid",
+    );
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -45,6 +45,7 @@ export {
   parseImageDimensionError,
   parseImageSizeError,
 } from "./pi-embedded-helpers/errors.js";
+export type { ProviderRuntimeFailureKind } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 
 export {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -11,6 +11,7 @@ export {
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,
+  classifyProviderRuntimeFailureKind,
   formatBillingErrorMessage,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -465,7 +465,7 @@ const TIMEOUT_ERROR_CODES = new Set([
   "EAI_AGAIN",
 ]);
 const AUTH_SCOPE_HINT_RE =
-  /\b(?:missing|required|requires|insufficient)\s+(?:the\s+following\s+)?scopes?\b|\bmissing\s+scope\b|\binsufficient\s+permissions?\b/i;
+  /\b(?:missing|required|requires|insufficient)\s+(?:the\s+following\s+)?scopes?\b|\bmissing\s+scope\b/i;
 const AUTH_SCOPE_NAME_RE = /\b(?:api\.responses\.write|model\.request)\b/i;
 const HTML_BODY_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -502,8 +502,20 @@ function isHtmlErrorResponse(raw: string, status?: number): boolean {
   return HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
 }
 
-function isAuthScopeErrorMessage(raw: string, status?: number): boolean {
+function isOpenAICodexScopeContext(raw: string, provider?: string): boolean {
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  return (
+    normalizedProvider === "openai-codex" ||
+    /\bopenai\s+codex\b/i.test(raw) ||
+    /\bcodex\b.*\bscopes?\b/i.test(raw)
+  );
+}
+
+function isAuthScopeErrorMessage(raw: string, status?: number, provider?: string): boolean {
   if (!raw) {
+    return false;
+  }
+  if (!isOpenAICodexScopeContext(raw, provider)) {
     return false;
   }
   const inferred =
@@ -916,7 +928,7 @@ export function classifyProviderRuntimeFailureKind(
   if (message && classifyOAuthRefreshFailure(message)) {
     return "auth_refresh";
   }
-  if (message && isAuthScopeErrorMessage(message, status)) {
+  if (message && isAuthScopeErrorMessage(message, status, normalizedSignal.provider)) {
     return "auth_scope";
   }
   if (message && status === 403 && isHtmlErrorResponse(message, status)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -470,7 +470,7 @@ const AUTH_SCOPE_NAME_RE = /\b(?:api\.responses\.write|model\.request)\b/i;
 const HTML_BODY_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;
 const PROXY_ERROR_RE =
-  /\bproxy\b|\bproxyconnect\b|\bhttps?_proxy\b|\b407\b|\bproxy authentication required\b|\btunnel connection failed\b|\bconnect tunnel\b|\bsocks proxy\b/i;
+  /\bproxyconnect\b|\bhttps?_proxy\b|\b407\b|\bproxy authentication required\b|\btunnel connection failed\b|\bconnect tunnel\b|\bsocks proxy\b|\bproxy error\b/i;
 const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host\b|\bdns\b/i;
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -522,10 +522,18 @@ function isAuthScopeErrorMessage(raw: string, status?: number, provider?: string
     typeof status === "number" && Number.isFinite(status)
       ? status
       : extractLeadingHttpStatus(raw.trim())?.code;
+  const hasScopeHint = AUTH_SCOPE_HINT_RE.test(raw);
+  const hasKnownScopeName = AUTH_SCOPE_NAME_RE.test(raw);
+  if (!hasScopeHint && !hasKnownScopeName) {
+    return false;
+  }
+  if (typeof inferred !== "number") {
+    return hasScopeHint;
+  }
   if (inferred !== 401 && inferred !== 403) {
     return false;
   }
-  return AUTH_SCOPE_HINT_RE.test(raw) || AUTH_SCOPE_NAME_RE.test(raw);
+  return true;
 }
 
 function isProxyErrorMessage(raw: string, status?: number): boolean {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -18,6 +18,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   parseApiErrorInfo,
 } from "../../shared/assistant-error-format.js";
+import { classifyOAuthRefreshFailure } from "../auth-profiles/oauth-refresh-failure.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { isModelNotFoundErrorMessage } from "../live-model-errors.js";
@@ -407,6 +408,19 @@ export type FailoverClassification =
       kind: "context_overflow";
     };
 
+export type ProviderRuntimeFailureKind =
+  | "auth_scope"
+  | "auth_refresh"
+  | "auth_html_403"
+  | "proxy"
+  | "rate_limit"
+  | "dns"
+  | "timeout"
+  | "schema"
+  | "sandbox_blocked"
+  | "replay_invalid"
+  | "unknown";
+
 const BILLING_402_HINTS = [
   "insufficient credits",
   "insufficient quota",
@@ -450,6 +464,102 @@ const TIMEOUT_ERROR_CODES = new Set([
   "EPIPE",
   "EAI_AGAIN",
 ]);
+const AUTH_SCOPE_HINT_RE =
+  /\b(?:missing|required|requires|insufficient)\s+(?:the\s+following\s+)?scopes?\b|\bmissing\s+scope\b|\binsufficient\s+permissions?\b/i;
+const AUTH_SCOPE_NAME_RE = /\b(?:api\.responses\.write|model\.request)\b/i;
+const HTML_BODY_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
+const HTML_CLOSE_RE = /<\/html>/i;
+const PROXY_ERROR_RE =
+  /\bproxy\b|\bproxyconnect\b|\bhttps?_proxy\b|\b407\b|\bproxy authentication required\b|\btunnel connection failed\b|\bconnect tunnel\b|\bsocks proxy\b/i;
+const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host\b|\bdns\b/i;
+const INTERRUPTED_NETWORK_ERROR_RE =
+  /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
+const REPLAY_INVALID_RE =
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b/i;
+const SANDBOX_BLOCKED_RE =
+  /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b/i;
+
+function inferSignalStatus(signal: FailoverSignal): number | undefined {
+  if (typeof signal.status === "number" && Number.isFinite(signal.status)) {
+    return signal.status;
+  }
+  return extractLeadingHttpStatus(signal.message?.trim() ?? "")?.code;
+}
+
+function isHtmlErrorResponse(raw: string, status?: number): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const inferred =
+    typeof status === "number" && Number.isFinite(status)
+      ? status
+      : extractLeadingHttpStatus(trimmed)?.code;
+  if (typeof inferred !== "number" || inferred < 400) {
+    return false;
+  }
+  const rest = extractLeadingHttpStatus(trimmed)?.rest ?? trimmed;
+  return HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
+}
+
+function isAuthScopeErrorMessage(raw: string, status?: number): boolean {
+  if (!raw) {
+    return false;
+  }
+  const inferred =
+    typeof status === "number" && Number.isFinite(status)
+      ? status
+      : extractLeadingHttpStatus(raw.trim())?.code;
+  if (inferred !== 401 && inferred !== 403) {
+    return false;
+  }
+  return AUTH_SCOPE_HINT_RE.test(raw) || AUTH_SCOPE_NAME_RE.test(raw);
+}
+
+function isProxyErrorMessage(raw: string, status?: number): boolean {
+  if (!raw) {
+    return false;
+  }
+  if (status === 407) {
+    return true;
+  }
+  return PROXY_ERROR_RE.test(raw);
+}
+
+function isDnsTransportErrorMessage(raw: string): boolean {
+  return DNS_ERROR_RE.test(raw);
+}
+
+function isReplayInvalidErrorMessage(raw: string): boolean {
+  return REPLAY_INVALID_RE.test(raw);
+}
+
+function isSandboxBlockedErrorMessage(raw: string): boolean {
+  return Boolean(formatExecDeniedUserMessage(raw)) || SANDBOX_BLOCKED_RE.test(raw);
+}
+
+function isSchemaErrorMessage(raw: string): boolean {
+  if (!raw || isReplayInvalidErrorMessage(raw) || isContextOverflowError(raw)) {
+    return false;
+  }
+  return classifyFailoverReason(raw) === "format" || matchesFormatErrorPattern(raw);
+}
+
+function isTimeoutTransportErrorMessage(raw: string, status?: number): boolean {
+  if (!raw) {
+    return false;
+  }
+  if (isTimeoutErrorMessage(raw) || INTERRUPTED_NETWORK_ERROR_RE.test(raw)) {
+    return true;
+  }
+  if (
+    typeof status === "number" &&
+    [408, 499, 500, 502, 503, 504, 521, 522, 523, 524, 529].includes(status)
+  ) {
+    return true;
+  }
+  return false;
+}
 
 function includesAnyHint(text: string, hints: readonly string[]): boolean {
   return hints.some((hint) => text.includes(hint));
@@ -774,10 +884,7 @@ function classifyFailoverClassificationFromMessage(
 }
 
 export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassification | null {
-  const inferredStatus =
-    typeof signal.status === "number" && Number.isFinite(signal.status)
-      ? signal.status
-      : extractLeadingHttpStatus(signal.message?.trim() ?? "")?.code;
+  const inferredStatus = inferSignalStatus(signal);
   const messageClassification = signal.message
     ? classifyFailoverClassificationFromMessage(signal.message, signal.provider)
     : null;
@@ -794,6 +901,60 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
     return toReasonClassification(codeReason);
   }
   return messageClassification;
+}
+
+export function classifyProviderRuntimeFailureKind(
+  signal: FailoverSignal | string,
+): ProviderRuntimeFailureKind {
+  const normalizedSignal = typeof signal === "string" ? { message: signal } : signal;
+  const message = normalizedSignal.message?.trim() ?? "";
+  const status = inferSignalStatus(normalizedSignal);
+
+  if (!message && typeof status !== "number") {
+    return "unknown";
+  }
+  if (message && classifyOAuthRefreshFailure(message)) {
+    return "auth_refresh";
+  }
+  if (message && isAuthScopeErrorMessage(message, status)) {
+    return "auth_scope";
+  }
+  if (message && status === 403 && isHtmlErrorResponse(message, status)) {
+    return "auth_html_403";
+  }
+  if (message && isProxyErrorMessage(message, status)) {
+    return "proxy";
+  }
+  const failoverClassification = classifyFailoverSignal({
+    ...normalizedSignal,
+    status,
+    message: message || undefined,
+  });
+  if (failoverClassification?.kind === "reason" && failoverClassification.reason === "rate_limit") {
+    return "rate_limit";
+  }
+  if (message && isDnsTransportErrorMessage(message)) {
+    return "dns";
+  }
+  if (message && isSandboxBlockedErrorMessage(message)) {
+    return "sandbox_blocked";
+  }
+  if (message && isReplayInvalidErrorMessage(message)) {
+    return "replay_invalid";
+  }
+  if (message && isSchemaErrorMessage(message)) {
+    return "schema";
+  }
+  if (
+    failoverClassification?.kind === "reason" &&
+    (failoverClassification.reason === "timeout" || failoverClassification.reason === "overloaded")
+  ) {
+    return "timeout";
+  }
+  if (message && isTimeoutTransportErrorMessage(message, status)) {
+    return "timeout";
+  }
+  return "unknown";
 }
 
 function coerceText(value: unknown): string {
@@ -947,6 +1108,12 @@ export function formatAssistantErrorText(
     return "LLM request failed with an unknown error.";
   }
 
+  const providerRuntimeFailureKind = classifyProviderRuntimeFailureKind({
+    status: extractLeadingHttpStatus(raw)?.code,
+    message: raw,
+    provider: opts?.provider ?? msg.provider,
+  });
+
   const unknownTool =
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
     raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
@@ -964,6 +1131,28 @@ export function formatAssistantErrorText(
   const diskSpaceCopy = formatDiskSpaceErrorCopy(raw);
   if (diskSpaceCopy) {
     return diskSpaceCopy;
+  }
+
+  if (providerRuntimeFailureKind === "auth_refresh") {
+    return "Authentication refresh failed. Re-authenticate this provider and try again.";
+  }
+
+  if (providerRuntimeFailureKind === "auth_scope") {
+    return (
+      "Authentication is missing the required OpenAI Codex scopes. " +
+      "Re-run OpenAI/Codex login and try again."
+    );
+  }
+
+  if (providerRuntimeFailureKind === "auth_html_403") {
+    return (
+      "Authentication failed with an HTML 403 response from the provider. " +
+      "Re-authenticate and verify your provider account access."
+    );
+  }
+
+  if (providerRuntimeFailureKind === "proxy") {
+    return "LLM request failed: proxy or tunnel configuration blocked the provider request.";
   }
 
   if (isContextOverflowError(raw)) {
@@ -1025,6 +1214,17 @@ export function formatAssistantErrorText(
 
   if (isBillingErrorMessage(raw)) {
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
+  }
+
+  if (providerRuntimeFailureKind === "schema") {
+    return "LLM request failed: provider rejected the request schema or tool payload.";
+  }
+
+  if (providerRuntimeFailureKind === "replay_invalid") {
+    return (
+      "Session history or replay state is invalid. " +
+      "Use /new to start a fresh session and try again."
+    );
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -77,7 +77,40 @@ describe("buildEmbeddedSandboxInfo", () => {
       workspaceAccess: "none",
       agentWorkspaceMount: undefined,
       hostBrowserAllowed: false,
-      elevated: { allowed: true, defaultLevel: "on" },
+      elevated: {
+        allowed: true,
+        defaultLevel: "on",
+        fullAccessAvailable: true,
+      },
+    });
+  });
+
+  it("keeps full-access unavailability truth when provided", () => {
+    const sandbox = createSandboxContext();
+
+    expect(
+      buildEmbeddedSandboxInfo(sandbox, {
+        enabled: true,
+        allowed: true,
+        defaultLevel: "full",
+        fullAccessAvailable: false,
+        fullAccessBlockedReason: "runtime",
+      }),
+    ).toEqual({
+      enabled: true,
+      workspaceDir: "/tmp/openclaw-sandbox",
+      containerWorkspaceDir: "/workspace",
+      workspaceAccess: "none",
+      agentWorkspaceMount: undefined,
+      browserBridgeUrl: "http://localhost:9222",
+      browserNoVncUrl: "http://localhost:6080",
+      hostBrowserAllowed: true,
+      elevated: {
+        allowed: true,
+        defaultLevel: "full",
+        fullAccessAvailable: false,
+        fullAccessBlockedReason: "runtime",
+      },
     });
   });
 });

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -119,7 +119,6 @@ describe("resolveEmbeddedFullAccessState", () => {
   it("treats direct host runs with allowed elevation as full-access available", () => {
     expect(
       resolveEmbeddedFullAccessState({
-        sandboxEnabled: false,
         execElevated: {
           enabled: true,
           allowed: true,
@@ -132,7 +131,6 @@ describe("resolveEmbeddedFullAccessState", () => {
   it("keeps explicit runtime blocks even when host exec is allowed", () => {
     expect(
       resolveEmbeddedFullAccessState({
-        sandboxEnabled: false,
         execElevated: {
           enabled: true,
           allowed: true,

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -103,7 +103,6 @@ describe("buildEmbeddedSandboxInfo", () => {
       workspaceAccess: "none",
       agentWorkspaceMount: undefined,
       browserBridgeUrl: "http://localhost:9222",
-      browserNoVncUrl: "http://localhost:6080",
       hostBrowserAllowed: true,
       elevated: {
         allowed: true,

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildEmbeddedSandboxInfo } from "./pi-embedded-runner.js";
+import { resolveEmbeddedFullAccessState } from "./pi-embedded-runner/sandbox-info.js";
 import type { SandboxContext } from "./sandbox.js";
 
 function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxContext {
@@ -110,6 +111,39 @@ describe("buildEmbeddedSandboxInfo", () => {
         fullAccessAvailable: false,
         fullAccessBlockedReason: "runtime",
       },
+    });
+  });
+});
+
+describe("resolveEmbeddedFullAccessState", () => {
+  it("treats direct host runs with allowed elevation as full-access available", () => {
+    expect(
+      resolveEmbeddedFullAccessState({
+        sandboxEnabled: false,
+        execElevated: {
+          enabled: true,
+          allowed: true,
+          defaultLevel: "full",
+        },
+      }),
+    ).toEqual({ available: true });
+  });
+
+  it("keeps explicit runtime blocks even when host exec is allowed", () => {
+    expect(
+      resolveEmbeddedFullAccessState({
+        sandboxEnabled: false,
+        execElevated: {
+          enabled: true,
+          allowed: true,
+          defaultLevel: "full",
+          fullAccessAvailable: false,
+          fullAccessBlockedReason: "runtime",
+        },
+      }),
+    ).toEqual({
+      available: false,
+      blockedReason: "runtime",
     });
   });
 });

--- a/src/agents/pi-embedded-runner/sandbox-info.ts
+++ b/src/agents/pi-embedded-runner/sandbox-info.ts
@@ -2,10 +2,10 @@ import type { ExecElevatedDefaults } from "../bash-tools.js";
 import type { resolveSandboxContext } from "../sandbox.js";
 import type { EmbeddedFullAccessBlockedReason, EmbeddedSandboxInfo } from "./types.js";
 
-export function resolveEmbeddedFullAccessState(params: {
-  sandboxEnabled: boolean;
-  execElevated?: ExecElevatedDefaults;
-}): { available: boolean; blockedReason?: EmbeddedFullAccessBlockedReason } {
+export function resolveEmbeddedFullAccessState(params: { execElevated?: ExecElevatedDefaults }): {
+  available: boolean;
+  blockedReason?: EmbeddedFullAccessBlockedReason;
+} {
   if (params.execElevated?.fullAccessAvailable === true) {
     return { available: true };
   }
@@ -21,9 +21,6 @@ export function resolveEmbeddedFullAccessState(params: {
       blockedReason: "host-policy",
     };
   }
-  if (!params.sandboxEnabled) {
-    return { available: true };
-  }
   return { available: true };
 }
 
@@ -37,7 +34,6 @@ export function buildEmbeddedSandboxInfo(
   const elevatedConfigured = execElevated?.enabled === true;
   const elevatedAllowed = Boolean(execElevated?.enabled && execElevated.allowed);
   const fullAccess = resolveEmbeddedFullAccessState({
-    sandboxEnabled: true,
     execElevated,
   });
   return {

--- a/src/agents/pi-embedded-runner/sandbox-info.ts
+++ b/src/agents/pi-embedded-runner/sandbox-info.ts
@@ -1,6 +1,34 @@
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import type { resolveSandboxContext } from "../sandbox.js";
-import type { EmbeddedSandboxInfo } from "./types.js";
+import type { EmbeddedFullAccessBlockedReason, EmbeddedSandboxInfo } from "./types.js";
+
+export function resolveEmbeddedFullAccessState(params: {
+  sandboxEnabled: boolean;
+  execElevated?: ExecElevatedDefaults;
+}): { available: boolean; blockedReason?: EmbeddedFullAccessBlockedReason } {
+  if (!params.sandboxEnabled) {
+    return {
+      available: false,
+      blockedReason: "runtime",
+    };
+  }
+  if (params.execElevated?.fullAccessAvailable === true) {
+    return { available: true };
+  }
+  if (params.execElevated?.fullAccessAvailable === false) {
+    return {
+      available: false,
+      blockedReason: params.execElevated.fullAccessBlockedReason ?? "host-policy",
+    };
+  }
+  if (!params.execElevated?.enabled || !params.execElevated.allowed) {
+    return {
+      available: false,
+      blockedReason: "host-policy",
+    };
+  }
+  return { available: true };
+}
 
 export function buildEmbeddedSandboxInfo(
   sandbox?: Awaited<ReturnType<typeof resolveSandboxContext>>,
@@ -9,7 +37,12 @@ export function buildEmbeddedSandboxInfo(
   if (!sandbox?.enabled) {
     return undefined;
   }
+  const elevatedConfigured = execElevated?.enabled === true;
   const elevatedAllowed = Boolean(execElevated?.enabled && execElevated.allowed);
+  const fullAccess = resolveEmbeddedFullAccessState({
+    sandboxEnabled: true,
+    execElevated,
+  });
   return {
     enabled: true,
     workspaceDir: sandbox.workspaceDir,
@@ -18,11 +51,15 @@ export function buildEmbeddedSandboxInfo(
     agentWorkspaceMount: sandbox.workspaceAccess === "ro" ? "/agent" : undefined,
     browserBridgeUrl: sandbox.browser?.bridgeUrl,
     hostBrowserAllowed: sandbox.browserAllowHostControl,
-    ...(elevatedAllowed
+    ...(elevatedConfigured
       ? {
           elevated: {
-            allowed: true,
+            allowed: elevatedAllowed,
             defaultLevel: execElevated?.defaultLevel ?? "off",
+            fullAccessAvailable: fullAccess.available,
+            ...(fullAccess.blockedReason
+              ? { fullAccessBlockedReason: fullAccess.blockedReason }
+              : {}),
           },
         }
       : {}),

--- a/src/agents/pi-embedded-runner/sandbox-info.ts
+++ b/src/agents/pi-embedded-runner/sandbox-info.ts
@@ -6,12 +6,6 @@ export function resolveEmbeddedFullAccessState(params: {
   sandboxEnabled: boolean;
   execElevated?: ExecElevatedDefaults;
 }): { available: boolean; blockedReason?: EmbeddedFullAccessBlockedReason } {
-  if (!params.sandboxEnabled) {
-    return {
-      available: false,
-      blockedReason: "runtime",
-    };
-  }
   if (params.execElevated?.fullAccessAvailable === true) {
     return { available: true };
   }
@@ -26,6 +20,9 @@ export function resolveEmbeddedFullAccessState(params: {
       available: false,
       blockedReason: "host-policy",
     };
+  }
+  if (!params.sandboxEnabled) {
+    return { available: true };
   }
   return { available: true };
 }

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -93,6 +93,8 @@ export type EmbeddedPiCompactResult = {
   };
 };
 
+export type EmbeddedFullAccessBlockedReason = "sandbox" | "host-policy" | "channel" | "runtime";
+
 export type EmbeddedSandboxInfo = {
   enabled: boolean;
   workspaceDir?: string;
@@ -104,5 +106,7 @@ export type EmbeddedSandboxInfo = {
   elevated?: {
     allowed: boolean;
     defaultLevel: "on" | "off" | "ask" | "full";
+    fullAccessAvailable: boolean;
+    fullAccessBlockedReason?: EmbeddedFullAccessBlockedReason;
   };
 };

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -68,6 +68,7 @@ describe("handleAgentEnd", () => {
       event: "embedded_run_agent_end",
       runId: "run-1",
       error: "LLM request failed: connection refused by the provider endpoint.",
+      providerRuntimeFailureKind: "timeout",
       rawErrorPreview: "connection refused",
       consoleMessage:
         "embedded run agent end: runId=run-1 isError=true model=unknown provider=unknown error=LLM request failed: connection refused by the provider endpoint. rawError=connection refused",
@@ -101,6 +102,7 @@ describe("handleAgentEnd", () => {
       runId: "run-1",
       error: "The AI service is temporarily overloaded. Please try again in a moment.",
       failoverReason: "overloaded",
+      providerRuntimeFailureKind: "timeout",
       providerErrorType: "overloaded_error",
       consoleMessage:
         'embedded run agent end: runId=run-1 isError=true model=claude-test provider=anthropic error=The AI service is temporarily overloaded. Please try again in a moment. rawError={"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
@@ -157,6 +159,26 @@ describe("handleAgentEnd", () => {
         phase: "error",
         error: "x-api-key: ***",
       },
+    });
+  });
+
+  it("logs runtime failure kind for missing-scope auth errors", async () => {
+    const ctx = createContext({
+      role: "assistant",
+      stopReason: "error",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      errorMessage:
+        '401 {"type":"error","error":{"type":"permission_error","message":"Missing scopes: api.responses.write"}}',
+      content: [{ type: "text", text: "" }],
+    });
+
+    await handleAgentEnd(ctx);
+
+    expect(vi.mocked(ctx.log.warn).mock.calls[0]?.[1]).toMatchObject({
+      failoverReason: "auth",
+      providerRuntimeFailureKind: "auth_scope",
+      httpCode: "401",
     });
   });
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -5,7 +5,11 @@ import {
   buildTextObservationFields,
   sanitizeForConsole,
 } from "./pi-embedded-error-observation.js";
-import { classifyFailoverReason, formatAssistantErrorText } from "./pi-embedded-helpers.js";
+import {
+  classifyFailoverReason,
+  classifyProviderRuntimeFailureKind,
+  formatAssistantErrorText,
+} from "./pi-embedded-helpers.js";
 import {
   consumePendingToolMediaReply,
   hasAssistantVisibleReply,
@@ -51,6 +55,10 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
     const failoverReason = classifyFailoverReason(rawError ?? "", {
       provider: lastAssistant.provider,
     });
+    const providerRuntimeFailureKind = classifyProviderRuntimeFailureKind({
+      message: rawError ?? "",
+      provider: lastAssistant.provider,
+    });
     const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
     const observedError = buildApiErrorObservationFields(rawError);
     const safeErrorText =
@@ -68,6 +76,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
       isError: true,
       error: safeErrorText,
       failoverReason,
+      providerRuntimeFailureKind,
       model: lastAssistant.model,
       provider: lastAssistant.provider,
       ...observedError,

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -5,11 +5,7 @@ import {
   buildTextObservationFields,
   sanitizeForConsole,
 } from "./pi-embedded-error-observation.js";
-import {
-  classifyFailoverReason,
-  classifyProviderRuntimeFailureKind,
-  formatAssistantErrorText,
-} from "./pi-embedded-helpers.js";
+import { classifyFailoverReason, formatAssistantErrorText } from "./pi-embedded-helpers.js";
 import {
   consumePendingToolMediaReply,
   hasAssistantVisibleReply,
@@ -55,10 +51,6 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
     const failoverReason = classifyFailoverReason(rawError ?? "", {
       provider: lastAssistant.provider,
     });
-    const providerRuntimeFailureKind = classifyProviderRuntimeFailureKind({
-      message: rawError ?? "",
-      provider: lastAssistant.provider,
-    });
     const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
     const observedError = buildApiErrorObservationFields(rawError, {
       provider: lastAssistant.provider,
@@ -83,7 +75,6 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
       model: lastAssistant.model,
       provider: lastAssistant.provider,
       ...observedError,
-      providerRuntimeFailureKind,
       consoleMessage: `embedded run agent end: runId=${safeRunId} isError=true model=${safeModel} provider=${safeProvider} error=${safeErrorText}${rawErrorConsoleSuffix}`,
     });
   } else {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -80,10 +80,10 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
       isError: true,
       error: safeErrorText,
       failoverReason,
-      providerRuntimeFailureKind,
       model: lastAssistant.model,
       provider: lastAssistant.provider,
       ...observedError,
+      providerRuntimeFailureKind,
       consoleMessage: `embedded run agent end: runId=${safeRunId} isError=true model=${safeModel} provider=${safeProvider} error=${safeErrorText}${rawErrorConsoleSuffix}`,
     });
   } else {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -60,9 +60,13 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
       provider: lastAssistant.provider,
     });
     const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
-    const observedError = buildApiErrorObservationFields(rawError);
+    const observedError = buildApiErrorObservationFields(rawError, {
+      provider: lastAssistant.provider,
+    });
     const safeErrorText =
-      buildTextObservationFields(errorText).textPreview ?? "LLM request failed.";
+      buildTextObservationFields(errorText, {
+        provider: lastAssistant.provider,
+      }).textPreview ?? "LLM request failed.";
     lifecycleErrorText = safeErrorText;
     const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
     const safeModel = sanitizeForConsole(lastAssistant.model) ?? "unknown";

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -939,7 +939,7 @@ describe("buildAgentSystemPrompt", () => {
         containerWorkspaceDir: "/workspace",
         workspaceAccess: "ro",
         agentWorkspaceMount: "/agent",
-        elevated: { allowed: true, defaultLevel: "on" },
+        elevated: { allowed: true, defaultLevel: "on", fullAccessAvailable: true },
       },
     });
 
@@ -955,6 +955,35 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Sub-agents stay sandboxed");
     expect(prompt).toContain("User can toggle with /elevated on|off|ask|full.");
     expect(prompt).toContain("Current elevated level: on");
+  });
+
+  it("does not advertise /elevated full when auto-approved full access is unavailable", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      sandboxInfo: {
+        enabled: true,
+        workspaceDir: "/tmp/sandbox",
+        containerWorkspaceDir: "/workspace",
+        workspaceAccess: "ro",
+        agentWorkspaceMount: "/agent",
+        elevated: {
+          allowed: true,
+          defaultLevel: "full",
+          fullAccessAvailable: false,
+          fullAccessBlockedReason: "runtime",
+        },
+      },
+    });
+
+    expect(prompt).toContain("Elevated exec is available for this session.");
+    expect(prompt).toContain("User can toggle with /elevated on|off|ask.");
+    expect(prompt).not.toContain("User can toggle with /elevated on|off|ask|full.");
+    expect(prompt).toContain(
+      "Auto-approved /elevated full is unavailable here (runtime constraints).",
+    );
+    expect(prompt).toContain(
+      "Current elevated level: full (full auto-approval unavailable here; use ask/on instead).",
+    );
   });
 
   it("includes reaction guidance when provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -12,7 +12,10 @@ import {
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
-import type { EmbeddedSandboxInfo } from "./pi-embedded-runner/types.js";
+import type {
+  EmbeddedFullAccessBlockedReason,
+  EmbeddedSandboxInfo,
+} from "./pi-embedded-runner/types.js";
 import {
   normalizePromptCapabilityIds,
   normalizeStructuredPromptSection,
@@ -336,6 +339,19 @@ function buildExecApprovalPromptGuidance(params: {
   return "When exec returns approval-pending, include the concrete /approve command from tool output as plain chat text for the user, and do not ask for a different or rotated code.";
 }
 
+function formatFullAccessBlockedReason(reason?: EmbeddedFullAccessBlockedReason): string {
+  if (reason === "host-policy") {
+    return "host policy";
+  }
+  if (reason === "channel") {
+    return "channel constraints";
+  }
+  if (reason === "sandbox") {
+    return "sandbox constraints";
+  }
+  return "runtime constraints";
+}
+
 export function buildAgentSystemPrompt(params: {
   workspaceDir: string;
   defaultThinkLevel?: ThinkLevel;
@@ -470,6 +486,11 @@ export function buildAgentSystemPrompt(params: {
   const sanitizedSandboxContainerWorkspace = sandboxContainerWorkspace
     ? sanitizeForPromptLiteral(sandboxContainerWorkspace)
     : "";
+  const elevated = params.sandboxInfo?.elevated;
+  const fullAccessBlockedReasonLabel =
+    elevated?.fullAccessAvailable === false
+      ? formatFullAccessBlockedReason(elevated.fullAccessBlockedReason)
+      : undefined;
   const displayWorkspaceDir =
     params.sandboxInfo?.enabled && sanitizedSandboxContainerWorkspace
       ? sanitizedSandboxContainerWorkspace
@@ -652,17 +673,35 @@ export function buildAgentSystemPrompt(params: {
             : params.sandboxInfo.hostBrowserAllowed === false
               ? "Host browser control: blocked."
               : "",
-          params.sandboxInfo.elevated?.allowed
+          elevated?.allowed
             ? "Elevated exec is available for this session."
-            : "",
-          params.sandboxInfo.elevated?.allowed
+            : elevated
+              ? "Elevated exec is unavailable for this session."
+              : "",
+          elevated?.allowed && elevated.fullAccessAvailable
             ? "User can toggle with /elevated on|off|ask|full."
             : "",
-          params.sandboxInfo.elevated?.allowed
+          elevated?.allowed && !elevated.fullAccessAvailable
+            ? "User can toggle with /elevated on|off|ask."
+            : "",
+          elevated?.allowed && elevated.fullAccessAvailable
             ? "You may also send /elevated on|off|ask|full when needed."
             : "",
-          params.sandboxInfo.elevated?.allowed
-            ? `Current elevated level: ${params.sandboxInfo.elevated.defaultLevel} (ask runs exec on host with approvals; full auto-approves).`
+          elevated?.allowed && !elevated.fullAccessAvailable
+            ? "You may also send /elevated on|off|ask when needed."
+            : "",
+          elevated?.fullAccessAvailable === false
+            ? `Auto-approved /elevated full is unavailable here (${fullAccessBlockedReasonLabel}).`
+            : "",
+          elevated?.allowed && elevated.fullAccessAvailable
+            ? `Current elevated level: ${elevated.defaultLevel} (ask runs exec on host with approvals; full auto-approves).`
+            : elevated?.allowed
+              ? `Current elevated level: ${elevated.defaultLevel} (full auto-approval unavailable here; use ask/on instead).`
+              : elevated
+                ? "Current elevated level: off (elevated exec unavailable)."
+                : "",
+          elevated && !elevated.allowed
+            ? "Do not tell the user to switch to /elevated full in this session."
             : "",
         ]
           .filter(Boolean)

--- a/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
@@ -349,6 +349,7 @@ describe("directive behavior", () => {
         enabled: true,
         allowed: true,
         defaultLevel: "on",
+        fullAccessAvailable: true,
       });
     });
   });

--- a/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
@@ -352,7 +352,7 @@ describe("directive behavior", () => {
         fullAccessAvailable: true,
       });
     });
-  });
+  }, 240_000);
   it("persists /reasoning off on discord even when model defaults reasoning on", async () => {
     await withTempHome(async (home) => {
       const storePath = sessionStorePath(home);

--- a/src/auto-reply/reply/commands-system-prompt.test.ts
+++ b/src/auto-reply/reply/commands-system-prompt.test.ts
@@ -165,4 +165,38 @@ describe("resolveCommandsSystemPromptBundle", () => {
       }),
     );
   });
+
+  it("uses the resolved session key and forwards full-access block reasons", async () => {
+    const { resolveCommandsSystemPromptBundle } = await import("./commands-system-prompt.js");
+    const sandboxRuntime = await import("../../agents/sandbox.js");
+    const systemPromptRuntime = await import("../../agents/system-prompt.js");
+
+    vi.mocked(sandboxRuntime.resolveSandboxRuntimeStatus).mockImplementation(({ sessionKey }) => {
+      expect(sessionKey).toBe("agent:target:default");
+      return { sandboxed: true, mode: "workspace-write" } as never;
+    });
+
+    const params = makeParams();
+    params.sessionKey = "agent:target:default";
+    params.ctx.SessionKey = "agent:source:default";
+    params.elevated = {
+      enabled: true,
+      allowed: false,
+      failures: [],
+    };
+
+    await resolveCommandsSystemPromptBundle(params);
+
+    expect(vi.mocked(systemPromptRuntime.buildAgentSystemPrompt)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandboxInfo: expect.objectContaining({
+          enabled: true,
+          elevated: expect.objectContaining({
+            fullAccessAvailable: false,
+            fullAccessBlockedReason: "host-policy",
+          }),
+        }),
+      }),
+    );
+  });
 });

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -112,7 +112,6 @@ export async function resolveCommandsSystemPromptBundle(
     },
   });
   const fullAccessState = resolveEmbeddedFullAccessState({
-    sandboxEnabled: sandboxRuntime.sandboxed,
     execElevated: {
       enabled: params.elevated.enabled,
       allowed: params.elevated.allowed,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -111,6 +111,14 @@ export async function resolveCommandsSystemPromptBundle(
       defaultModel: defaultModelLabel,
     },
   });
+  const fullAccessState = resolveEmbeddedFullAccessState({
+    sandboxEnabled: true,
+    execElevated: {
+      enabled: params.elevated.enabled,
+      allowed: params.elevated.allowed,
+      defaultLevel: (params.resolvedElevatedLevel ?? "off") as "on" | "off" | "ask" | "full",
+    },
+  });
   const sandboxInfo = sandboxRuntime.sandboxed
     ? {
         enabled: true,
@@ -119,18 +127,10 @@ export async function resolveCommandsSystemPromptBundle(
         elevated: {
           allowed: params.elevated.allowed,
           defaultLevel: (params.resolvedElevatedLevel ?? "off") as "on" | "off" | "ask" | "full",
-          fullAccessAvailable: resolveEmbeddedFullAccessState({
-            sandboxEnabled: true,
-            execElevated: {
-              enabled: params.elevated.enabled,
-              allowed: params.elevated.allowed,
-              defaultLevel: (params.resolvedElevatedLevel ?? "off") as
-                | "on"
-                | "off"
-                | "ask"
-                | "full",
-            },
-          }).available,
+          fullAccessAvailable: fullAccessState.available,
+          ...(fullAccessState.blockedReason
+            ? { fullAccessBlockedReason: fullAccessState.blockedReason }
+            : {}),
         },
       }
     : { enabled: false };

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -4,6 +4,7 @@ import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { canExecRequestNode } from "../../agents/exec-defaults.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
+import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
 import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
@@ -118,6 +119,18 @@ export async function resolveCommandsSystemPromptBundle(
         elevated: {
           allowed: params.elevated.allowed,
           defaultLevel: (params.resolvedElevatedLevel ?? "off") as "on" | "off" | "ask" | "full",
+          fullAccessAvailable: resolveEmbeddedFullAccessState({
+            sandboxEnabled: true,
+            execElevated: {
+              enabled: params.elevated.enabled,
+              allowed: params.elevated.allowed,
+              defaultLevel: (params.resolvedElevatedLevel ?? "off") as
+                | "on"
+                | "off"
+                | "ask"
+                | "full",
+            },
+          }).available,
         },
       }
     : { enabled: false };

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -112,7 +112,7 @@ export async function resolveCommandsSystemPromptBundle(
     },
   });
   const fullAccessState = resolveEmbeddedFullAccessState({
-    sandboxEnabled: true,
+    sandboxEnabled: sandboxRuntime.sandboxed,
     execElevated: {
       enabled: params.elevated.enabled,
       allowed: params.elevated.allowed,

--- a/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
+++ b/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
@@ -38,4 +38,17 @@ describe("buildExecOverridePromptHint", () => {
     );
     expect(result).toContain("Current elevated level: full.");
   });
+
+  it("warns when auto-approved full access is unavailable", () => {
+    const result = buildExecOverridePromptHint({
+      elevatedLevel: "full",
+      fullAccessAvailable: false,
+      fullAccessBlockedReason: "runtime",
+    });
+
+    expect(result).toContain("Current elevated level: full.");
+    expect(result).toContain(
+      "Auto-approved /elevated full is unavailable here (runtime). Use ask/on instead and do not ask the user to switch to /elevated full.",
+    );
+  });
 });

--- a/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
+++ b/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
@@ -48,7 +48,7 @@ describe("buildExecOverridePromptHint", () => {
 
     expect(result).toContain("Current elevated level: full.");
     expect(result).toContain(
-      "Auto-approved /elevated full is unavailable here (runtime). Use ask/on instead and do not ask the user to switch to /elevated full.",
+      "Auto-approved /elevated full is unavailable here (runtime). Do not ask the user to switch to /elevated full.",
     );
   });
 });

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -48,12 +48,14 @@ vi.mock("../../process/command-queue.js", () => ({
   getQueueSize: vi.fn().mockReturnValue(0),
 }));
 
-vi.mock("../../routing/session-key.js", () => ({
-  DEFAULT_AGENT_ID: "main",
-  DEFAULT_MAIN_KEY: "main",
-  normalizeMainKey: vi.fn().mockReturnValue("main"),
-  normalizeAgentId: vi.fn((id?: string) => id ?? "default"),
-}));
+vi.mock(import("../../routing/session-key.js"), async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../routing/session-key.js")>();
+  return {
+    ...actual,
+    normalizeMainKey: () => "main",
+    normalizeAgentId: (id: string | undefined | null) => id ?? "default",
+  };
+});
 
 vi.mock("../../utils/provider-utils.js", () => ({
   isReasoningTagProvider: vi.fn().mockReturnValue(false),

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -49,6 +49,8 @@ vi.mock("../../process/command-queue.js", () => ({
 }));
 
 vi.mock("../../routing/session-key.js", () => ({
+  DEFAULT_AGENT_ID: "main",
+  DEFAULT_MAIN_KEY: "main",
   normalizeMainKey: vi.fn().mockReturnValue("main"),
   normalizeAgentId: vi.fn((id?: string) => id ?? "default"),
 }));

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -228,7 +228,7 @@ export async function runPreparedReply(
   const fullAccessState = resolveEmbeddedFullAccessState({
     sandboxEnabled: resolveSandboxRuntimeStatus({
       cfg,
-      sessionKey: ctx.SessionKey,
+      sessionKey,
     }).sandboxed,
     execElevated: {
       enabled: elevatedEnabled,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -4,7 +4,6 @@ import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
 import type { EmbeddedFullAccessBlockedReason } from "../../agents/pi-embedded-runner/types.js";
-import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
@@ -76,7 +75,7 @@ export function buildExecOverridePromptHint(params: {
   const elevatedLine = `Current elevated level: ${params.elevatedLevel}.`;
   const fullAccessLine =
     params.fullAccessAvailable === false
-      ? `Auto-approved /elevated full is unavailable here (${params.fullAccessBlockedReason ?? "runtime"}). Use ask/on instead and do not ask the user to switch to /elevated full.`
+      ? `Auto-approved /elevated full is unavailable here (${params.fullAccessBlockedReason ?? "runtime"}). Do not ask the user to switch to /elevated full.`
       : undefined;
   return [
     "## Current Exec Session State",
@@ -226,10 +225,6 @@ export async function runPreparedReply(
     isFastTestEnv: process.env.OPENCLAW_TEST_FAST === "1",
   });
   const fullAccessState = resolveEmbeddedFullAccessState({
-    sandboxEnabled: resolveSandboxRuntimeStatus({
-      cfg,
-      sessionKey,
-    }).sandboxed,
     execElevated: {
       enabled: elevatedEnabled,
       allowed: elevatedAllowed,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -2,6 +2,9 @@ import crypto from "node:crypto";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
+import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
+import type { EmbeddedFullAccessBlockedReason } from "../../agents/pi-embedded-runner/types.js";
+import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
@@ -53,6 +56,8 @@ type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node"
 export function buildExecOverridePromptHint(params: {
   execOverrides?: ExecOverrides;
   elevatedLevel: ElevatedLevel;
+  fullAccessAvailable?: boolean;
+  fullAccessBlockedReason?: EmbeddedFullAccessBlockedReason;
 }): string | undefined {
   const exec = params.execOverrides;
   if (!exec && params.elevatedLevel === "off") {
@@ -69,12 +74,19 @@ export function buildExecOverridePromptHint(params: {
       ? `Current session exec defaults: ${parts.join(" ")}.`
       : "Current session exec defaults: inherited from configured agent/global defaults.";
   const elevatedLine = `Current elevated level: ${params.elevatedLevel}.`;
+  const fullAccessLine =
+    params.fullAccessAvailable === false
+      ? `Auto-approved /elevated full is unavailable here (${params.fullAccessBlockedReason ?? "runtime"}). Use ask/on instead and do not ask the user to switch to /elevated full.`
+      : undefined;
   return [
     "## Current Exec Session State",
     execLine,
     elevatedLine,
+    fullAccessLine,
     "If the user asks to run a command, use the current exec state above. Do not assume a prior denial still applies after `/exec` or `/elevated` changed.",
-  ].join("\n");
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 let piEmbeddedRuntimePromise: Promise<typeof import("../../agents/pi-embedded.runtime.js")> | null =
@@ -213,6 +225,17 @@ export async function runPreparedReply(
     cfg,
     isFastTestEnv: process.env.OPENCLAW_TEST_FAST === "1",
   });
+  const fullAccessState = resolveEmbeddedFullAccessState({
+    sandboxEnabled: resolveSandboxRuntimeStatus({
+      cfg,
+      sessionKey: ctx.SessionKey,
+    }).sandboxed,
+    execElevated: {
+      enabled: elevatedEnabled,
+      allowed: elevatedAllowed,
+      defaultLevel: resolvedElevatedLevel ?? "off",
+    },
+  });
   let currentSystemSent = systemSent;
 
   const isFirstTurnInSession = isNewSession || !currentSystemSent;
@@ -261,6 +284,8 @@ export async function runPreparedReply(
     buildExecOverridePromptHint({
       execOverrides,
       elevatedLevel: resolvedElevatedLevel,
+      fullAccessAvailable: fullAccessState.available,
+      fullAccessBlockedReason: fullAccessState.blockedReason,
     }),
   ].filter(Boolean);
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
@@ -609,6 +634,10 @@ export async function runPreparedReply(
         enabled: elevatedEnabled,
         allowed: elevatedAllowed,
         defaultLevel: resolvedElevatedLevel ?? "off",
+        fullAccessAvailable: fullAccessState.available,
+        ...(fullAccessState.blockedReason
+          ? { fullAccessBlockedReason: fullAccessState.blockedReason }
+          : {}),
       },
       timeoutMs,
       blockReplyBreak: resolvedBlockStreamingBreak,

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -141,6 +141,31 @@ describe("loginOpenAICodexOAuth", () => {
     );
   });
 
+  it("normalizes slash-terminated authorize paths too", async () => {
+    const creds = {
+      provider: "openai-codex" as const,
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "user@example.com",
+    };
+    mocks.loginOpenAICodex.mockImplementation(
+      async (opts: { onAuth: (event: { url: string }) => Promise<void> }) => {
+        await opts.onAuth({
+          url: "https://auth.openai.com/oauth/authorize/?state=abc",
+        });
+        return creds;
+      },
+    );
+
+    const openUrl = vi.fn(async () => {});
+    await runCodexOAuth({ isRemote: false, openUrl });
+
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://auth.openai.com/oauth/authorize/?state=abc&scope=openid+profile+email+offline_access+model.request+api.responses.write",
+    );
+  });
+
   it("reports oauth errors and rethrows", async () => {
     mocks.loginOpenAICodex.mockRejectedValue(new Error("oauth failed"));
 

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -88,7 +88,7 @@ describe("loginOpenAICodexOAuth", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("passes through Pi-provided OAuth authorize URL without mutation", async () => {
+  it("adds required Codex OAuth scopes to Pi-provided authorize URLs", async () => {
     const creds = {
       provider: "openai-codex" as const,
       access: "access-token",
@@ -109,10 +109,35 @@ describe("loginOpenAICodexOAuth", () => {
     const { runtime } = await runCodexOAuth({ isRemote: false, openUrl });
 
     expect(openUrl).toHaveBeenCalledWith(
-      "https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access&state=abc",
+      "https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access+model.request+api.responses.write&state=abc",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Open: https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access&state=abc",
+      "Open: https://auth.openai.com/oauth/authorize?scope=openid+profile+email+offline_access+model.request+api.responses.write&state=abc",
+    );
+  });
+
+  it("adds a scope parameter when the upstream authorize url omitted it", async () => {
+    const creds = {
+      provider: "openai-codex" as const,
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "user@example.com",
+    };
+    mocks.loginOpenAICodex.mockImplementation(
+      async (opts: { onAuth: (event: { url: string }) => Promise<void> }) => {
+        await opts.onAuth({
+          url: "https://auth.openai.com/oauth/authorize?state=abc",
+        });
+        return creds;
+      },
+    );
+
+    const openUrl = vi.fn(async () => {});
+    await runCodexOAuth({ isRemote: false, openUrl });
+
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://auth.openai.com/oauth/authorize?state=abc&scope=openid+profile+email+offline_access+model.request+api.responses.write",
     );
   });
 

--- a/src/media/base64.ts
+++ b/src/media/base64.ts
@@ -36,15 +36,44 @@ export function estimateBase64DecodedBytes(base64: string): number {
   return Math.max(0, estimated);
 }
 
-const BASE64_CHARS_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+function isBase64DataChar(code: number): boolean {
+  return (
+    (code >= 0x41 && code <= 0x5a) ||
+    (code >= 0x61 && code <= 0x7a) ||
+    (code >= 0x30 && code <= 0x39) ||
+    code === 0x2b ||
+    code === 0x2f
+  );
+}
 
 /**
  * Normalize and validate a base64 string.
  * Returns canonical base64 (no whitespace) or undefined when invalid.
  */
 export function canonicalizeBase64(base64: string): string | undefined {
-  const cleaned = base64.replace(/\s+/g, "");
-  if (!cleaned || cleaned.length % 4 !== 0 || !BASE64_CHARS_RE.test(cleaned)) {
+  let cleaned = "";
+  let padding = 0;
+  let sawPadding = false;
+  for (let i = 0; i < base64.length; i += 1) {
+    const code = base64.charCodeAt(i);
+    if (code <= 0x20) {
+      continue;
+    }
+    if (code === 0x3d) {
+      padding += 1;
+      if (padding > 2) {
+        return undefined;
+      }
+      sawPadding = true;
+      cleaned += "=";
+      continue;
+    }
+    if (sawPadding || !isBase64DataChar(code)) {
+      return undefined;
+    }
+    cleaned += base64[i];
+  }
+  if (!cleaned || cleaned.length % 4 !== 0) {
     return undefined;
   }
   return cleaned;

--- a/src/plugins/provider-openai-codex-oauth.test.ts
+++ b/src/plugins/provider-openai-codex-oauth.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./provider-openai-codex-oauth.js";
+
+describe("provider-openai-codex-oauth", () => {
+  it("normalizes required scopes for slash-terminated authorize URLs", () => {
+    const normalized = __testing.normalizeOpenAICodexAuthorizeUrl(
+      "https://auth.openai.com/oauth/authorize/?scope=openid%20profile",
+    );
+    const url = new URL(normalized);
+    const scopes = new Set((url.searchParams.get("scope") ?? "").split(/\s+/).filter(Boolean));
+
+    expect(url.pathname).toBe("/oauth/authorize/");
+    expect(scopes).toEqual(
+      new Set([
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "model.request",
+        "api.responses.write",
+      ]),
+    );
+  });
+});

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -26,7 +26,7 @@ function normalizeOpenAICodexAuthorizeUrl(rawUrl: string): string {
   }
   try {
     const url = new URL(trimmed);
-    if (!/openai\.com$/i.test(url.hostname) || !/\/oauth\/authorize$/i.test(url.pathname)) {
+    if (!/(?:^|\.)openai\.com$/i.test(url.hostname) || !/\/oauth\/authorize$/i.test(url.pathname)) {
       return rawUrl;
     }
 

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -26,7 +26,10 @@ function normalizeOpenAICodexAuthorizeUrl(rawUrl: string): string {
   }
   try {
     const url = new URL(trimmed);
-    if (!/(?:^|\.)openai\.com$/i.test(url.hostname) || !/\/oauth\/authorize$/i.test(url.pathname)) {
+    if (
+      !/(?:^|\.)openai\.com$/i.test(url.hostname) ||
+      !/\/oauth\/authorize\/?$/i.test(url.pathname)
+    ) {
       return rawUrl;
     }
 

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -49,6 +49,10 @@ function normalizeOpenAICodexAuthorizeUrl(rawUrl: string): string {
   }
 }
 
+export const __testing = {
+  normalizeOpenAICodexAuthorizeUrl,
+};
+
 export async function loginOpenAICodexOAuth(params: {
   prompter: WizardPrompter;
   runtime: RuntimeEnv;

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -10,6 +10,41 @@ import {
 
 const manualInputPromptMessage = "Paste the authorization code (or full redirect URL):";
 const openAICodexOAuthOriginator = "openclaw";
+const OPENAI_CODEX_OAUTH_REQUIRED_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  "model.request",
+  "api.responses.write",
+] as const;
+
+function normalizeOpenAICodexAuthorizeUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return rawUrl;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (!/openai\.com$/i.test(url.hostname) || !/\/oauth\/authorize$/i.test(url.pathname)) {
+      return rawUrl;
+    }
+
+    const existing = new Set(
+      (url.searchParams.get("scope") ?? "")
+        .split(/\s+/)
+        .map((scope) => scope.trim())
+        .filter(Boolean),
+    );
+    for (const scope of OPENAI_CODEX_OAUTH_REQUIRED_SCOPES) {
+      existing.add(scope);
+    }
+    url.searchParams.set("scope", Array.from(existing).join(" "));
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
 
 export async function loginOpenAICodexOAuth(params: {
   prompter: WizardPrompter;
@@ -60,7 +95,11 @@ export async function loginOpenAICodexOAuth(params: {
     });
 
     const creds = await loginOpenAICodex({
-      onAuth: baseOnAuth,
+      onAuth: async (event) =>
+        await baseOnAuth({
+          ...event,
+          url: normalizeOpenAICodexAuthorizeUrl(event.url),
+        }),
       onPrompt,
       originator: openAICodexOAuthOriginator,
       onManualCodeInput: isRemote


### PR DESCRIPTION
## Summary

This is the compact runtime-truthfulness slice of the GPT-5.4 / Codex parity program tracked in #64227.

It combines the original Contract 1 auth/runtime truthfulness work from #64229 with the Contract 4 permission truthfulness work from #64231, so OpenClaw tells the truth about both provider/runtime failures and whether `/elevated full` is actually available.

## Scope

- Closes #64229
- Closes #64231
- Refs #64227
- combines auth/runtime failure classification with truthful full-access surfacing
- no tool-compat or replay/liveness scope in this PR
- no benchmark harness scope in this PR

## What changed

- normalize OpenAI Codex authorize URLs so the required scopes are always present:
  - `openid`
  - `profile`
  - `email`
  - `offline_access`
  - `model.request`
  - `api.responses.write`
- add typed provider/runtime failure classification for:
  - `auth_scope`
  - `auth_refresh`
  - `auth_html_403`
  - `proxy`
  - `dns`
  - `timeout`
  - `schema`
  - `sandbox_blocked`
  - `replay_invalid`
  - `unknown`
- thread `providerRuntimeFailureKind` through embedded-run observation fields and lifecycle logging
- surface more truthful user-facing copy for scope failures, refresh failures, HTML 403 auth failures, proxy/tunnel misroutes, and replay-invalid failures
- extend embedded elevated metadata with `fullAccessAvailable` and `fullAccessBlockedReason`
- advertise `/elevated full` only when auto-approved host exec is actually available for the current runtime
- update current exec hints so unavailable full access is explained precisely instead of being suggested as if it were always possible

## Validation

- full repo `check` stack completed while landing the combined branch commits
- `pnpm exec vitest run src/commands/openai-codex-oauth.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/failover-error.test.ts src/agents/pi-embedded-error-observation.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts src/agents/system-prompt.test.ts src/auto-reply/reply/get-reply-run.exec-hint.test.ts`

## Non-goals

- does not supersede #64230 or #64232
- does not widen the generic failover-reason enum for every caller in this slice
- does not introduce a new permission system
- does not change exec enforcement in `bash-tools.exec`
