### PR TITLE
fix(android): normalize IPv6 host input in manual gateway URLs

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -251,7 +251,16 @@ internal fun composeGatewayManualUrl(hostInput: String, portInput: String, tls: 
   }
   if (port !in 1..65535) return null
   val scheme = if (tls) "https" else "http"
-  return "$scheme://$host:$port"
+  val normalizedHost =
+    if (host.startsWith("[") && host.endsWith("]")) {
+      host
+    } else if (host.contains(':')) {
+      // Manual host input accepts raw IPv6 literals, but URLs require bracketed IPv6 hosts.
+      "[$host]"
+    } else {
+      host
+    }
+  return "$scheme://$normalizedHost:$port"
 }
 
 private fun parseJsonObject(input: String): JsonObject? {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -479,6 +479,13 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun composeGatewayManualUrlWrapsBareIpv6Hosts() {
+    val url = composeGatewayManualUrl("::1", "18789", tls = false)
+
+    assertEquals("http://[::1]:18789", url)
+  }
+
+  @Test
   fun resolveGatewayConnectConfigManualAcceptsTailscaleHostWithoutPort() {
     val resolved =
       resolveGatewayConnectConfig(
@@ -498,6 +505,28 @@ class GatewayConfigResolverTest {
     assertEquals("mydevice.tail1234.ts.net", resolved?.host)
     assertEquals(443, resolved?.port)
     assertEquals(true, resolved?.tls)
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigManualAcceptsBareIpv6LoopbackHost() {
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = false,
+        setupCode = "",
+        savedManualHost = "",
+        savedManualPort = "",
+        savedManualTls = false,
+        manualHostInput = "::1",
+        manualPortInput = "18789",
+        manualTlsInput = false,
+        fallbackBootstrapToken = "",
+        fallbackToken = "",
+        fallbackPassword = "",
+      )
+
+    assertEquals("::1", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
   }
 
   private fun encodeSetupCode(payloadJson: String): String {


### PR DESCRIPTION
## Summary
- Normalize raw IPv6 host input by wrapping it in brackets when constructing manual gateway URLs
- Ensure compatibility with URL formatting requirements for IPv6 addresses
- Add test coverage for bare IPv6 host inputs (e.g., ::1)

## Why
Manual gateway configuration accepted raw IPv6 literals, but URLs require IPv6 hosts to be enclosed in brackets. Without normalization, inputs like ::1 produced invalid URLs (e.g., http://::1:18789), causing connection failures.

## Testing
- Added unit test for IPv6 host normalization in GatewayConfigResolver
- Verified URL generation for both IPv4 and IPv6 inputs