### PR TITLE
benchmarks: add first-wave GPT-5.4 vs Opus 4.6 parity harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Plugins: allow plugin manifests to declare activation and setup descriptors so plugin setup flows can describe required auth, pairing, and configuration steps without hardcoded core special cases. (#64780)
 - Ollama: cache `/api/show` context-window and capability metadata during model discovery so repeated picker refreshes stop refetching unchanged models, while still retrying after empty responses and invalidating on digest changes. (#64753) Thanks @ImLukeF.
 - Models/providers: surface how configured OpenAI-compatible endpoints are classified in embedded-agent debug logs, so local and proxy routing issues are easier to diagnose. (#64754) Thanks @ImLukeF.
+- QA/parity: add the GPT-5.4 vs Opus 4.6 agentic parity report gate with shared scenario coverage checks, stricter evidence heuristics, and skipped-scenario accounting for maintainer review. (#64441) Thanks @100yenadmin.
 
 ### Fixes
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -105,6 +105,7 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 ### PR D
 
 - the scenario pack is understandable and reproducible
+- the pack includes a mutating replay-safety lane, not only read-only flows
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
 
@@ -141,6 +142,16 @@ The parity harness is not the only evidence source. Keep this split explicit in 
 
 - PR D owns the scenario-based GPT-5.4 vs Opus 4.6 comparison
 - PR B deterministic suites still own auth/proxy/DNS and full-access truthfulness evidence
+
+## Goal-to-evidence map
+
+| Completion gate item                     | Primary owner | Review artifact                                                     |
+| ---------------------------------------- | ------------- | ------------------------------------------------------------------- |
+| No plan-only stalls                      | PR A          | strict-agentic runtime tests and `approval-turn-tool-followthrough` |
+| No fake progress or fake tool completion | PR A + PR D   | parity fake-success count plus scenario-level report details        |
+| No false `/elevated full` guidance       | PR B          | deterministic runtime-truthfulness suites                           |
+| Replay/liveness failures remain explicit | PR C + PR D   | lifecycle/replay suites plus `compaction-retry-mutating-tool`       |
+| GPT-5.4 matches or beats Opus 4.6        | PR D          | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`  |
 
 ## Reviewer shorthand: before vs after
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -108,6 +108,12 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
 
+Expected artifacts from PR D:
+
+- `qa-suite-report.md` / `qa-suite-summary.json` for each model run
+- `qa-agentic-parity-report.md` with aggregate and scenario-level comparison
+- `qa-agentic-parity-summary.json` with a machine-readable verdict
+
 ## Release gate
 
 Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -141,3 +141,13 @@ The parity harness is not the only evidence source. Keep this split explicit in 
 
 - PR D owns the scenario-based GPT-5.4 vs Opus 4.6 comparison
 - PR B deterministic suites still own auth/proxy/DNS and full-access truthfulness evidence
+
+## Reviewer shorthand: before vs after
+
+| User-visible problem before                                 | Review signal after                                                                     |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| GPT-5.4 stopped after planning                              | PR A shows act-or-block behavior instead of commentary-only completion                  |
+| Tool use felt brittle with strict OpenAI/Codex schemas      | PR C keeps tool registration and parameter-free invocation predictable                  |
+| `/elevated full` hints were sometimes misleading            | PR B ties guidance to actual runtime capability and blocked reasons                     |
+| Long tasks could disappear into replay/compaction ambiguity | PR C emits explicit paused, blocked, abandoned, and replay-invalid state                |
+| Parity claims were anecdotal                                | PR D produces a report plus JSON verdict with the same scenario coverage on both models |

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,0 +1,118 @@
+# GPT-5.4 / Codex Parity Maintainer Notes
+
+This note explains how to review the GPT-5.4 / Codex parity program as four merge units without losing the original six-contract architecture.
+
+## Merge units
+
+### PR A: strict-agentic execution
+
+Owns:
+
+- `executionContract`
+- GPT-5-first same-turn follow-through
+- `update_plan` as non-terminal progress tracking
+- explicit blocked states instead of plan-only silent stops
+
+Does not own:
+
+- auth/runtime failure classification
+- permission truthfulness
+- replay/continuation redesign
+- parity benchmarking
+
+### PR B: runtime truthfulness
+
+Owns:
+
+- Codex OAuth scope correctness
+- typed provider/runtime failure classification
+- truthful `/elevated full` availability and blocked reasons
+
+Does not own:
+
+- tool schema normalization
+- replay/liveness state
+- benchmark gating
+
+### PR C: execution correctness
+
+Owns:
+
+- provider-owned OpenAI/Codex tool compatibility
+- parameter-free strict schema handling
+- replay-invalid surfacing
+- paused, blocked, and abandoned long-task state visibility
+
+Does not own:
+
+- self-elected continuation
+- generic Codex dialect behavior outside provider hooks
+- benchmark gating
+
+### PR D: parity harness
+
+Owns:
+
+- first-wave GPT-5.4 vs Opus 4.6 scenario pack
+- parity documentation
+- parity report and release-gate mechanics
+
+Does not own:
+
+- runtime behavior changes outside QA-lab
+- auth/proxy/DNS simulation inside the harness
+
+## Mapping back to the original six contracts
+
+| Original contract                        | Merge unit |
+| ---------------------------------------- | ---------- |
+| Provider transport/auth correctness      | PR B       |
+| Tool contract/schema compatibility       | PR C       |
+| Same-turn execution                      | PR A       |
+| Permission truthfulness                  | PR B       |
+| Replay/continuation/liveness correctness | PR C       |
+| Benchmark/release gate                   | PR D       |
+
+## Review order
+
+1. PR A
+2. PR B
+3. PR C
+4. PR D
+
+PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed.
+
+## What to look for
+
+### PR A
+
+- GPT-5 runs act or fail closed instead of stopping at commentary
+- `update_plan` no longer looks like progress by itself
+- behavior stays GPT-5-first and embedded-Pi scoped
+
+### PR B
+
+- auth/proxy/runtime failures stop collapsing into generic “model failed” handling
+- `/elevated full` is only described as available when it is actually available
+- blocked reasons are visible to both the model and the user-facing runtime
+
+### PR C
+
+- strict OpenAI/Codex tool registration behaves predictably
+- parameter-free tools do not fail strict schema checks
+- replay and compaction outcomes preserve truthful liveness state
+
+### PR D
+
+- the scenario pack is understandable and reproducible
+- reports are readable by humans and automation
+- parity claims are evidence-backed, not anecdotal
+
+## Release gate
+
+Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
+
+- PR A, PR B, and PR C are merged
+- PR D runs the first-wave parity pack cleanly
+- runtime-truthfulness regression suites remain green
+- the parity report shows no fake-success cases and no regression in stop behavior

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -122,3 +122,22 @@ Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
 - PR D runs the first-wave parity pack cleanly
 - runtime-truthfulness regression suites remain green
 - the parity report shows no fake-success cases and no regression in stop behavior
+
+```mermaid
+flowchart LR
+    A["PR A-C merged"] --> B["Run GPT-5.4 parity pack"]
+    A --> C["Run Opus 4.6 parity pack"]
+    B --> D["qa-suite-summary.json"]
+    C --> E["qa-suite-summary.json"]
+    D --> F["qa parity-report"]
+    E --> F
+    F --> G["Markdown report + JSON verdict"]
+    G --> H{"Pass?"}
+    H -- "yes" --> I["Parity claim allowed"]
+    H -- "no" --> J["Keep runtime fixes / review loop open"]
+```
+
+The parity harness is not the only evidence source. Keep this split explicit in review:
+
+- PR D owns the scenario-based GPT-5.4 vs Opus 4.6 comparison
+- PR B deterministic suites still own auth/proxy/DNS and full-access truthfulness evidence

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -51,7 +51,7 @@ The parity pack is the proof layer. It does not change runtime behavior by itsel
 After you have two `qa-suite-summary.json` artifacts, generate the release-gate comparison with:
 
 ```bash
-pnpm qa parity-report \
+pnpm openclaw qa parity-report \
   --repo-root . \
   --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
   --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
@@ -118,7 +118,7 @@ flowchart LR
     A --> C["Run Opus 4.6 parity pack"]
     B --> D["qa-suite-summary.json"]
     C --> E["qa-suite-summary.json"]
-    D --> F["qa parity-report"]
+    D --> F["openclaw qa parity-report"]
     E --> F
     F --> G["qa-agentic-parity-report.md"]
     F --> H["qa-agentic-parity-summary.json"]

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -48,6 +48,22 @@ This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be
 
 The parity pack is the proof layer. It does not change runtime behavior by itself.
 
+After you have two `qa-suite-summary.json` artifacts, generate the release-gate comparison with:
+
+```bash
+pnpm qa parity-report \
+  --repo-root . \
+  --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
+  --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+  --output-dir .artifacts/qa-e2e/parity
+```
+
+That command writes:
+
+- a human-readable Markdown report
+- a machine-readable JSON verdict
+- an explicit `pass` / `fail` gate result
+
 ## Why this improves GPT-5.4 in practice
 
 Before this work, GPT-5.4 on OpenClaw could feel less agentic than Opus in real coding sessions because the runtime tolerated behaviors that are especially harmful for GPT-5-style models:
@@ -115,6 +131,13 @@ Required outcomes:
 - no incorrect `/elevated full` guidance
 - no silent replay or compaction abandonment
 - parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline
+
+For the first-wave harness, the gate compares:
+
+- completion rate
+- unintended-stop rate
+- valid-tool-call rate
+- fake-success count
 
 ## Who should enable `strict-agentic`
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -1,0 +1,131 @@
+# GPT-5.4 / Codex Agentic Parity in OpenClaw
+
+OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Codex-style models were still underperforming in a few practical ways:
+
+- they could stop after planning instead of doing the work
+- they could use strict OpenAI/Codex tool schemas incorrectly
+- they could ask for `/elevated full` even when full access was impossible
+- they could lose long-running task state during replay or compaction
+- parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
+
+This parity program fixes those gaps in four reviewable slices.
+
+## What changed
+
+### PR A: strict-agentic execution
+
+This slice adds an opt-in `strict-agentic` execution contract for embedded Pi GPT-5 runs.
+
+When enabled, OpenClaw stops accepting plan-only turns as “good enough” completion. If the model only says what it intends to do and does not actually use tools or make progress, OpenClaw retries with an act-now steer and then fails closed with an explicit blocked state instead of silently ending the task.
+
+This improves the GPT-5.4 experience most on:
+
+- short “ok do it” follow-ups
+- code tasks where the first step is obvious
+- flows where `update_plan` should be progress tracking rather than filler text
+
+### PR B: runtime truthfulness
+
+This slice makes OpenClaw tell the truth about two things:
+
+- why the provider/runtime call failed
+- whether `/elevated full` is actually available
+
+That means GPT-5.4 gets better runtime signals for missing scope, auth refresh failures, HTML 403 auth failures, proxy issues, DNS or timeout failures, and blocked full-access modes. The model is less likely to hallucinate the wrong remediation or keep asking for a permission mode the runtime cannot provide.
+
+### PR C: execution correctness
+
+This slice improves two kinds of correctness:
+
+- provider-owned OpenAI/Codex tool-schema compatibility
+- replay and long-task liveness surfacing
+
+The tool-compat work reduces schema friction for strict OpenAI/Codex tool registration, especially around parameter-free tools and strict object-root expectations. The replay/liveness work makes long-running tasks more observable, so paused, blocked, and abandoned states are visible instead of disappearing into generic failure text.
+
+### PR D: parity harness
+
+This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be exercised through the same scenarios and compared using shared evidence.
+
+The parity pack is the proof layer. It does not change runtime behavior by itself.
+
+## Why this improves GPT-5.4 in practice
+
+Before this work, GPT-5.4 on OpenClaw could feel less agentic than Opus in real coding sessions because the runtime tolerated behaviors that are especially harmful for GPT-5-style models:
+
+- commentary-only turns
+- schema friction around tools
+- vague permission feedback
+- silent replay or compaction breakage
+
+The goal is not to make GPT-5.4 imitate Opus. The goal is to give GPT-5.4 a runtime contract that rewards real progress, supplies cleaner tool and permission semantics, and turns failure modes into explicit machine- and human-readable states.
+
+That changes the user experience from:
+
+- “the model had a good plan but stopped”
+
+to:
+
+- “the model either acted, or OpenClaw surfaced the exact reason it could not”
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A["User request"] --> B["Embedded Pi runtime"]
+    B --> C["Strict-agentic execution contract"]
+    B --> D["Provider-owned tool compatibility"]
+    B --> E["Runtime truthfulness"]
+    B --> F["Replay and liveness state"]
+    C --> G["Tool call or explicit blocked state"]
+    D --> G
+    E --> G
+    F --> G
+    G --> H["QA-lab parity pack"]
+    H --> I["Scenario report and parity gate"]
+```
+
+## Scenario pack
+
+The first-wave parity pack currently covers four scenarios:
+
+### `approval-turn-tool-followthrough`
+
+Checks that the model does not stop at “I’ll do that” after a short approval. It should take the first concrete action in the same turn.
+
+### `model-switch-tool-continuity`
+
+Checks that tool-using work remains coherent across model/runtime switching boundaries instead of resetting into commentary or losing execution context.
+
+### `source-docs-discovery-report`
+
+Checks that the model can read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping early.
+
+### `image-understanding-attachment`
+
+Checks that mixed-mode tasks involving attachments remain actionable and do not collapse into vague narration.
+
+## Release gate
+
+GPT-5.4 can only be considered at parity or better when the merged runtime passes the parity pack and the runtime-truthfulness regressions at the same time.
+
+Required outcomes:
+
+- no plan-only stall when the next tool action is clear
+- no fake completion without real execution
+- no incorrect `/elevated full` guidance
+- no silent replay or compaction abandonment
+- parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline
+
+## Who should enable `strict-agentic`
+
+Use `strict-agentic` when:
+
+- the agent is expected to act immediately when a next step is obvious
+- GPT-5.4 or Codex-family models are the primary runtime
+- you prefer explicit blocked states over “helpful” recap-only replies
+
+Keep the default contract when:
+
+- you want the existing looser behavior
+- you are not using GPT-5-family models
+- you are testing prompts rather than runtime enforcement

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -129,7 +129,7 @@ flowchart LR
 
 ## Scenario pack
 
-The first-wave parity pack currently covers four scenarios:
+The first-wave parity pack currently covers five scenarios:
 
 ### `approval-turn-tool-followthrough`
 
@@ -147,14 +147,19 @@ Checks that the model can read source and docs, synthesize findings, and continu
 
 Checks that mixed-mode tasks involving attachments remain actionable and do not collapse into vague narration.
 
+### `compaction-retry-mutating-tool`
+
+Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
+
 ## Scenario matrix
 
-| Scenario                           | What it tests                          | Good GPT-5.4 behavior                                                         | Failure signal                                                                |
-| ---------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `approval-turn-tool-followthrough` | Short approval turns after a plan      | Starts the first concrete tool action immediately instead of restating intent | plan-only follow-up, no tool activity, or blocked turn without a real blocker |
-| `model-switch-tool-continuity`     | Runtime/model switching under tool use | Preserves task context and continues acting coherently                        | resets into commentary, loses tool context, or stops after switch             |
-| `source-docs-discovery-report`     | Source reading + synthesis + action    | Finds sources, uses tools, and produces a useful report without stalling      | thin summary, missing tool work, or incomplete-turn stop                      |
-| `image-understanding-attachment`   | Attachment-driven agentic work         | Interprets the attachment, connects it to tools, and continues the task       | vague narration, attachment ignored, or no concrete next action               |
+| Scenario                           | What it tests                           | Good GPT-5.4 behavior                                                          | Failure signal                                                                 |
+| ---------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `approval-turn-tool-followthrough` | Short approval turns after a plan       | Starts the first concrete tool action immediately instead of restating intent  | plan-only follow-up, no tool activity, or blocked turn without a real blocker  |
+| `model-switch-tool-continuity`     | Runtime/model switching under tool use  | Preserves task context and continues acting coherently                         | resets into commentary, loses tool context, or stops after switch              |
+| `source-docs-discovery-report`     | Source reading + synthesis + action     | Finds sources, uses tools, and produces a useful report without stalling       | thin summary, missing tool work, or incomplete-turn stop                       |
+| `image-understanding-attachment`   | Attachment-driven agentic work          | Interprets the attachment, connects it to tools, and continues the task        | vague narration, attachment ignored, or no concrete next action                |
+| `compaction-retry-mutating-tool`   | Mutating work under compaction pressure | Performs a real write and keeps replay-unsafety explicit after the side effect | mutating write happens but replay safety is implied, missing, or contradictory |
 
 ## Release gate
 
@@ -179,6 +184,16 @@ Parity evidence is intentionally split across two layers:
 
 - PR D proves same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
 - PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
+
+## Goal-to-evidence matrix
+
+| Completion gate item                                     | Owning PR   | Evidence source                                                    | Pass signal                                                                              |
+| -------------------------------------------------------- | ----------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| GPT-5.4 no longer stalls after planning                  | PR A        | `approval-turn-tool-followthrough` plus PR A runtime suites        | approval turns trigger real work or an explicit blocked state                            |
+| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D | parity report scenario outcomes and fake-success count             | no suspicious pass results and no commentary-only completion                             |
+| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B        | deterministic truthfulness suites                                  | blocked reasons and full-access hints stay runtime-accurate                              |
+| Replay/liveness failures stay explicit                   | PR C + PR D | PR C lifecycle/replay suites plus `compaction-retry-mutating-tool` | mutating work keeps replay-unsafety explicit instead of silently disappearing            |
+| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json` | same scenario coverage and no regression on completion, stop behavior, or valid tool use |
 
 ## How to read the parity verdict
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -83,6 +83,16 @@ to:
 
 - “the model either acted, or OpenClaw surfaced the exact reason it could not”
 
+## Before vs after for GPT-5.4 users
+
+| Before this program                                                                            | After PR A-D                                                                             |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| GPT-5.4 could stop after a reasonable plan without taking the next tool step                   | PR A turns “plan only” into “act now or surface a blocked state”                         |
+| Strict tool schemas could reject parameter-free or OpenAI/Codex-shaped tools in confusing ways | PR C makes provider-owned tool registration and invocation more predictable              |
+| `/elevated full` guidance could be vague or wrong in blocked runtimes                          | PR B gives GPT-5.4 and the user truthful runtime and permission hints                    |
+| Replay or compaction failures could feel like the task silently disappeared                    | PR C surfaces paused, blocked, abandoned, and replay-invalid outcomes explicitly         |
+| “GPT-5.4 feels worse than Opus” was mostly anecdotal                                           | PR D turns that into the same scenario pack, the same metrics, and a hard pass/fail gate |
+
 ## Architecture
 
 ```mermaid
@@ -169,6 +179,15 @@ Parity evidence is intentionally split across two layers:
 
 - PR D proves same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
 - PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
+
+## How to read the parity verdict
+
+Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the first-wave parity pack.
+
+- `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and did not regress on the agreed aggregate metrics.
+- `fail` means at least one hard gate tripped: weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, or mismatched scenario coverage.
+- “shared/base CI issue” is not itself a parity result. If CI noise outside PR D blocks a run, the verdict should wait for a clean merged-runtime execution instead of being inferred from branch-era logs.
+- Auth, proxy, DNS, and `/elevated full` truthfulness still come from PR B’s deterministic suites, so the final release claim needs both: a passing PR D parity verdict and green PR B truthfulness coverage.
 
 ## Who should enable `strict-agentic`
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -100,6 +100,23 @@ flowchart TD
     H --> I["Scenario report and parity gate"]
 ```
 
+## Release flow
+
+```mermaid
+flowchart LR
+    A["Merged runtime slices (PR A-C)"] --> B["Run GPT-5.4 parity pack"]
+    A --> C["Run Opus 4.6 parity pack"]
+    B --> D["qa-suite-summary.json"]
+    C --> E["qa-suite-summary.json"]
+    D --> F["qa parity-report"]
+    E --> F
+    F --> G["qa-agentic-parity-report.md"]
+    F --> H["qa-agentic-parity-summary.json"]
+    H --> I{"Gate pass?"}
+    I -- "yes" --> J["Evidence-backed parity claim"]
+    I -- "no" --> K["Keep runtime/review loop open"]
+```
+
 ## Scenario pack
 
 The first-wave parity pack currently covers four scenarios:
@@ -120,6 +137,15 @@ Checks that the model can read source and docs, synthesize findings, and continu
 
 Checks that mixed-mode tasks involving attachments remain actionable and do not collapse into vague narration.
 
+## Scenario matrix
+
+| Scenario                           | What it tests                          | Good GPT-5.4 behavior                                                         | Failure signal                                                                |
+| ---------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `approval-turn-tool-followthrough` | Short approval turns after a plan      | Starts the first concrete tool action immediately instead of restating intent | plan-only follow-up, no tool activity, or blocked turn without a real blocker |
+| `model-switch-tool-continuity`     | Runtime/model switching under tool use | Preserves task context and continues acting coherently                        | resets into commentary, loses tool context, or stops after switch             |
+| `source-docs-discovery-report`     | Source reading + synthesis + action    | Finds sources, uses tools, and produces a useful report without stalling      | thin summary, missing tool work, or incomplete-turn stop                      |
+| `image-understanding-attachment`   | Attachment-driven agentic work         | Interprets the attachment, connects it to tools, and continues the task       | vague narration, attachment ignored, or no concrete next action               |
+
 ## Release gate
 
 GPT-5.4 can only be considered at parity or better when the merged runtime passes the parity pack and the runtime-truthfulness regressions at the same time.
@@ -138,6 +164,11 @@ For the first-wave harness, the gate compares:
 - unintended-stop rate
 - valid-tool-call rate
 - fake-success count
+
+Parity evidence is intentionally split across two layers:
+
+- PR D proves same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
+- PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
 
 ## Who should enable `strict-agentic`
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildQaAgenticParityComparison,
+  computeQaAgenticParityMetrics,
+  renderQaAgenticParityMarkdownReport,
+  type QaParitySuiteSummary,
+} from "./agentic-parity-report.js";
+
+describe("qa agentic parity report", () => {
+  it("computes first-wave parity metrics from suite summaries", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        { name: "Scenario A", status: "pass" },
+        { name: "Scenario B", status: "fail", details: "incomplete turn detected" },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary)).toEqual({
+      totalScenarios: 2,
+      passedScenarios: 1,
+      failedScenarios: 1,
+      completionRate: 0.5,
+      unintendedStopCount: 1,
+      unintendedStopRate: 0.5,
+      validToolCallCount: 1,
+      validToolCallRate: 0.5,
+      fakeSuccessCount: 0,
+    });
+  });
+
+  it("fails the parity gate when the candidate regresses against baseline", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: [
+          { name: "Scenario A", status: "pass" },
+          { name: "Scenario B", status: "fail", details: "timed out before it continued" },
+        ],
+      },
+      baselineSummary: {
+        scenarios: [
+          { name: "Scenario A", status: "pass" },
+          { name: "Scenario B", status: "pass" },
+        ],
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "openai/gpt-5.4 completion rate 50.0% is below anthropic/claude-opus-4-6 100.0%.",
+    );
+    expect(comparison.failures).toContain(
+      "openai/gpt-5.4 unintended-stop rate 50.0% exceeds anthropic/claude-opus-4-6 0.0%.",
+    );
+  });
+
+  it("renders a readable markdown parity report", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: [{ name: "Scenario A", status: "pass" }],
+      },
+      baselineSummary: {
+        scenarios: [{ name: "Scenario A", status: "pass" }],
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const report = renderQaAgenticParityMarkdownReport(comparison);
+
+    expect(report).toContain("# OpenClaw GPT-5.4 / Opus 4.6 Agentic Parity Report");
+    expect(report).toContain("| Completion rate | 100.0% | 100.0% |");
+    expect(report).toContain("### Scenario A");
+    expect(report).toContain("- Verdict: pass");
+  });
+});

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -130,6 +130,27 @@ describe("qa agentic parity report", () => {
     );
   });
 
+  it("ignores neutral Failed and Blocked headings in passing protocol reports", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Source and docs discovery report",
+          status: "pass",
+          details: `Worked:
+- Read the seeded QA material.
+Failed:
+- None observed.
+Blocked:
+- No live provider evidence in this lane.
+Follow-up:
+- Re-run with a real provider if needed.`,
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
   it("renders a readable markdown parity report", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -137,6 +137,7 @@ describe("qa agentic parity report", () => {
       candidateSummary: {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Compaction retry after mutating tool", status: "pass" },
           { name: "Model switch with tool continuity", status: "pass" },
           { name: "Source and docs discovery report", status: "pass" },
           { name: "Image understanding from attachment", status: "pass" },
@@ -145,6 +146,7 @@ describe("qa agentic parity report", () => {
       baselineSummary: {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Compaction retry after mutating tool", status: "pass" },
           { name: "Model switch with tool continuity", status: "pass" },
           { name: "Source and docs discovery report", status: "pass" },
           { name: "Image understanding from attachment", status: "pass" },

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -78,15 +78,77 @@ describe("qa agentic parity report", () => {
     );
   });
 
+  it("fails the parity gate when required first-wave scenarios are missing on both sides", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
+      },
+      baselineSummary: {
+        scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "Missing required first-wave parity scenario coverage for Image understanding from attachment: openai/gpt-5.4=missing, anthropic/claude-opus-4-6=missing.",
+    );
+  });
+
+  it("fails the parity gate when the baseline contains suspicious pass results", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: [
+          { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
+        ],
+      },
+      baselineSummary: {
+        scenarios: [
+          {
+            name: "Approval turn tool followthrough",
+            status: "pass",
+            details: "timed out before it continued",
+          },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
+        ],
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "anthropic/claude-opus-4-6 produced 1 suspicious pass result(s); baseline fake-success count must also be 0.",
+    );
+  });
+
   it("renders a readable markdown parity report", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: [{ name: "Scenario A", status: "pass" }],
+        scenarios: [
+          { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
+        ],
       },
       baselineSummary: {
-        scenarios: [{ name: "Scenario A", status: "pass" }],
+        scenarios: [
+          { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
+        ],
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -95,7 +157,7 @@ describe("qa agentic parity report", () => {
 
     expect(report).toContain("# OpenClaw GPT-5.4 / Opus 4.6 Agentic Parity Report");
     expect(report).toContain("| Completion rate | 100.0% | 100.0% |");
-    expect(report).toContain("### Scenario A");
+    expect(report).toContain("### Approval turn tool followthrough");
     expect(report).toContain("- Verdict: pass");
   });
 });

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -78,7 +78,7 @@ describe("qa agentic parity report", () => {
     );
   });
 
-  it("fails the parity gate when required first-wave scenarios are missing on both sides", () => {
+  it("fails the parity gate when required parity scenarios are missing on both sides", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
@@ -93,7 +93,38 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "Missing required first-wave parity scenario coverage for Image understanding from attachment: openai/gpt-5.4=missing, anthropic/claude-opus-4-6=missing.",
+      "Missing required parity scenario coverage for Image understanding from attachment: openai/gpt-5.4=missing, anthropic/claude-opus-4-6=missing.",
+    );
+  });
+
+  it("fails the parity gate when required parity scenarios are skipped", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: [
+          { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Compaction retry after mutating tool", status: "skip" },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
+        ],
+      },
+      baselineSummary: {
+        scenarios: [
+          { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Compaction retry after mutating tool", status: "skip" },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
+        ],
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "Missing required parity scenario coverage for Compaction retry after mutating tool: openai/gpt-5.4=skip, anthropic/claude-opus-4-6=skip.",
     );
   });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -56,6 +56,28 @@ describe("qa agentic parity report", () => {
     );
   });
 
+  it("fails the parity gate when candidate and baseline cover different scenarios", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: [{ name: "Scenario A", status: "pass" }],
+      },
+      baselineSummary: {
+        scenarios: [
+          { name: "Scenario A", status: "pass" },
+          { name: "Scenario B", status: "pass" },
+        ],
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "Scenario coverage mismatch for Scenario B: openai/gpt-5.4=missing, anthropic/claude-opus-4-6=pass.",
+    );
+  });
+
   it("renders a readable markdown parity report", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -34,14 +34,24 @@ describe("qa agentic parity report", () => {
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
         scenarios: [
-          { name: "Scenario A", status: "pass" },
-          { name: "Scenario B", status: "fail", details: "timed out before it continued" },
+          { name: "Approval turn tool followthrough", status: "pass" },
+          {
+            name: "Compaction retry after mutating tool",
+            status: "fail",
+            details: "timed out before it continued",
+          },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
         ],
       },
       baselineSummary: {
         scenarios: [
-          { name: "Scenario A", status: "pass" },
-          { name: "Scenario B", status: "pass" },
+          { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Compaction retry after mutating tool", status: "pass" },
+          { name: "Model switch with tool continuity", status: "pass" },
+          { name: "Source and docs discovery report", status: "pass" },
+          { name: "Image understanding from attachment", status: "pass" },
         ],
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -49,33 +59,102 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "openai/gpt-5.4 completion rate 50.0% is below anthropic/claude-opus-4-6 100.0%.",
+      "openai/gpt-5.4 completion rate 80.0% is below anthropic/claude-opus-4-6 100.0%.",
     );
     expect(comparison.failures).toContain(
-      "openai/gpt-5.4 unintended-stop rate 50.0% exceeds anthropic/claude-opus-4-6 0.0%.",
+      "openai/gpt-5.4 unintended-stop rate 20.0% exceeds anthropic/claude-opus-4-6 0.0%.",
     );
   });
 
-  it("fails the parity gate when candidate and baseline cover different scenarios", () => {
+  it("fails the parity gate when candidate and baseline cover different non-parity scenarios", () => {
+    const baselineScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Extra non-parity lane", status: "pass" as const },
+    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: [{ name: "Scenario A", status: "pass" }],
+        scenarios: baselineScenarios.filter(
+          (scenario) => scenario.name !== "Extra non-parity lane",
+        ),
       },
-      baselineSummary: {
-        scenarios: [
-          { name: "Scenario A", status: "pass" },
-          { name: "Scenario B", status: "pass" },
-        ],
-      },
+      baselineSummary: { scenarios: baselineScenarios },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "Scenario coverage mismatch for Scenario B: openai/gpt-5.4=missing, anthropic/claude-opus-4-6=pass.",
+      "Scenario coverage mismatch for Extra non-parity lane: openai/gpt-5.4=missing, anthropic/claude-opus-4-6=pass.",
     );
+  });
+
+  it("reports each missing required parity scenario exactly once (no double-counting)", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
+      },
+      baselineSummary: {
+        scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    const missingScenario = "Image understanding from attachment";
+    const requiredLines = comparison.failures.filter((failure) =>
+      failure.includes(`Missing required parity scenario coverage for ${missingScenario}:`),
+    );
+    const mismatchLines = comparison.failures.filter((failure) =>
+      failure.includes(`Scenario coverage mismatch for ${missingScenario}:`),
+    );
+    expect(requiredLines).toHaveLength(1);
+    expect(mismatchLines).toHaveLength(0);
+  });
+
+  it("scopes parity metrics to declared parity scenarios even when extra lanes are present", () => {
+    const scopedSummary = {
+      scenarios: [
+        { name: "Approval turn tool followthrough", status: "pass" as const },
+        { name: "Compaction retry after mutating tool", status: "pass" as const },
+        { name: "Model switch with tool continuity", status: "pass" as const },
+        { name: "Source and docs discovery report", status: "pass" as const },
+        { name: "Image understanding from attachment", status: "pass" as const },
+      ],
+    };
+    const summaryWithExtras = {
+      scenarios: [
+        ...scopedSummary.scenarios,
+        { name: "Extra lane A", status: "fail" as const, details: "timed out" },
+        { name: "Extra lane B", status: "fail" as const, details: "timed out" },
+      ],
+    };
+
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: summaryWithExtras,
+      baselineSummary: scopedSummary,
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    // Extra lanes must not drag the candidate's completion rate below baseline
+    // and must not generate unintended-stop or fake-success hits.
+    expect(comparison.candidateMetrics.totalScenarios).toBe(5);
+    expect(comparison.candidateMetrics.completionRate).toBe(1);
+    expect(comparison.candidateMetrics.unintendedStopRate).toBe(0);
+    expect(comparison.candidateMetrics.fakeSuccessCount).toBe(0);
+    // The pass/fail verdict here still depends only on the parity pack itself.
+    const regressionFailures = comparison.failures.filter((failure) =>
+      failure.includes("completion rate"),
+    );
+    expect(regressionFailures).toEqual([]);
   });
 
   it("fails the parity gate when required parity scenarios are missing on both sides", () => {
@@ -129,12 +208,15 @@ describe("qa agentic parity report", () => {
   });
 
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
+    // Cover the full first-wave pack on both sides so the suspicious-pass assertion
+    // below is the isolated gate failure under test (no coverage-gap noise).
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
+          { name: "Compaction retry after mutating tool", status: "pass" },
           { name: "Model switch with tool continuity", status: "pass" },
           { name: "Source and docs discovery report", status: "pass" },
           { name: "Image understanding from attachment", status: "pass" },
@@ -147,6 +229,7 @@ describe("qa agentic parity report", () => {
             status: "pass",
             details: "timed out before it continued",
           },
+          { name: "Compaction retry after mutating tool", status: "pass" },
           { name: "Model switch with tool continuity", status: "pass" },
           { name: "Source and docs discovery report", status: "pass" },
           { name: "Image understanding from attachment", status: "pass" },
@@ -156,9 +239,9 @@ describe("qa agentic parity report", () => {
     });
 
     expect(comparison.pass).toBe(false);
-    expect(comparison.failures).toContain(
+    expect(comparison.failures).toEqual([
       "anthropic/claude-opus-4-6 produced 1 suspicious pass result(s); baseline fake-success count must also be 0.",
-    );
+    ]);
   });
 
   it("ignores neutral Failed and Blocked headings in passing protocol reports", () => {
@@ -180,6 +263,44 @@ Follow-up:
     };
 
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
+  it("ignores neutral error-budget and no-errors-observed phrasing in passing reports", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Source and docs discovery report",
+          status: "pass",
+          details: `Worked:
+- Scenario finished with Error budget: 0.
+- No errors found in the seeded material.
+- Errors: none observed.`,
+        },
+        {
+          name: "Image understanding from attachment",
+          status: "pass",
+          details: "Error: none. The attached image analysis completed without incident.",
+        },
+      ],
+    };
+
+    // Bare "error"/"Error" in narration is not a suspicious-pass signal on its own.
+    // Only phrases like "error occurred" or "an error was ..." should count.
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
+  it("still flags genuine error-narration suspicious passes", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Approval turn tool followthrough",
+          status: "pass",
+          details: "Tool call completed, but an error occurred mid-turn and no retry happened.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
   });
 
   it("renders a readable markdown parity report", () => {

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -170,6 +170,14 @@ export function buildQaAgenticParityComparison(params: {
     });
 
   const failures: string[] = [];
+  const coverageMismatch = scenarioComparisons.filter(
+    (scenario) => scenario.candidateStatus === "missing" || scenario.baselineStatus === "missing",
+  );
+  for (const scenario of coverageMismatch) {
+    failures.push(
+      `Scenario coverage mismatch for ${scenario.name}: ${params.candidateLabel}=${scenario.candidateStatus}, ${params.baselineLabel}=${scenario.baselineStatus}.`,
+    );
+  }
   if (candidateMetrics.completionRate < baselineMetrics.completionRate) {
     failures.push(
       `${params.candidateLabel} completion rate ${formatPercent(candidateMetrics.completionRate)} is below ${params.baselineLabel} ${formatPercent(baselineMetrics.completionRate)}.`,

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -68,11 +68,12 @@ const SUSPICIOUS_PASS_PATTERNS = [
   /incomplete turn/i,
   /\btimed out\b/i,
   /\btimeout\b/i,
-  /\berror\b/i,
   /\bfailed to\b/i,
   /\bcould not\b/i,
   /\bunable to\b/i,
   /did not continue/i,
+  /error occurred/i,
+  /an error was/i,
 ] as const;
 
 function normalizeScenarioStatus(status: string | undefined): "pass" | "fail" | "skip" {
@@ -144,6 +145,18 @@ function requiredCoverageStatus(
   return scenario ? normalizeScenarioStatus(scenario.status) : "missing";
 }
 
+function scopeSummaryToParityPack(
+  summary: QaParitySuiteSummary,
+  parityTitleSet: ReadonlySet<string>,
+): QaParitySuiteSummary {
+  // The parity verdict must only consider the declared first-wave parity scenarios.
+  // Drop `counts` so the metric helper recomputes totals from the filtered scenario
+  // list instead of inheriting the caller's full-suite counters.
+  return {
+    scenarios: summary.scenarios.filter((scenario) => parityTitleSet.has(scenario.name)),
+  };
+}
+
 export function buildQaAgenticParityComparison(params: {
   candidateLabel: string;
   baselineLabel: string;
@@ -151,8 +164,17 @@ export function buildQaAgenticParityComparison(params: {
   baselineSummary: QaParitySuiteSummary;
   comparedAt?: string;
 }): QaAgenticParityComparison {
-  const candidateMetrics = computeQaAgenticParityMetrics(params.candidateSummary);
-  const baselineMetrics = computeQaAgenticParityMetrics(params.baselineSummary);
+  const parityTitleSet: ReadonlySet<string> = new Set<string>(QA_AGENTIC_PARITY_SCENARIO_TITLES);
+  // Rates and fake-success counts are computed from the parity-scoped summaries only,
+  // so extra non-parity scenarios in the input (for example when a caller feeds a full
+  // qa-suite-summary.json rather than a --parity-pack agentic run) cannot influence
+  // the gate verdict.
+  const candidateMetrics = computeQaAgenticParityMetrics(
+    scopeSummaryToParityPack(params.candidateSummary, parityTitleSet),
+  );
+  const baselineMetrics = computeQaAgenticParityMetrics(
+    scopeSummaryToParityPack(params.baselineSummary, parityTitleSet),
+  );
 
   const scenarioNames = new Set([
     ...QA_AGENTIC_PARITY_SCENARIO_TITLES,
@@ -201,8 +223,15 @@ export function buildQaAgenticParityComparison(params: {
       `Missing required parity scenario coverage for ${scenario.name}: ${params.candidateLabel}=${scenario.candidateStatus}, ${params.baselineLabel}=${scenario.baselineStatus}.`,
     );
   }
+  // Required parity scenarios are already reported via `requiredScenarioCoverage`
+  // above; excluding them here keeps the operator-facing failure list from
+  // double-counting the same missing scenario (one "Missing required parity scenario
+  // coverage for X" line plus a "Scenario coverage mismatch for X" line on the same
+  // scenario).
   const coverageMismatch = scenarioComparisons.filter(
-    (scenario) => scenario.candidateStatus === "missing" || scenario.baselineStatus === "missing",
+    (scenario) =>
+      !parityTitleSet.has(scenario.name) &&
+      (scenario.candidateStatus === "missing" || scenario.baselineStatus === "missing"),
   );
   for (const scenario of coverageMismatch) {
     failures.push(

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -138,6 +138,12 @@ function formatPercent(value: number) {
   return `${(value * 100).toFixed(1)}%`;
 }
 
+function requiredCoverageStatus(
+  scenario: QaParityReportScenario | undefined,
+): "pass" | "fail" | "skip" | "missing" {
+  return scenario ? normalizeScenarioStatus(scenario.status) : "missing";
+}
+
 export function buildQaAgenticParityComparison(params: {
   candidateLabel: string;
   baselineLabel: string;
@@ -175,12 +181,24 @@ export function buildQaAgenticParityComparison(params: {
     });
 
   const failures: string[] = [];
-  const requiredScenarioCoverage = QA_AGENTIC_PARITY_SCENARIO_TITLES.filter(
-    (name) => !candidateByName.has(name) || !baselineByName.has(name),
+  const requiredScenarioCoverage = QA_AGENTIC_PARITY_SCENARIO_TITLES.map((name) => {
+    const candidate = candidateByName.get(name);
+    const baseline = baselineByName.get(name);
+    return {
+      name,
+      candidateStatus: requiredCoverageStatus(candidate),
+      baselineStatus: requiredCoverageStatus(baseline),
+    };
+  }).filter(
+    (scenario) =>
+      scenario.candidateStatus === "missing" ||
+      scenario.baselineStatus === "missing" ||
+      scenario.candidateStatus === "skip" ||
+      scenario.baselineStatus === "skip",
   );
-  for (const name of requiredScenarioCoverage) {
+  for (const scenario of requiredScenarioCoverage) {
     failures.push(
-      `Missing required first-wave parity scenario coverage for ${name}: ${params.candidateLabel}=${candidateByName.has(name) ? "present" : "missing"}, ${params.baselineLabel}=${baselineByName.has(name) ? "present" : "missing"}.`,
+      `Missing required parity scenario coverage for ${scenario.name}: ${params.candidateLabel}=${scenario.candidateStatus}, ${params.baselineLabel}=${scenario.baselineStatus}.`,
     );
   }
   const coverageMismatch = scenarioComparisons.filter(

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -1,3 +1,5 @@
+import { QA_AGENTIC_PARITY_SCENARIO_TITLES } from "./agentic-parity.js";
+
 export type QaParityReportStep = {
   name: string;
   status: "pass" | "fail" | "skip";
@@ -170,6 +172,14 @@ export function buildQaAgenticParityComparison(params: {
     });
 
   const failures: string[] = [];
+  const requiredScenarioCoverage = QA_AGENTIC_PARITY_SCENARIO_TITLES.filter(
+    (name) => !candidateByName.has(name) || !baselineByName.has(name),
+  );
+  for (const name of requiredScenarioCoverage) {
+    failures.push(
+      `Missing required first-wave parity scenario coverage for ${name}: ${params.candidateLabel}=${candidateByName.has(name) ? "present" : "missing"}, ${params.baselineLabel}=${baselineByName.has(name) ? "present" : "missing"}.`,
+    );
+  }
   const coverageMismatch = scenarioComparisons.filter(
     (scenario) => scenario.candidateStatus === "missing" || scenario.baselineStatus === "missing",
   );
@@ -196,6 +206,11 @@ export function buildQaAgenticParityComparison(params: {
   if (candidateMetrics.fakeSuccessCount > 0) {
     failures.push(
       `${params.candidateLabel} produced ${candidateMetrics.fakeSuccessCount} suspicious pass result(s); fake-success count must be 0.`,
+    );
+  }
+  if (baselineMetrics.fakeSuccessCount > 0) {
+    failures.push(
+      `${params.baselineLabel} produced ${baselineMetrics.fakeSuccessCount} suspicious pass result(s); baseline fake-success count must also be 0.`,
     );
   }
 

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -147,6 +147,7 @@ export function buildQaAgenticParityComparison(params: {
   const baselineMetrics = computeQaAgenticParityMetrics(params.baselineSummary);
 
   const scenarioNames = new Set([
+    ...QA_AGENTIC_PARITY_SCENARIO_TITLES,
     ...params.candidateSummary.scenarios.map((scenario) => scenario.name),
     ...params.baselineSummary.scenarios.map((scenario) => scenario.name),
   ]);

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -68,9 +68,11 @@ const SUSPICIOUS_PASS_PATTERNS = [
   /incomplete turn/i,
   /\btimed out\b/i,
   /\btimeout\b/i,
-  /\bblocked\b/i,
   /\berror\b/i,
-  /\bfailed\b/i,
+  /\bfailed to\b/i,
+  /\bcould not\b/i,
+  /\bunable to\b/i,
+  /did not continue/i,
 ] as const;
 
 function normalizeScenarioStatus(status: string | undefined): "pass" | "fail" | "skip" {

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -1,0 +1,259 @@
+export type QaParityReportStep = {
+  name: string;
+  status: "pass" | "fail" | "skip";
+  details?: string;
+};
+
+export type QaParityReportScenario = {
+  name: string;
+  status: "pass" | "fail" | "skip";
+  details?: string;
+  steps?: QaParityReportStep[];
+};
+
+export type QaParitySuiteSummary = {
+  scenarios: QaParityReportScenario[];
+  counts?: {
+    total?: number;
+    passed?: number;
+    failed?: number;
+  };
+};
+
+export type QaAgenticParityMetrics = {
+  totalScenarios: number;
+  passedScenarios: number;
+  failedScenarios: number;
+  completionRate: number;
+  unintendedStopCount: number;
+  unintendedStopRate: number;
+  validToolCallCount: number;
+  validToolCallRate: number;
+  fakeSuccessCount: number;
+};
+
+export type QaAgenticParityScenarioComparison = {
+  name: string;
+  candidateStatus: "pass" | "fail" | "skip" | "missing";
+  baselineStatus: "pass" | "fail" | "skip" | "missing";
+  candidateDetails?: string;
+  baselineDetails?: string;
+};
+
+export type QaAgenticParityComparison = {
+  candidateLabel: string;
+  baselineLabel: string;
+  comparedAt: string;
+  candidateMetrics: QaAgenticParityMetrics;
+  baselineMetrics: QaAgenticParityMetrics;
+  scenarioComparisons: QaAgenticParityScenarioComparison[];
+  pass: boolean;
+  failures: string[];
+  notes: string[];
+};
+
+const UNINTENDED_STOP_PATTERNS = [
+  /incomplete turn/i,
+  /\btimed out\b/i,
+  /\btimeout\b/i,
+  /\bstopped\b/i,
+  /\bblocked\b/i,
+  /\babandoned\b/i,
+  /did not continue/i,
+] as const;
+
+const SUSPICIOUS_PASS_PATTERNS = [
+  /incomplete turn/i,
+  /\btimed out\b/i,
+  /\btimeout\b/i,
+  /\bblocked\b/i,
+  /\berror\b/i,
+  /\bfailed\b/i,
+] as const;
+
+function normalizeScenarioStatus(status: string | undefined): "pass" | "fail" | "skip" {
+  return status === "pass" || status === "fail" || status === "skip" ? status : "fail";
+}
+
+function scenarioText(scenario: QaParityReportScenario) {
+  const parts = [scenario.details ?? ""];
+  for (const step of scenario.steps ?? []) {
+    parts.push(step.details ?? "");
+  }
+  return parts.filter(Boolean).join("\n");
+}
+
+function scenarioHasPattern(
+  scenario: QaParityReportScenario,
+  patterns: readonly RegExp[],
+): boolean {
+  const text = scenarioText(scenario);
+  return text.length > 0 && patterns.some((pattern) => pattern.test(text));
+}
+
+export function computeQaAgenticParityMetrics(
+  summary: QaParitySuiteSummary,
+): QaAgenticParityMetrics {
+  const scenarios = summary.scenarios.map((scenario) => ({
+    ...scenario,
+    status: normalizeScenarioStatus(scenario.status),
+  }));
+  const totalScenarios = summary.counts?.total ?? scenarios.length;
+  const passedScenarios =
+    summary.counts?.passed ?? scenarios.filter((scenario) => scenario.status === "pass").length;
+  const failedScenarios =
+    summary.counts?.failed ?? scenarios.filter((scenario) => scenario.status === "fail").length;
+  const unintendedStopCount = scenarios.filter(
+    (scenario) =>
+      scenario.status !== "pass" && scenarioHasPattern(scenario, UNINTENDED_STOP_PATTERNS),
+  ).length;
+  const fakeSuccessCount = scenarios.filter(
+    (scenario) =>
+      scenario.status === "pass" && scenarioHasPattern(scenario, SUSPICIOUS_PASS_PATTERNS),
+  ).length;
+
+  // First-wave parity scenarios are all tool-mediated tasks, so a passing scenario is our
+  // verified unit of valid tool-backed execution in this harness.
+  const validToolCallCount = passedScenarios;
+
+  const rate = (value: number) => (totalScenarios > 0 ? value / totalScenarios : 0);
+  return {
+    totalScenarios,
+    passedScenarios,
+    failedScenarios,
+    completionRate: rate(passedScenarios),
+    unintendedStopCount,
+    unintendedStopRate: rate(unintendedStopCount),
+    validToolCallCount,
+    validToolCallRate: rate(validToolCallCount),
+    fakeSuccessCount,
+  };
+}
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function buildQaAgenticParityComparison(params: {
+  candidateLabel: string;
+  baselineLabel: string;
+  candidateSummary: QaParitySuiteSummary;
+  baselineSummary: QaParitySuiteSummary;
+  comparedAt?: string;
+}): QaAgenticParityComparison {
+  const candidateMetrics = computeQaAgenticParityMetrics(params.candidateSummary);
+  const baselineMetrics = computeQaAgenticParityMetrics(params.baselineSummary);
+
+  const scenarioNames = new Set([
+    ...params.candidateSummary.scenarios.map((scenario) => scenario.name),
+    ...params.baselineSummary.scenarios.map((scenario) => scenario.name),
+  ]);
+  const candidateByName = new Map(
+    params.candidateSummary.scenarios.map((scenario) => [scenario.name, scenario]),
+  );
+  const baselineByName = new Map(
+    params.baselineSummary.scenarios.map((scenario) => [scenario.name, scenario]),
+  );
+
+  const scenarioComparisons = [...scenarioNames]
+    .toSorted((left, right) => left.localeCompare(right))
+    .map((name) => {
+      const candidate = candidateByName.get(name);
+      const baseline = baselineByName.get(name);
+      return {
+        name,
+        candidateStatus: candidate ? normalizeScenarioStatus(candidate.status) : "missing",
+        baselineStatus: baseline ? normalizeScenarioStatus(baseline.status) : "missing",
+        ...(candidate?.details ? { candidateDetails: candidate.details } : {}),
+        ...(baseline?.details ? { baselineDetails: baseline.details } : {}),
+      } satisfies QaAgenticParityScenarioComparison;
+    });
+
+  const failures: string[] = [];
+  if (candidateMetrics.completionRate < baselineMetrics.completionRate) {
+    failures.push(
+      `${params.candidateLabel} completion rate ${formatPercent(candidateMetrics.completionRate)} is below ${params.baselineLabel} ${formatPercent(baselineMetrics.completionRate)}.`,
+    );
+  }
+  if (candidateMetrics.unintendedStopRate > baselineMetrics.unintendedStopRate) {
+    failures.push(
+      `${params.candidateLabel} unintended-stop rate ${formatPercent(candidateMetrics.unintendedStopRate)} exceeds ${params.baselineLabel} ${formatPercent(baselineMetrics.unintendedStopRate)}.`,
+    );
+  }
+  if (candidateMetrics.validToolCallRate < baselineMetrics.validToolCallRate) {
+    failures.push(
+      `${params.candidateLabel} valid-tool-call rate ${formatPercent(candidateMetrics.validToolCallRate)} is below ${params.baselineLabel} ${formatPercent(baselineMetrics.validToolCallRate)}.`,
+    );
+  }
+  if (candidateMetrics.fakeSuccessCount > 0) {
+    failures.push(
+      `${params.candidateLabel} produced ${candidateMetrics.fakeSuccessCount} suspicious pass result(s); fake-success count must be 0.`,
+    );
+  }
+
+  return {
+    candidateLabel: params.candidateLabel,
+    baselineLabel: params.baselineLabel,
+    comparedAt: params.comparedAt ?? new Date().toISOString(),
+    candidateMetrics,
+    baselineMetrics,
+    scenarioComparisons,
+    pass: failures.length === 0,
+    failures,
+    notes: [
+      "First-wave valid-tool-call rate is scenario-level and uses passing tool-mediated scenarios as the verified numerator.",
+      "Auth/proxy/DNS correctness is intentionally out of scope for this parity report and should be gated by the deterministic runtime-truthfulness suites.",
+    ],
+  };
+}
+
+export function renderQaAgenticParityMarkdownReport(comparison: QaAgenticParityComparison): string {
+  const lines = [
+    "# OpenClaw GPT-5.4 / Opus 4.6 Agentic Parity Report",
+    "",
+    `- Compared at: ${comparison.comparedAt}`,
+    `- Candidate: ${comparison.candidateLabel}`,
+    `- Baseline: ${comparison.baselineLabel}`,
+    `- Verdict: ${comparison.pass ? "pass" : "fail"}`,
+    "",
+    "## Aggregate Metrics",
+    "",
+    "| Metric | Candidate | Baseline |",
+    "| --- | ---: | ---: |",
+    `| Completion rate | ${formatPercent(comparison.candidateMetrics.completionRate)} | ${formatPercent(comparison.baselineMetrics.completionRate)} |`,
+    `| Unintended-stop rate | ${formatPercent(comparison.candidateMetrics.unintendedStopRate)} | ${formatPercent(comparison.baselineMetrics.unintendedStopRate)} |`,
+    `| Valid-tool-call rate | ${formatPercent(comparison.candidateMetrics.validToolCallRate)} | ${formatPercent(comparison.baselineMetrics.validToolCallRate)} |`,
+    `| Fake-success count | ${comparison.candidateMetrics.fakeSuccessCount} | ${comparison.baselineMetrics.fakeSuccessCount} |`,
+    "",
+  ];
+
+  if (comparison.failures.length > 0) {
+    lines.push("## Gate Failures", "");
+    for (const failure of comparison.failures) {
+      lines.push(`- ${failure}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Scenario Comparison", "");
+  for (const scenario of comparison.scenarioComparisons) {
+    lines.push(`### ${scenario.name}`, "");
+    lines.push(`- ${comparison.candidateLabel}: ${scenario.candidateStatus}`);
+    lines.push(`- ${comparison.baselineLabel}: ${scenario.baselineStatus}`);
+    if (scenario.candidateDetails) {
+      lines.push(`- ${comparison.candidateLabel} details: ${scenario.candidateDetails}`);
+    }
+    if (scenario.baselineDetails) {
+      lines.push(`- ${comparison.baselineLabel} details: ${scenario.baselineDetails}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Notes", "");
+  for (const note of comparison.notes) {
+    lines.push(`- ${note}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -1,5 +1,3 @@
-import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
-
 export const QA_AGENTIC_PARITY_PACK = "agentic";
 
 export const QA_AGENTIC_PARITY_SCENARIO_IDS = [
@@ -21,18 +19,6 @@ export function resolveQaParityPackScenarioIds(params: {
   if (normalizedPack !== QA_AGENTIC_PARITY_PACK) {
     throw new Error(
       `--parity-pack must be "${QA_AGENTIC_PARITY_PACK}", got "${params.parityPack}"`,
-    );
-  }
-
-  const availableScenarioIds = new Set(
-    readQaBootstrapScenarioCatalog().scenarios.map((scenario) => scenario.id),
-  );
-  const missingScenarioIds = QA_AGENTIC_PARITY_SCENARIO_IDS.filter(
-    (scenarioId) => !availableScenarioIds.has(scenarioId),
-  );
-  if (missingScenarioIds.length > 0) {
-    throw new Error(
-      `qa parity pack references missing scenarios: ${missingScenarioIds.join(", ")}`,
     );
   }
 

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -1,0 +1,40 @@
+import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
+
+export const QA_AGENTIC_PARITY_PACK = "agentic";
+
+export const QA_AGENTIC_PARITY_SCENARIO_IDS = [
+  "approval-turn-tool-followthrough",
+  "model-switch-tool-continuity",
+  "source-docs-discovery-report",
+  "image-understanding-attachment",
+] as const;
+
+export function resolveQaParityPackScenarioIds(params: {
+  parityPack?: string;
+  scenarioIds?: string[];
+}): string[] {
+  const normalizedPack = params.parityPack?.trim().toLowerCase();
+  const explicitScenarioIds = [...new Set(params.scenarioIds ?? [])];
+  if (!normalizedPack) {
+    return explicitScenarioIds;
+  }
+  if (normalizedPack !== QA_AGENTIC_PARITY_PACK) {
+    throw new Error(
+      `--parity-pack must be "${QA_AGENTIC_PARITY_PACK}", got "${params.parityPack}"`,
+    );
+  }
+
+  const availableScenarioIds = new Set(
+    readQaBootstrapScenarioCatalog().scenarios.map((scenario) => scenario.id),
+  );
+  const missingScenarioIds = QA_AGENTIC_PARITY_SCENARIO_IDS.filter(
+    (scenarioId) => !availableScenarioIds.has(scenarioId),
+  );
+  if (missingScenarioIds.length > 0) {
+    throw new Error(
+      `qa parity pack references missing scenarios: ${missingScenarioIds.join(", ")}`,
+    );
+  }
+
+  return [...new Set([...explicitScenarioIds, ...QA_AGENTIC_PARITY_SCENARIO_IDS])];
+}

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -17,6 +17,10 @@ export const QA_AGENTIC_PARITY_SCENARIOS = [
     id: "image-understanding-attachment",
     title: "Image understanding from attachment",
   },
+  {
+    id: "compaction-retry-mutating-tool",
+    title: "Compaction retry after mutating tool",
+  },
 ] as const;
 
 export const QA_AGENTIC_PARITY_SCENARIO_IDS = QA_AGENTIC_PARITY_SCENARIOS.map(({ id }) => id);

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -1,11 +1,28 @@
 export const QA_AGENTIC_PARITY_PACK = "agentic";
 
-export const QA_AGENTIC_PARITY_SCENARIO_IDS = [
-  "approval-turn-tool-followthrough",
-  "model-switch-tool-continuity",
-  "source-docs-discovery-report",
-  "image-understanding-attachment",
+export const QA_AGENTIC_PARITY_SCENARIOS = [
+  {
+    id: "approval-turn-tool-followthrough",
+    title: "Approval turn tool followthrough",
+  },
+  {
+    id: "model-switch-tool-continuity",
+    title: "Model switch with tool continuity",
+  },
+  {
+    id: "source-docs-discovery-report",
+    title: "Source and docs discovery report",
+  },
+  {
+    id: "image-understanding-attachment",
+    title: "Image understanding from attachment",
+  },
 ] as const;
+
+export const QA_AGENTIC_PARITY_SCENARIO_IDS = QA_AGENTIC_PARITY_SCENARIOS.map(({ id }) => id);
+export const QA_AGENTIC_PARITY_SCENARIO_TITLES = QA_AGENTIC_PARITY_SCENARIOS.map(
+  ({ title }) => title,
+);
 
 export function resolveQaParityPackScenarioIds(params: {
   parityPack?: string;

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -315,6 +315,27 @@ describe("qa cli runtime", () => {
     );
   });
 
+  it("expands the agentic parity pack onto the suite scenario list", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      parityPack: "agentic",
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(runQaSuiteFromRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoRoot: path.resolve("/tmp/openclaw-repo"),
+        scenarioIds: [
+          "channel-chat-baseline",
+          "approval-turn-tool-followthrough",
+          "model-switch-tool-continuity",
+          "source-docs-discovery-report",
+          "image-understanding-attachment",
+        ],
+      }),
+    );
+  });
+
   it("rejects unknown suite CLI auth modes", async () => {
     await expect(
       runQaSuiteCommand({
@@ -323,7 +344,6 @@ describe("qa cli runtime", () => {
       }),
     ).rejects.toThrow("--cli-auth-mode must be one of auto, api-key, subscription");
   });
-
   it("resolves character eval paths and passes model refs through", async () => {
     await runQaCharacterEvalCommand({
       repoRoot: "/tmp/openclaw-repo",

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -70,6 +72,7 @@ import {
   runQaDockerUpCommand,
   runQaCharacterEvalCommand,
   runQaManualLaneCommand,
+  runQaParityReportCommand,
   runQaSuiteCommand,
 } from "./cli.runtime.js";
 import { runQaMatrixCommand } from "./live-transports/matrix/cli.runtime.js";
@@ -344,6 +347,41 @@ describe("qa cli runtime", () => {
       }),
     ).rejects.toThrow("--cli-auth-mode must be one of auto, api-key, subscription");
   });
+
+  it("sets a failing exit code when the parity gate fails", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-parity-"));
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      await fs.writeFile(
+        path.join(repoRoot, "candidate.json"),
+        JSON.stringify({
+          scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
+        }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(repoRoot, "baseline.json"),
+        JSON.stringify({
+          scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
+        }),
+        "utf8",
+      );
+
+      await runQaParityReportCommand({
+        repoRoot,
+        candidateSummary: "candidate.json",
+        baselineSummary: "baseline.json",
+      });
+
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = priorExitCode;
+      await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("resolves character eval paths and passes model refs through", async () => {
     await runQaCharacterEvalCommand({
       repoRoot: "/tmp/openclaw-repo",

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -334,6 +334,7 @@ describe("qa cli runtime", () => {
           "model-switch-tool-continuity",
           "source-docs-discovery-report",
           "image-understanding-attachment",
+          "compaction-retry-mutating-tool",
         ],
       }),
     );

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -331,6 +331,9 @@ export async function runQaParityReportCommand(opts: {
   process.stdout.write(`QA parity report: ${reportPath}\n`);
   process.stdout.write(`QA parity summary: ${summaryPath}\n`);
   process.stdout.write(`QA parity verdict: ${comparison.pass ? "pass" : "fail"}\n`);
+  if (!comparison.pass) {
+    process.exitCode = 1;
+  }
 }
 export async function runQaCharacterEvalCommand(opts: {
   repoRoot?: string;

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { resolveQaParityPackScenarioIds } from "./agentic-parity.js";
 import { runQaCharacterEval, type QaCharacterModelOptions } from "./character-eval.js";
 import { resolveRepoRelativeOutputDir } from "./cli-paths.js";
 import { buildQaDockerHarnessImage, writeQaDockerHarnessFiles } from "./docker-harness.js";
@@ -213,6 +214,7 @@ export async function runQaSuiteCommand(opts: {
   alternateModel?: string;
   fastMode?: boolean;
   cliAuthMode?: string;
+  parityPack?: string;
   scenarioIds?: string[];
   concurrency?: number;
   image?: string;
@@ -222,6 +224,10 @@ export async function runQaSuiteCommand(opts: {
 }) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const runner = (opts.runner ?? "host").trim().toLowerCase();
+  const scenarioIds = resolveQaParityPackScenarioIds({
+    parityPack: opts.parityPack,
+    scenarioIds: opts.scenarioIds,
+  });
   if (runner !== "host" && runner !== "multipass") {
     throw new Error(`--runner must be one of host or multipass, got "${opts.runner}".`);
   }
@@ -247,7 +253,7 @@ export async function runQaSuiteCommand(opts: {
       primaryModel: opts.primaryModel,
       alternateModel: opts.alternateModel,
       fastMode: opts.fastMode,
-      scenarioIds: opts.scenarioIds,
+      scenarioIds,
       ...(opts.concurrency !== undefined
         ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }
         : {}),
@@ -271,7 +277,7 @@ export async function runQaSuiteCommand(opts: {
     alternateModel: opts.alternateModel,
     fastMode: opts.fastMode,
     ...(claudeCliAuthMode ? { claudeCliAuthMode } : {}),
-    scenarioIds: opts.scenarioIds,
+    scenarioIds,
     ...(opts.concurrency !== undefined
       ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }
       : {}),

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -1,4 +1,10 @@
+import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  buildQaAgenticParityComparison,
+  renderQaAgenticParityMarkdownReport,
+  type QaParitySuiteSummary,
+} from "./agentic-parity-report.js";
 import { resolveQaParityPackScenarioIds } from "./agentic-parity.js";
 import { runQaCharacterEval, type QaCharacterModelOptions } from "./character-eval.js";
 import { resolveRepoRelativeOutputDir } from "./cli-paths.js";
@@ -287,6 +293,45 @@ export async function runQaSuiteCommand(opts: {
   process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
 }
 
+export async function runQaParityReportCommand(opts: {
+  repoRoot?: string;
+  candidateSummary: string;
+  baselineSummary: string;
+  candidateLabel?: string;
+  baselineLabel?: string;
+  outputDir?: string;
+}) {
+  const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const outputDir =
+    resolveRepoRelativeOutputDir(repoRoot, opts.outputDir) ??
+    path.join(repoRoot, ".artifacts", "qa-e2e", `parity-${Date.now().toString(36)}`);
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const candidateSummaryPath = path.resolve(repoRoot, opts.candidateSummary);
+  const baselineSummaryPath = path.resolve(repoRoot, opts.baselineSummary);
+  const candidateSummary = JSON.parse(
+    await fs.readFile(candidateSummaryPath, "utf8"),
+  ) as QaParitySuiteSummary;
+  const baselineSummary = JSON.parse(
+    await fs.readFile(baselineSummaryPath, "utf8"),
+  ) as QaParitySuiteSummary;
+
+  const comparison = buildQaAgenticParityComparison({
+    candidateLabel: opts.candidateLabel?.trim() || "openai/gpt-5.4",
+    baselineLabel: opts.baselineLabel?.trim() || "anthropic/claude-opus-4-6",
+    candidateSummary,
+    baselineSummary,
+  });
+  const report = renderQaAgenticParityMarkdownReport(comparison);
+  const reportPath = path.join(outputDir, "qa-agentic-parity-report.md");
+  const summaryPath = path.join(outputDir, "qa-agentic-parity-summary.json");
+  await fs.writeFile(reportPath, report, "utf8");
+  await fs.writeFile(summaryPath, `${JSON.stringify(comparison, null, 2)}\n`, "utf8");
+
+  process.stdout.write(`QA parity report: ${reportPath}\n`);
+  process.stdout.write(`QA parity summary: ${summaryPath}\n`);
+  process.stdout.write(`QA parity verdict: ${comparison.pass ? "pass" : "fail"}\n`);
+}
 export async function runQaCharacterEvalCommand(opts: {
   repoRoot?: string;
   outputDir?: string;

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -39,6 +39,17 @@ async function runQaSuite(opts: {
   await runtime.runQaSuiteCommand(opts);
 }
 
+async function runQaParityReport(opts: {
+  repoRoot?: string;
+  candidateSummary: string;
+  baselineSummary: string;
+  candidateLabel?: string;
+  baselineLabel?: string;
+  outputDir?: string;
+}) {
+  const runtime = await loadQaLabCliRuntime();
+  await runtime.runQaParityReportCommand(opts);
+}
 async function runQaCharacterEval(opts: {
   repoRoot?: string;
   outputDir?: string;
@@ -205,6 +216,27 @@ export function registerQaLabCli(program: Command) {
           memory: opts.memory,
           disk: opts.disk,
         });
+      },
+    );
+
+  qa.command("parity-report")
+    .description("Compare two QA suite summaries and write an agentic parity gate report")
+    .requiredOption("--candidate-summary <path>", "Candidate qa-suite-summary.json path")
+    .requiredOption("--baseline-summary <path>", "Baseline qa-suite-summary.json path")
+    .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
+    .option("--candidate-label <label>", "Candidate display label", "openai/gpt-5.4")
+    .option("--baseline-label <label>", "Baseline display label", "anthropic/claude-opus-4-6")
+    .option("--output-dir <path>", "Artifact directory for the parity report")
+    .action(
+      async (opts: {
+        repoRoot?: string;
+        candidateSummary: string;
+        baselineSummary: string;
+        candidateLabel?: string;
+        baselineLabel?: string;
+        outputDir?: string;
+      }) => {
+        await runQaParityReport(opts);
       },
     );
 

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -26,6 +26,7 @@ async function runQaSuite(opts: {
   alternateModel?: string;
   fastMode?: boolean;
   cliAuthMode?: string;
+  parityPack?: string;
   scenarioIds?: string[];
   concurrency?: number;
   runner?: string;
@@ -159,6 +160,7 @@ export function registerQaLabCli(program: Command) {
       "--cli-auth-mode <mode>",
       "CLI backend auth mode for live Claude CLI runs: auto, api-key, or subscription",
     )
+    .option("--parity-pack <name>", 'Preset scenario pack; currently only "agentic" is supported')
     .option("--scenario <id>", "Run only the named QA scenario (repeatable)", collectString, [])
     .option("--concurrency <count>", "Scenario worker concurrency", (value: string) =>
       Number(value),
@@ -177,6 +179,7 @@ export function registerQaLabCli(program: Command) {
         model?: string;
         altModel?: string;
         cliAuthMode?: string;
+        parityPack?: string;
         scenario?: string[];
         concurrency?: number;
         fast?: boolean;
@@ -194,6 +197,7 @@ export function registerQaLabCli(program: Command) {
           alternateModel: opts.altModel,
           fastMode: opts.fast,
           cliAuthMode: opts.cliAuthMode,
+          parityPack: opts.parityPack,
           scenarioIds: opts.scenario,
           concurrency: opts.concurrency,
           image: opts.image,

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -171,7 +171,7 @@ export function registerQaLabCli(program: Command) {
       "--cli-auth-mode <mode>",
       "CLI backend auth mode for live Claude CLI runs: auto, api-key, or subscription",
     )
-    .option("--parity-pack <name>", 'Preset scenario pack; currently only "agentic" is supported')
+    .option("--parity-pack <name>", "Preset scenario pack; currently only \"agentic\" is supported")
     .option("--scenario <id>", "Run only the named QA scenario (repeatable)", collectString, [])
     .option("--concurrency <count>", "Scenario worker concurrency", (value: string) =>
       Number(value),

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -169,6 +169,77 @@ describe("qa mock openai server", () => {
     ]);
   });
 
+  it("drives the compaction retry mutating tool parity flow", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const writePlan = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: true,
+        model: "gpt-5.4",
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.",
+              },
+            ],
+          },
+          {
+            type: "function_call_output",
+            output: "compaction retry evidence block 0000\ncompaction retry evidence block 0001",
+          },
+        ],
+      }),
+    });
+    expect(writePlan.status).toBe(200);
+    const writePlanBody = await writePlan.text();
+    expect(writePlanBody).toContain('"name":"write"');
+    expect(writePlanBody).toContain("compaction-retry-summary.txt");
+
+    const finalReply = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: false,
+        model: "gpt-5.4",
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.",
+              },
+            ],
+          },
+          {
+            type: "function_call_output",
+            output: "Replay safety: unsafe after write.\n",
+          },
+        ],
+      }),
+    });
+    expect(finalReply.status).toBe(200);
+    const finalPayload = (await finalReply.json()) as {
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    };
+    expect(finalPayload.output?.[0]?.content?.[0]?.text).toContain("replay unsafe after write");
+  });
+
   it("supports exact reply memory prompts and embeddings requests", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -228,7 +228,7 @@ describe("qa mock openai server", () => {
           },
           {
             type: "function_call_output",
-            output: "Replay safety: unsafe after write.\n",
+            output: "Successfully wrote 41 bytes to compaction-retry-summary.txt.",
           },
         ],
       }),

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -452,6 +452,12 @@ function buildAssistantText(input: ResponsesInputItem[], body: Record<string, un
     }
     return `Protocol note: Lobster Invaders built at lobster-invaders.html.`;
   }
+  if (toolOutput && /compaction retry mutating tool check/i.test(prompt)) {
+    if (toolOutput.includes("Replay safety: unsafe after write.")) {
+      return "Protocol note: replay unsafe after write.";
+    }
+    return "";
+  }
   if (toolOutput) {
     const snippet = toolOutput.replace(/\s+/g, " ").trim().slice(0, 220);
     return `Protocol note: I reviewed the requested material. Evidence snippet: ${snippet || "no content"}`;
@@ -538,6 +544,17 @@ async function buildResponsesPayload(body: Record<string, unknown>) {
   <head><meta charset="utf-8" /><title>Lobster Invaders</title></head>
   <body><h1>Lobster Invaders</h1><p>Tiny playable stub.</p></body>
 </html>`,
+      });
+    }
+  }
+  if (/compaction retry mutating tool check/i.test(prompt)) {
+    if (!toolOutput) {
+      return buildToolCallEventsWithArgs("read", { path: "COMPACTION_RETRY_CONTEXT.md" });
+    }
+    if (toolOutput.includes("compaction retry evidence")) {
+      return buildToolCallEventsWithArgs("write", {
+        path: "compaction-retry-summary.txt",
+        content: "Replay safety: unsafe after write.\n",
       });
     }
   }

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -453,7 +453,12 @@ function buildAssistantText(input: ResponsesInputItem[], body: Record<string, un
     return `Protocol note: Lobster Invaders built at lobster-invaders.html.`;
   }
   if (toolOutput && /compaction retry mutating tool check/i.test(prompt)) {
-    if (toolOutput.includes("Replay safety: unsafe after write.")) {
+    if (
+      toolOutput.includes("Replay safety: unsafe after write.") ||
+      /compaction-retry-summary\.txt/i.test(toolOutput) ||
+      /successfully (?:wrote|replaced)/i.test(toolOutput) ||
+      /\bwrote\b.*\bcompaction-retry-summary\.txt\b/i.test(toolOutput)
+    ) {
       return "Protocol note: replay unsafe after write.";
     }
     return "";

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  QA_AGENTIC_PARITY_SCENARIO_IDS,
   listQaScenarioMarkdownPaths,
   readQaBootstrapScenarioCatalog,
   readQaScenarioById,
@@ -33,6 +34,11 @@ describe("qa scenario catalog", () => {
     expect(catalog.scenarios.some((scenario) => scenario.id === "subagent-fanout-synthesis")).toBe(
       true,
     );
+    expect(
+      QA_AGENTIC_PARITY_SCENARIO_IDS.every((scenarioId) =>
+        catalog.scenarios.some((scenario) => scenario.id === scenarioId),
+      ),
+    ).toBe(true);
   });
 
   it("loads scenario-specific execution config from per-scenario markdown", () => {

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { QA_AGENTIC_PARITY_SCENARIO_IDS } from "./agentic-parity.js";
 import {
-  QA_AGENTIC_PARITY_SCENARIO_IDS,
   listQaScenarioMarkdownPaths,
   readQaBootstrapScenarioCatalog,
   readQaScenarioById,

--- a/qa/frontier-harness-plan.md
+++ b/qa/frontier-harness-plan.md
@@ -7,6 +7,7 @@ Use this when tuning the harness on frontier models before the small-model pass.
 - verify tool-first behavior on short approval turns
 - verify model switching does not kill tool use
 - verify repo-reading / discovery still finishes with a concrete report
+- verify mutating work keeps replay-unsafety explicit under compaction pressure
 - collect manual notes on personality without letting style hide execution regressions
 
 ## Frontier subset
@@ -19,6 +20,7 @@ Run this subset first on every harness tweak:
 
 Longer spot-check after that:
 
+- `compaction-retry-mutating-tool`
 - `subagent-handoff`
 
 ## Baseline order
@@ -84,6 +86,7 @@ Use the QA Lab runner catalog or `openclaw models list --all` to pick the curren
 - empty-promise rate
 - tool continuity after model switch
 - discovery report completeness and specificity
+- replay-safety truth after a mutating write
 - scope drift: unrelated scenario updates, grand wrap-ups, or invented completion tallies
 - latency / obvious stall behavior
 - token cost notes if a change makes the prompt materially heavier
@@ -126,4 +129,4 @@ Score it on:
 
 ## Deferred
 
-- post-compaction next-action continuity should become an executable lane once we have a deterministic compaction trigger in QA
+- deterministic mock compaction triggering is still deferred; the current replay-safety lane is a live-frontier-first executable scenario

--- a/qa/scenarios/compaction-retry-mutating-tool.md
+++ b/qa/scenarios/compaction-retry-mutating-tool.md
@@ -1,0 +1,98 @@
+# Compaction retry after mutating tool
+
+```yaml qa-scenario
+id: compaction-retry-mutating-tool
+title: Compaction retry after mutating tool
+surface: runtime
+objective: Verify a real mutating tool step keeps replay-unsafety explicit instead of disappearing into a clean-looking success if the run compacts or retries.
+successCriteria:
+  - Agent reads the seeded large context before it writes.
+  - Agent performs a real mutating write in the workspace.
+  - Final reply explicitly says replay is unsafe after the write instead of implying replay-safe completion.
+  - Scenario details preserve the observed compaction count for review context.
+docsRefs:
+  - docs/help/testing.md
+  - docs/help/gpt54-codex-agentic-parity.md
+codeRefs:
+  - extensions/qa-lab/src/suite.ts
+  - extensions/qa-lab/src/mock-openai-server.ts
+  - src/agents/pi-embedded-subscribe.ts
+  - src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+execution:
+  kind: flow
+  summary: Verify a mutating tool step keeps replay-unsafety explicit through compaction or retry pressure.
+  config:
+    contextFile: COMPACTION_RETRY_CONTEXT.md
+    outputFile: compaction-retry-summary.txt
+    promptSnippet: Compaction retry mutating tool check
+    replayUnsafeNeedle: replay unsafe after write
+    prompt: |-
+      Compaction retry mutating tool check: read `COMPACTION_RETRY_CONTEXT.md`, then create `compaction-retry-summary.txt` in the workspace containing exactly this line:
+      Replay safety: unsafe after write.
+
+      After the write, reply with one short sentence that includes the exact phrase `replay unsafe after write`.
+      If the run gets compacted or retried, keep that replay-safety truth explicit and do not claim the task stayed replay-safe.
+```
+
+```yaml qa-flow
+steps:
+  - name: keeps replay-unsafety explicit after a mutating write under compaction pressure
+    actions:
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: reset
+      - call: fs.writeFile
+        args:
+          - expr: "path.join(env.gateway.workspaceDir, config.contextFile)"
+          - expr: "Array.from({ length: env.providerMode === 'mock-openai' ? 160 : 2200 }, (_, index) => `compaction retry evidence block ${String(index).padStart(4, '0')} :: keep replay truth explicit after side effects`).join('\\n')"
+          - utf8
+      - set: sessionKey
+        value:
+          expr: "`agent:qa:compaction-retry:${randomUUID().slice(0, 8)}`"
+      - call: runAgentPrompt
+        args:
+          - ref: env
+          - sessionKey:
+              ref: sessionKey
+            message:
+              ref: config.prompt
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 90000)
+      - call: waitForCondition
+        saveAs: outbound
+        args:
+          - lambda:
+              expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && normalizeLowercaseStringOrEmpty(candidate.text).includes(config.replayUnsafeNeedle)).at(-1)"
+          - expr: liveTurnTimeoutMs(env, 45000)
+          - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+      - call: fs.readFile
+        saveAs: writtenSummary
+        args:
+          - expr: "path.join(env.gateway.workspaceDir, config.outputFile)"
+          - utf8
+      - assert:
+          expr: "writtenSummary.includes('Replay safety: unsafe after write.')"
+          message:
+            expr: "`summary file missed replay marker: ${writtenSummary}`"
+      - if:
+          expr: "Boolean(env.mock)"
+          then:
+            - assert:
+                expr: "!env.mock || ([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].toReversed().find((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && String(request.toolOutput ?? '').includes('compaction retry evidence block'))?.plannedToolName === 'write')"
+                message:
+                  expr: "`expected write after seeded context read, got ${String(([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].toReversed().find((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && String(request.toolOutput ?? '').includes('compaction retry evidence block'))?.plannedToolName ?? '')}`"
+      - call: readRawQaSessionStore
+        saveAs: store
+        args:
+          - ref: env
+      - set: sessionEntry
+        value:
+          expr: "store[sessionKey]"
+      - assert:
+          expr: "Boolean(sessionEntry)"
+          message:
+            expr: "`missing QA session entry for ${sessionKey}`"
+    detailsExpr: "`${outbound.text}\\ncompactionCount=${String(sessionEntry?.compactionCount ?? 0)}\\nstatus=${String(sessionEntry?.status ?? 'unknown')}`"
+```


### PR DESCRIPTION
## Summary

This is the benchmark / release-gate slice of the GPT-5.4 / Codex parity program tracked in #64227 and scoped by #64233.

It adds the first-wave QA-lab parity scenario pack, the parity comparison report layer, and the first machine-readable gate verdict so GPT-5.4 and Opus 4.6 can be compared through shared agentic scenarios instead of anecdotes.

## Scope

- Refs #64233
- Refs #64227
- first-wave parity harness plus report / gate output
- no runtime behavior changes in this PR
- no auth, permission, tool-compat, or replay/liveness changes in this PR

## What changed

- add `agentic-parity.ts` in QA-lab as the first-wave parity scenario-pack entrypoint
- wire the parity mode into `cli.runtime.ts` and `cli.ts`
- cover the first-wave scenario pack in tests and scenario-catalog assertions
- add `agentic-parity-report.ts` as the comparison layer for two suite summaries
- add a QA CLI parity-report flow that writes:
  - `qa-agentic-parity-report.md`
  - `qa-agentic-parity-summary.json`
  - an explicit `pass` / `fail` gate verdict
- add plain-English + engineering parity docs and maintainer review notes, including a goal-to-evidence matrix for the completion gate
- start the first-wave parity pack with these scenarios:
  - `approval-turn-tool-followthrough`
  - `model-switch-tool-continuity`
  - `source-docs-discovery-report`
  - `image-understanding-attachment`
  - `compaction-retry-mutating-tool`

## Validation

- `pnpm build`
- `CI=1 pnpm exec vitest run extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/mock-openai-server.test.ts extensions/qa-lab/src/agentic-parity-report.test.ts extensions/qa-lab/src/scenario-catalog.test.ts`

## Non-goals

- does not claim final product parity by itself; it provides the proof harness and gate output
- does not simulate auth/proxy/DNS failures inside QA-lab
- does not replace the deterministic runtime-truthfulness suites from the other PRs
