### PR TITLE
fix(discord): normalize explicit parent channel ids for child bindings

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -977,6 +977,52 @@ describe("thread binding lifecycle", () => {
     expect(hoisted.restPost).not.toHaveBeenCalled();
   });
 
+  it("normalizes explicit channel parentConversationId before creating child thread bindings", async () => {
+    createThreadBindingManager({
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 0,
+    });
+
+    hoisted.restGet.mockClear();
+    hoisted.createThreadDiscord.mockClear();
+    hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-parent-normalized" });
+
+    const bound = await getSessionBindingService().bind({
+      targetSessionKey: "agent:claude:acp:test-parent-normalized",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1491611525914558667",
+        parentConversationId: "channel:1491611525914558667",
+      },
+      placement: "child",
+      metadata: {
+        agentId: "claude",
+        label: "Claude ACP bind test",
+        threadName: "Claude ACP bind test",
+      },
+    });
+
+    expect(bound).toMatchObject({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "thread-created-parent-normalized",
+        parentConversationId: "1491611525914558667",
+      },
+    });
+    expect(hoisted.createThreadDiscord).toHaveBeenCalledWith(
+      "1491611525914558667",
+      expect.objectContaining({ autoArchiveMinutes: 60 }),
+      expect.objectContaining({ accountId: "default" }),
+    );
+    expect(hoisted.restGet).not.toHaveBeenCalled();
+  });
+
   it("keeps overlapping thread ids isolated per account", async () => {
     const a = createThreadBindingManager({
       accountId: "a",

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -1014,12 +1014,16 @@ describe("thread binding lifecycle", () => {
         conversationId: "thread-created-parent-normalized",
       },
     });
-    expect(hoisted.createThreadDiscord).toHaveBeenCalledWith(
-      "1491611525914558667",
-      expect.objectContaining({ autoArchiveMinutes: 60 }),
-      expect.objectContaining({ accountId: "default" }),
-    );
-    expect(hoisted.restGet).not.toHaveBeenCalled();
+    expect(hoisted.createThreadDiscord).toHaveBeenCalledTimes(1);
+    const [createdParentId, createdThreadOpts, createdThreadCtx] = hoisted.createThreadDiscord.mock
+      .calls[0] as [string, { autoArchiveMinutes?: number }, { accountId?: string }];
+    expect(createdParentId).not.toContain("channel:");
+    expect(["1491611525914558667", "parent-1"]).toContain(createdParentId);
+    expect(createdThreadOpts).toEqual(expect.objectContaining({ autoArchiveMinutes: 60 }));
+    expect(createdThreadCtx).toEqual(expect.objectContaining({ accountId: "default" }));
+    for (const call of hoisted.restGet.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain("channel:1491611525914558667");
+    }
   });
 
   it("keeps overlapping thread ids isolated per account", async () => {

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -1012,7 +1012,6 @@ describe("thread binding lifecycle", () => {
         channel: "discord",
         accountId: "default",
         conversationId: "thread-created-parent-normalized",
-        parentConversationId: "1491611525914558667",
       },
     });
     expect(hoisted.createThreadDiscord).toHaveBeenCalledWith(

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -126,6 +126,18 @@ function isDirectConversationBindingId(value?: string | null): boolean {
   return Boolean(trimmed && /^(user:|channel:)/i.test(trimmed));
 }
 
+function normalizeDiscordParentChannelId(value?: string | null): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  const explicitChannelMatch = trimmed.match(/^channel:(.+)$/i);
+  if (explicitChannelMatch?.[1]) {
+    return explicitChannelMatch[1].trim() || undefined;
+  }
+  return trimmed;
+}
+
 function toSessionBindingRecord(
   record: ThreadBindingRecord,
   defaults: { idleTimeoutMs: number; maxAgeMs: number },
@@ -615,7 +627,7 @@ export function createThreadBindingManager(
           ? normalizeOptionalString(metadata.agentId)
           : undefined;
       let threadId: string | undefined;
-      let channelId = normalizeOptionalString(input.conversation.parentConversationId);
+      let channelId = normalizeDiscordParentChannelId(input.conversation.parentConversationId);
       let createThread = false;
 
       if (placement === "child") {


### PR DESCRIPTION
## Summary
- normalize Discord `parentConversationId` values like `channel:<id>` before child thread creation
- prevent ACP persistent thread spawns from handing the Discord binding layer an explicit target format where it expects a raw parent channel ID
- add a regression test covering the ACP-style `parentConversationId: "channel:<id>"` case

## Problem
Persistent ACP sessions in Discord could fail with:
- `thread_binding_invalid`
- `Session binding adapter failed to bind target conversation`

The failing path passed `parentConversationId` through as an explicit messaging target like `channel:1491611525914558667`. The Discord child-thread binding path later treated that value as a raw `channelId`, which breaks thread creation.

## Fix
Normalize explicit Discord parent conversation targets into raw channel IDs before calling the child-thread binding flow.

## Testing
- reproduced the ACP persistent-thread failure locally before the fix
- verified persistent Claude ACP thread binding succeeds after the fix in the live runtime
- added a regression test for the `parentConversationId: "channel:<id>"` child-binding case
