### PR TITLE
fix(daemon): keep launchd stop persistent without reinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ Docs: https://docs.openclaw.ai
 - Models/fallback: preserve `/models` selection across transient primary-model failures and config reloads so the fallback chain no longer permanently clobbers a user-chosen model. (#64471) Thanks @hoyyeva.
 
 - Sandbox/security: auto-derive CDP source-range from Docker network gateway and refuse to start the socat relay without one, so peer containers cannot reach CDP unauthenticated. (#61404) Thanks @dims.
+- Daemon/launchd: keep `openclaw gateway stop` persistent without uninstalling the macOS LaunchAgent, re-enable it on explicit restart or repair, and harden launchd label handling. (#64447) Thanks @ngutman.
 
 ## 2026.4.9
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -829,7 +829,7 @@ export const registerTelegramHandlers = ({
       // for reactions, we cannot determine if the reaction came from a topic, so block all
       // reactions if requireTopic is enabled for this DM.
       if (!isGroup) {
-        const requireTopic = (eventAuthContext.groupConfig)
+        const requireTopic = (eventAuthContext.groupConfig as TelegramDirectConfig | undefined)
           ?.requireTopic;
         if (requireTopic === true) {
           logVerbose(

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -68,7 +68,7 @@ async function maybeRepairLaunchAgentBootstrap(params: {
   }
 
   params.runtime.log(`Bootstrapping ${params.title} LaunchAgent...`);
-  const repair = await repairLaunchAgentBootstrap({ env: params.env });
+  const repair = await repairLaunchAgentBootstrap({ env: params.env, forceEnable: true });
   if (!repair.ok) {
     params.runtime.error(
       `${params.title} LaunchAgent bootstrap failed: ${repair.detail ?? "unknown error"}`,

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -68,7 +68,7 @@ async function maybeRepairLaunchAgentBootstrap(params: {
   }
 
   params.runtime.log(`Bootstrapping ${params.title} LaunchAgent...`);
-  const repair = await repairLaunchAgentBootstrap({ env: params.env, forceEnable: true });
+  const repair = await repairLaunchAgentBootstrap({ env: params.env });
   if (!repair.ok) {
     params.runtime.error(
       `${params.title} LaunchAgent bootstrap failed: ${repair.detail ?? "unknown error"}`,

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -65,4 +65,17 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(args[1]).toContain('launchctl start "$label" >/dev/null 2>&1');
     expect(args[1]).not.toContain('basename "$service_target"');
   });
+
+  it("rejects invalid launchd labels before spawning the helper", () => {
+    expect(() =>
+      scheduleDetachedLaunchdRestartHandoff({
+        env: {
+          HOME: "/Users/test",
+          OPENCLAW_LAUNCHD_LABEL: "../evil/label",
+        },
+        mode: "kickstart",
+      }),
+    ).toThrow("Invalid launchd label");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -67,15 +67,15 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
   });
 
   it("rejects invalid launchd labels before spawning the helper", () => {
-    expect(() =>
+    expect(() => {
       scheduleDetachedLaunchdRestartHandoff({
         env: {
           HOME: "/Users/test",
-          OPENCLAW_LAUNCHD_LABEL: "../evil/label",
+          OPENCLAW_LAUNCHD_LABEL: "../evil/\n\u001b[31mlabel\u001b[0m",
         },
         mode: "kickstart",
-      }),
-    ).toThrow("Invalid launchd label");
+      });
+    }).toThrow("Invalid launchd label: ../evil/label");
     expect(spawnMock).not.toHaveBeenCalled();
   });
 });

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -38,11 +38,34 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     const [, args] = spawnMock.mock.calls[0] as [string, string[]];
     expect(args[0]).toBe("-c");
     expect(args[2]).toBe("openclaw-launchd-restart-handoff");
-    expect(args[6]).toBe("9876");
+    expect(args[6]).toBe("0");
+    expect(args[7]).toBe("9876");
     expect(args[1]).toContain('while kill -0 "$wait_pid" >/dev/null 2>&1; do');
-    expect(args[1]).toContain('launchctl enable "$service_target" >/dev/null 2>&1');
-    expect(args[1]).toContain('launchctl kickstart -k "$service_target" >/dev/null 2>&1');
+    expect(args[1]).not.toContain('launchctl enable "$service_target" >/dev/null 2>&1\nif !');
+    expect(args[1]).toContain(
+      'if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then',
+    );
     expect(args[1]).not.toContain("sleep 1");
     expect(unrefMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("only injects launchctl enable when the caller requested re-enable", () => {
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+
+    scheduleDetachedLaunchdRestartHandoff({
+      env: {
+        HOME: "/Users/test",
+        OPENCLAW_PROFILE: "default",
+      },
+      mode: "kickstart",
+      shouldEnable: true,
+      enableMarkerPath: "/Users/test/.openclaw/service/marker",
+    });
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args[6]).toBe("1");
+    expect(args[8]).toBe("/Users/test/.openclaw/service/marker");
+    expect(args[1]).toContain('launchctl enable "$service_target" >/dev/null 2>&1');
+    expect(args[1]).toContain('rm -f "$enable_marker_path" >/dev/null 2>&1 || true');
   });
 });

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -40,6 +40,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(args[2]).toBe("openclaw-launchd-restart-handoff");
     expect(args[6]).toBe("9876");
     expect(args[1]).toContain('while kill -0 "$wait_pid" >/dev/null 2>&1; do');
+    expect(args[1]).toContain('launchctl enable "$service_target" >/dev/null 2>&1');
     expect(args[1]).toContain('launchctl kickstart -k "$service_target" >/dev/null 2>&1');
     expect(args[1]).not.toContain("sleep 1");
     expect(unrefMock).toHaveBeenCalledTimes(1);

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -38,10 +38,10 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     const [, args] = spawnMock.mock.calls[0] as [string, string[]];
     expect(args[0]).toBe("-c");
     expect(args[2]).toBe("openclaw-launchd-restart-handoff");
-    expect(args[6]).toBe("0");
-    expect(args[7]).toBe("9876");
+    expect(args[6]).toBe("9876");
+    expect(args[7]).toBe("ai.openclaw.gateway");
     expect(args[1]).toContain('while kill -0 "$wait_pid" >/dev/null 2>&1; do');
-    expect(args[1]).not.toContain('launchctl enable "$service_target" >/dev/null 2>&1\nif !');
+    expect(args[1]).toContain('launchctl enable "$service_target" >/dev/null 2>&1');
     expect(args[1]).toContain(
       'if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then',
     );
@@ -49,7 +49,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(unrefMock).toHaveBeenCalledTimes(1);
   });
 
-  it("only injects launchctl enable when the caller requested re-enable", () => {
+  it("passes the plain label separately for start-after-exit mode", () => {
     spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
 
     scheduleDetachedLaunchdRestartHandoff({
@@ -57,15 +57,12 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
         HOME: "/Users/test",
         OPENCLAW_PROFILE: "default",
       },
-      mode: "kickstart",
-      shouldEnable: true,
-      enableMarkerPath: "/Users/test/.openclaw/service/marker",
+      mode: "start-after-exit",
     });
 
     const [, args] = spawnMock.mock.calls[0] as [string, string[]];
-    expect(args[6]).toBe("1");
-    expect(args[8]).toBe("/Users/test/.openclaw/service/marker");
-    expect(args[1]).toContain('launchctl enable "$service_target" >/dev/null 2>&1');
-    expect(args[1]).toContain('rm -f "$enable_marker_path" >/dev/null 2>&1 || true');
+    expect(args[7]).toBe("ai.openclaw.gateway");
+    expect(args[1]).toContain('launchctl start "$label" >/dev/null 2>&1');
+    expect(args[1]).not.toContain('basename "$service_target"');
   });
 });

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -79,8 +79,8 @@ fi
 domain="$2"
 plist_path="$3"
 ${waitForCallerPid}
+launchctl enable "$service_target" >/dev/null 2>&1
 if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then
-  launchctl enable "$service_target" >/dev/null 2>&1
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
   fi
@@ -91,11 +91,12 @@ fi
   return `service_target="$1"
 domain="$2"
 plist_path="$3"
+label="$(basename "$service_target")"
 ${waitForCallerPid}
-if ! launchctl start "$service_target" >/dev/null 2>&1; then
-  launchctl enable "$service_target" >/dev/null 2>&1
+launchctl enable "$service_target" >/dev/null 2>&1
+if ! launchctl start "$label" >/dev/null 2>&1; then
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
-    launchctl start "$service_target" >/dev/null 2>&1 || launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
+    launchctl start "$label" >/dev/null 2>&1 || launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
   else
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
   fi

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
 import { resolveGatewayLaunchAgentLabel } from "./constants.js";
 
 export type LaunchdRestartHandoffMode = "kickstart" | "start-after-exit";
@@ -23,7 +24,7 @@ export type LaunchdRestartTarget = {
 function assertValidLaunchAgentLabel(label: string): string {
   const trimmed = label.trim();
   if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
-    throw new Error(`Invalid launchd label: ${trimmed}`);
+    throw new Error(`Invalid launchd label: ${sanitizeForLog(trimmed)}`);
   }
   return trimmed;
 }

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -85,6 +85,7 @@ fi
 `;
 
   if (mode === "kickstart") {
+    // Restart is explicit operator intent; undo any previous `launchctl disable`.
     return `service_target="$1"
 domain="$2"
 plist_path="$3"
@@ -98,6 +99,7 @@ fi
 `;
   }
 
+  // Restart is explicit operator intent; undo any previous `launchctl disable`.
   return `service_target="$1"
 domain="$2"
 plist_path="$3"

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -20,6 +20,14 @@ export type LaunchdRestartTarget = {
   serviceTarget: string;
 };
 
+function assertValidLaunchAgentLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+    throw new Error(`Invalid launchd label: ${trimmed}`);
+  }
+  return trimmed;
+}
+
 function resolveGuiDomain(): string {
   if (typeof process.getuid !== "function") {
     return "gui/501";
@@ -30,9 +38,9 @@ function resolveGuiDomain(): string {
 function resolveLaunchAgentLabel(env?: Record<string, string | undefined>): string {
   const envLabel = normalizeOptionalString(env?.OPENCLAW_LAUNCHD_LABEL);
   if (envLabel) {
-    return envLabel;
+    return assertValidLaunchAgentLabel(envLabel);
   }
-  return resolveGatewayLaunchAgentLabel(env?.OPENCLAW_PROFILE);
+  return assertValidLaunchAgentLabel(resolveGatewayLaunchAgentLabel(env?.OPENCLAW_PROFILE));
 }
 
 export function resolveLaunchdRestartTarget(
@@ -66,9 +74,8 @@ export function isCurrentProcessLaunchdServiceLabel(
 }
 
 function buildLaunchdRestartScript(mode: LaunchdRestartHandoffMode): string {
-  const waitForCallerPid = `should_enable="$4"
-wait_pid="$5"
-enable_marker_path="$6"
+  const waitForCallerPid = `wait_pid="$4"
+label="$5"
 if [ -n "$wait_pid" ] && [ "$wait_pid" -gt 1 ] 2>/dev/null; then
   while kill -0 "$wait_pid" >/dev/null 2>&1; do
     sleep 0.1
@@ -81,12 +88,7 @@ fi
 domain="$2"
 plist_path="$3"
 ${waitForCallerPid}
-if [ "$should_enable" = "1" ]; then
-  launchctl enable "$service_target" >/dev/null 2>&1
-  if [ -n "$enable_marker_path" ]; then
-    rm -f "$enable_marker_path" >/dev/null 2>&1 || true
-  fi
-fi
+launchctl enable "$service_target" >/dev/null 2>&1
 if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
@@ -98,14 +100,8 @@ fi
   return `service_target="$1"
 domain="$2"
 plist_path="$3"
-label="$(basename "$service_target")"
 ${waitForCallerPid}
-if [ "$should_enable" = "1" ]; then
-  launchctl enable "$service_target" >/dev/null 2>&1
-  if [ -n "$enable_marker_path" ]; then
-    rm -f "$enable_marker_path" >/dev/null 2>&1 || true
-  fi
-fi
+launchctl enable "$service_target" >/dev/null 2>&1
 if ! launchctl start "$label" >/dev/null 2>&1; then
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
     launchctl start "$label" >/dev/null 2>&1 || launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
@@ -119,9 +115,7 @@ fi
 export function scheduleDetachedLaunchdRestartHandoff(params: {
   env?: Record<string, string | undefined>;
   mode: LaunchdRestartHandoffMode;
-  shouldEnable?: boolean;
   waitForPid?: number;
-  enableMarkerPath?: string;
 }): LaunchdRestartHandoffResult {
   const target = resolveLaunchdRestartTarget(params.env);
   const waitForPid =
@@ -138,9 +132,8 @@ export function scheduleDetachedLaunchdRestartHandoff(params: {
         target.serviceTarget,
         target.domain,
         target.plistPath,
-        params.shouldEnable ? "1" : "0",
         String(waitForPid),
-        params.enableMarkerPath ?? "",
+        target.label,
       ],
       {
         detached: true,

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -66,7 +66,9 @@ export function isCurrentProcessLaunchdServiceLabel(
 }
 
 function buildLaunchdRestartScript(mode: LaunchdRestartHandoffMode): string {
-  const waitForCallerPid = `wait_pid="$4"
+  const waitForCallerPid = `should_enable="$4"
+wait_pid="$5"
+enable_marker_path="$6"
 if [ -n "$wait_pid" ] && [ "$wait_pid" -gt 1 ] 2>/dev/null; then
   while kill -0 "$wait_pid" >/dev/null 2>&1; do
     sleep 0.1
@@ -79,7 +81,12 @@ fi
 domain="$2"
 plist_path="$3"
 ${waitForCallerPid}
-launchctl enable "$service_target" >/dev/null 2>&1
+if [ "$should_enable" = "1" ]; then
+  launchctl enable "$service_target" >/dev/null 2>&1
+  if [ -n "$enable_marker_path" ]; then
+    rm -f "$enable_marker_path" >/dev/null 2>&1 || true
+  fi
+fi
 if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
@@ -93,7 +100,12 @@ domain="$2"
 plist_path="$3"
 label="$(basename "$service_target")"
 ${waitForCallerPid}
-launchctl enable "$service_target" >/dev/null 2>&1
+if [ "$should_enable" = "1" ]; then
+  launchctl enable "$service_target" >/dev/null 2>&1
+  if [ -n "$enable_marker_path" ]; then
+    rm -f "$enable_marker_path" >/dev/null 2>&1 || true
+  fi
+fi
 if ! launchctl start "$label" >/dev/null 2>&1; then
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
     launchctl start "$label" >/dev/null 2>&1 || launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
@@ -107,7 +119,9 @@ fi
 export function scheduleDetachedLaunchdRestartHandoff(params: {
   env?: Record<string, string | undefined>;
   mode: LaunchdRestartHandoffMode;
+  shouldEnable?: boolean;
   waitForPid?: number;
+  enableMarkerPath?: string;
 }): LaunchdRestartHandoffResult {
   const target = resolveLaunchdRestartTarget(params.env);
   const waitForPid =
@@ -124,7 +138,9 @@ export function scheduleDetachedLaunchdRestartHandoff(params: {
         target.serviceTarget,
         target.domain,
         target.plistPath,
+        params.shouldEnable ? "1" : "0",
         String(waitForPid),
+        params.enableMarkerPath ?? "",
       ],
       {
         detached: true,

--- a/src/daemon/launchd.integration.e2e.test.ts
+++ b/src/daemon/launchd.integration.e2e.test.ts
@@ -14,6 +14,7 @@ import {
   uninstallLaunchAgent,
 } from "./launchd.js";
 import type { GatewayServiceEnv } from "./service-types.js";
+import { resolveGatewayService, startGatewayService } from "./service.js";
 
 const WAIT_INTERVAL_MS = 200;
 const WAIT_TIMEOUT_MS = 30_000;
@@ -162,6 +163,40 @@ describeLaunchdIntegration("launchd integration", () => {
     }
     const before = await waitForRunningRuntime({ env: launchEnv });
     await restartLaunchAgent({ env: launchEnv, stdout });
+    const after = await waitForRunningRuntime({ env: launchEnv, pidNot: before.pid });
+    expect(after.pid).toBeGreaterThan(1);
+    expect(after.pid).not.toBe(before.pid);
+    await fs.access(resolveLaunchAgentPlistPath(launchEnv));
+  }, 60_000);
+
+  it("stops persistently without reinstall and starts later", async () => {
+    if (!env) {
+      throw new Error("launchd integration env was not initialized");
+    }
+    const launchEnv = env;
+    try {
+      await withTimeout({
+        run: async () => {
+          await installLaunchAgent({
+            env: launchEnv,
+            stdout,
+            programArguments: [process.execPath, "-e", "setInterval(() => {}, 1000);"],
+          });
+          await waitForRunningRuntime({ env: launchEnv });
+        },
+        timeoutMs: STARTUP_TIMEOUT_MS,
+        message: "Timed out initializing launchd integration runtime",
+      });
+    } catch {
+      return;
+    }
+
+    const before = await waitForRunningRuntime({ env: launchEnv });
+    await stopLaunchAgent({ env: launchEnv, stdout });
+    await waitForNotRunningRuntime({ env: launchEnv });
+    const service = resolveGatewayService();
+    const startResult = await startGatewayService(service, { env: launchEnv, stdout });
+    expect(startResult.outcome).toBe("started");
     const after = await waitForRunningRuntime({ env: launchEnv, pidNot: before.pid });
     expect(after.pid).toBeGreaterThan(1);
     expect(after.pid).not.toBe(before.pid);

--- a/src/daemon/launchd.integration.e2e.test.ts
+++ b/src/daemon/launchd.integration.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   readLaunchAgentRuntime,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
   uninstallLaunchAgent,
 } from "./launchd.js";
 import type { GatewayServiceEnv } from "./service-types.js";
@@ -85,6 +86,30 @@ async function waitForRunningRuntime(params: {
   );
 }
 
+async function waitForNotRunningRuntime(params: {
+  env: GatewayServiceEnv;
+  timeoutMs?: number;
+}): Promise<void> {
+  const timeoutMs = params.timeoutMs ?? WAIT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = "unknown";
+  let lastPid: number | undefined;
+  while (Date.now() < deadline) {
+    const runtime = await readLaunchAgentRuntime(params.env);
+    lastStatus = runtime.status ?? "unknown";
+    lastPid = runtime.pid;
+    if (runtime.status !== "running" && runtime.pid === undefined) {
+      return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, WAIT_INTERVAL_MS);
+    });
+  }
+  throw new Error(
+    `Timed out waiting for launchd runtime to stop (status=${lastStatus}, pid=${lastPid ?? "none"})`,
+  );
+}
+
 describeLaunchdIntegration("launchd integration", () => {
   let env: GatewayServiceEnv | undefined;
   let homeDir = "";
@@ -136,6 +161,38 @@ describeLaunchdIntegration("launchd integration", () => {
       return;
     }
     const before = await waitForRunningRuntime({ env: launchEnv });
+    await restartLaunchAgent({ env: launchEnv, stdout });
+    const after = await waitForRunningRuntime({ env: launchEnv, pidNot: before.pid });
+    expect(after.pid).toBeGreaterThan(1);
+    expect(after.pid).not.toBe(before.pid);
+    await fs.access(resolveLaunchAgentPlistPath(launchEnv));
+  }, 60_000);
+
+  it("stops persistently without reinstall and restarts later", async () => {
+    if (!env) {
+      throw new Error("launchd integration env was not initialized");
+    }
+    const launchEnv = env;
+    try {
+      await withTimeout({
+        run: async () => {
+          await installLaunchAgent({
+            env: launchEnv,
+            stdout,
+            programArguments: [process.execPath, "-e", "setInterval(() => {}, 1000);"],
+          });
+          await waitForRunningRuntime({ env: launchEnv });
+        },
+        timeoutMs: STARTUP_TIMEOUT_MS,
+        message: "Timed out initializing launchd integration runtime",
+      });
+    } catch {
+      return;
+    }
+
+    const before = await waitForRunningRuntime({ env: launchEnv });
+    await stopLaunchAgent({ env: launchEnv, stdout });
+    await waitForNotRunningRuntime({ env: launchEnv });
     await restartLaunchAgent({ env: launchEnv, stdout });
     const after = await waitForRunningRuntime({ env: launchEnv, pidNot: before.pid });
     expect(after.pid).toBeGreaterThan(1);

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -48,6 +49,19 @@ const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
   vi.fn<(port?: number) => number[]>(() => []),
 );
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
+
+function resolveDisableMarkerPath(
+  env: Record<string, string | undefined>,
+  label = "ai.openclaw.gateway",
+) {
+  const profile = env.OPENCLAW_PROFILE?.trim();
+  const suffix = !profile || profile.toLowerCase() === "default" ? "" : `-${profile}`;
+  return path.join(
+    env.OPENCLAW_STATE_DIR ?? path.join(env.HOME ?? "/Users/test", `.openclaw${suffix}`),
+    "service",
+    `${encodeURIComponent(label)}.launchd-disabled-by-openclaw`,
+  );
+}
 
 function expectLaunchctlEnableBootstrapOrder(env: Record<string, string | undefined>) {
   const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
@@ -318,7 +332,7 @@ describe("launchctl list detection", () => {
 });
 
 describe("launchd bootstrap repair", () => {
-  it("enables, bootstraps, and kickstarts the resolved label", async () => {
+  it("bootstraps and kickstarts the resolved label without enabling unrelated disabled state", async () => {
     const env: Record<string, string | undefined> = {
       HOME: "/Users/test",
       OPENCLAW_PROFILE: "default",
@@ -326,11 +340,16 @@ describe("launchd bootstrap repair", () => {
     const repair = await repairLaunchAgentBootstrap({ env });
     expect(repair).toEqual({ ok: true, status: "repaired" });
 
-    const { serviceId, bootstrapIndex } = expectLaunchctlEnableBootstrapOrder(env);
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    const bootstrapIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "bootstrap" && c[1] === domain,
+    );
     const kickstartIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
@@ -395,6 +414,30 @@ describe("launchd bootstrap repair", () => {
       status: "kickstart-failed",
       detail: "launchctl kickstart failed: permission denied",
     });
+  });
+
+  it("re-enables when the disabled marker shows OpenClaw owns the stop state", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+    state.files.set(resolveDisableMarkerPath(env), "disabled_by_openclaw\n");
+
+    await repairLaunchAgentBootstrap({ env });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
+    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(false);
+  });
+
+  it("allows explicit repairs to force re-enable disabled services", async () => {
+    const env: Record<string, string | undefined> = {
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "default",
+    };
+
+    await repairLaunchAgentBootstrap({ env, forceEnable: true });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
   });
 });
 
@@ -492,6 +535,7 @@ describe("launchd install", () => {
     expect(state.launchctlCalls).toContainEqual(["disable", serviceId]);
     expect(state.launchctlCalls).toContainEqual(["stop", "ai.openclaw.gateway"]);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
+    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(true);
     expect(output).toContain("Stopped LaunchAgent");
   });
 
@@ -508,6 +552,7 @@ describe("launchd install", () => {
 
     expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
+    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(false);
     expect(output).toContain("Stopped LaunchAgent (degraded)");
     expect(output).toContain("used bootout fallback");
   });
@@ -527,6 +572,22 @@ describe("launchd install", () => {
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
     expect(output).toContain("Stopped LaunchAgent (degraded)");
     expect(output).toContain("did not fully stop the service");
+  });
+
+  it("falls back to bootout when launchctl stop itself errors", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.stopError = "stop failed due to transient launchd error";
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
+    expect(output).toContain("Stopped LaunchAgent (degraded)");
+    expect(output).toContain("launchctl stop failed; used bootout fallback");
   });
 
   it("falls back to bootout when launchctl print cannot confirm the stop state", async () => {
@@ -553,8 +614,24 @@ describe("launchd install", () => {
     state.bootoutError = "launchctl bootout permission denied";
 
     await expect(stopLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
-      "launchctl print could not confirm stop: launchctl print permission denied; launchctl bootout failed: launchctl bootout permission denied",
+      "launchctl print could not confirm stop; used bootout fallback and left service unloaded: launchctl print permission denied; launchctl bootout failed: launchctl bootout permission denied",
     );
+  });
+
+  it("sanitizes launchctl details before writing warnings", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.disableError = "boom\n\u001b[31mred\u001b[0m\tmsg";
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(output).not.toContain("\u001b[31m");
+    expect(output).not.toContain("\nred\n");
+    expect(output).toContain("boom red msg");
   });
 
   it("restarts LaunchAgent with kickstart and no bootout", async () => {
@@ -572,10 +649,28 @@ describe("launchd install", () => {
     const serviceId = `${domain}/${label}`;
     expect(result).toEqual({ outcome: "completed" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789);
-    expect(state.launchctlCalls).toContainEqual(["enable", serviceId]);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
     expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", serviceId]);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
+  });
+
+  it("re-enables before restart when OpenClaw owns the persisted disabled state", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    state.files.set(resolveDisableMarkerPath(env), "disabled_by_openclaw\n");
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    expect(state.launchctlCalls).toContainEqual(["enable", serviceId]);
+    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(false);
   });
 
   it("uses the configured gateway port for stale cleanup", async () => {
@@ -614,12 +709,15 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    const { serviceId } = expectLaunchctlEnableBootstrapOrder(env);
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
     const kickstartCalls = state.launchctlCalls.filter(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
     expect(result).toEqual({ outcome: "completed" });
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(true);
     expect(kickstartCalls).toHaveLength(2);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
   });
@@ -636,7 +734,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 
@@ -653,7 +751,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(true);
   });
 
@@ -669,7 +767,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 
@@ -686,9 +784,30 @@ describe("launchd install", () => {
     expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).toHaveBeenCalledWith({
       env,
       mode: "kickstart",
+      shouldEnable: false,
       waitForPid: process.pid,
+      enableMarkerPath: undefined,
     });
     expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("passes marker-owned re-enable intent to the detached handoff", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.files.set(resolveDisableMarkerPath(env), "disabled_by_openclaw\n");
+    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(true);
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).toHaveBeenCalledWith({
+      env,
+      mode: "kickstart",
+      shouldEnable: true,
+      waitForPid: process.pid,
+      enableMarkerPath: resolveDisableMarkerPath(env),
+    });
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,6 +11,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -22,6 +23,15 @@ const state = vi.hoisted(() => ({
   bootstrapCode: 1,
   kickstartError: "",
   kickstartFailuresRemaining: 0,
+  disableError: "",
+  disableCode: 1,
+  stopError: "",
+  stopCode: 1,
+  bootoutError: "",
+  bootoutCode: 1,
+  serviceLoaded: true,
+  serviceRunning: true,
+  stopLeavesRunning: false,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -78,14 +88,56 @@ vi.mock("./exec-file.js", () => ({
         state.printNotLoadedRemaining -= 1;
         return { stdout: "", stderr: "Could not find service", code: 113 };
       }
-      return { stdout: state.printOutput, stderr: "", code: 0 };
+      if (!state.serviceLoaded) {
+        return { stdout: "", stderr: "Could not find service", code: 113 };
+      }
+      if (state.printOutput) {
+        return { stdout: state.printOutput, stderr: "", code: 0 };
+      }
+      if (!state.serviceRunning) {
+        return { stdout: ["state = waiting", "pid = 0"].join("\n"), stderr: "", code: 0 };
+      }
+      return { stdout: ["state = running", "pid = 4242"].join("\n"), stderr: "", code: 0 };
     }
-    if (call[0] === "bootstrap" && state.bootstrapError) {
-      return { stdout: "", stderr: state.bootstrapError, code: state.bootstrapCode };
+    if (call[0] === "disable" && state.disableError) {
+      return { stdout: "", stderr: state.disableError, code: state.disableCode };
     }
-    if (call[0] === "kickstart" && state.kickstartError && state.kickstartFailuresRemaining > 0) {
-      state.kickstartFailuresRemaining -= 1;
-      return { stdout: "", stderr: state.kickstartError, code: 1 };
+    if (call[0] === "stop") {
+      if (state.stopError) {
+        return { stdout: "", stderr: state.stopError, code: state.stopCode };
+      }
+      if (!state.stopLeavesRunning) {
+        state.serviceRunning = false;
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (call[0] === "bootout") {
+      if (state.bootoutError) {
+        return { stdout: "", stderr: state.bootoutError, code: state.bootoutCode };
+      }
+      state.serviceLoaded = false;
+      state.serviceRunning = false;
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (call[0] === "enable") {
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (call[0] === "bootstrap") {
+      if (state.bootstrapError) {
+        return { stdout: "", stderr: state.bootstrapError, code: state.bootstrapCode };
+      }
+      state.serviceLoaded = true;
+      state.serviceRunning = true;
+      return { stdout: "", stderr: "", code: 0 };
+    }
+    if (call[0] === "kickstart") {
+      if (state.kickstartError && state.kickstartFailuresRemaining > 0) {
+        state.kickstartFailuresRemaining -= 1;
+        return { stdout: "", stderr: state.kickstartError, code: 1 };
+      }
+      state.serviceLoaded = true;
+      state.serviceRunning = true;
+      return { stdout: "", stderr: "", code: 0 };
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -162,6 +214,15 @@ beforeEach(() => {
   state.bootstrapCode = 1;
   state.kickstartError = "";
   state.kickstartFailuresRemaining = 0;
+  state.disableError = "";
+  state.disableCode = 1;
+  state.stopError = "";
+  state.stopCode = 1;
+  state.bootoutError = "";
+  state.bootoutCode = 1;
+  state.serviceLoaded = true;
+  state.serviceRunning = true;
+  state.stopLeavesRunning = false;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -406,6 +467,58 @@ describe("launchd install", () => {
     expect(state.fileModes.get(plistPath)).toBe(0o644);
   });
 
+  it("stops LaunchAgent by disabling relaunch before stopping the process", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    expect(state.launchctlCalls).toContainEqual(["disable", serviceId]);
+    expect(state.launchctlCalls).toContainEqual(["stop", "ai.openclaw.gateway"]);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
+    expect(output).toContain("Stopped LaunchAgent");
+  });
+
+  it("falls back to bootout when disable fails so stop remains authoritative", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.disableError = "Operation not permitted";
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
+    expect(output).toContain("Stopped LaunchAgent (degraded)");
+    expect(output).toContain("used bootout fallback");
+  });
+
+  it("falls back to bootout when stop does not fully stop the service", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.stopLeavesRunning = true;
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(true);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
+    expect(output).toContain("Stopped LaunchAgent (degraded)");
+    expect(output).toContain("did not fully stop the service");
+  });
+
   it("restarts LaunchAgent with kickstart and no bootout", async () => {
     const env = {
       ...createDefaultLaunchdEnv(),
@@ -421,6 +534,7 @@ describe("launchd install", () => {
     const serviceId = `${domain}/${label}`;
     expect(result).toEqual({ outcome: "completed" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789);
+    expect(state.launchctlCalls).toContainEqual(["enable", serviceId]);
     expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", serviceId]);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
@@ -484,7 +598,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 
@@ -517,7 +631,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -554,6 +554,23 @@ describe("launchd install", () => {
     expect(output).toContain("did not fully stop the service");
   });
 
+  it("treats launchctl print state=running as running even when pid is missing", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.stopLeavesRunning = true;
+    state.printOutput = "state = running\n";
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
+    expect(output).toContain("Stopped LaunchAgent (degraded)");
+    expect(output).toContain("did not fully stop the service");
+  });
+
   it("falls back to bootout when launchctl stop itself errors", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -49,19 +48,6 @@ const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
   vi.fn<(port?: number) => number[]>(() => []),
 );
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
-
-function resolveDisableMarkerPath(
-  env: Record<string, string | undefined>,
-  label = "ai.openclaw.gateway",
-) {
-  const profile = env.OPENCLAW_PROFILE?.trim();
-  const suffix = !profile || profile.toLowerCase() === "default" ? "" : `-${profile}`;
-  return path.join(
-    env.OPENCLAW_STATE_DIR ?? path.join(env.HOME ?? "/Users/test", `.openclaw${suffix}`),
-    "service",
-    `${encodeURIComponent(label)}.launchd-disabled-by-openclaw`,
-  );
-}
 
 function expectLaunchctlEnableBootstrapOrder(env: Record<string, string | undefined>) {
   const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
@@ -332,7 +318,7 @@ describe("launchctl list detection", () => {
 });
 
 describe("launchd bootstrap repair", () => {
-  it("bootstraps and kickstarts the resolved label without enabling unrelated disabled state", async () => {
+  it("enables, bootstraps, and kickstarts the resolved label", async () => {
     const env: Record<string, string | undefined> = {
       HOME: "/Users/test",
       OPENCLAW_PROFILE: "default",
@@ -340,16 +326,11 @@ describe("launchd bootstrap repair", () => {
     const repair = await repairLaunchAgentBootstrap({ env });
     expect(repair).toEqual({ ok: true, status: "repaired" });
 
-    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const serviceId = `${domain}/ai.openclaw.gateway`;
-    const bootstrapIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootstrap" && c[1] === domain,
-    );
+    const { serviceId, bootstrapIndex } = expectLaunchctlEnableBootstrapOrder(env);
     const kickstartIndex = state.launchctlCalls.findIndex(
       (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === serviceId,
     );
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
     expect(kickstartIndex).toBeGreaterThanOrEqual(0);
     expect(bootstrapIndex).toBeLessThan(kickstartIndex);
   });
@@ -414,30 +395,6 @@ describe("launchd bootstrap repair", () => {
       status: "kickstart-failed",
       detail: "launchctl kickstart failed: permission denied",
     });
-  });
-
-  it("re-enables when the disabled marker shows OpenClaw owns the stop state", async () => {
-    const env: Record<string, string | undefined> = {
-      HOME: "/Users/test",
-      OPENCLAW_PROFILE: "default",
-    };
-    state.files.set(resolveDisableMarkerPath(env), "disabled_by_openclaw\n");
-
-    await repairLaunchAgentBootstrap({ env });
-
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
-    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(false);
-  });
-
-  it("allows explicit repairs to force re-enable disabled services", async () => {
-    const env: Record<string, string | undefined> = {
-      HOME: "/Users/test",
-      OPENCLAW_PROFILE: "default",
-    };
-
-    await repairLaunchAgentBootstrap({ env, forceEnable: true });
-
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
   });
 });
 
@@ -535,7 +492,6 @@ describe("launchd install", () => {
     expect(state.launchctlCalls).toContainEqual(["disable", serviceId]);
     expect(state.launchctlCalls).toContainEqual(["stop", "ai.openclaw.gateway"]);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
-    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(true);
     expect(output).toContain("Stopped LaunchAgent");
   });
 
@@ -552,7 +508,6 @@ describe("launchd install", () => {
 
     expect(state.launchctlCalls.some((call) => call[0] === "stop")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
-    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(false);
     expect(output).toContain("Stopped LaunchAgent (degraded)");
     expect(output).toContain("used bootout fallback");
   });
@@ -649,28 +604,10 @@ describe("launchd install", () => {
     const serviceId = `${domain}/${label}`;
     expect(result).toEqual({ outcome: "completed" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789);
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls).toContainEqual(["enable", serviceId]);
     expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", serviceId]);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
-  });
-
-  it("re-enables before restart when OpenClaw owns the persisted disabled state", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
-    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const serviceId = `${domain}/ai.openclaw.gateway`;
-    state.files.set(resolveDisableMarkerPath(env), "disabled_by_openclaw\n");
-
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
-
-    expect(state.launchctlCalls).toContainEqual(["enable", serviceId]);
-    expect(state.files.has(resolveDisableMarkerPath(env))).toBe(false);
   });
 
   it("uses the configured gateway port for stale cleanup", async () => {
@@ -716,7 +653,7 @@ describe("launchd install", () => {
     );
 
     expect(result).toEqual({ outcome: "completed" });
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(true);
     expect(kickstartCalls).toHaveLength(2);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
@@ -734,7 +671,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 
@@ -751,7 +688,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(true);
   });
 
@@ -767,7 +704,7 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
-    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });
 
@@ -784,30 +721,9 @@ describe("launchd install", () => {
     expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).toHaveBeenCalledWith({
       env,
       mode: "kickstart",
-      shouldEnable: false,
       waitForPid: process.pid,
-      enableMarkerPath: undefined,
     });
     expect(state.launchctlCalls).toEqual([]);
-  });
-
-  it("passes marker-owned re-enable intent to the detached handoff", async () => {
-    const env = createDefaultLaunchdEnv();
-    state.files.set(resolveDisableMarkerPath(env), "disabled_by_openclaw\n");
-    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(true);
-
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
-
-    expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).toHaveBeenCalledWith({
-      env,
-      mode: "kickstart",
-      shouldEnable: true,
-      waitForPid: process.pid,
-      enableMarkerPath: resolveDisableMarkerPath(env),
-    });
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {
@@ -882,5 +798,14 @@ describe("resolveLaunchAgentPlistPath", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveLaunchAgentPlistPath(env)).toBe(expected);
+  });
+
+  it("rejects invalid launchd labels that contain path separators", () => {
+    expect(() =>
+      resolveLaunchAgentPlistPath({
+        HOME: "/Users/test",
+        OPENCLAW_LAUNCHD_LABEL: "../evil/label",
+      }),
+    ).toThrow("Invalid launchd label");
   });
 });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -19,6 +19,9 @@ const state = vi.hoisted(() => ({
   listOutput: "",
   printOutput: "",
   printNotLoadedRemaining: 0,
+  printError: "",
+  printCode: 1,
+  printFailuresRemaining: 0,
   bootstrapError: "",
   bootstrapCode: 1,
   kickstartError: "",
@@ -87,6 +90,10 @@ vi.mock("./exec-file.js", () => ({
       if (state.printNotLoadedRemaining > 0) {
         state.printNotLoadedRemaining -= 1;
         return { stdout: "", stderr: "Could not find service", code: 113 };
+      }
+      if (state.printError && state.printFailuresRemaining > 0) {
+        state.printFailuresRemaining -= 1;
+        return { stdout: "", stderr: state.printError, code: state.printCode };
       }
       if (!state.serviceLoaded) {
         return { stdout: "", stderr: "Could not find service", code: 113 };
@@ -210,6 +217,9 @@ beforeEach(() => {
   state.listOutput = "";
   state.printOutput = "";
   state.printNotLoadedRemaining = 0;
+  state.printError = "";
+  state.printCode = 1;
+  state.printFailuresRemaining = 0;
   state.bootstrapError = "";
   state.bootstrapCode = 1;
   state.kickstartError = "";
@@ -517,6 +527,34 @@ describe("launchd install", () => {
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
     expect(output).toContain("Stopped LaunchAgent (degraded)");
     expect(output).toContain("did not fully stop the service");
+  });
+
+  it("falls back to bootout when launchctl print cannot confirm the stop state", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.printError = "launchctl print permission denied";
+    state.printFailuresRemaining = 10;
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(true);
+    expect(output).toContain("Stopped LaunchAgent (degraded)");
+    expect(output).toContain("could not confirm stop");
+  });
+
+  it("throws when launchctl print cannot confirm stop and bootout also fails", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.printError = "launchctl print permission denied";
+    state.printFailuresRemaining = 10;
+    state.bootoutError = "launchctl bootout permission denied";
+
+    await expect(stopLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
+      "launchctl print could not confirm stop: launchctl print permission denied; launchctl bootout failed: launchctl bootout permission denied",
+    );
   });
 
   it("restarts LaunchAgent with kickstart and no bootout", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -42,7 +42,9 @@ const state = vi.hoisted(() => ({
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
   isCurrentProcessLaunchdServiceLabel: vi.fn<(label: string) => boolean>(() => false),
-  scheduleDetachedLaunchdRestartHandoff: vi.fn((_params: unknown) => ({ ok: true, pid: 7331 })),
+  scheduleDetachedLaunchdRestartHandoff: vi.fn<
+    (_params: unknown) => { ok: boolean; pid?: number; detail?: string }
+  >(() => ({ ok: true, pid: 7331 })),
 }));
 const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
   vi.fn<(port?: number) => number[]>(() => []),
@@ -495,6 +497,29 @@ describe("launchd install", () => {
     expect(output).toContain("Stopped LaunchAgent");
   });
 
+  it("treats already-unloaded services as successfully stopped without bootout fallback", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    state.serviceLoaded = false;
+    state.serviceRunning = false;
+    state.stopError = "Could not find service";
+    state.stopCode = 113;
+    stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    await stopLaunchAgent({ env, stdout });
+
+    expect(state.launchctlCalls).toContainEqual([
+      "disable",
+      `${typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501"}/ai.openclaw.gateway`,
+    ]);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
+    expect(output).toContain("Stopped LaunchAgent");
+    expect(output).not.toContain("degraded");
+  });
+
   it("falls back to bootout when disable fails so stop remains authoritative", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = new PassThrough();
@@ -724,6 +749,22 @@ describe("launchd install", () => {
       waitForPid: process.pid,
     });
     expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("surfaces detached handoff failures", async () => {
+    const env = createDefaultLaunchdEnv();
+    launchdRestartHandoffState.isCurrentProcessLaunchdServiceLabel.mockReturnValue(true);
+    launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReturnValue({
+      ok: false,
+      detail: "spawn failed",
+    });
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    ).rejects.toThrow("launchd restart handoff failed: spawn failed");
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -36,12 +36,20 @@ import type {
 const LAUNCH_AGENT_DIR_MODE = 0o755;
 const LAUNCH_AGENT_PLIST_MODE = 0o644;
 
+function assertValidLaunchAgentLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+    throw new Error(`Invalid launchd label: ${sanitizeForLog(trimmed)}`);
+  }
+  return trimmed;
+}
+
 function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefined> }): string {
   const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();
   if (envLabel) {
-    return envLabel;
+    return assertValidLaunchAgentLabel(envLabel);
   }
-  return resolveGatewayLaunchAgentLabel(args?.env?.OPENCLAW_PROFILE);
+  return assertValidLaunchAgentLabel(resolveGatewayLaunchAgentLabel(args?.env?.OPENCLAW_PROFILE));
 }
 
 function resolveLaunchAgentPlistPathForLabel(
@@ -196,11 +204,8 @@ async function bootstrapLaunchAgentOrThrow(params: {
   serviceTarget: string;
   plistPath: string;
   actionHint: string;
-  enableBeforeBootstrap?: boolean;
 }) {
-  if (params.enableBeforeBootstrap) {
-    await execLaunchctl(["enable", params.serviceTarget]);
-  }
+  await execLaunchctl(["enable", params.serviceTarget]);
   const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
   if (boot.code === 0) {
     return;
@@ -324,18 +329,12 @@ export type LaunchAgentBootstrapRepairResult =
 
 export async function repairLaunchAgentBootstrap(args: {
   env?: Record<string, string | undefined>;
-  forceEnable?: boolean;
 }): Promise<LaunchAgentBootstrapRepairResult> {
   const env = args.env ?? (process.env as Record<string, string | undefined>);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
-  await enableLaunchAgentIfOwnedStop({
-    env,
-    serviceTarget: `${domain}/${label}`,
-    label,
-    force: args.forceEnable,
-  });
+  await execLaunchctl(["enable", `${domain}/${label}`]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   let repairStatus: LaunchAgentBootstrapRepairResult["status"] = "repaired";
   if (boot.code !== 0) {
@@ -483,61 +482,6 @@ function formatLaunchctlResultDetail(res: {
     .slice(0, 1000);
 }
 
-function resolveLaunchAgentDisableMarkerPath(env: GatewayServiceEnv, label: string): string {
-  return path.join(
-    resolveGatewayStateDir(env),
-    "service",
-    `${encodeURIComponent(label)}.launchd-disabled-by-openclaw`,
-  );
-}
-
-async function hasLaunchAgentDisableMarker(params: {
-  env: GatewayServiceEnv;
-  label: string;
-}): Promise<boolean> {
-  try {
-    await fs.access(resolveLaunchAgentDisableMarkerPath(params.env, params.label));
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function writeLaunchAgentDisableMarker(params: {
-  env: GatewayServiceEnv;
-  label: string;
-}): Promise<void> {
-  const markerPath = resolveLaunchAgentDisableMarkerPath(params.env, params.label);
-  await ensureSecureDirectory(path.dirname(markerPath));
-  await fs.writeFile(markerPath, "disabled_by_openclaw\n", { mode: 0o600 });
-  await fs.chmod(markerPath, 0o600).catch(() => undefined);
-}
-
-async function clearLaunchAgentDisableMarker(params: {
-  env: GatewayServiceEnv;
-  label: string;
-}): Promise<void> {
-  await fs
-    .unlink(resolveLaunchAgentDisableMarkerPath(params.env, params.label))
-    .catch(() => undefined);
-}
-
-async function enableLaunchAgentIfOwnedStop(params: {
-  env: GatewayServiceEnv;
-  serviceTarget: string;
-  label: string;
-  force?: boolean;
-}): Promise<boolean> {
-  const shouldEnable =
-    params.force || (await hasLaunchAgentDisableMarker({ env: params.env, label: params.label }));
-  if (!shouldEnable) {
-    return false;
-  }
-  await execLaunchctl(["enable", params.serviceTarget]);
-  await clearLaunchAgentDisableMarker({ env: params.env, label: params.label });
-  return true;
-}
-
 async function bootoutLaunchAgentOrThrow(params: {
   serviceTarget: string;
   warning: string;
@@ -612,7 +556,6 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
     });
     return;
   }
-  await writeLaunchAgentDisableMarker({ env: serviceEnv, label });
 
   // `launchctl stop` targets the plain label (not the fully-qualified service target).
   const stop = await execLaunchctl(["stop", label]);
@@ -711,7 +654,6 @@ async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: 
     serviceTarget: `${domain}/${label}`,
     plistPath: params.plistPath,
     actionHint: "openclaw gateway install --force",
-    enableBeforeBootstrap: true,
   });
 }
 
@@ -768,17 +710,11 @@ export async function restartLaunchAgent({
   // Restart requests issued from inside the managed gateway process tree need a
   // detached handoff. A direct `kickstart -k` would terminate the caller before
   // it can finish the restart command.
-  const shouldEnable = await hasLaunchAgentDisableMarker({ env: serviceEnv, label });
-
   if (isCurrentProcessLaunchdServiceLabel(label)) {
     const handoff = scheduleDetachedLaunchdRestartHandoff({
       env: serviceEnv,
       mode: "kickstart",
-      shouldEnable,
       waitForPid: process.pid,
-      enableMarkerPath: shouldEnable
-        ? resolveLaunchAgentDisableMarkerPath(serviceEnv, label)
-        : undefined,
     });
     if (!handoff.ok) {
       throw new Error(`launchd restart handoff failed: ${handoff.detail ?? "unknown error"}`);
@@ -792,9 +728,9 @@ export async function restartLaunchAgent({
     cleanStaleGatewayProcessesSync(cleanupPort);
   }
 
-  // Only re-enable disabled LaunchAgents when OpenClaw itself owns the
-  // persisted stop state.
-  await enableLaunchAgentIfOwnedStop({ env: serviceEnv, serviceTarget, label });
+  // `openclaw gateway restart` is an explicit operator request to bring the
+  // LaunchAgent back, so clear any persisted disabled state before restart.
+  await execLaunchctl(["enable", serviceTarget]);
 
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
 import {
   GATEWAY_LAUNCH_AGENT_LABEL,
   resolveGatewayServiceDescription,
@@ -195,8 +196,11 @@ async function bootstrapLaunchAgentOrThrow(params: {
   serviceTarget: string;
   plistPath: string;
   actionHint: string;
+  enableBeforeBootstrap?: boolean;
 }) {
-  await execLaunchctl(["enable", params.serviceTarget]);
+  if (params.enableBeforeBootstrap) {
+    await execLaunchctl(["enable", params.serviceTarget]);
+  }
   const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
   if (boot.code === 0) {
     return;
@@ -320,14 +324,18 @@ export type LaunchAgentBootstrapRepairResult =
 
 export async function repairLaunchAgentBootstrap(args: {
   env?: Record<string, string | undefined>;
+  forceEnable?: boolean;
 }): Promise<LaunchAgentBootstrapRepairResult> {
   const env = args.env ?? (process.env as Record<string, string | undefined>);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
-  // launchd can persist "disabled" state after bootout; clear it before bootstrap
-  // (matches the same guard in installLaunchAgent and restartLaunchAgent).
-  await execLaunchctl(["enable", `${domain}/${label}`]);
+  await enableLaunchAgentIfOwnedStop({
+    env,
+    serviceTarget: `${domain}/${label}`,
+    label,
+    force: args.forceEnable,
+  });
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   let repairStatus: LaunchAgentBootstrapRepairResult["status"] = "repaired";
   if (boot.code !== 0) {
@@ -469,7 +477,80 @@ function formatLaunchctlResultDetail(res: {
   stderr: string;
   code: number;
 }): string {
-  return (res.stderr || res.stdout).trim();
+  return sanitizeForLog((res.stderr || res.stdout).replace(/[\r\n\t]+/g, " "))
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1000);
+}
+
+function resolveLaunchAgentDisableMarkerPath(env: GatewayServiceEnv, label: string): string {
+  return path.join(
+    resolveGatewayStateDir(env),
+    "service",
+    `${encodeURIComponent(label)}.launchd-disabled-by-openclaw`,
+  );
+}
+
+async function hasLaunchAgentDisableMarker(params: {
+  env: GatewayServiceEnv;
+  label: string;
+}): Promise<boolean> {
+  try {
+    await fs.access(resolveLaunchAgentDisableMarkerPath(params.env, params.label));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeLaunchAgentDisableMarker(params: {
+  env: GatewayServiceEnv;
+  label: string;
+}): Promise<void> {
+  const markerPath = resolveLaunchAgentDisableMarkerPath(params.env, params.label);
+  await ensureSecureDirectory(path.dirname(markerPath));
+  await fs.writeFile(markerPath, "disabled_by_openclaw\n", { mode: 0o600 });
+  await fs.chmod(markerPath, 0o600).catch(() => undefined);
+}
+
+async function clearLaunchAgentDisableMarker(params: {
+  env: GatewayServiceEnv;
+  label: string;
+}): Promise<void> {
+  await fs
+    .unlink(resolveLaunchAgentDisableMarkerPath(params.env, params.label))
+    .catch(() => undefined);
+}
+
+async function enableLaunchAgentIfOwnedStop(params: {
+  env: GatewayServiceEnv;
+  serviceTarget: string;
+  label: string;
+  force?: boolean;
+}): Promise<boolean> {
+  const shouldEnable =
+    params.force || (await hasLaunchAgentDisableMarker({ env: params.env, label: params.label }));
+  if (!shouldEnable) {
+    return false;
+  }
+  await execLaunchctl(["enable", params.serviceTarget]);
+  await clearLaunchAgentDisableMarker({ env: params.env, label: params.label });
+  return true;
+}
+
+async function bootoutLaunchAgentOrThrow(params: {
+  serviceTarget: string;
+  warning: string;
+  stdout: NodeJS.WritableStream;
+}): Promise<void> {
+  const bootout = await execLaunchctl(["bootout", params.serviceTarget]);
+  if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
+    throw new Error(
+      `${params.warning}; launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
+    );
+  }
+  params.stdout.write(`${formatLine("Warning", params.warning)}\n`);
+  params.stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", params.serviceTarget)}\n`);
 }
 
 type LaunchAgentProbeResult =
@@ -524,43 +605,33 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
   // the command still leaves the gateway down.
   const disable = await execLaunchctl(["disable", serviceTarget]);
   if (disable.code !== 0) {
-    const bootout = await execLaunchctl(["bootout", serviceTarget]);
-    if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
-      throw new Error(
-        `launchctl disable failed: ${formatLaunchctlResultDetail(disable)}; launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
-      );
-    }
-    stdout.write(
-      `${formatLine("Warning", `launchctl disable failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(disable)}`)}\n`,
-    );
-    stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+    await bootoutLaunchAgentOrThrow({
+      serviceTarget,
+      stdout,
+      warning: `launchctl disable failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(disable)}`,
+    });
     return;
   }
+  await writeLaunchAgentDisableMarker({ env: serviceEnv, label });
 
   // `launchctl stop` targets the plain label (not the fully-qualified service target).
   const stop = await execLaunchctl(["stop", label]);
   if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
-    throw new Error(`launchctl stop failed: ${formatLaunchctlResultDetail(stop)}`);
+    await bootoutLaunchAgentOrThrow({
+      serviceTarget,
+      stdout,
+      warning: `launchctl stop failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(stop)}`,
+    });
+    return;
   }
 
   const stopState = await waitForLaunchAgentStopped(serviceTarget);
   if (stopState.state !== "stopped" && stopState.state !== "not-loaded") {
-    const bootout = await execLaunchctl(["bootout", serviceTarget]);
-    if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
-      const reason =
-        stopState.state === "unknown"
-          ? `launchctl print could not confirm stop: ${stopState.detail ?? "unknown error"}`
-          : "launchctl stop left the service running";
-      throw new Error(
-        `${reason}; launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
-      );
-    }
     const warning =
       stopState.state === "unknown"
         ? `launchctl print could not confirm stop; used bootout fallback and left service unloaded: ${stopState.detail ?? "unknown error"}`
         : "launchctl stop did not fully stop the service; used bootout fallback and left service unloaded";
-    stdout.write(`${formatLine("Warning", warning)}\n`);
-    stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+    await bootoutLaunchAgentOrThrow({ serviceTarget, stdout, warning });
     return;
   }
 
@@ -640,6 +711,7 @@ async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: 
     serviceTarget: `${domain}/${label}`,
     plistPath: params.plistPath,
     actionHint: "openclaw gateway install --force",
+    enableBeforeBootstrap: true,
   });
 }
 
@@ -696,11 +768,17 @@ export async function restartLaunchAgent({
   // Restart requests issued from inside the managed gateway process tree need a
   // detached handoff. A direct `kickstart -k` would terminate the caller before
   // it can finish the restart command.
+  const shouldEnable = await hasLaunchAgentDisableMarker({ env: serviceEnv, label });
+
   if (isCurrentProcessLaunchdServiceLabel(label)) {
     const handoff = scheduleDetachedLaunchdRestartHandoff({
       env: serviceEnv,
       mode: "kickstart",
+      shouldEnable,
       waitForPid: process.pid,
+      enableMarkerPath: shouldEnable
+        ? resolveLaunchAgentDisableMarkerPath(serviceEnv, label)
+        : undefined,
     });
     if (!handoff.ok) {
       throw new Error(`launchd restart handoff failed: ${handoff.detail ?? "unknown error"}`);
@@ -714,9 +792,9 @@ export async function restartLaunchAgent({
     cleanStaleGatewayProcessesSync(cleanupPort);
   }
 
-  // Clear any persisted disabled state left behind by `openclaw gateway stop`
-  // before trying the normal restart path.
-  await execLaunchctl(["enable", serviceTarget]);
+  // Only re-enable disabled LaunchAgents when OpenClaw itself owns the
+  // persisted stop state.
+  await enableLaunchAgentIfOwnedStop({ env: serviceEnv, serviceTarget, label });
 
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -464,14 +464,80 @@ function isUnsupportedGuiDomain(detail: string): boolean {
   );
 }
 
-export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
-  const domain = resolveGuiDomain();
-  const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
-  if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+function formatLaunchctlResultDetail(res: {
+  stdout: string;
+  stderr: string;
+  code: number;
+}): string {
+  return (res.stderr || res.stdout).trim();
+}
+
+async function isLaunchAgentProcessRunning(serviceTarget: string): Promise<boolean> {
+  const probe = await execLaunchctl(["print", serviceTarget]);
+  if (probe.code !== 0) {
+    return false;
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  const runtime = parseLaunchctlPrint(probe.stdout || probe.stderr || "");
+  return typeof runtime.pid === "number" && runtime.pid > 1;
+}
+
+async function waitForLaunchAgentStopped(serviceTarget: string): Promise<boolean> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (!(await isLaunchAgentProcessRunning(serviceTarget))) {
+      return true;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+  }
+  return false;
+}
+
+export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
+  const serviceEnv = env ?? (process.env as GatewayServiceEnv);
+  const domain = resolveGuiDomain();
+  const label = resolveLaunchAgentLabel({ env: serviceEnv });
+  const serviceTarget = `${domain}/${label}`;
+
+  // Keep the LaunchAgent installed, but persistently suppress KeepAlive/RunAtLoad
+  // before stopping the current process. If disable fails, fall back to bootout so
+  // the command still leaves the gateway down.
+  const disable = await execLaunchctl(["disable", serviceTarget]);
+  if (disable.code !== 0) {
+    const bootout = await execLaunchctl(["bootout", serviceTarget]);
+    if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
+      throw new Error(
+        `launchctl disable failed: ${formatLaunchctlResultDetail(disable)}; launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
+      );
+    }
+    stdout.write(
+      `${formatLine("Warning", `launchctl disable failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(disable)}`)}\n`,
+    );
+    stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+    return;
+  }
+
+  // `launchctl stop` targets the plain label (not the fully-qualified service target).
+  const stop = await execLaunchctl(["stop", label]);
+  if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
+    throw new Error(`launchctl stop failed: ${formatLaunchctlResultDetail(stop)}`);
+  }
+
+  if (!(await waitForLaunchAgentStopped(serviceTarget))) {
+    const bootout = await execLaunchctl(["bootout", serviceTarget]);
+    if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
+      throw new Error(
+        `launchctl stop left the service running and launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
+      );
+    }
+    stdout.write(
+      `${formatLine("Warning", "launchctl stop did not fully stop the service; used bootout fallback and left service unloaded")}\n`,
+    );
+    stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
+    return;
+  }
+
+  stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }
 
 async function writeLaunchAgentPlist({
@@ -620,6 +686,10 @@ export async function restartLaunchAgent({
   if (cleanupPort !== null) {
     cleanStaleGatewayProcessesSync(cleanupPort);
   }
+
+  // Clear any persisted disabled state left behind by `openclaw gateway stop`
+  // before trying the normal restart path.
+  await execLaunchctl(["enable", serviceTarget]);
 
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -205,6 +205,8 @@ async function bootstrapLaunchAgentOrThrow(params: {
   plistPath: string;
   actionHint: string;
 }) {
+  // `disable` state survives bootout and plist rewrites; explicit start/repair
+  // paths must clear it before asking launchd to load the job again.
   await execLaunchctl(["enable", params.serviceTarget]);
   const boot = await execLaunchctl(["bootstrap", params.domain, params.plistPath]);
   if (boot.code === 0) {
@@ -504,6 +506,8 @@ type LaunchAgentProbeResult =
   | { state: "unknown"; detail?: string };
 
 async function probeLaunchAgentState(serviceTarget: string): Promise<LaunchAgentProbeResult> {
+  // `launchctl print` output is not a stable API, so this is only a stop
+  // confirmation probe. Unknown output falls back to bootout instead of success.
   const probe = await execLaunchctl(["print", serviceTarget]);
   if (probe.code !== 0) {
     if (isLaunchctlNotLoaded(probe)) {
@@ -545,8 +549,8 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
   const serviceTarget = `${domain}/${label}`;
 
   // Keep the LaunchAgent installed, but persistently suppress KeepAlive/RunAtLoad
-  // before stopping the current process. If disable fails, fall back to bootout so
-  // the command still leaves the gateway down.
+  // before stopping the current process. Without `disable`, launchd can relaunch
+  // the process as soon as `stop` exits.
   const disable = await execLaunchctl(["disable", serviceTarget]);
   if (disable.code !== 0) {
     await bootoutLaunchAgentOrThrow({

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -519,7 +519,10 @@ async function probeLaunchAgentState(serviceTarget: string): Promise<LaunchAgent
     };
   }
   const runtime = parseLaunchctlPrint(probe.stdout || probe.stderr || "");
-  if (typeof runtime.pid === "number" && runtime.pid > 1) {
+  if (
+    normalizeLowercaseStringOrEmpty(runtime.state) === "running" ||
+    (typeof runtime.pid === "number" && runtime.pid > 1)
+  ) {
     return { state: "running" };
   }
   return { state: "stopped" };

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -472,25 +472,45 @@ function formatLaunchctlResultDetail(res: {
   return (res.stderr || res.stdout).trim();
 }
 
-async function isLaunchAgentProcessRunning(serviceTarget: string): Promise<boolean> {
+type LaunchAgentProbeResult =
+  | { state: "running" }
+  | { state: "stopped" }
+  | { state: "not-loaded" }
+  | { state: "unknown"; detail?: string };
+
+async function probeLaunchAgentState(serviceTarget: string): Promise<LaunchAgentProbeResult> {
   const probe = await execLaunchctl(["print", serviceTarget]);
   if (probe.code !== 0) {
-    return false;
+    if (isLaunchctlNotLoaded(probe)) {
+      return { state: "not-loaded" };
+    }
+    return {
+      state: "unknown",
+      detail: formatLaunchctlResultDetail(probe) || undefined,
+    };
   }
   const runtime = parseLaunchctlPrint(probe.stdout || probe.stderr || "");
-  return typeof runtime.pid === "number" && runtime.pid > 1;
+  if (typeof runtime.pid === "number" && runtime.pid > 1) {
+    return { state: "running" };
+  }
+  return { state: "stopped" };
 }
 
-async function waitForLaunchAgentStopped(serviceTarget: string): Promise<boolean> {
+async function waitForLaunchAgentStopped(serviceTarget: string): Promise<LaunchAgentProbeResult> {
+  let lastUnknown: LaunchAgentProbeResult | null = null;
   for (let attempt = 0; attempt < 10; attempt += 1) {
-    if (!(await isLaunchAgentProcessRunning(serviceTarget))) {
-      return true;
+    const probe = await probeLaunchAgentState(serviceTarget);
+    if (probe.state === "stopped" || probe.state === "not-loaded") {
+      return probe;
+    }
+    if (probe.state === "unknown") {
+      lastUnknown = probe;
     }
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
   }
-  return false;
+  return lastUnknown ?? { state: "running" };
 }
 
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
@@ -523,16 +543,23 @@ export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs
     throw new Error(`launchctl stop failed: ${formatLaunchctlResultDetail(stop)}`);
   }
 
-  if (!(await waitForLaunchAgentStopped(serviceTarget))) {
+  const stopState = await waitForLaunchAgentStopped(serviceTarget);
+  if (stopState.state !== "stopped" && stopState.state !== "not-loaded") {
     const bootout = await execLaunchctl(["bootout", serviceTarget]);
     if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
+      const reason =
+        stopState.state === "unknown"
+          ? `launchctl print could not confirm stop: ${stopState.detail ?? "unknown error"}`
+          : "launchctl stop left the service running";
       throw new Error(
-        `launchctl stop left the service running and launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
+        `${reason}; launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`,
       );
     }
-    stdout.write(
-      `${formatLine("Warning", "launchctl stop did not fully stop the service; used bootout fallback and left service unloaded")}\n`,
-    );
+    const warning =
+      stopState.state === "unknown"
+        ? `launchctl print could not confirm stop; used bootout fallback and left service unloaded: ${stopState.detail ?? "unknown error"}`
+        : "launchctl stop did not fully stop the service; used bootout fallback and left service unloaded";
+    stdout.write(`${formatLine("Warning", warning)}\n`);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
     return;
   }


### PR DESCRIPTION
## Summary
- make `openclaw gateway stop` persistently stop macOS LaunchAgents without requiring reinstall before a later start or restart
- disable the LaunchAgent before stopping so `KeepAlive` does not immediately relaunch it, then fall back to `bootout` if stop cannot be made authoritative
- treat explicit start, restart, and repair flows as operator intent to bring the LaunchAgent back by re-enabling it before bootstrap or kickstart
- validate LaunchAgent labels before constructing plist paths or `launchctl` targets

## Changes
- `src/daemon/launchd.ts`
  - validate the resolved LaunchAgent label before using it in plist paths or `launchctl` commands
  - change `stopLaunchAgent` from unconditional `bootout` to `disable + stop`, with a `bootout` fallback when disable fails, stop fails, or `launchctl print` cannot confirm the service is down
  - sanitize `launchctl` output before surfacing warning or error details
  - enable the LaunchAgent before bootstrap in install/repair flows and before `kickstart -k` in `restartLaunchAgent`
- `src/daemon/launchd-restart-handoff.ts`
  - validate the resolved LaunchAgent label in the detached restart helper
  - enable before kickstart/start in the detached restart helper
  - pass the plain label explicitly for `launchctl start` instead of deriving it with `basename`
- tests
  - update unit coverage for persistent stop, degraded fallback paths, explicit re-enable on repair/restart, detached handoff label passing, and label validation
  - add an integration test covering stop -> restart without reinstall

## Test plan
- [x] `pnpm test src/daemon/launchd.test.ts src/daemon/launchd-restart-handoff.test.ts src/commands/doctor-gateway-daemon-flow.test.ts src/cli/daemon-cli/launchd-recovery.test.ts`
- [x] `pnpm test src/daemon/launchd.integration.e2e.test.ts src/cli/daemon-cli/lifecycle-core.test.ts src/daemon/service.test.ts src/cli/daemon-cli/lifecycle.test.ts`
- [x] manual macOS CLI e2e with temp `HOME` + `OPENCLAW_PROFILE`: install -> health check -> `openclaw gateway stop` -> verify down -> `openclaw gateway restart` -> verify healthy -> `openclaw gateway status --deep`
- [x] pre-commit `pnpm check`
