### PR TITLE
fix(browser): set DISPLAY env var for WSL2 Chrome launches

### DIFF
--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -330,10 +330,21 @@ export async function launchOpenClawChrome(
     // environments (e.g. Docker), while keeping stderr piped for diagnostics.
     // Cast to ChildProcessWithoutNullStreams so callers can use .stderr safely;
     // the tuple overload resolution varies across @types/node versions.
+    // Detect WSL2 and set DISPLAY for Chrome to connect to Windows X server
+    const isWSL2 = () => {
+      try {
+        return fs.existsSync("/proc/sys/fs/binfmt_misc/WSLInterop") ||
+               process.release?.name === "wsl";
+      } catch {
+        return false;
+      }
+    };
     return spawn(exe.path, args, {
       stdio: ["ignore", "ignore", "pipe"],
       env: {
         ...process.env,
+        // Fix for WSL2: Chrome needs DISPLAY set to connect to X server on Windows
+        ...(isWSL2() ? { DISPLAY: ":0" } : {}),
         // Reduce accidental sharing with the user's env.
         HOME: os.homedir(),
       },


### PR DESCRIPTION
## Fix for Issue #64464

Chrome fails to start in WSL2 because the DISPLAY environment variable is not set. Chrome needs DISPLAY to connect to the X server running on Windows.

### Changes

- Added WSL2 detection function that checks:
  - `/proc/sys/fs/binfmt_misc/WSLInterop` file existence
  - `process.release?.name === "wsl"`
- When WSL2 is detected, sets `DISPLAY=":0"` in the Chrome spawn environment

This allows `openclaw browser start` to work in WSL2 without manually setting the DISPLAY environment variable.

### Testing

Tested on WSL2 with Chrome installed on Windows host.