### PR TITLE
fix: prevent fallback persistence from clobbering user /models picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/ACPX: wrap plugin tools on the MCP bridge with the shared `before_tool_call` handler so block and approval hooks fire consistently across all execution paths. (#63886) Thanks @eleqtrizit.
 
 - Logging/security: redact Gmail watcher `--hook-token` values from startup logging and `logs.tail` output. (#62661) Thanks @eleqtrizit.
+- Models/fallback: preserve `/models` selection across transient primary-model failures and config reloads so the fallback chain no longer permanently clobbers a user-chosen model. (#64471) Thanks @hoyyeva.
 
 - Sandbox/security: auto-derive CDP source-range from Docker network gateway and refuse to start the socat relay without one, so peer containers cannot reach CDP unauthenticated. (#61404) Thanks @dims.
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -829,7 +829,7 @@ export const registerTelegramHandlers = ({
       // for reactions, we cannot determine if the reaction came from a topic, so block all
       // reactions if requireTopic is enabled for this DM.
       if (!isGroup) {
-        const requireTopic = (eventAuthContext.groupConfig as TelegramDirectConfig | undefined)
+        const requireTopic = (eventAuthContext.groupConfig)
           ?.requireTopic;
         if (requireTopic === true) {
           logVerbose(
@@ -1569,13 +1569,18 @@ export const registerTelegramHandlers = ({
 
           // Directly set model override in session
           try {
-            // Get session store path
-            const storePath = telegramDeps.resolveStorePath(cfg.session?.store, {
+            // Use the fresh runtimeCfg (loaded at callback entry) so store path
+            // and default-model resolution stay consistent with the next
+            // inbound message.  The outer `cfg` is a snapshot captured at
+            // handler-registration time and becomes stale after config reloads,
+            // which can cause the override to be written to the wrong store or
+            // incorrectly treated as the default model (clearing the override).
+            const storePath = telegramDeps.resolveStorePath(runtimeCfg.session?.store, {
               agentId: sessionState.agentId,
             });
 
             const resolvedDefault = resolveDefaultModelForAgent({
-              cfg,
+              cfg: runtimeCfg,
               agentId: sessionState.agentId,
             });
             const isDefaultSelection =

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1048,6 +1048,93 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("persists non-default model override using fresh config, not stale startup snapshot", async () => {
+    // Regression: the callback handler used the startup `cfg` snapshot for
+    // store path and default-model resolution.  If the config was reloaded
+    // (e.g. default model changed) the override could be written to the wrong
+    // store or incorrectly cleared because `isDefaultSelection` was wrong.
+    onSpy.mockClear();
+    replySpy.mockClear();
+    editMessageTextSpy.mockClear();
+
+    const storePath = `/tmp/openclaw-telegram-model-fresh-cfg-${process.pid}-${Date.now()}.json`;
+
+    await rm(storePath, { force: true });
+    try {
+      // Startup config: default is openai/gpt-5.4
+      const startupConfig = {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.4",
+            models: {
+              "openai/gpt-5.4": {},
+              "anthropic/claude-opus-4-6": {},
+            },
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+          },
+        },
+        session: {
+          store: storePath,
+        },
+      } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+
+      // Fresh config: default changed to anthropic/claude-opus-4-6
+      const freshConfig = {
+        ...startupConfig,
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-6",
+            models: {
+              "openai/gpt-5.4": {},
+              "anthropic/claude-opus-4-6": {},
+            },
+          },
+        },
+      };
+
+      // Bot created with startup config; loadConfig now returns fresh config
+      loadConfig.mockReturnValue(freshConfig);
+      createTelegramBot({
+        token: "tok",
+        config: startupConfig,
+      });
+      const callbackHandler = onSpy.mock.calls.find(
+        (call) => call[0] === "callback_query",
+      )?.[1] as (ctx: Record<string, unknown>) => Promise<void>;
+      expect(callbackHandler).toBeDefined();
+
+      // User selects openai/gpt-5.4 — was default at startup but NOT default
+      // in fresh config.  The override must be persisted.
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-model-fresh-cfg-1",
+          data: "mdl_sel_openai/gpt-5.4",
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 20,
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      // Override must be persisted (not cleared) because openai/gpt-5.4 is
+      // NOT the default in the fresh config.
+      const entry = Object.values(loadSessionStore(storePath, { skipCache: true }))[0];
+      expect(entry?.providerOverride).toBe("openai");
+      expect(entry?.modelOverride).toBe("gpt-5.4");
+    } finally {
+      await rm(storePath, { force: true });
+    }
+  });
+
   it("rejects ambiguous compact model callbacks and returns provider list", async () => {
     onSpy.mockClear();
     replySpy.mockClear();

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1677,6 +1677,140 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionStore.main.authProfileOverride).toBeUndefined();
   });
 
+  it("does not persist fallback selection for legacy user overrides without modelOverrideSource", async () => {
+    // Regression: older persisted sessions can have a user-selected override
+    // (modelOverride set) but no modelOverrideSource field, because the field
+    // was added later.  These legacy entries must still be protected from
+    // fallback overwrite, matching the backward-compat treatment in
+    // session-reset-service.
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("openai-codex", "gpt-5.4"),
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        attempts: [],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "anthropic";
+    followupRun.run.model = "claude-opus-4-6";
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      // Legacy entry: override is set but the source field is missing.
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+      // modelOverrideSource intentionally absent
+    };
+    const sessionStore = { main: sessionEntry };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    // Legacy user override must survive the fallback unchanged.
+    expect(sessionEntry.providerOverride).toBe("anthropic");
+    expect(sessionEntry.modelOverride).toBe("claude-opus-4-6");
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
+  });
+
+  it("does not persist fallback selection when modelOverrideSource is user", async () => {
+    // Regression: fallback persistence overwrote user-initiated /models
+    // selections.  When the user explicitly picked a model, the fallback
+    // should NOT clobber it even when the primary model fails.
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("openai-codex", "gpt-5.4"),
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        attempts: [],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "anthropic";
+    followupRun.run.model = "claude-opus-4-6";
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      // User explicitly selected this model via /models
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+      modelOverrideSource: "user",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    // The user's /models selection must survive the fallback.
+    expect(sessionEntry.providerOverride).toBe("anthropic");
+    expect(sessionEntry.modelOverride).toBe("claude-opus-4-6");
+    expect(sessionEntry.modelOverrideSource).toBe("user");
+  });
+
   it("keeps same-provider auth profile when fallback only changes model", async () => {
     const applyFallbackCandidateSelectionToEntry =
       await getApplyFallbackCandidateSelectionToEntry();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -647,6 +647,26 @@ export async function runAgentTurnWithFallback(params: {
       return undefined;
     }
 
+    // Don't overwrite a user-initiated model override (e.g. from /models or
+    // /model) with the fallback model.  The user's explicit selection should
+    // survive transient primary-model failures so subsequent messages still
+    // target the model the user chose.  Fallback persistence is only
+    // appropriate when the override was itself set by a previous fallback
+    // ("auto") or when there is no override yet.
+    //
+    // `modelOverrideSource` was added later, so older persisted sessions can
+    // carry a user-selected override without the source field.  Treat any
+    // entry with a `modelOverride` but missing `modelOverrideSource` as legacy
+    // user state, matching the backward-compat treatment in
+    // session-reset-service.
+    const isUserModelOverride =
+      activeSessionEntry.modelOverrideSource === "user" ||
+      (activeSessionEntry.modelOverrideSource === undefined &&
+        Boolean(normalizeOptionalString(activeSessionEntry.modelOverride)));
+    if (isUserModelOverride) {
+      return undefined;
+    }
+
     const previousState = snapshotFallbackSelectionState(activeSessionEntry);
     const applied = applyFallbackCandidateSelectionToEntry({
       entry: activeSessionEntry,


### PR DESCRIPTION
## Summary

  - **Problem**: Selecting a model via `/models` shows "Model changed to X" but the next message reverts to a previous model.
  - **Why it matters**: `/models` is the primary way users switch models per-session. When it silently fails, users lose trust in model selection and can get
  permanently stuck on a fallback model they never chose.
  - **What changed**: (1) Skip fallback persistence when the active `modelOverride` was set by the user (`modelOverrideSource === "user"`, plus legacy entries
   with no source field). (2) In the Telegram `/models` callback, use the fresh `runtimeCfg` instead of the stale startup `cfg` snapshot for store path and
  default-model resolution.
  - **What did NOT change**: No changes to how the fallback chain itself is resolved, no changes to how `/models` shows the picker, no schema/config changes.
  Channels other than Telegram are unaffected by the second fix (they don't have inline-button model pickers).

  ## Change Type (select all)

  - [x] Bug fix

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [x] Integrations

  ## Linked Issue/PR

  - Closes #63611
  - Related #63712, #63900
  - [x] This PR fixes a bug or regression

  ## Root Cause (if applicable)

  - **Root cause**: Two independent issues, both leading to the same user-visible symptom.
    1. `persistFallbackCandidateSelection` in `agent-runner-execution.ts` unconditionally overwrites `modelOverride`/`providerOverride` with the fallback
  model whenever a fallback succeeds. The session entry already carries `modelOverrideSource: "user" | "auto"` to distinguish user picks from fallback-set
  values, but the persistence path never checked it. So one transient failure of a user-selected model permanently pinned the session to the fallback.
    2. The Telegram `/models` callback handler in `bot-handlers.runtime.ts` used the outer `cfg` (a snapshot captured at handler-registration time, closed
  over by `registerTelegramHandlers`) for `resolveStorePath` and `resolveDefaultModelForAgent`, while the inbound message pipeline always uses fresh config
  via `loadConfig()`. After a config reload, the override could be written to the wrong store file, or the selected model could be misidentified as "the
  default" — which deletes the override instead of saving it.
  - **Missing detection / guardrail**: No regression test exercising "user picks model X via `/models` → X fails → fallback Y succeeds → next message still
  targets X." Existing tests covered the fallback persistence path but not the user-override interaction.
  - **Contributing context**: `modelOverrideSource` was added later in the codebase. `session-reset-service.ts` already treats `modelOverride` set with
  `modelOverrideSource === undefined` as legacy user state for backward compat — that pattern wasn't applied here.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
  - **Target tests added**:
    - `src/auto-reply/reply/agent-runner-execution.test.ts` — "does not persist fallback selection when modelOverrideSource is user" + "does not persist
  fallback selection for legacy user overrides without modelOverrideSource"
    - `extensions/telegram/src/bot.test.ts` — "persists non-default model override using fresh config, not stale startup snapshot"
  - **Scenario the tests lock in**:
    1. With `modelOverrideSource: "user"` (and the legacy `undefined` case), a successful fallback to a different model must NOT mutate
  `modelOverride`/`providerOverride`.
    2. With a Telegram bot started with one default model, after `loadConfig` returns a different default, the callback must still persist the user's
  selection correctly.
  - **Why this is the smallest reliable guardrail**: Both bugs are pure state-mutation issues at well-defined seams (the persistence helper and the callback
  handler). Unit tests against those seams catch the regression without needing a running gateway or live model failures.

  ## User-visible / Behavior Changes

  - `/models` selections now survive transient primary-model failures. When the user-selected model rate-limits and a fallback model serves a single response,
   the next message attempts the user-selected model again (instead of being permanently routed to the fallback).
  - No config changes, no command changes, no UI changes.

  ## Diagram

  ```text
  Before (fallback path):
    user picks X via /models   →  modelOverride = X, source = "user"
    send message               →  X fails  →  fallback Y succeeds
    persist fallback           →  modelOverride = Y, source = "auto"  ← clobbered
    next message               →  uses Y (forever)

  After:
    user picks X via /models   →  modelOverride = X, source = "user"
    send message               →  X fails  →  fallback Y succeeds
    persist fallback           →  source === "user"  →  skip
    next message               →  uses X (the user's choice)

```

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Human Verification (required)

  - Verified scenarios:
    - Full unit test suites for agent-runner-execution, model-selection, model-overrides, and the Telegram bot pass locally (114/114 across the related files,
   plus the 2 new regression tests).
    - Manually traced the flow from /models callback → session store write → next-message session load → createModelSelectionState → fallback persistence to
  confirm the override survives.
  - Edge cases checked:
    - Legacy session entries with modelOverride set but modelOverrideSource === undefined (backward compat — now covered by an explicit test).
    - Cross-provider user selection (e.g., user picks openai/... while config primary is anthropic/...): resolveAgentModelFallbackCandidates already returns
  no fallbacks in that case, so this PR has no effect there. The user instead sees the existing FallbackSummaryError with cooldown details, which is the
  correct UX.
  - What I did NOT verify: End-to-end behavior against a live model that actually rate-limits (no live LLM testing in this PR — covered by mocked unit tests
  against the same seam).

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No — legacy session entries (with modelOverride set but no modelOverrideSource) are explicitly handled.

  Risks and Mitigations

  - Risk: A user whose selected model is in long cooldown will pay the failed-primary cost on every message (since fallback is no longer persisted), making
  responses slower until they switch models manually.
    - Mitigation: This is strictly better than the previous behavior (silent permanent override). When the entire fallback chain is exhausted, the existing
  FallbackSummaryError already surfaces a cooldown message to the user, who can then re-select via /models. No new mitigation added in this PR to keep scope
  tight.