### PR TITLE
fix: preserve WhatsApp gateway media access

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -41,6 +41,15 @@ export const SendParamsSchema = Type.Object(
     message: Type.Optional(Type.String()),
     mediaUrl: Type.Optional(Type.String()),
     mediaUrls: Type.Optional(Type.Array(Type.String())),
+    mediaAccess: Type.Optional(
+      Type.Object(
+        {
+          mediaLocalRoots: Type.Optional(Type.Array(Type.String())),
+          workspaceDir: Type.Optional(Type.String()),
+        },
+        { additionalProperties: false },
+      ),
+    ),
     gifPlayback: Type.Optional(Type.Boolean()),
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -225,6 +225,32 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("forwards explicit media access into outbound delivery", async () => {
+    mockDeliverySuccess("m-media-access");
+
+    await runSend({
+      to: "channel:C1",
+      message: "hi",
+      mediaUrl: "file:///tmp/report.pdf",
+      mediaAccess: {
+        mediaLocalRoots: ["/tmp/workspace", "  ", "/tmp/uploads"],
+        workspaceDir: "/tmp/workspace",
+      },
+      channel: "slack",
+      idempotencyKey: "idem-media-access",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        mediaAccess: {
+          localRoots: ["/tmp/workspace", "/tmp/uploads"],
+          workspaceDir: "/tmp/workspace",
+        },
+      }),
+    );
+  });
+
   it("forwards gateway client scopes into outbound delivery", async () => {
     mockDeliverySuccess("m-scope");
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -197,6 +197,10 @@ export const sendHandlers: GatewayRequestHandlers = {
       message?: string;
       mediaUrl?: string;
       mediaUrls?: string[];
+      mediaAccess?: {
+        mediaLocalRoots?: string[];
+        workspaceDir?: string;
+      };
       gifPlayback?: boolean;
       channel?: string;
       accountId?: string;
@@ -229,6 +233,20 @@ export const sendHandlers: GatewayRequestHandlers = {
       ? request.mediaUrls
           .map((entry) => normalizeOptionalString(entry))
           .filter((entry): entry is string => Boolean(entry))
+      : undefined;
+    const explicitMediaAccess = request.mediaAccess
+      ? {
+          ...(Array.isArray(request.mediaAccess.mediaLocalRoots)
+            ? {
+                localRoots: request.mediaAccess.mediaLocalRoots
+                  .map((entry) => normalizeOptionalString(entry))
+                  .filter((entry): entry is string => Boolean(entry)),
+              }
+            : {}),
+          ...(normalizeOptionalString(request.mediaAccess.workspaceDir)
+            ? { workspaceDir: normalizeOptionalString(request.mediaAccess.workspaceDir) }
+            : {}),
+        }
       : undefined;
     if (!message && !mediaUrl && (mediaUrls?.length ?? 0) === 0) {
       respond(
@@ -344,6 +362,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           gifPlayback: request.gifPlayback,
           threadId: threadId ?? null,
           deps: outboundDeps,
+          mediaAccess: explicitMediaAccess,
           gatewayClientScopes: client?.connect?.scopes ?? [],
           mirror: outboundSessionKey
             ? {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -129,6 +129,7 @@ type ChannelHandlerParams = {
   threadId?: string | number | null;
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
+  mediaAccess?: OutboundMediaAccess;
   gifPlayback?: boolean;
   forceDocument?: boolean;
   silent?: boolean;
@@ -568,6 +569,7 @@ async function deliverOutboundPayloadsCore(
     cfg,
     agentId: params.session?.agentId ?? params.mirror?.agentId,
     mediaSources: collectPayloadMediaSources(payloads),
+    mediaAccess: params.mediaAccess,
     sessionKey: params.session?.key,
     messageProvider: params.session?.key ? undefined : channel,
     accountId: params.session?.requesterAccountId ?? accountId,

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -308,6 +308,21 @@ describe("gateway url override hardening", () => {
         },
       },
     },
+    {
+      name: "forwards media access into gateway send params",
+      params: {
+        agentId: "work",
+        mediaUrl: "file:///tmp/report.pdf",
+      },
+      expected: {
+        params: {
+          mediaAccess: {
+            mediaLocalRoots: expect.arrayContaining(["/tmp/openclaw"]),
+            workspaceDir: expect.stringContaining("workspace-work"),
+          },
+        },
+      },
+    },
   ])("$name", async ({ params, expected }) => {
     expect(await sendMattermostGatewayMessage(params)).toMatchObject(expected);
   });

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -1,5 +1,7 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { OutboundMediaAccess } from "../../media/load-options.js";
+import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import type { PollInput } from "../../polls.js";
 import { normalizePollInput } from "../../polls.js";
 import {
@@ -58,6 +60,7 @@ type MessageSendParams = {
   channel?: string;
   mediaUrl?: string;
   mediaUrls?: string[];
+  mediaAccess?: Pick<OutboundMediaAccess, "localRoots" | "workspaceDir">;
   gifPlayback?: boolean;
   forceDocument?: boolean;
   accountId?: string;
@@ -287,6 +290,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       gifPlayback: params.gifPlayback,
       forceDocument: params.forceDocument,
       deps: params.deps,
+      mediaAccess: params.mediaAccess,
       bestEffort: params.bestEffort,
       abortSignal: params.abortSignal,
       silent: params.silent,
@@ -310,6 +314,17 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     };
   }
 
+  const gatewayMediaAccess =
+    params.mediaAccess ??
+    resolveAgentScopedOutboundMediaAccess({
+      cfg,
+      agentId: params.agentId,
+      sessionKey: params.requesterSessionKey ?? params.mirror?.sessionKey,
+      accountId: params.requesterAccountId ?? params.accountId,
+      requesterSenderId: params.requesterSenderId,
+      mediaSources: mirrorMediaUrls.length ? mirrorMediaUrls : undefined,
+    });
+
   const result = await callMessageGateway<{ messageId: string }>({
     gateway: params.gateway,
     method: "send",
@@ -318,6 +333,17 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       message: params.content,
       mediaUrl: params.mediaUrl,
       mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
+      mediaAccess:
+        gatewayMediaAccess.localRoots?.length || gatewayMediaAccess.workspaceDir
+          ? {
+              ...(gatewayMediaAccess.localRoots?.length
+                ? { mediaLocalRoots: gatewayMediaAccess.localRoots }
+                : {}),
+              ...(gatewayMediaAccess.workspaceDir
+                ? { workspaceDir: gatewayMediaAccess.workspaceDir }
+                : {}),
+            }
+          : undefined,
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,
       agentId: params.agentId,


### PR DESCRIPTION
## Summary
- forward outbound media access through `callMessageGateway` for gateway-delivered sends
- let the gateway send handler merge caller-provided media roots/workspace into outbound delivery
- cover the new gateway media-access propagation with regression tests

## Testing
- pnpm test -- src/infra/outbound/message.channels.test.ts src/gateway/server-methods/send.test.ts