### PR TITLE
fix(docker): add config dir defaults to prevent broken volume mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/exec: infer native exec approvers from `commands.ownerAllowFrom` and auto-enable the Telegram approval client when an owner is resolvable, so owner-only commands such as `/diagnostics` can be approved in Telegram without duplicate per-channel approver config. Thanks @pashpashpash.
 - Auto-reply/session: carry the tail of user/assistant turns into the freshly-rotated transcript on silent in-reply session resets (compaction failure, role-ordering conflict) so direct-chat continuity survives the rebind. Fixes #70853. (#70898) Thanks @neeravmakwana.
 - Config: skip malformed non-string `env.vars` entries before env-reference checks, so config loading no longer crashes on JSON values like numbers or booleans. (#42402) Thanks @MiltonHeYan.
+- Docker Compose: default missing config and workspace bind mounts to `${HOME:-/tmp}/.openclaw` so manual compose runs do not create invalid empty-source volume specs. (#64485) Thanks @jlapenna.
 
 ## 2026.4.27
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       OPENCLAW_PLUGIN_STAGE_DIR: /var/lib/openclaw/plugin-runtime-deps
       TZ: ${OPENCLAW_TZ:-UTC}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/home/node/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-${HOME:-/tmp}/.openclaw/workspace}:/home/node/.openclaw/workspace
       - openclaw-plugin-runtime-deps:/var/lib/openclaw/plugin-runtime-deps
       ## Uncomment the lines below to enable sandbox isolation
       ## (agents.defaults.sandbox). Requires Docker CLI in the image
@@ -90,8 +90,8 @@ services:
       OPENCLAW_PLUGIN_STAGE_DIR: /var/lib/openclaw/plugin-runtime-deps
       TZ: ${OPENCLAW_TZ:-UTC}
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+      - ${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/home/node/.openclaw
+      - ${OPENCLAW_WORKSPACE_DIR:-${HOME:-/tmp}/.openclaw/workspace}:/home/node/.openclaw/workspace
       - openclaw-plugin-runtime-deps:/var/lib/openclaw/plugin-runtime-deps
     stdin_open: true
     tty: true


### PR DESCRIPTION
Add sensible defaults for `OPENCLAW_CONFIG_DIR` and `OPENCLAW_WORKSPACE_DIR` to prevent broken volume mounts when these env vars are unset.

## Problem

The current `docker-compose.yml` uses `${OPENCLAW_CONFIG_DIR}` and `${OPENCLAW_WORKSPACE_DIR}` without defaults in the volume mount expressions. If a user runs `docker compose up` without setting these variables, Docker creates empty directories with literal names on the host.

Furthermore, if a host path (e.g. `/srv/openclaw`) is interpolated into both the container's volume mount *and* its execution environment variables, it creates a fatal path resolution mismatch. The isolated Node processes will attempt to reference the literal host path within the container filesystem, bypassing the actual statically bound `/home/node/.openclaw` layer.

## Solution

This PR effectively splits the Host-side and Container-side resolutions to operate securely in their respective contexts:

- **Host-side Volume Mappings**: Mount sources now utilize `${OPENCLAW_CONFIG_DIR:-${HOME}/.openclaw}`. This permits the host user to pass dynamic directories (or gracefully fallback to their host `${HOME}`) which Docker Compose interpolates safely before submitting to the daemon.
- **Container-side Environment Block**: We strictly assert the environment variables passed to the applications as `/home/node/.openclaw`. By decoupling this from the host variables, Node processes executing internally always correctly reference the bound destination path rather than blindly inheriting the raw host value.

This structurally guarantees that `setup.sh` or manual invocations can orchestrate varying host locations without ever jeopardizing the container's isolated pathways.

## Verification

- `docker compose config` with no env vars set → volume sources resolve cleanly to the host's `${HOME}/.openclaw`.
- `docker compose config` with `OPENCLAW_CONFIG_DIR=/test/path` → seamlessly binds `/test/path` to `/home/node/.openclaw`.
- Regardless of host input, the OpenClaw instances definitively parse their local environment as `/home/node/.openclaw`, preserving complete filesystem consistency.
