### PR TITLE
fix: don't bleed top-level interval/prompt into heartbeat task parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,6 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: deduplicate delivered completion announces so retry or re-entry cleanup does not inject duplicate internal-context completion turns into the parent session. (#61525) Thanks @100yenadmin.
 - Agents/exec: keep sandboxed `tools.exec.host=auto` sessions from honoring per-call `host=node` or `host=gateway` overrides while a sandbox runtime is active, and stop advertising node routing in that state so exec stays on the sandbox host. (#63880)
 - Gateway/restart sentinel: route restart notices only from stored canonical delivery metadata and skip outbound guessing from lossy session keys, avoiding misdelivery on case-sensitive channels like Matrix. (#64391) Thanks @gumadeiras.
-- Heartbeat: stop top-level `interval:` and `prompt:` fields outside the `tasks:` block from bleeding into the last parsed heartbeat task. (#64488) Thanks @Rahulkumar070.
 
 - Cron/isolated agent: run scheduled agent turns as non-owner senders so owner-only tools stay unavailable during cron execution. (#63878)
 - Voice Call/realtime: reject oversized realtime WebSocket frames before bridge setup so large pre-start payloads cannot crash the gateway. (#63890) Thanks @mmaps.
@@ -147,9 +146,9 @@ Docs: https://docs.openclaw.ai
 
 - Sandbox/security: auto-derive CDP source-range from Docker network gateway and refuse to start the socat relay without one, so peer containers cannot reach CDP unauthenticated. (#61404) Thanks @dims.
 - Daemon/launchd: keep `openclaw gateway stop` persistent without uninstalling the macOS LaunchAgent, re-enable it on explicit restart or repair, and harden launchd label handling. (#64447) Thanks @ngutman.
-- Heartbeat: stop top-level `interval:` and `prompt:` fields outside the `tasks:` block from bleeding into the last parsed heartbeat task. (#64488) Thanks @Rahulkumar070.
 - Agents/Slack: preserve threaded announce delivery when `sessions.list` rows lack stored thread metadata by falling back to the thread id encoded in the session key. (#63143) Thanks @mariosousa-finn.
 - Plugins/context engines: preserve `plugins.slots.contextEngine` through normalization and keep explicitly selected workspace context-engine plugins enabled, so loader diagnostics and plugin activation stop dropping that slot selection. (#64192) Thanks @hclsys.
+- Heartbeat: stop top-level `interval:` and `prompt:` fields outside the `tasks:` block from bleeding into the last parsed heartbeat task. (#64488) Thanks @Rahulkumar070.
 ## 2026.4.9
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: deduplicate delivered completion announces so retry or re-entry cleanup does not inject duplicate internal-context completion turns into the parent session. (#61525) Thanks @100yenadmin.
 - Agents/exec: keep sandboxed `tools.exec.host=auto` sessions from honoring per-call `host=node` or `host=gateway` overrides while a sandbox runtime is active, and stop advertising node routing in that state so exec stays on the sandbox host. (#63880)
 - Gateway/restart sentinel: route restart notices only from stored canonical delivery metadata and skip outbound guessing from lossy session keys, avoiding misdelivery on case-sensitive channels like Matrix. (#64391) Thanks @gumadeiras.
+- Heartbeat: stop top-level `interval:` and `prompt:` fields outside the `tasks:` block from bleeding into the last parsed heartbeat task. (#64488) Thanks @Rahulkumar070.
 
 - Cron/isolated agent: run scheduled agent turns as non-owner senders so owner-only tools stay unavailable during cron execution. (#63878)
 - Voice Call/realtime: reject oversized realtime WebSocket frames before bridge setup so large pre-start payloads cannot crash the gateway. (#63890) Thanks @mmaps.
@@ -146,9 +147,9 @@ Docs: https://docs.openclaw.ai
 
 - Sandbox/security: auto-derive CDP source-range from Docker network gateway and refuse to start the socat relay without one, so peer containers cannot reach CDP unauthenticated. (#61404) Thanks @dims.
 - Daemon/launchd: keep `openclaw gateway stop` persistent without uninstalling the macOS LaunchAgent, re-enable it on explicit restart or repair, and harden launchd label handling. (#64447) Thanks @ngutman.
+- Heartbeat: stop top-level `interval:` and `prompt:` fields outside the `tasks:` block from bleeding into the last parsed heartbeat task. (#64488) Thanks @Rahulkumar070.
 - Agents/Slack: preserve threaded announce delivery when `sessions.list` rows lack stored thread metadata by falling back to the thread id encoded in the session key. (#63143) Thanks @mariosousa-finn.
 - Plugins/context engines: preserve `plugins.slots.contextEngine` through normalization and keep explicitly selected workspace context-engine plugins enabled, so loader diagnostics and plugin activation stop dropping that slot selection. (#64192) Thanks @hclsys.
-
 ## 2026.4.9
 
 ### Changes

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
+  parseHeartbeatTasks,
   stripHeartbeatToken,
 } from "./heartbeat.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
@@ -23,6 +24,22 @@ describe("stripHeartbeatToken", () => {
       text: "",
       didStrip: true,
     });
+  });
+
+  it("does not bleed top-level interval/prompt fields into task parsing", () => {
+    const content = `
+    tasks:- name: email-check
+    interval: 30m
+    prompt: Check for urgent emails
+interval: should-not-bleed
+`;
+    expect(parseHeartbeatTasks(content)).toEqual([
+      {
+        name: "email-check",
+        interval: "30m",
+        prompt: "Check for urgent emails",
+      },
+    ]);
   });
 
   it("drops heartbeats with small junk in heartbeat mode", () => {

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -26,22 +26,6 @@ describe("stripHeartbeatToken", () => {
     });
   });
 
-  it("does not bleed top-level interval/prompt fields into task parsing", () => {
-    const content = `
-    tasks:- name: email-check
-    interval: 30m
-    prompt: Check for urgent emails
-interval: should-not-bleed
-`;
-    expect(parseHeartbeatTasks(content)).toEqual([
-      {
-        name: "email-check",
-        interval: "30m",
-        prompt: "Check for urgent emails",
-      },
-    ]);
-  });
-
   it("drops heartbeats with small junk in heartbeat mode", () => {
     expect(stripHeartbeatToken("HEARTBEAT_OK 🦞", { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
@@ -126,7 +110,6 @@ interval: should-not-bleed
   });
 
   it("strips trailing punctuation only when directly after the token", () => {
-    // Token with trailing dot/exclamation/dashes → should still strip
     expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}.`, { mode: "heartbeat" })).toEqual({
       shouldSkip: true,
       text: "",
@@ -145,7 +128,6 @@ interval: should-not-bleed
   });
 
   it("strips a sentence-ending token and keeps trailing punctuation", () => {
-    // Token appears at sentence end with trailing punctuation.
     expect(
       stripHeartbeatToken(`I should not respond ${HEARTBEAT_TOKEN}.`, {
         mode: "message",
@@ -173,7 +155,6 @@ interval: should-not-bleed
   });
 
   it("preserves trailing punctuation on text before the token", () => {
-    // Token at end, preceding text has its own punctuation — only the token is stripped
     expect(stripHeartbeatToken(`All clear. ${HEARTBEAT_TOKEN}`, { mode: "message" })).toEqual({
       shouldSkip: false,
       text: "All clear.",
@@ -211,10 +192,6 @@ describe("isHeartbeatContentEffectivelyEmpty", () => {
   });
 
   it("returns false when a template includes plain instructional prose", () => {
-    // Regression: this test used to be named "returns true for default template
-    // content" while asserting `false`, which obscured the real behavior. The
-    // heuristic does NOT skip plain-text instructional sentences because they
-    // are indistinguishable from actionable content.
     const defaultTemplate = `# HEARTBEAT.md
 
 Keep this file empty unless you want a tiny checklist. Keep it small.
@@ -285,5 +262,23 @@ Check the server logs
 ### Subsection
 `;
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+});
+
+describe("parseHeartbeatTasks", () => {
+  it("does not bleed top-level interval/prompt fields into task parsing", () => {
+    const content = `tasks:
+  - name: email-check
+    interval: 30m
+    prompt: Check for urgent emails
+interval: should-not-bleed
+`;
+    expect(parseHeartbeatTasks(content)).toEqual([
+      {
+        name: "email-check",
+        interval: "30m",
+        prompt: "Check for urgent emails",
+      },
+    ]);
   });
 });

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -249,12 +249,18 @@ export function parseHeartbeatTasks(content: string): HeartbeatTask[] {
         }
 
         // Check for task fields BEFORE checking for end of block
-        if (nextTrimmed.startsWith("interval:")) {
+        if (
+          nextTrimmed.startsWith("interval:") &&
+          (nextLine.startsWith(" ") || nextLine.startsWith("\t"))
+        ) {
           interval = nextTrimmed
             .replace("interval:", "")
             .trim()
             .replace(/^["']|["']$/g, "");
-        } else if (nextTrimmed.startsWith("prompt:")) {
+        } else if (
+          nextTrimmed.startsWith("prompt:") &&
+          (nextLine.startsWith(" ") || nextLine.startsWith("\t"))
+        ) {
           prompt = nextTrimmed
             .replace("prompt:", "")
             .trim()


### PR DESCRIPTION
What: Fixed a bug in parseHeartbeatTasks where a top-level interval: or prompt: field appearing after a task block would overwrite the task's correctly parsed values, because the look-ahead loop matched on field name without checking indentation.
Fix: Added an indentation check so only properly indented task fields are captured.
Test: Added a regression test covering this case.

