### PR TITLE
fix(agents): persist subagent spawn model to override fields

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -43,7 +43,7 @@ import {
   resolveAuthProfileOrder,
   shouldPreferExplicitConfigApiKeyAuth,
 } from "../model-auth.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { normalizeProviderId, resolveDefaultModelForAgent } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { disposeSessionMcpRuntime } from "../pi-bundle-mcp-tools.js";
 import {
@@ -234,6 +234,14 @@ export async function runEmbeddedPiAgent(
         agentId: params.agentId,
         sessionKey: normalizedSessionKey,
       });
+      // Resolve agent-specific defaults for live-switch/recovery paths
+      // Note: params.config is guaranteed to be defined here (early return at line 127)
+      const agentDefaultRef = params.config
+        ? resolveDefaultModelForAgent({
+            cfg: params.config,
+            agentId: params.agentId,
+          })
+        : { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL };
       await ensureOpenClawModelsJson(params.config, agentDir);
       const resolvedSessionKey = normalizedSessionKey;
       const hookRunner = getGlobalHookRunner();
@@ -751,8 +759,8 @@ export async function runEmbeddedPiAgent(
             cfg: params.config,
             sessionKey: resolvedSessionKey,
             agentId: params.agentId,
-            defaultProvider: DEFAULT_PROVIDER,
-            defaultModel: DEFAULT_MODEL,
+            defaultProvider: agentDefaultRef.provider,
+            defaultModel: agentDefaultRef.model,
             currentProvider: provider,
             currentModel: modelId,
             currentAuthProfileId: preferredProfileId,

--- a/src/agents/subagent-spawn.model-override.test.ts
+++ b/src/agents/subagent-spawn.model-override.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for subagent spawn model override persistence.
+ *
+ * Background: When spawning a subagent with a model override, the spawn path
+ * must write to override fields (modelOverride, providerOverride) rather than
+ * runtime fields (model, modelProvider). The agent startup path in agent-command.ts
+ * reads from override fields to determine the initial model selection.
+ *
+ * Related issues: #48271, #43768, #57306
+ */
+import os from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSubagentSpawnTestConfig,
+  expectPersistedModelOverride,
+  installSessionStoreCaptureMock,
+  loadSubagentSpawnModuleForTest,
+  setupAcceptedSubagentGatewayMock,
+} from "./subagent-spawn.test-helpers.js";
+
+const callGatewayMock = vi.fn();
+const updateSessionStoreMock = vi.fn();
+const pruneLegacyStoreKeysMock = vi.fn();
+
+let resetSubagentRegistryForTests: typeof import("./subagent-registry.js").resetSubagentRegistryForTests;
+let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+
+describe("subagent spawn model override persistence (regression)", () => {
+  beforeEach(async () => {
+    ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock,
+      loadConfig: () => createSubagentSpawnTestConfig(os.tmpdir()),
+      updateSessionStoreMock,
+      pruneLegacyStoreKeysMock,
+      workspaceDir: os.tmpdir(),
+    }));
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    updateSessionStoreMock.mockReset();
+    pruneLegacyStoreKeysMock.mockReset();
+    setupAcceptedSubagentGatewayMock(callGatewayMock);
+
+    updateSessionStoreMock.mockImplementation(
+      async (
+        _storePath: string,
+        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+      ) => {
+        const store: Record<string, Record<string, unknown>> = {};
+        await mutator(store);
+        return store;
+      },
+    );
+  });
+
+  it("persists model to override fields so child startup reads correct model", async () => {
+    const operations: string[] = [];
+    callGatewayMock.mockImplementation(async (opts: { method?: string }) => {
+      operations.push(`gateway:${opts.method ?? "unknown"}`);
+      if (opts.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (opts.method === "agent") {
+        return { runId: "run-1", status: "accepted", acceptedAt: 1000 };
+      }
+      return {};
+    });
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(updateSessionStoreMock, {
+      operations,
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    await spawnSubagentDirect(
+      { task: "test", model: "anthropic/claude-opus-4-6" },
+      { agentSessionKey: "agent:main:main", agentChannel: "discord" },
+    );
+
+    // Verify override fields are set (not runtime fields)
+    expectPersistedModelOverride({
+      persistedStore,
+      sessionKey: /^agent:main:subagent:/,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      source: "user",
+    });
+
+    // Verify runtime fields are NOT set (they would cause the bug)
+    const [, entry] = Object.entries(persistedStore ?? {})[0] ?? [];
+    expect(entry).not.toHaveProperty("model");
+    expect(entry).not.toHaveProperty("modelProvider");
+  });
+
+  it("persists ollama model override correctly", async () => {
+    const operations: string[] = [];
+    callGatewayMock.mockImplementation(async (opts: { method?: string }) => {
+      operations.push(`gateway:${opts.method ?? "unknown"}`);
+      if (opts.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (opts.method === "agent") {
+        return { runId: "run-1", status: "accepted", acceptedAt: 1000 };
+      }
+      return {};
+    });
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(updateSessionStoreMock, {
+      operations,
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    // Use the exact model from the original bug report
+    await spawnSubagentDirect(
+      { task: "test", model: "ollama/gemma4:e4b" },
+      { agentSessionKey: "agent:main:main", agentChannel: "discord" },
+    );
+
+    // Verify override fields are set correctly for ollama model
+    expectPersistedModelOverride({
+      persistedStore,
+      sessionKey: /^agent:main:subagent:/,
+      provider: "ollama",
+      model: "gemma4:e4b",
+      source: "user",
+    });
+  });
+
+  it("sets modelOverrideSource to user for spawn-initiated overrides", async () => {
+    callGatewayMock.mockImplementation(async (opts: { method?: string }) => {
+      if (opts.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (opts.method === "agent") {
+        return { runId: "run-1", status: "accepted", acceptedAt: 1000 };
+      }
+      return {};
+    });
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    installSessionStoreCaptureMock(updateSessionStoreMock, {
+      operations: [],
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    await spawnSubagentDirect(
+      { task: "test", model: "google/gemini-2.5-flash" },
+      { agentSessionKey: "agent:main:main", agentChannel: "discord" },
+    );
+
+    const [, entry] = Object.entries(persistedStore ?? {})[0] ?? [];
+    expect(entry).toHaveProperty("modelOverrideSource", "user");
+  });
+});

--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSubagentSpawnTestConfig,
-  expectPersistedRuntimeModel,
+  expectPersistedModelOverride,
   installSessionStoreCaptureMock,
   loadSubagentSpawnModuleForTest,
   setupAcceptedSubagentGatewayMock,
@@ -15,7 +15,7 @@ const pruneLegacyStoreKeysMock = vi.fn();
 let resetSubagentRegistryForTests: typeof import("./subagent-registry.js").resetSubagentRegistryForTests;
 let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
 
-describe("spawnSubagentDirect runtime model persistence", () => {
+describe("spawnSubagentDirect model override persistence", () => {
   beforeEach(async () => {
     ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
       callGatewayMock,
@@ -42,7 +42,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     );
   });
 
-  it("persists runtime model fields on the child session before starting the run", async () => {
+  it("persists model override fields on the child session before starting the run", async () => {
     const operations: string[] = [];
     callGatewayMock.mockImplementation(async (opts: { method?: string }) => {
       operations.push(`gateway:${opts.method ?? "unknown"}`);
@@ -81,11 +81,12 @@ describe("spawnSubagentDirect runtime model persistence", () => {
       modelApplied: true,
     });
     expect(updateSessionStoreMock).toHaveBeenCalledTimes(1);
-    expectPersistedRuntimeModel({
+    expectPersistedModelOverride({
       persistedStore,
       sessionKey: /^agent:main:subagent:/,
       provider: "openai-codex",
       model: "gpt-5.4",
+      source: "user",
     });
     expect(pruneLegacyStoreKeysMock).toHaveBeenCalledTimes(1);
     expect(operations.indexOf("gateway:sessions.patch")).toBeGreaterThan(-1);

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -92,11 +92,12 @@ export function installSessionStoreCaptureMock(
   );
 }
 
-export function expectPersistedRuntimeModel(params: {
+export function expectPersistedModelOverride(params: {
   persistedStore: SessionStore | undefined;
   sessionKey: string | RegExp;
   provider: string;
   model: string;
+  source?: "user" | "auto";
 }) {
   const [persistedKey, persistedEntry] = Object.entries(params.persistedStore ?? {})[0] ?? [];
   if (typeof params.sessionKey === "string") {
@@ -105,9 +106,20 @@ export function expectPersistedRuntimeModel(params: {
     expect(persistedKey).toMatch(params.sessionKey);
   }
   expect(persistedEntry).toMatchObject({
-    modelProvider: params.provider,
-    model: params.model,
+    providerOverride: params.provider,
+    modelOverride: params.model,
+    ...(params.source ? { modelOverrideSource: params.source } : {}),
   });
+}
+
+/** @deprecated Use expectPersistedModelOverride instead */
+export function expectPersistedRuntimeModel(params: {
+  persistedStore: SessionStore | undefined;
+  sessionKey: string | RegExp;
+  provider: string;
+  model: string;
+}) {
+  expectPersistedModelOverride({ ...params, source: "user" });
 }
 
 export async function loadSubagentSpawnModuleForTest(params: {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSubagentSpawnTestConfig,
-  expectPersistedRuntimeModel,
+  expectPersistedModelOverride,
   installSessionStoreCaptureMock,
   loadSubagentSpawnModuleForTest,
 } from "./subagent-spawn.test-helpers.js";
@@ -149,11 +149,12 @@ describe("spawnSubagentDirect seam flow", () => {
       label: undefined,
     });
 
-    expectPersistedRuntimeModel({
+    expectPersistedModelOverride({
       persistedStore,
       sessionKey: childSessionKey,
       provider: "openai-codex",
       model: "gpt-5.4",
+      source: "user",
     });
     expect(operations.indexOf("gateway:sessions.patch")).toBeGreaterThan(-1);
     expect(operations.indexOf("store:update")).toBeGreaterThan(

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -194,8 +194,9 @@ async function persistInitialChildSessionRuntimeModel(params: {
         candidates: target.storeKeys,
       });
       store[target.canonicalKey] = mergeSessionEntry(store[target.canonicalKey], {
-        model,
-        ...(provider ? { modelProvider: provider } : {}),
+        modelOverride: model,
+        ...(provider ? { providerOverride: provider } : {}),
+        modelOverrideSource: "user",
       });
     });
     return undefined;


### PR DESCRIPTION
## Summary

- Problem: When spawning a subagent with a model override (via `sessions_spawn` or `subagents.model` config), the child session runs on the default model instead of the requested model, despite `modelApplied: true` in the spawn response.
- Why it matters: Subagent model routing is broken. Users are billed for expensive models (Opus) when they configured cheaper ones (Sonnet/Gemma). The `modelApplied: true` response is misleading.
- What changed: `persistInitialChildSessionRuntimeModel()` now writes to `modelOverride`/`providerOverride`/`modelOverrideSource` instead of `model`/`modelProvider`. Secondary fix: live-switch path uses agent-resolved defaults instead of global constants.
- What did NOT change (scope boundary): `agentCommand` startup logic is unchanged - it already reads override fields correctly.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48271
- Closes #43768
- Related #57306, #62755, #62562, #63221
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `persistInitialChildSessionRuntimeModel()` writes to runtime fields (`model`, `modelProvider`), but `agentCommandInternal()` reads from override fields (`modelOverride`, `providerOverride`) for startup model selection.
- Missing detection / guardrail: Tests expected runtime field persistence, which locked in the buggy behavior.
- Contributing context: The distinction between runtime fields ("what actually ran") and override fields ("what should run") was not enforced at the spawn boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-spawn.model-override.test.ts` (new), updated assertions in `subagent-spawn.model-session.test.ts`
- Scenario the test should lock in: Spawn persistence writes override fields, and first-run model selection reads those override fields.
- Why this is the smallest reliable guardrail: The bug is a field-contract mismatch between spawn and startup; unit tests at both boundaries are the minimal coverage.

## AI disclosure

- [x] AI-assisted (Claude Opus 4.5 via Claude Code)
- [x] Tested (build + check + unit tests pass)
- [x] I understand what the code does

Co-Authored-By: Claude <noreply@anthropic.com>