### PR TITLE
fix: use lightweight status RPC for doctor Phase A health gate

### DIFF
--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -5,8 +5,6 @@ import { collectChannelStatusIssues } from "../infra/channels-status-issues.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
-import { formatHealthCheckFailure } from "./health-format.js";
-import { healthCommand } from "./health.js";
 
 export type GatewayMemoryProbe = {
   checked: boolean;
@@ -24,7 +22,7 @@ export async function checkGatewayHealth(params: {
     typeof params.timeoutMs === "number" && params.timeoutMs > 0 ? params.timeoutMs : 10_000;
   let healthOk = false;
   try {
-    await healthCommand({ json: false, timeoutMs, config: params.cfg }, params.runtime);
+    await callGateway({ method: "status", timeoutMs, config: params.cfg });
     healthOk = true;
   } catch (err) {
     const message = String(err);
@@ -32,7 +30,7 @@ export async function checkGatewayHealth(params: {
       note("Gateway not running.", "Gateway");
       note(gatewayDetails.message, "Gateway connection");
     } else {
-      params.runtime.error(formatHealthCheckFailure(err));
+      params.runtime.error(String(err));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes issue #64400: CLI  and  trigger false restarts due to hardcoded 3000ms loopback timeouts.

### Problem

When heavily loaded with agents, background crons, or slow RPCs at startup, the OpenClaw gateway can take longer than 3 seconds to respond to health checks. The  command's Phase A gate was calling the heavyweight  RPC (which probes all channels) via , using the same call path as the detailed health check. This caused false timeouts and triggered unsafe restart paths.

### Fix

Replace the heavyweight  call in  (used for Phase A liveness gating in ) with a direct lightweight  RPC call. The  method returns a simple gateway status summary without channel probing, making it appropriate for fast liveness checks.

**Before:**
```typescript
await healthCommand({ json: false, timeoutMs, config: params.cfg }, params.runtime);
```

**After:**
```typescript
await callGateway({ method: "status", timeoutMs, config: params.cfg });
```

Also removes unused imports (, ).

### Testing

The fast-path mocks already mock , so existing tests are unaffected. The  handler is registered in  and is lighter than  (no channel probing).