### PR TITLE
fix: clear model/provider override on /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1053,6 +1053,45 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     expect(result.sessionEntry.reasoningLevel).toBe("low");
   });
 
+  it("/new clears modelOverride and providerOverride from previous session", async () => {
+    const storePath = await createStorePath("openclaw-reset-model-override-");
+    const sessionKey = "agent:main:telegram:dm:user-model";
+    const existingSessionId = "existing-session-model";
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: { modelOverride: "gpt-4", providerOverride: "openai" },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "user-model",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    // Model and provider overrides should be cleared on reset
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+  });
+
   it("/new in a new session does not preserve overrides", async () => {
     const storePath = await createStorePath("openclaw-new-no-preserve-");
     const sessionKey = "agent:main:telegram:dm:user3";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -373,13 +373,27 @@ export async function initSessionState(params: {
     sessionEntry.outputTokens = undefined;
     sessionEntry.contextTokens = undefined;
   }
-  // Preserve per-session overrides while resetting compaction state on /new.
-  sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
+  // Clear model/provider overrides on /new and /reset so the session starts
+  // fresh with the configured default model. Do NOT preserve old overrides.
+  // Preserve other per-session settings (thinking, verbose, reasoning, ttsAuto)
+  // which were explicitly carried over in sessionEntry construction above.
+  if (resetTriggered) {
+    const { modelOverride: _, providerOverride: __, ...rest } = sessionEntry;
+    sessionStore[sessionKey] = { ...rest };
+  } else {
+    // Preserve per-session overrides for non-reset session updates.
+    sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
+  }
   await updateSessionStore(
     storePath,
     (store) => {
-      // Preserve per-session overrides while resetting compaction state on /new.
-      store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      // Apply the same logic as the in-memory update above.
+      if (resetTriggered) {
+        const { modelOverride: _, providerOverride: __, ...rest } = sessionEntry;
+        store[sessionKey] = { ...rest };
+      } else {
+        store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      }
     },
     {
       activeSessionKey: sessionKey,


### PR DESCRIPTION
## Summary
- Clears `modelOverride` and `providerOverride` when `/new` or `/reset` is triggered
- Ensures reset sessions start fresh with the configured default model
- Preserves other per-session settings (thinking, verbose, reasoning, ttsAuto) as intended

## Problem
After `/new` or `/reset`, the session incorrectly inherited the previous `modelOverride`/`providerOverride` via the spread operator, causing the new session to remain pinned to the old model instead of falling back to `agents.defaults.model.primary`.

## Test plan
- [x] Existing session tests pass (`pnpm test src/auto-reply/reply/session.test.ts`)
- [ ] Manual testing: set `/model gpt`, run `/new`, verify session uses default model

Fixes #64475

🤖 Generated with [Claude Code](https://claude.com/claude-code)