### PR TITLE
fix: .env.example ships a known-weak literal token that becomes the...

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@
 # -----------------------------------------------------------------------------
 # Gateway auth + paths
 # -----------------------------------------------------------------------------
-# Recommended if the gateway binds beyond loopback.
-OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
+# Recommended if the gateway binds beyond loopback. Leave blank to generate a random token at startup.
+OPENCLAW_GATEWAY_TOKEN=
 # Example generator: openssl rand -hex 32
 
 # Optional alternative auth mode (use token OR password).

--- a/src/gateway/credentials.test.ts
+++ b/src/gateway/credentials.test.ts
@@ -543,6 +543,17 @@ describe("resolveGatewayCredentialsFromValues", () => {
     expect(resolved).toEqual({ token: undefined, password: undefined });
   });
 
+  it("treats the shipped example gateway token as unset", () => {
+    const resolved = resolveGatewayCredentialsFromValues({
+      configToken: "change-me-to-a-long-random-token",
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "change-me-to-a-long-random-token",
+      } as NodeJS.ProcessEnv,
+      tokenPrecedence: "config-first",
+    });
+    expect(resolved).toEqual({ token: undefined, password: undefined });
+  });
+
   it("accepts config credentials that do not contain env var references", () => {
     const resolved = resolveGatewayCredentialsFromValues({
       configToken: "real-token-value",

--- a/src/gateway/credentials.ts
+++ b/src/gateway/credentials.ts
@@ -28,6 +28,11 @@ export type GatewayRemoteCredentialPrecedence = "remote-first" | "env-first";
 export type GatewayRemoteCredentialFallback = "remote-env-local" | "remote-only";
 
 const GATEWAY_SECRET_REF_UNAVAILABLE_ERROR_CODE = "GATEWAY_SECRET_REF_UNAVAILABLE"; // pragma: allowlist secret
+const EXAMPLE_GATEWAY_TOKEN = "change-me-to-a-long-random-token"; // pragma: allowlist secret
+
+function sanitizeGatewayToken(value: string | undefined): string | undefined {
+  return value === EXAMPLE_GATEWAY_TOKEN ? undefined : value;
+}
 
 export class GatewaySecretRefUnavailableError extends Error {
   readonly code = GATEWAY_SECRET_REF_UNAVAILABLE_ERROR_CODE;
@@ -80,9 +85,9 @@ export function resolveGatewayCredentialsFromValues(params: {
   passwordPrecedence?: GatewayCredentialPrecedence;
 }): ResolvedGatewayCredentials {
   const env = params.env ?? process.env;
-  const envToken = trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
+  const envToken = sanitizeGatewayToken(trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN));
   const envPassword = trimToUndefined(env.OPENCLAW_GATEWAY_PASSWORD);
-  const configToken = trimCredentialToUndefined(params.configToken);
+  const configToken = sanitizeGatewayToken(trimCredentialToUndefined(params.configToken));
   const configPassword = trimCredentialToUndefined(params.configPassword);
   const tokenPrecedence = params.tokenPrecedence ?? "env-first";
   const passwordPrecedence = params.passwordPrecedence ?? "env-first";

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -117,6 +117,22 @@ describe("ensureGatewayStartupAuth", () => {
     });
   });
 
+  it("replaces the shipped example gateway token at startup", async () => {
+    const result = await ensureGatewayStartupAuth({
+      cfg: {},
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "change-me-to-a-long-random-token",
+      } as NodeJS.ProcessEnv,
+      persist: true,
+    });
+
+    expect(result.generatedToken).toMatch(/^[0-9a-f]{48}$/);
+    expect(result.persistedGeneratedToken).toBe(true);
+    expect(result.auth.mode).toBe("token");
+    expect(result.auth.token).toBe(result.generatedToken);
+    expect(mocks.replaceConfigFile).toHaveBeenCalledTimes(1);
+  });
+
   it("does not generate when token already exists", async () => {
     await expectResolvedToken({
       cfg: {


### PR DESCRIPTION
## Fix Summary
`openclaw/.env.example` ships with `OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token` as an uncommented, active default. Users who follow the quick-start instructions (step 1: "Copy this file to `.env`") and skip step 2 ("Fill only the values you use") deploy a gateway protected by a publicly known credential, allowing any LAN-adjacent party who has read the repository to authenticate as a trusted operator.

## Issue Linkage
Fixes #64520

## Security Snapshot
- CVSS v3.1: 7.3 (High)
- CVSS v4.0: 8.5 (High)

## Implementation Details
### Files Changed
- `.env.example` (+2/-2)
- `src/gateway/credentials.test.ts` (+11/-0)
- `src/gateway/credentials.ts` (+7/-2)
- `src/gateway/startup-auth.test.ts` (+16/-0)

### Technical Analysis
1. Clone the repo.
2. Follow the quick-start instructions literally: `cp openclaw/.env.example openclaw/.env`.
3. Skip replacing the token value (or overlook step 2).
4. Start the gateway via `docker compose up` or `openclaw gateway run`.
5. From a second host on the LAN, authenticate using the known literal: `Authorization: Bearer change-me-to-a-long-random-token`.
6. Observe full gateway access as a trusted operator.

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed (with pre-existing baseline failures)

## Risk and Compatibility
- non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: github-copilot/claude-sonnet-4.6
