### PR TITLE
fix(slack): register subagent_delivery_target hook for thread routing

### DIFF
--- a/extensions/slack/index.test.ts
+++ b/extensions/slack/index.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
-import entry from "./index.js";
+import { beforeAll, describe, expect, it } from "vitest";
 import setupEntry from "./setup-entry.js";
 
+let entry: typeof import("./index.js").default;
+
 describe("slack bundled entries", () => {
+  beforeAll(async () => {
+    ({ default: entry } = await import("./index.js"));
+  });
+
   it("declares the channel plugin without importing the broad api barrel", () => {
     expect(entry.kind).toBe("bundled-channel-entry");
     expect(entry.id).toBe("slack");

--- a/extensions/slack/index.ts
+++ b/extensions/slack/index.ts
@@ -4,6 +4,15 @@ import {
 } from "openclaw/plugin-sdk/channel-entry-contract";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
 
+type SlackSubagentHooksModule = typeof import("./subagent-hooks-api.js");
+
+let slackSubagentHooksPromise: Promise<SlackSubagentHooksModule> | null = null;
+
+function loadSlackSubagentHooksModule() {
+  slackSubagentHooksPromise ??= import("./subagent-hooks-api.js");
+  return slackSubagentHooksPromise;
+}
+
 function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
   const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
     specifier: "./runtime-api.js",
@@ -29,5 +38,19 @@ export default defineBundledChannelEntry({
     specifier: "./runtime-api.js",
     exportName: "setSlackRuntime",
   },
-  registerFull: registerSlackPluginHttpRoutes,
+  registerFull(api) {
+    registerSlackPluginHttpRoutes(api);
+    api.on("subagent_spawning", async (event) => {
+      const { handleSlackSubagentSpawning } = await loadSlackSubagentHooksModule();
+      return handleSlackSubagentSpawning(api, event);
+    });
+    api.on("subagent_delivery_target", async (event) => {
+      const { handleSlackSubagentDeliveryTarget } = await loadSlackSubagentHooksModule();
+      return handleSlackSubagentDeliveryTarget(event);
+    });
+    api.on("subagent_ended", async (event) => {
+      const { handleSlackSubagentEnded } = await loadSlackSubagentHooksModule();
+      handleSlackSubagentEnded(event);
+    });
+  },
 });

--- a/extensions/slack/src/subagent-hooks.test.ts
+++ b/extensions/slack/src/subagent-hooks.test.ts
@@ -1,0 +1,90 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  getRequiredHookHandler,
+  registerHookHandlersForTest,
+} from "../../../test/helpers/plugins/subagent-hooks.js";
+
+let registerSlackSubagentHooks: typeof import("./subagent-hooks.js").registerSlackSubagentHooks;
+
+function registerHandlersForTest(config: Record<string, unknown> = {}) {
+  return registerHookHandlersForTest<OpenClawPluginApi>({
+    config,
+    register: registerSlackSubagentHooks,
+  });
+}
+
+describe("slack subagent hook handlers", () => {
+  beforeAll(async () => {
+    ({ registerSlackSubagentHooks } = await import("./subagent-hooks.js"));
+  });
+
+  it("marks thread routing ready on subagent_spawning for slack threads", () => {
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHookHandler(handlers, "subagent_spawning");
+
+    expect(
+      handler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          requester: {
+            channel: "slack",
+            accountId: "default",
+            to: "channel:C123",
+            threadId: "1775841953.287659",
+          },
+          threadRequested: true,
+        },
+        {},
+      ),
+    ).toMatchObject({ status: "ok", threadBindingReady: true });
+  });
+
+  it("returns the originating slack thread as the delivery target", () => {
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHookHandler(handlers, "subagent_delivery_target");
+
+    expect(
+      handler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          expectsCompletionMessage: true,
+          requesterOrigin: {
+            channel: "slack",
+            accountId: "default",
+            to: "channel:C123",
+            threadId: "1775841953.287659",
+          },
+        },
+        {},
+      ),
+    ).toEqual({
+      origin: {
+        channel: "slack",
+        accountId: "default",
+        to: "channel:C123",
+        threadId: "1775841953.287659",
+      },
+    });
+  });
+
+  it("returns undefined when slack delivery is missing thread context", () => {
+    const handlers = registerHandlersForTest();
+    const handler = getRequiredHookHandler(handlers, "subagent_delivery_target");
+
+    expect(
+      handler(
+        {
+          childSessionKey: "agent:main:subagent:child",
+          expectsCompletionMessage: true,
+          requesterOrigin: {
+            channel: "slack",
+            accountId: "default",
+            to: "channel:C123",
+          },
+        },
+        {},
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/slack/src/subagent-hooks.ts
+++ b/extensions/slack/src/subagent-hooks.ts
@@ -1,0 +1,101 @@
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalStringifiedId,
+} from "openclaw/plugin-sdk/text-runtime";
+import type { OpenClawPluginApi } from "../runtime-api.js";
+
+type SlackSubagentSpawningEvent = {
+  threadRequested?: boolean;
+  requester?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+  };
+};
+
+type SlackSubagentEndedEvent = {
+  targetSessionKey: string;
+};
+
+type SlackSubagentDeliveryTargetEvent = {
+  expectsCompletionMessage?: boolean;
+  requesterOrigin?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+  };
+};
+
+type SlackSubagentSpawningResult =
+  | { status: "ok"; threadBindingReady?: boolean }
+  | { status: "error"; error: string }
+  | undefined;
+
+type SlackSubagentDeliveryTargetResult =
+  | {
+      origin: {
+        channel: "slack";
+        accountId?: string;
+        to: string;
+        threadId: string;
+      };
+    }
+  | undefined;
+
+export function handleSlackSubagentSpawning(
+  _api: OpenClawPluginApi,
+  event: SlackSubagentSpawningEvent,
+): SlackSubagentSpawningResult {
+  if (!event.threadRequested) {
+    return undefined;
+  }
+  if (normalizeOptionalLowercaseString(event.requester?.channel) !== "slack") {
+    return undefined;
+  }
+  const to = event.requester?.to?.trim();
+  const threadId = normalizeOptionalStringifiedId(event.requester?.threadId);
+  if (!to || !threadId) {
+    return {
+      status: "error",
+      error: "Slack thread-bound subagent spawns require an originating channel and thread_ts.",
+    };
+  }
+  return { status: "ok", threadBindingReady: true };
+}
+
+export function handleSlackSubagentDeliveryTarget(
+  event: SlackSubagentDeliveryTargetEvent,
+): SlackSubagentDeliveryTargetResult {
+  if (!event.expectsCompletionMessage) {
+    return undefined;
+  }
+  if (normalizeOptionalLowercaseString(event.requesterOrigin?.channel) !== "slack") {
+    return undefined;
+  }
+  const to = event.requesterOrigin?.to?.trim();
+  const threadId = normalizeOptionalStringifiedId(event.requesterOrigin?.threadId);
+  if (!to || !threadId) {
+    return undefined;
+  }
+  return {
+    origin: {
+      channel: "slack",
+      accountId: event.requesterOrigin?.accountId?.trim() || undefined,
+      to,
+      threadId,
+    },
+  };
+}
+
+export function handleSlackSubagentEnded(_event: SlackSubagentEndedEvent) {
+  // Slack thread routing can resolve directly from requesterOrigin, so there is
+  // no per-session binding state to clean up here.
+}
+
+export function registerSlackSubagentHooks(api: OpenClawPluginApi) {
+  api.on("subagent_spawning", (event) => handleSlackSubagentSpawning(api, event));
+  api.on("subagent_delivery_target", (event) => handleSlackSubagentDeliveryTarget(event));
+  api.on("subagent_ended", (event) => handleSlackSubagentEnded(event));
+}

--- a/extensions/slack/subagent-hooks-api.ts
+++ b/extensions/slack/subagent-hooks-api.ts
@@ -1,0 +1,7 @@
+// Subagent hooks live behind a dedicated barrel so the bundled entry can lazy
+// load only the handlers it needs.
+export {
+  handleSlackSubagentDeliveryTarget,
+  handleSlackSubagentEnded,
+  handleSlackSubagentSpawning,
+} from "./src/subagent-hooks.js";


### PR DESCRIPTION
## Summary\n- register Slack subagent spawning, delivery target, and ended hooks in the bundled entry\n- route Slack subagent completion messages back to the originating channel thread using requesterOrigin.threadId\n- add focused tests covering Slack subagent hook behavior\n\n## Testing\n- node scripts/run-vitest.mjs run --config vitest.config.ts extensions/slack/index.test.ts extensions/slack/src/subagent-hooks.test.ts