### PR TITLE
fix(env): replace known-weak literal token in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@
 # Gateway auth + paths
 # -----------------------------------------------------------------------------
 # Recommended if the gateway binds beyond loopback.
-OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
-# Example generator: openssl rand -hex 32
+OPENCLAW_GATEWAY_TOKEN=
+# Generate a real token first, for example: openssl rand -hex 32
 
 # Optional alternative auth mode (use token OR password).
 # OPENCLAW_GATEWAY_PASSWORD=change-me-to-a-strong-password

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -132,6 +132,35 @@ describe("ensureGatewayStartupAuth", () => {
     });
   });
 
+  it("rejects the known-weak literal token from config", async () => {
+    await expect(
+      ensureGatewayStartupAuth({
+        cfg: {
+          gateway: {
+            auth: {
+              mode: "token",
+              token: "change-me-to-a-long-random-token",
+            },
+          },
+        },
+        env: {} as NodeJS.ProcessEnv,
+        persist: true,
+      }),
+    ).rejects.toThrow(/replace the example placeholder token/i);
+  });
+
+  it("rejects the known-weak literal token from OPENCLAW_GATEWAY_TOKEN", async () => {
+    await expect(
+      ensureGatewayStartupAuth({
+        cfg: {},
+        env: {
+          OPENCLAW_GATEWAY_TOKEN: "change-me-to-a-long-random-token",
+        } as NodeJS.ProcessEnv,
+        persist: true,
+      }),
+    ).rejects.toThrow(/replace the example placeholder token/i);
+  });
+
   it("does not generate in password mode", async () => {
     await expectNoTokenGeneration(
       {

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -137,6 +137,21 @@ function hasGatewayPasswordOverrideCandidate(params: {
   );
 }
 
+const KNOWN_WEAK_GATEWAY_TOKENS = new Set(["change-me-to-a-long-random-token"]);
+
+function assertGatewayTokenIsNotKnownWeakLiteral(token: string | undefined): void {
+  const normalized = normalizeOptionalString(token);
+  if (!normalized) {
+    return;
+  }
+  if (!KNOWN_WEAK_GATEWAY_TOKENS.has(normalized)) {
+    return;
+  }
+  throw new Error(
+    "Invalid gateway auth token: replace the example placeholder token before startup. Generate a real secret, for example with `openssl rand -hex 32`.",
+  );
+}
+
 export async function ensureGatewayStartupAuth(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -195,6 +210,7 @@ export async function ensureGatewayStartupAuth(params: {
     authOverride,
     tailscaleOverride: params.tailscaleOverride,
   });
+  assertGatewayTokenIsNotKnownWeakLiteral(resolved.mode === "token" ? resolved.token : undefined);
   if (resolved.mode !== "token" || (resolved.token?.trim().length ?? 0) > 0) {
     assertHooksTokenSeparateFromGatewayAuth({ cfg: params.cfg, auth: resolved });
     return { cfg: params.cfg, auth: resolved, persistedGeneratedToken: false };
@@ -229,6 +245,7 @@ export async function ensureGatewayStartupAuth(params: {
     authOverride: params.authOverride,
     tailscaleOverride: params.tailscaleOverride,
   });
+  assertGatewayTokenIsNotKnownWeakLiteral(nextAuth.mode === "token" ? nextAuth.token : undefined);
   assertHooksTokenSeparateFromGatewayAuth({ cfg: nextCfg, auth: nextAuth });
   return {
     cfg: nextCfg,


### PR DESCRIPTION
## Summary
- replace the active example gateway token in `.env.example` with an empty value
- reject the known-weak literal placeholder token during gateway startup
- add startup-auth tests covering config and env-token rejection

## Testing
- `/root/openclaw-fork/node_modules/.bin/vitest run --maxWorkers 1 --maxConcurrency 1 src/gateway/startup-auth.test.ts -t "known-weak literal token|does not generate when token already exists"`

Closes #64520