### PR TITLE
fix(reply): allow OpenClaw tmp media in normalizer

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
 const saveMediaSource = vi.hoisted(() => vi.fn());
@@ -148,6 +149,47 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrl: undefined,
       mediaUrls: undefined,
     });
+  });
+
+  it("keeps tool-generated media under the OpenClaw tmp root when sandbox mode is off", async () => {
+    const tmpAudioPath = path.join(resolvePreferredOpenClawTmpDir(), "tts", "reply.opus");
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: { sandbox: { mode: "off" } },
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [tmpAudioPath],
+      audioAsVoice: true,
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: tmpAudioPath,
+      mediaUrls: [tmpAudioPath],
+      audioAsVoice: true,
+    });
+    expect(saveMediaSource).not.toHaveBeenCalled();
+  });
+
+  it("still drops absolute host-local media outside the OpenClaw tmp root when sandbox mode is off", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: { sandbox: { mode: "off" } },
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/tmp/not-openclaw/reply.opus"],
+      audioAsVoice: true,
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+      audioAsVoice: true,
+    });
+    expect(saveMediaSource).not.toHaveBeenCalled();
   });
 
   it("persists volatile agent-state media from the workspace into host outbound media", async () => {

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
@@ -14,6 +15,10 @@ vi.mock("../../media/store.js", () => ({
 }));
 
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
+
+function asOpenClawConfig(config: OpenClawConfig): OpenClawConfig {
+  return config;
+}
 
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
@@ -91,7 +96,7 @@ describe("createReplyMediaPathNormalizer", () => {
       containerWorkdir: "/workspace",
     });
     const normalize = createReplyMediaPathNormalizer({
-      cfg: { tools: { fs: { workspaceOnly: true } } },
+      cfg: asOpenClawConfig({ tools: { fs: { workspaceOnly: true } } }),
       sessionKey: "session-key",
       workspaceDir: "/tmp/agent-workspace",
     });
@@ -152,9 +157,9 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("keeps tool-generated media under the OpenClaw tmp root when sandbox mode is off", async () => {
-    const tmpAudioPath = path.join(resolvePreferredOpenClawTmpDir(), "tts", "reply.opus");
+    const tmpAudioPath = path.join(resolvePreferredOpenClawTmpDir(), "tts-abc123", "reply.opus");
     const normalize = createReplyMediaPathNormalizer({
-      cfg: { sandbox: { mode: "off" } },
+      cfg: asOpenClawConfig({}),
       sessionKey: "session-key",
       workspaceDir: "/tmp/agent-workspace",
     });
@@ -174,7 +179,7 @@ describe("createReplyMediaPathNormalizer", () => {
 
   it("still drops absolute host-local media outside the OpenClaw tmp root when sandbox mode is off", async () => {
     const normalize = createReplyMediaPathNormalizer({
-      cfg: { sandbox: { mode: "off" } },
+      cfg: asOpenClawConfig({}),
       sessionKey: "session-key",
       workspaceDir: "/tmp/agent-workspace",
     });
@@ -188,6 +193,29 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: true,
+    });
+    expect(saveMediaSource).not.toHaveBeenCalled();
+  });
+
+  it("still drops non-media files under the OpenClaw tmp root", async () => {
+    const tmpPromptPath = path.join(
+      resolvePreferredOpenClawTmpDir(),
+      "openclaw-cli-system-prompt-abc123",
+      "system-prompt.md",
+    );
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: asOpenClawConfig({}),
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [tmpPromptPath],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
     });
     expect(saveMediaSource).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -8,6 +8,7 @@ import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { saveMediaSource } from "../../media/store.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -34,12 +35,19 @@ function isManagedGlobalReplyMediaPath(candidate: string): boolean {
   return MANAGED_GLOBAL_MEDIA_SUBDIRS.has(firstSegment) || firstSegment.startsWith("tool-");
 }
 
+function isManagedTmpReplyMediaPath(candidate: string): boolean {
+  return isPathInside(resolvePreferredOpenClawTmpDir(), candidate);
+}
+
 function isAllowedAbsoluteReplyMediaPath(params: {
   candidate: string;
   workspaceDir: string;
   sandboxRoot?: string;
 }): boolean {
-  if (isManagedGlobalReplyMediaPath(params.candidate)) {
+  if (
+    isManagedGlobalReplyMediaPath(params.candidate) ||
+    isManagedTmpReplyMediaPath(params.candidate)
+  ) {
     return true;
   }
   const volatileRoots = [params.workspaceDir, params.sandboxRoot]

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -19,6 +19,10 @@ const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
 const AGENT_STATE_MEDIA_DIRNAME = path.join(".openclaw", "media");
 const MANAGED_GLOBAL_MEDIA_SUBDIRS = new Set(["outbound"]);
+const MANAGED_TMP_REPLY_MEDIA_DIRS = new Set(["tts"]);
+const MANAGED_TMP_REPLY_MEDIA_PREFIXES = ["tts-"];
+
+let cachedPreferredTmpDir: string | undefined;
 
 function isPathInside(root: string, candidate: string): boolean {
   const relative = path.relative(path.resolve(root), path.resolve(candidate));
@@ -35,8 +39,24 @@ function isManagedGlobalReplyMediaPath(candidate: string): boolean {
   return MANAGED_GLOBAL_MEDIA_SUBDIRS.has(firstSegment) || firstSegment.startsWith("tool-");
 }
 
+function resolveCachedPreferredTmpDir(): string {
+  if (!cachedPreferredTmpDir) {
+    cachedPreferredTmpDir = resolvePreferredOpenClawTmpDir();
+  }
+  return cachedPreferredTmpDir;
+}
+
 function isManagedTmpReplyMediaPath(candidate: string): boolean {
-  return isPathInside(resolvePreferredOpenClawTmpDir(), candidate);
+  const tmpRoot = resolveCachedPreferredTmpDir();
+  const relative = path.relative(path.resolve(tmpRoot), path.resolve(candidate));
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return false;
+  }
+  const firstSegment = relative.split(path.sep)[0] ?? "";
+  return (
+    MANAGED_TMP_REPLY_MEDIA_DIRS.has(firstSegment) ||
+    MANAGED_TMP_REPLY_MEDIA_PREFIXES.some((prefix) => firstSegment.startsWith(prefix))
+  );
 }
 
 function isAllowedAbsoluteReplyMediaPath(params: {


### PR DESCRIPTION
## Summary
- allow reply media normalization to keep OpenClaw-managed temp files under the preferred tmp root even when sandbox mode is off
- preserve the existing host-path restrictions by only allowing the managed OpenClaw tmp directory, not arbitrary /tmp paths
- add focused regression tests covering sandbox.mode=off for both allowed /tmp/openclaw media and blocked unrelated absolute host-local media

Closes #64533

## Testing
- attempted: OPENCLAW_LOCAL_CHECK=0 pnpm test src/auto-reply/reply/reply-media-paths.test.ts
- blocked locally because this worktree does not have node_modules / vitest installed
- attempted pnpm install, but dependency installation was blocked by transient registry/network resolution in this environment
- sending to CI for verification