### PR TITLE
fix(reply): allow TTS and tool-generated media under managed tmp dir

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -7,6 +7,7 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { saveMediaSource } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
@@ -41,6 +42,18 @@ function isAllowedAbsoluteReplyMediaPath(params: {
 }): boolean {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
     return true;
+  }
+  // Allow media generated under the managed OpenClaw tmp dir (e.g. TTS audio
+  // written to /tmp/openclaw/tts-*/voice-*.mp3). This is consistent with
+  // buildMediaLocalRoots() which includes the same preferredTmpDir.
+  try {
+    const tmpDir = resolvePreferredOpenClawTmpDir();
+    if (isPathInside(tmpDir, params.candidate)) {
+      return true;
+    }
+  } catch {
+    // Tmp dir resolution can fail in exotic environments; proceed to
+    // workspace / sandbox checks below.
   }
   const volatileRoots = [params.workspaceDir, params.sandboxRoot]
     .filter((root): root is string => Boolean(root))


### PR DESCRIPTION
## Summary

Fixes #64529 — TTS-generated audio is silently dropped because `/tmp/openclaw/` is not in the reply media path allowlist.

## Root Cause

Two security allowlists in OpenClaw are inconsistent:

| Allowlist | Includes `/tmp/openclaw/`? |
|---|---|
| `buildMediaLocalRoots()` (media **loading**) | ✅ Yes, via `preferredTmpDir` |
| `isAllowedAbsoluteReplyMediaPath()` (reply **normalizer**) | ❌ No |

TTS tools write audio files to `/tmp/openclaw/tts-*/voice-*.mp3`. The file is generated successfully, but the reply pipeline blocks it:

```
dropping blocked reply media /tmp/openclaw/tts-w1q7or/voice-1775861103004.mp3:
Error: Absolute host-local MEDIA paths are blocked in normal replies.
```

## Fix

Add `resolvePreferredOpenClawTmpDir()` as an allowed root in `isAllowedAbsoluteReplyMediaPath()`, making it consistent with `buildMediaLocalRoots()`. The call is wrapped in try/catch for graceful degradation in environments where tmp dir resolution fails.

## Impact

- TTS audio delivery works again on all channels
- Any tool writing media to `/tmp/openclaw/` benefits from this fix
- No security regression: the tmp dir is already managed/secured by OpenClaw (`0o700` perms, ownership checks)