### PR TITLE
fix(whatsapp): normalize explicit heartbeat target

### DIFF
--- a/extensions/whatsapp/src/heartbeat-recipients.test.ts
+++ b/extensions/whatsapp/src/heartbeat-recipients.test.ts
@@ -100,6 +100,19 @@ describe("resolveWhatsAppHeartbeatRecipients", () => {
     expect(result).toEqual({ recipients: ["+15550007777"], source: "flag" });
   });
 
+  it("preserves explicit WhatsApp group JIDs passed via --to", () => {
+    const result = resolveWith({}, { to: " whatsapp:120363999999999999@g.us " });
+    expect(result).toEqual({
+      recipients: ["120363999999999999@g.us"],
+      source: "flag",
+    });
+  });
+
+  it("ignores invalid explicit --to values", () => {
+    const result = resolveWith({}, { to: "not-a-whatsapp-target" });
+    expect(result).toEqual({ recipients: [], source: "flag" });
+  });
+
   it("returns ambiguous session recipients when no allowFrom list exists", () => {
     setSessionStore({
       a: { lastChannel: "whatsapp", lastTo: "+15550000001", updatedAt: 2, sessionId: "a" },

--- a/extensions/whatsapp/src/heartbeat-recipients.ts
+++ b/extensions/whatsapp/src/heartbeat-recipients.ts
@@ -8,6 +8,7 @@ import {
   resolveStorePath,
   type OpenClawConfig,
 } from "./heartbeat-recipients.runtime.js";
+import { normalizeWhatsAppTarget } from "./normalize.js";
 
 type HeartbeatRecipientsResult = { recipients: string[]; source: string };
 type HeartbeatRecipientsOpts = { to?: string; all?: boolean; accountId?: string };
@@ -52,7 +53,8 @@ export function resolveWhatsAppHeartbeatRecipients(
   opts: HeartbeatRecipientsOpts = {},
 ): HeartbeatRecipientsResult {
   if (opts.to) {
-    return { recipients: [normalizeE164(opts.to)], source: "flag" };
+    const normalizedTarget = normalizeWhatsAppTarget(opts.to);
+    return { recipients: normalizedTarget ? [normalizedTarget] : [], source: "flag" };
   }
 
   const sessionRecipients = getSessionRecipients(cfg);


### PR DESCRIPTION
## Summary

- Problem: explicit WhatsApp heartbeat targets from `--to` were normalized as E.164-only values.
- Why it matters: explicit group JIDs like `120363999999999999@g.us` could be corrupted or rejected, and invalid explicit targets could degrade into an unintended phone-like target.
- What changed: `heartbeat-recipients.ts` now normalizes explicit targets with the WhatsApp-aware target normalizer, and tests now cover direct targets, group JIDs, and invalid explicit targets.
- What did NOT change (scope boundary): implicit session/allowFrom recipient resolution and outbound send behavior remain unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related #21533
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: the explicit target path in `extensions/whatsapp/src/heartbeat-recipients.ts` used `normalizeE164(opts.to)` instead of the channel-aware WhatsApp target normalizer, so group JIDs were not preserved on that path.
- Missing detection / guardrail: there was no explicit `--to` unit test covering group JIDs or invalid explicit WhatsApp targets.
- Contributing context (if known): other WhatsApp target paths already accept both direct E.164-style targets and group JIDs, so this explicit heartbeat path had drifted from the channel contract.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/heartbeat-recipients.test.ts`
- Scenario the test should lock in: explicit `--to` preserves WhatsApp group JIDs and rejects invalid explicit targets instead of coercing them through E.164 normalization.
- Why this is the smallest reliable guardrail: the bug is isolated to recipient normalization inside the explicit heartbeat target resolver.
- Existing test that already covers this (if any): shared core coverage already exercises generic WhatsApp target behavior in `src/infra/outbound/targets.shared-test.ts` and `src/infra/heartbeat-runner.returns-default-unset.test.ts`, but this PR adds the missing extension-local regression tests for the explicit path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Explicit WhatsApp heartbeat targets now preserve valid group JIDs passed through `--to`, and invalid explicit targets resolve to no recipient instead of a malformed phone-like target.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): explicit heartbeat `--to` target set to either a direct number or a WhatsApp group JID

### Steps

1. Resolve WhatsApp heartbeat recipients with an explicit `--to 120363999999999999@g.us` target.
2. Resolve the same path with an invalid explicit target.
3. Compare behavior before and after the change.

### Expected

- Valid WhatsApp group JIDs are preserved on the explicit heartbeat path.
- Invalid explicit targets do not turn into malformed direct-recipient values.

### Actual

- Before this change, the explicit path normalized `--to` through E.164-only logic.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios: explicit direct targets still normalize to E.164, explicit group JIDs are preserved, invalid explicit targets return no recipients; `pnpm test extensions/whatsapp/src/heartbeat-recipients.test.ts`, `pnpm test:extension whatsapp`, `pnpm check`, and `pnpm build:strict-smoke` all passed locally.
- Edge cases checked: valid group JID input and invalid explicit target input.
- What you did **not** verify: live delivery against a real WhatsApp session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: callers that previously relied on malformed explicit targets being coerced into a phone-like value will now get no target.
  - Mitigation: this aligns the explicit heartbeat path with the existing WhatsApp target contract and is covered by regression tests.
