### PR TITLE
fix: exclude ephemeral loopback port from CLI session mcpConfigHash (closes #64386)

### DIFF
--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -259,10 +259,11 @@ async function prepareModeSpecificBundleMcpConfig(params: {
   mode: CliBundleMcpMode;
   backend: CliBackendConfig;
   mergedConfig: BundleMcpConfig;
+  mcpConfigHash: string;
   env?: Record<string, string>;
 }): Promise<PreparedCliBundleMcpConfig> {
   const serializedConfig = `${JSON.stringify(params.mergedConfig, null, 2)}\n`;
-  const mcpConfigHash = crypto.createHash("sha256").update(serializedConfig).digest("hex");
+  const mcpConfigHash = params.mcpConfigHash;
 
   if (params.mode === "codex-config-overrides") {
     return {
@@ -348,6 +349,11 @@ export async function prepareCliBundleMcpConfig(params: {
     params.warn?.(`bundle MCP skipped for ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
   mergedConfig = applyMergePatch(mergedConfig, bundleConfig.config) as BundleMcpConfig;
+
+  // Compute hash BEFORE merging additionalConfig (which contains ephemeral loopback server)
+  const serializedConfigForHash = `${JSON.stringify(mergedConfig, null, 2)}\n`;
+  const mcpConfigHash = crypto.createHash("sha256").update(serializedConfigForHash).digest("hex");
+
   if (params.additionalConfig) {
     mergedConfig = applyMergePatch(mergedConfig, params.additionalConfig) as BundleMcpConfig;
   }
@@ -356,6 +362,7 @@ export async function prepareCliBundleMcpConfig(params: {
     mode,
     backend: params.backend,
     mergedConfig,
+    mcpConfigHash,
     env: params.env,
   });
 }


### PR DESCRIPTION
## Summary

- **Problem:** Every gateway restart silently wipes all persisted Claude CLI session memory. The first turn after restart resets the session because `mcpConfigHash` changes.
- **Why it matters:** Users experience "the agent suddenly forgot everything" after every gateway restart. Affects all deployments using the `claude-cli` backend with the loopback MCP bridge (default since #35676).
- **What changed:** Compute `mcpConfigHash` from user-authored `mergedConfig` **before** `additionalConfig` (containing the ephemeral loopback server URL) is merged in. The loopback config is still merged for the actual `mcp.json` / CLI args, just excluded from the session identity hash.
- **What did NOT change:** The actual MCP config written to disk still includes the loopback server. User-authored MCP config changes still correctly invalidate sessions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64386
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Two independently-correct commits interact badly: (1) `12100719b8` introduced `mcpConfigHash` for CLI session reuse, (2) `3de09fbe74` merged the loopback MCP server (with OS-assigned ephemeral port) into the same `mergedConfig` that gets hashed. The ephemeral port changes on every gateway restart → hash changes → all sessions invalidated.
- **Missing detection / guardrail:** No test asserts hash stability across simulated gateway restarts with port churn.
- **Contributing context:** The loopback URL is constructed with `port=0` (OS-assigned), so `http://127.0.0.1:<random-port>/mcp` produces a different hash every time.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/cli-runner/bundle-mcp.test.ts`
- Scenario the test should lock in: Hash computed at run N+1 equals hash at run N when only the loopback port differs
- If no new test is added, why not: Keeping PR minimal — happy to add if requested

## User-visible / Behavior Changes

- CLI sessions now persist across gateway restarts (previously silently reset every restart)
- Session reuse is still correctly invalidated when user-authored MCP config changes

## Diagram (if applicable)

```text
Before:
gateway restart -> new ephemeral port -> hash(mergedConfig + loopback) changes -> session reset

After:
gateway restart -> new ephemeral port -> hash(mergedConfig only, no loopback) unchanged -> session preserved
```

## Security Impact (required)

- New permissions/capabilities? No
- Auth boundary changes? No
- Secrets/token exposure risk? No
- New external calls? No
- Sandbox/isolation changes? No

## Evidence

- Code trace confirms ephemeral port is sole source of hash instability (auth token uses env var reference, not literal)
- `pnpm check` passes
- AI-assisted: fix authored by Claude Code, reviewed and verified manually

## Human Verification (required)

- Verified scenarios: Traced hash computation path, confirmed additionalConfig merge happens after hash
- Edge cases checked: No additionalConfig (hash unchanged), only additionalConfig changes (hash unchanged, correct), user MCP config changes (hash changes, correct)
- What you did **not** verify: Live gateway restart test

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: If additionalConfig contains user-meaningful config that should affect session identity
  - Mitigation: Currently additionalConfig only contains the loopback server (gateway-internal runtime state). The function signature documents this separation clearly.