### PR TITLE
fix(openai): default openai-codex provider api to responses

### DIFF
--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { normalizeConfig } from "./provider-policy-api.js";
+
+describe("openai provider policy public artifact", () => {
+  it("defaults openai-codex provider configs to the Codex responses API", () => {
+    expect(
+      normalizeConfig({
+        provider: "openai-codex",
+        providerConfig: {
+          baseUrl: "https://chatgpt.com/backend-api",
+          models: [
+            {
+              id: "gpt-5.4",
+              name: "GPT-5.4",
+              reasoning: true,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 400_000,
+              maxTokens: 128_000,
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses",
+      models: [{ id: "gpt-5.4" }],
+    });
+  });
+
+  it("preserves explicit api values for openai-codex provider configs", () => {
+    const providerConfig = {
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses" as const,
+      models: [],
+    };
+
+    expect(
+      normalizeConfig({
+        provider: "openai-codex",
+        providerConfig,
+      }),
+    ).toBe(providerConfig);
+  });
+});

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -1,5 +1,13 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 
+const OPENAI_CODEX_API = "openai-codex-responses";
+
 export function normalizeConfig(params: { provider: string; providerConfig: ModelProviderConfig }) {
+  if (params.provider === "openai-codex" && !params.providerConfig.api) {
+    return {
+      ...params.providerConfig,
+      api: OPENAI_CODEX_API,
+    };
+  }
   return params.providerConfig;
 }


### PR DESCRIPTION
## Summary
- default `openai-codex` provider configs without an explicit `api` to `openai-codex-responses`
- add a regression test for the lightweight OpenAI provider policy artifact

## Root cause
The lightweight `extensions/openai/provider-policy-api.ts` public artifact returned `providerConfig` unchanged for every OpenAI-owned provider. When startup auto-defaulting normalized an `openai-codex` config that omitted `api`, it never injected the Codex transport API, so later materialization could persist the wrong transport.

## Changes
- teach the OpenAI provider policy artifact to set `api: "openai-codex-responses"` when the provider is `openai-codex` and the field is absent
- preserve explicit `api` values unchanged
- add targeted tests covering both the missing-api and explicit-api cases

## Testing
- `pnpm test:extension openai`

Closes #64534


