### PR TITLE
fix(whatsapp): lazy default auth dir for profile state (#64555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ Docs: https://docs.openclaw.ai
 - Slack: honor ambient HTTP(S) proxy settings for Socket Mode WebSocket connections, including NO_PROXY exclusions, so proxy-only deployments can connect without a monkey patch. (#62878) Thanks @mjamiv.
 - Slack/actions: pass the already resolved read token into `downloadFile` so SecretRef-backed bot tokens no longer fail after a raw config re-read. (#62097) Thanks @martingarramon.
 - Network/fetch guard: skip target DNS pinning when trusted env-proxy mode is active so proxy-only sandboxes can let the trusted proxy resolve outbound hosts. (#59007) Thanks @cluster2600.
+- WhatsApp: resolve the default web auth dir lazily and centralize OAuth root resolution on `process.env` so Baileys credentials stay under the active `OPENCLAW_STATE_DIR` / profile instead of being fixed at module load. (#64555)
 
 ## 2026.4.7-1
 

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -45,8 +45,12 @@ const { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId } =
 export const listWhatsAppAccountIds = listAccountIds;
 export const resolveDefaultWhatsAppAccountId = resolveDefaultAccountId;
 
+function oauthRootForAccounts(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveOAuthDir(env);
+}
+
 export function listWhatsAppAuthDirs(cfg: OpenClawConfig): string[] {
-  const oauthDir = resolveOAuthDir();
+  const oauthDir = oauthRootForAccounts();
   const whatsappDir = path.join(oauthDir, "whatsapp");
   const authDirs = new Set<string>([oauthDir, path.join(whatsappDir, DEFAULT_ACCOUNT_ID)]);
 
@@ -75,12 +79,12 @@ export function hasAnyWhatsAppAuth(cfg: OpenClawConfig): boolean {
 }
 
 function resolveDefaultAuthDir(accountId: string): string {
-  return path.join(resolveOAuthDir(), "whatsapp", normalizeAccountId(accountId));
+  return path.join(oauthRootForAccounts(), "whatsapp", normalizeAccountId(accountId));
 }
 
 function resolveLegacyAuthDir(): string {
   // Legacy Baileys creds lived in the same directory as OAuth tokens.
-  return resolveOAuthDir();
+  return oauthRootForAccounts();
 }
 
 function legacyAuthExists(authDir: string): boolean {

--- a/extensions/whatsapp/src/auth-store.lazy-dir.test.ts
+++ b/extensions/whatsapp/src/auth-store.lazy-dir.test.ts
@@ -14,6 +14,7 @@ describe("WA_WEB_AUTH_DIR lazy resolution", () => {
 
   afterEach(() => {
     envSnapshot.restore();
+    vi.resetModules();
   });
 
   it("stringifies to credentials under OPENCLAW_STATE_DIR after import", async () => {

--- a/extensions/whatsapp/src/auth-store.lazy-dir.test.ts
+++ b/extensions/whatsapp/src/auth-store.lazy-dir.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
+import { captureEnv } from "openclaw/plugin-sdk/testing";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("WA_WEB_AUTH_DIR lazy resolution", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_OAUTH_DIR"]);
+  });
+
+  afterEach(() => {
+    envSnapshot.restore();
+  });
+
+  it("stringifies to credentials under OPENCLAW_STATE_DIR after import", async () => {
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-profile-"));
+    try {
+      process.env.OPENCLAW_STATE_DIR = isolated;
+      delete process.env.OPENCLAW_OAUTH_DIR;
+
+      vi.resetModules();
+      const { WA_WEB_AUTH_DIR } = await import("./auth-store.js");
+      const expected = path.join(isolated, "credentials", "whatsapp", DEFAULT_ACCOUNT_ID);
+      const rawDir = WA_WEB_AUTH_DIR as unknown;
+      expect(String(rawDir)).toBe(expected);
+    } finally {
+      fs.rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("listWhatsAppAuthDirs stays aligned with the lazy default web auth dir", async () => {
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-list-"));
+    try {
+      process.env.OPENCLAW_STATE_DIR = isolated;
+      delete process.env.OPENCLAW_OAUTH_DIR;
+
+      vi.resetModules();
+      const { WA_WEB_AUTH_DIR } = await import("./auth-store.js");
+      const { listWhatsAppAuthDirs } = await import("./accounts.js");
+      const dirs = listWhatsAppAuthDirs({});
+      expect(dirs).toContain(String(WA_WEB_AUTH_DIR as unknown));
+      expect(dirs).toContain(path.join(isolated, "credentials"));
+    } finally {
+      fs.rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/whatsapp/src/auth-store.ts
+++ b/extensions/whatsapp/src/auth-store.ts
@@ -16,7 +16,30 @@ export function resolveDefaultWebAuthDir(): string {
   return path.join(resolveOAuthDir(), "whatsapp", DEFAULT_ACCOUNT_ID);
 }
 
-export const WA_WEB_AUTH_DIR = resolveDefaultWebAuthDir();
+// Historic export: resolve only when coerced to string so `OPENCLAW_STATE_DIR` and
+// profile env apply before the first read (mirrors `LazyWebChannelAuthDir` in `src/channel-web.ts`).
+class LazyWhatsAppWebAuthDir {
+  #value: string | null = null;
+
+  #read(): string {
+    this.#value ??= resolveDefaultWebAuthDir();
+    return this.#value;
+  }
+
+  toString(): string {
+    return this.#read();
+  }
+
+  valueOf(): string {
+    return this.#read();
+  }
+
+  [Symbol.toPrimitive](): string {
+    return this.#read();
+  }
+}
+
+export const WA_WEB_AUTH_DIR = new LazyWhatsAppWebAuthDir() as unknown as string;
 
 export function readCredsJsonRaw(filePath: string): string | null {
   try {

--- a/src/channel-web.ts
+++ b/src/channel-web.ts
@@ -31,7 +31,13 @@ class LazyWebChannelAuthDir {
   #value: string | null = null;
 
   #read(): string {
-    this.#value ??= resolveWebChannelAuthDir();
+    if (this.#value !== null) {
+      return this.#value;
+    }
+    const raw = resolveWebChannelAuthDir();
+    // Bundled web-channel plugins may expose a lazy/string-like export; always cache a
+    // primitive path so outer coercions (`String(...)`, template literals) stay safe.
+    this.#value = typeof raw === "string" ? raw : String(raw);
     return this.#value;
   }
 

--- a/src/channels/channels-misc.test.ts
+++ b/src/channels/channels-misc.test.ts
@@ -67,4 +67,45 @@ describe("WA_WEB_AUTH_DIR", () => {
     expect(readLazyString(webEntry.WA_WEB_AUTH_DIR)).toBe("/tmp/openclaw-whatsapp-auth");
     expect(resolveWebChannelAuthDir).toHaveBeenCalledTimes(1);
   });
+
+  it("normalizes a lazy string-like plugin export to a cached primitive path", async () => {
+    class PluginLazyAuthPath {
+      readonly #path = "/tmp/openclaw-lazy-inner";
+      toString() {
+        return this.#path;
+      }
+      valueOf() {
+        return this.#path;
+      }
+      [Symbol.toPrimitive]() {
+        return this.#path;
+      }
+    }
+    const resolveWebChannelAuthDir = vi.fn(() => new PluginLazyAuthPath());
+
+    vi.resetModules();
+    vi.doMock("../plugins/runtime/runtime-web-channel-plugin.js", () => ({
+      createWebChannelSocket: vi.fn(),
+      extractMediaPlaceholder: vi.fn(),
+      extractText: vi.fn(),
+      formatError: vi.fn(),
+      getStatusCode: vi.fn(),
+      logWebSelfId: vi.fn(),
+      loginWeb: vi.fn(),
+      logoutWeb: vi.fn(),
+      monitorWebChannel: vi.fn(),
+      monitorWebInbox: vi.fn(),
+      pickWebChannel: vi.fn(),
+      resolveHeartbeatRecipients: vi.fn(),
+      resolveWebChannelAuthDir,
+      runWebHeartbeatOnce: vi.fn(),
+      sendWebChannelMessage: vi.fn(),
+      sendWebChannelReaction: vi.fn(),
+      waitForWebChannelConnection: vi.fn(),
+      webAuthExists: vi.fn(),
+    }));
+
+    const channelWeb = await import("../channel-web.js");
+    expect(readLazyString(channelWeb.WA_WEB_AUTH_DIR)).toBe("/tmp/openclaw-lazy-inner");
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: The bundled WhatsApp extension exposed `WA_WEB_AUTH_DIR` as a value computed at module load. If the light runtime loaded before `OPENCLAW_STATE_DIR` / `--profile` env was authoritative, Baileys creds could resolve under the default state dir instead of the active profile dir (see #64555).
- Why it matters: Multi-tenant and `--profile` deployments rely on isolated credential paths; writing or reading the wrong `creds.json` breaks isolation and can cause 440 conflict loops when two gateways share one store.
- What changed: Resolve the default web auth directory lazily (same coercion pattern as `LazyWebChannelAuthDir` in `src/channel-web.ts`) and route OAuth root resolution in `accounts.ts` through a single helper that calls `resolveOAuthDir` with the process env explicitly.
- What did NOT change: No new env vars, no doctor/docs-only changes, and no behavior change for callers that already pass explicit `authDir` paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64555
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `WA_WEB_AUTH_DIR` was initialized eagerly at module evaluation time via `resolveDefaultWebAuthDir()`, so the first resolved path could be pinned before profile/state env was guaranteed for that load sequence.
- Missing detection / guardrail: No unit test asserted that the exported default path stayed under `OPENCLAW_STATE_DIR` after a fresh import with env set.
- Contributing context (if known): Core already lazy-resolves the web channel auth dir in `src/channel-web.ts`; the plugin export remained eager.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auth-store.lazy-dir.test.ts`
- Scenario the test should lock in: After `OPENCLAW_STATE_DIR` is set, a fresh dynamic import of `auth-store` yields `String(WA_WEB_AUTH_DIR)` under that state dir, and `listWhatsAppAuthDirs` includes the same root.
- Why this is the smallest reliable guardrail: It fails if the export becomes eager again or if `accounts` diverges from the OAuth root used for the default web dir.
- Existing test that already covers this (if any): `extensions/whatsapp/src/accounts.whatsapp-auth.test.ts` (OAuth override via `OPENCLAW_OAUTH_DIR`).
- If no new test is added, why not: N/A (tests added).

## User-visible / Behavior Changes

None for correctly configured single-profile installs. Profile and `OPENCLAW_STATE_DIR` isolation for WhatsApp default auth should match the active env consistently.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes` — credentials are read/written under the correct profile state directory instead of possibly defaulting to the main state dir when the lazy export was wrong.)

## Repro + Verification

### Environment

- OS: macOS / Linux (CI)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): WhatsApp (bundled extension)

### Steps

1. Set `OPENCLAW_STATE_DIR` to an isolated directory.
2. Dynamically import `extensions/whatsapp/src/auth-store.js` (or use gateway after profile env).
3. Coerce `WA_WEB_AUTH_DIR` to string and confirm it lives under `\`$OPENCLAW_STATE_DIR/credentials/whatsapp/default\``.

### Expected

Default Baileys auth path is under the active state dir.

### Actual

Matches expected after this change; covered by new unit tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test` on `extensions/whatsapp/src/auth-store.lazy-dir.test.ts` and `accounts.whatsapp-auth.test.ts`; `pnpm exec oxfmt --check` on touched sources.
- Edge cases checked: `OPENCLAW_STATE_DIR` isolation path alignment with `listWhatsAppAuthDirs`.
- What I did not verify: Full gateway pairing against live WhatsApp (not required for this path-resolution fix).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: Callers relying on `typeof WA_WEB_AUTH_DIR === \"string\"` could see `object` at runtime (same pattern as core `LazyWebChannelAuthDir`).
  - Mitigation: Export remains cast as `string` for TypeScript; runtime stringification uses `String()` / coercion like existing web channel surface.
