### PR TITLE
Anthropic: scope normalizeConfig hook to Anthropic provider keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/config: accept and honor `agents.defaults.heartbeat.timeoutSeconds` and per-agent heartbeat timeout overrides for heartbeat agent turns. (#64491) Thanks @cedillarack.
 - OpenAI/Codex: add required Codex OAuth scopes, classify provider/runtime failures more clearly, and stop suggesting `/elevated full` when auto-approved host exec is unavailable. (#64439) Thanks @100yenadmin.
 - Providers/OpenAI: add OpenAI/Codex tool-schema compatibility and preserve embedded-run replay/liveness truth across compaction retries and mutating side effects. (#64300) Thanks @100yenadmin.
+- Models: scope Anthropic relay API defaults to Anthropic-owned provider keys so `models.json` normalization stops writing `api: anthropic-messages` onto other providers such as `openai-codex` without an explicit `api`. (#64534)
 
 ## 2026.4.9
 

--- a/extensions/anthropic/config-defaults.normalize-hook.test.ts
+++ b/extensions/anthropic/config-defaults.normalize-hook.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { CLAUDE_CLI_BACKEND_ID } from "./cli-shared.js";
+import {
+  normalizeAnthropicProviderConfig,
+  normalizeAnthropicProviderConfigForPluginHook,
+} from "./config-defaults.js";
+
+describe("normalizeAnthropicProviderConfigForPluginHook", () => {
+  it("does not apply Anthropic relay api defaults to openai-codex", () => {
+    const providerConfig = {
+      baseUrl: "https://chatgpt.com/backend-api",
+      models: [{ id: "gpt-5.4", name: "GPT-5.4" }],
+    };
+    expect(
+      normalizeAnthropicProviderConfigForPluginHook({
+        provider: "openai-codex",
+        providerConfig,
+      }),
+    ).toBeUndefined();
+    expect(normalizeAnthropicProviderConfig(providerConfig)).toMatchObject({
+      api: "anthropic-messages",
+    });
+  });
+
+  it("applies relay api default for anthropic when models exist and api is missing", () => {
+    expect(
+      normalizeAnthropicProviderConfigForPluginHook({
+        provider: "anthropic",
+        providerConfig: {
+          baseUrl: "https://api.anthropic.com",
+          models: [{ id: "claude-sonnet-4-6" }],
+        },
+      }),
+    ).toMatchObject({ api: "anthropic-messages" });
+  });
+
+  it("applies relay api default for Claude CLI provider key", () => {
+    expect(
+      normalizeAnthropicProviderConfigForPluginHook({
+        provider: CLAUDE_CLI_BACKEND_ID,
+        providerConfig: {
+          baseUrl: "https://api.anthropic.com",
+          models: [{ id: "claude-sonnet-4-6" }],
+        },
+      }),
+    ).toMatchObject({ api: "anthropic-messages" });
+  });
+});

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -159,6 +159,24 @@ export function normalizeAnthropicProviderConfig<T extends { api?: string; model
   return { ...providerConfig, api: ANTHROPIC_PROVIDER_API };
 }
 
+const ANTHROPIC_CONFIG_PROVIDER_ID = "anthropic";
+
+/**
+ * Body for the Anthropic plugin `normalizeConfig` hook during models.json normalization.
+ * Must only run for Anthropic-owned provider keys so relay API defaults are not applied to
+ * unrelated providers (for example `openai-codex` with custom models and no explicit `api`).
+ */
+export function normalizeAnthropicProviderConfigForPluginHook<
+  T extends { api?: string; models?: unknown[] },
+>(ctx: { provider: string; providerConfig: T }): T | undefined {
+  const id = normalizeProviderId(ctx.provider);
+  if (id !== ANTHROPIC_CONFIG_PROVIDER_ID && id !== CLAUDE_CLI_BACKEND_ID) {
+    return undefined;
+  }
+  const next = normalizeAnthropicProviderConfig(ctx.providerConfig);
+  return next === ctx.providerConfig ? undefined : next;
+}
+
 export function applyAnthropicConfigDefaults(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -31,7 +31,7 @@ import {
 } from "./cli-shared.js";
 import {
   applyAnthropicConfigDefaults,
-  normalizeAnthropicProviderConfig,
+  normalizeAnthropicProviderConfigForPluginHook,
 } from "./config-defaults.js";
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { buildAnthropicReplayPolicy } from "./replay-policy.js";
@@ -466,7 +466,7 @@ export function registerAnthropicPlugin(api: OpenClawPluginApi): void {
         },
       }),
     ],
-    normalizeConfig: ({ providerConfig }) => normalizeAnthropicProviderConfig(providerConfig),
+    normalizeConfig: (ctx) => normalizeAnthropicProviderConfigForPluginHook(ctx),
     applyConfigDefaults: ({ config, env }) => applyAnthropicConfigDefaults({ config, env }),
     resolveDynamicModel: (ctx) => resolveAnthropicForwardCompatModel(ctx),
     resolveSyntheticAuth: ({ provider }) =>


### PR DESCRIPTION
## Summary

- Problem: The Anthropic plugin’s global `normalizeConfig` hook runs for every provider during `models.json` planning. It called `normalizeAnthropicProviderConfig`, which adds `api: anthropic-messages` when a provider has models but no `api`. That logic was intended only for Anthropic relay setups, but it also matched other providers such as `openai-codex`, persisting the wrong API type and breaking Codex requests (see #64534).
- Why it matters: `agents/*/agent/models.json` could show `api: anthropic-messages` for `openai-codex` without an explicit `api`, sending the wrong wire format to ChatGPT backend URLs.
- What changed: Introduced `normalizeAnthropicProviderConfigForPluginHook` in `extensions/anthropic/config-defaults.ts` so relay API defaulting runs only when the config provider id is `anthropic` or `claude-cli`. Wired the Anthropic plugin `normalizeConfig` hook to use it.
- What did NOT change: Bundled `provider-policy-api` for the `anthropic` artifact and `normalizeAnthropicProviderConfig` behavior for real Anthropic configs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64534
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `normalizeProviderConfigWithPlugin` iterates all provider plugins’ `normalizeConfig` hooks. Anthropic’s hook applied `normalizeAnthropicProviderConfig` without checking `ctx.provider`, so any provider with `models` and no `api` received `anthropic-messages`.
- Missing detection / guardrail: Provider-scoped guard on the hook body.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/anthropic/config-defaults.normalize-hook.test.ts`
- Scenario the test should lock in: `openai-codex` with models and no `api` must not get `api: anthropic-messages` from the hook; `anthropic` and `claude-cli` still get the relay default when appropriate.
- Why this is the smallest reliable guardrail: Exercises the exported hook helper directly.
- Existing test that already covers this (if any): None for this cross-provider case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`models.json` generation no longer injects `api: anthropic-messages` for non-Anthropic providers when `api` is omitted. Users configuring `openai-codex` without an explicit `api` should no longer see that incorrect default from this hook.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux / macOS (local dev)
- Runtime/container: N/A
- Model/provider: `openai-codex` (config without `api`)
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.openai-codex` with `baseUrl` + `models` only

### Steps

1. Configure `openai-codex` with models and no `api`, restart gateway or run models json refresh.
2. Inspect `agents/<agent>/agent/models.json` (before fix: erroneous `api: anthropic-messages` for that provider when the hook ran).

### Expected

Non-Anthropic providers do not receive Anthropic relay `api` defaults from this hook.

### Actual

Hook returns `undefined` for `openai-codex`; relay default still applies for `anthropic` / `claude-cli`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Unit tests for the hook helper; `pnpm test extensions/anthropic/config-defaults.normalize-hook.test.ts` passes.
- Edge cases checked: `anthropic` and `claude-cli` still get relay default when models exist and `api` is missing.
- What you did **not** verify: Full gateway E2E against live ChatGPT backend.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
