### PR TITLE
fix(ollama): enable streaming usage for OpenAI-compat endpoint (closes #64326)

### DIFF
--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -65,6 +65,8 @@ export function resolveOpenAICompletionsCompatDefaults(
     endpointClass === "mistral-public" ||
     knownProviderFamily === "mistral" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "chutes"));
+  // Ollama's OpenAI-compat endpoint supports streaming usage when stream_options.include_usage is sent.
+  const isOllama = input.provider === "ollama" || knownProviderFamily === "ollama";
 
   return {
     supportsStore:
@@ -76,7 +78,8 @@ export function resolveOpenAICompletionsCompatDefaults(
       endpointClass !== "xai-native" &&
       !usesExplicitProxyLikeEndpoint,
     supportsUsageInStreaming:
-      !isNonStandard && (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat),
+      !isNonStandard &&
+      (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat || isOllama),
     maxTokensField: usesMaxTokens ? "max_tokens" : "max_completion_tokens",
     thinkingFormat: isZai ? "zai" : isOpenRouterLike ? "openrouter" : "openai",
     supportsStrictMode: !isZai && !usesConfiguredNonOpenAIEndpoint,


### PR DESCRIPTION
## Summary

- **Problem:** Ollama provider reports hardcoded 32768 input tokens for every message, triggering premature compaction and breaking multi-turn conversations.
- **Why it matters:** All Ollama local model users experience broken conversations — compaction fires after every response, wiping context.
- **What changed:** Added Ollama to the `supportsUsageInStreaming` list in `resolveOpenAICompletionsCompatDefaults`, so `stream_options.include_usage=true` is sent to Ollama's OpenAI-compat endpoint. This makes Ollama return real `usage.prompt_tokens` and `usage.completion_tokens` in the final streaming chunk.
- **What did NOT change:** Native Ollama API path (already correct), other providers' streaming usage behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64326
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `resolveOpenAICompletionsCompatDefaults` in `src/agents/openai-completions-compat.ts` did not recognize Ollama as supporting streaming usage. Without `stream_options.include_usage=true` in the request, Ollama's OpenAI-compat endpoint omits usage data from streaming responses. The OpenAI transport stream then reports 0 input tokens (or falls back to incorrect values), while a separate code path uses `contextWindow` (32768) as the token count, triggering compaction.
- **Missing detection / guardrail:** No test for Ollama OpenAI-compat streaming usage support.
- **Contributing context:** Ollama's native API path correctly returns `prompt_eval_count`, but when accessed via `/v1/chat/completions` (OpenAI-compat), usage requires explicit opt-in via `stream_options`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/openai-completions-compat.test.ts`
- Scenario the test should lock in: `resolveOpenAICompletionsCompatDefaults({ provider: "ollama" }).supportsUsageInStreaming === true`
- If no new test is added, why not: Keeping PR minimal — happy to add if requested

## User-visible / Behavior Changes

- Ollama models via OpenAI-compat endpoint now report accurate token counts
- Multi-turn conversations no longer break due to premature compaction
- Compaction only triggers when context actually approaches the limit

## Diagram (if applicable)

```text
Before:
request to Ollama /v1/chat/completions (no stream_options.include_usage)
-> Ollama omits usage in stream -> reported as 0 or contextWindow -> compaction triggers

After:
request to Ollama /v1/chat/completions (stream_options.include_usage=true)
-> Ollama returns real usage in final chunk -> accurate token count -> no premature compaction
```

## Security Impact (required)

- New permissions/capabilities? No
- Auth boundary changes? No
- Secrets/token exposure risk? No
- New external calls? No
- Sandbox/isolation changes? No

## Evidence

- Code trace confirms Ollama was missing from streaming usage support list
- `pnpm check` passes
- AI-assisted: fix authored by Claude Code, reviewed and verified manually

## Human Verification (required)

- Verified scenarios: Traced the full path from request construction through streaming usage parsing
- Edge cases checked: Native Ollama API (unaffected), non-Ollama providers (unaffected)
- What you did **not** verify: Live Ollama integration test

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Older Ollama versions might not support stream_options.include_usage
  - Mitigation: Ollama silently ignores unknown request fields, so this is safe for older versions (they just won't return usage, same as before)