### PR TITLE
fix: preserve Telegram topic routing for exec completions

### DIFF
--- a/docs/refactor/cron-heartbeat-redesign-plan.md
+++ b/docs/refactor/cron-heartbeat-redesign-plan.md
@@ -1,0 +1,657 @@
+# Cron and Heartbeat Redesign Plan
+
+## Purpose
+
+This document turns the cron and heartbeat architecture investigation into an
+implementation plan for OpenClaw. The goal is to fix the current ownership blur
+between cron scheduling, heartbeat execution, detached runs, and outbound
+delivery without doing a flag-day rewrite.
+
+The intended workflow is:
+
+1. capture the target architecture here
+2. create pebbles issues that reference this document
+3. implement the work as small, dependency-ordered tasks
+
+## Executive Summary
+
+The main architectural problem is not missing scheduling features. It is split
+ownership of a single automation outcome across multiple subsystems.
+
+Today:
+
+- cron owns durable scheduling, due-time math, and partial run bookkeeping
+- `sessionTarget="main"` cron jobs do not execute directly
+- those jobs enqueue an in-memory system event
+- heartbeat later decides whether and how to turn that event into a model run
+- final user-visible delivery often happens inside heartbeat, not inside cron
+
+That means there is no single subsystem that owns the complete lifecycle of a
+main-session cron run from "job is due" through "reply delivered or failed".
+
+The redesign should preserve current product behavior where practical, but move
+the internal architecture to this model:
+
+- cron owns the durable run lifecycle and final outcome for all cron jobs
+- execution happens through explicit execution adapters
+- heartbeat remains a scheduler-triggered main-session turn mechanism, but is no
+  longer the hidden semantic owner of cron work
+- outbound target resolution and delivery semantics converge onto shared logic
+- restart semantics become durable and explainable
+
+## Current State
+
+### Main-session cron
+
+Main-session cron currently routes through `executeMainSessionCronJob()` in
+`src/cron/service/timer.ts`.
+
+The relevant flow is:
+
+1. resolve a text payload with `resolveJobPayloadTextForMain()`
+2. enqueue a system event with context key `cron:<jobId>`
+3. if `wakeMode === "now"`, try `runHeartbeatOnce()`
+4. otherwise request a heartbeat wake
+5. heartbeat later drains the pending system event queue
+6. heartbeat builds a cron-specific prompt and runs the agent turn
+7. heartbeat decides whether to relay the result to the user
+
+This path is structurally important because cron and heartbeat split execution
+responsibility:
+
+- cron knows when the job was due
+- heartbeat knows whether a model turn actually ran
+- heartbeat often owns the actual delivery path
+
+### In-memory handoff
+
+`src/infra/system-events.ts` defines system events as a lightweight in-memory
+queue. The file comment is explicit that the queue is intentionally not
+persisted.
+
+This is fine for ephemeral notifications, but it is a mismatch for durable cron
+work. A durable scheduled job currently hands off to a non-durable queue before
+the user-visible work actually happens.
+
+### Heartbeat responsibilities
+
+`src/infra/heartbeat-runner.ts` currently owns all of the following:
+
+- preflight gating
+- active-hours checks
+- queue busy checks
+- session selection
+- isolated heartbeat session creation
+- pending event inspection
+- cron event prompt construction
+- exec completion prompt construction
+- `HEARTBEAT.md` parsing
+- task-due evaluation for heartbeat task blocks
+- model execution
+- reasoning payload filtering
+- delivery target selection
+- outbound delivery
+- transcript and session cleanup details
+
+That is too much responsibility in one module. It also makes it easy for cron
+behavior to accrete inside heartbeat because heartbeat already sits at the
+center of multiple side-effecting concerns.
+
+### Detached / isolated cron
+
+Detached cron runs are comparatively cleaner. `runCronIsolatedAgentTurn()` and
+the isolated-agent modules already own more of their execution lifecycle.
+
+However, detached cron still duplicates delivery logic and target resolution in
+places that overlap with heartbeat:
+
+- `src/cron/isolated-agent/delivery-target.ts`
+- `src/cron/isolated-agent/delivery-dispatch.ts`
+- `src/infra/outbound/targets.ts`
+- `src/infra/outbound/deliver.ts`
+
+This duplication increases the chance that thread handling, account selection,
+or "last target" behavior drifts between heartbeat and cron.
+
+## Concrete Architectural Problems
+
+### 1. Durable schedule, non-durable execution handoff
+
+The most serious mismatch is:
+
+- due-time state is persisted in the cron store
+- main-session execution requests are not
+
+If the process crashes after enqueueing a system event but before heartbeat
+drains it, cron has already moved forward while the execution request is lost.
+
+### 2. Final outcome ownership is ambiguous
+
+Cron emits run events and updates job state. Heartbeat decides whether a main
+session turn actually happened and what was delivered. This leads to partial
+truth in each subsystem rather than one authoritative run record.
+
+### 3. Wake mode changes execution subsystem, not just timing
+
+`wakeMode` appears to be a scheduling knob, but it materially changes execution
+behavior:
+
+- `now` attempts to force immediate heartbeat execution
+- `next-heartbeat` relies on later heartbeat scheduling
+
+That means a timing field also selects the execution path, which makes the
+behavior harder to reason about from configuration alone.
+
+### 4. Delivery resolution is split
+
+Heartbeat and isolated cron both need to answer:
+
+- which channel should receive output
+- which recipient should be used
+- which account id should be applied
+- whether a thread/topic id should be preserved
+- when direct delivery should be blocked or allowed
+
+Those decisions should be owned by shared outbound resolution logic, not by
+two partially overlapping stacks.
+
+### 5. Heartbeat is both a feature and an execution substrate
+
+Heartbeat should be conceptually simple: periodically run a main-session turn
+based on `HEARTBEAT.md` or similar workspace instructions.
+
+Instead, heartbeat is also being used as:
+
+- a cron reminder executor
+- an exec completion relay mechanism
+- an isolated-session recycling coordinator
+- a delivery policy owner
+
+That is an architectural smell. Cron and exec completion can reuse heartbeat
+execution machinery, but only through explicit seams.
+
+## Goals
+
+### Primary goals
+
+- give every cron run one clear owner for final outcome
+- make main-session cron execution durable or explicitly non-durable with a new
+  product concept
+- reduce delivery logic duplication
+- make restart semantics explicit and testable
+- split heartbeat into smaller, scheduler-neutral modules
+
+### Secondary goals
+
+- preserve existing user-facing configuration where feasible
+- avoid a rewrite that invalidates unrelated cron and heartbeat behavior
+- keep extension/channel boundaries intact
+- maintain prompt-cache stability where request assembly changes
+
+### Non-goals
+
+- redesign the public cron job schema from scratch
+- change heartbeat product semantics unrelated to architecture
+- merge heartbeat and cron into a single user-facing feature
+- remove isolated cron or heartbeat isolated sessions
+
+## Target Architecture
+
+## Ownership Model
+
+The target model should be:
+
+- `CronService` owns job schedules and durable run records
+- `CronExecutionOrchestrator` owns execution dispatch for a specific run
+- execution adapters perform the actual work
+- outbound delivery is resolved and executed through shared infra
+- heartbeat is a reusable execution adapter, not the semantic owner of cron
+
+In other words:
+
+due job -> durable cron run -> explicit execution adapter -> shared delivery ->
+final persisted outcome
+
+## Execution adapters
+
+Introduce explicit execution modes for cron runs:
+
+- `main-session-turn`
+- `detached-session-turn`
+- `webhook`
+
+Possible future adapters can be added later without changing the scheduler
+ownership model.
+
+### `main-session-turn`
+
+This adapter represents "perform this cron-triggered turn in the main session".
+
+Important point: this is not the same as "enqueue a system event and hope
+heartbeat gets to it". The adapter may internally use heartbeat machinery for
+prompt building or turn execution, but the adapter must receive a durable
+execution request tied to a cron run id.
+
+### `detached-session-turn`
+
+This covers today's isolated/current/session-bound cron execution modes and
+should own:
+
+- session lifecycle
+- prompt execution
+- result synthesis
+- shared outbound delivery integration
+
+### `webhook`
+
+Webhook delivery can stay simpler because it is already closer to a direct,
+single-owner execution path.
+
+## Durable run record
+
+Cron needs a durable run object separate from job state. The job state can keep
+last-run summaries for listing and status, but the run record should be the
+authoritative lifecycle entry.
+
+Proposed minimum fields:
+
+- `runId`
+- `jobId`
+- `scheduledAtMs`
+- `startedAtMs`
+- `completedAtMs`
+- `executionMode`
+- `status`
+- `deliveryStatus`
+- `sessionKey`
+- `sessionId`
+- `summary`
+- `error`
+- `provider`
+- `model`
+- `usage`
+- `handoffState`
+
+Suggested status vocabulary:
+
+- `pending`
+- `running`
+- `succeeded`
+- `failed`
+- `skipped`
+
+Suggested delivery status vocabulary:
+
+- `not_requested`
+- `pending`
+- `delivered`
+- `failed`
+- `unknown`
+
+If desired, the existing event vocabulary can continue to map onto these more
+precise run states for UI compatibility.
+
+## Durable scheduled-turn request
+
+Main-session cron needs a durable request object representing the pending turn.
+
+This request should include:
+
+- `requestId`
+- `source = cron`
+- `runId`
+- `jobId`
+- `agentId`
+- `sessionKey`
+- `prompt/input text`
+- `delivery intent`
+- `createdAtMs`
+- `claimedAtMs`
+- `completedAtMs`
+
+Heartbeat may initially consume this request because it already has main-session
+turn execution machinery. But the request must be durable and claimable, not a
+raw entry in the ephemeral system-event queue.
+
+## Shared outbound resolution
+
+The target architecture should have one shared outbound resolution layer that
+all automation paths use.
+
+That shared layer should answer:
+
+- which target channel is used
+- how `last` is resolved
+- how explicit `to` overrides are handled
+- how account id precedence works
+- when thread/topic ids are retained or dropped
+- when direct delivery is blocked
+- how plugin-provided target normalization participates
+
+`deliverOutboundPayloads()` can remain the common sink. The main missing piece
+is consolidating target resolution and policy logic.
+
+## Heartbeat module split
+
+`src/infra/heartbeat-runner.ts` should be broken into smaller modules with clear
+ownership:
+
+- `heartbeat-preflight`
+- `heartbeat-prompt`
+- `heartbeat-executor`
+- `heartbeat-delivery`
+- `heartbeat-session`
+
+The exact file names can vary, but the responsibilities should separate along
+those seams.
+
+This will let cron reuse a main-session turn executor without inheriting
+heartbeat-only product semantics by accident.
+
+## Proposed Module Plan
+
+### New cron-side modules
+
+- `src/cron/service/run-records.ts`
+  durable run creation, updates, lookups, and retention
+
+- `src/cron/execution/orchestrator.ts`
+  select execution adapter, drive status transitions, and own final outcome
+
+- `src/cron/execution/adapters/main-session-turn.ts`
+  durable handoff into main-session execution
+
+- `src/cron/execution/adapters/detached-session-turn.ts`
+  extracted detached execution wrapper around existing isolated cron machinery
+
+- `src/cron/execution/adapters/webhook.ts`
+  explicit webhook execution path if needed
+
+- `src/cron/execution/types.ts`
+  closed unions for execution state and adapter result contracts
+
+- `src/cron/execution/shared-delivery.ts`
+  cron-facing integration with the shared outbound resolver
+
+### New shared execution request module
+
+- `src/infra/scheduled-turn-requests.ts`
+  durable pending-turn request store with create/claim/complete behavior
+
+This should be general enough for cron first, without prematurely widening the
+surface to unrelated features.
+
+### Heartbeat decomposition targets
+
+- `src/infra/heartbeat-preflight.ts`
+- `src/infra/heartbeat-prompt.ts`
+- `src/infra/heartbeat-executor.ts`
+- `src/infra/heartbeat-delivery.ts`
+- `src/infra/heartbeat-session.ts`
+
+The top-level `heartbeat-runner.ts` can stay as the orchestration shell while
+the implementation details move into those modules.
+
+## Migration Strategy
+
+This should be a staged redesign through incremental cleanup.
+
+### Phase 1: Durable run ownership
+
+Introduce durable cron run records without changing user-facing behavior.
+
+Scope:
+
+- create run record on due/forced execution
+- preserve existing job state updates
+- tie `runId` to both main-session and detached execution paths
+- do not yet replace main-session system-event handoff
+
+Success criteria:
+
+- every cron execution has a durable run record
+- final status can be tied back to a run id
+- cron no longer treats "attempted handoff" as equivalent to "succeeded"
+
+### Phase 2: Main-session durable execution request
+
+Replace direct main-session system-event enqueue as the execution handoff for
+cron with a durable scheduled-turn request.
+
+Scope:
+
+- create durable request records for main-session cron runs
+- teach heartbeat or a cron-owned consumer to claim and execute them
+- keep existing prompt shape for compatibility where possible
+
+Success criteria:
+
+- restart no longer loses pending main-session cron work
+- cron can observe whether a main-session turn actually completed
+- handoff state is explicit in the durable run record
+
+### Phase 3: Heartbeat decomposition
+
+Split heartbeat into focused modules without changing behavior.
+
+Scope:
+
+- extract preflight, prompt, session, execution, delivery logic
+- keep current `runHeartbeatOnce()` entrypoint
+
+Success criteria:
+
+- smaller modules with clearer ownership
+- cron can reuse executor pieces through explicit interfaces
+
+### Phase 4: Shared outbound resolution
+
+Collapse duplicated delivery target logic.
+
+Scope:
+
+- compare heartbeat and isolated-cron target behavior
+- move common target logic under shared outbound infra
+- preserve special channel/plugin behaviors through shared seams
+
+Success criteria:
+
+- one place to fix routing/account/thread bugs
+- heartbeat and cron agree on target semantics
+
+### Phase 5: Cleanup and behavior simplification
+
+Once durable execution and shared delivery exist, simplify remaining legacy
+paths and remove compatibility shims that are no longer needed.
+
+Possible cleanup targets:
+
+- main-session cron-specific implicit heartbeat coupling
+- duplicate delivery-plan helpers that only exist for the old split path
+- run-state fields that duplicate durable run records without adding value
+
+## Task Breakdown
+
+The implementation should be broken into the following pebbles tasks.
+
+### Task A: Persist cron run lifecycle
+
+Deliverables:
+
+- durable run store
+- run record types
+- creation/update helpers
+- integration into cron due/force execution
+- tests for create/update/restart visibility
+
+Dependencies:
+
+- none
+
+### Task B: Extract cron execution orchestrator
+
+Deliverables:
+
+- move execution branching out of `src/cron/service/timer.ts`
+- explicit adapter contracts
+- scheduler reduced to due-time and run dispatch responsibilities
+
+Dependencies:
+
+- Task A
+
+### Task C: Add durable main-session scheduled-turn requests
+
+Deliverables:
+
+- request store
+- create/claim/complete helpers
+- cron main-session path uses durable requests instead of only in-memory events
+- restart coverage
+
+Dependencies:
+
+- Task A
+- Task B
+
+### Task D: Decompose heartbeat runner
+
+Deliverables:
+
+- extracted modules for preflight/prompt/execution/delivery/session
+- behavior-preserving tests
+
+Dependencies:
+
+- Task C can proceed in parallel for some subparts, but the safer ordering is
+  after Task B so the seam is clearer
+
+### Task E: Unify outbound target resolution
+
+Deliverables:
+
+- shared target resolution path for heartbeat and detached cron
+- parity coverage for account/thread/last-target behavior
+
+Dependencies:
+
+- Task B
+- ideally after Task D so heartbeat delivery seams are explicit
+
+### Task F: Final cleanup and docs
+
+Deliverables:
+
+- remove obsolete bridging code
+- document the new internal ownership model
+- ensure run logs and operational docs match reality
+
+Dependencies:
+
+- Tasks C, D, and E
+
+## Testing Plan
+
+### Unit and integration coverage
+
+Add or update tests for:
+
+- due cron run creates durable run record
+- force run creates durable run record
+- detached cron success/failure updates run record correctly
+- main-session cron crash/restart preserves pending work
+- claimed scheduled-turn request is not executed twice
+- busy-lane retries do not lose run ownership
+- delivery success/failure updates both run record and job summary correctly
+- thread/account/last-target behavior matches between heartbeat and cron
+
+### Regression focus
+
+Protect these existing behavior classes:
+
+- one-shot disable/retry behavior
+- recurring backoff behavior
+- startup catch-up behavior
+- `wakeMode="now"` busy retry fallback
+- `HEARTBEAT_OK` ack stripping for heartbeat product behavior
+- isolated heartbeat session key stability
+- direct delivery idempotency for detached cron
+
+### Restart and durability scenarios
+
+Explicitly test:
+
+- crash after cron marks a run started but before execution begins
+- crash after main-session request is created but before it is claimed
+- crash after request is claimed but before completion is recorded
+- restart with stale pending requests
+
+## Risks and Constraints
+
+### Prompt-cache stability
+
+The repo guidance is explicit that prompt-cache stability is correctness and
+performance sensitive.
+
+Any new request assembly for pending cron/main-session execution must preserve
+deterministic ordering. If durable scheduled-turn requests feed prompt context,
+the order in which they are assembled must be stable across runs.
+
+### Public behavior drift
+
+This plan changes internals first. It should not casually change:
+
+- visible cron configuration
+- heartbeat prompt semantics
+- plugin/channel contracts
+- transcript ownership rules
+
+### Channel and plugin boundaries
+
+Do not solve delivery drift by hardcoding channel-specific logic into cron or
+heartbeat. Shared outbound resolution must continue to rely on existing plugin
+and channel seams.
+
+### Operational complexity
+
+Adding durable run and request stores introduces new retention and cleanup work.
+Retention policy should be explicit from the beginning to avoid unbounded growth.
+
+## Recommended First Slice
+
+The first implementation slice should be:
+
+1. persist cron run lifecycle
+2. extract the execution orchestrator seam just enough to support the run record
+3. begin the durable main-session request path
+
+Reason:
+
+- this fixes the biggest architectural lie first
+- it creates an explicit place for later heartbeat decomposition
+- it avoids a risky heartbeat rewrite before ownership is clarified
+
+## Open Questions
+
+These should be resolved during implementation, but they do not block the plan:
+
+- whether durable scheduled-turn requests should live in the cron store or a new
+  infra-level store
+- whether the durable request mechanism should be cron-specific first or
+  generalized immediately
+- how much existing system-event prompt wording should be preserved verbatim for
+  main-session cron compatibility
+- whether run retention belongs in cron config or should start with a fixed
+  default
+
+## Definition of Done
+
+This redesign is done when:
+
+- every cron run has one durable owner for final outcome
+- main-session cron no longer relies solely on an ephemeral queue to bridge
+  durable scheduling to actual execution
+- heartbeat is no longer the hidden owner of cron work
+- heartbeat delivery and detached cron delivery share one target-resolution
+  contract
+- restart scenarios are covered by tests and behave predictably

--- a/specs/telegram-topic-misroute-investigation.md
+++ b/specs/telegram-topic-misroute-investigation.md
@@ -1,0 +1,159 @@
+# Telegram Topic Misroute Investigation
+
+## Scope
+
+Observed misroute:
+
+- Intended/origin session key: `agent:main:telegram:group:-1003774691294:topic:47`
+- Intended/origin session id: `fd9b66a7-ebbf-4a7b-8415-b5d366379cd2`
+- Intended delivery context: Telegram group `-1003774691294`, thread/topic `47`
+- Observed/misrouted session key: `agent:main:telegram:group:-1003774691294:topic:2175`
+- Observed/misrouted session id: `942dc58d-ce55-4790-89f1-05d4ad12757d`
+- Observed delivery context: Telegram group `-1003774691294`, thread/topic `2175`
+
+Misrouted text:
+
+> The review-worker spawn finished successfully.
+>
+> Active review workers now:
+>
+> • Ren 6687c550 for PR #380
+> • Stimpy f667e0d7 for PR #381
+>
+> They’re both up in fresh openclaw worktrees and working from the review-pr flow.
+
+## Conclusion
+
+This does **not** look like a Telegram topic session-key derivation bug. The topic-scoped session machinery correctly distinguishes topic `47` from topic `2175`.
+
+This looks most like a **completion-event routing bug caused by mutable last-route contamination**:
+
+- a delayed completion event is associated with session key `agent:main:telegram:group:-1003774691294:topic:47`
+- but the delayed event does **not** preserve the original topic delivery context
+- when the completion is delivered later, it reuses whatever delivery route is currently stored on that session
+- if that stored route has drifted to Telegram topic `2175`, the completion can land in `2175` even though the originating session key was still `...:topic:47`
+
+So the best classification is:
+
+- not a raw session binding bug
+- not primarily a Telegram send bug
+- yes, a completion-event routing bug
+- enabled by last-thread / last-route contamination
+
+## Why The Session Keys Themselves Look Correct
+
+Telegram topic routing is explicitly topic-qualified:
+
+- `extensions/telegram/src/bot/helpers.ts` builds group peer ids as `<chatId>:topic:<threadId>`
+- `extensions/telegram/src/conversation-route.ts` uses that peer id to resolve the route and session key
+- `extensions/telegram/src/bot-message-context.session.ts` records inbound last-route updates back to the topic session, including topic-qualified `to` values like `telegram:<chatId>:topic:<threadId>`
+
+That means topic `47` and topic `2175` should naturally produce different session keys and different inbound last-route updates. I did not find a source path that would collapse those two topic keys together.
+
+## Strongest Suspected Wrong-Target Path
+
+### 1. Background exec completion enqueues by `sessionKey` only
+
+In `src/agents/bash-tools.exec-runtime.ts`, `maybeNotifyOnExit(...)` does this:
+
+- builds a completion summary
+- calls `enqueueSystemEvent(summary, { sessionKey, trusted: false })`
+- wakes heartbeat with `requestHeartbeatNow(...)`
+
+Critically, it does **not** attach a `deliveryContext`.
+
+`emitExecSystemEvent(...)` in the same file has the same shape: it queues by `sessionKey` and optional `contextKey`, but not by `deliveryContext`.
+
+### 2. System events can carry delivery context, but exec completions do not
+
+`src/infra/system-events.ts` supports per-event `deliveryContext`, and heartbeat preflight explicitly reads it through `resolveSystemEventDeliveryContext(...)`.
+
+That means the infrastructure already has the right abstraction, but exec completion events are not using it.
+
+### 3. Heartbeat delivery then falls back to mutable session routing state
+
+`src/infra/heartbeat-runner.ts` reads pending system events, resolves any event-scoped delivery context, and passes that into `resolveHeartbeatDeliveryTarget(...)`.
+
+`src/infra/outbound/targets.ts` and `src/infra/outbound/targets-session.ts` then resolve the delivery target from:
+
+- explicit turn-source context, if any
+- otherwise the session entry’s stored `deliveryContext` / `lastTo` / `lastThreadId`
+
+That fallback is where the contamination can happen.
+
+## Important Telegram-Specific Detail
+
+Heartbeat mode intentionally avoids inheriting a stale `threadId`, but that is not enough to protect Telegram forum topics.
+
+Reason:
+
+- Telegram topic routing can live in the raw `to` value itself, for example `telegram:-1003774691294:topic:2175`
+- `resolveSessionDeliveryTarget(...)` can still reuse that raw topic-qualified `to`
+- `extensions/telegram/src/send.ts` parses the topic out of `to` itself before sending
+
+So even if `threadId` is blank at heartbeat time, a contaminated topic-qualified `to` can still route the message into topic `2175`.
+
+That matches the observed symptom very well.
+
+## Most Likely Concrete Root Cause
+
+The likely failure chain is:
+
+1. Some background/async operation was started from session key `agent:main:telegram:group:-1003774691294:topic:47`.
+2. Its completion path queued only `sessionKey`, not the origin delivery context for topic `47`.
+3. Before the completion was delivered, the session’s mutable stored route had become topic `2175` or otherwise resolved to `telegram:-1003774691294:topic:2175`.
+4. The delayed completion reused that mutable route and delivered into topic `2175`.
+
+I did **not** identify the earlier write that contaminated the stored route to `2175`. That may be a separate bug or race. But the completion-event path is the part that makes the misroute possible even when the original session key was still `...:topic:47`.
+
+## Exact Suspected Source Files / Functions
+
+Primary suspects:
+
+- `src/agents/bash-tools.exec-runtime.ts`
+  - `maybeNotifyOnExit(...)`
+  - `emitExecSystemEvent(...)`
+- `src/infra/system-events.ts`
+  - `enqueueSystemEvent(...)`
+  - `resolveSystemEventDeliveryContext(...)`
+- `src/infra/heartbeat-runner.ts`
+  - `resolveHeartbeatPreflight(...)`
+- `src/infra/outbound/targets.ts`
+  - `resolveHeartbeatDeliveryTarget(...)`
+- `src/infra/outbound/targets-session.ts`
+  - `resolveSessionDeliveryTarget(...)`
+- `extensions/telegram/src/send.ts`
+  - `sendMessageTelegram(...)` parses topic-qualified `to` targets directly
+
+Files I checked and ruled out as the primary source:
+
+- `extensions/telegram/src/conversation-route.ts`
+- `extensions/telegram/src/bot-message-context.session.ts`
+- `src/routing/resolve-route.ts`
+- `src/agents/subagent-spawn.ts`
+- `src/agents/subagent-announce-delivery.ts`
+
+The subagent completion path appears to preserve requester origin, including thread id, and is less likely to explain this specific topic swap.
+
+## Recommended Fix
+
+Safe, surgical fix to implement later:
+
+1. Capture immutable origin `deliveryContext` when an async exec/background job is created.
+2. Store that origin context on the process session or pass it directly into completion event enqueueing.
+3. In `maybeNotifyOnExit(...)` and `emitExecSystemEvent(...)`, call `enqueueSystemEvent(...)` with both:
+   - `sessionKey`
+   - `deliveryContext` for the original requester route
+4. Add a regression test:
+   - start async exec from Telegram topic `47`
+   - mutate the session’s stored last route to topic `2175`
+   - complete the exec
+   - assert that the completion still delivers to topic `47`
+
+That keeps delayed completions pinned to the originating conversation instead of a mutable later session route.
+
+## Bottom Line
+
+The exact source session key `agent:main:telegram:group:-1003774691294:topic:47` could still have been the correct originating session while the completion message landed in topic `2175`.
+
+The most plausible reason is that async exec completion delivery is keyed to the session but not pinned to the original Telegram topic delivery context, so later session-route drift can redirect the completion into the wrong topic.

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import type { DeliveryContext } from "../utils/delivery-context.js";
 import { createSessionSlug as createSessionSlugId } from "./session-slug.js";
 
 const DEFAULT_JOB_TTL_MS = 30 * 60 * 1000; // 30 minutes
@@ -30,6 +31,7 @@ export interface ProcessSession {
   command: string;
   scopeKey?: string;
   sessionKey?: string;
+  notifyDeliveryContext?: DeliveryContext;
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   exitNotified?: boolean;

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -305,11 +305,21 @@ describe("emitExecSystemEvent", () => {
     emitExecSystemEvent("Exec finished", {
       sessionKey: "agent:ops:main",
       contextKey: "exec:run-1",
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:-100123:topic:47",
+        threadId: 47,
+      },
     });
 
     expect(enqueueSystemEventMock).toHaveBeenCalledWith("Exec finished", {
       sessionKey: "agent:ops:main",
       contextKey: "exec:run-1",
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:-100123:topic:47",
+        threadId: 47,
+      },
     });
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -27,6 +27,7 @@ import { logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit, TerminationReason } from "../process/supervisor/types.js";
+import { normalizeDeliveryContext, type DeliveryContext } from "../utils/delivery-context.js";
 import {
   addSession,
   appendOutput,
@@ -343,7 +344,11 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   const summary = output
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
-  enqueueSystemEvent(summary, { sessionKey, trusted: false });
+  enqueueSystemEvent(summary, {
+    sessionKey,
+    deliveryContext: session.notifyDeliveryContext,
+    trusted: false,
+  });
   requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
 }
 
@@ -409,13 +414,17 @@ export function resolveApprovalRunningNoticeMs(value?: number) {
 
 export function emitExecSystemEvent(
   text: string,
-  opts: { sessionKey?: string; contextKey?: string },
+  opts: { sessionKey?: string; contextKey?: string; deliveryContext?: DeliveryContext },
 ) {
   const sessionKey = opts.sessionKey?.trim();
   if (!sessionKey) {
     return;
   }
-  enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
+  enqueueSystemEvent(text, {
+    sessionKey,
+    contextKey: opts.contextKey,
+    deliveryContext: opts.deliveryContext,
+  });
   requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
 }
 
@@ -547,6 +556,7 @@ export async function runExecProcess(opts: {
   notifyOnExitEmptySuccess?: boolean;
   scopeKey?: string;
   sessionKey?: string;
+  notifyDeliveryContext?: DeliveryContext;
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
@@ -564,6 +574,7 @@ export async function runExecProcess(opts: {
     command: opts.command,
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
+    notifyDeliveryContext: normalizeDeliveryContext(opts.notifyDeliveryContext),
     notifyOnExit: opts.notifyOnExit,
     notifyOnExitEmptySuccess: opts.notifyOnExitEmptySuccess === true,
     exitNotified: false,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -22,6 +22,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
@@ -1387,6 +1388,12 @@ export function createExecTool(
   const notifyOnExit = defaults?.notifyOnExit !== false;
   const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
   const notifySessionKey = normalizeOptionalString(defaults?.sessionKey);
+  const notifyDeliveryContext = normalizeDeliveryContext({
+    channel: defaults?.messageProvider,
+    to: defaults?.currentChannelId,
+    accountId: defaults?.accountId,
+    threadId: defaults?.currentThreadTs,
+  });
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
   // Derive agentId only when sessionKey is an agent session key.
   const parsedAgentSession = parseAgentSessionKey(defaults?.sessionKey);
@@ -1733,6 +1740,7 @@ export function createExecTool(
         notifyOnExitEmptySuccess,
         scopeKey: defaults?.scopeKey,
         sessionKey: notifySessionKey,
+        notifyDeliveryContext,
         timeoutSec: effectiveTimeout,
         onUpdate,
       });

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -206,18 +206,18 @@ const requireRunningSessionId = (result: { details: unknown }) => {
   return requireSessionId(result.details as { sessionId?: string });
 };
 
-function hasNotifyEventForPrefix(prefix: string): boolean {
-  return peekSystemEvents(DEFAULT_NOTIFY_SESSION_KEY).some((event) => event.includes(prefix));
+function hasNotifyEventForPrefix(prefix: string, sessionKey = DEFAULT_NOTIFY_SESSION_KEY): boolean {
+  return peekSystemEvents(sessionKey).some((event) => event.includes(prefix));
 }
 
-async function waitForNotifyEvent(sessionId: string) {
+async function waitForNotifyEvent(sessionId: string, sessionKey = DEFAULT_NOTIFY_SESSION_KEY) {
   const prefix = sessionId.slice(0, 8);
   let finished = getFinishedSession(sessionId);
-  let hasEvent = hasNotifyEventForPrefix(prefix);
+  let hasEvent = hasNotifyEventForPrefix(prefix, sessionKey);
   await expect
     .poll(() => {
       finished = getFinishedSession(sessionId);
-      hasEvent = hasNotifyEventForPrefix(prefix);
+      hasEvent = hasNotifyEventForPrefix(prefix, sessionKey);
       return Boolean(finished && hasEvent);
     }, NOTIFY_POLL_OPTIONS)
     .toBe(true);
@@ -577,6 +577,32 @@ describe("exec notifyOnExit", () => {
     expect(hasEvent).toBe(true);
     expect(queuedEvent).toMatchObject({ trusted: false });
     expect(formatted).toContain("System (untrusted):");
+  });
+
+  it("preserves the origin delivery context on background exec completion events", async () => {
+    const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+    const tool = createNotifyOnExitExecTool({
+      sessionKey,
+      messageProvider: "telegram",
+      currentChannelId: "telegram:-1003774691294:topic:47",
+      currentThreadTs: "47",
+    });
+
+    const sessionId = await startBackgroundCommand(tool, echoAfterDelay("notify"));
+
+    await waitForNotifyEvent(sessionId, sessionKey);
+    const queuedEvent = peekSystemEventEntries(sessionKey).find((event) =>
+      event.text.includes(sessionId.slice(0, 8)),
+    );
+
+    expect(queuedEvent).toMatchObject({
+      trusted: false,
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:-1003774691294:topic:47",
+        threadId: "47",
+      },
+    });
   });
 
   it("scopes notifyOnExit heartbeat wake to the exec session key", async () => {

--- a/src/cron/execution/adapters/detached-session-turn.ts
+++ b/src/cron/execution/adapters/detached-session-turn.ts
@@ -1,0 +1,42 @@
+import type { CronServiceState } from "../../service/state.js";
+import type { CronJob } from "../../types.js";
+import { timeoutErrorMessage } from "../errors.js";
+import type { CronExecutionResult } from "../types.js";
+
+/** Execute a cron run through the detached isolated-agent path. */
+export async function executeDetachedCronTurn(params: {
+  state: CronServiceState;
+  job: CronJob;
+  abortSignal?: AbortSignal;
+}): Promise<CronExecutionResult> {
+  const { state, job, abortSignal } = params;
+  if (job.payload.kind !== "agentTurn") {
+    return { status: "skipped", error: "isolated job requires payload.kind=agentTurn" };
+  }
+  if (abortSignal?.aborted) {
+    return { status: "error", error: timeoutErrorMessage() };
+  }
+
+  const res = await state.deps.runIsolatedAgentJob({
+    job,
+    message: job.payload.message,
+    abortSignal,
+  });
+
+  if (abortSignal?.aborted) {
+    return { status: "error", error: timeoutErrorMessage() };
+  }
+
+  return {
+    status: res.status,
+    error: res.error,
+    summary: res.summary,
+    delivered: res.delivered,
+    deliveryAttempted: res.deliveryAttempted,
+    sessionId: res.sessionId,
+    sessionKey: res.sessionKey,
+    model: res.model,
+    provider: res.provider,
+    usage: res.usage,
+  };
+}

--- a/src/cron/execution/adapters/main-session-turn.ts
+++ b/src/cron/execution/adapters/main-session-turn.ts
@@ -1,0 +1,93 @@
+import { resolveJobPayloadTextForMain } from "../../service/jobs.js";
+import type { CronServiceState } from "../../service/state.js";
+import type { CronJob } from "../../types.js";
+import { timeoutErrorMessage } from "../errors.js";
+import type { CronExecutionResult, WaitWithAbort } from "../types.js";
+
+/** Execute a cron run that targets the main session through the heartbeat-facing path. */
+export async function executeMainSessionCronTurn(params: {
+  state: CronServiceState;
+  job: CronJob;
+  abortSignal?: AbortSignal;
+  waitWithAbort: WaitWithAbort;
+}): Promise<CronExecutionResult> {
+  const { state, job, abortSignal, waitWithAbort } = params;
+  const text = resolveJobPayloadTextForMain(job);
+  if (!text) {
+    const kind = job.payload.kind;
+    return {
+      status: "skipped",
+      error:
+        kind === "systemEvent"
+          ? "main job requires non-empty systemEvent text"
+          : 'main job requires payload.kind="systemEvent"',
+    };
+  }
+  const targetMainSessionKey = job.sessionKey;
+  state.deps.enqueueSystemEvent(text, {
+    agentId: job.agentId,
+    sessionKey: targetMainSessionKey,
+    contextKey: `cron:${job.id}`,
+  });
+  if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
+    const reason = `cron:${job.id}`;
+    const isRecurringJob = job.schedule.kind !== "at";
+    const maxWaitMs = state.deps.wakeNowHeartbeatBusyMaxWaitMs ?? 2 * 60_000;
+    const retryDelayMs = state.deps.wakeNowHeartbeatBusyRetryDelayMs ?? 250;
+    const waitStartedAt = state.deps.nowMs();
+
+    for (;;) {
+      if (abortSignal?.aborted) {
+        return { status: "error", error: timeoutErrorMessage() };
+      }
+      const heartbeatResult = await state.deps.runHeartbeatOnce({
+        reason,
+        agentId: job.agentId,
+        sessionKey: targetMainSessionKey,
+        heartbeat: { target: "last" },
+      });
+      if (heartbeatResult.status !== "skipped" || heartbeatResult.reason !== "requests-in-flight") {
+        if (heartbeatResult.status === "ran") {
+          return { status: "ok", summary: text };
+        }
+        if (heartbeatResult.status === "skipped") {
+          return { status: "skipped", error: heartbeatResult.reason, summary: text };
+        }
+        return { status: "error", error: heartbeatResult.reason, summary: text };
+      }
+      if (isRecurringJob) {
+        state.deps.requestHeartbeatNow({
+          reason,
+          agentId: job.agentId,
+          sessionKey: targetMainSessionKey,
+        });
+        return { status: "ok", summary: text };
+      }
+      if (abortSignal?.aborted) {
+        return { status: "error", error: timeoutErrorMessage() };
+      }
+      if (state.deps.nowMs() - waitStartedAt > maxWaitMs) {
+        if (abortSignal?.aborted) {
+          return { status: "error", error: timeoutErrorMessage() };
+        }
+        state.deps.requestHeartbeatNow({
+          reason,
+          agentId: job.agentId,
+          sessionKey: targetMainSessionKey,
+        });
+        return { status: "ok", summary: text };
+      }
+      await waitWithAbort(retryDelayMs);
+    }
+  }
+
+  if (abortSignal?.aborted) {
+    return { status: "error", error: timeoutErrorMessage() };
+  }
+  state.deps.requestHeartbeatNow({
+    reason: `cron:${job.id}`,
+    agentId: job.agentId,
+    sessionKey: targetMainSessionKey,
+  });
+  return { status: "ok", summary: text };
+}

--- a/src/cron/execution/errors.ts
+++ b/src/cron/execution/errors.ts
@@ -1,0 +1,22 @@
+/** Return the canonical timeout error text for cron execution paths. */
+export function timeoutErrorMessage(): string {
+  return "cron: job execution timed out";
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  return err.name === "AbortError" || err.message === timeoutErrorMessage();
+}
+
+/** Normalize execution errors to the stable text persisted in cron state and logs. */
+export function normalizeCronRunErrorText(err: unknown): string {
+  if (isAbortError(err)) {
+    return timeoutErrorMessage();
+  }
+  if (typeof err === "string") {
+    return err === `Error: ${timeoutErrorMessage()}` ? timeoutErrorMessage() : err;
+  }
+  return String(err);
+}

--- a/src/cron/execution/orchestrator.ts
+++ b/src/cron/execution/orchestrator.ts
@@ -1,0 +1,85 @@
+import type { CronServiceState } from "../service/state.js";
+import { resolveCronJobTimeoutMs } from "../service/timeout-policy.js";
+import type { CronJob } from "../types.js";
+import { executeDetachedCronTurn } from "./adapters/detached-session-turn.js";
+import { executeMainSessionCronTurn } from "./adapters/main-session-turn.js";
+import { timeoutErrorMessage } from "./errors.js";
+import type { CronExecutionResult, WaitWithAbort } from "./types.js";
+
+function createWaitWithAbort(abortSignal?: AbortSignal): WaitWithAbort {
+  return async (ms: number) => {
+    if (!abortSignal) {
+      await new Promise<void>((resolve) => setTimeout(resolve, ms));
+      return;
+    }
+    if (abortSignal.aborted) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+}
+
+/** Dispatch a cron run through the appropriate execution adapter for its session target. */
+export async function executeCronRunCore(
+  state: CronServiceState,
+  job: CronJob,
+  abortSignal?: AbortSignal,
+): Promise<CronExecutionResult> {
+  if (abortSignal?.aborted) {
+    return { status: "error", error: timeoutErrorMessage() };
+  }
+  if (job.sessionTarget === "main") {
+    return await executeMainSessionCronTurn({
+      state,
+      job,
+      abortSignal,
+      waitWithAbort: createWaitWithAbort(abortSignal),
+    });
+  }
+
+  return await executeDetachedCronTurn({
+    state,
+    job,
+    abortSignal,
+  });
+}
+
+/** Wrap cron execution with the per-job timeout policy before dispatching to adapters. */
+export async function executeCronRunCoreWithTimeout(
+  state: CronServiceState,
+  job: CronJob,
+): Promise<CronExecutionResult> {
+  const jobTimeoutMs = resolveCronJobTimeoutMs(job);
+  if (typeof jobTimeoutMs !== "number") {
+    return await executeCronRunCore(state, job);
+  }
+
+  const runAbortController = new AbortController();
+  let timeoutId: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      executeCronRunCore(state, job, runAbortController.signal),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          runAbortController.abort(timeoutErrorMessage());
+          reject(new Error(timeoutErrorMessage()));
+        }, jobTimeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/src/cron/execution/types.ts
+++ b/src/cron/execution/types.ts
@@ -1,0 +1,9 @@
+import type { CronRunOutcome, CronRunTelemetry } from "../types.js";
+
+export type CronExecutionResult = CronRunOutcome &
+  CronRunTelemetry & {
+    delivered?: boolean;
+    deliveryAttempted?: boolean;
+  };
+
+export type WaitWithAbort = (ms: number) => Promise<void>;

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -12,6 +12,7 @@ import type { CronDeliveryStatus, CronRunStatus, CronRunTelemetry } from "./type
 export type CronRunLogEntry = {
   ts: number;
   jobId: string;
+  runId?: string;
   action: "finished";
   status?: CronRunStatus;
   error?: string;

--- a/src/cron/service.persists-run-records.test.ts
+++ b/src/cron/service.persists-run-records.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createNoopLogger,
+  createStartedCronServiceWithFinishedBarrier,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+import { loadCronStore } from "./store.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-run-records-" });
+installCronTestHooks({ logger: noopLogger });
+
+type CronAddInput = Parameters<CronService["add"]>[0];
+
+function buildMainSessionSystemEventJob(name: string): CronAddInput {
+  return {
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "tick" },
+  };
+}
+
+function buildIsolatedAgentTurnJob(name: string): CronAddInput {
+  return {
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "test" },
+    delivery: { mode: "none" },
+  };
+}
+
+describe("CronService persists durable run records", () => {
+  it("persists a finalized run record for scheduled main-session cron", async () => {
+    const store = await makeStorePath();
+    const { cron, finished } = createStartedCronServiceWithFinishedBarrier({
+      storePath: store.storePath,
+      logger: noopLogger,
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildMainSessionSystemEventJob("main-run-record"));
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForOk(job.id);
+      await cron.list({ includeDisabled: true });
+
+      const loaded = await loadCronStore(store.storePath);
+      expect(loaded.runs).toHaveLength(1);
+      expect(loaded.runs?.[0]).toMatchObject({
+        jobId: job.id,
+        trigger: "due",
+        status: "ok",
+        summary: "tick",
+      });
+      expect(loaded.runs?.[0]?.runId).toMatch(/^cron:/);
+      expect(loaded.runs?.[0]?.endedAtMs).toBeTypeOf("number");
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("persists a finalized run record for manual cron runs", async () => {
+    const store = await makeStorePath();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "done",
+        delivered: true,
+        sessionId: "sess-123",
+        sessionKey: "agent:main:cron:job-1:run:sess-123",
+      })),
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add(buildIsolatedAgentTurnJob("manual-run-record"));
+      await cron.run(job.id, "force");
+
+      const loaded = await loadCronStore(store.storePath);
+      expect(loaded.runs).toHaveLength(1);
+      expect(loaded.runs?.[0]).toMatchObject({
+        jobId: job.id,
+        trigger: "manual",
+        status: "ok",
+        summary: "done",
+        delivered: true,
+        sessionId: "sess-123",
+      });
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("marks stale running run records as interrupted on startup", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2026-01-01T00:00:00.000Z");
+    const staleStore = {
+      version: 1 as const,
+      jobs: [
+        {
+          id: "job-1",
+          name: "Interrupted job",
+          enabled: true,
+          createdAtMs: now - 60_000,
+          updatedAtMs: now - 60_000,
+          schedule: { kind: "every" as const, everyMs: 60_000 },
+          sessionTarget: "main" as const,
+          wakeMode: "next-heartbeat" as const,
+          payload: { kind: "systemEvent" as const, text: "tick" },
+          state: {
+            runningAtMs: now - 5_000,
+          },
+        },
+      ],
+      runs: [
+        {
+          runId: "cron:job-1:stale",
+          jobId: "job-1",
+          trigger: "due" as const,
+          startedAtMs: now - 5_000,
+          status: "running" as const,
+        },
+      ],
+    };
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(store.storePath, JSON.stringify(staleStore, null, 2), "utf-8");
+    vi.setSystemTime(new Date(now));
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await cron.start();
+    cron.stop();
+
+    const loaded = await loadCronStore(store.storePath);
+    expect(loaded.runs?.[0]).toMatchObject({
+      runId: "cron:job-1:stale",
+      status: "error",
+      error: "gateway restarted before cron run completed",
+    });
+    expect(loaded.runs?.[0]?.endedAtMs).toBeTypeOf("number");
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -6,6 +6,7 @@ import {
   createRunningTaskRun,
   failTaskRunByRunId,
 } from "../../tasks/task-executor.js";
+import { normalizeCronRunErrorText } from "../execution/errors.js";
 import type { CronJob, CronJobCreate, CronJobPatch, CronRunRecord } from "../types.js";
 import {
   applyJobPatch,
@@ -33,7 +34,6 @@ import {
   armTimer,
   emit,
   executeJobCoreWithTimeout,
-  normalizeCronRunErrorText,
   runMissedJobs,
   stopTimer,
   wake,

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -6,7 +6,7 @@ import {
   createRunningTaskRun,
   failTaskRunByRunId,
 } from "../../tasks/task-executor.js";
-import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
+import type { CronJob, CronJobCreate, CronJobPatch, CronRunRecord } from "../types.js";
 import {
   applyJobPatch,
   assertSupportedJobSpec,
@@ -21,6 +21,11 @@ import {
   recomputeNextRunsForMaintenance,
 } from "./jobs.js";
 import { locked } from "./locked.js";
+import {
+  appendRunningCronRunRecord,
+  failRunningCronRunsForJob,
+  finalizeCronRunRecord,
+} from "./run-records.js";
 import type { CronServiceState } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
 import {
@@ -63,6 +68,7 @@ function mergeManualRunSnapshotAfterReload(params: {
     enabled: boolean;
     updatedAtMs: number;
     state: CronJob["state"];
+    runRecord?: CronRunRecord;
   } | null;
   removed: boolean;
 }) {
@@ -83,6 +89,17 @@ function mergeManualRunSnapshotAfterReload(params: {
   reloaded.enabled = params.snapshot.enabled;
   reloaded.updatedAtMs = params.snapshot.updatedAtMs;
   reloaded.state = params.snapshot.state;
+  if (params.snapshot.runRecord) {
+    params.state.store.runs ??= [];
+    const existingIndex = params.state.store.runs.findIndex(
+      (run) => run.runId === params.snapshot?.runRecord?.runId,
+    );
+    if (existingIndex >= 0) {
+      params.state.store.runs[existingIndex] = params.snapshot.runRecord;
+    } else {
+      params.state.store.runs.push(params.snapshot.runRecord);
+    }
+  }
 }
 
 async function ensureLoadedForRead(state: CronServiceState) {
@@ -116,6 +133,12 @@ export async function start(state: CronServiceState) {
           "cron: clearing stale running marker on startup",
         );
         job.state.runningAtMs = undefined;
+        failRunningCronRunsForJob({
+          store: state.store!,
+          jobId: job.id,
+          endedAtMs: state.deps.nowMs(),
+          error: "gateway restarted before cron run completed",
+        });
         clearedAnyRunningMarker = true;
         // One-shot jobs are not retried after interruption; recurring jobs
         // (cron/every) are eligible for startup catch-up so they don't
@@ -372,6 +395,7 @@ type PreparedManualRun =
       ok: true;
       ran: true;
       jobId: string;
+      runId: string;
       taskRunId?: string;
       startedAt: number;
       executionJob: CronJob;
@@ -590,8 +614,20 @@ async function prepareManualRun(
     job.state.lastError = undefined;
     // Persist the running marker before releasing lock so timer ticks that
     // force-reload from disk cannot start the same job concurrently.
+    const runRecord = appendRunningCronRunRecord({
+      store: state.store!,
+      jobId: job.id,
+      trigger: "manual",
+      scheduledAtMs: job.state.nextRunAtMs,
+      startedAtMs: preflight.now,
+    });
     await persist(state);
-    emit(state, { jobId: job.id, action: "started", runAtMs: preflight.now });
+    emit(state, {
+      jobId: job.id,
+      runId: runRecord.runId,
+      action: "started",
+      runAtMs: preflight.now,
+    });
     const taskRunId = tryCreateManualTaskRun({
       state,
       job,
@@ -602,6 +638,7 @@ async function prepareManualRun(
       ok: true,
       ran: true,
       jobId: job.id,
+      runId: runRecord.runId,
       taskRunId,
       startedAt: preflight.now,
       executionJob,
@@ -617,6 +654,7 @@ async function finishPreparedManualRun(
   const executionJob = prepared.executionJob;
   const startedAt = prepared.startedAt;
   const jobId = prepared.jobId;
+  const runId = prepared.runId;
   const taskRunId = prepared.taskRunId;
 
   let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
@@ -651,9 +689,26 @@ async function finishPreparedManualRun(
       },
       { preserveSchedule: mode === "force" },
     );
+    finalizeCronRunRecord({
+      store: state.store!,
+      runId,
+      status: coreResult.status,
+      endedAtMs: endedAt,
+      error: coreResult.error,
+      summary: coreResult.summary,
+      delivered: coreResult.delivered,
+      deliveryStatus: job.state.lastDeliveryStatus,
+      deliveryError: job.state.lastDeliveryError,
+      sessionId: coreResult.sessionId,
+      sessionKey: coreResult.sessionKey,
+      model: coreResult.model,
+      provider: coreResult.provider,
+      usage: coreResult.usage,
+    });
 
     emit(state, {
       jobId: job.id,
+      runId,
       action: "finished",
       status: coreResult.status,
       error: coreResult.error,
@@ -685,6 +740,7 @@ async function finishPreparedManualRun(
           enabled: job.enabled,
           updatedAtMs: job.updatedAtMs,
           state: structuredClone(job.state),
+          runRecord: structuredClone(state.store?.runs?.find((run) => run.runId === runId)),
         };
     const postRunRemoved = shouldDelete;
     // Isolated Telegram send can persist target writeback directly to disk.

--- a/src/cron/service/run-records.ts
+++ b/src/cron/service/run-records.ts
@@ -1,0 +1,102 @@
+import { randomBytes } from "node:crypto";
+import type {
+  CronDeliveryStatus,
+  CronRunRecord,
+  CronRunStatus,
+  CronRunTrigger,
+  CronStoreFile,
+} from "../types.js";
+
+const DEFAULT_MAX_CRON_RUN_RECORDS = 500;
+
+function ensureRuns(store: CronStoreFile): CronRunRecord[] {
+  store.runs ??= [];
+  return store.runs;
+}
+
+function pruneRunRecords(store: CronStoreFile, maxRecords = DEFAULT_MAX_CRON_RUN_RECORDS): void {
+  const runs = ensureRuns(store);
+  if (runs.length <= maxRecords) {
+    return;
+  }
+  store.runs = runs.slice(runs.length - maxRecords);
+}
+
+export function createCronRunId(jobId: string, startedAtMs: number): string {
+  return `cron:${jobId}:${startedAtMs}:${randomBytes(4).toString("hex")}`;
+}
+
+export function appendRunningCronRunRecord(params: {
+  store: CronStoreFile;
+  jobId: string;
+  trigger: CronRunTrigger;
+  scheduledAtMs?: number;
+  startedAtMs: number;
+}): CronRunRecord {
+  const record: CronRunRecord = {
+    runId: createCronRunId(params.jobId, params.startedAtMs),
+    jobId: params.jobId,
+    trigger: params.trigger,
+    scheduledAtMs: params.scheduledAtMs,
+    startedAtMs: params.startedAtMs,
+    status: "running",
+  };
+  ensureRuns(params.store).push(record);
+  pruneRunRecords(params.store);
+  return record;
+}
+
+export function finalizeCronRunRecord(params: {
+  store: CronStoreFile;
+  runId: string;
+  status: CronRunStatus;
+  endedAtMs: number;
+  error?: string;
+  summary?: string;
+  delivered?: boolean;
+  deliveryStatus?: CronDeliveryStatus;
+  deliveryError?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  model?: string;
+  provider?: string;
+  usage?: CronRunRecord["usage"];
+}): CronRunRecord | undefined {
+  const record = ensureRuns(params.store).find((entry) => entry.runId === params.runId);
+  if (!record) {
+    return undefined;
+  }
+  record.status = params.status;
+  record.endedAtMs = params.endedAtMs;
+  record.error = params.error;
+  record.summary = params.summary;
+  record.delivered = params.delivered;
+  record.deliveryStatus = params.deliveryStatus;
+  record.deliveryError = params.deliveryError;
+  record.sessionId = params.sessionId;
+  record.sessionKey = params.sessionKey;
+  record.model = params.model;
+  record.provider = params.provider;
+  record.usage = params.usage;
+  return record;
+}
+
+export function failRunningCronRunsForJob(params: {
+  store: CronStoreFile;
+  jobId: string;
+  endedAtMs: number;
+  error: string;
+}): boolean {
+  let changed = false;
+  for (const run of ensureRuns(params.store)) {
+    if (run.jobId !== params.jobId || run.status !== "running") {
+      continue;
+    }
+    run.status = "error";
+    run.endedAtMs = params.endedAtMs;
+    run.error = params.error;
+    run.deliveryStatus ??= "unknown";
+    changed = true;
+  }
+  return changed;
+}

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -14,6 +14,7 @@ import type {
 
 export type CronEvent = {
   jobId: string;
+  runId?: string;
   action: "added" | "updated" | "removed" | "started" | "finished";
   runAtMs?: number;
   durationMs?: number;

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -53,6 +53,7 @@ export async function ensureLoaded(
   state.store = {
     version: 1,
     jobs,
+    runs: loaded.runs ?? [],
   };
   state.storeLoadedAtMs = state.deps.nowMs();
   state.storeFileMtimeMs = fileMtimeMs;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,6 +1,5 @@
 import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
-import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import {
@@ -10,15 +9,11 @@ import {
 } from "../../tasks/task-executor.js";
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { resolveCronDeliveryPlan } from "../delivery-plan.js";
+import { normalizeCronRunErrorText, timeoutErrorMessage } from "../execution/errors.js";
+import { executeCronRunCore, executeCronRunCoreWithTimeout } from "../execution/orchestrator.js";
+import type { CronExecutionResult } from "../execution/types.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
-import type {
-  CronDeliveryStatus,
-  CronJob,
-  CronMessageChannel,
-  CronRunOutcome,
-  CronRunStatus,
-  CronRunTelemetry,
-} from "../types.js";
+import type { CronDeliveryStatus, CronJob, CronMessageChannel, CronRunStatus } from "../types.js";
 import {
   computeJobPreviousRunAtMs,
   computeJobNextRunAtMs,
@@ -27,7 +22,6 @@ import {
   nextWakeAtMs,
   recomputeNextRunsForMaintenance,
   recordScheduleComputeError,
-  resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
 import { appendRunningCronRunRecord, finalizeCronRunRecord } from "./run-records.js";
@@ -53,16 +47,13 @@ const DEFAULT_MAX_MISSED_JOBS_PER_RESTART = 5;
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
 const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
 
-type TimedCronRunOutcome = CronRunOutcome &
-  CronRunTelemetry & {
-    jobId: string;
-    runId: string;
-    taskRunId?: string;
-    delivered?: boolean;
-    deliveryAttempted?: boolean;
-    startedAt: number;
-    endedAt: number;
-  };
+type TimedCronRunOutcome = CronExecutionResult & {
+  jobId: string;
+  runId: string;
+  taskRunId?: string;
+  startedAt: number;
+  endedAt: number;
+};
 
 type StartupCatchupCandidate = {
   jobId: string;
@@ -75,33 +66,7 @@ type StartupCatchupPlan = {
   deferredJobIds: string[];
 };
 
-export async function executeJobCoreWithTimeout(
-  state: CronServiceState,
-  job: CronJob,
-): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
-  const jobTimeoutMs = resolveCronJobTimeoutMs(job);
-  if (typeof jobTimeoutMs !== "number") {
-    return await executeJobCore(state, job);
-  }
-
-  const runAbortController = new AbortController();
-  let timeoutId: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      executeJobCore(state, job, runAbortController.signal),
-      new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          runAbortController.abort(timeoutErrorMessage());
-          reject(new Error(timeoutErrorMessage()));
-        }, jobTimeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  }
-}
+export const executeJobCoreWithTimeout = executeCronRunCoreWithTimeout;
 
 function resolveRunConcurrency(state: CronServiceState): number {
   const raw = state.deps.cronConfig?.maxConcurrentRuns;
@@ -110,27 +75,6 @@ function resolveRunConcurrency(state: CronServiceState): number {
   }
   return Math.max(1, Math.floor(raw));
 }
-function timeoutErrorMessage(): string {
-  return "cron: job execution timed out";
-}
-
-function isAbortError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  return err.name === "AbortError" || err.message === timeoutErrorMessage();
-}
-
-export function normalizeCronRunErrorText(err: unknown): string {
-  if (isAbortError(err)) {
-    return timeoutErrorMessage();
-  }
-  if (typeof err === "string") {
-    return err === `Error: ${timeoutErrorMessage()}` ? timeoutErrorMessage() : err;
-  }
-  return String(err);
-}
-
 function createCronTaskRunId(jobId: string, startedAt: number): string {
   return `cron:${jobId}:${startedAt}`;
 }
@@ -1156,181 +1100,7 @@ export async function runDueJobs(state: CronServiceState) {
   }
 }
 
-export async function executeJobCore(
-  state: CronServiceState,
-  job: CronJob,
-  abortSignal?: AbortSignal,
-): Promise<
-  CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
-> {
-  const resolveAbortError = () => ({
-    status: "error" as const,
-    error: timeoutErrorMessage(),
-  });
-  const waitWithAbort = async (ms: number) => {
-    if (!abortSignal) {
-      await new Promise<void>((resolve) => setTimeout(resolve, ms));
-      return;
-    }
-    if (abortSignal.aborted) {
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        abortSignal.removeEventListener("abort", onAbort);
-        resolve();
-      }, ms);
-      const onAbort = () => {
-        clearTimeout(timer);
-        abortSignal.removeEventListener("abort", onAbort);
-        resolve();
-      };
-      abortSignal.addEventListener("abort", onAbort, { once: true });
-    });
-  };
-
-  if (abortSignal?.aborted) {
-    return resolveAbortError();
-  }
-  if (job.sessionTarget === "main") {
-    return await executeMainSessionCronJob(state, job, abortSignal, waitWithAbort);
-  }
-
-  return await executeDetachedCronJob(state, job, abortSignal, resolveAbortError);
-}
-
-async function executeMainSessionCronJob(
-  state: CronServiceState,
-  job: CronJob,
-  abortSignal: AbortSignal | undefined,
-  waitWithAbort: (ms: number) => Promise<void>,
-): Promise<
-  CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
-> {
-  const text = resolveJobPayloadTextForMain(job);
-  if (!text) {
-    const kind = job.payload.kind;
-    return {
-      status: "skipped",
-      error:
-        kind === "systemEvent"
-          ? "main job requires non-empty systemEvent text"
-          : 'main job requires payload.kind="systemEvent"',
-    };
-  }
-  const targetMainSessionKey = job.sessionKey;
-  state.deps.enqueueSystemEvent(text, {
-    agentId: job.agentId,
-    sessionKey: targetMainSessionKey,
-    contextKey: `cron:${job.id}`,
-  });
-  if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
-    const reason = `cron:${job.id}`;
-    const isRecurringJob = job.schedule.kind !== "at";
-    const maxWaitMs = state.deps.wakeNowHeartbeatBusyMaxWaitMs ?? 2 * 60_000;
-    const retryDelayMs = state.deps.wakeNowHeartbeatBusyRetryDelayMs ?? 250;
-    const waitStartedAt = state.deps.nowMs();
-
-    let heartbeatResult: HeartbeatRunResult;
-    for (;;) {
-      if (abortSignal?.aborted) {
-        return { status: "error", error: timeoutErrorMessage() };
-      }
-      heartbeatResult = await state.deps.runHeartbeatOnce({
-        reason,
-        agentId: job.agentId,
-        sessionKey: targetMainSessionKey,
-        heartbeat: { target: "last" },
-      });
-      if (heartbeatResult.status !== "skipped" || heartbeatResult.reason !== "requests-in-flight") {
-        break;
-      }
-      if (isRecurringJob) {
-        // Recurring main-session cron jobs should not hold the cron lane open
-        // while the main lane is busy, or their measured duration starts to
-        // reflect queue wait instead of cron bookkeeping (#58833).
-        state.deps.requestHeartbeatNow({
-          reason,
-          agentId: job.agentId,
-          sessionKey: targetMainSessionKey,
-        });
-        return { status: "ok", summary: text };
-      }
-      if (abortSignal?.aborted) {
-        return { status: "error", error: timeoutErrorMessage() };
-      }
-      if (state.deps.nowMs() - waitStartedAt > maxWaitMs) {
-        if (abortSignal?.aborted) {
-          return { status: "error", error: timeoutErrorMessage() };
-        }
-        state.deps.requestHeartbeatNow({
-          reason,
-          agentId: job.agentId,
-          sessionKey: targetMainSessionKey,
-        });
-        return { status: "ok", summary: text };
-      }
-      await waitWithAbort(retryDelayMs);
-    }
-
-    if (heartbeatResult.status === "ran") {
-      return { status: "ok", summary: text };
-    }
-    if (heartbeatResult.status === "skipped") {
-      return { status: "skipped", error: heartbeatResult.reason, summary: text };
-    }
-    return { status: "error", error: heartbeatResult.reason, summary: text };
-  }
-
-  if (abortSignal?.aborted) {
-    return { status: "error", error: timeoutErrorMessage() };
-  }
-  state.deps.requestHeartbeatNow({
-    reason: `cron:${job.id}`,
-    agentId: job.agentId,
-    sessionKey: targetMainSessionKey,
-  });
-  return { status: "ok", summary: text };
-}
-
-async function executeDetachedCronJob(
-  state: CronServiceState,
-  job: CronJob,
-  abortSignal: AbortSignal | undefined,
-  resolveAbortError: () => { status: "error"; error: string },
-): Promise<
-  CronRunOutcome & CronRunTelemetry & { delivered?: boolean; deliveryAttempted?: boolean }
-> {
-  if (job.payload.kind !== "agentTurn") {
-    return { status: "skipped", error: "isolated job requires payload.kind=agentTurn" };
-  }
-  if (abortSignal?.aborted) {
-    return resolveAbortError();
-  }
-
-  const res = await state.deps.runIsolatedAgentJob({
-    job,
-    message: job.payload.message,
-    abortSignal,
-  });
-
-  if (abortSignal?.aborted) {
-    return { status: "error", error: timeoutErrorMessage() };
-  }
-
-  return {
-    status: res.status,
-    error: res.error,
-    summary: res.summary,
-    delivered: res.delivered,
-    deliveryAttempted: res.deliveryAttempted,
-    sessionId: res.sessionId,
-    sessionKey: res.sessionKey,
-    model: res.model,
-    provider: res.provider,
-    usage: res.usage,
-  };
-}
+export const executeJobCore = executeCronRunCore;
 
 /**
  * Execute a job. This version is used by the `run` command and other
@@ -1366,8 +1136,7 @@ export async function executeJob(
   let coreResult: {
     status: CronRunStatus;
     delivered?: boolean;
-  } & CronRunOutcome &
-    CronRunTelemetry;
+  } & CronExecutionResult;
   try {
     coreResult = await executeJobCore(state, job);
   } catch (err) {
@@ -1414,8 +1183,7 @@ function emitJobFinished(
   result: {
     status: CronRunStatus;
     delivered?: boolean;
-  } & CronRunOutcome &
-    CronRunTelemetry,
+  } & CronExecutionResult,
   runAtMs: number,
   runId?: string,
 ) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -30,6 +30,7 @@ import {
   resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
+import { appendRunningCronRunRecord, finalizeCronRunRecord } from "./run-records.js";
 import type { CronEvent, CronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 import { DEFAULT_JOB_TIMEOUT_MS, resolveCronJobTimeoutMs } from "./timeout-policy.js";
@@ -55,6 +56,7 @@ const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
 type TimedCronRunOutcome = CronRunOutcome &
   CronRunTelemetry & {
     jobId: string;
+    runId: string;
     taskRunId?: string;
     delivered?: boolean;
     deliveryAttempted?: boolean;
@@ -65,6 +67,7 @@ type TimedCronRunOutcome = CronRunOutcome &
 type StartupCatchupCandidate = {
   jobId: string;
   job: CronJob;
+  runId: string;
 };
 
 type StartupCatchupPlan = {
@@ -130,6 +133,10 @@ export function normalizeCronRunErrorText(err: unknown): string {
 
 function createCronTaskRunId(jobId: string, startedAt: number): string {
   return `cron:${jobId}:${startedAt}`;
+}
+
+function resolveScheduledRunAtMs(job: CronJob, startedAt: number): number {
+  return hasScheduledNextRunAtMs(job.state.nextRunAtMs) ? job.state.nextRunAtMs : startedAt;
 }
 
 function tryCreateCronTaskRun(params: {
@@ -584,8 +591,24 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     startedAt: result.startedAt,
     endedAt: result.endedAt,
   });
+  finalizeCronRunRecord({
+    store,
+    runId: result.runId,
+    status: result.status,
+    endedAtMs: result.endedAt,
+    error: result.error,
+    summary: result.summary,
+    delivered: result.delivered,
+    deliveryStatus: job.state.lastDeliveryStatus,
+    deliveryError: job.state.lastDeliveryError,
+    sessionId: result.sessionId,
+    sessionKey: result.sessionKey,
+    model: result.model,
+    provider: result.provider,
+    usage: result.usage,
+  });
 
-  emitJobFinished(state, job, result, result.startedAt);
+  emitJobFinished(state, job, result, result.startedAt, result.runId);
 
   if (shouldDelete) {
     store.jobs = jobs.filter((entry) => entry.id !== job.id);
@@ -694,27 +717,40 @@ export async function onTimer(state: CronServiceState) {
       }
 
       const now = state.deps.nowMs();
-      for (const job of due) {
+      const preparedDue = due.map((job) => {
         job.state.runningAtMs = now;
         job.state.lastError = undefined;
-      }
+        return {
+          id: job.id,
+          job,
+          runId: appendRunningCronRunRecord({
+            store: state.store!,
+            jobId: job.id,
+            trigger: "due",
+            scheduledAtMs: resolveScheduledRunAtMs(job, now),
+            startedAtMs: now,
+          }).runId,
+        };
+      });
       await persist(state);
-
-      return due.map((j) => ({
-        id: j.id,
-        job: j,
-      }));
+      return preparedDue;
     });
 
     const runDueJob = async (params: {
       id: string;
       job: CronJob;
+      runId: string;
     }): Promise<TimedCronRunOutcome> => {
-      const { id, job } = params;
+      const { id, job, runId } = params;
       const startedAt = state.deps.nowMs();
       job.state.runningAtMs = startedAt;
       markCronJobActive(job.id);
-      emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
+      emit(state, {
+        jobId: job.id,
+        runId,
+        action: "started",
+        runAtMs: startedAt,
+      });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
       const taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
 
@@ -722,6 +758,7 @@ export async function onTimer(state: CronServiceState) {
         const result = await executeJobCoreWithTimeout(state, job);
         return {
           jobId: id,
+          runId,
           taskRunId,
           ...result,
           startedAt,
@@ -735,6 +772,7 @@ export async function onTimer(state: CronServiceState) {
         );
         return {
           jobId: id,
+          runId,
           taskRunId,
           status: "error",
           error: errorText,
@@ -986,14 +1024,25 @@ async function planStartupCatchup(
         "cron: running missed jobs after restart",
       );
     }
-    for (const job of startupCandidates) {
+    const preparedCandidates = startupCandidates.map((job) => {
       job.state.runningAtMs = now;
       job.state.lastError = undefined;
-    }
+      return {
+        jobId: job.id,
+        job,
+        runId: appendRunningCronRunRecord({
+          store: state.store!,
+          jobId: job.id,
+          trigger: "startup-catchup",
+          scheduledAtMs: resolveScheduledRunAtMs(job, now),
+          startedAtMs: now,
+        }).runId,
+      };
+    });
     await persist(state);
 
     return {
-      candidates: startupCandidates.map((job) => ({ jobId: job.id, job })),
+      candidates: preparedCandidates,
       deferredJobIds: deferred.map((job) => job.id),
     };
   });
@@ -1020,11 +1069,17 @@ async function runStartupCatchupCandidate(
     job: candidate.job,
     startedAt,
   });
-  emit(state, { jobId: candidate.job.id, action: "started", runAtMs: startedAt });
+  emit(state, {
+    jobId: candidate.job.id,
+    runId: candidate.runId,
+    action: "started",
+    runAtMs: startedAt,
+  });
   try {
     const result = await executeJobCoreWithTimeout(state, candidate.job);
     return {
       jobId: candidate.jobId,
+      runId: candidate.runId,
       taskRunId,
       status: result.status,
       error: result.error,
@@ -1041,6 +1096,7 @@ async function runStartupCatchupCandidate(
   } catch (err) {
     return {
       jobId: candidate.jobId,
+      runId: candidate.runId,
       taskRunId,
       status: "error",
       error: normalizeCronRunErrorText(err),
@@ -1293,7 +1349,19 @@ export async function executeJob(
   job.state.runningAtMs = startedAt;
   job.state.lastError = undefined;
   markCronJobActive(job.id);
-  emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
+  const runRecord = appendRunningCronRunRecord({
+    store: state.store!,
+    jobId: job.id,
+    trigger: "due",
+    scheduledAtMs: resolveScheduledRunAtMs(job, startedAt),
+    startedAtMs: startedAt,
+  });
+  emit(state, {
+    jobId: job.id,
+    runId: runRecord.runId,
+    action: "started",
+    runAtMs: startedAt,
+  });
 
   let coreResult: {
     status: CronRunStatus;
@@ -1314,8 +1382,24 @@ export async function executeJob(
     startedAt,
     endedAt,
   });
+  finalizeCronRunRecord({
+    store: state.store!,
+    runId: runRecord.runId,
+    status: coreResult.status,
+    endedAtMs: endedAt,
+    error: coreResult.error,
+    summary: coreResult.summary,
+    delivered: coreResult.delivered,
+    deliveryStatus: job.state.lastDeliveryStatus,
+    deliveryError: job.state.lastDeliveryError,
+    sessionId: coreResult.sessionId,
+    sessionKey: coreResult.sessionKey,
+    model: coreResult.model,
+    provider: coreResult.provider,
+    usage: coreResult.usage,
+  });
 
-  emitJobFinished(state, job, coreResult, startedAt);
+  emitJobFinished(state, job, coreResult, startedAt, runRecord.runId);
 
   if (shouldDelete && state.store) {
     state.store.jobs = state.store.jobs.filter((j) => j.id !== job.id);
@@ -1333,9 +1417,11 @@ function emitJobFinished(
   } & CronRunOutcome &
     CronRunTelemetry,
   runAtMs: number,
+  runId?: string,
 ) {
   emit(state, {
     jobId: job.id,
+    runId,
     action: "finished",
     status: result.status,
     error: result.error,

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -12,6 +12,7 @@ function makeStore(jobId: string, enabled: boolean): CronStoreFile {
   const now = Date.now();
   return {
     version: 1,
+    runs: [],
     jobs: [
       {
         id: jobId,
@@ -47,7 +48,7 @@ describe("cron store", () => {
   it("returns empty store when file does not exist", async () => {
     const store = await makeStorePath();
     const loaded = await loadCronStore(store.storePath);
-    expect(loaded).toEqual({ version: 1, jobs: [] });
+    expect(loaded).toEqual({ version: 1, jobs: [], runs: [] });
   });
 
   it("throws when store contains invalid JSON", async () => {
@@ -172,7 +173,7 @@ describe("cron store", () => {
 });
 
 describe("saveCronStore", () => {
-  const dummyStore: CronStoreFile = { version: 1, jobs: [] };
+  const dummyStore: CronStoreFile = { version: 1, jobs: [], runs: [] };
 
   beforeEach(() => {
     vi.useRealTimers();

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -23,6 +23,7 @@ function stripRuntimeOnlyCronFields(store: CronStoreFile): unknown {
       const { state: _state, updatedAtMs: _updatedAtMs, ...rest } = job;
       return rest;
     }),
+    runs: store.runs ?? [],
   };
 }
 
@@ -34,12 +35,14 @@ function parseCronStoreForBackupComparison(raw: string): CronStoreFile | null {
     }
     const version = (parsed as { version?: unknown }).version;
     const jobs = (parsed as { jobs?: unknown }).jobs;
+    const runs = (parsed as { runs?: unknown }).runs;
     if (version !== 1 || !Array.isArray(jobs)) {
       return null;
     }
     return {
       version: 1,
       jobs: jobs.filter(Boolean) as CronStoreFile["jobs"],
+      runs: Array.isArray(runs) ? (runs.filter(Boolean) as CronStoreFile["runs"]) : [],
     };
   } catch {
     return null;
@@ -90,16 +93,18 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
         ? (parsed as Record<string, unknown>)
         : {};
     const jobs = Array.isArray(parsedRecord.jobs) ? (parsedRecord.jobs as never[]) : [];
+    const runs = Array.isArray(parsedRecord.runs) ? (parsedRecord.runs as never[]) : [];
     const store = {
       version: 1 as const,
       jobs: jobs.filter(Boolean) as never as CronStoreFile["jobs"],
+      runs: runs.filter(Boolean) as never as CronStoreFile["runs"],
     };
     serializedStoreCache.set(storePath, JSON.stringify(store, null, 2));
     return store;
   } catch (err) {
     if ((err as { code?: unknown })?.code === "ENOENT") {
       serializedStoreCache.delete(storePath);
-      return { version: 1, jobs: [] };
+      return { version: 1, jobs: [], runs: [] };
     }
     throw err;
   }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -45,6 +45,8 @@ export type CronDeliveryPatch = Partial<CronDelivery>;
 
 export type CronRunStatus = "ok" | "error" | "skipped";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
+export type CronRunRecordStatus = "running" | CronRunStatus;
+export type CronRunTrigger = "due" | "manual" | "startup-catchup";
 
 export type CronUsageSummary = {
   input_tokens?: number;
@@ -69,6 +71,23 @@ export type CronRunOutcome = {
   sessionId?: string;
   sessionKey?: string;
 };
+
+export type CronRunRecord = {
+  runId: string;
+  jobId: string;
+  trigger: CronRunTrigger;
+  scheduledAtMs?: number;
+  startedAtMs: number;
+  endedAtMs?: number;
+  status: CronRunRecordStatus;
+  error?: string;
+  summary?: string;
+  delivered?: boolean;
+  deliveryStatus?: CronDeliveryStatus;
+  deliveryError?: string;
+  sessionId?: string;
+  sessionKey?: string;
+} & CronRunTelemetry;
 
 export type CronFailureAlert = {
   after?: number;
@@ -151,6 +170,7 @@ export type CronJob = CronJobBase<
 export type CronStoreFile = {
   version: 1;
   jobs: CronJob[];
+  runs?: CronRunRecord[];
 };
 
 export type CronJobCreate = Omit<CronJob, "id" | "createdAtMs" | "updatedAtMs" | "state"> & {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -509,6 +509,7 @@ export function buildGatewayCronService(params: {
           {
             ts: Date.now(),
             jobId: evt.jobId,
+            runId: evt.runId,
             action: "finished",
             status: evt.status,
             error: evt.error,

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -358,4 +358,71 @@ describe("Ghost reminder bug (issue #13317)", () => {
       expect(options?.messageThreadId).toBeUndefined();
     });
   });
+
+  it("keeps exec-event delivery pinned to the original Telegram topic when session route drifts", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The review-worker spawn finished successfully.",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "telegram:-1003774691294:topic:47",
+        "The review-worker spawn finished successfully.",
+        expect.objectContaining({ messageThreadId: 47 }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## What
Preserves the originating delivery context for delayed exec completion events so Telegram forum-topic completions stay pinned to the topic where the work started, even if the session's stored last-route later drifts to a different topic.

## Why
Background exec completions were being queued by session key alone and later re-resolved from mutable session routing state. In Telegram forum topics that could redirect a completion started in one topic into another topic.

## Changes
- Preserve exec completion delivery context on process sessions
- Attach delivery context to queued exec system events
- Pass ambient channel delivery context into exec background runs
- Add Telegram topic regression for topic drift
- Add notifyOnExit payload coverage for delivery context
- Include the investigation memo in specs

## Testing
- `pnpm test src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts`
- Expected: targeted agents + infra suites pass, including the new topic 47 vs 2175 regression
