### PR TITLE
fix(agents): clear auto failover session model stickiness (#64571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/config: accept and honor `agents.defaults.heartbeat.timeoutSeconds` and per-agent heartbeat timeout overrides for heartbeat agent turns. (#64491) Thanks @cedillarack.
 - OpenAI/Codex: add required Codex OAuth scopes, classify provider/runtime failures more clearly, and stop suggesting `/elevated full` when auto-approved host exec is unavailable. (#64439) Thanks @100yenadmin.
 - Providers/OpenAI: add OpenAI/Codex tool-schema compatibility and preserve embedded-run replay/liveness truth across compaction retries and mutating side effects. (#64300) Thanks @100yenadmin.
+- Agents/model fallback: clear persisted `auto` failover session overrides and sticky runtime model fields during inbound model selection so the configured primary is consulted again instead of staying pinned on the last fallback model. (#64571)
 
 ## 2026.4.9
 

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -490,6 +490,49 @@ describe("createModelSelectionState respects session model override", () => {
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
   });
 
+  it("clears auto failover sticky session state so the configured primary model is used", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "github-copilot/claude-sonnet-4.6" },
+          models: {
+            "github-copilot/claude-sonnet-4.6": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:monica:telegram:direct:1";
+    const sessionEntry = makeEntry({
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "kimi-k2.5-thinking",
+      modelProvider: "azure",
+      model: "kimi-k2.5-thinking",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentId: "monica",
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "github-copilot",
+      defaultModel: "claude-sonnet-4.6",
+      provider: "github-copilot",
+      model: "claude-sonnet-4.6",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("github-copilot");
+    expect(state.model).toBe("claude-sonnet-4.6");
+    expect(state.resetModelOverride).toBe(true);
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.model).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+  });
+
   it("keeps allowed legacy combined session overrides after normalization", async () => {
     const cfg = {
       agents: {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -527,7 +527,7 @@ describe("createModelSelectionState respects session model override", () => {
 
     expect(state.provider).toBe("github-copilot");
     expect(state.model).toBe("claude-sonnet-4.6");
-    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverride).toBe(false);
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
     expect(sessionStore[sessionKey]?.model).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -317,7 +317,9 @@ export async function createModelSelectionState(params: {
         store[sessionKey] = sessionEntry;
       });
     }
-    resetModelOverride = true;
+    // Do not set `resetModelOverride` here: that flag is reserved for allowlist/disallowed
+    // override recovery and triggers `Model override not allowed...` system events
+    // (`get-reply-directives-apply.ts`). Auto-failover cleanup only retries the primary.
   }
 
   const directStoredOverride = resolvePersistedOverrideModelRef({

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -17,7 +17,10 @@ import {
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
-import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  clearAutoFailoverSessionModelStickyState,
+} from "../../sessions/model-overrides.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import type { ThinkLevel } from "./directives.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
@@ -299,6 +302,24 @@ export async function createModelSelectionState(params: {
   let modelCatalog: ModelCatalog | null = null;
   let resetModelOverride = false;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
+
+  if (
+    sessionEntry &&
+    sessionStore &&
+    sessionKey &&
+    clearAutoFailoverSessionModelStickyState(sessionEntry)
+  ) {
+    sessionStore[sessionKey] = sessionEntry;
+    if (storePath) {
+      await (
+        await loadSessionStoreRuntime()
+      ).updateSessionStore(storePath, (store) => {
+        store[sessionKey] = sessionEntry;
+      });
+    }
+    resetModelOverride = true;
+  }
+
   const directStoredOverride = resolvePersistedOverrideModelRef({
     defaultProvider,
     overrideProvider: sessionEntry?.providerOverride,

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -260,4 +260,36 @@ describe("clearAutoFailoverSessionModelStickyState", () => {
     expect(entry.authProfileOverride).toBe("user-picked-profile");
     expect(entry.authProfileOverrideSource).toBe("user");
   });
+
+  it("preserves legacy user auth profile when source is unset but profile id is present", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-legacy-auth",
+      updatedAt: Date.now(),
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      authProfileOverride: "legacy-user-profile",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.authProfileOverride).toBe("legacy-user-profile");
+    expect(entry.modelOverride).toBeUndefined();
+  });
+
+  it("clears auth fields when compaction count implies auto-sourced profile", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-inferred-auto-auth",
+      updatedAt: Date.now(),
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      authProfileOverride: "auto-bound-profile",
+      authProfileOverrideCompactionCount: 1,
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.authProfileOverride).toBeUndefined();
+  });
 });

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
-import { applyModelOverrideToSessionEntry } from "./model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  clearAutoFailoverSessionModelStickyState,
+} from "./model-overrides.js";
 
 function applyOpenAiSelection(entry: SessionEntry) {
   return applyModelOverrideToSessionEntry({
@@ -171,5 +174,66 @@ describe("applyModelOverrideToSessionEntry", () => {
     });
     expect(withFlag.updated).toBe(true);
     expect(withFlagEntry.liveModelSwitchPending).toBe(true);
+  });
+});
+
+describe("clearAutoFailoverSessionModelStickyState", () => {
+  it("clears auto failover overrides, runtime model identity, and related fields", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-auto",
+      updatedAt: before,
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      modelProvider: "azure",
+      model: "gpt-5.4",
+      authProfileOverride: "p1",
+      authProfileOverrideSource: "auto",
+      contextTokens: 120_000,
+      fallbackNoticeSelectedModel: "azure/gpt-5.4",
+      fallbackNoticeActiveModel: "azure/gpt-5.4",
+      fallbackNoticeReason: "failover",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.authProfileOverride).toBeUndefined();
+    expect(entry.authProfileOverrideSource).toBeUndefined();
+    expect(entry.contextTokens).toBeUndefined();
+    expect(entry.fallbackNoticeSelectedModel).toBeUndefined();
+    expect(entry.fallbackNoticeActiveModel).toBeUndefined();
+    expect(entry.fallbackNoticeReason).toBeUndefined();
+    expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
+  it("returns false when the session is not an auto failover override", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-user",
+      updatedAt: Date.now(),
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(false);
+    expect(entry.modelOverride).toBe("gpt-4o");
+  });
+
+  it("returns false when modelOverrideSource is user", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-explicit",
+      updatedAt: Date.now(),
+      modelOverrideSource: "user",
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(false);
+    expect(entry.modelOverride).toBe("gpt-4o");
   });
 });

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -236,4 +236,28 @@ describe("clearAutoFailoverSessionModelStickyState", () => {
     expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(false);
     expect(entry.modelOverride).toBe("gpt-4o");
   });
+
+  it("preserves user auth profile overrides when clearing auto model failover", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-auto-user-profile",
+      updatedAt: Date.now(),
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      modelProvider: "azure",
+      model: "gpt-5.4",
+      authProfileOverride: "user-picked-profile",
+      authProfileOverrideSource: "user",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.authProfileOverride).toBe("user-picked-profile");
+    expect(entry.authProfileOverrideSource).toBe("user");
+  });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -8,17 +8,34 @@ export type ModelOverrideSelection = {
 };
 
 /**
+ * Mirrors auth override source inference in `resolveSessionAuthProfileOverride`
+ * (`src/agents/auth-profiles/session-override.ts`) so cleanup stays consistent.
+ */
+function inferredAuthProfileOverrideSource(entry: SessionEntry): "auto" | "user" | undefined {
+  const current = normalizeOptionalString(entry.authProfileOverride);
+  return (
+    entry.authProfileOverrideSource ??
+    (typeof entry.authProfileOverrideCompactionCount === "number"
+      ? "auto"
+      : current
+        ? "user"
+        : undefined)
+  );
+}
+
+/**
  * Clears failover-persisted session model state (`modelOverrideSource: "auto"`) plus
  * sticky runtime `model` / `modelProvider` fields so the next inbound turn re-resolves
  * the agent primary from config instead of staying pinned on the last fallback model.
  *
- * Preserves `authProfileOverride*` when `authProfileOverrideSource === "user"` — failover
- * can persist `modelOverrideSource: "auto"` alongside a user-selected auth profile.
+ * Clears `authProfileOverride*` only when auth is not user-attributed (explicit `"user"`,
+ * or legacy undefined source with a profile id and no compaction counter — inferred user).
  */
 export function clearAutoFailoverSessionModelStickyState(entry: SessionEntry): boolean {
   if (entry.modelOverrideSource !== "auto") {
     return false;
   }
+  const shouldClearAuthProfileFields = inferredAuthProfileOverrideSource(entry) !== "user";
   let updated = false;
   const del = (key: keyof SessionEntry) => {
     if (Object.hasOwn(entry, key)) {
@@ -29,7 +46,7 @@ export function clearAutoFailoverSessionModelStickyState(entry: SessionEntry): b
   del("providerOverride");
   del("modelOverride");
   del("modelOverrideSource");
-  if (entry.authProfileOverrideSource !== "user") {
+  if (shouldClearAuthProfileFields) {
     del("authProfileOverride");
     del("authProfileOverrideSource");
     del("authProfileOverrideCompactionCount");

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -7,6 +7,40 @@ export type ModelOverrideSelection = {
   isDefault?: boolean;
 };
 
+/**
+ * Clears failover-persisted session model state (`modelOverrideSource: "auto"`) plus
+ * sticky runtime `model` / `modelProvider` fields so the next inbound turn re-resolves
+ * the agent primary from config instead of staying pinned on the last fallback model.
+ */
+export function clearAutoFailoverSessionModelStickyState(entry: SessionEntry): boolean {
+  if (entry.modelOverrideSource !== "auto") {
+    return false;
+  }
+  let updated = false;
+  const del = (key: keyof SessionEntry) => {
+    if (Object.hasOwn(entry, key)) {
+      delete entry[key];
+      updated = true;
+    }
+  };
+  del("providerOverride");
+  del("modelOverride");
+  del("modelOverrideSource");
+  del("authProfileOverride");
+  del("authProfileOverrideSource");
+  del("authProfileOverrideCompactionCount");
+  del("model");
+  del("modelProvider");
+  del("contextTokens");
+  del("fallbackNoticeSelectedModel");
+  del("fallbackNoticeActiveModel");
+  del("fallbackNoticeReason");
+  if (updated) {
+    entry.updatedAt = Date.now();
+  }
+  return updated;
+}
+
 export function applyModelOverrideToSessionEntry(params: {
   entry: SessionEntry;
   selection: ModelOverrideSelection;

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -11,6 +11,9 @@ export type ModelOverrideSelection = {
  * Clears failover-persisted session model state (`modelOverrideSource: "auto"`) plus
  * sticky runtime `model` / `modelProvider` fields so the next inbound turn re-resolves
  * the agent primary from config instead of staying pinned on the last fallback model.
+ *
+ * Preserves `authProfileOverride*` when `authProfileOverrideSource === "user"` — failover
+ * can persist `modelOverrideSource: "auto"` alongside a user-selected auth profile.
  */
 export function clearAutoFailoverSessionModelStickyState(entry: SessionEntry): boolean {
   if (entry.modelOverrideSource !== "auto") {
@@ -26,9 +29,11 @@ export function clearAutoFailoverSessionModelStickyState(entry: SessionEntry): b
   del("providerOverride");
   del("modelOverride");
   del("modelOverrideSource");
-  del("authProfileOverride");
-  del("authProfileOverrideSource");
-  del("authProfileOverrideCompactionCount");
+  if (entry.authProfileOverrideSource !== "user") {
+    del("authProfileOverride");
+    del("authProfileOverrideSource");
+    del("authProfileOverrideCompactionCount");
+  }
   del("model");
   del("modelProvider");
   del("contextTokens");


### PR DESCRIPTION
## Summary

- **Problem:** After a successful model failover, persisted `modelOverrideSource: "auto"` overrides plus sticky `model` / `modelProvider` session fields kept subsequent inbound turns on the fallback model instead of re-consulting the agent configured primary.
- **Why it matters:** Operators could change the agent primary or expect the next message to retry the primary while healthy; the session stayed pinned until manual intervention.
- **What changed:** At the start of `createModelSelectionState`, clear auto failover sticky fields (overrides, auth-profile fields written with failover, runtime model identity, cached context window, fallback notice metadata) and persist when a session store path is present. Exposed helper `clearAutoFailoverSessionModelStickyState` in `src/sessions/model-overrides.ts`.
- **What did NOT change:** User-initiated overrides (`modelOverrideSource: "user"` or legacy overrides without source), allowlist enforcement, or failover persistence during an active failing run.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #64571

## Root Cause

- **Root cause:** Failover persistence wrote `auto` overrides and `updateSessionStoreAfterAgentRun` wrote last-run model identity; inbound selection honored those before agent primary.
- **Missing detection / guardrail:** No per-turn reconciliation that `auto` failover state should not pin the next message if the configured primary should be tried again.

## Regression Test Plan

- **Coverage:** Unit tests in `src/sessions/model-overrides.test.ts` and `src/auto-reply/reply/model-selection.test.ts`.
- **Scenario:** Session with `modelOverrideSource: "auto"` and fallback overrides clears at model selection; resolved provider/model match configured primary; `resetModelOverride` is set for directive handling.

## User-visible / Behavior Changes

- After a prior successful run on a fallback model, the next user message again selects the agent configured primary (then failover may still occur if the primary remains unavailable).

## Diagram

N/A

## Security Impact

- New permissions/capabilities? **No**
- New network endpoints / listeners? **No**
- Touches auth/secrets/pairing? **No** (clears session-scoped override metadata only for auto failover)


Made with [Cursor](https://cursor.com)