### PR TITLE
fix(agents): incomplete turn + Codex prepareArguments (#64570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI replay: preserve malformed function-call arguments in stored assistant history, avoid double-encoding preserved raw strings on replay, and coerce replayed string args back to objects at Anthropic and Google provider boundaries. (#61956) Thanks @100yenadmin.
 - Heartbeat/config: accept and honor `agents.defaults.heartbeat.timeoutSeconds` and per-agent heartbeat timeout overrides for heartbeat agent turns. (#64491) Thanks @cedillarack.
 - CLI/devices: make implicit `openclaw devices approve` selection preview-only and require approving the exact request ID, preventing latest-request races during device pairing. (#64160) Thanks @coygeek.
+- Agents/embedded: avoid false incomplete-turn errors when the model stops after `message(send)` with only a silent reply token (zero visible payloads), and validate Codex dynamic-tool `prepareArguments` is a function. (#64570)
 
 ## 2026.4.9
 

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -175,4 +175,33 @@ describe("createCodexDynamicToolBridge", () => {
       messagingToolSentTargets: [],
     });
   });
+
+  it("rejects non-function prepareArguments", async () => {
+    const base = createTool({
+      name: "broken",
+      execute: vi.fn(async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        details: {},
+      })),
+    });
+    const tool = { ...base, prepareArguments: "not-a-function" } as AnyAgentTool;
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      tool: "broken",
+      arguments: {},
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.contentItems[0]).toMatchObject({
+      type: "inputText",
+      text: expect.stringContaining("prepareArguments"),
+    });
+  });
 });

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -16,6 +16,11 @@ import {
   type JsonValue,
 } from "./protocol.js";
 
+/** pi-agent tools may expose optional `prepareArguments`; not declared on `AnyAgentTool`. */
+type AnyAgentToolWithPrepare = AnyAgentTool & {
+  prepareArguments?: (args: Record<string, unknown>) => unknown;
+};
+
 export type CodexDynamicToolBridge = {
   specs: CodexDynamicToolSpec[];
   handleToolCall: (params: CodexDynamicToolCallParams) => Promise<CodexDynamicToolCallResponse>;
@@ -52,7 +57,7 @@ export function createCodexDynamicToolBridge(params: {
     })),
     telemetry,
     handleToolCall: async (call) => {
-      const tool = toolMap.get(call.tool);
+      const tool = toolMap.get(call.tool) as AnyAgentToolWithPrepare | undefined;
       if (!tool) {
         return {
           contentItems: [{ type: "inputText", text: `Unknown OpenClaw tool: ${call.tool}` }],
@@ -61,7 +66,14 @@ export function createCodexDynamicToolBridge(params: {
       }
       const args = jsonObjectToRecord(call.arguments);
       try {
-        const preparedArgs = tool.prepareArguments ? tool.prepareArguments(args) : args;
+        let preparedArgs = args;
+        const prepare = tool.prepareArguments;
+        if (prepare != null) {
+          if (typeof prepare !== "function") {
+            throw new TypeError(`Tool ${tool.name} prepareArguments must be a function`);
+          }
+          preparedArgs = prepare.call(tool, args) as Record<string, unknown>;
+        }
         const result = await tool.execute(call.callId, preparedArgs, params.signal);
         collectToolTelemetry({
           toolName: tool.name,

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -13,6 +14,7 @@ import {
   extractPlanningOnlyPlanDetails,
   isLikelyExecutionAckPrompt,
   resolveAckExecutionFastPathInstruction,
+  resolveIncompleteTurnPayloadText,
   resolvePlanningOnlyRetryLimit,
   resolvePlanningOnlyRetryInstruction,
   STRICT_AGENTIC_BLOCKED_TEXT,
@@ -258,6 +260,75 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
       explanation: "I'll inspect the code. Then I'll patch the issue. Finally I'll run tests.",
       steps: ["I'll inspect the code.", "Then I'll patch the issue.", "Finally I'll run tests."],
     });
+  });
+
+  it("surfaces incomplete-turn guidance when stop/end_turn yields zero payloads after side effects", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [],
+      didSendViaMessagingTool: false,
+      lastAssistant: {
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.4",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toContain("verify before retrying");
+  });
+
+  it("does not surface incomplete-turn error for message(send) with only silent token after normal stop", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [SILENT_REPLY_TOKEN],
+      didSendViaMessagingTool: true,
+      lastAssistant: {
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.4",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBeNull();
+  });
+
+  it("still surfaces incomplete-turn when messaging ran but assistant text is empty", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [],
+      didSendViaMessagingTool: true,
+      lastAssistant: {
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.4",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toContain("verify before retrying");
   });
 
   it("marks incomplete-turn retries as replay-invalid abandoned runs", () => {

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -1,3 +1,4 @@
+import { isSilentReplyPayloadText } from "../../../auto-reply/tokens.js";
 import type { EmbeddedPiExecutionContract } from "../../../config/types.agent-defaults.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
@@ -11,9 +12,11 @@ type ReplayMetadataAttempt = Pick<
 
 type IncompleteTurnAttempt = Pick<
   EmbeddedRunAttemptResult,
+  | "assistantTexts"
   | "clientToolCall"
   | "yieldDetected"
   | "didSendDeterministicApprovalPrompt"
+  | "didSendViaMessagingTool"
   | "lastToolError"
   | "lastAssistant"
   | "replayMetadata"
@@ -45,6 +48,29 @@ export function isIncompleteTerminalAssistantTurn(params: {
   lastAssistant?: { stopReason?: string } | null;
 }): boolean {
   return !params.hasAssistantVisibleText && params.lastAssistant?.stopReason === "toolUse";
+}
+
+function isEmptyVisiblePayloadAfterNormalStop(stopReason: unknown): boolean {
+  return stopReason === "stop" || stopReason === "end_turn";
+}
+
+/**
+ * `message(action=send)` plus an assistant reply of only SILENT_REPLY_TOKEN yields zero
+ * outbound payloads after stripping, but is an intentional success — not an incomplete turn.
+ * Empty assistant text with messaging is ambiguous (e.g. another destination), so do not suppress.
+ */
+function isMessagingSilentReplyOnlySuccess(attempt: {
+  assistantTexts: string[];
+  didSendViaMessagingTool: boolean;
+}): boolean {
+  if (!attempt.didSendViaMessagingTool) {
+    return false;
+  }
+  const segments = attempt.assistantTexts.map((t) => t.trim()).filter(Boolean);
+  if (segments.length === 0) {
+    return false;
+  }
+  return segments.every((t) => isSilentReplyPayloadText(t));
 }
 
 const PLANNING_ONLY_PROMISE_RE =
@@ -144,7 +170,19 @@ export function resolveIncompleteTurnPayloadText(params: {
     hasAssistantVisibleText: params.payloadCount > 0,
     lastAssistant: params.attempt.lastAssistant,
   });
-  if (!incompleteTerminalAssistant && stopReason !== "error") {
+  const emptyAfterNormalCompletion =
+    isEmptyVisiblePayloadAfterNormalStop(stopReason) && !incompleteTerminalAssistant;
+  if (!incompleteTerminalAssistant && stopReason !== "error" && !emptyAfterNormalCompletion) {
+    return null;
+  }
+
+  if (
+    emptyAfterNormalCompletion &&
+    isMessagingSilentReplyOnlySuccess({
+      assistantTexts: params.attempt.assistantTexts,
+      didSendViaMessagingTool: params.attempt.didSendViaMessagingTool,
+    })
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
Single-commit replacement for #64576 (reviewer-friendly).

## Changes
- **Embedded runner:** Treat `stop`/`end_turn` with zero visible payloads as an incomplete-turn candidate when appropriate, but **suppress** the false error when `message(send)` ran and every non-empty assistant segment is silent-only (`NO_REPLY` / `isSilentReplyPayloadText`), matching payload stripping.
- **Codex dynamic tools:** Fail closed if `prepareArguments` is present but not a function; call with `tool` as `this`.

## Issue
Fixes #64570

## Supersedes
Closes the review thread from #64576.

Made with [Cursor](https://cursor.com)