### PR TITLE
fix(agents): clear auto failover session-model stickiness (#64571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI replay: preserve malformed function-call arguments in stored assistant history, avoid double-encoding preserved raw strings on replay, and coerce replayed string args back to objects at Anthropic and Google provider boundaries. (#61956) Thanks @100yenadmin.
 - Heartbeat/config: accept and honor `agents.defaults.heartbeat.timeoutSeconds` and per-agent heartbeat timeout overrides for heartbeat agent turns. (#64491) Thanks @cedillarack.
 - CLI/devices: make implicit `openclaw devices approve` selection preview-only and require approving the exact request ID, preventing latest-request races during device pairing. (#64160) Thanks @coygeek.
+- OpenAI/Codex: add required Codex OAuth scopes, classify provider/runtime failures more clearly, and stop suggesting `/elevated full` when auto-approved host exec is unavailable. (#64439) Thanks @100yenadmin.
+- Providers/OpenAI: add OpenAI/Codex tool-schema compatibility and preserve embedded-run replay/liveness truth across compaction retries and mutating side effects. (#64300) Thanks @100yenadmin.
+- Agents/model fallback: clear persisted `auto` failover session overrides and sticky runtime model fields during inbound model selection so the configured primary is consulted again instead of staying pinned on the last fallback model. (#64571)
 
 ## 2026.4.9
 

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -490,6 +490,49 @@ describe("createModelSelectionState respects session model override", () => {
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
   });
 
+  it("clears auto failover sticky session state so the configured primary model is used", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "github-copilot/claude-sonnet-4.6" },
+          models: {
+            "github-copilot/claude-sonnet-4.6": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:monica:telegram:direct:1";
+    const sessionEntry = makeEntry({
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "kimi-k2.5-thinking",
+      modelProvider: "azure",
+      model: "kimi-k2.5-thinking",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentId: "monica",
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "github-copilot",
+      defaultModel: "claude-sonnet-4.6",
+      provider: "github-copilot",
+      model: "claude-sonnet-4.6",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("github-copilot");
+    expect(state.model).toBe("claude-sonnet-4.6");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.model).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+  });
+
   it("keeps allowed legacy combined session overrides after normalization", async () => {
     const cfg = {
       agents: {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -17,7 +17,10 @@ import {
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
-import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  clearAutoFailoverSessionModelStickyState,
+} from "../../sessions/model-overrides.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import type { ThinkLevel } from "./directives.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
@@ -92,6 +95,12 @@ const FUZZY_VARIANT_TOKENS = [
   "small",
   "nano",
 ];
+
+const UNSAFE_SESSION_STORE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function isUnsafeSessionStoreKey(sessionKey: string): boolean {
+  return UNSAFE_SESSION_STORE_KEYS.has(normalizeLowercaseStringOrEmpty(sessionKey.trim()));
+}
 
 function boundedLevenshteinDistance(a: string, b: string, maxDistance: number): number | null {
   if (a === b) {
@@ -299,6 +308,49 @@ export async function createModelSelectionState(params: {
   let modelCatalog: ModelCatalog | null = null;
   let resetModelOverride = false;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
+
+  if (
+    sessionEntry &&
+    sessionStore &&
+    sessionKey &&
+    clearAutoFailoverSessionModelStickyState(sessionEntry)
+  ) {
+    if (!isUnsafeSessionStoreKey(sessionKey)) {
+      sessionStore[sessionKey] = sessionEntry;
+    }
+    if (storePath) {
+      const { updateSessionStore } = await loadSessionStoreRuntime();
+      await updateSessionStore(storePath, (store) => {
+        const requestedSessionKey = sessionKey.trim();
+        if (!requestedSessionKey || isUnsafeSessionStoreKey(requestedSessionKey)) {
+          return;
+        }
+        const normalizedRequestedKey = normalizeLowercaseStringOrEmpty(requestedSessionKey);
+        const matchedStoreKey =
+          (Object.prototype.hasOwnProperty.call(store, requestedSessionKey)
+            ? requestedSessionKey
+            : undefined) ??
+          (Object.prototype.hasOwnProperty.call(store, normalizedRequestedKey)
+            ? normalizedRequestedKey
+            : undefined) ??
+          Object.keys(store).find(
+            (key) => normalizeLowercaseStringOrEmpty(key) === normalizedRequestedKey,
+          );
+        if (!matchedStoreKey || isUnsafeSessionStoreKey(matchedStoreKey)) {
+          return;
+        }
+        const latestEntry = store[matchedStoreKey];
+        if (!latestEntry || !clearAutoFailoverSessionModelStickyState(latestEntry)) {
+          return;
+        }
+        store[matchedStoreKey] = latestEntry;
+      });
+    }
+    // Do not set `resetModelOverride` here: that flag is reserved for allowlist/disallowed
+    // override recovery and triggers `Model override not allowed...` system events
+    // (`get-reply-directives-apply.ts`). Auto-failover cleanup only retries the primary.
+  }
+
   const directStoredOverride = resolvePersistedOverrideModelRef({
     defaultProvider,
     overrideProvider: sessionEntry?.providerOverride,

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
-import { applyModelOverrideToSessionEntry } from "./model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  clearAutoFailoverSessionModelStickyState,
+} from "./model-overrides.js";
 
 function applyOpenAiSelection(entry: SessionEntry) {
   return applyModelOverrideToSessionEntry({
@@ -171,5 +174,122 @@ describe("applyModelOverrideToSessionEntry", () => {
     });
     expect(withFlag.updated).toBe(true);
     expect(withFlagEntry.liveModelSwitchPending).toBe(true);
+  });
+});
+
+describe("clearAutoFailoverSessionModelStickyState", () => {
+  it("clears auto failover overrides, runtime model identity, and related fields", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-auto",
+      updatedAt: before,
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      modelProvider: "azure",
+      model: "gpt-5.4",
+      authProfileOverride: "p1",
+      authProfileOverrideSource: "auto",
+      contextTokens: 120_000,
+      fallbackNoticeSelectedModel: "azure/gpt-5.4",
+      fallbackNoticeActiveModel: "azure/gpt-5.4",
+      fallbackNoticeReason: "failover",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.authProfileOverride).toBeUndefined();
+    expect(entry.authProfileOverrideSource).toBeUndefined();
+    expect(entry.contextTokens).toBeUndefined();
+    expect(entry.fallbackNoticeSelectedModel).toBeUndefined();
+    expect(entry.fallbackNoticeActiveModel).toBeUndefined();
+    expect(entry.fallbackNoticeReason).toBeUndefined();
+    expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
+  it("returns false when the session is not an auto failover override", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-user",
+      updatedAt: Date.now(),
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(false);
+    expect(entry.modelOverride).toBe("gpt-4o");
+  });
+
+  it("returns false when modelOverrideSource is user", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-explicit",
+      updatedAt: Date.now(),
+      modelOverrideSource: "user",
+      providerOverride: "openai",
+      modelOverride: "gpt-4o",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(false);
+    expect(entry.modelOverride).toBe("gpt-4o");
+  });
+
+  it("preserves user auth profile overrides when clearing auto model failover", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-auto-user-profile",
+      updatedAt: Date.now(),
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      modelProvider: "azure",
+      model: "gpt-5.4",
+      authProfileOverride: "user-picked-profile",
+      authProfileOverrideSource: "user",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.authProfileOverride).toBe("user-picked-profile");
+    expect(entry.authProfileOverrideSource).toBe("user");
+  });
+
+  it("preserves legacy user auth profile when source is unset but profile id is present", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-legacy-auth",
+      updatedAt: Date.now(),
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      authProfileOverride: "legacy-user-profile",
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.authProfileOverride).toBe("legacy-user-profile");
+    expect(entry.modelOverride).toBeUndefined();
+  });
+
+  it("clears auth fields when compaction count implies auto-sourced profile", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-inferred-auto-auth",
+      updatedAt: Date.now(),
+      modelOverrideSource: "auto",
+      providerOverride: "azure",
+      modelOverride: "gpt-5.4",
+      authProfileOverride: "auto-bound-profile",
+      authProfileOverrideCompactionCount: 1,
+    };
+
+    expect(clearAutoFailoverSessionModelStickyState(entry)).toBe(true);
+
+    expect(entry.authProfileOverride).toBeUndefined();
   });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -7,6 +7,62 @@ export type ModelOverrideSelection = {
   isDefault?: boolean;
 };
 
+/**
+ * Mirrors auth override source inference in `resolveSessionAuthProfileOverride`
+ * (`src/agents/auth-profiles/session-override.ts`) so cleanup stays consistent.
+ */
+function inferredAuthProfileOverrideSource(entry: SessionEntry): "auto" | "user" | undefined {
+  const current = normalizeOptionalString(entry.authProfileOverride);
+  return (
+    entry.authProfileOverrideSource ??
+    (typeof entry.authProfileOverrideCompactionCount === "number"
+      ? "auto"
+      : current
+        ? "user"
+        : undefined)
+  );
+}
+
+/**
+ * Clears failover-persisted session model state (`modelOverrideSource: "auto"`) plus
+ * sticky runtime `model` / `modelProvider` fields so the next inbound turn re-resolves
+ * the agent primary from config instead of staying pinned on the last fallback model.
+ *
+ * Clears `authProfileOverride*` only when auth is not user-attributed (explicit `"user"`,
+ * or legacy undefined source with a profile id and no compaction counter — inferred user).
+ */
+export function clearAutoFailoverSessionModelStickyState(entry: SessionEntry): boolean {
+  if (entry.modelOverrideSource !== "auto") {
+    return false;
+  }
+  const shouldClearAuthProfileFields = inferredAuthProfileOverrideSource(entry) !== "user";
+  let updated = false;
+  const del = (key: keyof SessionEntry) => {
+    if (Object.hasOwn(entry, key)) {
+      delete entry[key];
+      updated = true;
+    }
+  };
+  del("providerOverride");
+  del("modelOverride");
+  del("modelOverrideSource");
+  if (shouldClearAuthProfileFields) {
+    del("authProfileOverride");
+    del("authProfileOverrideSource");
+    del("authProfileOverrideCompactionCount");
+  }
+  del("model");
+  del("modelProvider");
+  del("contextTokens");
+  del("fallbackNoticeSelectedModel");
+  del("fallbackNoticeActiveModel");
+  del("fallbackNoticeReason");
+  if (updated) {
+    entry.updatedAt = Date.now();
+  }
+  return updated;
+}
+
 export function applyModelOverrideToSessionEntry(params: {
   entry: SessionEntry;
   selection: ModelOverrideSelection;


### PR DESCRIPTION
## Summary

- **Problem:** successful failover persisted auto model-selection state plus sticky runtime model fields, so later turns stayed pinned to fallback instead of retrying the configured primary.
- **Core fix:** clear auto-failover sticky session model state at inbound model selection, before override resolution.
- **Review-driven hardening:** preserve user/legacy-user auth profile overrides, avoid false model-override-not-allowed signaling, and persist cleanup from latest on-disk entry inside the store lock path while guarding unsafe object keys.
- **Scope boundary:** does not change user-initiated model overrides, normal failover behavior during an active failing run, or allowlist semantics.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #64571

## Root Cause

- Failover persistence and runtime-model persistence outlived the transient fallback turn, and inbound selection consumed that persisted state on later turns before consulting configured primary.

## Regression Test Plan

- Unit tests:
  - src/sessions/model-overrides.test.ts
  - src/auto-reply/reply/model-selection.test.ts
- Scenarios covered:
  - auto failover sticky model state clears and primary is selected next turn
  - user and legacy-user auth profile overrides are preserved
  - inferred auto auth profile state (compaction-count path) is cleared
  - disallowed-override reset signaling remains distinct from auto-failover cleanup

## User-visible / Behavior Changes

- After a fallback-success turn, the next inbound turn re-consults agent primary config instead of staying pinned to the prior fallback.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? **No**
- New network endpoints/listeners? **No**
- Touches auth/secrets/pairing? Session auth-profile override persistence only (state correctness hardening).
