### PR TITLE
refactor(memory-core): remove redundant compareOptionalStrings helper [AI]

### DIFF
--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -188,9 +188,7 @@ function isLegacyPhaseDreamingJob(job: ManagedCronJobLike): boolean {
   return name === LEGACY_REM_SLEEP_CRON_NAME && payloadText === LEGACY_REM_SLEEP_EVENT_TEXT;
 }
 
-function compareOptionalStrings(a: string | undefined, b: string | undefined): boolean {
-  return a === b;
-}
+
 
 async function migrateLegacyPhaseDreamingCronJobs(params: {
   cron: CronServiceLike;
@@ -231,10 +229,10 @@ function buildManagedDreamingPatch(
 ): ManagedCronJobPatch | null {
   const patch: ManagedCronJobPatch = {};
 
-  if (!compareOptionalStrings(normalizeTrimmedString(job.name), desired.name)) {
+  if (normalizeTrimmedString(job.name) !== desired.name) {
     patch.name = desired.name;
   }
-  if (!compareOptionalStrings(normalizeTrimmedString(job.description), desired.description)) {
+  if (normalizeTrimmedString(job.description) !== desired.description) {
     patch.description = desired.description;
   }
   if (job.enabled !== true) {
@@ -246,8 +244,8 @@ function buildManagedDreamingPatch(
   const scheduleTz = normalizeTrimmedString(job.schedule?.tz);
   if (
     scheduleKind !== "cron" ||
-    !compareOptionalStrings(scheduleExpr, desired.schedule.expr) ||
-    !compareOptionalStrings(scheduleTz, desired.schedule.tz)
+    scheduleExpr !== desired.schedule.expr ||
+    scheduleTz !== desired.schedule.tz
   ) {
     patch.schedule = desired.schedule;
   }
@@ -263,7 +261,7 @@ function buildManagedDreamingPatch(
 
   const payloadKind = normalizeLowercaseStringOrEmpty(normalizeTrimmedString(job.payload?.kind));
   const payloadText = normalizeTrimmedString(job.payload?.text);
-  if (payloadKind !== "systemevent" || !compareOptionalStrings(payloadText, desired.payload.text)) {
+  if (payloadKind !== "systemevent" || payloadText !== desired.payload.text) {
     patch.payload = desired.payload;
   }
 


### PR DESCRIPTION
## Summary

- Remove redundant `compareOptionalStrings` helper function which simply does `a === b` comparison
- Inline the comparisons directly for cleaner code

This is a pure code cleanup change, functionality remains identical.

[AI-assisted]
