### PR TITLE
fix(compaction): preserve original error message for unknown compaction failures

### DIFF
--- a/src/agents/pi-embedded-runner/compact-reasons.test.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.test.ts
@@ -37,4 +37,25 @@ describe("classifyCompactionReason", () => {
       ),
     ).toBe("guard_blocked");
   });
+
+  it("preserves unknown error messages with sanitized spaces", () => {
+    expect(classifyCompactionReason("No API provider registered for api: ollama")).toBe(
+      "unknown:No_API_provider_registered_for_api:_ollama",
+    );
+    expect(classifyCompactionReason("Some error with   multiple   spaces")).toBe(
+      "unknown:Some_error_with_multiple_spaces",
+    );
+  });
+
+  it("truncates long unknown error messages to 100 chars", () => {
+    const longError = "x".repeat(200);
+    const result = classifyCompactionReason(longError);
+    expect(result).toBe(`unknown:${"x".repeat(100)}`);
+    expect(result.length).toBe(108); // "unknown:" (8) + 100
+  });
+
+  it("returns 'unknown' for empty/undefined reason", () => {
+    expect(classifyCompactionReason(undefined)).toBe("unknown");
+    expect(classifyCompactionReason("")).toBe("unknown");
+  });
 });

--- a/src/agents/pi-embedded-runner/compact-reasons.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.ts
@@ -57,5 +57,10 @@ export function classifyCompactionReason(reason?: string): string {
   ) {
     return "provider_error_5xx";
   }
-  return "unknown";
+  // Preserve original error message for unknown errors instead of masking it.
+  // Replace spaces with underscores for logfmt compatibility; cap at 100 chars
+  // to avoid flooding the diagnostic log line.
+  const MAX_DETAIL_LENGTH = 100;
+  const sanitized = (reason?.replace(/\s+/g, "_") ?? "unspecified").slice(0, MAX_DETAIL_LENGTH);
+  return `unknown:${sanitized}`;
 }


### PR DESCRIPTION
## Problem

When compaction fails with an unclassified error, the logs only show `reason=unknown`, making it impossible to diagnose the actual failure cause.

Example from real world: we saw `reason=unknown` but the actual error was `No API provider registered for api: ollama`.

## Solution

Change the `return "unknown"` fallback in `classifyCompactionReason()` to preserve the original error message:

- Spaces replaced with underscores for logfmt compatibility
- Capped at 100 chars to avoid flooding the diagnostic log line
- Empty/undefined reasons still return `"unknown"`

Before: `reason=unknown`
After:  `reason=unknown:No_API_provider_registered_for_api:_ollama`

## Changes

- `src/agents/pi-embedded-runner/compact-reasons.ts`: Preserve and sanitize original error message for unknown compaction failures
- `src/agents/pi-embedded-runner/compact-reasons.test.ts`: Add test coverage for unknown errors, long messages, and empty input

## Review Feedback Addressed

- **Greptile (P1)**: Spaces in error messages breaking logfmt — fixed by replacing spaces with underscores
- **Greptile (P2)**: No test coverage for fallthrough — added tests for unknown errors, truncation, and empty input
- **clawsweeper**: Unrelated README localization removed from this PR; added 100-char cap on detail to prevent log flooding
