### PR TITLE
feat(discord): forward appliedTags in channel-edit actions for forum posts

### DIFF
--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -197,7 +197,9 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const autoArchiveDuration = readNumberParam(actionParams, "autoArchiveDuration", {
       integer: true,
     });
-    const appliedTags = readStringArrayParam(actionParams, "appliedTags");
+    const appliedTags = Array.isArray(actionParams.appliedTags)
+      ? (actionParams.appliedTags as string[])
+      : undefined;
     const availableTags = parseAvailableTags(actionParams.availableTags);
     return await handleDiscordAction(
       {

--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -13,6 +13,15 @@ import {
   readDiscordModerationCommand,
 } from "./runtime.moderation-shared.js";
 
+/** Read appliedTags preserving empty arrays (for clearing forum tags), with camelCase/snake_case support. */
+function readAppliedTags(params: Record<string, unknown>): string[] | undefined {
+  const raw = params.appliedTags ?? params.applied_tags;
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  return raw.filter((entry): entry is string => typeof entry === "string");
+}
+
 type Ctx = Pick<
   ChannelMessageActionContext,
   "action" | "params" | "cfg" | "accountId" | "requesterSenderId" | "mediaLocalRoots"
@@ -197,9 +206,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const autoArchiveDuration = readNumberParam(actionParams, "autoArchiveDuration", {
       integer: true,
     });
-    const appliedTags = Array.isArray(actionParams.appliedTags)
-      ? (actionParams.appliedTags as string[])
-      : undefined;
+    const appliedTags = readAppliedTags(actionParams);
     const availableTags = parseAvailableTags(actionParams.availableTags);
     return await handleDiscordAction(
       {

--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -197,6 +197,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const autoArchiveDuration = readNumberParam(actionParams, "autoArchiveDuration", {
       integer: true,
     });
+    const appliedTags = readStringArrayParam(actionParams, "appliedTags");
     const availableTags = parseAvailableTags(actionParams.availableTags);
     return await handleDiscordAction(
       {
@@ -212,6 +213,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         archived,
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
+        appliedTags: appliedTags ?? undefined,
         availableTags,
       },
       cfg,

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -87,4 +87,26 @@ describe("handleDiscordMessageAction", () => {
 
     expect(handleDiscordActionMock).not.toHaveBeenCalled();
   });
+
+  it("forwards appliedTags for channel-edit actions", async () => {
+    await handleDiscordMessageAction({
+      action: "channel-edit",
+      params: {
+        channelId: "thread-123",
+        appliedTags: ["tag-1", "tag-2"],
+      },
+      cfg: {
+        channels: { discord: { token: "tok", actions: { channels: true } } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "channelEdit",
+        channelId: "thread-123",
+        appliedTags: ["tag-1", "tag-2"],
+      }),
+      expect.any(Object),
+    );
+  });
 });

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -131,4 +131,26 @@ describe("handleDiscordMessageAction", () => {
       expect.any(Object),
     );
   });
+
+  it("accepts snake_case applied_tags input", async () => {
+    await handleDiscordMessageAction({
+      action: "channel-edit",
+      params: {
+        channelId: "thread-789",
+        applied_tags: ["tag-a", "tag-b"],
+      },
+      cfg: {
+        channels: { discord: { token: "tok", actions: { channels: true } } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "channelEdit",
+        channelId: "thread-789",
+        appliedTags: ["tag-a", "tag-b"],
+      }),
+      expect.any(Object),
+    );
+  });
 });

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -109,4 +109,26 @@ describe("handleDiscordMessageAction", () => {
       expect.any(Object),
     );
   });
+
+  it("forwards empty appliedTags array for clearing forum tags", async () => {
+    await handleDiscordMessageAction({
+      action: "channel-edit",
+      params: {
+        channelId: "thread-456",
+        appliedTags: [],
+      },
+      cfg: {
+        channels: { discord: { token: "tok", actions: { channels: true } } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "channelEdit",
+        channelId: "thread-456",
+        appliedTags: [],
+      }),
+      expect.any(Object),
+    );
+  });
 });

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -34,6 +34,15 @@ import {
 } from "../send.js";
 import { readDiscordParentIdParam } from "./runtime.shared.js";
 
+/** Read appliedTags preserving empty arrays (for clearing forum tags), with camelCase/snake_case support. */
+function readAppliedTags(params: Record<string, unknown>): string[] | undefined {
+  const raw = params.appliedTags ?? params.applied_tags;
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  return raw.filter((entry): entry is string => typeof entry === "string");
+}
+
 export const discordGuildActionRuntime = {
   addRoleDiscord,
   createChannelDiscord,
@@ -383,9 +392,7 @@ export async function handleDiscordGuildAction(
       const autoArchiveDuration = readNumberParam(params, "autoArchiveDuration", {
         integer: true,
       });
-      const appliedTags = Array.isArray(params.appliedTags)
-        ? (params.appliedTags as string[])
-        : undefined;
+      const appliedTags = readAppliedTags(params);
       const availableTags = parseAvailableTags(params.availableTags);
       const editPayload = {
         channelId,

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -383,6 +383,7 @@ export async function handleDiscordGuildAction(
       const autoArchiveDuration = readNumberParam(params, "autoArchiveDuration", {
         integer: true,
       });
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const availableTags = parseAvailableTags(params.availableTags);
       const editPayload = {
         channelId,
@@ -395,6 +396,7 @@ export async function handleDiscordGuildAction(
         archived,
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
+        appliedTags: appliedTags ?? undefined,
         availableTags,
       };
       const channel = accountId

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -383,7 +383,9 @@ export async function handleDiscordGuildAction(
       const autoArchiveDuration = readNumberParam(params, "autoArchiveDuration", {
         integer: true,
       });
-      const appliedTags = readStringArrayParam(params, "appliedTags");
+      const appliedTags = Array.isArray(params.appliedTags)
+        ? (params.appliedTags as string[])
+        : undefined;
       const availableTags = parseAvailableTags(params.availableTags);
       const editPayload = {
         channelId,

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -602,6 +602,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       archived: undefined,
       locked: undefined,
       autoArchiveDuration: undefined,
+      appliedTags: undefined,
     });
   });
 
@@ -627,6 +628,31 @@ describe("handleDiscordGuildAction - channel management", () => {
       archived: true,
       locked: false,
       autoArchiveDuration: 1440,
+      appliedTags: undefined,
+    });
+  });
+
+  it("forwards appliedTags when editing forum posts", async () => {
+    await handleDiscordGuildAction(
+      "channelEdit",
+      {
+        channelId: "C1",
+        appliedTags: ["tag-1", "tag-2"],
+      },
+      channelsEnabled,
+    );
+    expect(editChannelDiscord).toHaveBeenCalledWith({
+      channelId: "C1",
+      name: undefined,
+      topic: undefined,
+      position: undefined,
+      parentId: undefined,
+      nsfw: undefined,
+      rateLimitPerUser: undefined,
+      archived: undefined,
+      locked: undefined,
+      autoArchiveDuration: undefined,
+      appliedTags: ["tag-1", "tag-2"],
     });
   });
 
@@ -653,6 +679,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       archived: undefined,
       locked: undefined,
       autoArchiveDuration: undefined,
+      appliedTags: undefined,
     });
   });
 

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -680,6 +680,30 @@ describe("handleDiscordGuildAction - channel management", () => {
     });
   });
 
+  it("accepts snake_case applied_tags input", async () => {
+    await handleDiscordGuildAction(
+      "channelEdit",
+      {
+        channelId: "C1",
+        applied_tags: ["tag-a", "tag-b"],
+      },
+      channelsEnabled,
+    );
+    expect(editChannelDiscord).toHaveBeenCalledWith({
+      channelId: "C1",
+      name: undefined,
+      topic: undefined,
+      position: undefined,
+      parentId: undefined,
+      nsfw: undefined,
+      rateLimitPerUser: undefined,
+      archived: undefined,
+      locked: undefined,
+      autoArchiveDuration: undefined,
+      appliedTags: ["tag-a", "tag-b"],
+    });
+  });
+
   it.each([
     ["parentId is null", { parentId: null }],
     ["clearParent is true", { clearParent: true }],

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -656,6 +656,30 @@ describe("handleDiscordGuildAction - channel management", () => {
     });
   });
 
+  it("forwards empty appliedTags array to clear forum tags", async () => {
+    await handleDiscordGuildAction(
+      "channelEdit",
+      {
+        channelId: "C1",
+        appliedTags: [],
+      },
+      channelsEnabled,
+    );
+    expect(editChannelDiscord).toHaveBeenCalledWith({
+      channelId: "C1",
+      name: undefined,
+      topic: undefined,
+      position: undefined,
+      parentId: undefined,
+      nsfw: undefined,
+      rateLimitPerUser: undefined,
+      archived: undefined,
+      locked: undefined,
+      autoArchiveDuration: undefined,
+      appliedTags: [],
+    });
+  });
+
   it.each([
     ["parentId is null", { parentId: null }],
     ["clearParent is true", { clearParent: true }],

--- a/extensions/discord/src/send.channels.test.ts
+++ b/extensions/discord/src/send.channels.test.ts
@@ -1,0 +1,50 @@
+import { Routes } from "discord-api-types/v10";
+import { describe, expect, it } from "vitest";
+import { editChannelDiscord } from "./send.js";
+import { makeDiscordRest } from "./send.test-harness.js";
+
+describe("editChannelDiscord", () => {
+  it("passes applied_tags in the Discord PATCH body", async () => {
+    const { patchMock, rest } = makeDiscordRest();
+    patchMock.mockResolvedValue({ id: "thread-1" });
+
+    await editChannelDiscord(
+      {
+        channelId: "thread-1",
+        appliedTags: ["tag-1", "tag-2"],
+      },
+      { rest, token: "t" },
+    );
+
+    expect(patchMock).toHaveBeenCalledWith(
+      Routes.channel("thread-1"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          applied_tags: ["tag-1", "tag-2"],
+        }),
+      }),
+    );
+  });
+
+  it("preserves explicit empty applied_tags when clearing forum tags", async () => {
+    const { patchMock, rest } = makeDiscordRest();
+    patchMock.mockResolvedValue({ id: "thread-1" });
+
+    await editChannelDiscord(
+      {
+        channelId: "thread-1",
+        appliedTags: [],
+      },
+      { rest, token: "t" },
+    );
+
+    expect(patchMock).toHaveBeenCalledWith(
+      Routes.channel("thread-1"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          applied_tags: [],
+        }),
+      }),
+    );
+  });
+});

--- a/extensions/discord/src/send.channels.ts
+++ b/extensions/discord/src/send.channels.ts
@@ -70,6 +70,9 @@ export async function editChannelDiscord(
   if (payload.autoArchiveDuration !== undefined) {
     body.auto_archive_duration = payload.autoArchiveDuration;
   }
+  if (payload.appliedTags !== undefined) {
+    body.applied_tags = payload.appliedTags;
+  }
   if (payload.availableTags !== undefined) {
     body.available_tags = payload.availableTags.map((t) => ({
       ...(t.id !== undefined && { id: t.id }),

--- a/extensions/discord/src/send.types.ts
+++ b/extensions/discord/src/send.types.ts
@@ -167,6 +167,7 @@ export type DiscordChannelEdit = {
   archived?: boolean;
   locked?: boolean;
   autoArchiveDuration?: number;
+  appliedTags?: string[];
   availableTags?: DiscordForumTag[];
 };
 


### PR DESCRIPTION
## Summary
- Add `appliedTags` string array support to the Discord channel-edit action pipeline
- Parse and forward `appliedTags` through both guild-admin and guild runtime handlers
- Include `applied_tags` in the Discord API request body for channel edits
- Add `appliedTags` field to `DiscordChannelEdit` type

## Test plan
- [x] Unit test: forwards appliedTags for channel-edit actions in handle-action
- [x] Unit test: forwards appliedTags when editing forum posts in guild runtime
- [x] Existing channel-edit tests updated with `appliedTags: undefined` baseline
- [x] New `send.channels.test.ts` for the send layer