### PR TITLE
fix(exec): honor user's explicit "full" when approvals default matches

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -199,13 +199,19 @@ export function resolveExecHostApprovalContext(params: {
     security: params.security,
     ask: params.ask,
   });
-  // Session/config tool policy is the caller's requested contract. The host file
-  // may tighten that contract, but it must not silently broaden it.
-  const effectiveRequestedSecurity =
-    params.security === "full"
+  // If the user's tool config explicitly requests "full" security, and the
+  // approvals file did NOT explicitly override it (i.e., it fell back to the
+  // default), preserve the user's "full" to honor their explicit intent.
+  // This preserves the host-can-tighten invariant: explicit host overrides
+  // (from agents.*.security or agents.<id>.security) can still restrict "full".
+  const approvalsSourceIsDefault =
+    !approvals.agentSources?.security ||
+    approvals.agentSources.security === "defaults.security";
+  const effectiveSecurity =
+    params.security === "full" && approvalsSourceIsDefault
       ? "full"
       : minSecurity(params.security, approvals.agent.security);
-  const hostSecurity = effectiveRequestedSecurity;
+  const hostSecurity = effectiveSecurity;
   const hostAsk = maxAsk(params.ask, approvals.agent.ask);
   const askFallback = minSecurity(hostSecurity, approvals.agent.askFallback);
   if (hostSecurity === "deny") {

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -201,7 +201,11 @@ export function resolveExecHostApprovalContext(params: {
   });
   // Session/config tool policy is the caller's requested contract. The host file
   // may tighten that contract, but it must not silently broaden it.
-  const hostSecurity = minSecurity(params.security, approvals.agent.security);
+  const effectiveRequestedSecurity =
+    params.security === "full"
+      ? "full"
+      : minSecurity(params.security, approvals.agent.security);
+  const hostSecurity = effectiveRequestedSecurity;
   const hostAsk = maxAsk(params.ask, approvals.agent.ask);
   const askFallback = minSecurity(hostSecurity, approvals.agent.askFallback);
   if (hostSecurity === "deny") {


### PR DESCRIPTION
Thank you for the detailed review.

After careful consideration, I agree with the P1 comment - my fix is too aggressive. If a host administrator explicitly sets `defaults.security: "deny"` to enforce a restrictive policy, my fix would incorrectly bypass that.

The issue is that if a user's `exec-approvals.json` has stale/incorrect defaults, that's a configuration problem, not a code bug. The `minSecurity()` function exists precisely to ensure host-wide policies are respected.

I should not have bypassed `minSecurity()` when the source is `defaults.security`, because `defaults.security` can be an explicit restrictive policy set by the host admin, not just an accidental fallback.

I'll close this PR. The real fix for users experiencing this issue is to:
1. Run `openclaw doctor` to inspect the effective policy
2. Fix any stale/incorrect values in `~/.openclaw/exec-approvals.json`

Thank you for the thorough review - this was a valuable learning experience about the importance of preserving security invariants.