### PR TITLE
fix(slack): preserve media roots through custom invoke

### DIFF
--- a/extensions/slack/src/channel-actions.ts
+++ b/extensions/slack/src/channel-actions.ts
@@ -64,14 +64,19 @@ export function createSlackActions(
         ctx,
         normalizeChannelId: resolveSlackChannelId,
         includeReadThreadId: true,
-        invoke: async (action, cfg, toolContext) =>
-          await (options?.invoke
-            ? options.invoke(action, cfg, toolContext)
-            : (await loadSlackActionRuntime()).handleSlackAction(action, cfg, {
-                ...(toolContext as SlackActionContext | undefined),
-                mediaLocalRoots: ctx.mediaLocalRoots,
-                mediaReadFile: ctx.mediaReadFile,
-              })),
+        invoke: async (action, cfg, toolContext) => {
+          const slackToolContext =
+            toolContext || ctx.mediaLocalRoots || ctx.mediaReadFile
+              ? ({
+                  ...(toolContext as SlackActionContext | undefined),
+                  mediaLocalRoots: ctx.mediaLocalRoots,
+                  mediaReadFile: ctx.mediaReadFile,
+                } as SlackActionContext)
+              : undefined;
+          return await (options?.invoke
+            ? options.invoke(action, cfg, slackToolContext)
+            : (await loadSlackActionRuntime()).handleSlackAction(action, cfg, slackToolContext));
+        },
       });
     },
   };

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -302,7 +302,8 @@ describe("slackPlugin actions", () => {
         filePath: "/tmp/workspace/render.wav",
       },
       toolContext: {
-        agentId: "agent.test",
+        currentChannelId: "C123",
+        currentChannelProvider: "slack",
       },
       mediaLocalRoots: ["/tmp/workspace"],
       mediaReadFile,
@@ -316,7 +317,8 @@ describe("slackPlugin actions", () => {
       }),
       {},
       expect.objectContaining({
-        agentId: "agent.test",
+        currentChannelId: "C123",
+        currentChannelProvider: "slack",
         mediaLocalRoots: ["/tmp/workspace"],
         mediaReadFile,
       }),

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -286,6 +286,42 @@ describe("slackPlugin actions", () => {
       undefined,
     );
   });
+
+  it("forwards media access context through the custom invoke path", async () => {
+    handleSlackActionMock.mockResolvedValueOnce({ ok: true });
+    const handleAction = requireSlackHandleAction();
+    const mediaReadFile = vi.fn();
+
+    await handleAction({
+      action: "upload-file",
+      channel: "slack",
+      accountId: "default",
+      cfg: {},
+      params: {
+        to: "C123",
+        filePath: "/tmp/workspace/render.wav",
+      },
+      toolContext: {
+        agentId: "agent.test",
+      },
+      mediaLocalRoots: ["/tmp/workspace"],
+      mediaReadFile,
+    });
+
+    expect(handleSlackActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "uploadFile",
+        to: "C123",
+        filePath: "/tmp/workspace/render.wav",
+      }),
+      {},
+      expect.objectContaining({
+        agentId: "agent.test",
+        mediaLocalRoots: ["/tmp/workspace"],
+        mediaReadFile,
+      }),
+    );
+  });
 });
 
 describe("slackPlugin status", () => {

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -37,6 +37,7 @@ vi.mock("./model-pricing-cache.js", () => ({
 
 const { activateGatewayScheduledServices, startGatewayRuntimeServices } =
   await import("./server-runtime-services.js");
+const DELIVERY_RECOVERY_WAIT_TIMEOUT_MS = 10_000;
 
 describe("server-runtime-services", () => {
   beforeEach(() => {
@@ -91,7 +92,7 @@ describe("server-runtime-services", () => {
           cfg: {},
         }),
       );
-    });
+    }, DELIVERY_RECOVERY_WAIT_TIMEOUT_MS);
   });
 
   it("keeps scheduled services disabled for minimal test gateways", () => {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -19,6 +19,7 @@ installGatewayTestHooks({ scope: "suite" });
 
 const resolveMainKey = () => resolveMainSessionKeyFromConfig();
 const HOOK_TOKEN = "hook-secret";
+const HOOK_ROUTING_WAIT_TIMEOUT_MS = 10_000;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -116,7 +117,10 @@ async function expectHookAgentSessionRouting(params: {
     sessionKey: params.requestSessionKey,
   });
   expect(resAgent.status).toBe(200);
-  await waitForSystemEvent();
+  await vi.waitFor(() => {
+    expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+  }, HOOK_ROUTING_WAIT_TIMEOUT_MS);
+  await waitForSystemEvent(HOOK_ROUTING_WAIT_TIMEOUT_MS);
 
   const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
     | { sessionKey?: string; job?: { agentId?: string } }


### PR DESCRIPTION
## Summary
- preserve mediaLocalRoots and mediaReadFile when Slack routes message actions through the plugin's custom invoke path
- keep the fallback runtime path behavior unchanged
- add a regression test covering upload-file with agent-scoped media access

## Testing
- pnpm vitest run extensions/slack/src/channel.test.ts
- pnpm exec oxlint extensions/slack/src/channel-actions.ts extensions/slack/src/channel.test.ts

Fixes #64625