### PR TITLE
fix(msteams): accept SingleTenant sts.windows.net issuer in JWT validator (#64270)

### DIFF
--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -289,9 +289,12 @@ describe("createBotFrameworkJwtValidator", () => {
     expect(opts.issuer as string[]).toContain("https://login.microsoftonline.com/tenant-id/v2.0");
   });
 
-  it("validates a token with STS Windows issuer", async () => {
+  it("validates a SingleTenant token with tenant-scoped STS Windows issuer (#64270)", async () => {
+    // Regression for #64270: the sts.windows.net issuer was hardcoded to a
+    // single tenant UUID, so every other SingleTenant bot deployment hit 401.
+    // The tenant-aware form must accept the deployment's own tenant.
     jwtState.decodedPayload = {
-      iss: "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+      iss: `https://sts.windows.net/${creds.tenantId}/`,
     };
 
     const validator = await createBotFrameworkJwtValidator(creds);
@@ -299,9 +302,20 @@ describe("createBotFrameworkJwtValidator", () => {
 
     expect(jwtState.verifyCalls).toHaveLength(1);
     const opts = jwtState.verifyCalls[0]?.options as Record<string, unknown>;
-    expect(opts.issuer as string[]).toContain(
-      "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
-    );
+    expect(opts.issuer as string[]).toContain(`https://sts.windows.net/${creds.tenantId}/`);
+  });
+
+  it("rejects STS Windows tokens issued by a different tenant (#64270)", async () => {
+    // Guardrail against regressing back to a hardcoded tenant: the previously
+    // hardcoded UUID must NOT be accepted when the bot is configured for a
+    // different tenant. This also prevents cross-tenant token reuse.
+    jwtState.decodedPayload = {
+      iss: "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+    };
+
+    const validator = await createBotFrameworkJwtValidator(creds);
+    await expect(validator.validate("Bearer token-sts-other-tenant")).resolves.toBe(false);
+    expect(jwtState.verifyCalls).toHaveLength(0);
   });
 
   it("rejects tokens with unknown issuer", async () => {

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -644,7 +644,11 @@ const BOT_FRAMEWORK_ISSUERS: ReadonlyArray<{
     jwksUri: "https://login.microsoftonline.com/common/discovery/v2.0/keys",
   },
   {
-    issuer: "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+    // SingleTenant bot deployments (Microsoft's default since 2025-07-31) get
+    // tokens signed by the Azure AD v1 endpoint, whose issuer is scoped to the
+    // bot's tenant. This must be a function so each deployment accepts its own
+    // tenant rather than a single hardcoded one (#64270).
+    issuer: (tenantId: string) => `https://sts.windows.net/${tenantId}/`,
     jwksUri: "https://login.microsoftonline.com/common/discovery/v2.0/keys",
   },
 ];


### PR DESCRIPTION
## Summary

Fixes SingleTenant bot JWT validation failures. SingleTenant has been Microsoft's default bot type since 2025-07-31, so every new Teams bot deployment was hitting `401 Unauthorized` on incoming webhooks.

## Root cause

The `sts.windows.net` v1 issuer entry in `BOT_FRAMEWORK_ISSUERS` was hardcoded to one specific tenant UUID (`d6d49420-f39b-4df7-a1dc-d59a935871db`). SingleTenant tokens carry issuer `https://sts.windows.net/{tenantId}/` scoped to the bot's own tenant, so every other deployment failed issuer validation.

The second half of the bug report, missing `https://api.botframework.com` from the audience list, was already fixed in #62674. The current `createBotFrameworkJwtValidator` builds `allowedAudiences = [appId, api://appId, https://api.botframework.com]`, so no further audience changes are needed. Verified against `extensions/msteams/src/sdk.ts`.

## Fix

- Change the `sts.windows.net` entry from a hardcoded string to `(tenantId) => \`https://sts.windows.net/${tenantId}/\``, matching the shape of the existing `login.microsoftonline.com/.../v2.0` v2 entry. `createBotFrameworkJwtValidator` already resolves function-form issuers against `creds.tenantId`, so no caller changes are needed.
- Rename the existing STS Windows test to explicitly reference SingleTenant and #64270, and have it read `creds.tenantId` so it exercises the tenant-aware path.
- Add a regression guardrail test: the previously hardcoded UUID must be rejected when the bot is configured for a different tenant. This prevents silently accepting cross-tenant tokens if the string ever gets reintroduced.

## Note on related PR

#64276 (by @mschaepers, the issue reporter) proposes the same `sts.windows.net` fix. This PR builds on their approach with identical production semantics, plus an extra regression test for the cross-tenant case and a code comment that documents why the function form exists. If #64276 lands first, this PR becomes a small test-only follow-up.

## Test plan

- [x] `pnpm test extensions/msteams/src/sdk.test.ts` (13 passed, including the two new SingleTenant cases)
- [ ] CI green

Fixes #64270

Generated with [Claude Code](https://claude.com/claude-code)