### PR TITLE
fix(security): include Matrix avatar params in sandbox media normalization + log gmail watcher stop failures [AI-assisted]

### DIFF
--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -109,7 +109,9 @@ export function createGatewayReloadHandlers(params: {
     }
 
     if (plan.restartGmailWatcher) {
-      await stopGmailWatcher().catch(() => {});
+      await stopGmailWatcher().catch((err) => {
+        params.logHooks.warn(`gmail watcher stop failed during reload: ${String(err)}`);
+      });
       await startGmailWatcherWithLogs({
         cfg: nextConfig,
         log: params.logHooks,

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -104,6 +104,81 @@ describe("message action media helpers", () => {
     }
   });
 
+  maybeIt("normalizes Matrix avatarPath and avatarUrl sandbox media params", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-avatar-"));
+    try {
+      const args: Record<string, unknown> = {
+        avatarPath: "/workspace/avatars/profile.png",
+        avatarUrl: "file:///workspace/avatars/remote-avatar.jpg",
+      };
+
+      await normalizeSandboxMediaParams({
+        args,
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot,
+        },
+      });
+
+      expect(args).toMatchObject({
+        avatarPath: path.join(sandboxRoot, "avatars", "profile.png"),
+        avatarUrl: path.join(sandboxRoot, "avatars", "remote-avatar.jpg"),
+      });
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
+  maybeIt("normalizes Matrix snake_case avatar_path and avatar_url aliases", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-avatar-snake-"));
+    try {
+      const args: Record<string, unknown> = {
+        avatar_path: "/workspace/avatars/profile.png",
+        avatar_url: "file:///workspace/avatars/remote-avatar.jpg",
+      };
+
+      await normalizeSandboxMediaParams({
+        args,
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot,
+        },
+      });
+
+      expect(args).toMatchObject({
+        avatar_path: path.join(sandboxRoot, "avatars", "profile.png"),
+        avatar_url: path.join(sandboxRoot, "avatars", "remote-avatar.jpg"),
+      });
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
+  maybeIt("keeps remote HTTP avatarUrl unchanged under sandbox normalization", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-avatar-remote-"));
+    try {
+      const args: Record<string, unknown> = {
+        avatarUrl: "https://example.com/avatars/profile.png",
+        avatarPath: "/workspace/avatars/local.png",
+      };
+
+      await normalizeSandboxMediaParams({
+        args,
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot,
+        },
+      });
+
+      expect(args).toMatchObject({
+        avatarUrl: "https://example.com/avatars/profile.png",
+        avatarPath: path.join(sandboxRoot, "avatars", "local.png"),
+      });
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
   maybeIt(
     "keeps remote HTTP mediaUrl and fileUrl aliases unchanged under sandbox normalization",
     async () => {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -23,6 +23,10 @@ const SANDBOX_MEDIA_PARAM_KEYS = [
   "mediaUrl",
   "fileUrl",
   "image",
+  "avatarPath",
+  "avatar_path",
+  "avatarUrl",
+  "avatar_url",
 ] as const;
 
 function readMediaParam(

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -152,7 +152,7 @@ export function getToolResult(
 
 function collectActionMediaSourceHints(params: Record<string, unknown>): string[] {
   const sources: string[] = [];
-  for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl"] as const) {
+  for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl", "image"] as const) {
     const source = typeof params[key] === "string" ? params[key] : undefined;
     const normalized = normalizeOptionalString(source);
     if (normalized && source) {


### PR DESCRIPTION
## Summary

Follow-up to #64377. The Matrix `set-profile` action accepts `avatarPath`, `avatar_path`, `avatarUrl`, and `avatar_url` parameters that can point to local file paths or `file:///` URLs, but these were not included in `SANDBOX_MEDIA_PARAM_KEYS`. A sandboxed agent could use these parameters to bypass sandbox path rewriting and reference files outside the sandbox.

Also adds `image` to `collectActionMediaSourceHints` for consistency with `SANDBOX_MEDIA_PARAM_KEYS` (the key was added to the array in #64377 but missed in the hints list), and replaces a silent `.catch(() => {})` in the gmail watcher stop path with a warning log.

## Root Cause

### 1. Missing Matrix avatar params in `SANDBOX_MEDIA_PARAM_KEYS`

PR #64377 added `image` to `SANDBOX_MEDIA_PARAM_KEYS` for Discord event cover images, but the Matrix extension has four analogous avatar parameters that were overlooked:

- `avatarPath` — local file path for avatar upload (`extensions/matrix/src/actions.ts:268`)
- `avatar_path` — snake_case alias (`extensions/matrix/src/actions.ts:100-106`)
- `avatarUrl` — URL (can be `file:///`) for avatar (`extensions/matrix/src/actions.ts:274`)
- `avatar_url` — snake_case alias (`extensions/matrix/src/actions.ts:90-93`)

These parameters flow through `normalizeSandboxMediaParams` but were not in the key list, so sandbox path rewriting was silently skipped.

### 2. Missing `image` in `collectActionMediaSourceHints`

`collectActionMediaSourceHints` (message-action-runner.ts:155) iterates a hardcoded list that did not include `image`, creating an inconsistency with `SANDBOX_MEDIA_PARAM_KEYS` after #64377.

### 3. Silent `.catch(() => {})` in gmail watcher stop

`server-reload-handlers.ts:112` swallows errors from `stopGmailWatcher()` during hot config reload with no logging. A failure to stop the watcher could indicate a resource leak that would be impossible to diagnose without a log signal.

## Fix

1. Add `avatarPath`, `avatar_path`, `avatarUrl`, `avatar_url` to `SANDBOX_MEDIA_PARAM_KEYS`
2. Add `image` to `collectActionMediaSourceHints` key list
3. Replace `.catch(() => {})` with `.catch((err) => { params.logHooks.warn(...) })` in gmail watcher stop

## What did NOT change

- No changes to `normalizeSandboxMediaParams` logic — the function already handles these keys correctly once they are in the array
- No changes to `resolveSandboxedMediaSource` — path rewriting works for any key in the array
- No changes to the Matrix extension itself — the fix is entirely in the shared sandbox normalization layer

## Testing

3 new regression tests in `message-action-params.test.ts`:
- `normalizes Matrix avatarPath and avatarUrl sandbox media params` — verifies local paths and `file:///` URLs are rewritten
- `normalizes Matrix snake_case avatar_path and avatar_url aliases` — verifies snake_case variants
- `keeps remote HTTP avatarUrl unchanged under sandbox normalization` — verifies HTTP URLs pass through

All 11 tests in `message-action-params.test.ts` pass. Full outbound test suite (33 files, 396+ tests) passes.

## Security Impact

This is a security fix. Without it, a sandboxed agent on a Matrix-connected deployment could use `set-profile` with `avatarPath: "/etc/passwd"` to read arbitrary host files.

## Change Type

- [x] Bug fix (security)
- [x] Observability improvement

---

**AI-assisted PR** — built with Claude (Anthropic). Degree of testing: fully tested (11 tests pass including 3 new regression tests). The fix was cross-reviewed against the #64377 pattern before submission.