### PR TITLE
fix(msteams): wire CLI --media path into pending upload store (#49784)

### DIFF
--- a/extensions/msteams/src/file-consent-helpers.ts
+++ b/extensions/msteams/src/file-consent-helpers.ts
@@ -11,6 +11,7 @@
 
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
 import { buildFileConsentCard } from "./file-consent.js";
+import { storePendingUploadFs } from "./pending-uploads-fs.js";
 import { storePendingUpload } from "./pending-uploads.js";
 
 export type FileConsentMedia = {
@@ -24,9 +25,32 @@ export type FileConsentActivityResult = {
   uploadId: string;
 };
 
+function buildConsentActivity(params: {
+  media: FileConsentMedia;
+  description?: string;
+  uploadId: string;
+}): Record<string, unknown> {
+  const { media, description, uploadId } = params;
+  const consentCard = buildFileConsentCard({
+    filename: media.filename,
+    description: description || `File: ${media.filename}`,
+    sizeInBytes: media.buffer.length,
+    context: { uploadId },
+  });
+  return {
+    type: "message",
+    attachments: [consentCard],
+  };
+}
+
 /**
  * Prepare a FileConsentCard activity for large files or non-images in personal chats.
  * Returns the activity object and uploadId - caller is responsible for sending.
+ *
+ * This variant only writes to the in-memory store. Use it when the caller and
+ * the `fileConsent/invoke` handler share the same process (for example the
+ * messenger reply path). For proactive CLI sends where the invoke arrives in
+ * a different process, use {@link prepareFileConsentActivityFs} instead.
  */
 export function prepareFileConsentActivity(params: {
   media: FileConsentMedia;
@@ -42,18 +66,46 @@ export function prepareFileConsentActivity(params: {
     conversationId,
   });
 
-  const consentCard = buildFileConsentCard({
+  const activity = buildConsentActivity({ media, description, uploadId });
+  return { activity, uploadId };
+}
+
+/**
+ * Prepare a FileConsentCard activity and persist the pending upload to the
+ * filesystem so a different process can read it when the user accepts.
+ *
+ * This is used by the proactive CLI `message send --media` path: the CLI
+ * process sends the card and exits, but the `fileConsent/invoke` callback is
+ * delivered to the long-lived gateway monitor process. The FS-backed store
+ * bridges those two processes. The in-memory store is also populated so
+ * same-process flows keep the fast path.
+ */
+export async function prepareFileConsentActivityFs(params: {
+  media: FileConsentMedia;
+  conversationId: string;
+  description?: string;
+}): Promise<FileConsentActivityResult> {
+  const { media, conversationId, description } = params;
+
+  // Populate the in-memory store first so the uploadId is consistent, then
+  // mirror the same entry to the FS store under the same id so an invoke
+  // handler in another process can find it.
+  const uploadId = storePendingUpload({
+    buffer: media.buffer,
     filename: media.filename,
-    description: description || `File: ${media.filename}`,
-    sizeInBytes: media.buffer.length,
-    context: { uploadId },
+    contentType: media.contentType,
+    conversationId,
   });
 
-  const activity: Record<string, unknown> = {
-    type: "message",
-    attachments: [consentCard],
-  };
+  await storePendingUploadFs({
+    id: uploadId,
+    buffer: media.buffer,
+    filename: media.filename,
+    contentType: media.contentType,
+    conversationId,
+  });
 
+  const activity = buildConsentActivity({ media, description, uploadId });
   return { activity, uploadId };
 }
 

--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import {
   type MSTeamsActivityHandler,
@@ -9,6 +12,7 @@ import {
   createActivityHandler,
   createMSTeamsMessageHandlerDeps,
 } from "./monitor-handler.test-helpers.js";
+import { getPendingUploadFs, storePendingUploadFs } from "./pending-uploads-fs.js";
 import { clearPendingUploads, getPendingUpload, storePendingUpload } from "./pending-uploads.js";
 import { setMSTeamsRuntime } from "./runtime.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
@@ -25,19 +29,32 @@ vi.mock("./file-consent.js", async () => {
   };
 });
 
-const runtimeStub: PluginRuntime = {
-  logging: {
-    shouldLogVerbose: () => false,
-  },
-  channel: {
-    debounce: {
-      resolveInboundDebounceMs: () => 0,
-      createInboundDebouncer: () => ({
-        enqueue: async () => {},
-      }),
+function createRuntimeStub(stateDir?: string): PluginRuntime {
+  return {
+    logging: {
+      shouldLogVerbose: () => false,
     },
-  },
-} as unknown as PluginRuntime;
+    channel: {
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: () => ({
+          enqueue: async () => {},
+        }),
+      },
+    },
+    state: {
+      resolveStateDir: (env?: NodeJS.ProcessEnv) => {
+        const override = env?.OPENCLAW_STATE_DIR?.trim();
+        if (override) {
+          return override;
+        }
+        return stateDir ?? path.join(os.homedir(), ".openclaw");
+      },
+    },
+  } as unknown as PluginRuntime;
+}
+
+const runtimeStub: PluginRuntime = createRuntimeStub();
 
 function createDeps(): MSTeamsMessageHandlerDeps {
   return createMSTeamsMessageHandlerDeps({
@@ -292,5 +309,136 @@ describe("msteams file consent invoke authz", () => {
       contentType: "text/plain",
     });
     expect(sendActivity).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("msteams file consent invoke FS fallback", () => {
+  let tmpDir: string;
+  let originalStateDir: string | undefined;
+
+  beforeEach(async () => {
+    originalStateDir = process.env.OPENCLAW_STATE_DIR;
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-invoke-"));
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+    setMSTeamsRuntime(createRuntimeStub(tmpDir));
+    clearPendingUploads();
+    fileConsentMockState.uploadToConsentUrl.mockReset();
+    fileConsentMockState.uploadToConsentUrl.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+    try {
+      await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      // tmp dir may already be gone
+    }
+  });
+
+  it("reads pending upload from FS store when in-memory store is empty (cross-process CLI path)", async () => {
+    // Simulate the CLI process writing to the FS store before exiting; the
+    // in-memory store in this (monitor) process is empty.
+    const uploadId = "cli-upload-id-123";
+    const conversationId = "19:victim@thread.v2";
+    await storePendingUploadFs({
+      id: uploadId,
+      buffer: Buffer.from("CLI PAYLOAD"),
+      filename: "cli.bin",
+      contentType: "application/octet-stream",
+      conversationId,
+    });
+
+    expect(getPendingUpload(uploadId)).toBeUndefined();
+
+    const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
+    const updateActivity = vi.fn(async () => ({ id: "activity-id" }));
+    const context = {
+      activity: {
+        type: "invoke",
+        name: "fileConsent/invoke",
+        conversation: { id: `${conversationId};messageid=abc123` },
+        value: {
+          type: "fileUpload",
+          action: "accept",
+          uploadInfo: {
+            name: "cli.bin",
+            uploadUrl: "https://upload.example.com/put",
+            contentUrl: "https://content.example.com/cli.bin",
+            uniqueId: "unique-cli",
+            fileType: "bin",
+          },
+          context: { uploadId },
+        },
+      },
+      sendActivity,
+      sendActivities: async () => [],
+      updateActivity,
+    } as unknown as MSTeamsTurnContext;
+
+    const handler = registerMSTeamsHandlers(
+      createActivityHandler(),
+      createDeps(),
+    ) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+
+    await handler.run(context);
+
+    // The upload should have run using the FS-loaded buffer
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://upload.example.com/put",
+      }),
+    );
+
+    // FS entry should have been cleaned up after successful upload
+    expect(await getPendingUploadFs(uploadId)).toBeUndefined();
+  });
+
+  it("cleans up FS entry on decline even when in-memory store is empty", async () => {
+    const uploadId = "cli-decline-id";
+    const conversationId = "19:victim@thread.v2";
+    await storePendingUploadFs({
+      id: uploadId,
+      buffer: Buffer.from("DECLINED"),
+      filename: "decline.txt",
+      contentType: "text/plain",
+      conversationId,
+    });
+
+    const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
+    const updateActivity = vi.fn(async () => ({ id: "activity-id" }));
+    const context = {
+      activity: {
+        type: "invoke",
+        name: "fileConsent/invoke",
+        conversation: { id: `${conversationId};messageid=abc123` },
+        value: {
+          type: "fileUpload",
+          action: "decline",
+          context: { uploadId },
+        },
+      },
+      sendActivity,
+      sendActivities: async () => [],
+      updateActivity,
+    } as unknown as MSTeamsTurnContext;
+
+    const handler = registerMSTeamsHandlers(
+      createActivityHandler(),
+      createDeps(),
+    ) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+
+    await handler.run(context);
+
+    expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(await getPendingUploadFs(uploadId)).toBeUndefined();
   });
 });

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -9,6 +9,7 @@ import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.j
 export type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
+import { getPendingUploadFs, removePendingUploadFs } from "./pending-uploads-fs.js";
 import { getPendingUpload, removePendingUpload } from "./pending-uploads.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
@@ -123,7 +124,20 @@ async function handleFileConsentInvoke(
     typeof consentResponse.context?.uploadId === "string"
       ? consentResponse.context.uploadId
       : undefined;
-  const pendingFile = getPendingUpload(uploadId);
+  // Prefer the in-memory store (same-process reply path); fall back to the
+  // FS-backed store so CLI `message send --media` flows work even when the
+  // invoke callback is delivered to a different process.
+  const inMemoryFile = getPendingUpload(uploadId);
+  const fsFile = inMemoryFile ? undefined : await getPendingUploadFs(uploadId);
+  const pendingFile:
+    | {
+        buffer: Buffer;
+        filename: string;
+        contentType?: string;
+        conversationId: string;
+        consentCardActivityId?: string;
+      }
+    | undefined = inMemoryFile ?? fsFile;
   if (pendingFile) {
     const pendingConversationId = normalizeMSTeamsConversationId(pendingFile.conversationId);
     const invokeConversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
@@ -200,6 +214,7 @@ async function handleFileConsentInvoke(
         await context.sendActivity("File upload failed. Please try again.");
       } finally {
         removePendingUpload(uploadId);
+        await removePendingUploadFs(uploadId);
       }
     } else {
       log.debug?.("pending file not found for consent", { uploadId });
@@ -209,6 +224,7 @@ async function handleFileConsentInvoke(
     // User declined
     log.debug?.("user declined file consent", { uploadId });
     removePendingUpload(uploadId);
+    await removePendingUploadFs(uploadId);
   }
 
   return true;

--- a/extensions/msteams/src/pending-uploads-fs.test.ts
+++ b/extensions/msteams/src/pending-uploads-fs.test.ts
@@ -1,0 +1,219 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { prepareFileConsentActivityFs } from "./file-consent-helpers.js";
+import {
+  getPendingUploadFs,
+  removePendingUploadFs,
+  setPendingUploadActivityIdFs,
+  storePendingUploadFs,
+} from "./pending-uploads-fs.js";
+import { clearPendingUploads } from "./pending-uploads.js";
+import { setMSTeamsRuntime } from "./runtime.js";
+import { msteamsRuntimeStub } from "./test-runtime.js";
+
+async function makeTempStateDir(): Promise<string> {
+  return await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-pending-"));
+}
+
+function makeEnv(stateDir: string): NodeJS.ProcessEnv {
+  return { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+}
+
+describe("msteams pending uploads (fs-backed)", () => {
+  beforeEach(() => {
+    setMSTeamsRuntime(msteamsRuntimeStub);
+    clearPendingUploads();
+  });
+
+  it("stores and retrieves a pending upload by id", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+
+    await storePendingUploadFs(
+      {
+        id: "upload-1",
+        buffer: Buffer.from("hello world"),
+        filename: "greeting.txt",
+        contentType: "text/plain",
+        conversationId: "19:conv@thread.v2",
+      },
+      { env },
+    );
+
+    const loaded = await getPendingUploadFs("upload-1", { env });
+    expect(loaded).toBeDefined();
+    expect(loaded?.id).toBe("upload-1");
+    expect(loaded?.filename).toBe("greeting.txt");
+    expect(loaded?.contentType).toBe("text/plain");
+    expect(loaded?.conversationId).toBe("19:conv@thread.v2");
+    expect(loaded?.buffer.toString("utf8")).toBe("hello world");
+  });
+
+  it("returns undefined for missing and undefined ids", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+
+    expect(await getPendingUploadFs(undefined, { env })).toBeUndefined();
+    expect(await getPendingUploadFs("does-not-exist", { env })).toBeUndefined();
+  });
+
+  it("persists so another reader finds the entry (simulates cross-process)", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+
+    // First "process": writer
+    await storePendingUploadFs(
+      {
+        id: "upload-x",
+        buffer: Buffer.from("top secret"),
+        filename: "secret.bin",
+        conversationId: "19:conv@thread.v2",
+      },
+      { env },
+    );
+
+    // Confirm the backing file actually exists on disk with expected shape
+    const storePath = path.join(stateDir, "msteams-pending-uploads.json");
+    const raw = await fs.promises.readFile(storePath, "utf-8");
+    const parsed = JSON.parse(raw) as {
+      version: number;
+      uploads: Record<string, { bufferBase64: string; filename: string }>;
+    };
+    expect(parsed.version).toBe(1);
+    expect(parsed.uploads["upload-x"]?.filename).toBe("secret.bin");
+    expect(Buffer.from(parsed.uploads["upload-x"].bufferBase64, "base64").toString("utf8")).toBe(
+      "top secret",
+    );
+
+    // Second "process": reader using the same state dir
+    const reader = await getPendingUploadFs("upload-x", { env });
+    expect(reader?.buffer.toString("utf8")).toBe("top secret");
+    expect(reader?.filename).toBe("secret.bin");
+  });
+
+  it("removes persisted entries", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+
+    await storePendingUploadFs(
+      {
+        id: "upload-rm",
+        buffer: Buffer.from("x"),
+        filename: "rm.bin",
+        conversationId: "19:conv@thread.v2",
+      },
+      { env },
+    );
+    expect(await getPendingUploadFs("upload-rm", { env })).toBeDefined();
+
+    await removePendingUploadFs("upload-rm", { env });
+    expect(await getPendingUploadFs("upload-rm", { env })).toBeUndefined();
+  });
+
+  it("remove is a no-op for unknown ids", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+
+    await expect(removePendingUploadFs("never-existed", { env })).resolves.toBeUndefined();
+    await expect(removePendingUploadFs(undefined, { env })).resolves.toBeUndefined();
+  });
+
+  it("expires entries past their ttl on read", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+
+    await storePendingUploadFs(
+      {
+        id: "upload-old",
+        buffer: Buffer.from("stale"),
+        filename: "stale.txt",
+        conversationId: "19:conv@thread.v2",
+      },
+      { env, ttlMs: 1 },
+    );
+    // Wait past ttl
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(await getPendingUploadFs("upload-old", { env, ttlMs: 1 })).toBeUndefined();
+  });
+
+  it("updates consent card activity id on an existing entry", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+
+    await storePendingUploadFs(
+      {
+        id: "upload-a",
+        buffer: Buffer.from("payload"),
+        filename: "f.txt",
+        conversationId: "19:conv@thread.v2",
+      },
+      { env },
+    );
+
+    await setPendingUploadActivityIdFs("upload-a", "activity-xyz", { env });
+    const loaded = await getPendingUploadFs("upload-a", { env });
+    expect(loaded?.consentCardActivityId).toBe("activity-xyz");
+  });
+
+  it("ignores malformed or empty store files and returns undefined", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+    const storePath = path.join(stateDir, "msteams-pending-uploads.json");
+    await fs.promises.writeFile(storePath, "not valid json", "utf-8");
+
+    // Should not throw and should treat as empty
+    expect(await getPendingUploadFs("anything", { env })).toBeUndefined();
+
+    await fs.promises.writeFile(storePath, JSON.stringify({ version: 2, uploads: {} }), "utf-8");
+    expect(await getPendingUploadFs("anything", { env })).toBeUndefined();
+  });
+});
+
+describe("prepareFileConsentActivityFs end-to-end", () => {
+  beforeEach(() => {
+    setMSTeamsRuntime(msteamsRuntimeStub);
+    clearPendingUploads();
+  });
+
+  it("writes the pending upload to the fs store with the same id as the card", async () => {
+    const stateDir = await makeTempStateDir();
+    const env = makeEnv(stateDir);
+    // Redirect state dir via env so the helper's FS writes land under our tmp
+    const originalEnv = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      const result = await prepareFileConsentActivityFs({
+        media: {
+          buffer: Buffer.from("cli file"),
+          filename: "cli.bin",
+          contentType: "application/octet-stream",
+        },
+        conversationId: "19:victim@thread.v2",
+        description: "Sent via CLI",
+      });
+
+      expect(result.uploadId).toMatch(/[0-9a-f-]/);
+      const attachments = result.activity.attachments as Array<Record<string, unknown>>;
+      expect(attachments).toHaveLength(1);
+      const content = attachments[0]?.content as { acceptContext: { uploadId: string } };
+      expect(content.acceptContext.uploadId).toBe(result.uploadId);
+
+      // Reader in (simulated) other process finds the entry under the same key
+      const loaded = await getPendingUploadFs(result.uploadId, { env });
+      expect(loaded).toBeDefined();
+      expect(loaded?.filename).toBe("cli.bin");
+      expect(loaded?.contentType).toBe("application/octet-stream");
+      expect(loaded?.conversationId).toBe("19:victim@thread.v2");
+      expect(loaded?.buffer.toString("utf8")).toBe("cli file");
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = originalEnv;
+      }
+    }
+  });
+});

--- a/extensions/msteams/src/pending-uploads-fs.test.ts
+++ b/extensions/msteams/src/pending-uploads-fs.test.ts
@@ -29,7 +29,9 @@ function makeEnv(stateDir: string): NodeJS.ProcessEnv {
 async function cleanupTempDirs(): Promise<void> {
   while (createdTempDirs.length > 0) {
     const dir = createdTempDirs.pop();
-    if (!dir) continue;
+    if (!dir) {
+      continue;
+    }
     try {
       await fs.promises.rm(dir, { recursive: true, force: true });
     } catch {

--- a/extensions/msteams/src/pending-uploads-fs.test.ts
+++ b/extensions/msteams/src/pending-uploads-fs.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { prepareFileConsentActivityFs } from "./file-consent-helpers.js";
 import {
   getPendingUploadFs,
@@ -13,18 +13,39 @@ import { clearPendingUploads } from "./pending-uploads.js";
 import { setMSTeamsRuntime } from "./runtime.js";
 import { msteamsRuntimeStub } from "./test-runtime.js";
 
+// Track temp dirs created by each test so afterEach can clean them up.
+const createdTempDirs: string[] = [];
+
 async function makeTempStateDir(): Promise<string> {
-  return await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-pending-"));
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-pending-"));
+  createdTempDirs.push(dir);
+  return dir;
 }
 
 function makeEnv(stateDir: string): NodeJS.ProcessEnv {
   return { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 }
 
+async function cleanupTempDirs(): Promise<void> {
+  while (createdTempDirs.length > 0) {
+    const dir = createdTempDirs.pop();
+    if (!dir) continue;
+    try {
+      await fs.promises.rm(dir, { recursive: true, force: true });
+    } catch {
+      // tmp dir may already be gone
+    }
+  }
+}
+
 describe("msteams pending uploads (fs-backed)", () => {
   beforeEach(() => {
     setMSTeamsRuntime(msteamsRuntimeStub);
     clearPendingUploads();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDirs();
   });
 
   it("stores and retrieves a pending upload by id", async () => {
@@ -175,6 +196,10 @@ describe("prepareFileConsentActivityFs end-to-end", () => {
   beforeEach(() => {
     setMSTeamsRuntime(msteamsRuntimeStub);
     clearPendingUploads();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDirs();
   });
 
   it("writes the pending upload to the fs store with the same id as the card", async () => {

--- a/extensions/msteams/src/pending-uploads-fs.ts
+++ b/extensions/msteams/src/pending-uploads-fs.ts
@@ -1,0 +1,235 @@
+/**
+ * Filesystem-backed pending upload store for the FileConsentCard flow.
+ *
+ * The CLI `message send --media` path runs in a different process from the
+ * gateway's bot monitor that receives the `fileConsent/invoke` callback.
+ * An in-memory `pending-uploads.ts` store cannot bridge those processes, so
+ * when the user clicks "Allow" the monitor handler's lookup misses and the
+ * user sees "card action not supported".
+ *
+ * This FS store persists pending uploads to a JSON file (with the file buffer
+ * base64-encoded) so any process that shares the OpenClaw state dir can read
+ * them back. The in-memory store in `pending-uploads.ts` is still the fast
+ * path for same-process flows (for example the messenger reply path); this FS
+ * store is a cross-process fallback.
+ */
+
+import { resolveMSTeamsStorePath } from "./storage.js";
+import { readJsonFile, withFileLock, writeJsonFile } from "./store-fs.js";
+
+/** TTL for persisted pending uploads (matches in-memory store). */
+const PENDING_UPLOAD_TTL_MS = 5 * 60 * 1000;
+
+/** Cap to avoid unbounded growth if a process crashes mid-flow. */
+const MAX_PENDING_UPLOADS = 100;
+
+const STORE_FILENAME = "msteams-pending-uploads.json";
+
+export type PendingUploadFsRecord = {
+  id: string;
+  bufferBase64: string;
+  filename: string;
+  contentType?: string;
+  conversationId: string;
+  /** Activity ID of the original FileConsentCard, used to replace it after upload */
+  consentCardActivityId?: string;
+  createdAt: number;
+};
+
+export type PendingUploadFs = {
+  id: string;
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+  conversationId: string;
+  consentCardActivityId?: string;
+  createdAt: number;
+};
+
+type PendingUploadStoreData = {
+  version: 1;
+  uploads: Record<string, PendingUploadFsRecord>;
+};
+
+const empty: PendingUploadStoreData = { version: 1, uploads: {} };
+
+export type PendingUploadsFsOptions = {
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+  stateDir?: string;
+  storePath?: string;
+  ttlMs?: number;
+};
+
+function resolveFilePath(options: PendingUploadsFsOptions | undefined): string {
+  return resolveMSTeamsStorePath({
+    filename: STORE_FILENAME,
+    env: options?.env,
+    homedir: options?.homedir,
+    stateDir: options?.stateDir,
+    storePath: options?.storePath,
+  });
+}
+
+function pruneExpired(
+  uploads: Record<string, PendingUploadFsRecord>,
+  nowMs: number,
+  ttlMs: number,
+): Record<string, PendingUploadFsRecord> {
+  const kept: Record<string, PendingUploadFsRecord> = {};
+  for (const [id, record] of Object.entries(uploads)) {
+    if (nowMs - record.createdAt <= ttlMs) {
+      kept[id] = record;
+    }
+  }
+  return kept;
+}
+
+function pruneToLimit(
+  uploads: Record<string, PendingUploadFsRecord>,
+): Record<string, PendingUploadFsRecord> {
+  const entries = Object.entries(uploads);
+  if (entries.length <= MAX_PENDING_UPLOADS) {
+    return uploads;
+  }
+  // Oldest createdAt first; drop the oldest until we fit.
+  entries.sort((a, b) => a[1].createdAt - b[1].createdAt);
+  const keep = entries.slice(entries.length - MAX_PENDING_UPLOADS);
+  return Object.fromEntries(keep);
+}
+
+function recordToUpload(record: PendingUploadFsRecord): PendingUploadFs {
+  return {
+    id: record.id,
+    buffer: Buffer.from(record.bufferBase64, "base64"),
+    filename: record.filename,
+    contentType: record.contentType,
+    conversationId: record.conversationId,
+    consentCardActivityId: record.consentCardActivityId,
+    createdAt: record.createdAt,
+  };
+}
+
+function isValidStore(value: unknown): value is PendingUploadStoreData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<PendingUploadStoreData>;
+  return (
+    candidate.version === 1 &&
+    typeof candidate.uploads === "object" &&
+    candidate.uploads !== null &&
+    !Array.isArray(candidate.uploads)
+  );
+}
+
+async function readStore(filePath: string, ttlMs: number): Promise<PendingUploadStoreData> {
+  const { value } = await readJsonFile<unknown>(filePath, empty);
+  if (!isValidStore(value)) {
+    return { version: 1, uploads: {} };
+  }
+  const uploads = pruneToLimit(pruneExpired(value.uploads, Date.now(), ttlMs));
+  return { version: 1, uploads };
+}
+
+/**
+ * Persist a pending upload record so another process can read it back.
+ * Pass in the pre-generated id (same as the one placed in the consent card
+ * context) so the in-memory and FS stores share the same key.
+ */
+export async function storePendingUploadFs(
+  upload: {
+    id: string;
+    buffer: Buffer;
+    filename: string;
+    contentType?: string;
+    conversationId: string;
+    consentCardActivityId?: string;
+  },
+  options?: PendingUploadsFsOptions,
+): Promise<void> {
+  const ttlMs = options?.ttlMs ?? PENDING_UPLOAD_TTL_MS;
+  const filePath = resolveFilePath(options);
+  await withFileLock(filePath, empty, async () => {
+    const store = await readStore(filePath, ttlMs);
+    store.uploads[upload.id] = {
+      id: upload.id,
+      bufferBase64: upload.buffer.toString("base64"),
+      filename: upload.filename,
+      contentType: upload.contentType,
+      conversationId: upload.conversationId,
+      consentCardActivityId: upload.consentCardActivityId,
+      createdAt: Date.now(),
+    };
+    store.uploads = pruneToLimit(pruneExpired(store.uploads, Date.now(), ttlMs));
+    await writeJsonFile(filePath, store);
+  });
+}
+
+/**
+ * Retrieve a persisted pending upload. Expired entries are treated as absent.
+ */
+export async function getPendingUploadFs(
+  id: string | undefined,
+  options?: PendingUploadsFsOptions,
+): Promise<PendingUploadFs | undefined> {
+  if (!id) {
+    return undefined;
+  }
+  const ttlMs = options?.ttlMs ?? PENDING_UPLOAD_TTL_MS;
+  const filePath = resolveFilePath(options);
+  const store = await readStore(filePath, ttlMs);
+  const record = store.uploads[id];
+  if (!record) {
+    return undefined;
+  }
+  if (Date.now() - record.createdAt > ttlMs) {
+    return undefined;
+  }
+  return recordToUpload(record);
+}
+
+/**
+ * Remove a persisted pending upload (after successful upload or decline).
+ * No-op if the entry is already gone.
+ */
+export async function removePendingUploadFs(
+  id: string | undefined,
+  options?: PendingUploadsFsOptions,
+): Promise<void> {
+  if (!id) {
+    return;
+  }
+  const ttlMs = options?.ttlMs ?? PENDING_UPLOAD_TTL_MS;
+  const filePath = resolveFilePath(options);
+  await withFileLock(filePath, empty, async () => {
+    const store = await readStore(filePath, ttlMs);
+    if (!(id in store.uploads)) {
+      return;
+    }
+    delete store.uploads[id];
+    await writeJsonFile(filePath, store);
+  });
+}
+
+/**
+ * Set the consent card activity ID on a persisted entry. Called after the
+ * FileConsentCard activity is sent and we know its message id.
+ */
+export async function setPendingUploadActivityIdFs(
+  id: string,
+  activityId: string,
+  options?: PendingUploadsFsOptions,
+): Promise<void> {
+  const ttlMs = options?.ttlMs ?? PENDING_UPLOAD_TTL_MS;
+  const filePath = resolveFilePath(options);
+  await withFileLock(filePath, empty, async () => {
+    const store = await readStore(filePath, ttlMs);
+    const record = store.uploads[id];
+    if (!record) {
+      return;
+    }
+    record.consentCardActivityId = activityId;
+    await writeJsonFile(filePath, store);
+  });
+}

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -11,6 +11,7 @@ const mockState = vi.hoisted(() => ({
   runtimeConvertMarkdownTables: vi.fn((text: string) => text),
   requiresFileConsent: vi.fn(),
   prepareFileConsentActivity: vi.fn(),
+  prepareFileConsentActivityFs: vi.fn(),
   extractFilename: vi.fn(async () => "fallback.bin"),
   sendMSTeamsMessages: vi.fn(),
   uploadAndShareSharePoint: vi.fn(),
@@ -41,6 +42,7 @@ vi.mock("./send-context.js", () => ({
 vi.mock("./file-consent-helpers.js", () => ({
   requiresFileConsent: mockState.requiresFileConsent,
   prepareFileConsentActivity: mockState.prepareFileConsentActivity,
+  prepareFileConsentActivityFs: mockState.prepareFileConsentActivityFs,
 }));
 
 vi.mock("./media-helpers.js", () => ({
@@ -166,6 +168,7 @@ describe("sendMessageMSTeams", () => {
     mockState.runtimeConvertMarkdownTables.mockImplementation((text: string) => text);
     mockState.requiresFileConsent.mockReset();
     mockState.prepareFileConsentActivity.mockReset();
+    mockState.prepareFileConsentActivityFs.mockReset();
     mockState.extractFilename.mockReset();
     mockState.sendMSTeamsMessages.mockReset();
     mockState.uploadAndShareSharePoint.mockReset();

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -7,7 +7,7 @@ import {
   formatMSTeamsSendErrorHint,
   formatUnknownError,
 } from "./errors.js";
-import { prepareFileConsentActivity, requiresFileConsent } from "./file-consent-helpers.js";
+import { prepareFileConsentActivityFs, requiresFileConsent } from "./file-consent-helpers.js";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import {
   getDriveItemProperties,
@@ -16,6 +16,7 @@ import {
 } from "./graph-upload.js";
 import { extractFilename, extractMessageId } from "./media-helpers.js";
 import { buildConversationReference, sendMSTeamsMessages } from "./messenger.js";
+import { setPendingUploadActivityIdFs } from "./pending-uploads-fs.js";
 import { setPendingUploadActivityId } from "./pending-uploads.js";
 import { buildMSTeamsPollCard } from "./polls.js";
 import { resolveMSTeamsSendContext, type MSTeamsProactiveContext } from "./send-context.js";
@@ -154,7 +155,11 @@ export async function sendMessageMSTeams(
         thresholdBytes: FILE_CONSENT_THRESHOLD_BYTES,
       })
     ) {
-      const { activity, uploadId } = prepareFileConsentActivity({
+      // Proactive CLI sends run in a different process from the gateway's
+      // monitor that receives the fileConsent/invoke callback. Use the FS-
+      // backed helper so the invoke handler can find the pending upload when
+      // the user clicks "Allow".
+      const { activity, uploadId } = await prepareFileConsentActivityFs({
         media: { buffer: media.buffer, filename: fileName, contentType: media.contentType },
         conversationId,
         description: messageText || undefined,
@@ -170,8 +175,11 @@ export async function sendMessageMSTeams(
         errorPrefix: "msteams consent card send",
       });
 
-      // Store the activity ID so the accept handler can replace the consent card in-place
+      // Store the activity ID so the accept handler can replace the consent
+      // card in-place. Mirror it into the FS store too because the invoke
+      // callback may be delivered to a different process than the CLI send.
       setPendingUploadActivityId(uploadId, messageId);
+      await setPendingUploadActivityIdFs(uploadId, messageId);
 
       log.info("sent file consent card", { conversationId, messageId, uploadId });
 


### PR DESCRIPTION
## Summary

`openclaw message send --media <file>` targeting a Teams DM silently failed after the user clicked "Allow" on the FileConsentCard. The CLI send path stored the pending upload in an in-memory map and then exited — when Teams delivered the `fileConsent/invoke` callback to the long-lived gateway monitor process, its in-memory lookup missed and the user saw "This card action is not supported".

## Root cause

The outbound CLI path went through `prepareFileConsentActivity`, which only wrote to `pending-uploads.ts` (in-memory). That store cannot span the CLI and gateway processes, so the invoke handler's `getPendingUpload(uploadId)` returned `undefined` and the upload silently dropped.

## Fix

- New filesystem-backed pending upload store at `extensions/msteams/src/pending-uploads-fs.ts` (base64-encoded buffers, TTL-pruned, file-locked, bounded cap)
- New `prepareFileConsentActivityFs` helper in `file-consent-helpers.ts` that mirrors the pending upload into the FS store under the same `uploadId` already placed in the card context
- `send.ts` (CLI `--media` path) now calls the FS helper and also persists the consent card activity id via `setPendingUploadActivityIdFs`
- `monitor-handler.ts` falls back to the FS store when the in-memory lookup misses and cleans up both stores on upload/decline
- Same-process reply path (`messenger.ts`) is unchanged: it keeps using the in-memory fast path

## Test plan

- [x] `pending-uploads-fs.test.ts`: store/get/remove round-trip, TTL expiry, malformed file tolerance, cross-process read simulation, `prepareFileConsentActivityFs` end-to-end against a tmp state dir
- [x] `monitor-handler.file-consent.test.ts`: FS-fallback invoke handler uploads when in-memory store is empty, cleans up FS entry on accept and decline
- [x] Existing monitor-handler file-consent tests still pass (in-memory path preserved)
- [x] Full msteams suite: 777 tests passing
- [ ] Manual: `openclaw message send --channel msteams --media file.pdf` to a Teams personal DM, click Allow, verify file info card replaces consent card

Fixes #49784

🤖 Generated with [Claude Code](https://claude.com/claude-code)