### PR TITLE
fix: honor provider-prefixed configured model ids for routed providers

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2138,6 +2138,8 @@ Notes:
 
 OpenClaw uses the built-in model catalog. Add custom providers via `models.providers` in config or `~/.openclaw/agents/<agentId>/agent/models.json`.
 
+When resolving configured models for routed/custom providers, OpenClaw honors both bare requested model ids like `gpt-5.4` and provider-prefixed configured ids like `rr/gpt-5.4`. This keeps configured model overrides applied even when runtime lookups use the bare id form. Provider-specific compat hints such as `models.providers.<id>.models[].compat.supportsUsageInStreaming` still need to be configured explicitly when required by the upstream endpoint behavior.
+
 ```json5
 {
   models: {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -943,6 +943,52 @@ describe("resolveModel", () => {
     });
   });
 
+  it("prefers the prefixed configured entry when both bare and prefixed ids are present", () => {
+    const cfg = {
+      models: {
+        providers: {
+          rr: {
+            baseUrl: "http://localhost:8402/v1",
+            api: "openai-completions",
+            models: [
+              {
+                // Bare entry listed first — must NOT win for a prefixed request.
+                ...makeModel("gpt-5.4"),
+                provider: "rr",
+                api: "openai-completions",
+                compat: {
+                  supportsUsageInStreaming: false,
+                },
+              },
+              {
+                // Prefixed entry listed second — must win for a prefixed request.
+                ...makeModel("rr/gpt-5.4"),
+                provider: "rr",
+                api: "openai-completions",
+                compat: {
+                  supportsUsageInStreaming: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("rr", "rr/gpt-5.4", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "rr",
+      id: "rr/gpt-5.4",
+      api: "openai-completions",
+      baseUrl: "http://localhost:8402/v1",
+      compat: {
+        supportsUsageInStreaming: true,
+      },
+    });
+  });
+
   it("applies configured overrides to github-copilot dynamic models", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -907,6 +907,42 @@ describe("resolveModel", () => {
     );
   });
 
+  it("matches provider-prefixed configured model ids for bare runtime requests", () => {
+    const cfg = {
+      models: {
+        providers: {
+          rr: {
+            baseUrl: "http://localhost:8402/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("rr/gpt-5.4"),
+                provider: "rr",
+                api: "openai-completions",
+                compat: {
+                  supportsUsageInStreaming: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("rr", "gpt-5.4", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "rr",
+      id: "rr/gpt-5.4",
+      api: "openai-completions",
+      baseUrl: "http://localhost:8402/v1",
+      compat: {
+        supportsUsageInStreaming: true,
+      },
+    });
+  });
+
   it("applies configured overrides to github-copilot dynamic models", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -254,48 +254,72 @@ function findInlineModelMatch(params: {
   modelId: string;
 }) {
   const inlineModels = buildInlineProviderModels(params.providers);
-  const exact = inlineModels.find(
-    (entry) =>
-      entry.provider === params.provider &&
-      matchesConfiguredModelId(params.provider, entry.id, params.modelId),
+  const exact = findConfiguredModelMatch(
+    inlineModels.filter((entry) => entry.provider === params.provider),
+    params.provider,
+    params.modelId,
   );
   if (exact) {
     return exact;
   }
   const normalizedProvider = normalizeProviderId(params.provider);
-  return inlineModels.find(
-    (entry) =>
-      normalizeProviderId(entry.provider) === normalizedProvider &&
-      matchesConfiguredModelId(params.provider, entry.id, params.modelId),
+  return findConfiguredModelMatch(
+    inlineModels.filter((entry) => normalizeProviderId(entry.provider) === normalizedProvider),
+    params.provider,
+    params.modelId,
   );
 }
 
 export { buildModelAliasLines };
 
-function matchesConfiguredModelId(
+/**
+ * Find the best-matching configured model entry from a list, respecting match priority:
+ * 1. Exact id match always wins.
+ * 2. Configured id is provider-prefixed, runtime request is bare (e.g. rr/gpt-5.4 vs gpt-5.4).
+ *    This is the primary bug fix path.
+ * 3. Configured id is bare, runtime request is provider-prefixed (symmetric fallback).
+ *    Only used when no exact or primary match exists, so a mixed list with both
+ *    `gpt-5.4` and `rr/gpt-5.4` entries always resolves the prefixed request to
+ *    the prefixed entry, regardless of array order.
+ */
+function findConfiguredModelMatch<T extends { id?: string }>(
+  models: T[] | undefined,
   provider: string,
-  candidateId: string | undefined,
-  requestedModelId: string | undefined,
-) {
-  if (typeof candidateId !== "string" || typeof requestedModelId !== "string") {
-    return false;
+  requestedModelId: string,
+): T | undefined {
+  if (!models?.length) {
+    return undefined;
   }
-  const candidate = candidateId.trim();
   const requested = requestedModelId.trim();
-  if (!candidate || !requested) {
-    return false;
-  }
-  if (candidate === requested) {
-    return true;
+  if (!requested) {
+    return undefined;
   }
   const normalizedProvider = normalizeProviderId(provider);
   const prefixes = [provider, normalizedProvider].filter(
     (value, index, values): value is string =>
       typeof value === "string" && value.trim().length > 0 && values.indexOf(value) === index,
   );
-  return prefixes.some(
-    (prefix) => candidate === `${prefix}/${requested}` || requested === `${prefix}/${candidate}`,
-  );
+  // Pass 1: exact match or primary direction (configured prefixed, requested bare).
+  const primary = models.find((entry) => {
+    const candidate = entry.id?.trim();
+    if (!candidate) {
+      return false;
+    }
+    return (
+      candidate === requested || prefixes.some((prefix) => candidate === `${prefix}/${requested}`)
+    );
+  });
+  if (primary) {
+    return primary;
+  }
+  // Pass 2: symmetric fallback (configured bare, requested prefixed).
+  return models.find((entry) => {
+    const candidate = entry.id?.trim();
+    if (!candidate) {
+      return false;
+    }
+    return prefixes.some((prefix) => requested === `${prefix}/${candidate}`);
+  });
 }
 
 function resolveConfiguredProviderConfig(
@@ -329,9 +353,7 @@ function applyConfiguredProviderOverrides(params: {
       headers: sanitizeModelHeaders(discoveredModel.headers, { stripSecretRefMarkers: true }),
     };
   }
-  const configuredModel = providerConfig.models?.find((candidate) =>
-    matchesConfiguredModelId(params.provider, candidate.id, modelId),
-  );
+  const configuredModel = findConfiguredModelMatch(providerConfig.models, params.provider, modelId);
   const discoveredHeaders = sanitizeModelHeaders(discoveredModel.headers, {
     stripSecretRefMarkers: true,
   });
@@ -555,9 +577,7 @@ function resolveConfiguredFallbackModel(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, cfg, agentDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
-  const configuredModel = providerConfig?.models?.find((candidate) =>
-    matchesConfiguredModelId(provider, candidate.id, modelId),
-  );
+  const configuredModel = findConfiguredModelMatch(providerConfig?.models, provider, modelId);
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -255,7 +255,9 @@ function findInlineModelMatch(params: {
 }) {
   const inlineModels = buildInlineProviderModels(params.providers);
   const exact = inlineModels.find(
-    (entry) => entry.provider === params.provider && entry.id === params.modelId,
+    (entry) =>
+      entry.provider === params.provider &&
+      matchesConfiguredModelId(params.provider, entry.id, params.modelId),
   );
   if (exact) {
     return exact;
@@ -263,11 +265,38 @@ function findInlineModelMatch(params: {
   const normalizedProvider = normalizeProviderId(params.provider);
   return inlineModels.find(
     (entry) =>
-      normalizeProviderId(entry.provider) === normalizedProvider && entry.id === params.modelId,
+      normalizeProviderId(entry.provider) === normalizedProvider &&
+      matchesConfiguredModelId(params.provider, entry.id, params.modelId),
   );
 }
 
 export { buildModelAliasLines };
+
+function matchesConfiguredModelId(
+  provider: string,
+  candidateId: string | undefined,
+  requestedModelId: string | undefined,
+) {
+  if (typeof candidateId !== "string" || typeof requestedModelId !== "string") {
+    return false;
+  }
+  const candidate = candidateId.trim();
+  const requested = requestedModelId.trim();
+  if (!candidate || !requested) {
+    return false;
+  }
+  if (candidate === requested) {
+    return true;
+  }
+  const normalizedProvider = normalizeProviderId(provider);
+  const prefixes = [provider, normalizedProvider].filter(
+    (value, index, values): value is string =>
+      typeof value === "string" && value.trim().length > 0 && values.indexOf(value) === index,
+  );
+  return prefixes.some(
+    (prefix) => candidate === `${prefix}/${requested}` || requested === `${prefix}/${candidate}`,
+  );
+}
 
 function resolveConfiguredProviderConfig(
   cfg: OpenClawConfig | undefined,
@@ -300,7 +329,9 @@ function applyConfiguredProviderOverrides(params: {
       headers: sanitizeModelHeaders(discoveredModel.headers, { stripSecretRefMarkers: true }),
     };
   }
-  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  const configuredModel = providerConfig.models?.find((candidate) =>
+    matchesConfiguredModelId(params.provider, candidate.id, modelId),
+  );
   const discoveredHeaders = sanitizeModelHeaders(discoveredModel.headers, {
     stripSecretRefMarkers: true,
   });
@@ -524,7 +555,9 @@ function resolveConfiguredFallbackModel(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, cfg, agentDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
-  const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
+  const configuredModel = providerConfig?.models?.find((candidate) =>
+    matchesConfiguredModelId(provider, candidate.id, modelId),
+  );
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
   });


### PR DESCRIPTION
## Summary
- Fix routed model resolution so bare runtime requests like `gpt-5.4` still match configured provider-prefixed model ids like `rr/gpt-5.4`, preserving configured overrides for routed/custom providers.
- Add a regression test covering requested model id `gpt-5.4`, configured model id `rr/gpt-5.4`, and confirmation that the configured override still applies, including `compat.supportsUsageInStreaming: true`.
- Document that configured model resolution honors both bare and provider-prefixed ids for routed providers, while the `~/.openclaw/openclaw.json` compat override for `rr/gpt-5.4` remains intentionally required.

## Root Cause
Runtime model resolution looked up configured models with exact `candidate.id === modelId` matching. For routed providers, the live session path requested the bare id `gpt-5.4`, while config stored the model as `rr/gpt-5.4`. That mismatch caused the resolver to miss the configured override, so provider-specific compat like `supportsUsageInStreaming` never applied.

## Source Files Changed
- `src/agents/pi-embedded-runner/model.ts`
- `src/agents/pi-embedded-runner/model.test.ts`
- `docs/gateway/configuration-reference.md`

## Config Note
This change makes resolver matching durable in source, but the compat override remains intentionally required in `~/.openclaw/openclaw.json` for the routed model:

```json
{
  "compat": {
    "supportsUsageInStreaming": true
  }
}
```

Applied to:
- `rr/gpt-5.4`

## Rebuild And Validation
Rebuild/test work performed on the `v2026.4.2` release line:
- `corepack pnpm exec vitest run src/agents/pi-embedded-runner/model.test.ts`
- `"/opt/homebrew/bin/pnpm" build`

Validation results on the rebuilt global install:
- live `agent:main:main` turn returned real `agentMeta.usage`
- `lastCallUsage` populated for `rr/gpt-5.4`
- `~/.openclaw/agents/main/sessions/sessions.json` persisted real totals with `totalTokensFresh: true`
- `session_status` returned a real context line: `📚 Context: 73k/200k (37%) · 🧹 Compactions: 0`

## Test Plan
- [x] `corepack pnpm exec vitest run src/agents/pi-embedded-runner/model.test.ts`
- [x] `"/opt/homebrew/bin/pnpm" build`
- [x] `node "/opt/homebrew/lib/node_modules/openclaw/dist/index.js" agent --agent main --message "Reply with exactly ok." --timeout 60 --json`
- [x] `node "/opt/homebrew/lib/node_modules/openclaw/dist/index.js" agent --agent main --message "Call the session_status tool exactly once, then reply with only the Context line it reports." --timeout 60 --json`

Made with [Cursor](https://cursor.com)