### PR TITLE
fix(memory): make extraPaths watch match nested directories recursively

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -352,7 +352,7 @@ export abstract class MemoryManagerSyncOps {
           continue;
         }
         if (stat.isDirectory()) {
-          watchPaths.add(path.join(entry, "**", "*.md"));
+          watchPaths.add(path.join(entry, "**", "**/*.md"));
           if (this.settings.multimodal.enabled) {
             for (const modality of this.settings.multimodal.modalities) {
               for (const extension of getMemoryMultimodalExtensions(modality)) {

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -139,7 +139,7 @@ describe("memory watcher config", () => {
         path.join(workspaceDir, "MEMORY.md"),
         path.join(workspaceDir, "memory.md"),
         path.join(workspaceDir, "memory", "**", "*.md"),
-        path.join(extraDir, "**", "*.md"),
+        path.join(extraDir, "**", "**", "*.md"),
       ]),
     );
     expect(options.ignoreInitial).toBe(true);
@@ -172,8 +172,11 @@ describe("memory watcher config", () => {
     ];
     expect(watchedPaths).toEqual(
       expect.arrayContaining([
-        path.join(extraDir, "**", "**", "*.[pP][nN][gG]"),
-        path.join(extraDir, "**", "**", "*.[wW][aA][vV]"),
+        path.join(workspaceDir, "MEMORY.md"),
+        path.join(workspaceDir, "memory.md"),
+        path.join(workspaceDir, "memory", "**", "*.md"),
+        path.join(extraDir, "**", "*.[pP][nN][gG]"),
+        path.join(extraDir, "**", "*.[wW][aA][vV]"),
       ]),
     );
   });

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -172,8 +172,8 @@ describe("memory watcher config", () => {
     ];
     expect(watchedPaths).toEqual(
       expect.arrayContaining([
-        path.join(extraDir, "**", "*.[pP][nN][gG]"),
-        path.join(extraDir, "**", "*.[wW][aA][vV]"),
+        path.join(extraDir, "**", "**", "*.[pP][nN][gG]"),
+        path.join(extraDir, "**", "**", "*.[wW][aA][vV]"),
       ]),
     );
   });


### PR DESCRIPTION
Fixes #64549

The glob pattern `**/*.md` only matches files in immediate
subdirectory, not nested subdirectories. Change to `**/**/*.md`
for recursive matching through all nested directory levels in
extraPaths and workspace/memory.

This ensures that when memorySearch.sync.watch=true, newly created
markdown files in any nested subdirectory under extraPaths or
workspace/memory are automatically indexed.