### PR TITLE
test(qa): (GPT 5.4 Parity vs. Opus Agentic) expand GPT-5.4 / Opus parity second wave

### DIFF
--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,6 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as four merge units without losing the original six-contract architecture.
+This note explains how to review the GPT-5.4 / Codex parity program as five merge units without losing the original six-contract architecture.
 
 ## Merge units
 
@@ -62,6 +62,19 @@ Does not own:
 - runtime behavior changes outside QA-lab
 - auth/proxy/DNS simulation inside the harness
 
+### PR E: second-wave parity expansion
+
+Owns:
+
+- second-wave parity scenario expansion
+- merged-main proof packaging
+- goal-to-evidence parity documentation
+
+Does not own:
+
+- runtime behavior changes outside QA-lab
+- auth/proxy/DNS truthfulness logic
+
 ## Mapping back to the original six contracts
 
 | Original contract                        | Merge unit |
@@ -79,8 +92,9 @@ Does not own:
 2. PR B
 3. PR C
 4. PR D
+5. PR E
 
-PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed.
+PR D establishes the proof base. PR E expands scenario breadth and merged-main proof depth. Neither should be the reason runtime-correctness PRs are delayed.
 
 ## What to look for
 
@@ -109,6 +123,12 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
 
+### PR E
+
+- the parity pack widens beyond the first wave without adding runtime-scope behavior
+- subagent, memory, thread-isolation, and restart-capability lanes are covered
+- merged-main parity proof is explicitly documented and traceable
+
 Expected artifacts from PR D:
 
 - `qa-suite-report.md` / `qa-suite-summary.json` for each model run
@@ -120,7 +140,7 @@ Expected artifacts from PR D:
 Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
 
 - PR A, PR B, and PR C are merged
-- PR D runs the first-wave parity pack cleanly
+- PR D and PR E run the full parity pack cleanly
 - runtime-truthfulness regression suites remain green
 - the parity report shows no fake-success cases and no regression in stop behavior
 
@@ -140,18 +160,18 @@ flowchart LR
 
 The parity harness is not the only evidence source. Keep this split explicit in review:
 
-- PR D owns the scenario-based GPT-5.4 vs Opus 4.6 comparison
+- PR D and PR E own the scenario-based GPT-5.4 vs Opus 4.6 comparison
 - PR B deterministic suites still own auth/proxy/DNS and full-access truthfulness evidence
 
 ## Goal-to-evidence map
 
-| Completion gate item                     | Primary owner | Review artifact                                                     |
-| ---------------------------------------- | ------------- | ------------------------------------------------------------------- |
-| No plan-only stalls                      | PR A          | strict-agentic runtime tests and `approval-turn-tool-followthrough` |
-| No fake progress or fake tool completion | PR A + PR D   | parity fake-success count plus scenario-level report details        |
-| No false `/elevated full` guidance       | PR B          | deterministic runtime-truthfulness suites                           |
-| Replay/liveness failures remain explicit | PR C + PR D   | lifecycle/replay suites plus `compaction-retry-mutating-tool`       |
-| GPT-5.4 matches or beats Opus 4.6        | PR D          | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`  |
+| Completion gate item                     | Primary owner      | Review artifact                                                                    |
+| ---------------------------------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| No plan-only stalls                      | PR A               | strict-agentic runtime tests and `approval-turn-tool-followthrough`                |
+| No fake progress or fake tool completion | PR A + PR D + PR E | parity fake-success count plus scenario-level report details                       |
+| No false `/elevated full` guidance       | PR B               | deterministic runtime-truthfulness suites                                          |
+| Replay/liveness failures remain explicit | PR C + PR D + PR E | lifecycle/replay suites plus `compaction-retry-mutating-tool` and continuity lanes |
+| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`                 |
 
 ## Reviewer shorthand: before vs after
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,6 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as five merge units without losing the original six-contract architecture.
+This note explains how to review the GPT-5.4 / Codex parity program as a two-wave closeout without losing the original six-contract architecture.
 
 ## Merge units
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,7 +8,7 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in five reviewable slices: three merged runtime contracts, a proof-harness base, and a second-wave proof expansion.
+This parity program fixes those gaps in two waves: three merged runtime contracts, a merged proof-harness base, and a second-wave proof expansion that broadens the merged-main parity evidence.
 
 ## What changed
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,7 +8,7 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in four reviewable slices.
+This parity program fixes those gaps in five reviewable slices: three merged runtime contracts, a proof-harness base, and a second-wave proof expansion.
 
 ## What changed
 
@@ -48,6 +48,16 @@ This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be
 
 The parity pack is the proof layer. It does not change runtime behavior by itself.
 
+### PR E: second-wave parity expansion
+
+This slice keeps the work proof-only and expands the parity pack with more agentic continuity lanes:
+
+- subagent delegation and synthesis
+- memory recall and thread isolation
+- restart-triggered capability recovery in the same session
+
+PR E does not add new runtime behavior. It makes the parity claim stronger by widening the proof surface and turning the final closeout into a merged-main ten-scenario comparison instead of a smaller first-wave sample.
+
 After you have two `qa-suite-summary.json` artifacts, generate the release-gate comparison with:
 
 ```bash
@@ -85,13 +95,13 @@ to:
 
 ## Before vs after for GPT-5.4 users
 
-| Before this program                                                                            | After PR A-D                                                                             |
-| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 could stop after a reasonable plan without taking the next tool step                   | PR A turns “plan only” into “act now or surface a blocked state”                         |
-| Strict tool schemas could reject parameter-free or OpenAI/Codex-shaped tools in confusing ways | PR C makes provider-owned tool registration and invocation more predictable              |
-| `/elevated full` guidance could be vague or wrong in blocked runtimes                          | PR B gives GPT-5.4 and the user truthful runtime and permission hints                    |
-| Replay or compaction failures could feel like the task silently disappeared                    | PR C surfaces paused, blocked, abandoned, and replay-invalid outcomes explicitly         |
-| “GPT-5.4 feels worse than Opus” was mostly anecdotal                                           | PR D turns that into the same scenario pack, the same metrics, and a hard pass/fail gate |
+| Before this program                                                                            | After PR A-E                                                                                     |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| GPT-5.4 could stop after a reasonable plan without taking the next tool step                   | PR A turns “plan only” into “act now or surface a blocked state”                                 |
+| Strict tool schemas could reject parameter-free or OpenAI/Codex-shaped tools in confusing ways | PR C makes provider-owned tool registration and invocation more predictable                      |
+| `/elevated full` guidance could be vague or wrong in blocked runtimes                          | PR B gives GPT-5.4 and the user truthful runtime and permission hints                            |
+| Replay or compaction failures could feel like the task silently disappeared                    | PR C surfaces paused, blocked, abandoned, and replay-invalid outcomes explicitly                 |
+| “GPT-5.4 feels worse than Opus” was mostly anecdotal                                           | PR D and PR E turn that into the same scenario pack, the same metrics, and a hard pass/fail gate |
 
 ## Architecture
 
@@ -129,7 +139,7 @@ flowchart LR
 
 ## Scenario pack
 
-The first-wave parity pack currently covers five scenarios:
+The parity pack now covers ten scenarios in two waves.
 
 ### `approval-turn-tool-followthrough`
 
@@ -151,6 +161,26 @@ Checks that mixed-mode tasks involving attachments remain actionable and do not 
 
 Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
 
+### `subagent-handoff`
+
+Checks that the agent can delegate one bounded task to a subagent and fold the child result back into the parent reply instead of stalling or leaving the user with a “waiting” placeholder.
+
+### `subagent-fanout-synthesis`
+
+Checks that the agent can launch two bounded subagent tasks, wait for both, and synthesize both results into a single coherent parent answer.
+
+### `memory-recall`
+
+Checks that the agent can remember a seeded fact, switch context, and later recall the same fact accurately instead of hallucinating or losing the state.
+
+### `thread-memory-isolation`
+
+Checks that a memory-backed answer requested inside a thread stays inside that thread and does not leak into the root channel.
+
+### `config-restart-capability-flip`
+
+Checks that a restart-triggering config change restores a capability and that the same live session actually uses the restored tool after wake-up instead of losing continuity.
+
 ## Scenario matrix
 
 | Scenario                           | What it tests                           | Good GPT-5.4 behavior                                                          | Failure signal                                                                 |
@@ -160,6 +190,11 @@ Checks that a task with a real mutating write keeps replay-unsafety explicit ins
 | `source-docs-discovery-report`     | Source reading + synthesis + action     | Finds sources, uses tools, and produces a useful report without stalling       | thin summary, missing tool work, or incomplete-turn stop                       |
 | `image-understanding-attachment`   | Attachment-driven agentic work          | Interprets the attachment, connects it to tools, and continues the task        | vague narration, attachment ignored, or no concrete next action                |
 | `compaction-retry-mutating-tool`   | Mutating work under compaction pressure | Performs a real write and keeps replay-unsafety explicit after the side effect | mutating write happens but replay safety is implied, missing, or contradictory |
+| `subagent-handoff`                 | Single delegated worker flow            | Launches one bounded subagent and folds the result back cleanly                | no delegation, dangling “waiting”, or missing child result                     |
+| `subagent-fanout-synthesis`        | Multi-worker synthesis                  | Launches two bounded subagents and combines both results in one parent answer  | only one child result lands, or synthesis collapses into partial output        |
+| `memory-recall`                    | Durable recall after context shift      | Remembers a seeded fact and recalls it accurately later                        | guessed fact, forgotten fact, or drift after the context switch                |
+| `thread-memory-isolation`          | Scoped threaded recall                  | Answers correctly inside the thread and keeps the root channel quiet           | answer leaks to the root channel or ignores the threaded memory task           |
+| `config-restart-capability-flip`   | Restart + capability continuity         | Same session resumes after restart and uses the restored tool successfully     | capability remains missing, wake-up fails, or the session loses acting context |
 
 ## Release gate
 
@@ -173,7 +208,7 @@ Required outcomes:
 - no silent replay or compaction abandonment
 - parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline
 
-For the first-wave harness, the gate compares:
+For the current parity pack, the gate compares:
 
 - completion rate
 - unintended-stop rate
@@ -182,22 +217,41 @@ For the first-wave harness, the gate compares:
 
 Parity evidence is intentionally split across two layers:
 
-- PR D proves same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
+- PR D and PR E prove same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
 - PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
 
 ## Goal-to-evidence matrix
 
-| Completion gate item                                     | Owning PR   | Evidence source                                                    | Pass signal                                                                              |
-| -------------------------------------------------------- | ----------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 no longer stalls after planning                  | PR A        | `approval-turn-tool-followthrough` plus PR A runtime suites        | approval turns trigger real work or an explicit blocked state                            |
-| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D | parity report scenario outcomes and fake-success count             | no suspicious pass results and no commentary-only completion                             |
-| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B        | deterministic truthfulness suites                                  | blocked reasons and full-access hints stay runtime-accurate                              |
-| Replay/liveness failures stay explicit                   | PR C + PR D | PR C lifecycle/replay suites plus `compaction-retry-mutating-tool` | mutating work keeps replay-unsafety explicit instead of silently disappearing            |
-| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json` | same scenario coverage and no regression on completion, stop behavior, or valid tool use |
+| Completion gate item                                     | Owning PR          | Evidence source                                                                             | Pass signal                                                                              |
+| -------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| GPT-5.4 no longer stalls after planning                  | PR A               | `approval-turn-tool-followthrough` plus PR A runtime suites                                 | approval turns trigger real work or an explicit blocked state                            |
+| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR E | parity report scenario outcomes and fake-success count                                      | no suspicious pass results and no commentary-only completion                             |
+| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B               | deterministic truthfulness suites                                                           | blocked reasons and full-access hints stay runtime-accurate                              |
+| Replay/liveness failures stay explicit                   | PR C + PR D + PR E | PR C lifecycle/replay suites plus `compaction-retry-mutating-tool` and continuity scenarios | mutating work keeps replay-unsafety explicit instead of silently disappearing            |
+| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`                          | same scenario coverage and no regression on completion, stop behavior, or valid tool use |
+
+## Merged-main parity proof
+
+The final release claim should come from one merged-main run, not from branch-era anecdotes.
+
+Required inputs:
+
+- merged PR A, PR B, and PR C runtime behavior
+- merged PR D proof harness
+- merged PR E second-wave parity expansion
+- generated `qa-suite-summary.json` for GPT-5.4
+- generated `qa-suite-summary.json` for Opus 4.6
+
+Required outputs:
+
+- `qa-agentic-parity-report.md`
+- `qa-agentic-parity-summary.json`
+
+Only treat parity as complete when those generated artifacts come from the merged runtime and the full ten-scenario pack.
 
 ## How to read the parity verdict
 
-Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the first-wave parity pack.
+Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the merged-main parity pack.
 
 - `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and did not regress on the agreed aggregate metrics.
 - `fail` means at least one hard gate tripped: weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, or mismatched scenario coverage.

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -7,6 +7,28 @@ import {
   type QaParitySuiteSummary,
 } from "./agentic-parity-report.js";
 
+const FULL_PARITY_PASS_SCENARIOS = [
+  { name: "Approval turn tool followthrough", status: "pass" as const },
+  { name: "Compaction retry after mutating tool", status: "pass" as const },
+  { name: "Model switch with tool continuity", status: "pass" as const },
+  { name: "Source and docs discovery report", status: "pass" as const },
+  { name: "Image understanding from attachment", status: "pass" as const },
+  { name: "Subagent handoff", status: "pass" as const },
+  { name: "Subagent fanout synthesis", status: "pass" as const },
+  { name: "Memory recall after context switch", status: "pass" as const },
+  { name: "Thread memory isolation", status: "pass" as const },
+  { name: "Config restart capability flip", status: "pass" as const },
+];
+
+function withScenarioOverride(
+  name: string,
+  override: Partial<(typeof FULL_PARITY_PASS_SCENARIOS)[number]>,
+) {
+  return FULL_PARITY_PASS_SCENARIOS.map((scenario) =>
+    scenario.name === name ? { ...scenario, ...override } : scenario,
+  );
+}
+
 describe("qa agentic parity report", () => {
   it("computes first-wave parity metrics from suite summaries", () => {
     const summary: QaParitySuiteSummary = {
@@ -216,21 +238,9 @@ describe("qa agentic parity report", () => {
     // whole parity pack as pass on both sides except the one scenario we
     // deliberately fail on both sides, so the assertion can pin the
     // isolated gate failure under test.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-    const scenariosWithBothFail = parityPassScenarios.map((scenario, index) =>
-      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
-    );
+    const scenariosWithBothFail = withScenarioOverride("Approval turn tool followthrough", {
+      status: "fail",
+    });
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
@@ -254,26 +264,14 @@ describe("qa agentic parity report", () => {
     // by the relative completion-rate comparison, but surface it as a
     // named required-scenario failure too so operators see a concrete
     // scenario name alongside the rate differential.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-    const candidateWithOneFail = parityPassScenarios.map((scenario, index) =>
-      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
-    );
+    const candidateWithOneFail = withScenarioOverride("Approval turn tool followthrough", {
+      status: "fail",
+    });
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: { scenarios: candidateWithOneFail },
-      baselineSummary: { scenarios: parityPassScenarios },
+      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
 
@@ -286,28 +284,16 @@ describe("qa agentic parity report", () => {
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
     // Cover the full second-wave pack on both sides so the suspicious-pass assertion
     // below is the isolated gate failure under test (no coverage-gap noise).
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: parityPassScenarios,
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
       },
       baselineSummary: {
-        scenarios: parityPassScenarios.map((scenario, index) =>
-          index === 0 ? { ...scenario, details: "timed out before it continued" } : scenario,
-        ),
+        scenarios: withScenarioOverride("Approval turn tool followthrough", {
+          details: "timed out before it continued",
+        }),
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -506,28 +492,15 @@ Follow-up:
   });
 
   it("accepts matching run.primaryProvider labels without throwing", () => {
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: parityPassScenarios,
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
       },
       baselineSummary: {
-        scenarios: parityPassScenarios,
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -538,26 +511,31 @@ Follow-up:
   it("skips run.primaryProvider verification when the summary is missing a run block (legacy summaries)", () => {
     // Pre-PR-L summaries don't carry a `run` block. The gate must still
     // work against those, trusting the caller-supplied label.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
-      candidateSummary: { scenarios: parityPassScenarios },
-      baselineSummary: { scenarios: parityPassScenarios },
+      candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
+      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("skips provider verification for arbitrary display labels when run metadata is present", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "GPT-5.4 candidate",
+      baselineLabel: "Opus 4.6 baseline",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
     expect(comparison.pass).toBe(true);
   });
 
@@ -565,23 +543,11 @@ Follow-up:
     // Cover the full 10-scenario parity pack on both sides so the pass
     // verdict is not disrupted by required-scenario coverage failures
     // added by the second-wave expansion.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
-      candidateSummary: { scenarios: parityPassScenarios },
-      baselineSummary: { scenarios: parityPassScenarios },
+      candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
+      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -377,27 +377,26 @@ Follow-up:
   });
 
   it("renders a readable markdown parity report", () => {
+    // Cover the full 10-scenario parity pack on both sides so the pass
+    // verdict is not disrupted by required-scenario coverage failures
+    // added by the second-wave expansion.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
-      candidateSummary: {
-        scenarios: [
-          { name: "Approval turn tool followthrough", status: "pass" },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
-      },
-      baselineSummary: {
-        scenarios: [
-          { name: "Approval turn tool followthrough", status: "pass" },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
-      },
+      candidateSummary: { scenarios: parityPassScenarios },
+      baselineSummary: { scenarios: parityPassScenarios },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -208,32 +208,30 @@ describe("qa agentic parity report", () => {
   });
 
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
-    // Cover the full first-wave pack on both sides so the suspicious-pass assertion
+    // Cover the full second-wave pack on both sides so the suspicious-pass assertion
     // below is the isolated gate failure under test (no coverage-gap noise).
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: [
-          { name: "Approval turn tool followthrough", status: "pass" },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
+        scenarios: parityPassScenarios,
       },
       baselineSummary: {
-        scenarios: [
-          {
-            name: "Approval turn tool followthrough",
-            status: "pass",
-            details: "timed out before it continued",
-          },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
+        scenarios: parityPassScenarios.map((scenario, index) =>
+          index === 0 ? { ...scenario, details: "timed out before it continued" } : scenario,
+        ),
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -4,10 +4,11 @@ import {
   computeQaAgenticParityMetrics,
   QaParityLabelMismatchError,
   renderQaAgenticParityMarkdownReport,
+  type QaParityReportScenario,
   type QaParitySuiteSummary,
 } from "./agentic-parity-report.js";
 
-const FULL_PARITY_PASS_SCENARIOS = [
+const FULL_PARITY_PASS_SCENARIOS: QaParityReportScenario[] = [
   { name: "Approval turn tool followthrough", status: "pass" as const },
   { name: "Compaction retry after mutating tool", status: "pass" as const },
   { name: "Model switch with tool continuity", status: "pass" as const },
@@ -22,7 +23,7 @@ const FULL_PARITY_PASS_SCENARIOS = [
 
 function withScenarioOverride(
   name: string,
-  override: Partial<(typeof FULL_PARITY_PASS_SCENARIOS)[number]>,
+  override: Partial<QaParityReportScenario>,
 ) {
   return FULL_PARITY_PASS_SCENARIOS.map((scenario) =>
     scenario.name === name ? { ...scenario, ...override } : scenario,
@@ -416,6 +417,22 @@ Follow-up:
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
   });
 
+  it("does not flag structured status lines that end in `done`", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Compaction retry after mutating tool",
+          status: "pass",
+          details: `Confirmed, replay unsafe after write.
+compactionCount=0
+status=done`,
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
   it("does not flag positive-tone passes when the scenario shows real tool-call evidence", () => {
     // A legitimate tool-mediated pass that happens to include
     // "successfully" in its prose must not be flagged. The
@@ -520,11 +537,19 @@ Follow-up:
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -550,11 +575,19 @@ Follow-up:
       baselineLabel: "Opus 4.6 baseline",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -568,11 +601,19 @@ Follow-up:
       baselineLabel: "Opus 4.6 / baseline",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -587,16 +628,24 @@ Follow-up:
         baselineLabel: "anthropic/claude-opus-4-6",
         candidateSummary: {
           scenarios: FULL_PARITY_PASS_SCENARIOS,
-          run: { primaryProvider: "openai", primaryModel: "gpt-5.4-alt" },
+          run: {
+            primaryProvider: "openai",
+            primaryModel: "openai/gpt-5.4-alt",
+            primaryModelName: "gpt-5.4-alt",
+          },
         },
         baselineSummary: {
           scenarios: FULL_PARITY_PASS_SCENARIOS,
-          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+          run: {
+            primaryProvider: "anthropic",
+            primaryModel: "anthropic/claude-opus-4-6",
+            primaryModelName: "claude-opus-4-6",
+          },
         },
         comparedAt: "2026-04-11T00:00:00.000Z",
       }),
     ).toThrow(
-      /candidate summary run\.primaryProvider=openai and run\.primaryModel=gpt-5\.4-alt do not match --candidate-label=openai\/gpt-5\.4/,
+      /candidate summary run\.primaryProvider=openai and run\.primaryModel=openai\/gpt-5\.4-alt do not match --candidate-label=openai\/gpt-5\.4/,
     );
   });
 
@@ -606,11 +655,19 @@ Follow-up:
       baselineLabel: "anthropic:claude-opus-4-6",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -207,6 +207,81 @@ describe("qa agentic parity report", () => {
     );
   });
 
+  it("fails the parity gate when a required parity scenario fails on both sides", () => {
+    // Regression for the loop-7 Codex-connector P1 finding: without this
+    // check, a required parity scenario that fails on both candidate and
+    // baseline still produces pass=true because the downstream metric
+    // comparisons are purely relative (candidate vs baseline). Cover the
+    // whole parity pack as pass on both sides except the one scenario we
+    // deliberately fail on both sides, so the assertion can pin the
+    // isolated gate failure under test.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+    const scenariosWithBothFail = parityPassScenarios.map((scenario, index) =>
+      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
+    );
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: { scenarios: scenariosWithBothFail },
+      baselineSummary: { scenarios: scenariosWithBothFail },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.4=fail, anthropic/claude-opus-4-6=fail.",
+    );
+    // Metric comparisons are relative, so a same-on-both-sides failure
+    // must not appear as a relative metric failure. The required-scenario
+    // failure line is the only thing keeping the gate honest here.
+    expect(comparison.failures.some((failure) => failure.includes("completion rate"))).toBe(false);
+  });
+
+  it("fails the parity gate when a required parity scenario fails on the candidate only", () => {
+    // A candidate regression below a passing baseline is already caught
+    // by the relative completion-rate comparison, but surface it as a
+    // named required-scenario failure too so operators see a concrete
+    // scenario name alongside the rate differential.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+    const candidateWithOneFail = parityPassScenarios.map((scenario, index) =>
+      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
+    );
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: { scenarios: candidateWithOneFail },
+      baselineSummary: { scenarios: parityPassScenarios },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.4=fail, anthropic/claude-opus-4-6=pass.",
+    );
+  });
+
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
     // Cover the full second-wave pack on both sides so the suspicious-pass assertion
     // below is the isolated gate failure under test (no coverage-gap noise).

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildQaAgenticParityComparison,
   computeQaAgenticParityMetrics,
+  QaParityLabelMismatchError,
   renderQaAgenticParityMarkdownReport,
   type QaParitySuiteSummary,
 } from "./agentic-parity-report.js";
@@ -374,6 +375,190 @@ Follow-up:
     };
 
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
+  });
+
+  it("flags positive-tone fake success when the scenario has no tool-call evidence", () => {
+    // A prose-only pass that says "Successfully completed the delegation"
+    // without any recorded `plannedToolName` or tool-call evidence is
+    // exactly the fake-success shape the old failure-tone-only regex set
+    // missed. This regression pins the positive-tone branch.
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Subagent handoff",
+          status: "pass",
+          details: "Successfully completed the delegation. The subagent returned its result.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
+  });
+
+  it("flags a bare `Done.` prose pass as fake success", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Approval turn tool followthrough",
+          status: "pass",
+          details: "Done.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
+  });
+
+  it("does not flag positive-tone passes when the scenario shows real tool-call evidence", () => {
+    // A legitimate tool-mediated pass that happens to include
+    // "successfully" in its prose must not be flagged. The
+    // `plannedToolName` evidence (or any of the other tool-call
+    // evidence patterns) exempts the scenario from positive-tone
+    // detection. Without this exemption, real tool-backed passes with
+    // self-congratulatory prose would count as fake successes and break
+    // the gate.
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Source and docs discovery report",
+          status: "pass",
+          details:
+            "Successfully completed the report. plannedToolName=read recorded via /debug/requests.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
+  it("flags positive-tone passes alongside failure-tone passes when both occur", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Approval turn tool followthrough",
+          status: "pass",
+          details: "Task executed successfully without errors.",
+        },
+        {
+          name: "Subagent handoff",
+          status: "pass",
+          details: "Tool call completed, but an error occurred mid-turn.",
+        },
+      ],
+    };
+
+    // Both scenarios should count: one is positive-tone (evasive fake
+    // success), the other is failure-tone (classic fake success).
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(2);
+  });
+
+  it("throws QaParityLabelMismatchError when the candidate run.primaryProvider does not match the label", () => {
+    // Regression for the gate footgun: if an operator swaps the
+    // --candidate-summary and --baseline-summary paths, the gate would
+    // silently produce a reversed verdict. PR L #64789 ships the `run`
+    // block on every summary so the parity report can verify it against
+    // the caller-supplied label; this test pins the precondition check.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+    ];
+
+    expect(() =>
+      buildQaAgenticParityComparison({
+        candidateLabel: "openai/gpt-5.4",
+        baselineLabel: "anthropic/claude-opus-4-6",
+        candidateSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        },
+        baselineSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        },
+        comparedAt: "2026-04-11T00:00:00.000Z",
+      }),
+    ).toThrow(QaParityLabelMismatchError);
+  });
+
+  it("throws QaParityLabelMismatchError when the baseline run.primaryProvider does not match the label", () => {
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+    ];
+
+    expect(() =>
+      buildQaAgenticParityComparison({
+        candidateLabel: "openai/gpt-5.4",
+        baselineLabel: "anthropic/claude-opus-4-6",
+        candidateSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "openai" },
+        },
+        baselineSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "openai" },
+        },
+        comparedAt: "2026-04-11T00:00:00.000Z",
+      }),
+    ).toThrow(/baseline summary run.primaryProvider=openai does not match --baseline-label/);
+  });
+
+  it("accepts matching run.primaryProvider labels without throwing", () => {
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: parityPassScenarios,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: parityPassScenarios,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("skips run.primaryProvider verification when the summary is missing a run block (legacy summaries)", () => {
+    // Pre-PR-L summaries don't carry a `run` block. The gate must still
+    // work against those, trusting the caller-supplied label.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: { scenarios: parityPassScenarios },
+      baselineSummary: { scenarios: parityPassScenarios },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+    expect(comparison.pass).toBe(true);
   });
 
   it("renders a readable markdown parity report", () => {

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -33,8 +33,12 @@ describe("qa agentic parity report", () => {
   it("computes first-wave parity metrics from suite summaries", () => {
     const summary: QaParitySuiteSummary = {
       scenarios: [
-        { name: "Scenario A", status: "pass" },
-        { name: "Scenario B", status: "fail", details: "incomplete turn detected" },
+        { name: "Approval turn tool followthrough", status: "pass" },
+        {
+          name: "Compaction retry after mutating tool",
+          status: "fail",
+          details: "incomplete turn detected",
+        },
       ],
     };
 
@@ -48,6 +52,23 @@ describe("qa agentic parity report", () => {
       validToolCallCount: 1,
       validToolCallRate: 0.5,
       fakeSuccessCount: 0,
+    });
+  });
+
+  it("keeps non-tool scenarios out of the valid-tool-call metric", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        { name: "Approval turn tool followthrough", status: "pass" },
+        { name: "Memory recall after context switch", status: "pass" },
+        { name: "Image understanding from attachment", status: "pass" },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary)).toMatchObject({
+      totalScenarios: 3,
+      passedScenarios: 3,
+      validToolCallCount: 1,
+      validToolCallRate: 1,
     });
   });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -21,10 +21,7 @@ const FULL_PARITY_PASS_SCENARIOS: QaParityReportScenario[] = [
   { name: "Config restart capability flip", status: "pass" as const },
 ];
 
-function withScenarioOverride(
-  name: string,
-  override: Partial<QaParityReportScenario>,
-) {
+function withScenarioOverride(name: string, override: Partial<QaParityReportScenario>) {
   return FULL_PARITY_PASS_SCENARIOS.map((scenario) =>
     scenario.name === name ? { ...scenario, ...override } : scenario,
   );
@@ -455,6 +452,25 @@ status=done`,
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
   });
 
+  it("does not flag positive-tone prose on non-tool scenarios", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Memory recall after context switch",
+          status: "pass",
+          details: "Successfully completed the recall and returned the remembered fact.",
+        },
+        {
+          name: "Image understanding from attachment",
+          status: "pass",
+          details: "Done. Successfully identified the attachment contents.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
   it("flags positive-tone passes alongside failure-tone passes when both occur", () => {
     const summary: QaParitySuiteSummary = {
       scenarios: [
@@ -667,6 +683,32 @@ status=done`,
           primaryProvider: "anthropic",
           primaryModel: "anthropic/claude-opus-4-6",
           primaryModelName: "claude-opus-4-6",
+        },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("accepts structured labels whose model ref contains nested path segments", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4/reasoning",
+      baselineLabel: "anthropic/claude-opus-4-6/extended",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4/reasoning",
+          primaryModelName: "gpt-5.4/reasoning",
+        },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6/extended",
+          primaryModelName: "claude-opus-4-6/extended",
         },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -328,9 +328,30 @@ Follow-up:
 
     const report = renderQaAgenticParityMarkdownReport(comparison);
 
-    expect(report).toContain("# OpenClaw GPT-5.4 / Opus 4.6 Agentic Parity Report");
+    expect(report).toContain(
+      "# OpenClaw Agentic Parity Report — openai/gpt-5.4 vs anthropic/claude-opus-4-6",
+    );
     expect(report).toContain("| Completion rate | 100.0% | 100.0% |");
     expect(report).toContain("### Approval turn tool followthrough");
     expect(report).toContain("- Verdict: pass");
+  });
+
+  it("parametrizes the markdown header from the comparison labels", () => {
+    // Regression for the loop-7 Copilot finding: callers that configure
+    // non-gpt-5.4 / non-opus labels (for example an internal candidate vs
+    // another candidate) must see the labels in the rendered H1 instead of
+    // the hardcoded "GPT-5.4 / Opus 4.6" title that would otherwise confuse
+    // readers of saved reports.
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4-alt",
+      baselineLabel: "openai/gpt-5.4",
+      candidateSummary: { scenarios: [] },
+      baselineSummary: { scenarios: [] },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+    const report = renderQaAgenticParityMarkdownReport(comparison);
+    expect(report).toContain(
+      "# OpenClaw Agentic Parity Report — openai/gpt-5.4-alt vs openai/gpt-5.4",
+    );
   });
 });

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -484,11 +484,13 @@ Follow-up:
         },
         baselineSummary: {
           scenarios: parityPassScenarios,
-          run: { primaryProvider: "openai" },
+          run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
         },
         comparedAt: "2026-04-11T00:00:00.000Z",
       }),
-    ).toThrow(/baseline summary run.primaryProvider=openai does not match --baseline-label/);
+    ).toThrow(
+      /baseline summary run\.primaryProvider=openai and run\.primaryModel=gpt-5\.4 do not match --baseline-label/,
+    );
   });
 
   it("accepts matching run.primaryProvider labels without throwing", () => {
@@ -525,6 +527,62 @@ Follow-up:
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "GPT-5.4 candidate",
       baselineLabel: "Opus 4.6 baseline",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("skips provider verification for mixed-case or decorated display labels", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "Candidate: GPT-5.4",
+      baselineLabel: "Opus 4.6 / baseline",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("throws when a structured label mismatches the recorded model even if the provider matches", () => {
+    expect(() =>
+      buildQaAgenticParityComparison({
+        candidateLabel: "openai/gpt-5.4",
+        baselineLabel: "anthropic/claude-opus-4-6",
+        candidateSummary: {
+          scenarios: FULL_PARITY_PASS_SCENARIOS,
+          run: { primaryProvider: "openai", primaryModel: "gpt-5.4-alt" },
+        },
+        baselineSummary: {
+          scenarios: FULL_PARITY_PASS_SCENARIOS,
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        },
+        comparedAt: "2026-04-11T00:00:00.000Z",
+      }),
+    ).toThrow(
+      /candidate summary run\.primaryProvider=openai and run\.primaryModel=gpt-5\.4-alt do not match --candidate-label=openai\/gpt-5\.4/,
+    );
+  });
+
+  it("accepts colon-delimited structured labels when provider and model both match", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai:gpt-5.4",
+      baselineLabel: "anthropic:claude-opus-4-6",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -149,9 +149,10 @@ function scopeSummaryToParityPack(
   summary: QaParitySuiteSummary,
   parityTitleSet: ReadonlySet<string>,
 ): QaParitySuiteSummary {
-  // The parity verdict must only consider the declared first-wave parity scenarios.
-  // Drop `counts` so the metric helper recomputes totals from the filtered scenario
-  // list instead of inheriting the caller's full-suite counters.
+  // The parity verdict must only consider the declared parity scenarios
+  // (the full first-wave + second-wave pack from QA_AGENTIC_PARITY_SCENARIOS).
+  // Drop `counts` so the metric helper recomputes totals from the filtered
+  // scenario list instead of inheriting the caller's full-suite counters.
   return {
     scenarios: summary.scenarios.filter((scenario) => parityTitleSet.has(scenario.name)),
   };
@@ -281,8 +282,13 @@ export function buildQaAgenticParityComparison(params: {
 }
 
 export function renderQaAgenticParityMarkdownReport(comparison: QaAgenticParityComparison): string {
+  // Title is parametrized from the candidate / baseline labels so reports
+  // for any candidate/baseline pair (not only gpt-5.4 vs opus 4.6) render
+  // with an accurate header. The default CLI labels are still
+  // openai/gpt-5.4 vs anthropic/claude-opus-4-6, but the helper works for
+  // any parity comparison a caller configures.
   const lines = [
-    "# OpenClaw GPT-5.4 / Opus 4.6 Agentic Parity Report",
+    `# OpenClaw Agentic Parity Report — ${comparison.candidateLabel} vs ${comparison.baselineLabel}`,
     "",
     `- Compared at: ${comparison.comparedAt}`,
     `- Candidate: ${comparison.candidateLabel}`,

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -13,6 +13,19 @@ export type QaParityReportScenario = {
   steps?: QaParityReportStep[];
 };
 
+/**
+ * Optional self-describing run metadata written by PR L (#64789). Before
+ * that PR merges, older summaries only have `scenarios` + `counts`; the
+ * parity report treats a missing `run` block as "unknown provenance" and
+ * skips the label-match verification rather than failing open.
+ */
+export type QaParityRunBlock = {
+  primaryProvider?: string;
+  primaryModel?: string;
+  providerMode?: string;
+  scenarioIds?: readonly string[] | null;
+};
+
 export type QaParitySuiteSummary = {
   scenarios: QaParityReportScenario[];
   counts?: {
@@ -20,6 +33,8 @@ export type QaParitySuiteSummary = {
     passed?: number;
     failed?: number;
   };
+  /** Self-describing run metadata — see PR L #64789 for the writer side. */
+  run?: QaParityRunBlock;
 };
 
 export type QaAgenticParityMetrics = {
@@ -64,7 +79,11 @@ const UNINTENDED_STOP_PATTERNS = [
   /did not continue/i,
 ] as const;
 
-const SUSPICIOUS_PASS_PATTERNS = [
+// Failure-tone patterns: a passing scenario whose details text matches any
+// of these is treated as a "fake success" — the scenario is marked pass but
+// the supporting text reveals something went wrong. Adding new patterns here
+// widens the net for bad prose that correlates with runtime failure modes.
+const SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS = [
   /incomplete turn/i,
   /\btimed out\b/i,
   /\btimeout\b/i,
@@ -75,6 +94,49 @@ const SUSPICIOUS_PASS_PATTERNS = [
   /error occurred/i,
   /an error was/i,
 ] as const;
+
+// Positive-tone patterns: a passing scenario whose details read as plausible
+// self-congratulatory prose ("Successfully completed", "Done.", "Task
+// executed successfully") is ALSO suspicious — it's the shape of a fake
+// success that evades the failure-tone net above. Criterion 2 of the
+// GPT-5.4 parity completion gate (#64227) specifically targets this: a
+// model that says "I did the thing" without actually doing it should not
+// count as a pass. A positive-tone pattern only fires as a suspicious pass
+// when the scenario is ALSO missing a recorded tool-call assertion in its
+// prose — see `scenarioLacksToolCallEvidence` below. That keeps the check
+// from false-positiving on legitimate tool-mediated scenarios that happen
+// to include "successfully" in their details.
+const SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS = [
+  /successfully (?:completed|executed|finished|handled|delegated|ran)/i,
+  /\bdone\.?\s*$/im,
+  /task (?:done|executed|completed|handled|finished) successfully/i,
+  /everything (?:worked|ran) (?:as expected|successfully)/i,
+  /finished the operation/i,
+  /all (?:steps|tasks) (?:completed|finished) successfully/i,
+] as const;
+
+// Evidence a scenario actually did its tool-mediated work. A scenario
+// whose details contain any of these is considered tool-backed and is
+// exempt from the positive-tone fake-success check. The patterns match
+// the `plannedToolName=...` / `tool call succeeded` / `executed tool`
+// phrases scenarios emit when their `/debug/requests` assertions fire
+// (PR J #64681), so a scenario with real tool evidence is never flagged
+// even if its prose also includes "successfully".
+const TOOL_CALL_EVIDENCE_PATTERNS = [
+  /plannedToolName/i,
+  /tool call (?:succeeded|completed|returned)/i,
+  /executed tool/i,
+  /function_call_output/i,
+  /tool_use/i,
+] as const;
+
+function scenarioLacksToolCallEvidence(scenario: QaParityReportScenario): boolean {
+  const text = scenarioText(scenario);
+  if (text.length === 0) {
+    return true;
+  }
+  return !TOOL_CALL_EVIDENCE_PATTERNS.some((pattern) => pattern.test(text));
+}
 
 function normalizeScenarioStatus(status: string | undefined): "pass" | "fail" | "skip" {
   return status === "pass" || status === "fail" || status === "skip" ? status : "fail";
@@ -112,10 +174,28 @@ export function computeQaAgenticParityMetrics(
     (scenario) =>
       scenario.status !== "pass" && scenarioHasPattern(scenario, UNINTENDED_STOP_PATTERNS),
   ).length;
-  const fakeSuccessCount = scenarios.filter(
-    (scenario) =>
-      scenario.status === "pass" && scenarioHasPattern(scenario, SUSPICIOUS_PASS_PATTERNS),
-  ).length;
+  const fakeSuccessCount = scenarios.filter((scenario) => {
+    if (scenario.status !== "pass") {
+      return false;
+    }
+    // Failure-tone patterns catch obviously-broken passes regardless of
+    // whether the scenario shows tool-call evidence — "timed out" under a
+    // pass is always fake.
+    if (scenarioHasPattern(scenario, SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS)) {
+      return true;
+    }
+    // Positive-tone patterns only fire when the scenario doesn't also show
+    // real tool-call evidence. A legitimate tool-mediated pass with
+    // self-congratulatory prose stays clean; a prose-only pass with
+    // "Successfully completed the delegation" gets flagged.
+    if (
+      scenarioHasPattern(scenario, SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS) &&
+      scenarioLacksToolCallEvidence(scenario)
+    ) {
+      return true;
+    }
+    return false;
+  }).length;
 
   // First-wave parity scenarios are all tool-mediated tasks, so a passing scenario is our
   // verified unit of valid tool-backed execution in this harness.
@@ -155,7 +235,78 @@ function scopeSummaryToParityPack(
   // scenario list instead of inheriting the caller's full-suite counters.
   return {
     scenarios: summary.scenarios.filter((scenario) => parityTitleSet.has(scenario.name)),
+    ...(summary.run ? { run: summary.run } : {}),
   };
+}
+
+/**
+ * Normalize a provider label into the `provider` half of a `provider/model`
+ * string. Accepts bare provider names (`"openai"`), provider/model tuples
+ * (`"openai/gpt-5.4"`), and colon-separated forms (`"openai:gpt-5.4"`).
+ * Returns the provider portion lowercased so comparisons against the
+ * `run.primaryProvider` field don't get confused by case drift.
+ */
+function extractProviderFromLabel(label: string): string | null {
+  const trimmed = label.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const separatorMatch = /^([^/:]+)[/:]/.exec(trimmed);
+  if (separatorMatch) {
+    return separatorMatch[1]?.toLowerCase() ?? null;
+  }
+  return trimmed.toLowerCase();
+}
+
+/**
+ * Verify the `run.primaryProvider` field on a summary matches the caller-
+ * supplied label. PR L #64789 ships the `run` block; before it lands, older
+ * summaries don't have the field and this check is a no-op.
+ *
+ * Throws `QaParityLabelMismatchError` when the summary reports a different
+ * provider than the caller claimed — this catches the "swapped candidate
+ * and baseline summary paths" footgun the earlier adversarial review
+ * flagged. Returns silently when the field is absent (legacy summaries) or
+ * when the fields match.
+ */
+function verifySummaryLabelMatch(params: {
+  summary: QaParitySuiteSummary;
+  label: string;
+  role: "candidate" | "baseline";
+}): void {
+  const runProvider = params.summary.run?.primaryProvider?.trim();
+  if (!runProvider) {
+    return;
+  }
+  const labelProvider = extractProviderFromLabel(params.label);
+  if (!labelProvider) {
+    return;
+  }
+  if (runProvider.toLowerCase() === labelProvider) {
+    return;
+  }
+  throw new QaParityLabelMismatchError({
+    role: params.role,
+    label: params.label,
+    runProvider,
+  });
+}
+
+export class QaParityLabelMismatchError extends Error {
+  readonly role: "candidate" | "baseline";
+  readonly label: string;
+  readonly runProvider: string;
+
+  constructor(params: { role: "candidate" | "baseline"; label: string; runProvider: string }) {
+    super(
+      `${params.role} summary run.primaryProvider=${params.runProvider} does not match --${params.role}-label=${params.label}. ` +
+        `Check that the --candidate-summary / --baseline-summary paths weren't swapped.`,
+    );
+    this.name = "QaParityLabelMismatchError";
+    this.role = params.role;
+    this.label = params.label;
+    this.runProvider = params.runProvider;
+  }
 }
 
 export function buildQaAgenticParityComparison(params: {
@@ -165,6 +316,22 @@ export function buildQaAgenticParityComparison(params: {
   baselineSummary: QaParitySuiteSummary;
   comparedAt?: string;
 }): QaAgenticParityComparison {
+  // Precondition: verify the `run.primaryProvider` field on each summary
+  // matches the caller-supplied label (when the `run` block is present).
+  // Throws `QaParityLabelMismatchError` on mismatch so the release gate
+  // fails loudly instead of silently producing a reversed verdict when an
+  // operator swaps the --candidate-summary and --baseline-summary paths.
+  // Legacy summaries without a `run` block are accepted as-is.
+  verifySummaryLabelMatch({
+    summary: params.candidateSummary,
+    label: params.candidateLabel,
+    role: "candidate",
+  });
+  verifySummaryLabelMatch({
+    summary: params.baselineSummary,
+    label: params.baselineLabel,
+    role: "baseline",
+  });
   const parityTitleSet: ReadonlySet<string> = new Set<string>(QA_AGENTIC_PARITY_SCENARIO_TITLES);
   // Rates and fake-success counts are computed from the parity-scoped summaries only,
   // so extra non-parity scenarios in the input (for example when a caller feeds a full

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -239,35 +239,47 @@ function scopeSummaryToParityPack(
   };
 }
 
+type StructuredQaParityLabel = {
+  provider: string;
+  model: string;
+};
+
 /**
- * Normalize a provider label into the `provider` half of a `provider/model`
- * string. Accepts bare provider names (`"openai"`), provider/model tuples
- * (`"openai/gpt-5.4"`), and colon-separated forms (`"openai:gpt-5.4"`).
- * Returns the provider portion lowercased so comparisons against the
- * `run.primaryProvider` field don't get confused by case drift.
+ * Only treat caller labels as provenance-checked identifiers when they are
+ * exact lower-case provider/model refs. Human-facing display labels like
+ * "GPT-5.4 candidate" or "Candidate: GPT-5.4" should render in the report
+ * without being misread as structured provider ids.
  */
-function extractProviderFromLabel(label: string): string | null {
+function parseStructuredLabelRef(label: string): StructuredQaParityLabel | null {
   const trimmed = label.trim();
   if (trimmed.length === 0) {
     return null;
   }
-  const separatorMatch = /^([^/:]+)[/:]/.exec(trimmed);
-  if (separatorMatch) {
-    return separatorMatch[1]?.toLowerCase() ?? null;
+  if (trimmed !== trimmed.toLowerCase()) {
+    return null;
   }
-  return null;
+  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._-]*)$/.exec(trimmed);
+  if (!separatorMatch) {
+    return null;
+  }
+  return {
+    provider: separatorMatch[1] ?? "",
+    model: separatorMatch[2] ?? "",
+  };
 }
 
 /**
- * Verify the `run.primaryProvider` field on a summary matches the caller-
- * supplied label. PR L #64789 ships the `run` block; before it lands, older
- * summaries don't have the field and this check is a no-op.
+ * Verify the `run.primaryProvider` + `run.primaryModel` fields on a summary
+ * match the caller-supplied label when that label is a structured
+ * `provider/model` or `provider:model` ref. PR L #64789 ships the `run`
+ * block; before it lands, older summaries don't have the field and this check
+ * is a no-op.
  *
  * Throws `QaParityLabelMismatchError` when the summary reports a different
- * provider than the caller claimed — this catches the "swapped candidate
- * and baseline summary paths" footgun the earlier adversarial review
- * flagged. Returns silently when the field is absent (legacy summaries) or
- * when the fields match.
+ * provider/model than the caller claimed — this catches the "swapped
+ * candidate and baseline summary paths" footgun the earlier adversarial
+ * review flagged. Returns silently when the fields are absent (legacy
+ * summaries) or when the fields match.
  */
 function verifySummaryLabelMatch(params: {
   summary: QaParitySuiteSummary;
@@ -275,20 +287,25 @@ function verifySummaryLabelMatch(params: {
   role: "candidate" | "baseline";
 }): void {
   const runProvider = params.summary.run?.primaryProvider?.trim();
-  if (!runProvider) {
+  const runModel = params.summary.run?.primaryModel?.trim();
+  if (!runProvider || !runModel) {
     return;
   }
-  const labelProvider = extractProviderFromLabel(params.label);
-  if (!labelProvider) {
+  const labelRef = parseStructuredLabelRef(params.label);
+  if (!labelRef) {
     return;
   }
-  if (runProvider.toLowerCase() === labelProvider) {
+  if (
+    runProvider.toLowerCase() === labelRef.provider &&
+    runModel.toLowerCase() === labelRef.model
+  ) {
     return;
   }
   throw new QaParityLabelMismatchError({
     role: params.role,
     label: params.label,
     runProvider,
+    runModel,
   });
 }
 
@@ -296,16 +313,23 @@ export class QaParityLabelMismatchError extends Error {
   readonly role: "candidate" | "baseline";
   readonly label: string;
   readonly runProvider: string;
+  readonly runModel: string;
 
-  constructor(params: { role: "candidate" | "baseline"; label: string; runProvider: string }) {
+  constructor(params: {
+    role: "candidate" | "baseline";
+    label: string;
+    runProvider: string;
+    runModel: string;
+  }) {
     super(
-      `${params.role} summary run.primaryProvider=${params.runProvider} does not match --${params.role}-label=${params.label}. ` +
+      `${params.role} summary run.primaryProvider=${params.runProvider} and run.primaryModel=${params.runModel} do not match --${params.role}-label=${params.label}. ` +
         `Check that the --candidate-summary / --baseline-summary paths weren't swapped.`,
     );
     this.name = "QaParityLabelMismatchError";
     this.role = params.role;
     this.label = params.label;
     this.runProvider = params.runProvider;
+    this.runModel = params.runModel;
   }
 }
 

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -255,7 +255,7 @@ function extractProviderFromLabel(label: string): string | null {
   if (separatorMatch) {
     return separatorMatch[1]?.toLowerCase() ?? null;
   }
-  return trimmed.toLowerCase();
+  return null;
 }
 
 /**

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -1,4 +1,7 @@
-import { QA_AGENTIC_PARITY_SCENARIO_TITLES } from "./agentic-parity.js";
+import {
+  QA_AGENTIC_PARITY_SCENARIO_TITLES,
+  QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES,
+} from "./agentic-parity.js";
 
 export type QaParityReportStep = {
   name: string;
@@ -165,6 +168,7 @@ export function computeQaAgenticParityMetrics(
     ...scenario,
     status: normalizeScenarioStatus(scenario.status),
   }));
+  const toolBackedTitleSet: ReadonlySet<string> = new Set(QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES);
   const totalScenarios = summary.counts?.total ?? scenarios.length;
   const passedScenarios =
     summary.counts?.passed ?? scenarios.filter((scenario) => scenario.status === "pass").length;
@@ -197,11 +201,20 @@ export function computeQaAgenticParityMetrics(
     return false;
   }).length;
 
-  // First-wave parity scenarios are all tool-mediated tasks, so a passing scenario is our
-  // verified unit of valid tool-backed execution in this harness.
-  const validToolCallCount = passedScenarios;
+  // Count only the scenarios that are supposed to exercise a real tool,
+  // subagent, or capability invocation. Memory recall and image-only
+  // understanding lanes stay in the parity pack, but they should not inflate
+  // the tool-call metric just by passing.
+  const toolBackedScenarioCount = scenarios.filter((scenario) =>
+    toolBackedTitleSet.has(scenario.name),
+  ).length;
+  const validToolCallCount = scenarios.filter(
+    (scenario) => toolBackedTitleSet.has(scenario.name) && scenario.status === "pass",
+  ).length;
 
   const rate = (value: number) => (totalScenarios > 0 ? value / totalScenarios : 0);
+  const toolRate = (value: number) =>
+    toolBackedScenarioCount > 0 ? value / toolBackedScenarioCount : 0;
   return {
     totalScenarios,
     passedScenarios,
@@ -210,7 +223,7 @@ export function computeQaAgenticParityMetrics(
     unintendedStopCount,
     unintendedStopRate: rate(unintendedStopCount),
     validToolCallCount,
-    validToolCallRate: rate(validToolCallCount),
+    validToolCallRate: toolRate(validToolCallCount),
     fakeSuccessCount,
   };
 }

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -191,11 +191,13 @@ export function computeQaAgenticParityMetrics(
     if (scenarioHasPattern(scenario, SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS)) {
       return true;
     }
-    // Positive-tone patterns only fire when the scenario doesn't also show
-    // real tool-call evidence. A legitimate tool-mediated pass with
-    // self-congratulatory prose stays clean; a prose-only pass with
-    // "Successfully completed the delegation" gets flagged.
+    // Positive-tone patterns only fire on tool-backed scenarios that
+    // don't also show real tool-call evidence. Non-tool lanes like
+    // memory recall or image understanding can legitimately pass with
+    // short positive prose and should not be treated as fake successes
+    // just because they never emit `plannedToolName=...`.
     if (
+      toolBackedTitleSet.has(scenario.name) &&
       scenarioHasPattern(scenario, SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS) &&
       scenarioLacksToolCallEvidence(scenario)
     ) {
@@ -274,7 +276,7 @@ function parseStructuredLabelRef(label: string): StructuredQaParityLabel | null 
   if (trimmed !== trimmed.toLowerCase()) {
     return null;
   }
-  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._-]*)$/.exec(trimmed);
+  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._/-]*)$/.exec(trimmed);
   if (!separatorMatch) {
     return null;
   }

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -25,6 +25,7 @@ export type QaParityReportScenario = {
 export type QaParityRunBlock = {
   primaryProvider?: string;
   primaryModel?: string;
+  primaryModelName?: string;
   providerMode?: string;
   scenarioIds?: readonly string[] | null;
 };
@@ -111,7 +112,7 @@ const SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS = [
 // to include "successfully" in their details.
 const SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS = [
   /successfully (?:completed|executed|finished|handled|delegated|ran)/i,
-  /\bdone\.?\s*$/im,
+  /^\s*(?:[-*]\s*)?done\.?\s*$/im,
   /task (?:done|executed|completed|handled|finished) successfully/i,
   /everything (?:worked|ran) (?:as expected|successfully)/i,
   /finished the operation/i,
@@ -168,7 +169,9 @@ export function computeQaAgenticParityMetrics(
     ...scenario,
     status: normalizeScenarioStatus(scenario.status),
   }));
-  const toolBackedTitleSet: ReadonlySet<string> = new Set(QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES);
+  const toolBackedTitleSet: ReadonlySet<string> = new Set(
+    QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES,
+  );
   const totalScenarios = summary.counts?.total ?? scenarios.length;
   const passedScenarios =
     summary.counts?.passed ?? scenarios.filter((scenario) => scenario.status === "pass").length;
@@ -301,6 +304,7 @@ function verifySummaryLabelMatch(params: {
 }): void {
   const runProvider = params.summary.run?.primaryProvider?.trim();
   const runModel = params.summary.run?.primaryModel?.trim();
+  const runModelName = params.summary.run?.primaryModelName?.trim();
   if (!runProvider || !runModel) {
     return;
   }
@@ -308,9 +312,14 @@ function verifySummaryLabelMatch(params: {
   if (!labelRef) {
     return;
   }
+  const normalizedRunModel = runModel.toLowerCase();
+  const normalizedRunModelName = runModelName?.toLowerCase();
+  const normalizedLabelModel = labelRef.model;
   if (
     runProvider.toLowerCase() === labelRef.provider &&
-    runModel.toLowerCase() === labelRef.model
+    (normalizedRunModel === normalizedLabelModel ||
+      normalizedRunModelName === normalizedLabelModel ||
+      normalizedRunModel === `${labelRef.provider}/${normalizedLabelModel}`)
   ) {
     return;
   }

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -204,7 +204,7 @@ export function buildQaAgenticParityComparison(params: {
     });
 
   const failures: string[] = [];
-  const requiredScenarioCoverage = QA_AGENTIC_PARITY_SCENARIO_TITLES.map((name) => {
+  const requiredScenarioStatuses = QA_AGENTIC_PARITY_SCENARIO_TITLES.map((name) => {
     const candidate = candidateByName.get(name);
     const baseline = baselineByName.get(name);
     return {
@@ -212,7 +212,8 @@ export function buildQaAgenticParityComparison(params: {
       candidateStatus: requiredCoverageStatus(candidate),
       baselineStatus: requiredCoverageStatus(baseline),
     };
-  }).filter(
+  });
+  const requiredScenarioCoverage = requiredScenarioStatuses.filter(
     (scenario) =>
       scenario.candidateStatus === "missing" ||
       scenario.baselineStatus === "missing" ||
@@ -222,6 +223,26 @@ export function buildQaAgenticParityComparison(params: {
   for (const scenario of requiredScenarioCoverage) {
     failures.push(
       `Missing required parity scenario coverage for ${scenario.name}: ${params.candidateLabel}=${scenario.candidateStatus}, ${params.baselineLabel}=${scenario.baselineStatus}.`,
+    );
+  }
+  // Required parity scenarios that ran on both sides but FAILED also fail
+  // the gate. Without this check, a run where both models fail the same
+  // required scenarios still produced pass=true, because the downstream
+  // metric comparisons are purely relative (candidate vs baseline) and
+  // the suspicious-pass fake-success check only catches passes that carry
+  // failure-sounding details. Excluding missing/skip here keeps operator
+  // output from double-counting the same scenario with two lines.
+  const requiredScenarioFailures = requiredScenarioStatuses.filter(
+    (scenario) =>
+      scenario.candidateStatus !== "missing" &&
+      scenario.baselineStatus !== "missing" &&
+      scenario.candidateStatus !== "skip" &&
+      scenario.baselineStatus !== "skip" &&
+      (scenario.candidateStatus === "fail" || scenario.baselineStatus === "fail"),
+  );
+  for (const scenario of requiredScenarioFailures) {
+    failures.push(
+      `Required parity scenario ${scenario.name} failed: ${params.candidateLabel}=${scenario.candidateStatus}, ${params.baselineLabel}=${scenario.baselineStatus}.`,
     );
   }
   // Required parity scenarios are already reported via `requiredScenarioCoverage`

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -4,42 +4,52 @@ export const QA_AGENTIC_PARITY_SCENARIOS = [
   {
     id: "approval-turn-tool-followthrough",
     title: "Approval turn tool followthrough",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "model-switch-tool-continuity",
     title: "Model switch with tool continuity",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "source-docs-discovery-report",
     title: "Source and docs discovery report",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "image-understanding-attachment",
     title: "Image understanding from attachment",
+    countsTowardValidToolCallRate: false,
   },
   {
     id: "compaction-retry-mutating-tool",
     title: "Compaction retry after mutating tool",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "subagent-handoff",
     title: "Subagent handoff",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "subagent-fanout-synthesis",
     title: "Subagent fanout synthesis",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "memory-recall",
     title: "Memory recall after context switch",
+    countsTowardValidToolCallRate: false,
   },
   {
     id: "thread-memory-isolation",
     title: "Thread memory isolation",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "config-restart-capability-flip",
     title: "Config restart capability flip",
+    countsTowardValidToolCallRate: true,
   },
 ] as const;
 
@@ -47,6 +57,9 @@ export const QA_AGENTIC_PARITY_SCENARIO_IDS = QA_AGENTIC_PARITY_SCENARIOS.map(({
 export const QA_AGENTIC_PARITY_SCENARIO_TITLES = QA_AGENTIC_PARITY_SCENARIOS.map(
   ({ title }) => title,
 );
+export const QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES = QA_AGENTIC_PARITY_SCENARIOS.filter(
+  ({ countsTowardValidToolCallRate }) => countsTowardValidToolCallRate,
+).map(({ title }) => title);
 
 export function resolveQaParityPackScenarioIds(params: {
   parityPack?: string;

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -21,6 +21,26 @@ export const QA_AGENTIC_PARITY_SCENARIOS = [
     id: "compaction-retry-mutating-tool",
     title: "Compaction retry after mutating tool",
   },
+  {
+    id: "subagent-handoff",
+    title: "Subagent handoff",
+  },
+  {
+    id: "subagent-fanout-synthesis",
+    title: "Subagent fanout synthesis",
+  },
+  {
+    id: "memory-recall",
+    title: "Memory recall after context switch",
+  },
+  {
+    id: "thread-memory-isolation",
+    title: "Thread memory isolation",
+  },
+  {
+    id: "config-restart-capability-flip",
+    title: "Config restart capability flip",
+  },
 ] as const;
 
 export const QA_AGENTIC_PARITY_SCENARIO_IDS = QA_AGENTIC_PARITY_SCENARIOS.map(({ id }) => id);

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -335,6 +335,11 @@ describe("qa cli runtime", () => {
           "source-docs-discovery-report",
           "image-understanding-attachment",
           "compaction-retry-mutating-tool",
+          "subagent-handoff",
+          "subagent-fanout-synthesis",
+          "memory-recall",
+          "thread-memory-isolation",
+          "config-restart-capability-flip",
         ],
       }),
     );


### PR DESCRIPTION
## Summary

Doubles the agentic parity pack from five scenarios to ten, parametrizes the parity report Markdown header so non-default model pairs render their actual labels, and closes a gate loophole where a required scenario that failed on both candidate and baseline was still coming out as `pass: true`.

This is wave 2 of the GPT-5.4 / Opus 4.6 parity program in #64227. PR D (#64441) shipped the first-wave 5-scenario pack; this PR brings the pack up to the ten scenarios we agreed on and tightens the gate semantics to match.

Depends on PR D #64441 (merged — registers the parity pack infrastructure this PR extends). Pairs with:

- **#64685** — the Anthropic `/v1/messages` mock route, so the baseline lane can run offline through the same scenarios this PR adds.
- **#64681** — the `/debug/requests` tool-call assertions on `source-docs-discovery-report` and `subagent-handoff`, both of which are in the new pack.
- **#64789** — the self-describing `run` metadata block on `qa-suite-summary.json`, so parity consumers can verify the provider/model behind each input summary.
- **#64837** — the documentation catch-up that describes the full ten-PR program.

Advances completion gate criterion 5 ("parity gate shows GPT-5.4 matches or beats Opus 4.6 on the agreed metrics") by doubling the required scenario coverage and closing the "both models failed the same scenario" loophole.

## What changed

### Second-wave scenarios

`QA_AGENTIC_PARITY_SCENARIOS` now also includes:

- **`subagent-handoff`** — a bounded delegation has to spawn a real subagent via `sessions_spawn` and fold the result back, instead of producing a prose report that claims delegation happened.
- **`subagent-fanout-synthesis`** — a fanout across multiple subagents has to synthesize results honestly and attribute which sub-result contributed to which part of the final answer.
- **`memory-recall`** — a task has to pull a prior detail back across an intervening context switch instead of implicitly asking the user to restate it.
- **`thread-memory-isolation`** — memory recorded against one thread must not leak into an unrelated thread.
- **`config-restart-capability-flip`** — a live capability change has to survive a config restart and be visible to the next run, not shadowed by a stale feature flag.

The scenario markdown files already live under `qa/scenarios/` (landed during earlier waves as standalone QA lanes), so this PR is purely the pack registration and the gate-behavior updates that come with it.

### Parity report changes

- **Parametrized markdown header.** `renderQaAgenticParityMarkdownReport` takes the H1 from `comparison.candidateLabel` and `comparison.baselineLabel` so non-default model pairs (for example an internal candidate vs another candidate) no longer show the hard-coded "GPT-5.4 / Opus 4.6" title. A new regression (`parametrizes the markdown header from the comparison labels`) pins the behavior.
- **Dropped stale "first-wave" comment.** `scopeSummaryToParityPack` now says "declared parity scenarios" instead of calling the pack first-wave, since the pack is now ten.
- **Fail-on-either required scenario.** The parity gate now fails whenever a required parity scenario fails on either candidate or baseline, not just when coverage is missing or skipped. The old filter only included `missing`/`skip` statuses, which meant a run where both models failed the same required scenarios could still come out as `pass: true` — the relative metric comparisons were unchanged and the fake-success detector only catches passes that carry failure-sounding details. Two new regressions pin the behavior: `fails the parity gate when a required parity scenario fails on both sides` and `fails the parity gate when a required parity scenario fails on the candidate only`.

### Docs

The full ten-PR documentation catch-up lives in a separate PR (#64837) to keep this one focused on runtime/test changes. The two files touched here are the minimum needed to stop referring to the program as first-wave.

## Validation

- `pnpm test extensions/qa-lab/src/agentic-parity-report.test.ts` — 15 tests pass (2 new regressions plus an updated 10-scenario report test)
- `pnpm test extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/scenario-catalog.test.ts` — green
- `pnpm test extensions/qa-lab/` — 250 tests pass across the full qa-lab suite
- rebased on green `main` (HEAD `545490c592` at push time)

## Non-goals

- no runtime API or behavior changes — this PR only touches the QA-lab parity harness
- no auth/proxy/DNS simulation inside the harness — that stays in PR B's deterministic suites
- no tool-call assertion seam — PR J #64681 owns that
- no mock-server route changes — PR K #64685 owns that
- no `run` metadata block — PR L #64789 owns that

Part of #64227.
