### PR TITLE
fix: [codex-harness] parse Desktop app-server user agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replay: re-run tool/result pairing after strict replay tool-call ID sanitization on outbound requests so Anthropic-compatible providers like MiniMax no longer receive malformed orphan tool-result IDs such as `...toolresult1` during compaction and retry flows. (#67620) Thanks @stainlu.
 - Gateway/startup: fix spurious SIGUSR1 restart loop on Linux/systemd when plugin auto-enable is the only startup config write; the config hash guard was not captured for that write path, causing chokidar to treat each boot write as an external change and trigger a reload → restart cycle that corrupts manifest.db after repeated cycles. Fixes #67436. (#67557) thanks @openperf
 - OpenAI Codex/CLI: keep resumed `codex exec resume` runs on the safe non-interactive path without reintroducing the removed dangerous bypass flag by passing the supported `--skip-git-repo-check` resume arg that real Codex CLI requires outside trusted git directories. (#67666) Thanks @plgonzalezrx8.
+- Codex/app-server: parse Desktop-originated app-server user agents such as `Codex Desktop/0.118.0`, keeping the version gate working when the Codex CLI inherits a multi-word originator. (#64666) Thanks @cyrusaf.
 
 ## 2026.4.15-beta.1
 

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -200,10 +200,14 @@ describe("CodexAppServerClient", () => {
     expect(process.unref).toHaveBeenCalledTimes(1);
   });
   it("reads the Codex version from the app-server user agent", () => {
+    expect(readCodexVersionFromUserAgent("Codex Desktop/0.118.0")).toBe("0.118.0");
     expect(readCodexVersionFromUserAgent("openclaw/0.118.0 (macOS; test)")).toBe("0.118.0");
     expect(readCodexVersionFromUserAgent("codex_cli_rs/0.118.1-dev (linux; test)")).toBe(
       "0.118.1-dev",
     );
+    expect(readCodexVersionFromUserAgent("Codex Desktop/not-a-version")).toBeUndefined();
+    expect(readCodexVersionFromUserAgent("Codex Desktop/0.118")).toBeUndefined();
+    expect(readCodexVersionFromUserAgent("openclaw/0.118.0abc")).toBeUndefined();
     expect(readCodexVersionFromUserAgent("missing-version")).toBeUndefined();
   });
 

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -373,8 +373,11 @@ function assertSupportedCodexAppServerVersion(response: CodexInitializeResponse)
 
 export function readCodexVersionFromUserAgent(userAgent: string | undefined): string | undefined {
   // Codex returns `<originator>/<codex-version> ...`; the originator can be
-  // OpenClaw or an env override, so only the slash-delimited version is stable.
-  const match = userAgent?.match(/^[^/\s]+\/(\d+\.\d+\.\d+(?:[-+][^\s()]*)?)/);
+  // OpenClaw, Codex Desktop, or an env override, so only the slash-delimited
+  // version in the leading product field is stable.
+  const match = userAgent?.match(
+    /^[^/]+\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)(?:[\s(]|$)/,
+  );
   return match?.[1];
 }
 

--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -9,7 +9,7 @@ import {
   resolvePdfToolMaxTokens,
 } from "./pdf-tool.helpers.js";
 
-const ANTHROPIC_PDF_MODEL = "anthropic/claude-opus-4-6";
+const ANTHROPIC_PDF_MODEL = "anthropic/claude-opus-4-7";
 
 describe("parsePageRange", () => {
   it("parses a single page number", () => {
@@ -117,7 +117,7 @@ describe("pdf-tool.helpers", () => {
     expect(
       coercePdfAssistantText({
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         message: {
           role: "assistant",
           stopReason: "stop",

--- a/src/agents/tools/pdf-tool.model-config.test.ts
+++ b/src/agents/tools/pdf-tool.model-config.test.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolvePdfModelConfigForTool } from "./pdf-tool.model-config.js";
 import { resetPdfToolAuthEnv, withTempPdfAgentDir } from "./pdf-tool.test-support.js";
 
-const ANTHROPIC_PDF_MODEL = "anthropic/claude-opus-4-6";
+const ANTHROPIC_PDF_MODEL = "anthropic/claude-opus-4-7";
 
 function withDefaultModel(primary: string): OpenClawConfig {
   return {


### PR DESCRIPTION
## Summary

- Bug fix for the Codex bundled plugin/app-server integration.
- OpenClaw now accepts supported Codex app-server versions when initialize returns a Desktop-originated user agent such as `Codex Desktop/0.118.0 (...)`.
- The `0.118.0` minimum version gate is unchanged. CLI-shaped user agents still parse, and missing or malformed versions still fail closed.

## Context

Codex app-server reports its version in the leading user-agent product field: `<originator>/<codex-version> ...`.

When OpenClaw spawns the app-server from a normal CLI-style environment, the originator can be a no-whitespace token such as `openclaw`, which matched the existing parser and tests. When OpenClaw runs from a Codex Desktop-originated environment, it inherits `CODEX_INTERNAL_ORIGINATOR_OVERRIDE=Codex Desktop`; the same app-server then reports a leading product like `Codex Desktop/0.118.0 (...)`.

That Desktop originator is valid for the app-server, but OpenClaw treated it as unknown because the parser rejected whitespace before `/`.

## Root Cause

`readCodexVersionFromUserAgent()` required the product/originator before `/` to match a no-whitespace token. That made `Codex Desktop/0.118.0` return `undefined`, which tripped the compatibility diagnostic even though the version itself satisfied the minimum.

The fix parses the leading slash-delimited semver while allowing spaces in the originator. It still requires a semver-like version and a clean delimiter/end boundary after the version.

## Testing

- `pnpm test extensions/codex/src/app-server/client.test.ts`
- `pnpm test extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/models.test.ts extensions/codex/src/app-server/transport-websocket.test.ts`
- `pnpm check` via `scripts/committer`

## Manual Verification

- In a Codex Desktop-originated environment with `CODEX_INTERNAL_ORIGINATOR_OVERRIDE=Codex Desktop`, a real local `codex app-server --listen stdio://` initialize response returned `Codex Desktop/0.118.0 (Mac OS 26.4.0; arm64) dumb (openclaw; e2e-local)`.
- OpenClaw's built app-server client initialized successfully against that server and `listCodexAppServerModels()` returned models.

## Security / Compatibility

No new permissions, token handling, network calls, command execution surface, config/env changes, or migration. Backward compatible.
