### PR TITLE
fix: [codex-harness] avoid treating cumulative app-server usage as current context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Agents/channels: route cross-agent subagent spawns through the target agent's bound channel account while preserving peer and workspace/role-scoped bindings, so child sessions no longer inherit the caller's account in shared rooms, workspaces, or multi-account setups. (#67508) Thanks @lukeboyett and @gumadeiras.
 - Telegram/callbacks: treat permanent callback edit errors as completed updates so stale command pagination buttons no longer wedge the update watermark and block newer Telegram updates. (#68588) Thanks @Lucenx9.
 - Browser/CDP: allow the selected remote CDP profile host for CDP health and control checks without widening browser navigation SSRF policy, so WSL-to-Windows Chrome endpoints no longer appear offline under strict defaults. Fixes #68108. (#68207) Thanks @Mlightsnow.
+- Codex: stop cumulative app-server token totals from being treated as fresh context usage, so session status no longer reports inflated context percentages after long Codex threads. (#64669) Thanks @cyrusaf.
 
 ## 2026.4.18
 

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -50,7 +50,13 @@ describe("CodexAppServerEventProjector", () => {
         turnId: "turn-1",
         tokenUsage: {
           total: {
-            totalTokens: 12,
+            totalTokens: 900_000,
+            inputTokens: 700_000,
+            cachedInputTokens: 100_000,
+            outputTokens: 100_000,
+          },
+          last: {
+            totalTokens: 14,
             inputTokens: 5,
             cachedInputTokens: 2,
             outputTokens: 7,
@@ -83,8 +89,96 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.assistantTexts).toEqual(["hello"]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "hello" }]);
-    expect(result.attemptUsage).toMatchObject({ input: 5, output: 7, cacheRead: 2, total: 12 });
+    expect(result.attemptUsage).toMatchObject({ input: 5, output: 7, cacheRead: 2, total: 14 });
+    expect(result.lastAssistant?.usage).toMatchObject({
+      input: 5,
+      output: 7,
+      cacheRead: 2,
+      totalTokens: 14,
+    });
     expect(result.replayMetadata.replaySafe).toBe(true);
+  });
+
+  it("does not treat cumulative-only token usage as fresh context usage", async () => {
+    const params = createParams();
+    const projector = new CodexAppServerEventProjector(params, "thread-1", "turn-1");
+
+    await projector.handleNotification({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-1", itemId: "msg-1", delta: "done" },
+    });
+    await projector.handleNotification({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          total: {
+            totalTokens: 1_000_000,
+            inputTokens: 999_000,
+            cachedInputTokens: 500,
+            outputTokens: 500,
+          },
+        },
+      },
+    });
+
+    const result = projector.buildResult({
+      didSendViaMessagingTool: false,
+      messagingToolSentTexts: [],
+      messagingToolSentMediaUrls: [],
+      messagingToolSentTargets: [],
+    });
+
+    expect(result.assistantTexts).toEqual(["done"]);
+    expect(result.attemptUsage).toBeUndefined();
+    expect(result.lastAssistant?.usage).toMatchObject({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      totalTokens: 0,
+    });
+  });
+
+  it("normalizes snake_case current token usage fields", async () => {
+    const params = createParams();
+    const projector = new CodexAppServerEventProjector(params, "thread-1", "turn-1");
+
+    await projector.handleNotification({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-1", itemId: "msg-1", delta: "done" },
+    });
+    await projector.handleNotification({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          total: { total_tokens: 1_000_000 },
+          last_token_usage: {
+            total_tokens: 20,
+            input_tokens: 8,
+            cached_input_tokens: 3,
+            output_tokens: 9,
+          },
+        },
+      },
+    });
+
+    const result = projector.buildResult({
+      didSendViaMessagingTool: false,
+      messagingToolSentTexts: [],
+      messagingToolSentMediaUrls: [],
+      messagingToolSentTargets: [],
+    });
+
+    expect(result.attemptUsage).toMatchObject({ input: 8, output: 9, cacheRead: 3, total: 20 });
+    expect(result.lastAssistant?.usage).toMatchObject({
+      input: 8,
+      output: 9,
+      cacheRead: 3,
+      totalTokens: 20,
+    });
   });
 
   it("keeps intermediate agentMessage items out of the final visible reply", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -42,6 +42,15 @@ const ZERO_USAGE: Usage = {
   },
 };
 
+const CURRENT_TOKEN_USAGE_KEYS = [
+  "last",
+  "current",
+  "lastCall",
+  "lastCallUsage",
+  "lastTokenUsage",
+  "last_token_usage",
+] as const;
+
 export class CodexAppServerEventProjector {
   private readonly assistantTextByItem = new Map<string, string>();
   private readonly assistantItemOrder: string[] = [];
@@ -327,16 +336,16 @@ export class CodexAppServerEventProjector {
 
   private handleTokenUsage(params: JsonObject): void {
     const tokenUsage = isJsonObject(params.tokenUsage) ? params.tokenUsage : undefined;
-    const total = tokenUsage && isJsonObject(tokenUsage.total) ? tokenUsage.total : undefined;
-    if (!total) {
+    const current =
+      (tokenUsage ? readFirstJsonObject(tokenUsage, CURRENT_TOKEN_USAGE_KEYS) : undefined) ??
+      readFirstJsonObject(params, CURRENT_TOKEN_USAGE_KEYS);
+    if (!current) {
       return;
     }
-    this.tokenUsage = normalizeUsage({
-      input: readNumber(total, "inputTokens"),
-      output: readNumber(total, "outputTokens"),
-      cacheRead: readNumber(total, "cachedInputTokens"),
-      total: readNumber(total, "totalTokens"),
-    });
+    const usage = normalizeCodexTokenUsage(current);
+    if (usage) {
+      this.tokenUsage = usage;
+    }
   }
 
   private async handleTurnCompleted(params: JsonObject): Promise<void> {
@@ -522,6 +531,48 @@ function readNullableString(record: JsonObject, key: string): string | null | un
 function readNumber(record: JsonObject, key: string): number | undefined {
   const value = record[key];
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readFirstJsonObject(record: JsonObject, keys: readonly string[]): JsonObject | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (isJsonObject(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readNumberAlias(record: JsonObject, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const value = readNumber(record, key);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeCodexTokenUsage(record: JsonObject): NormalizedUsage | undefined {
+  return normalizeUsage({
+    input: readNumberAlias(record, ["inputTokens", "input_tokens", "input", "promptTokens"]),
+    output: readNumberAlias(record, ["outputTokens", "output_tokens", "output"]),
+    cacheRead: readNumberAlias(record, [
+      "cachedInputTokens",
+      "cached_input_tokens",
+      "cacheRead",
+      "cache_read",
+      "cache_read_input_tokens",
+      "cached_tokens",
+    ]),
+    cacheWrite: readNumberAlias(record, [
+      "cacheWrite",
+      "cache_write",
+      "cacheCreationInputTokens",
+      "cache_creation_input_tokens",
+    ]),
+    total: readNumberAlias(record, ["totalTokens", "total_tokens", "total"]),
+  });
 }
 
 function splitPlanText(text: string): string[] {


### PR DESCRIPTION
## Summary

- Problem: Codex app-server token usage projection used cumulative `tokenUsage.total` as assistant/attempt usage.
- Why it matters: downstream session accounting treats assistant/attempt usage as fresh current context-window usage, so cumulative Codex totals can inflate `totalTokens` and make `/status` show values like `999%`.
- What changed: Codex app-server projection now uses explicit current/last usage fields when available and normalizes both camelCase app-server fields and snake_case Codex-native usage fields.
- What did NOT change (scope boundary): this does not change generic session/status accounting, native compaction behavior, transcript fallback, billing aggregation, reset behavior, or Codex app-server startup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex app-server event projector treated `tokenUsage.total` as if it were the current turn/current call usage snapshot.
- Missing detection / guardrail: existing projector tests only covered a `tokenUsage.total` fixture and did not assert that cumulative totals must not populate assistant/attempt usage.
- Contributing context: OpenClaw downstream accounting intentionally uses assistant `usage`, `attemptUsage`, `lastCallUsage`, and `promptTokens` as current context-window snapshots, not cumulative thread/billing totals.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/event-projector.test.ts`
- Scenario the test should lock in: when a token usage notification has both cumulative and current usage, assistant/attempt usage uses the current usage; when only a huge cumulative total is present, it is not projected as fresh context usage.
- Why this is the smallest reliable guardrail: the bug occurs at the Codex app-server projection boundary before downstream session/status accounting sees the usage, so this test catches the bad value at the source.
- Existing test that already covers this (if any): existing projector tests continue to cover assistant text, plan, compaction, and tool metadata projection.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex-backed sessions should no longer persist cumulative app-server token totals as fresh context-window usage. This prevents inflated session context percentages in status output when only cumulative usage is available.

## Diagram (if applicable)

```text
Before:
thread/tokenUsage/updated
  -> tokenUsage.total
  -> assistant usage / attemptUsage
  -> lastCallUsage / promptTokens
  -> SessionEntry.totalTokens
  -> /status inflated context

After:
thread/tokenUsage/updated
  -> explicit current/last usage
  -> assistant usage / attemptUsage
  -> lastCallUsage / promptTokens
  -> SessionEntry.totalTokens

cumulative-only total
  -> ignored for fresh context accounting
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo test runner
- Model/provider: Codex app-server projection path
- Integration/channel (if any): Codex bundled plugin
- Relevant config (redacted): N/A

### Steps

1. Project a `thread/tokenUsage/updated` notification containing a large cumulative `tokenUsage.total` and a smaller current/last usage object.
2. Build the embedded attempt result.
3. Inspect `attemptUsage` and the final assistant message `usage`.

### Expected

- Current/last usage is projected into assistant/attempt usage.
- Cumulative-only totals are not treated as fresh context-window usage.

### Actual

- Before this fix, `tokenUsage.total` was projected into assistant/attempt usage.
- After this fix, cumulative-only totals are ignored for context accounting unless an explicit current/last usage field is present.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Verified scenarios:
  - `pnpm test extensions/codex/src/app-server/event-projector.test.ts`
  - `pnpm test extensions/codex`
  - pre-commit `pnpm check`
- Edge cases checked:
  - both cumulative and current usage are present
  - cumulative-only usage is huge
  - assistant text projection still works
  - plan/tool/compaction projection tests still pass
- What I did **not** verify:
  - live Codex app-server session against Codex Desktop
  - full repo test suite

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: if an older app-server only emits cumulative usage and no current/last usage field, OpenClaw will no longer show token context usage from that notification.
  - Mitigation: unknown context usage is safer than persisting cumulative billing/thread totals as fresh context-window usage; downstream already supports missing usage.
