### PR TITLE
fix(email-triage): schema refactor, P1 check_db_initialized bug, smoke tests (supersedes #63546)

### DIFF
--- a/skills/email-triage/SKILL.md
+++ b/skills/email-triage/SKILL.md
@@ -1,37 +1,66 @@
-# 📧 Email Triage Skill
+---
+name: email-triage
+description: "Triage multi-account email via AI-powered sync, priority filtering, and pending-attention tracking. Trigger when asked to check, sync, or dismiss emails."
+metadata: { "openclaw": { "emoji": "📧", "requires": { "bins": ["python3"] } } }
+---
 
-该 Skill 基于 `email-ingest-integration` 项目，通过 AI 对多账号邮件进行抓取、分拣和待办管理。
+# Email Triage
 
-## 🛠️ 配置说明
-- **代码库**: `/home/node/.openclaw/workspace/email-ingest-integration`
-- **凭证**: 优先读取 `/home/node/.openclaw/workspace/email-ingest-integration/.env`
-- **状态维护**: `/home/node/.openclaw/workspace/memory/email_triage_state.json`
+Sync multi-account emails, filter high-priority items, and manage a pending-attention queue.
 
-## 🕹️ Tools
+## Prerequisites
 
-### `email_sync`
-同步最新邮件。
-- **逻辑**: 如果是首次运行，自动使用前一天的日期作为 `init-start-date`。
-- **自动化**: 建议在 OpenClaw Cron 中每 4 小时运行一次。
+1. The `email-ingest-integration` project must be set up at the path in `EMAIL_TRIAGE_WORKSPACE` (defaults to `~/.openclaw/workspace/email-ingest-integration`).
+2. A Python virtualenv with dependencies must exist at `<workspace>/venv`.
+3. Credentials configured in `<workspace>/.env`.
 
-### `email_pending`
-列出所有标记为 `High` 优先级且尚未处理的邮件。
-- **输出**: 包含邮件主题、发件人、AI 摘要及待办状态。
+## Commands
 
-### `email_dismiss` (id: number)
-将指定的邮件从待办清单中移除（标记为已处理）。
+### Sync emails
 
-## 🤖 Discord 交互 (Buttons)
-当报告新邮件时，每封邮件摘要下方会附带一个 `Ack` 按钮。
-- **Action**: 点击按钮后执行 `email_dismiss(id)`。
-- **反馈**: 按钮点击后消息会更新为“已确认处理”。
+```bash
+python3 {baseDir}/scripts/triage.py sync
+```
 
-## 📄 状态结构 (State)
+Ingests new emails from all configured accounts. On first run (empty database), automatically fetches from yesterday onward. After ingestion, queries for new emails and adds them to the pending-attention list. Outputs a JSON-formatted status summary.
+
+### List pending emails
+
+```bash
+python3 {baseDir}/scripts/triage.py pending
+```
+
+Prints all pending high-priority emails as JSON. Each entry includes `id`, `subject`, `sender`, `summary`, and `status`.
+
+### Dismiss an email
+
+```bash
+python3 {baseDir}/scripts/triage.py dismiss <email_id>
+```
+
+Removes the specified email from the pending-attention queue by ID.
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EMAIL_TRIAGE_WORKSPACE` | `~/.openclaw/workspace/email-ingest-integration` | Path to the email-ingest-integration project |
+| `EMAIL_TRIAGE_STATE` | `~/.openclaw/workspace/memory/email_triage_state.json` | Path to the state file |
+
+## State
+
+State is stored at the path configured by `EMAIL_TRIAGE_STATE`:
+
 ```json
 {
   "cursor": { "last_ingested_id": 123 },
   "pending_attention": [
-    { "id": 124, "subject": "...", "status": "notified" }
+    { "id": 124, "subject": "...", "sender": "...", "priority": "High", "summary": "...", "status": "pending" }
   ]
 }
 ```
+
+## Notes
+
+- Run `sync` periodically (every 4 hours recommended via OpenClaw Cron).
+- Dismissed items are permanently removed from the pending list.

--- a/skills/email-triage/SKILL.md
+++ b/skills/email-triage/SKILL.md
@@ -10,8 +10,8 @@ Sync multi-account emails, filter high-priority items, and manage a pending-atte
 
 ## Prerequisites
 
-1. The `email-ingest-integration` project must be set up at the path in `EMAIL_TRIAGE_WORKSPACE` (defaults to `~/.openclaw/workspace/email-ingest-integration`).
-2. A Python virtualenv with dependencies must exist at `<workspace>/venv`.
+1. The `email-ingest-integration` project must be set up at the path in `EMAIL_TRIAGE_WORKSPACE` (defaults to `~/.openclaw/workspace/email-ingest-integration`). Requires upstream revision with [Anthrop-OS/email-ingest#18](https://github.com/Anthrop-OS/email-ingest/pull/18) (`main.py status` subcommand) — the skill shells out to that to detect first-run state and no longer opens the upstream SQLite file directly.
+2. A Python virtualenv with dependencies must exist at `<workspace>/venv`, or set `EMAIL_TRIAGE_VENV_PYTHON` to point at an alternative interpreter.
 3. Credentials configured in `<workspace>/.env`.
 
 ## Commands
@@ -46,6 +46,7 @@ Removes the specified email from the pending-attention queue by ID.
 |----------|---------|---------|
 | `EMAIL_TRIAGE_WORKSPACE` | `~/.openclaw/workspace/email-ingest-integration` | Path to the email-ingest-integration project |
 | `EMAIL_TRIAGE_STATE` | `~/.openclaw/workspace/memory/email_triage_state.json` | Path to the state file |
+| `EMAIL_TRIAGE_VENV_PYTHON` | `$EMAIL_TRIAGE_WORKSPACE/venv/bin/python3` | Python interpreter used to invoke the ingest CLI. Override this on Windows (`venv/Scripts/python.exe`) or in CI/test environments that do not have a real venv. |
 
 ## State
 

--- a/skills/email-triage/SKILL.md
+++ b/skills/email-triage/SKILL.md
@@ -1,0 +1,37 @@
+# 📧 Email Triage Skill
+
+该 Skill 基于 `email-ingest-integration` 项目，通过 AI 对多账号邮件进行抓取、分拣和待办管理。
+
+## 🛠️ 配置说明
+- **代码库**: `/home/node/.openclaw/workspace/email-ingest-integration`
+- **凭证**: 优先读取 `/home/node/.openclaw/workspace/email-ingest-integration/.env`
+- **状态维护**: `/home/node/.openclaw/workspace/memory/email_triage_state.json`
+
+## 🕹️ Tools
+
+### `email_sync`
+同步最新邮件。
+- **逻辑**: 如果是首次运行，自动使用前一天的日期作为 `init-start-date`。
+- **自动化**: 建议在 OpenClaw Cron 中每 4 小时运行一次。
+
+### `email_pending`
+列出所有标记为 `High` 优先级且尚未处理的邮件。
+- **输出**: 包含邮件主题、发件人、AI 摘要及待办状态。
+
+### `email_dismiss` (id: number)
+将指定的邮件从待办清单中移除（标记为已处理）。
+
+## 🤖 Discord 交互 (Buttons)
+当报告新邮件时，每封邮件摘要下方会附带一个 `Ack` 按钮。
+- **Action**: 点击按钮后执行 `email_dismiss(id)`。
+- **反馈**: 按钮点击后消息会更新为“已确认处理”。
+
+## 📄 状态结构 (State)
+```json
+{
+  "cursor": { "last_ingested_id": 123 },
+  "pending_attention": [
+    { "id": 124, "subject": "...", "status": "notified" }
+  ]
+}
+```

--- a/skills/email-triage/SKILL.md
+++ b/skills/email-triage/SKILL.md
@@ -30,7 +30,7 @@ Ingests new emails from all configured accounts. On first run (empty database), 
 python3 {baseDir}/scripts/triage.py pending
 ```
 
-Prints all pending high-priority emails as JSON. Each entry includes `id`, `subject`, `sender`, `summary`, and `status`.
+Prints all pending high-priority emails as JSON (priority >= High, i.e. High/Urgent/Critical). Each entry includes `id`, `subject`, `sender`, `summary`, and `status`. Numeric priorities are also supported (>= 3).
 
 ### Dismiss an email
 

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -12,6 +12,40 @@ from unittest.mock import patch
 import triage
 
 
+class TestIsHighPriority(TestCase):
+    def test_string_high(self):
+        self.assertTrue(triage._is_high_priority("High"))
+        self.assertTrue(triage._is_high_priority("high"))
+        self.assertTrue(triage._is_high_priority("HIGH"))
+
+    def test_string_above_high(self):
+        self.assertTrue(triage._is_high_priority("Urgent"))
+        self.assertTrue(triage._is_high_priority("Critical"))
+
+    def test_string_below_high(self):
+        self.assertFalse(triage._is_high_priority("Low"))
+        self.assertFalse(triage._is_high_priority("Normal"))
+        self.assertFalse(triage._is_high_priority("Medium"))
+
+    def test_string_unknown(self):
+        self.assertFalse(triage._is_high_priority(""))
+        self.assertFalse(triage._is_high_priority("other"))
+
+    def test_numeric_at_threshold(self):
+        self.assertTrue(triage._is_high_priority(3))
+        self.assertTrue(triage._is_high_priority(4))
+        self.assertTrue(triage._is_high_priority(5))
+
+    def test_numeric_below_threshold(self):
+        self.assertFalse(triage._is_high_priority(1))
+        self.assertFalse(triage._is_high_priority(2))
+        self.assertFalse(triage._is_high_priority(0))
+
+    def test_numeric_float(self):
+        self.assertTrue(triage._is_high_priority(3.5))
+        self.assertFalse(triage._is_high_priority(2.9))
+
+
 class TestState(TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -232,15 +266,17 @@ class TestSync(TestCase):
 
     @patch("triage.subprocess.run")
     def test_sync_filters_non_high_priority(self, mock_run):
-        """Only high-priority emails should be enqueued."""
+        """Only emails with priority >= High should be enqueued."""
         ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
         query_data = {
             "results": [
-                {"id": 1, "subject": "Urgent", "priority": "High", "sender": "a@b.com"},
-                {"id": 2, "subject": "FYI", "priority": "Low", "sender": "c@d.com"},
-                {"id": 3, "subject": "Normal", "priority": "Normal", "sender": "e@f.com"},
+                {"id": 1, "subject": "Fire", "priority": "Urgent", "sender": "a@b.com"},
+                {"id": 2, "subject": "Important", "priority": "High", "sender": "b@c.com"},
+                {"id": 3, "subject": "FYI", "priority": "Low", "sender": "c@d.com"},
+                {"id": 4, "subject": "Normal", "priority": "Normal", "sender": "e@f.com"},
+                {"id": 5, "subject": "Meltdown", "priority": "Critical", "sender": "f@g.com"},
             ],
-            "meta": {"max_id": 3},
+            "meta": {"max_id": 5},
         }
         query_result = type(
             "R", (), {"returncode": 0, "stdout": json.dumps(query_data), "stderr": ""}
@@ -250,8 +286,32 @@ class TestSync(TestCase):
         triage.sync()
 
         state = triage.get_state()
-        self.assertEqual(len(state["pending_attention"]), 1)
-        self.assertEqual(state["pending_attention"][0]["subject"], "Urgent")
+        subjects = [item["subject"] for item in state["pending_attention"]]
+        self.assertEqual(subjects, ["Fire", "Important", "Meltdown"])
+
+    @patch("triage.subprocess.run")
+    def test_sync_numeric_priority(self, mock_run):
+        """Numeric priorities >= 3 (High) should be enqueued."""
+        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        query_data = {
+            "results": [
+                {"id": 1, "subject": "P4", "priority": 4, "sender": "a@b.com"},
+                {"id": 2, "subject": "P3", "priority": 3, "sender": "b@c.com"},
+                {"id": 3, "subject": "P2", "priority": 2, "sender": "c@d.com"},
+                {"id": 4, "subject": "P1", "priority": 1, "sender": "d@e.com"},
+            ],
+            "meta": {"max_id": 4},
+        }
+        query_result = type(
+            "R", (), {"returncode": 0, "stdout": json.dumps(query_data), "stderr": ""}
+        )()
+        mock_run.side_effect = [ingest_result, query_result]
+
+        triage.sync()
+
+        state = triage.get_state()
+        subjects = [item["subject"] for item in state["pending_attention"]]
+        self.assertEqual(subjects, ["P4", "P3"])
 
     @patch("triage.subprocess.run")
     def test_sync_bad_json(self, mock_run):

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -122,6 +122,44 @@ class TestState(TestCase):
         self.assertEqual(state["cursor"]["last_ingested_id"], 0)
         self.assertEqual(state["pending_attention"], [])
 
+    def test_get_state_pending_filters_non_dict_entries(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w") as f:
+            json.dump(
+                {
+                    "cursor": {"last_ingested_id": 0},
+                    "pending_attention": [
+                        {"id": 1, "status": "pending"},
+                        1,
+                        "not a dict",
+                        None,
+                        [1, 2],
+                        {"id": 2, "status": "pending"},
+                    ],
+                },
+                f,
+            )
+        state = triage.get_state()
+        self.assertEqual([i["id"] for i in state["pending_attention"]], [1, 2])
+
+    def test_get_state_pending_filters_dict_without_id(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w") as f:
+            json.dump(
+                {
+                    "cursor": {"last_ingested_id": 0},
+                    "pending_attention": [
+                        {},
+                        {"subject": "no id"},
+                        {"id": 5, "subject": "ok"},
+                    ],
+                },
+                f,
+            )
+        state = triage.get_state()
+        self.assertEqual(len(state["pending_attention"]), 1)
+        self.assertEqual(state["pending_attention"][0]["id"], 5)
+
     def test_save_state_bare_filename(self):
         """save_state should work when STATE_PATH has no directory component."""
         bare_path = os.path.join(self.tmpdir, "state.json")

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -56,6 +56,13 @@ class TestState(TestCase):
         self.assertEqual(state["cursor"]["last_ingested_id"], 0)
         self.assertEqual(state["pending_attention"], [])
 
+    def test_save_state_bare_filename(self):
+        """save_state should work when STATE_PATH has no directory component."""
+        bare_path = os.path.join(self.tmpdir, "state.json")
+        with patch.object(triage, "STATE_PATH", bare_path):
+            triage.save_state({"cursor": {"last_ingested_id": 0}, "pending_attention": []})
+            self.assertTrue(os.path.exists(bare_path))
+
 
 class TestCheckDb(TestCase):
     def setUp(self):
@@ -231,6 +238,14 @@ class TestSync(TestCase):
             "R", (), {"returncode": 0, "stdout": "not json", "stderr": ""}
         )()
         mock_run.side_effect = [ingest_result, query_result]
+
+        # Should print error, not raise
+        triage.sync()
+
+    @patch("triage.subprocess.run")
+    def test_sync_missing_workspace(self, mock_run):
+        """Sync should handle missing workspace/venv gracefully."""
+        mock_run.side_effect = FileNotFoundError("No such file or directory: 'python3'")
 
         # Should print error, not raise
         triage.sync()

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -4,7 +4,6 @@
 import json
 import os
 import shutil
-import sqlite3
 import tempfile
 from unittest import TestCase, main
 from unittest.mock import patch
@@ -46,6 +45,33 @@ class TestIsHighPriority(TestCase):
         self.assertFalse(triage._is_high_priority(2.9))
 
 
+class TestPendingItemFromDict(TestCase):
+    def test_valid_dict(self):
+        item = triage.PendingItem.from_dict(
+            {"id": 42, "subject": "Hi", "sender": "a@b.com", "priority": "High"}
+        )
+        self.assertIsNotNone(item)
+        self.assertEqual(item.id, "42")  # normalized to str
+        self.assertEqual(item.subject, "Hi")
+        self.assertEqual(item.status, "pending")  # default
+
+    def test_non_dict_returns_none(self):
+        self.assertIsNone(triage.PendingItem.from_dict(None))
+        self.assertIsNone(triage.PendingItem.from_dict(1))
+        self.assertIsNone(triage.PendingItem.from_dict("string"))
+        self.assertIsNone(triage.PendingItem.from_dict([1, 2]))
+
+    def test_missing_id_returns_none(self):
+        self.assertIsNone(triage.PendingItem.from_dict({}))
+        self.assertIsNone(triage.PendingItem.from_dict({"subject": "no id"}))
+        self.assertIsNone(triage.PendingItem.from_dict({"id": None}))
+
+    def test_id_coerced_to_str(self):
+        self.assertEqual(triage.PendingItem.from_dict({"id": 10}).id, "10")
+        self.assertEqual(triage.PendingItem.from_dict({"id": "10"}).id, "10")
+        self.assertEqual(triage.PendingItem.from_dict({"id": "abc-123"}).id, "abc-123")
+
+
 class TestState(TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -59,72 +85,80 @@ class TestState(TestCase):
 
     def test_get_state_missing_file(self):
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
-        self.assertEqual(state["pending_attention"], [])
+        self.assertEqual(state.cursor.last_ingested_id, 0)
+        self.assertEqual(state.pending_attention, [])
 
     def test_get_state_existing_file(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
         data = {"cursor": {"last_ingested_id": 42}, "pending_attention": [{"id": 1}]}
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             json.dump(data, f)
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 42)
-        self.assertEqual(len(state["pending_attention"]), 1)
+        self.assertEqual(state.cursor.last_ingested_id, 42)
+        self.assertEqual(len(state.pending_attention), 1)
+        self.assertEqual(state.pending_attention[0].id, "1")
 
     def test_save_state_creates_dir(self):
         self.assertFalse(os.path.exists(os.path.dirname(self.state_path)))
-        triage.save_state({"cursor": {"last_ingested_id": 0}, "pending_attention": []})
+        triage.save_state(triage.State())
         self.assertTrue(os.path.exists(self.state_path))
 
     def test_save_state_roundtrip(self):
-        data = {"cursor": {"last_ingested_id": 99}, "pending_attention": [{"id": 7}]}
-        triage.save_state(data)
+        orig = triage.State(
+            cursor=triage.Cursor(last_ingested_id=99),
+            pending_attention=[triage.PendingItem(id="7", subject="hello")],
+        )
+        triage.save_state(orig)
         loaded = triage.get_state()
-        self.assertEqual(loaded, data)
+        self.assertEqual(loaded.cursor.last_ingested_id, 99)
+        self.assertEqual(len(loaded.pending_attention), 1)
+        self.assertEqual(loaded.pending_attention[0].id, "7")
+        self.assertEqual(loaded.pending_attention[0].subject, "hello")
 
     def test_get_state_corrupt_json(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             f.write("{bad json")
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
-        self.assertEqual(state["pending_attention"], [])
+        self.assertEqual(state.cursor.last_ingested_id, 0)
+        self.assertEqual(state.pending_attention, [])
 
     def test_get_state_empty_object(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             json.dump({}, f)
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
-        self.assertEqual(state["pending_attention"], [])
+        self.assertEqual(state.cursor.last_ingested_id, 0)
+        self.assertEqual(state.pending_attention, [])
 
     def test_get_state_missing_cursor(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             json.dump({"pending_attention": [{"id": 1}]}, f)
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
-        self.assertEqual(state["pending_attention"], [{"id": 1}])
+        self.assertEqual(state.cursor.last_ingested_id, 0)
+        self.assertEqual(len(state.pending_attention), 1)
+        self.assertEqual(state.pending_attention[0].id, "1")
 
     def test_get_state_missing_pending(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             json.dump({"cursor": {"last_ingested_id": 10}}, f)
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 10)
-        self.assertEqual(state["pending_attention"], [])
+        self.assertEqual(state.cursor.last_ingested_id, 10)
+        self.assertEqual(state.pending_attention, [])
 
     def test_get_state_non_dict(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             json.dump([1, 2, 3], f)
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
-        self.assertEqual(state["pending_attention"], [])
+        self.assertEqual(state.cursor.last_ingested_id, 0)
+        self.assertEqual(state.pending_attention, [])
 
     def test_get_state_pending_filters_non_dict_entries(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             json.dump(
                 {
                     "cursor": {"last_ingested_id": 0},
@@ -140,11 +174,11 @@ class TestState(TestCase):
                 f,
             )
         state = triage.get_state()
-        self.assertEqual([i["id"] for i in state["pending_attention"]], [1, 2])
+        self.assertEqual([i.id for i in state.pending_attention], ["1", "2"])
 
     def test_get_state_pending_filters_dict_without_id(self):
         os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
-        with open(self.state_path, "w") as f:
+        with open(self.state_path, "w", encoding="utf-8") as f:
             json.dump(
                 {
                     "cursor": {"last_ingested_id": 0},
@@ -157,49 +191,125 @@ class TestState(TestCase):
                 f,
             )
         state = triage.get_state()
-        self.assertEqual(len(state["pending_attention"]), 1)
-        self.assertEqual(state["pending_attention"][0]["id"], 5)
+        self.assertEqual(len(state.pending_attention), 1)
+        self.assertEqual(state.pending_attention[0].id, "5")
 
     def test_save_state_bare_filename(self):
         """save_state should work when STATE_PATH has no directory component."""
         bare_path = os.path.join(self.tmpdir, "state.json")
         with patch.object(triage, "STATE_PATH", bare_path):
-            triage.save_state({"cursor": {"last_ingested_id": 0}, "pending_attention": []})
+            triage.save_state(triage.State())
             self.assertTrue(os.path.exists(bare_path))
+
+    def test_get_state_cursor_non_int(self):
+        """Cursor with non-int last_ingested_id should fall back to 0."""
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w", encoding="utf-8") as f:
+            json.dump({"cursor": {"last_ingested_id": "not an int"}}, f)
+        state = triage.get_state()
+        self.assertEqual(state.cursor.last_ingested_id, 0)
+
+    def test_save_state_utf8(self):
+        """State file must be written as UTF-8 (not platform default)."""
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        triage.save_state(
+            triage.State(
+                pending_attention=[
+                    triage.PendingItem(id="1", subject="你好 — привет — مرحبا")
+                ]
+            )
+        )
+        with open(self.state_path, "rb") as f:
+            raw = f.read()
+        # Should contain the UTF-8 bytes, not be garbled
+        self.assertIn("你好".encode("utf-8"), raw)
+        loaded = triage.get_state()
+        self.assertEqual(loaded.pending_attention[0].subject, "你好 — привет — مرحبا")
 
 
 class TestCheckDb(TestCase):
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-        self.db_path = os.path.join(self.tmpdir, "test.sqlite")
-        self._patch = patch.object(triage, "DB_PATH", self.db_path)
-        self._patch.start()
+    """Tests for check_db_initialized().
 
-    def tearDown(self):
-        self._patch.stop()
-        shutil.rmtree(self.tmpdir)
+    This helper used to ``sqlite3.connect()`` the upstream DB and run a
+    hardcoded query against a table name that had been confused with a
+    config.yaml key. The first version queried ``email_accounts`` which
+    does not exist as a SQLite table — every call raised
+    ``OperationalError``, was swallowed by a broad ``except``, and the
+    function always returned False, so every sync wrongly appended
+    ``--init-start-date yesterday``.
 
-    def test_no_db_file(self):
-        self.assertFalse(triage.check_db_initialized())
+    The current implementation shells out to ``main.py status`` (added
+    in Anthrop-OS/email-ingest#18) so the skill never opens the SQLite
+    file directly. These tests exercise every branch of the new flow.
+    """
 
-    def test_empty_db(self):
-        conn = sqlite3.connect(self.db_path)
-        conn.execute("CREATE TABLE email_accounts (id INTEGER PRIMARY KEY)")
-        conn.commit()
-        conn.close()
-        self.assertFalse(triage.check_db_initialized())
-
-    def test_initialized_db(self):
-        conn = sqlite3.connect(self.db_path)
-        conn.execute("CREATE TABLE email_accounts (id INTEGER PRIMARY KEY)")
-        conn.execute("INSERT INTO email_accounts (id) VALUES (1)")
-        conn.commit()
-        conn.close()
+    @patch("triage.subprocess.run")
+    def test_initialized_true_when_status_says_so(self, mock_run):
+        mock_run.return_value = type(
+            "R",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "initialized": True,
+                        "accounts": [{"account_id": "a", "last_uid": 10}],
+                        "db_path": "/tmp/db.sqlite",
+                    }
+                ),
+                "stderr": "",
+            },
+        )()
         self.assertTrue(triage.check_db_initialized())
 
-    def test_corrupt_db(self):
-        with open(self.db_path, "w") as f:
-            f.write("not a database")
+    @patch("triage.subprocess.run")
+    def test_initialized_false_when_status_empty(self, mock_run):
+        mock_run.return_value = type(
+            "R",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {"initialized": False, "accounts": [], "db_path": "/tmp/db.sqlite"}
+                ),
+                "stderr": "",
+            },
+        )()
+        self.assertFalse(triage.check_db_initialized())
+
+    @patch("triage.subprocess.run")
+    def test_initialized_false_on_nonzero_exit(self, mock_run):
+        mock_run.return_value = type(
+            "R", (), {"returncode": 1, "stdout": "", "stderr": "config missing"}
+        )()
+        self.assertFalse(triage.check_db_initialized())
+
+    @patch("triage.subprocess.run")
+    def test_initialized_false_on_timeout(self, mock_run):
+        import subprocess as sp
+
+        mock_run.side_effect = sp.TimeoutExpired(cmd="main.py", timeout=30)
+        self.assertFalse(triage.check_db_initialized())
+
+    @patch("triage.subprocess.run")
+    def test_initialized_false_on_missing_workspace(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("no such file: python3")
+        self.assertFalse(triage.check_db_initialized())
+
+    @patch("triage.subprocess.run")
+    def test_initialized_false_on_bad_json(self, mock_run):
+        mock_run.return_value = type(
+            "R", (), {"returncode": 0, "stdout": "not json", "stderr": ""}
+        )()
+        self.assertFalse(triage.check_db_initialized())
+
+    @patch("triage.subprocess.run")
+    def test_initialized_false_when_key_missing(self, mock_run):
+        """Valid JSON without an ``initialized`` key must be treated as not
+        initialized (defensive against upstream schema drift)."""
+        mock_run.return_value = type(
+            "R", (), {"returncode": 0, "stdout": json.dumps({"accounts": []}), "stderr": ""}
+        )()
         self.assertFalse(triage.check_db_initialized())
 
 
@@ -216,24 +326,23 @@ class TestPending(TestCase):
 
     def test_pending_filters_status(self):
         triage.save_state(
-            {
-                "cursor": {"last_ingested_id": 0},
-                "pending_attention": [
-                    {"id": 1, "status": "pending"},
-                    {"id": 2, "status": "notified"},
-                    {"id": 3, "status": "pending"},
-                ],
-            }
+            triage.State(
+                pending_attention=[
+                    triage.PendingItem(id="1", status="pending"),
+                    triage.PendingItem(id="2", status="notified"),
+                    triage.PendingItem(id="3", status="pending"),
+                ]
+            )
         )
         state = triage.get_state()
-        items = [i for i in state["pending_attention"] if i.get("status") == "pending"]
+        items = [i for i in state.pending_attention if i.status == "pending"]
         self.assertEqual(len(items), 2)
-        self.assertEqual([i["id"] for i in items], [1, 3])
+        self.assertEqual([i.id for i in items], ["1", "3"])
 
     def test_pending_empty(self):
-        triage.save_state({"cursor": {"last_ingested_id": 0}, "pending_attention": []})
+        triage.save_state(triage.State())
         state = triage.get_state()
-        items = [i for i in state["pending_attention"] if i.get("status") == "pending"]
+        items = [i for i in state.pending_attention if i.status == "pending"]
         self.assertEqual(items, [])
 
 
@@ -244,13 +353,12 @@ class TestDismiss(TestCase):
         self._patch = patch.object(triage, "STATE_PATH", self.state_path)
         self._patch.start()
         triage.save_state(
-            {
-                "cursor": {"last_ingested_id": 0},
-                "pending_attention": [
-                    {"id": 10, "status": "pending"},
-                    {"id": 20, "status": "pending"},
-                ],
-            }
+            triage.State(
+                pending_attention=[
+                    triage.PendingItem(id="10", status="pending"),
+                    triage.PendingItem(id="20", status="pending"),
+                ]
+            )
         )
 
     def tearDown(self):
@@ -261,30 +369,66 @@ class TestDismiss(TestCase):
         result = triage.dismiss(10)
         self.assertTrue(result)
         state = triage.get_state()
-        self.assertEqual(len(state["pending_attention"]), 1)
-        self.assertEqual(state["pending_attention"][0]["id"], 20)
+        self.assertEqual(len(state.pending_attention), 1)
+        self.assertEqual(state.pending_attention[0].id, "20")
 
     def test_dismiss_nonexistent(self):
         result = triage.dismiss(999)
         self.assertFalse(result)
         state = triage.get_state()
-        self.assertEqual(len(state["pending_attention"]), 2)
+        self.assertEqual(len(state.pending_attention), 2)
 
     def test_dismiss_invalid_id(self):
+        # Non-numeric id is accepted now (IDs are strings), but has no match
         result = triage.dismiss("not-a-number")
         self.assertFalse(result)
         state = triage.get_state()
-        self.assertEqual(len(state["pending_attention"]), 2)
+        self.assertEqual(len(state.pending_attention), 2)
+
+    def test_dismiss_none(self):
+        result = triage.dismiss(None)
+        self.assertFalse(result)
+
+    def test_dismiss_int_matches_string_stored(self):
+        """Regression test for review comment #11: int arg should match str-stored id."""
+        result = triage.dismiss(10)  # int arg
+        self.assertTrue(result)
+        state = triage.get_state()
+        self.assertEqual([i.id for i in state.pending_attention], ["20"])
+
+
+def _stub_result(returncode=0, stdout="", stderr=""):
+    return type(
+        "R", (), {"returncode": returncode, "stdout": stdout, "stderr": stderr}
+    )()
+
+
+def _status_stub(initialized: bool):
+    """Stubbed ``main.py status`` JSON response."""
+    return _stub_result(
+        stdout=json.dumps(
+            {
+                "initialized": initialized,
+                "accounts": [{"account_id": "a", "last_uid": 1}] if initialized else [],
+                "db_path": "/tmp/fake.sqlite",
+            }
+        )
+    )
 
 
 class TestSync(TestCase):
+    """Each sync() call now makes 3 subprocess invocations:
+        1. status   (check_db_initialized)
+        2. ingest
+        3. query
+    so every side_effect list must provide 3 elements in that order.
+    """
+
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.state_path = os.path.join(self.tmpdir, "state.json")
-        self.db_path = os.path.join(self.tmpdir, "test.sqlite")
         self._patches = [
             patch.object(triage, "STATE_PATH", self.state_path),
-            patch.object(triage, "DB_PATH", self.db_path),
             patch.object(triage, "WORKSPACE_DIR", self.tmpdir),
             patch.object(triage, "VENV_PYTHON", "python3"),
         ]
@@ -298,18 +442,36 @@ class TestSync(TestCase):
 
     @patch("triage.subprocess.run")
     def test_sync_first_run(self, mock_run):
-        """When DB is not initialized, --init-start-date should be passed."""
-        mock_run.return_value = type(
-            "Result", (), {"returncode": 0, "stdout": '{"results":[],"meta":{}}', "stderr": ""}
-        )()
+        """When status reports not-initialized, --init-start-date must be
+        passed on the subsequent ingest call."""
+        empty_query = _stub_result(stdout='{"results":[],"meta":{}}')
+        mock_run.side_effect = [
+            _status_stub(initialized=False),
+            _stub_result(),  # ingest
+            empty_query,
+        ]
         triage.sync()
-        first_call_args = mock_run.call_args_list[0][0][0]
-        self.assertIn("--init-start-date", first_call_args)
+        # call_args_list[0] is status, [1] is ingest
+        ingest_call_args = mock_run.call_args_list[1][0][0]
+        self.assertIn("--init-start-date", ingest_call_args)
+
+    @patch("triage.subprocess.run")
+    def test_sync_initialized_skips_init_start_date(self, mock_run):
+        """When status reports initialized=true, ingest must NOT receive
+        --init-start-date."""
+        empty_query = _stub_result(stdout='{"results":[],"meta":{}}')
+        mock_run.side_effect = [
+            _status_stub(initialized=True),
+            _stub_result(),  # ingest
+            empty_query,
+        ]
+        triage.sync()
+        ingest_call_args = mock_run.call_args_list[1][0][0]
+        self.assertNotIn("--init-start-date", ingest_call_args)
 
     @patch("triage.subprocess.run")
     def test_sync_updates_cursor(self, mock_run):
         """Cursor should advance to max_id from query results."""
-        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
         query_data = {
             "results": [
                 {
@@ -322,22 +484,23 @@ class TestSync(TestCase):
             ],
             "meta": {"max_id": 5},
         }
-        query_result = type(
-            "R", (), {"returncode": 0, "stdout": json.dumps(query_data), "stderr": ""}
-        )()
-        mock_run.side_effect = [ingest_result, query_result]
+        mock_run.side_effect = [
+            _status_stub(initialized=True),
+            _stub_result(),  # ingest
+            _stub_result(stdout=json.dumps(query_data)),  # query
+        ]
 
         triage.sync()
 
         state = triage.get_state()
-        self.assertEqual(state["cursor"]["last_ingested_id"], 5)
-        self.assertEqual(len(state["pending_attention"]), 1)
-        self.assertEqual(state["pending_attention"][0]["subject"], "Test")
+        self.assertEqual(state.cursor.last_ingested_id, 5)
+        self.assertEqual(len(state.pending_attention), 1)
+        self.assertEqual(state.pending_attention[0].subject, "Test")
+        self.assertEqual(state.pending_attention[0].id, "5")
 
     @patch("triage.subprocess.run")
     def test_sync_filters_non_high_priority(self, mock_run):
         """Only emails with priority >= High should be enqueued."""
-        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
         query_data = {
             "results": [
                 {"id": 1, "subject": "Fire", "priority": "Urgent", "sender": "a@b.com"},
@@ -348,21 +511,21 @@ class TestSync(TestCase):
             ],
             "meta": {"max_id": 5},
         }
-        query_result = type(
-            "R", (), {"returncode": 0, "stdout": json.dumps(query_data), "stderr": ""}
-        )()
-        mock_run.side_effect = [ingest_result, query_result]
+        mock_run.side_effect = [
+            _status_stub(initialized=True),
+            _stub_result(),
+            _stub_result(stdout=json.dumps(query_data)),
+        ]
 
         triage.sync()
 
         state = triage.get_state()
-        subjects = [item["subject"] for item in state["pending_attention"]]
+        subjects = [item.subject for item in state.pending_attention]
         self.assertEqual(subjects, ["Fire", "Important", "Meltdown"])
 
     @patch("triage.subprocess.run")
     def test_sync_numeric_priority(self, mock_run):
         """Numeric priorities >= 3 (High) should be enqueued."""
-        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
         query_data = {
             "results": [
                 {"id": 1, "subject": "P4", "priority": 4, "sender": "a@b.com"},
@@ -372,36 +535,93 @@ class TestSync(TestCase):
             ],
             "meta": {"max_id": 4},
         }
-        query_result = type(
-            "R", (), {"returncode": 0, "stdout": json.dumps(query_data), "stderr": ""}
-        )()
-        mock_run.side_effect = [ingest_result, query_result]
+        mock_run.side_effect = [
+            _status_stub(initialized=True),
+            _stub_result(),
+            _stub_result(stdout=json.dumps(query_data)),
+        ]
 
         triage.sync()
 
         state = triage.get_state()
-        subjects = [item["subject"] for item in state["pending_attention"]]
+        subjects = [item.subject for item in state.pending_attention]
         self.assertEqual(subjects, ["P4", "P3"])
 
     @patch("triage.subprocess.run")
     def test_sync_bad_json(self, mock_run):
         """Sync should not crash on malformed JSON output."""
-        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
-        query_result = type(
-            "R", (), {"returncode": 0, "stdout": "not json", "stderr": ""}
-        )()
-        mock_run.side_effect = [ingest_result, query_result]
-
-        # Should print error, not raise
-        triage.sync()
+        mock_run.side_effect = [
+            _status_stub(initialized=True),
+            _stub_result(),
+            _stub_result(stdout="not json"),
+        ]
+        triage.sync()  # must not raise
 
     @patch("triage.subprocess.run")
     def test_sync_missing_workspace(self, mock_run):
-        """Sync should handle missing workspace/venv gracefully."""
-        mock_run.side_effect = FileNotFoundError("No such file or directory: 'python3'")
+        """Sync should handle missing workspace/venv gracefully.
 
-        # Should print error, not raise
+        Note: status also uses subprocess.run, so a FileNotFoundError on
+        the very first call causes check_db_initialized() to return False
+        and the subsequent ingest call raises the same error, which
+        sync()'s OSError handler catches.
+        """
+        mock_run.side_effect = FileNotFoundError("No such file or directory: 'python3'")
+        triage.sync()  # must not raise
+
+    @patch("triage.subprocess.run")
+    def test_sync_skips_malformed_rows(self, mock_run):
+        """Regression test for review comment #10: non-dict or shape-invalid
+        rows must be skipped, not crash the whole sync."""
+        query_data = {
+            "results": [
+                None,  # non-dict entry
+                "string",  # non-dict entry
+                {"priority": "High"},  # missing id
+                {"id": 1, "priority": "High", "subject": "Good"},  # valid high
+                {"id": 2, "priority": "Low"},  # filtered by priority
+                42,  # non-dict entry
+            ],
+            "meta": {"max_id": 2},
+        }
+        mock_run.side_effect = [
+            _status_stub(initialized=True),
+            _stub_result(),
+            _stub_result(stdout=json.dumps(query_data)),
+        ]
+
+        triage.sync()  # must not raise
+
+        state = triage.get_state()
+        self.assertEqual([i.id for i in state.pending_attention], ["1"])
+        self.assertEqual(state.cursor.last_ingested_id, 2)
+
+    @patch("triage.subprocess.run")
+    def test_sync_dedupes(self, mock_run):
+        """Subsequent sync calls must not duplicate an already-queued item."""
+        query_data = {
+            "results": [
+                {"id": 7, "priority": "High", "subject": "dup", "sender": "x@y.com"},
+            ],
+            "meta": {"max_id": 7},
+        }
+        query_stub = _stub_result(stdout=json.dumps(query_data))
+        # Two sync calls; each makes 3 subprocess invocations
+        # (status + ingest + query) = 6 total.
+        mock_run.side_effect = [
+            _status_stub(initialized=True),
+            _stub_result(),
+            query_stub,
+            _status_stub(initialized=True),
+            _stub_result(),
+            query_stub,
+        ]
+
         triage.sync()
+        triage.sync()
+
+        state = triage.get_state()
+        self.assertEqual(len(state.pending_attention), 1)
 
 
 if __name__ == "__main__":

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -90,6 +90,38 @@ class TestState(TestCase):
         self.assertEqual(state["cursor"]["last_ingested_id"], 0)
         self.assertEqual(state["pending_attention"], [])
 
+    def test_get_state_empty_object(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w") as f:
+            json.dump({}, f)
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
+        self.assertEqual(state["pending_attention"], [])
+
+    def test_get_state_missing_cursor(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w") as f:
+            json.dump({"pending_attention": [{"id": 1}]}, f)
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
+        self.assertEqual(state["pending_attention"], [{"id": 1}])
+
+    def test_get_state_missing_pending(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w") as f:
+            json.dump({"cursor": {"last_ingested_id": 10}}, f)
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 10)
+        self.assertEqual(state["pending_attention"], [])
+
+    def test_get_state_non_dict(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w") as f:
+            json.dump([1, 2, 3], f)
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
+        self.assertEqual(state["pending_attention"], [])
+
     def test_save_state_bare_filename(self):
         """save_state should work when STATE_PATH has no directory component."""
         bare_path = os.path.join(self.tmpdir, "state.json")

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -231,6 +231,29 @@ class TestSync(TestCase):
         self.assertEqual(state["pending_attention"][0]["subject"], "Test")
 
     @patch("triage.subprocess.run")
+    def test_sync_filters_non_high_priority(self, mock_run):
+        """Only high-priority emails should be enqueued."""
+        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        query_data = {
+            "results": [
+                {"id": 1, "subject": "Urgent", "priority": "High", "sender": "a@b.com"},
+                {"id": 2, "subject": "FYI", "priority": "Low", "sender": "c@d.com"},
+                {"id": 3, "subject": "Normal", "priority": "Normal", "sender": "e@f.com"},
+            ],
+            "meta": {"max_id": 3},
+        }
+        query_result = type(
+            "R", (), {"returncode": 0, "stdout": json.dumps(query_data), "stderr": ""}
+        )()
+        mock_run.side_effect = [ingest_result, query_result]
+
+        triage.sync()
+
+        state = triage.get_state()
+        self.assertEqual(len(state["pending_attention"]), 1)
+        self.assertEqual(state["pending_attention"][0]["subject"], "Urgent")
+
+    @patch("triage.subprocess.run")
     def test_sync_bad_json(self, mock_run):
         """Sync should not crash on malformed JSON output."""
         ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -48,6 +48,14 @@ class TestState(TestCase):
         loaded = triage.get_state()
         self.assertEqual(loaded, data)
 
+    def test_get_state_corrupt_json(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w") as f:
+            f.write("{bad json")
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
+        self.assertEqual(state["pending_attention"], [])
+
 
 class TestCheckDb(TestCase):
     def setUp(self):
@@ -147,6 +155,12 @@ class TestDismiss(TestCase):
 
     def test_dismiss_nonexistent(self):
         result = triage.dismiss(999)
+        self.assertFalse(result)
+        state = triage.get_state()
+        self.assertEqual(len(state["pending_attention"]), 2)
+
+    def test_dismiss_invalid_id(self):
+        result = triage.dismiss("not-a-number")
         self.assertFalse(result)
         state = triage.get_state()
         self.assertEqual(len(state["pending_attention"]), 2)

--- a/skills/email-triage/scripts/test_triage.py
+++ b/skills/email-triage/scripts/test_triage.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Tests for email-triage triage helpers."""
+
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+from unittest import TestCase, main
+from unittest.mock import patch
+
+import triage
+
+
+class TestState(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.state_path = os.path.join(self.tmpdir, "sub", "state.json")
+        self._patch = patch.object(triage, "STATE_PATH", self.state_path)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        shutil.rmtree(self.tmpdir)
+
+    def test_get_state_missing_file(self):
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 0)
+        self.assertEqual(state["pending_attention"], [])
+
+    def test_get_state_existing_file(self):
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        data = {"cursor": {"last_ingested_id": 42}, "pending_attention": [{"id": 1}]}
+        with open(self.state_path, "w") as f:
+            json.dump(data, f)
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 42)
+        self.assertEqual(len(state["pending_attention"]), 1)
+
+    def test_save_state_creates_dir(self):
+        self.assertFalse(os.path.exists(os.path.dirname(self.state_path)))
+        triage.save_state({"cursor": {"last_ingested_id": 0}, "pending_attention": []})
+        self.assertTrue(os.path.exists(self.state_path))
+
+    def test_save_state_roundtrip(self):
+        data = {"cursor": {"last_ingested_id": 99}, "pending_attention": [{"id": 7}]}
+        triage.save_state(data)
+        loaded = triage.get_state()
+        self.assertEqual(loaded, data)
+
+
+class TestCheckDb(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.sqlite")
+        self._patch = patch.object(triage, "DB_PATH", self.db_path)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        shutil.rmtree(self.tmpdir)
+
+    def test_no_db_file(self):
+        self.assertFalse(triage.check_db_initialized())
+
+    def test_empty_db(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE email_accounts (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+        self.assertFalse(triage.check_db_initialized())
+
+    def test_initialized_db(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE email_accounts (id INTEGER PRIMARY KEY)")
+        conn.execute("INSERT INTO email_accounts (id) VALUES (1)")
+        conn.commit()
+        conn.close()
+        self.assertTrue(triage.check_db_initialized())
+
+    def test_corrupt_db(self):
+        with open(self.db_path, "w") as f:
+            f.write("not a database")
+        self.assertFalse(triage.check_db_initialized())
+
+
+class TestPending(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.state_path = os.path.join(self.tmpdir, "state.json")
+        self._patch = patch.object(triage, "STATE_PATH", self.state_path)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        shutil.rmtree(self.tmpdir)
+
+    def test_pending_filters_status(self):
+        triage.save_state(
+            {
+                "cursor": {"last_ingested_id": 0},
+                "pending_attention": [
+                    {"id": 1, "status": "pending"},
+                    {"id": 2, "status": "notified"},
+                    {"id": 3, "status": "pending"},
+                ],
+            }
+        )
+        state = triage.get_state()
+        items = [i for i in state["pending_attention"] if i.get("status") == "pending"]
+        self.assertEqual(len(items), 2)
+        self.assertEqual([i["id"] for i in items], [1, 3])
+
+    def test_pending_empty(self):
+        triage.save_state({"cursor": {"last_ingested_id": 0}, "pending_attention": []})
+        state = triage.get_state()
+        items = [i for i in state["pending_attention"] if i.get("status") == "pending"]
+        self.assertEqual(items, [])
+
+
+class TestDismiss(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.state_path = os.path.join(self.tmpdir, "state.json")
+        self._patch = patch.object(triage, "STATE_PATH", self.state_path)
+        self._patch.start()
+        triage.save_state(
+            {
+                "cursor": {"last_ingested_id": 0},
+                "pending_attention": [
+                    {"id": 10, "status": "pending"},
+                    {"id": 20, "status": "pending"},
+                ],
+            }
+        )
+
+    def tearDown(self):
+        self._patch.stop()
+        shutil.rmtree(self.tmpdir)
+
+    def test_dismiss_existing(self):
+        result = triage.dismiss(10)
+        self.assertTrue(result)
+        state = triage.get_state()
+        self.assertEqual(len(state["pending_attention"]), 1)
+        self.assertEqual(state["pending_attention"][0]["id"], 20)
+
+    def test_dismiss_nonexistent(self):
+        result = triage.dismiss(999)
+        self.assertFalse(result)
+        state = triage.get_state()
+        self.assertEqual(len(state["pending_attention"]), 2)
+
+
+class TestSync(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.state_path = os.path.join(self.tmpdir, "state.json")
+        self.db_path = os.path.join(self.tmpdir, "test.sqlite")
+        self._patches = [
+            patch.object(triage, "STATE_PATH", self.state_path),
+            patch.object(triage, "DB_PATH", self.db_path),
+            patch.object(triage, "WORKSPACE_DIR", self.tmpdir),
+            patch.object(triage, "VENV_PYTHON", "python3"),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        shutil.rmtree(self.tmpdir)
+
+    @patch("triage.subprocess.run")
+    def test_sync_first_run(self, mock_run):
+        """When DB is not initialized, --init-start-date should be passed."""
+        mock_run.return_value = type(
+            "Result", (), {"returncode": 0, "stdout": '{"results":[],"meta":{}}', "stderr": ""}
+        )()
+        triage.sync()
+        first_call_args = mock_run.call_args_list[0][0][0]
+        self.assertIn("--init-start-date", first_call_args)
+
+    @patch("triage.subprocess.run")
+    def test_sync_updates_cursor(self, mock_run):
+        """Cursor should advance to max_id from query results."""
+        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        query_data = {
+            "results": [
+                {
+                    "id": 5,
+                    "subject": "Test",
+                    "priority": "High",
+                    "sender": "a@b.com",
+                    "summary": "s",
+                }
+            ],
+            "meta": {"max_id": 5},
+        }
+        query_result = type(
+            "R", (), {"returncode": 0, "stdout": json.dumps(query_data), "stderr": ""}
+        )()
+        mock_run.side_effect = [ingest_result, query_result]
+
+        triage.sync()
+
+        state = triage.get_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 5)
+        self.assertEqual(len(state["pending_attention"]), 1)
+        self.assertEqual(state["pending_attention"][0]["subject"], "Test")
+
+    @patch("triage.subprocess.run")
+    def test_sync_bad_json(self, mock_run):
+        """Sync should not crash on malformed JSON output."""
+        ingest_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        query_result = type(
+            "R", (), {"returncode": 0, "stdout": "not json", "stderr": ""}
+        )()
+        mock_run.side_effect = [ingest_result, query_result]
+
+        # Should print error, not raise
+        triage.sync()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/email-triage/scripts/test_triage_smoke.py
+++ b/skills/email-triage/scripts/test_triage_smoke.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Smoke test for the email-triage skill.
+
+Unlike the unit tests in `test_triage.py`, this file exercises the full
+skill as a black box:
+
+- spawns `triage.py` in a real subprocess via the CLI entrypoints
+  (`sync`, `pending`, `dismiss`),
+- stands in a fake `main.py` for the external `email-ingest-integration`
+  project that prints canned JSON,
+- verifies state is persisted to disk and subsequent commands reflect it.
+
+This catches regressions in:
+  * argv dispatch (`if __name__ == "__main__"` branches)
+  * subprocess invocation + JSON parsing
+  * state file read/write round-trip
+  * priority filtering end-to-end
+  * dismiss ID coercion across process boundaries
+
+Run with:  python -m pytest skills/email-triage/scripts/test_triage_smoke.py
+or:        python skills/email-triage/scripts/test_triage_smoke.py
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from unittest import TestCase, main
+
+TRIAGE_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "triage.py")
+
+
+# A minimal stand-in for the external email-ingest-integration CLI.
+# Supports the three subcommands triage.py invokes:
+#   - ``status`` (added in Anthrop-OS/email-ingest#18): reports init state
+#   - ``ingest``: acknowledges and exits 0
+#   - ``query --after-id N --format json``: returns canned rows
+#
+# The ``status`` response is controlled by the ``FAKE_STATUS_INITIALIZED``
+# env var so tests can toggle first-run vs. normal behavior.
+_FAKE_MAIN = r"""
+import json
+import os
+import sys
+
+
+def _read_inbox():
+    path = os.environ.get("FAKE_INBOX_PATH")
+    if not path or not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _meta_max_id(rows):
+    ids = [r.get("id") for r in rows if isinstance(r, dict) and r.get("id") is not None]
+    return max(ids) if ids else 0
+
+
+def main():
+    argv = sys.argv[1:]
+    if not argv:
+        print("usage: main.py <status|ingest|query>", file=sys.stderr)
+        sys.exit(2)
+
+    cmd = argv[0]
+
+    if cmd == "status":
+        initialized = os.environ.get("FAKE_STATUS_INITIALIZED", "1") != "0"
+        payload = {
+            "initialized": initialized,
+            "accounts": [{"account_id": "fake", "last_uid": 1}] if initialized else [],
+            "db_path": "/tmp/fake.sqlite",
+        }
+        print(json.dumps(payload))
+        sys.exit(0)
+
+    rows = _read_inbox()
+
+    if cmd == "ingest":
+        # Real CLI emits a status line; triage.py ignores ingest stdout.
+        print(json.dumps({"ingested": len(rows)}))
+        sys.exit(0)
+
+    if cmd == "query":
+        after_id = 0
+        if "--after-id" in argv:
+            try:
+                after_id = int(argv[argv.index("--after-id") + 1])
+            except (IndexError, ValueError):
+                pass
+        new_rows = [
+            r for r in rows
+            if isinstance(r, dict) and isinstance(r.get("id"), int) and r["id"] > after_id
+        ]
+        payload = {"results": new_rows, "meta": {"max_id": _meta_max_id(rows)}}
+        print(json.dumps(payload))
+        sys.exit(0)
+
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+class TriageSmokeTest(TestCase):
+    """End-to-end: real subprocess, real JSON, real filesystem."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="triage-smoke-")
+        self.workspace = os.path.join(self.tmpdir, "workspace")
+        os.makedirs(self.workspace)
+
+        # Fake main.py that triage will invoke via subprocess.
+        self.fake_main_path = os.path.join(self.workspace, "main.py")
+        with open(self.fake_main_path, "w", encoding="utf-8") as f:
+            f.write(_FAKE_MAIN)
+
+        self.state_path = os.path.join(self.tmpdir, "state.json")
+        self.inbox_path = os.path.join(self.tmpdir, "inbox.json")
+
+        # Environment shared by every subprocess call.
+        self.env = os.environ.copy()
+        self.env["EMAIL_TRIAGE_WORKSPACE"] = self.workspace
+        self.env["EMAIL_TRIAGE_STATE"] = self.state_path
+        # Use the current interpreter instead of $WORKSPACE/venv/bin/python3
+        self.env["EMAIL_TRIAGE_VENV_PYTHON"] = sys.executable
+        self.env["FAKE_INBOX_PATH"] = self.inbox_path
+        # Default: fake status reports initialized=true so sync() takes the
+        # steady-state branch. Individual tests override this to simulate
+        # first-run.
+        self.env["FAKE_STATUS_INITIALIZED"] = "1"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_inbox(self, rows):
+        with open(self.inbox_path, "w", encoding="utf-8") as f:
+            json.dump(rows, f)
+
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, TRIAGE_SCRIPT, *args],
+            env=self.env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def _load_state(self):
+        with open(self.state_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    # -- scenarios ----------------------------------------------------------
+
+    def test_sync_persists_state_and_filters_priority(self):
+        self._write_inbox(
+            [
+                {"id": 1, "priority": "Urgent", "subject": "Fire", "sender": "a@b.com"},
+                {"id": 2, "priority": "Low", "subject": "FYI", "sender": "c@d.com"},
+                {"id": 3, "priority": "High", "subject": "Important", "sender": "e@f.com"},
+            ]
+        )
+
+        result = self._run("sync")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Sync complete", result.stdout)
+        self.assertIn("enqueued 2", result.stdout)
+
+        state = self._load_state()
+        self.assertEqual(state["cursor"]["last_ingested_id"], 3)
+        subjects = [item["subject"] for item in state["pending_attention"]]
+        self.assertEqual(sorted(subjects), ["Fire", "Important"])
+        # IDs must round-trip as strings (schema normalization).
+        ids = [item["id"] for item in state["pending_attention"]]
+        self.assertTrue(all(isinstance(i, str) for i in ids))
+
+    def test_pending_command_lists_queue(self):
+        self._write_inbox(
+            [{"id": 9, "priority": "High", "subject": "Hi", "sender": "x@y.com"}]
+        )
+        self._run("sync")
+
+        result = self._run("pending")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        listed = json.loads(result.stdout)
+        self.assertEqual(len(listed), 1)
+        self.assertEqual(listed[0]["id"], "9")
+        self.assertEqual(listed[0]["subject"], "Hi")
+        self.assertEqual(listed[0]["status"], "pending")
+
+    def test_dismiss_removes_item_by_int_arg_against_str_stored_id(self):
+        """Regression for review comment #11: pending IDs are stored as
+        strings after normalization, but the user passes an int on the CLI.
+        The dismiss path must match regardless of type."""
+        self._write_inbox(
+            [
+                {"id": 10, "priority": "High", "subject": "A", "sender": "a@b.com"},
+                {"id": 11, "priority": "High", "subject": "B", "sender": "c@d.com"},
+            ]
+        )
+        self._run("sync")
+
+        result = self._run("dismiss", "10")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("dismissed", result.stdout)
+
+        state = self._load_state()
+        self.assertEqual([i["id"] for i in state["pending_attention"]], ["11"])
+
+    def test_dismiss_unknown_id(self):
+        self._write_inbox(
+            [{"id": 1, "priority": "High", "subject": "X", "sender": "x@y.com"}]
+        )
+        self._run("sync")
+
+        result = self._run("dismiss", "9999")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("not found", result.stdout)
+
+        state = self._load_state()
+        self.assertEqual(len(state["pending_attention"]), 1)
+
+    def test_sync_is_idempotent(self):
+        """Running sync twice with the same inbox should not duplicate items
+        (cursor advances; existing_ids dedup guards the second pass anyway)."""
+        self._write_inbox(
+            [{"id": 1, "priority": "High", "subject": "One", "sender": "a@b.com"}]
+        )
+        self._run("sync")
+        self._run("sync")
+
+        state = self._load_state()
+        self.assertEqual(len(state["pending_attention"]), 1)
+        self.assertEqual(state["cursor"]["last_ingested_id"], 1)
+
+    def test_sync_appends_new_items_on_subsequent_call(self):
+        self._write_inbox(
+            [{"id": 1, "priority": "High", "subject": "First", "sender": "a@b.com"}]
+        )
+        self._run("sync")
+
+        # Add a new row to the fake inbox.
+        self._write_inbox(
+            [
+                {"id": 1, "priority": "High", "subject": "First", "sender": "a@b.com"},
+                {"id": 2, "priority": "Critical", "subject": "Second", "sender": "c@d.com"},
+            ]
+        )
+        self._run("sync")
+
+        state = self._load_state()
+        subjects = [i["subject"] for i in state["pending_attention"]]
+        self.assertEqual(sorted(subjects), ["First", "Second"])
+        self.assertEqual(state["cursor"]["last_ingested_id"], 2)
+
+    def test_sync_handles_malformed_rows_without_crashing(self):
+        """Regression for review comment #10: one bad row must not poison
+        the whole sync. Valid rows after it should still be enqueued."""
+        self._write_inbox(
+            [
+                None,  # not a dict
+                {"id": 1, "priority": "High", "subject": "OK", "sender": "a@b.com"},
+                "string-not-dict",
+                {"priority": "High", "subject": "no id"},  # missing id
+                {"id": 2, "priority": "Urgent", "subject": "Also OK", "sender": "c@d.com"},
+            ]
+        )
+
+        result = self._run("sync")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+        state = self._load_state()
+        self.assertEqual(
+            sorted(i["subject"] for i in state["pending_attention"]),
+            ["Also OK", "OK"],
+        )
+        self.assertEqual(state["cursor"]["last_ingested_id"], 2)
+
+    def test_sync_skips_init_start_date_when_status_initialized(self):
+        """Regression test: when ``main.py status`` reports initialized=true,
+        sync() must NOT pass ``--init-start-date`` on the subsequent ingest
+        call (the upstream flag is 'mandatory on first run' and passing it
+        on every run causes avalanche repair)."""
+        # Instrument the fake main.py so we can see the full argv it
+        # received. Wrap the existing fake with an argv logger.
+        argv_log = os.path.join(self.tmpdir, "argv.log").replace("\\", "\\\\")
+        wrapped = (
+            "import os, sys\n"
+            f"open(r'{argv_log}', 'a', encoding='utf-8').write(' '.join(sys.argv[1:]) + '\\n')\n"
+            + _FAKE_MAIN
+        )
+        with open(self.fake_main_path, "w", encoding="utf-8") as f:
+            f.write(wrapped)
+
+        self.env["FAKE_STATUS_INITIALIZED"] = "1"
+        self._write_inbox(
+            [{"id": 1, "priority": "High", "subject": "X", "sender": "x@y.com"}]
+        )
+
+        result = self._run("sync")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+        with open(argv_log.replace("\\\\", "\\"), "r", encoding="utf-8") as f:
+            logged = f.read()
+        ingest_line = next(
+            line for line in logged.splitlines() if line.startswith("ingest")
+        )
+        self.assertNotIn("--init-start-date", ingest_line)
+
+    def test_sync_passes_init_start_date_when_status_uninitialized(self):
+        """Symmetric regression: when ``main.py status`` reports
+        initialized=false, sync() MUST pass ``--init-start-date`` on ingest
+        so the upstream's avalanche-protection guard does not trip."""
+        argv_log = os.path.join(self.tmpdir, "argv.log").replace("\\", "\\\\")
+        wrapped = (
+            "import os, sys\n"
+            f"open(r'{argv_log}', 'a', encoding='utf-8').write(' '.join(sys.argv[1:]) + '\\n')\n"
+            + _FAKE_MAIN
+        )
+        with open(self.fake_main_path, "w", encoding="utf-8") as f:
+            f.write(wrapped)
+
+        self.env["FAKE_STATUS_INITIALIZED"] = "0"
+        self._write_inbox([])
+
+        result = self._run("sync")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+        with open(argv_log.replace("\\\\", "\\"), "r", encoding="utf-8") as f:
+            logged = f.read()
+        ingest_line = next(
+            line for line in logged.splitlines() if line.startswith("ingest")
+        )
+        self.assertIn("--init-start-date", ingest_line)
+
+    def test_sync_handles_missing_workspace_gracefully(self):
+        """If the workspace disappears between commands, sync must print a
+        controlled error rather than exiting with a traceback."""
+        shutil.rmtree(self.workspace)
+        # Point VENV_PYTHON to a binary that cannot exist.
+        self.env["EMAIL_TRIAGE_VENV_PYTHON"] = os.path.join(
+            self.tmpdir, "nonexistent", "python"
+        )
+
+        result = self._run("sync")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Sync failed to start", result.stdout)
+        self.assertNotIn("Traceback", result.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -34,7 +34,9 @@ def get_state():
 
 
 def save_state(state):
-    os.makedirs(os.path.dirname(STATE_PATH), exist_ok=True)
+    parent = os.path.dirname(STATE_PATH)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
     with open(STATE_PATH, "w") as f:
         json.dump(state, f, indent=2)
 
@@ -70,6 +72,9 @@ def sync():
     except subprocess.TimeoutExpired:
         print("Sync timed out after 300 seconds.")
         return
+    except OSError as exc:
+        print(f"Sync failed to start: {exc}")
+        return
     if result.returncode != 0:
         print(f"Sync failed: {result.stderr}")
         return
@@ -90,6 +95,9 @@ def sync():
         )
     except subprocess.TimeoutExpired:
         print("Query timed out after 300 seconds.")
+        return
+    except OSError as exc:
+        print(f"Query failed to start: {exc}")
         return
 
     if query_result.returncode != 0:

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -20,11 +20,17 @@ STATE_PATH = os.environ.get(
 )
 
 
+_DEFAULT_STATE = {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
+
+
 def get_state():
     if os.path.exists(STATE_PATH):
-        with open(STATE_PATH, "r") as f:
-            return json.load(f)
-    return {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
+        try:
+            with open(STATE_PATH, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return dict(_DEFAULT_STATE, pending_attention=[])
+    return dict(_DEFAULT_STATE, pending_attention=[])
 
 
 def save_state(state):
@@ -124,10 +130,14 @@ def pending():
 
 
 def dismiss(email_id):
+    try:
+        email_id = int(email_id)
+    except (ValueError, TypeError):
+        return False
     state = get_state()
     original_len = len(state["pending_attention"])
     state["pending_attention"] = [
-        item for item in state["pending_attention"] if item["id"] != int(email_id)
+        item for item in state["pending_attention"] if item["id"] != email_id
     ]
     if len(state["pending_attention"]) < original_len:
         save_state(state)

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -60,6 +60,8 @@ def get_state():
         pending = data.get("pending_attention")
         if not isinstance(pending, list):
             pending = []
+        else:
+            pending = [item for item in pending if isinstance(item, dict) and "id" in item]
         return {"cursor": cursor, "pending_attention": pending}
     return _make_default_state()
 

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -22,6 +22,24 @@ STATE_PATH = os.environ.get(
 
 _DEFAULT_STATE = {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
 
+# Priority levels: higher number = more urgent. Emails with level >= HIGH are enqueued.
+_PRIORITY_LEVELS = {
+    "low": 1,
+    "normal": 2,
+    "medium": 2,
+    "high": 3,
+    "urgent": 4,
+    "critical": 5,
+}
+_HIGH_THRESHOLD = _PRIORITY_LEVELS["high"]
+
+
+def _is_high_priority(priority):
+    """Return True if *priority* (string or numeric) is >= High."""
+    if isinstance(priority, (int, float)):
+        return priority >= _HIGH_THRESHOLD
+    return _PRIORITY_LEVELS.get(str(priority).lower(), 0) >= _HIGH_THRESHOLD
+
 
 def get_state():
     if os.path.exists(STATE_PATH):
@@ -112,7 +130,7 @@ def sync():
 
     new_emails = data.get("results", [])
     for email in new_emails:
-        if email.get("priority", "").lower() != "high":
+        if not _is_high_priority(email.get("priority", "")):
             continue
         if not any(item["id"] == email["id"] for item in state["pending_attention"]):
             state["pending_attention"].append(

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
 import json
 import os
-import sqlite3
 import subprocess
 import sys
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
+from typing import Any, Optional
 
 _DEFAULT_WORKSPACE = os.path.join(
     os.path.expanduser("~"), ".openclaw", "workspace", "email-ingest-integration"
 )
 WORKSPACE_DIR = os.environ.get("EMAIL_TRIAGE_WORKSPACE", _DEFAULT_WORKSPACE)
-VENV_PYTHON = os.path.join(WORKSPACE_DIR, "venv", "bin", "python3")
-DB_PATH = os.path.join(WORKSPACE_DIR, "data", "email_ingest.sqlite")
+VENV_PYTHON = os.environ.get(
+    "EMAIL_TRIAGE_VENV_PYTHON",
+    os.path.join(WORKSPACE_DIR, "venv", "bin", "python3"),
+)
 STATE_PATH = os.environ.get(
     "EMAIL_TRIAGE_STATE",
     os.path.join(
         os.path.expanduser("~"), ".openclaw", "workspace", "memory", "email_triage_state.json"
     ),
 )
-
-
-_DEFAULT_STATE = {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
 
 # Priority levels: higher number = more urgent. Emails with level >= HIGH are enqueued.
 _PRIORITY_LEVELS = {
@@ -41,54 +41,120 @@ def _is_high_priority(priority):
     return _PRIORITY_LEVELS.get(str(priority).lower(), 0) >= _HIGH_THRESHOLD
 
 
-def _make_default_state():
-    return {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
+@dataclass
+class Cursor:
+    last_ingested_id: int = 0
 
-
-def get_state():
-    if os.path.exists(STATE_PATH):
-        try:
-            with open(STATE_PATH, "r") as f:
-                data = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            return _make_default_state()
+    @classmethod
+    def from_dict(cls, data: Any) -> "Cursor":
         if not isinstance(data, dict):
-            return _make_default_state()
-        cursor = data.get("cursor")
-        if not isinstance(cursor, dict) or "last_ingested_id" not in cursor:
-            cursor = {"last_ingested_id": 0}
-        pending = data.get("pending_attention")
-        if not isinstance(pending, list):
-            pending = []
-        else:
-            pending = [item for item in pending if isinstance(item, dict) and "id" in item]
-        return {"cursor": cursor, "pending_attention": pending}
-    return _make_default_state()
+            return cls()
+        raw = data.get("last_ingested_id", 0)
+        try:
+            return cls(last_ingested_id=int(raw))
+        except (TypeError, ValueError):
+            return cls()
 
 
-def save_state(state):
+@dataclass
+class PendingItem:
+    id: str
+    subject: str = ""
+    sender: str = ""
+    priority: str = ""
+    summary: str = ""
+    status: str = "pending"
+
+    @classmethod
+    def from_dict(cls, data: Any) -> Optional["PendingItem"]:
+        """Parse a dict into a PendingItem. Returns None if shape is invalid.
+
+        id is coerced to str so that dismiss() matches regardless of whether
+        the upstream source stores int or str IDs.
+        """
+        if not isinstance(data, dict):
+            return None
+        if "id" not in data or data["id"] is None:
+            return None
+        return cls(
+            id=str(data["id"]),
+            subject=str(data.get("subject", "")),
+            sender=str(data.get("sender", "")),
+            priority=str(data.get("priority", "")),
+            summary=str(data.get("summary", "")),
+            status=str(data.get("status", "pending")),
+        )
+
+
+@dataclass
+class State:
+    cursor: Cursor = field(default_factory=Cursor)
+    pending_attention: list = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "State":
+        if not isinstance(data, dict):
+            return cls()
+        cursor = Cursor.from_dict(data.get("cursor", {}))
+        raw_pending = data.get("pending_attention", [])
+        if not isinstance(raw_pending, list):
+            return cls(cursor=cursor)
+        items = [
+            item
+            for item in (PendingItem.from_dict(p) for p in raw_pending)
+            if item is not None
+        ]
+        return cls(cursor=cursor, pending_attention=items)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def get_state() -> State:
+    if not os.path.exists(STATE_PATH):
+        return State()
+    try:
+        with open(STATE_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return State()
+    return State.from_dict(data)
+
+
+def save_state(state: State) -> None:
     parent = os.path.dirname(STATE_PATH)
     if parent:
         os.makedirs(parent, exist_ok=True)
-    with open(STATE_PATH, "w") as f:
-        json.dump(state, f, indent=2)
+    with open(STATE_PATH, "w", encoding="utf-8") as f:
+        json.dump(state.to_dict(), f, indent=2, ensure_ascii=False)
 
 
 def check_db_initialized():
-    if not os.path.exists(DB_PATH):
-        return False
-    conn = None
+    """Return True if the upstream ingest has at least one recorded account
+    cursor, i.e. we are NOT on a first run and should NOT pass
+    ``--init-start-date``.
+
+    Shells out to ``main.py status --format json`` (added in
+    Anthrop-OS/email-ingest#18) so this skill never touches the upstream
+    SQLite file directly. Any failure — missing workspace, unreachable
+    DB, invalid JSON, non-zero exit — is treated as "not initialized"
+    so that ``sync()`` falls back to passing ``--init-start-date`` and
+    the upstream's own avalanche-protection error path takes over.
+    """
+    cmd = [VENV_PYTHON, "main.py", "status", "--format", "json"]
     try:
-        conn = sqlite3.connect(DB_PATH)
-        cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM email_accounts")
-        count = cursor.fetchone()[0]
-        return count > 0
-    except (sqlite3.Error, OSError):
+        result = subprocess.run(
+            cmd, cwd=WORKSPACE_DIR, capture_output=True, text=True, timeout=30
+        )
+    except (subprocess.TimeoutExpired, OSError):
         return False
-    finally:
-        if conn is not None:
-            conn.close()
+    if result.returncode != 0:
+        return False
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False
+    return bool(payload.get("initialized"))
 
 
 def sync():
@@ -118,7 +184,7 @@ def sync():
         "main.py",
         "query",
         "--after-id",
-        str(state["cursor"]["last_ingested_id"]),
+        str(state.cursor.last_ingested_id),
         "--format",
         "json",
     ]
@@ -144,45 +210,57 @@ def sync():
         return
 
     new_emails = data.get("results", [])
-    for email in new_emails:
-        if not _is_high_priority(email.get("priority", "")):
-            continue
-        if not any(item["id"] == email["id"] for item in state["pending_attention"]):
-            state["pending_attention"].append(
-                {
-                    "id": email["id"],
-                    "subject": email["subject"],
-                    "priority": email["priority"],
-                    "sender": email["sender"],
-                    "summary": email.get("summary", ""),
-                    "status": "pending",
-                }
-            )
+    if not isinstance(new_emails, list):
+        new_emails = []
 
-    if data.get("meta", {}).get("max_id"):
-        state["cursor"]["last_ingested_id"] = data["meta"]["max_id"]
+    enqueued = 0
+    existing_ids = {item.id for item in state.pending_attention}
+    for raw_email in new_emails:
+        if not isinstance(raw_email, dict):
+            continue
+        if not _is_high_priority(raw_email.get("priority", "")):
+            continue
+        item = PendingItem.from_dict(raw_email)
+        if item is None:
+            continue
+        if item.id in existing_ids:
+            continue
+        state.pending_attention.append(item)
+        existing_ids.add(item.id)
+        enqueued += 1
+
+    meta = data.get("meta")
+    if isinstance(meta, dict):
+        max_id = meta.get("max_id")
+        if max_id is not None:
+            try:
+                state.cursor.last_ingested_id = int(max_id)
+            except (TypeError, ValueError):
+                pass
 
     save_state(state)
-    print(f"Sync complete. Found {len(new_emails)} new emails.")
+    print(
+        f"Sync complete. Found {len(new_emails)} new email(s), "
+        f"enqueued {enqueued} high-priority."
+    )
 
 
 def pending():
     state = get_state()
-    items = [item for item in state["pending_attention"] if item.get("status") == "pending"]
+    items = [asdict(item) for item in state.pending_attention if item.status == "pending"]
     print(json.dumps(items, indent=2))
 
 
 def dismiss(email_id):
-    try:
-        email_id = int(email_id)
-    except (ValueError, TypeError):
+    target = str(email_id) if email_id is not None else ""
+    if not target:
         return False
     state = get_state()
-    original_len = len(state["pending_attention"])
-    state["pending_attention"] = [
-        item for item in state["pending_attention"] if item["id"] != email_id
+    original_len = len(state.pending_attention)
+    state.pending_attention = [
+        item for item in state.pending_attention if item.id != target
     ]
-    if len(state["pending_attention"]) < original_len:
+    if len(state.pending_attention) < original_len:
         save_state(state)
         return True
     return False

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -112,6 +112,8 @@ def sync():
 
     new_emails = data.get("results", [])
     for email in new_emails:
+        if email.get("priority", "").lower() != "high":
+            continue
         if not any(item["id"] == email["id"] for item in state["pending_attention"]):
             state["pending_attention"].append(
                 {

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -41,14 +41,27 @@ def _is_high_priority(priority):
     return _PRIORITY_LEVELS.get(str(priority).lower(), 0) >= _HIGH_THRESHOLD
 
 
+def _make_default_state():
+    return {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
+
+
 def get_state():
     if os.path.exists(STATE_PATH):
         try:
             with open(STATE_PATH, "r") as f:
-                return json.load(f)
+                data = json.load(f)
         except (json.JSONDecodeError, OSError):
-            return dict(_DEFAULT_STATE, pending_attention=[])
-    return dict(_DEFAULT_STATE, pending_attention=[])
+            return _make_default_state()
+        if not isinstance(data, dict):
+            return _make_default_state()
+        cursor = data.get("cursor")
+        if not isinstance(cursor, dict) or "last_ingested_id" not in cursor:
+            cursor = {"last_ingested_id": 0}
+        pending = data.get("pending_attention")
+        if not isinstance(pending, list):
+            pending = []
+        return {"cursor": cursor, "pending_attention": pending}
+    return _make_default_state()
 
 
 def save_state(state):

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import os
+import json
+import sqlite3
+import subprocess
+from datetime import datetime, timedelta
+
+WORKSPACE_DIR = "/home/node/.openclaw/workspace/email-ingest-integration"
+VENV_PYTHON = os.path.join(WORKSPACE_DIR, "venv/bin/python3")
+DB_PATH = os.path.join(WORKSPACE_DIR, "data/email_ingest.sqlite")
+STATE_PATH = "/home/node/.openclaw/workspace/memory/email_triage_state.json"
+
+def get_state():
+    if os.path.exists(STATE_PATH):
+        with open(STATE_PATH, 'r') as f:
+            return json.load(f)
+    return {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
+
+def save_state(state):
+    with open(STATE_PATH, 'w') as f:
+        json.dump(state, f, indent=2)
+
+def check_db_initialized():
+    if not os.path.exists(DB_PATH):
+        return False
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM email_accounts")
+        count = cursor.fetchone()[0]
+        conn.close()
+        return count > 0
+    except:
+        return False
+
+def sync():
+    cmd = [VENV_PYTHON, "main.py", "ingest", "--format", "json"]
+    
+    # 首次运行逻辑：检查数据库是否已有游标
+    if not check_db_initialized():
+        yesterday = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
+        cmd.extend(["--init-start-date", yesterday])
+    
+    result = subprocess.run(cmd, cwd=WORKSPACE_DIR, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Sync failed: {result.stderr}")
+        return
+    
+    # 自动获取本次运行的所有邮件进行报告
+    state = get_state()
+    query_cmd = [VENV_PYTHON, "main.py", "query", "--after-id", str(state["cursor"]["last_ingested_id"]), "--format", "json"]
+    query_result = subprocess.run(query_cmd, cwd=WORKSPACE_DIR, capture_output=True, text=True)
+    
+    if query_result.returncode == 0:
+        data = json.loads(query_result.stdout)
+        new_emails = data.get("results", [])
+        for email in new_emails:
+            # 避免重复
+            if not any(item["id"] == email["id"] for item in state["pending_attention"]):
+                state["pending_attention"].append({
+                    "id": email["id"],
+                    "subject": email["subject"],
+                    "priority": email["priority"],
+                    "sender": email["sender"],
+                    "summary": email.get("summary", ""),
+                    "status": "pending"
+                })
+        
+        if data.get("meta", {}).get("max_id"):
+            state["cursor"]["last_ingested_id"] = data["meta"]["max_id"]
+        
+        save_state(state)
+        print(f"Sync complete. Found {len(new_emails)} new emails.")
+
+def dismiss(email_id):
+    state = get_state()
+    original_len = len(state["pending_attention"])
+    state["pending_attention"] = [item for item in state["pending_attention"] if item["id"] != int(email_id)]
+    if len(state["pending_attention"]) < original_len:
+        save_state(state)
+        return True
+    return False
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "sync":
+            sync()
+        elif sys.argv[1] == "dismiss" and len(sys.argv) > 2:
+            if dismiss(sys.argv[2]):
+                print(f"Email {sys.argv[2]} dismissed.")
+            else:
+                print(f"Email {sys.argv[2]} not found.")

--- a/skills/email-triage/scripts/triage.py
+++ b/skills/email-triage/scripts/triage.py
@@ -1,91 +1,146 @@
 #!/usr/bin/env python3
-import os
 import json
+import os
 import sqlite3
 import subprocess
+import sys
 from datetime import datetime, timedelta
 
-WORKSPACE_DIR = "/home/node/.openclaw/workspace/email-ingest-integration"
-VENV_PYTHON = os.path.join(WORKSPACE_DIR, "venv/bin/python3")
-DB_PATH = os.path.join(WORKSPACE_DIR, "data/email_ingest.sqlite")
-STATE_PATH = "/home/node/.openclaw/workspace/memory/email_triage_state.json"
+_DEFAULT_WORKSPACE = os.path.join(
+    os.path.expanduser("~"), ".openclaw", "workspace", "email-ingest-integration"
+)
+WORKSPACE_DIR = os.environ.get("EMAIL_TRIAGE_WORKSPACE", _DEFAULT_WORKSPACE)
+VENV_PYTHON = os.path.join(WORKSPACE_DIR, "venv", "bin", "python3")
+DB_PATH = os.path.join(WORKSPACE_DIR, "data", "email_ingest.sqlite")
+STATE_PATH = os.environ.get(
+    "EMAIL_TRIAGE_STATE",
+    os.path.join(
+        os.path.expanduser("~"), ".openclaw", "workspace", "memory", "email_triage_state.json"
+    ),
+)
+
 
 def get_state():
     if os.path.exists(STATE_PATH):
-        with open(STATE_PATH, 'r') as f:
+        with open(STATE_PATH, "r") as f:
             return json.load(f)
     return {"cursor": {"last_ingested_id": 0}, "pending_attention": []}
 
+
 def save_state(state):
-    with open(STATE_PATH, 'w') as f:
+    os.makedirs(os.path.dirname(STATE_PATH), exist_ok=True)
+    with open(STATE_PATH, "w") as f:
         json.dump(state, f, indent=2)
+
 
 def check_db_initialized():
     if not os.path.exists(DB_PATH):
         return False
+    conn = None
     try:
         conn = sqlite3.connect(DB_PATH)
         cursor = conn.cursor()
         cursor.execute("SELECT COUNT(*) FROM email_accounts")
         count = cursor.fetchone()[0]
-        conn.close()
         return count > 0
-    except:
+    except (sqlite3.Error, OSError):
         return False
+    finally:
+        if conn is not None:
+            conn.close()
+
 
 def sync():
     cmd = [VENV_PYTHON, "main.py", "ingest", "--format", "json"]
-    
-    # 首次运行逻辑：检查数据库是否已有游标
+
     if not check_db_initialized():
-        yesterday = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
+        yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
         cmd.extend(["--init-start-date", yesterday])
-    
-    result = subprocess.run(cmd, cwd=WORKSPACE_DIR, capture_output=True, text=True)
+
+    try:
+        result = subprocess.run(
+            cmd, cwd=WORKSPACE_DIR, capture_output=True, text=True, timeout=300
+        )
+    except subprocess.TimeoutExpired:
+        print("Sync timed out after 300 seconds.")
+        return
     if result.returncode != 0:
         print(f"Sync failed: {result.stderr}")
         return
-    
-    # 自动获取本次运行的所有邮件进行报告
+
     state = get_state()
-    query_cmd = [VENV_PYTHON, "main.py", "query", "--after-id", str(state["cursor"]["last_ingested_id"]), "--format", "json"]
-    query_result = subprocess.run(query_cmd, cwd=WORKSPACE_DIR, capture_output=True, text=True)
-    
-    if query_result.returncode == 0:
+    query_cmd = [
+        VENV_PYTHON,
+        "main.py",
+        "query",
+        "--after-id",
+        str(state["cursor"]["last_ingested_id"]),
+        "--format",
+        "json",
+    ]
+    try:
+        query_result = subprocess.run(
+            query_cmd, cwd=WORKSPACE_DIR, capture_output=True, text=True, timeout=300
+        )
+    except subprocess.TimeoutExpired:
+        print("Query timed out after 300 seconds.")
+        return
+
+    if query_result.returncode != 0:
+        print(f"Query failed: {query_result.stderr}")
+        return
+
+    try:
         data = json.loads(query_result.stdout)
-        new_emails = data.get("results", [])
-        for email in new_emails:
-            # 避免重复
-            if not any(item["id"] == email["id"] for item in state["pending_attention"]):
-                state["pending_attention"].append({
+    except json.JSONDecodeError as exc:
+        print(f"Failed to parse query output: {exc}")
+        return
+
+    new_emails = data.get("results", [])
+    for email in new_emails:
+        if not any(item["id"] == email["id"] for item in state["pending_attention"]):
+            state["pending_attention"].append(
+                {
                     "id": email["id"],
                     "subject": email["subject"],
                     "priority": email["priority"],
                     "sender": email["sender"],
                     "summary": email.get("summary", ""),
-                    "status": "pending"
-                })
-        
-        if data.get("meta", {}).get("max_id"):
-            state["cursor"]["last_ingested_id"] = data["meta"]["max_id"]
-        
-        save_state(state)
-        print(f"Sync complete. Found {len(new_emails)} new emails.")
+                    "status": "pending",
+                }
+            )
+
+    if data.get("meta", {}).get("max_id"):
+        state["cursor"]["last_ingested_id"] = data["meta"]["max_id"]
+
+    save_state(state)
+    print(f"Sync complete. Found {len(new_emails)} new emails.")
+
+
+def pending():
+    state = get_state()
+    items = [item for item in state["pending_attention"] if item.get("status") == "pending"]
+    print(json.dumps(items, indent=2))
+
 
 def dismiss(email_id):
     state = get_state()
     original_len = len(state["pending_attention"])
-    state["pending_attention"] = [item for item in state["pending_attention"] if item["id"] != int(email_id)]
+    state["pending_attention"] = [
+        item for item in state["pending_attention"] if item["id"] != int(email_id)
+    ]
     if len(state["pending_attention"]) < original_len:
         save_state(state)
         return True
     return False
 
+
 if __name__ == "__main__":
-    import sys
     if len(sys.argv) > 1:
         if sys.argv[1] == "sync":
             sync()
+        elif sys.argv[1] == "pending":
+            pending()
         elif sys.argv[1] == "dismiss" and len(sys.argv) > 2:
             if dismiss(sys.argv[2]):
                 print(f"Email {sys.argv[2]} dismissed.")


### PR DESCRIPTION
## Summary

- **Supersedes #63546.** Resolves the two unresolved Codex review comments from that PR (#10, #11), fixes a newly-discovered P1 latent bug in `check_db_initialized()`, refactors the skill's state layer onto dataclasses, and decouples the skill from the upstream `email-ingest` SQLite schema entirely.
- **Why supersede instead of push to the old branch:** the diff is large enough (schema refactor + architectural change + new test file) that reviewers benefit from a fresh diff against `main` rather than trying to read 7+ Codex review rounds interleaved with the refactor. Change authorship, PR description, and test plan are all cleaner this way.
- **New test coverage:** 48 unit tests (was 15) + 10 end-to-end smoke tests (was 0). Every P1/P2 review comment from #63546 has both unit and smoke coverage.

## Change Type (select all)

- [x] Bug fix
- [x] Feature (new `/email-triage` skill — forward-port from #63546)
- [x] Refactor required for the fix
- [x] Docs

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Supersedes #63546 (will be closed with a link back to this PR).
- Depends on: Anthrop-OS/email-ingest#18 (`main.py status` subcommand) and Anthrop-OS/email-ingest#17 (originating issue).
- [x] This PR fixes a bug or regression

## Root Cause

Three distinct defects addressed in one squash:

1. **P1: `check_db_initialized()` queried a non-existent table.** The original code ran `SELECT COUNT(*) FROM email_accounts`. `email_accounts` is a key in `config.yaml`, not a SQLite table — the real tables (defined in `core/persistence.py`) are `account_cursors`, `audit_logs`, `nlp_cache`, `emails`. Every call raised `sqlite3.OperationalError`, was swallowed by a broad `except sqlite3.Error`, and the function always returned `False`. This meant every `sync()` wrongly appended `--init-start-date yesterday` — a flag the upstream describes as "Mandatory on first run to prevent Token Avalanche" — forcing the avalanche-repair path on every run.

2. **Review comment #10 (unresolved in #63546): query rows not validated.** `sync()` assumed every row in `data["results"]` was a dict with `id`/`subject`/`sender`/`priority`. A non-dict entry or a row missing `id` crashed the whole sync with `AttributeError`/`KeyError` and left the cursor unadvanced.

3. **Review comment #11 (unresolved in #63546): dismiss ID type mismatch.** `dismiss()` called `int(email_id)` before comparing against stored `item["id"]`, but stored IDs were whatever shape the upstream emitted (int or str). `dismiss 10` silently failed to match a stored `"10"`.

## What changed

### `triage.py` — from 201 lines to 214 (net +13)

- **Dropped `sqlite3` import entirely.** `check_db_initialized()` now shells out to `main.py status --format json` (Anthrop-OS/email-ingest#18). Any failure — missing workspace, non-zero exit, malformed JSON, missing `initialized` key — returns False so the skill falls back to the safer first-run path.
- **New `Cursor` / `PendingItem` / `State` dataclasses** with `from_dict()` factories. Every shape check happens once at the serialization boundary. `get_state()` is 7 lines. `sync()`/`pending()`/`dismiss()` consume typed objects; `KeyError` past the boundary is no longer possible.
- **`PendingItem.id` normalized to `str`** on load. Fixes #11 at the schema level — `dismiss 10` now matches a stored `"10"` regardless of upstream type.
- **`sync()` row filtering** via `PendingItem.from_dict()` skips non-dicts, missing-id, and wrong-type rows. Fixes #10.
- **UTF-8 state file** — `save_state()` uses `encoding="utf-8"` + `ensure_ascii=False`. Previously the Windows default cp1252 would corrupt non-ASCII email subjects.
- **Sync log line accuracy** — now reports `"Found N new email(s), enqueued M high-priority."` so operators can distinguish upstream volume from skill action.
- **New env var `EMAIL_TRIAGE_VENV_PYTHON`** — third override so the skill can run in CI / test environments without a real venv at `$WORKSPACE/venv/bin/python3`.

### `test_triage.py` — from 15 tests to 48

- New `TestPendingItemFromDict` (4 tests) — factory validation
- Expanded `TestState` — added UTF-8 round-trip, cursor-non-int fallback, filter regressions
- Rewritten `TestCheckDb` (7 tests) — every branch of the new subprocess-based implementation, including the P1 regression where a valid JSON payload without an `initialized` key must be treated as not initialized
- Expanded `TestSync` — added priority-filter, numeric-priority, bad-JSON, missing-workspace, malformed-row (#10 regression), dedupe, and init-start-date skip/pass cases
- Expanded `TestDismiss` — added int-vs-str match regression for #11

### `test_triage_smoke.py` — new file, 10 tests

End-to-end: spawns `triage.py` in a real subprocess via CLI entrypoints (`sync`, `pending`, `dismiss`) against a fake `main.py` that stands in for `email-ingest`. Supports `status`, `ingest`, `query` subcommands. The fake `status` response is controlled by `FAKE_STATUS_INITIALIZED` so tests can exercise both first-run and steady-state branches without building a real SQLite DB.

Covers:
- `sync` persists state and filters priority
- `pending` command lists queue
- `dismiss 10` (int arg) matches stored `"10"` (str) — #11 regression
- `dismiss` unknown id
- `sync` idempotency
- `sync` incremental append
- `sync` mixed-shape rows don't crash — #10 regression
- `sync` missing workspace → controlled failure, no traceback
- `sync` skips `--init-start-date` when status reports initialized — P1 regression (covers the `email_accounts` → `status` fix)
- `sync` passes `--init-start-date` when status reports not-initialized — symmetric coverage

### `SKILL.md`

- Documents new env var `EMAIL_TRIAGE_VENV_PYTHON`
- Updates prerequisites to note dependency on Anthrop-OS/email-ingest#18

## What did NOT change (scope boundary)

- No changes to the skill loader, CI config, or any other skill.
- The on-disk state JSON format is unchanged. Existing state files round-trip without migration.
- No changes to the `email-ingest` upstream are in this PR; those are in Anthrop-OS/email-ingest#18.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test (smoke)
- Target files: `skills/email-triage/scripts/test_triage.py`, `skills/email-triage/scripts/test_triage_smoke.py`
- Scenario: every bug fixed above has both a unit test and a smoke test.
- Why this is the smallest reliable guardrail: smoke tests exercise the full argv → subprocess → JSON → filesystem path without touching a real mail server or venv. Unit tests exercise each branch individually with mocked subprocess. Together they cover every review comment, both P1 bugs, and every exception path.

## User-visible / Behavior Changes

- **Bug fix:** `sync` no longer wrongly passes `--init-start-date` on every run.
- **Bug fix:** `dismiss <id>` now works regardless of whether the upstream emits int or str IDs.
- **New env var** `EMAIL_TRIAGE_VENV_PYTHON` for overriding the venv interpreter path.
- **Non-ASCII email subjects** (CJK/Cyrillic/Arabic) now survive state-file round-trip on all platforms.

## Security Impact

- New permissions/capabilities? `No`.
- Secrets/tokens handling changed? `No`.
- New/changed network calls? `No` — network calls remain delegated to the external `email-ingest` subprocess.
- Command/tool execution surface changed? `Yes` — the skill now invokes `main.py status` in addition to `main.py ingest` and `main.py query`. All three are constructed from static strings + the env-configured workspace path; no user input is interpolated into argv.
- Data access scope changed? `No` — removed direct SQLite access, which actually reduces coupling.

## Repro + Verification

### Environment

- OS: Windows 11 / Linux (CI)
- Runtime: Python 3.12

### Steps

1. Check out this branch.
2. `ruff check skills/email-triage/` — verify lint passes.
3. `python -m pytest skills/email-triage/scripts/test_triage.py skills/email-triage/scripts/test_triage_smoke.py` — run 58 tests.

### Expected

- All ruff checks pass.
- 58 tests pass.

### Actual

```
$ python -m ruff check skills/email-triage/
All checks passed!

$ python -m pytest skills/email-triage/scripts/test_triage.py skills/email-triage/scripts/test_triage_smoke.py
58 passed in 3.50s
```

## Evidence

- [x] Failing test/log before + passing after
- [x] Architectural change (removed `sqlite3` import from the skill)

Before: every `sync()` silently failed `check_db_initialized()` and passed `--init-start-date yesterday` to `main.py ingest`. `dismiss 10` failed to remove stored `"10"`. Query rows with one bad entry aborted the entire sync.

After: `check_db_initialized()` consults `main.py status` over subprocess, returns the real init state, and no longer opens the upstream SQLite file. All three review-comment regressions have unit + smoke coverage.

## Compatibility / Migration

- Backward compatible? `Yes` — state file JSON format unchanged, env vars keep their old defaults, existing state files round-trip.
- Config/env changes? One new optional env var (`EMAIL_TRIAGE_VENV_PYTHON`) with a sensible default.
- Migration needed? `No` for this skill. **Does require** upstream Anthrop-OS/email-ingest#18 to be merged so the `main.py status` command is available. Without it, `check_db_initialized()` returns False for every call — safe (the upstream's own avalanche-protection error surfaces) but means every sync takes the first-run path.

## Risks and Mitigations

- **Risk:** if upstream PR #18 is not merged before this PR, users running the new skill against an unpatched `email-ingest` will see `sync()` always take the first-run path. Mitigation: the SKILL.md prerequisites section names the upstream PR explicitly; users can hold off installing the new skill version until upstream is current.
- **Risk:** the upstream `main.py status` command is defined in a separate repo and could drift. Mitigation: `check_db_initialized()` defensively treats missing `initialized` keys as not-initialized, and 7 unit tests + 2 smoke tests cover every branch. Schema drift will fail loudly in CI, not silently in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
