### PR TITLE
test(qianfan,kimi-coding): add provider plugin and onboard config tests [AI-assisted]

### DIFF
--- a/extensions/kimi-coding/onboard.test.ts
+++ b/extensions/kimi-coding/onboard.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyKimiCodeConfig,
+  applyKimiCodeProviderConfig,
+  KIMI_CODING_MODEL_REF,
+  KIMI_MODEL_REF,
+} from "./onboard.js";
+import { KIMI_CODING_BASE_URL, KIMI_CODING_DEFAULT_MODEL_ID } from "./provider-catalog.js";
+
+describe("Kimi onboard config", () => {
+  it("exposes consistent model refs", () => {
+    expect(KIMI_MODEL_REF).toBe(`kimi/${KIMI_CODING_DEFAULT_MODEL_ID}`);
+    expect(KIMI_CODING_MODEL_REF).toBe(KIMI_MODEL_REF);
+  });
+
+  it("applies kimi provider config with correct baseUrl and api", () => {
+    const cfg = applyKimiCodeProviderConfig({} as never);
+    const kimiProvider = cfg.models?.providers?.kimi as Record<string, unknown>;
+
+    expect(kimiProvider).toBeDefined();
+    expect(kimiProvider.baseUrl).toBe(KIMI_CODING_BASE_URL);
+    expect(kimiProvider.api).toBe("anthropic-messages");
+  });
+
+  it("applies kimi config with default model as primary", () => {
+    const cfg = applyKimiCodeConfig({} as never);
+
+    expect(
+      (cfg.agents?.defaults?.model as { primary?: string })?.primary,
+    ).toBe(KIMI_MODEL_REF);
+  });
+
+  it("registers the Kimi alias for the default model", () => {
+    const cfg = applyKimiCodeConfig({} as never);
+
+    const alias = cfg.agents?.defaults?.models?.[KIMI_MODEL_REF]?.alias;
+    expect(alias).toBe("Kimi");
+  });
+
+  it("includes the default model in provider models list", () => {
+    const cfg = applyKimiCodeProviderConfig({} as never);
+    const kimiProvider = cfg.models?.providers?.kimi as Record<string, unknown>;
+    const models = kimiProvider.models as Array<{ id: string }>;
+
+    expect(models).toBeDefined();
+    expect(models.some((model) => model.id === KIMI_CODING_DEFAULT_MODEL_ID)).toBe(true);
+  });
+});

--- a/extensions/kimi-coding/replay-policy.test.ts
+++ b/extensions/kimi-coding/replay-policy.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { KIMI_REPLAY_POLICY } from "./replay-policy.js";
+
+describe("Kimi replay policy", () => {
+  it("disables signature preservation", () => {
+    expect(KIMI_REPLAY_POLICY.preserveSignatures).toBe(false);
+  });
+
+  it("is a stable object reference", () => {
+    expect(KIMI_REPLAY_POLICY).toEqual({ preserveSignatures: false });
+  });
+});

--- a/extensions/qianfan/index.test.ts
+++ b/extensions/qianfan/index.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import qianfanPlugin from "./index.js";
+import {
+  applyQianfanConfig,
+  applyQianfanProviderConfig,
+  QIANFAN_DEFAULT_MODEL_REF,
+} from "./onboard.js";
+import { buildQianfanProvider, QIANFAN_BASE_URL } from "./provider-catalog.js";
+
+describe("qianfan provider plugin", () => {
+  it("registers Qianfan with api-key auth metadata", async () => {
+    const provider = await registerSingleProviderPlugin(qianfanPlugin);
+
+    expect(provider.id).toBe("qianfan");
+    expect(provider.label).toBe("Qianfan");
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.auth![0].id).toBe("api-key");
+    expect(provider.auth![0].kind).toBe("api_key");
+  });
+
+  it("builds the static Qianfan model catalog", async () => {
+    const provider = await registerSingleProviderPlugin(qianfanPlugin);
+    expect(provider.catalog).toBeDefined();
+
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as never);
+
+    expect(catalog && "provider" in catalog).toBe(true);
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected single-provider catalog");
+    }
+
+    expect(catalog.provider.api).toBe("openai-completions");
+    expect(catalog.provider.baseUrl).toBe("https://qianfan.baidubce.com/v2");
+    expect(catalog.provider.models?.map((model) => model.id)).toEqual([
+      "deepseek-v3.2",
+      "ernie-5.0-thinking-preview",
+    ]);
+  });
+
+  it("marks deepseek-v3.2 as a reasoning model", async () => {
+    const provider = await registerSingleProviderPlugin(qianfanPlugin);
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as never);
+
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected single-provider catalog");
+    }
+
+    const deepseekModel = catalog.provider.models?.find(
+      (model) => model.id === "deepseek-v3.2",
+    );
+    expect(deepseekModel?.reasoning).toBe(true);
+    expect(deepseekModel?.input).toEqual(["text"]);
+    expect(deepseekModel?.contextWindow).toBe(98304);
+    expect(deepseekModel?.maxTokens).toBe(32768);
+  });
+
+  it("marks ernie-5.0-thinking-preview as a multimodal reasoning model", async () => {
+    const provider = await registerSingleProviderPlugin(qianfanPlugin);
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as never);
+
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected single-provider catalog");
+    }
+
+    const ernieModel = catalog.provider.models?.find(
+      (model) => model.id === "ernie-5.0-thinking-preview",
+    );
+    expect(ernieModel?.reasoning).toBe(true);
+    expect(ernieModel?.input).toEqual(["text", "image"]);
+    expect(ernieModel?.contextWindow).toBe(119000);
+    expect(ernieModel?.maxTokens).toBe(64000);
+  });
+});
+
+describe("buildQianfanProvider", () => {
+  it("returns provider config with correct base URL and API type", () => {
+    const provider = buildQianfanProvider();
+
+    expect(provider.baseUrl).toBe(QIANFAN_BASE_URL);
+    expect(provider.api).toBe("openai-completions");
+  });
+
+  it("includes both bundled models", () => {
+    const provider = buildQianfanProvider();
+
+    expect(provider.models).toHaveLength(2);
+    expect(provider.models[0].id).toBe("deepseek-v3.2");
+    expect(provider.models[1].id).toBe("ernie-5.0-thinking-preview");
+  });
+
+  it("sets zero cost for all models", () => {
+    const provider = buildQianfanProvider();
+
+    for (const model of provider.models) {
+      expect(model.cost).toEqual({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
+    }
+  });
+});
+
+describe("applyQianfanConfig", () => {
+  it("applies qianfan provider config with default model", () => {
+    const cfg = applyQianfanConfig({} as never);
+
+    expect(cfg.models?.providers?.qianfan).toBeDefined();
+    expect(
+      (cfg.agents?.defaults?.model as { primary?: string })?.primary,
+    ).toBe(QIANFAN_DEFAULT_MODEL_REF);
+  });
+
+  it("applies qianfan provider config with correct baseUrl and api", () => {
+    const cfg = applyQianfanProviderConfig({} as never);
+    const qianfanProvider = cfg.models?.providers?.qianfan as Record<
+      string,
+      unknown
+    >;
+
+    expect(qianfanProvider.baseUrl).toBe(QIANFAN_BASE_URL);
+    expect(qianfanProvider.api).toBe("openai-completions");
+  });
+
+  it("preserves existing provider baseUrl when explicitly configured", () => {
+    const customBaseUrl = "https://custom-qianfan.example.com/v2";
+    const cfg = applyQianfanConfig({
+      models: {
+        providers: {
+          qianfan: {
+            baseUrl: customBaseUrl,
+          },
+        },
+      },
+    } as never);
+
+    const qianfanProvider = cfg.models?.providers?.qianfan as Record<
+      string,
+      unknown
+    >;
+    expect(qianfanProvider.baseUrl).toBe(customBaseUrl);
+  });
+
+  it("registers the QIANFAN alias for the default model", () => {
+    const cfg = applyQianfanConfig({} as never);
+
+    const alias =
+      cfg.agents?.defaults?.models?.[QIANFAN_DEFAULT_MODEL_REF]?.alias;
+    expect(alias).toBe("QIANFAN");
+  });
+});


### PR DESCRIPTION
## Summary

Add test coverage for the Qianfan and Kimi Coding provider extensions which previously had no dedicated tests for plugin registration, catalog building, and onboard config application.

## Problem

The Qianfan (`extensions/qianfan`) and Kimi Coding (`extensions/kimi-coding`) provider extensions lacked test coverage for their plugin registration, model catalog, and onboard configuration logic. Qianfan had **zero test files** and Kimi Coding was missing tests for its onboard config and replay policy modules.

## Solution

### Qianfan (`extensions/qianfan/index.test.ts`) — 11 new tests

**Plugin registration (4 tests):**
- Verifies provider id, label, auth method metadata (id, kind)
- Validates static model catalog: baseUrl, api type, model id list
- Asserts `deepseek-v3.2` model properties: reasoning=true, text-only input, context window, max tokens
- Asserts `ernie-5.0-thinking-preview` model properties: reasoning=true, multimodal input (text+image), context window, max tokens

**`buildQianfanProvider` (3 tests):**
- Correct baseUrl and api type
- Both bundled models present
- Zero-cost defaults for all models

**`applyQianfanConfig` (4 tests):**
- Provider config with default primary model
- Correct baseUrl and api in provider config
- Preserves user-configured custom baseUrl
- Registers QIANFAN alias for the default model

### Kimi Coding — 7 new tests across 2 files

**`extensions/kimi-coding/onboard.test.ts` (5 tests):**
- Model ref consistency (`KIMI_MODEL_REF` = `KIMI_CODING_MODEL_REF`)
- Provider config baseUrl and api type
- Default model set as primary
- Kimi alias registration
- Default model included in provider models list

**`extensions/kimi-coding/replay-policy.test.ts` (2 tests):**
- Signature preservation disabled
- Stable object reference

## Testing

All 29 tests pass locally:

```
pnpm test:extension qianfan    → 11 passed
pnpm test:extension kimi-coding → 18 passed (including 11 pre-existing)
oxlint                           → 0 warnings, 0 errors
```

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs
- [x] Test-only

## Risks and Mitigations

**Risk:** very low; test-only change with no runtime code modifications.

## AI Assistance

This PR was AI-assisted.
- Degree of testing: fully tested
- I confirm I understand what the code does.
