### PR TITLE
test(qa): (GPT 5.4 Parity vs. Opus Agentic) gate parity prose scenarios on real tool calls

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -112,6 +112,16 @@ describe("qa scenario catalog", () => {
     );
   });
 
+  it("keeps mock-only image debug assertions guarded in live-frontier runs", () => {
+    const scenario = readQaScenarioById("image-understanding-attachment");
+    const imageRequestExpr = scenario.execution.flow?.steps
+      .flatMap((step) => step.actions ?? [])
+      .find((action) => action.set === "imageRequest")?.value?.expr;
+
+    expect(imageRequestExpr).toContain("env.mock ?");
+    expect(imageRequestExpr).toContain("/debug/requests");
+  });
+
   it("rejects malformed string matcher lists before running a flow", () => {
     expect(() =>
       validateQaScenarioExecutionConfig({

--- a/qa/scenarios/config-restart-capability-flip.md
+++ b/qa/scenarios/config-restart-capability-flip.md
@@ -151,6 +151,19 @@ steps:
                     ref: imageStartedAtMs
                   timeoutMs:
                     expr: liveTurnTimeoutMs(env, 45000)
+            # Tool-call assertion (criterion 2 of the parity completion
+            # gate in #64227): the restored `image_generate` capability
+            # must have actually fired as a real tool call. Without this
+            # assertion, a prose reply that just mentions a MEDIA path
+            # could satisfy the scenario, so strengthen it by requiring
+            # the mock to have recorded `plannedToolName: "image_generate"`
+            # against a post-restart request. Scoped to `!env.mock` so
+            # live-frontier runs (which don't expose `/debug/requests`)
+            # still pass the rest of the scenario.
+            - assert:
+                expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => String(request.allInputText ?? '').toLowerCase().includes('capability flip image check') && request.plannedToolName === 'image_generate')"
+                message:
+                  expr: "`expected image_generate tool call during capability flip scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].filter((request) => String(request.allInputText ?? '').toLowerCase().includes('capability flip image check')).map((request) => request.plannedToolName ?? null))}`"
           finally:
             - call: patchConfig
               args:

--- a/qa/scenarios/image-understanding-attachment.md
+++ b/qa/scenarios/image-understanding-attachment.md
@@ -64,9 +64,26 @@ steps:
           expr: "!missingColorGroup"
           message:
             expr: "`missing expected colors in image description: ${outbound.text}`"
+      # Image-processing assertion: verify the mock actually received an
+      # image on the scenario-unique prompt. This is as strong as a
+      # tool-call assertion for this scenario — unlike the
+      # `source-docs-discovery-report` / `subagent-handoff` /
+      # `config-restart-capability-flip` scenarios that rely on a real
+      # tool call to satisfy the parity criterion, image understanding
+      # is handled inside the provider's vision capability and does NOT
+      # emit a tool call the mock can record as `plannedToolName`. The
+      # `imageInputCount` field IS the tool-call evidence for vision
+      # scenarios: it proves the attachment reached the provider, which
+      # is the only thing an external harness can verify in mock mode.
+      # Match on the scenario-unique prompt substring so the assertion
+      # can't be accidentally satisfied by some other scenario's image
+      # request that happens to share a debug log with this one.
+      - set: imageRequest
+        value:
+          expr: "[...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].find((request) => String(request.prompt ?? '').includes('Image understanding check'))"
       - assert:
-          expr: "!env.mock || (((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.prompt ?? '').includes('Image understanding check'))?.imageInputCount ?? 0) >= 1)"
+          expr: "!env.mock || (imageRequest && (imageRequest.imageInputCount ?? 0) >= 1)"
           message:
-            expr: "`expected at least one input image, got ${String((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.prompt ?? '').includes('Image understanding check'))?.imageInputCount ?? 0)}`"
+            expr: "`expected at least one input image on the Image understanding check request, got imageInputCount=${String(imageRequest?.imageInputCount ?? 0)}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/image-understanding-attachment.md
+++ b/qa/scenarios/image-understanding-attachment.md
@@ -80,7 +80,7 @@ steps:
       # request that happens to share a debug log with this one.
       - set: imageRequest
         value:
-          expr: "[...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].find((request) => String(request.prompt ?? '').includes('Image understanding check'))"
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].find((request) => String(request.prompt ?? '').includes('Image understanding check')) : null"
       - assert:
           expr: "!env.mock || (imageRequest && (imageRequest.imageInputCount ?? 0) >= 1)"
           message:

--- a/qa/scenarios/memory-recall.md
+++ b/qa/scenarios/memory-recall.md
@@ -1,5 +1,35 @@
 # Memory recall after context switch
 
+<!--
+  This scenario deliberately stays prose-only and does NOT gate on a
+  `/debug/requests` tool-call assertion, even though it is one of the ten
+  scenarios in the parity pack. The adversarial review in the umbrella
+  #64227 thread called this out as a coverage gap, but the underlying
+  behavior the scenario tests is legitimately prose-shaped: the agent is
+  supposed to pull a prior-turn fact ("ALPHA-7") back across an
+  intervening context switch and reply with the code. In a real
+  conversation, the model can do this EITHER by calling a memory-search
+  tool (which the qa-lab mock server doesn't currently expose) OR by
+  reading the fact directly from prior-turn context in its own
+  conversation window. Both strategies are valid parity behavior.
+
+  Forcing a `plannedToolName` assertion here would either require
+  extending the mock with a synthetic `memory_search` tool lane (PR O
+  scope, not PR J) or fabricating a tool-call requirement the real
+  providers never implement. Either path would make this scenario test
+  the harness, not the models. So we keep it prose-only, covered by the
+  `recallExpectedAny` / `rememberAckAny` assertions above, and flag the
+  exception explicitly rather than silently.
+
+  Criterion 2 of the parity completion gate (no fake progress or fake
+  tool completion) is still enforced here through the parity report's
+  fake-success detector: a scenario that's marked `pass` but whose
+  details text matches a positive-tone or failure-tone fake-success
+  pattern gets flagged via `SUSPICIOUS_PASS_PATTERNS` in
+  `extensions/qa-lab/src/agentic-parity-report.ts`. See PR E #64662 for
+  the detector extension that catches positive-tone evasions.
+-->
+
 ```yaml qa-scenario
 id: memory-recall
 title: Memory recall after context switch

--- a/qa/scenarios/source-docs-discovery-report.md
+++ b/qa/scenarios/source-docs-discovery-report.md
@@ -60,9 +60,10 @@ steps:
       # require an actual read tool call before the prose report. Without this,
       # a model could fabricate a plausible Worked/Failed/Blocked/Follow-up
       # report without ever touching the repo files the prompt names. The
-      # debug request log is fetched once, lowercased for case-insensitive
-      # matching (the real prompt says "Worked, Failed, Blocked"), and
-      # reused for both the assertion and its failure-message diagnostic.
+      # debug request log is fetched once and reused for both the assertion
+      # and its failure-message diagnostic. Each request's allInputText is
+      # lowercased inline at match time (the real prompt writes it as
+      # "Worked, Failed, Blocked") so the contains check is case-insensitive.
       - set: discoveryDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"

--- a/qa/scenarios/source-docs-discovery-report.md
+++ b/qa/scenarios/source-docs-discovery-report.md
@@ -56,5 +56,13 @@ steps:
           expr: "!reportsDiscoveryScopeLeak(outbound.text)"
           message:
             expr: "`discovery report drifted beyond scope: ${outbound.text}`"
+      # Parity gate criterion 2 (no fake progress / fake tool completion):
+      # require an actual read tool call before the prose report. Without this,
+      # a model could fabricate a plausible Worked/Failed/Blocked/Follow-up
+      # report without ever touching the repo files the prompt names.
+      - assert:
+          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => String(request.allInputText ?? '').includes('worked, failed, blocked') && request.plannedToolName === 'read')"
+          message:
+            expr: "`expected at least one read tool call during discovery report scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/source-docs-discovery-report.md
+++ b/qa/scenarios/source-docs-discovery-report.md
@@ -59,10 +59,16 @@ steps:
       # Parity gate criterion 2 (no fake progress / fake tool completion):
       # require an actual read tool call before the prose report. Without this,
       # a model could fabricate a plausible Worked/Failed/Blocked/Follow-up
-      # report without ever touching the repo files the prompt names.
+      # report without ever touching the repo files the prompt names. The
+      # debug request log is fetched once, lowercased for case-insensitive
+      # matching (the real prompt says "Worked, Failed, Blocked"), and
+      # reused for both the assertion and its failure-message diagnostic.
+      - set: discoveryDebugRequests
+        value:
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => String(request.allInputText ?? '').includes('worked, failed, blocked') && request.plannedToolName === 'read')"
+          expr: "!env.mock || discoveryDebugRequests.some((request) => String(request.allInputText ?? '').toLowerCase().includes('worked, failed, blocked') && request.plannedToolName === 'read')"
           message:
-            expr: "`expected at least one read tool call during discovery report scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
+            expr: "`expected at least one read tool call during discovery report scenario, saw plannedToolNames=${JSON.stringify(discoveryDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/subagent-fanout-synthesis.md
+++ b/qa/scenarios/subagent-fanout-synthesis.md
@@ -113,6 +113,28 @@ steps:
                                   expr: "sawAlpha && sawBeta"
                                   message:
                                     expr: "`fanout child sessions missing (alpha=${String(sawAlpha)} beta=${String(sawBeta)})`"
+                              # Tool-call assertion (criterion 2 of the
+                              # parity completion gate in #64227): the
+                              # scenario must have actually invoked
+                              # `sessions_spawn` at least twice with
+                              # distinct labels, not just ended up with
+                              # two rows in the session store through
+                              # prose trickery. The session store alone
+                              # can be populated by other flows or by a
+                              # model that fabricates "delegation"
+                              # narration. `plannedToolName` on the
+                              # mock's `/debug/requests` log is the
+                              # tool-call ground truth: two recorded
+                              # sessions_spawn requests with distinct
+                              # labels means the model really dispatched
+                              # both subagents.
+                              - set: fanoutSpawnRequests
+                                value:
+                                  expr: "[...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].filter((request) => request.plannedToolName === 'sessions_spawn' && /subagent fanout synthesis check/i.test(String(request.allInputText ?? '')))"
+                              - assert:
+                                  expr: "fanoutSpawnRequests.length >= 2"
+                                  message:
+                                    expr: "`expected at least two sessions_spawn tool calls during subagent fanout scenario, saw ${fanoutSpawnRequests.length}`"
                         - set: details
                           value:
                             expr: "outbound.text"

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -46,5 +46,14 @@ steps:
           expr: "!['failed to delegate','could not delegate','subagent unavailable'].some((needle) => normalizeLowercaseStringOrEmpty(outbound.text).includes(needle))"
           message:
             expr: "`subagent handoff reported failure: ${outbound.text}`"
+      # Parity gate criterion 2 (no fake progress / fake tool completion):
+      # require an actual sessions_spawn tool call. Without this, a model
+      # could produce the three labeled sections ("Delegated task", "Result",
+      # "Evidence") as free-form prose without ever delegating to a real
+      # subagent.
+      - assert:
+          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
+          message:
+            expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,14 +50,17 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent. The debug request log is fetched once and the match is
-      # narrowed to the most recent matching request so a stale prior
-      # scenario on the same mock server cannot satisfy the gate.
+      # subagent. The debug request log is fetched once and filtered to
+      # pre-tool requests (no toolOutput) because that is when the mock
+      # server plans sessions_spawn; the follow-up request after the tool
+      # runs has plannedToolName unset, so a reverse-find on any matching
+      # input would often land on that post-tool request and fail even when
+      # the handoff succeeded.
       - set: subagentDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || (subagentDebugRequests.slice().reverse().find((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')))?.plannedToolName === 'sessions_spawn')"
+          expr: "!env.mock || subagentDebugRequests.some((request) => !request.toolOutput && /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
           message:
             expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify(subagentDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,16 +50,15 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent. The assertion must be pinned to THIS scenario's request
-      # window, so it matches the scenario-unique prompt text
-      # "Delegate one bounded QA task" (not a broad /delegate|subagent/
-      # regex) — otherwise the earlier subagent-fanout-synthesis scenario
-      # in catalog order also produces a pre-tool sessions_spawn request
-      # and would satisfy the assertion even when the current handoff run
-      # never delegates. The match is also pinned to pre-tool requests
-      # (no toolOutput) because the mock only plans sessions_spawn on
-      # requests with no toolOutput; the follow-up request after the tool
-      # runs has plannedToolName unset.
+      # subagent. The assertion is pinned to THIS scenario by matching the
+      # scenario-unique prompt substring "Delegate one bounded QA task"
+      # (not a broad /delegate|subagent/ regex) so the earlier
+      # subagent-fanout-synthesis scenario — which also contains "delegate"
+      # and produces its own pre-tool sessions_spawn request — cannot
+      # satisfy the assertion here. The match is also constrained to
+      # pre-tool requests (no toolOutput) because the mock only plans
+      # sessions_spawn on requests with no toolOutput; the follow-up
+      # request after the tool runs has plannedToolName unset.
       - set: subagentDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,17 +50,21 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent. The debug request log is fetched once and filtered to
-      # pre-tool requests (no toolOutput) because that is when the mock
-      # server plans sessions_spawn; the follow-up request after the tool
-      # runs has plannedToolName unset, so a reverse-find on any matching
-      # input would often land on that post-tool request and fail even when
-      # the handoff succeeded.
+      # subagent. The assertion must be pinned to THIS scenario's request
+      # window, so it matches the scenario-unique prompt text
+      # "Delegate one bounded QA task" (not a broad /delegate|subagent/
+      # regex) — otherwise the earlier subagent-fanout-synthesis scenario
+      # in catalog order also produces a pre-tool sessions_spawn request
+      # and would satisfy the assertion even when the current handoff run
+      # never delegates. The match is also pinned to pre-tool requests
+      # (no toolOutput) because the mock only plans sessions_spawn on
+      # requests with no toolOutput; the follow-up request after the tool
+      # runs has plannedToolName unset.
       - set: subagentDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || subagentDebugRequests.some((request) => !request.toolOutput && /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
+          expr: "!env.mock || subagentDebugRequests.some((request) => !request.toolOutput && /delegate one bounded qa task/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
           message:
             expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify(subagentDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,10 +50,15 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent.
+      # subagent. The debug request log is fetched once and the match is
+      # narrowed to the most recent matching request so a stale prior
+      # scenario on the same mock server cannot satisfy the gate.
+      - set: subagentDebugRequests
+        value:
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
+          expr: "!env.mock || (subagentDebugRequests.slice().reverse().find((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')))?.plannedToolName === 'sessions_spawn')"
           message:
-            expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
+            expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify(subagentDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```


### PR DESCRIPTION
## Summary

Closes the last "prose can satisfy a tool-mediated scenario" loophole in the parity pack. Two scenarios — `source-docs-discovery-report` and `subagent-handoff` — were only asserting on the textual shape of the agent's reply, which meant a model could produce a plausible protocol report without ever reading the files or delegating to a subagent. This PR wires them into the `/debug/requests` seam so the expected tool call actually has to land before the prose is accepted.

Scenario-YAML only. No runtime or harness code. Independent of #64441, #64662, and #64679 — review it any time.

Part of #64227 (advances completion gate criterion 2 — "GPT-5.4 no longer fakes progress or fake tool completion").

## Background

The QA suite runner exposes a `/debug/requests` endpoint on the mock OpenAI server (`extensions/qa-lab/src/mock-openai-server.ts`) that records every model request, including the `plannedToolName` the mock returned. Most first-wave parity scenarios already use it to assert that the agent actually invoked a specific tool. The pattern looks like:

```yaml
- assert:
    expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some(... && request.plannedToolName === 'read')"
```

Two scenarios in the pack weren't wired to it:

1. **`source-docs-discovery-report`** — checks that the reply has `Worked / Failed / Blocked / Follow-up` headings and mentions repo files, but never checks that the model actually read those files.
2. **`subagent-handoff`** — checks that the reply has `Delegated task / Result / Evidence` sections, but never checks that the model actually called `sessions_spawn` to delegate.

Both are fake-progress loopholes, and both are exactly the kind of thing the parity gate is supposed to catch.

## What changed

### `qa/scenarios/source-docs-discovery-report.md`

Adds:

```yaml
- assert:
    expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => String(request.allInputText ?? '').includes('worked, failed, blocked') && request.plannedToolName === 'read')"
    message:
      expr: "`expected at least one read tool call during discovery report scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
```

The mock server already returns a `read` tool call for prompts matching `/source and docs|worked, failed, blocked/` when no `toolOutput` is present, so real gpt-5.4 runs that follow the intended flow still pass. A prose-only shortcut no longer does.

### `qa/scenarios/subagent-handoff.md`

Adds:

```yaml
- assert:
    expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
    message:
      expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
```

Same idea — the mock already emits `sessions_spawn` for `/\bdelegate\b|subagent handoff/` prompts, so real runs continue to pass.

Both assertions are gated on `!env.mock` so they no-op in live-frontier mode where the mock's debug surface isn't available and the real provider records `plannedToolName` through a different channel.

## What's NOT changed

**`memory-recall`** is also in the second-wave parity pack and also has "prose-only" assertions, but reading a remembered fact from prior-turn context is a legitimate recall strategy — that's not fake progress. Forcing a `memory_search` tool call would require extending the mock's memory pipeline (today it routes remember/recall prompts through `extractRememberedFact` in prose, not through tool calls), and that belongs in a follow-up that extends `mock-openai-server.ts` with a real memory-tool lane. Out of scope here.

## Validation

- `pnpm test extensions/qa-lab/src/scenario-catalog.test.ts` — the test that ingests the scenario YAML, 4/4 pass
- rebased on green `main` (HEAD `545490c592` at push time)
