### PR TITLE
fix: move chat.history startup guard removal before logGatewayStartup

### DIFF
--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -273,6 +273,7 @@ export async function startGatewayPostAttachRuntime(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   unavailableGatewayMethods: Set<string>;
 }) {
+  params.unavailableGatewayMethods.delete("chat.history");
   logGatewayStartup({
     cfg: params.cfgAtStart,
     bindHost: params.bindHost,
@@ -322,7 +323,6 @@ export async function startGatewayPostAttachRuntime(params: {
       logHooks: params.logHooks,
       logChannels: params.logChannels,
     }));
-    params.unavailableGatewayMethods.delete("chat.history");
   }
 
   if (!params.minimalTestGateway) {


### PR DESCRIPTION
## Summary

Fixes the `chat.history unavailable during gateway startup` error that occurs when WebChat / Control UI reconnects during the gateway startup window.

Related: #63863 (related but distinct symptom — this PR addresses the guard rejection, not handler slowness)

## Problem

After gateway prints `ready (3 plugins; 1.8s)`, the first `chat.history` WS request is immediately rejected with `UNAVAILABLE` because the guard removal happens after `startGatewaySidecars()` completes (~11s delay).

```
22:28:22.910 [gateway] ready (3 plugins; ...; 1.7s)
22:28:33.989 [ws] ⇄ res ✗ chat.history 0ms errorCode=UNAVAILABLE
```

## Root cause

In `src/gateway/server-startup-post-attach.ts`, `startGatewayPostAttachRuntime`:

1. `logGatewayStartup()` prints `ready` (line ~276)
2. `startGatewaySidecars()` runs (~11s: lock cleanup, Gmail, hooks, model prewarm, channels)
3. **`unavailableGatewayMethods.delete("chat.history")` only executes after sidecars complete** (line ~325)

## Why this is safe

The `chat.history` handler only reads session store JSON + transcript JSONL from disk. It has **zero dependency** on channels, sidecars, Gmail watcher, hooks, or model prewarm.

## Change

**1 line moved**: `params.unavailableGatewayMethods.delete("chat.history")` from after `startGatewaySidecars()` (line 325) to just before `logGatewayStartup()` (line 276).

## Local verification

| Metric | Before | After |
|---|---|---|
| First chat.history after restart | ✗ UNAVAILABLE (0ms) | ✓ Success (2278ms) |
| Stable-period requests | ✓ Normal | ✓ Normal |
| New startup errors | — | None |

## Environment

- OpenClaw 2026.4.5, macOS Darwin 25.3.0 (arm64), npm global