### PR TITLE
qa-lab: record provider/model/mode in qa-suite-summary.json

### DIFF
--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { buildQaSuiteSummaryJson } from "./suite.js";
+
+describe("buildQaSuiteSummaryJson", () => {
+  const baseParams = {
+    scenarios: [
+      { name: "Scenario A", status: "pass" as const },
+      { name: "Scenario B", status: "fail" as const, details: "something broke" },
+    ],
+    startedAt: new Date("2026-04-11T00:00:00.000Z"),
+    finishedAt: new Date("2026-04-11T00:05:00.000Z"),
+    providerMode: "mock-openai" as const,
+    primaryModel: "openai/gpt-5.4",
+    alternateModel: "openai/gpt-5.4-alt",
+    fastMode: true,
+    concurrency: 2,
+  };
+
+  it("records provider/model/mode so parity gates can verify labels", () => {
+    const json = buildQaSuiteSummaryJson(baseParams);
+    expect(json.run).toMatchObject({
+      startedAt: "2026-04-11T00:00:00.000Z",
+      finishedAt: "2026-04-11T00:05:00.000Z",
+      providerMode: "mock-openai",
+      primaryModel: "openai/gpt-5.4",
+      primaryProvider: "openai",
+      primaryModelName: "gpt-5.4",
+      alternateModel: "openai/gpt-5.4-alt",
+      alternateProvider: "openai",
+      alternateModelName: "gpt-5.4-alt",
+      fastMode: true,
+      concurrency: 2,
+      scenarioIds: null,
+    });
+  });
+
+  it("includes scenarioIds in run metadata when provided", () => {
+    const scenarioIds = ["approval-turn-tool-followthrough", "subagent-handoff", "memory-recall"];
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      scenarioIds,
+    });
+    expect((json.run as { scenarioIds?: readonly string[] }).scenarioIds).toEqual(scenarioIds);
+  });
+
+  it("records an Anthropic baseline lane cleanly for parity runs", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      primaryModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-sonnet-4-6",
+    });
+    expect(json.run).toMatchObject({
+      primaryModel: "anthropic/claude-opus-4-6",
+      primaryProvider: "anthropic",
+      primaryModelName: "claude-opus-4-6",
+      alternateModel: "anthropic/claude-sonnet-4-6",
+      alternateProvider: "anthropic",
+      alternateModelName: "claude-sonnet-4-6",
+    });
+  });
+
+  it("leaves split fields null when a model ref is malformed", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      primaryModel: "not-a-real-ref",
+      alternateModel: "",
+    });
+    expect(json.run).toMatchObject({
+      primaryModel: "not-a-real-ref",
+      primaryProvider: null,
+      primaryModelName: null,
+      alternateModel: "",
+      alternateProvider: null,
+      alternateModelName: null,
+    });
+  });
+
+  it("keeps scenarios and counts alongside the run metadata", () => {
+    const json = buildQaSuiteSummaryJson(baseParams);
+    expect(json.scenarios).toHaveLength(2);
+    expect(json.counts).toEqual({
+      total: 2,
+      passed: 1,
+      failed: 1,
+    });
+  });
+});

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1328,6 +1328,53 @@ function createQaSuiteReportNotes(params: {
   ];
 }
 
+export type QaSuiteSummaryJsonParams = {
+  scenarios: QaSuiteScenarioResult[];
+  startedAt: Date;
+  finishedAt: Date;
+  providerMode: "mock-openai" | "live-frontier";
+  primaryModel: string;
+  alternateModel: string;
+  fastMode: boolean;
+  concurrency: number;
+  scenarioIds?: readonly string[];
+};
+
+/**
+ * Pure-ish JSON builder for qa-suite-summary.json. Exported so the GPT-5.4
+ * parity gate (agentic-parity-report.ts, #64441) and any future parity
+ * runner can assert-and-trust the provider/model that produced a given
+ * summary instead of blindly accepting the caller's candidateLabel /
+ * baselineLabel. Without the `run` block, a maintainer who swaps candidate
+ * and baseline summary paths could silently produce a mislabeled verdict.
+ */
+export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): Record<string, unknown> {
+  const primarySplit = splitModelRef(params.primaryModel);
+  const alternateSplit = splitModelRef(params.alternateModel);
+  return {
+    scenarios: params.scenarios,
+    counts: {
+      total: params.scenarios.length,
+      passed: params.scenarios.filter((scenario) => scenario.status === "pass").length,
+      failed: params.scenarios.filter((scenario) => scenario.status === "fail").length,
+    },
+    run: {
+      startedAt: params.startedAt.toISOString(),
+      finishedAt: params.finishedAt.toISOString(),
+      providerMode: params.providerMode,
+      primaryModel: params.primaryModel,
+      primaryProvider: primarySplit?.provider ?? null,
+      primaryModelName: primarySplit?.model ?? null,
+      alternateModel: params.alternateModel,
+      alternateProvider: alternateSplit?.provider ?? null,
+      alternateModelName: alternateSplit?.model ?? null,
+      fastMode: params.fastMode,
+      concurrency: params.concurrency,
+      scenarioIds: params.scenarioIds ? [...params.scenarioIds] : null,
+    },
+  };
+}
+
 async function writeQaSuiteArtifacts(params: {
   outputDir: string;
   startedAt: Date;
@@ -1338,6 +1385,7 @@ async function writeQaSuiteArtifacts(params: {
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
+  scenarioIds?: readonly string[];
 }) {
   const report = renderQaMarkdownReport({
     title: "OpenClaw QA Scenario Suite",
@@ -1357,18 +1405,7 @@ async function writeQaSuiteArtifacts(params: {
   await fs.writeFile(reportPath, report, "utf8");
   await fs.writeFile(
     summaryPath,
-    `${JSON.stringify(
-      {
-        scenarios: params.scenarios,
-        counts: {
-          total: params.scenarios.length,
-          passed: params.scenarios.filter((scenario) => scenario.status === "pass").length,
-          failed: params.scenarios.filter((scenario) => scenario.status === "fail").length,
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(buildQaSuiteSummaryJson(params), null, 2)}\n`,
     "utf8",
   );
   return { report, reportPath, summaryPath };
@@ -1527,6 +1564,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
         alternateModel,
         fastMode,
         concurrency,
+        scenarioIds: params?.scenarioIds,
       });
       lab.setLatestReport({
         outputPath: reportPath,
@@ -1670,6 +1708,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       alternateModel,
       fastMode,
       concurrency,
+      scenarioIds: params?.scenarioIds,
     });
     const latestReport = {
       outputPath: reportPath,


### PR DESCRIPTION
## Summary

Add a self-describing `run` block to `qa-suite-summary.json` so the GPT-5.4 parity gate in #64441 (and any future parity runner) can verify — not just trust — the `candidateLabel` / `baselineLabel` a caller passes to `runQaParityReportCommand`.

Tracked by #64227. Closes one half of criterion 5 ("parity gate shows GPT-5.4 ≥ Opus 4.6 on the agreed metrics"): without provider/model in the summary JSON, a maintainer who swaps candidate and baseline summary paths silently produces a mislabeled verdict. This PR removes that footgun.

## Why

The parity gate reads two summaries and emits a pass/fail verdict based on completion rate, unintended-stop rate, valid-tool-call rate, and fake-success count. Today the summary JSON only contains `{ scenarios, counts }` — nothing identifying the provider or model that produced the run. A parity-report call like:

```
pnpm openclaw qa parity-report \
  --candidate-summary qa-parity-candidate.json \
  --baseline-summary qa-parity-baseline.json \
  --candidate-label openai/gpt-5.4 \
  --baseline-label anthropic/claude-opus-4-6
```

has no way to detect whether the two summaries actually came from the claimed providers. If an operator swaps the paths, the verdict is reversed without any signal. That is criterion 5 of the completion gate in #64227 failing silently.

## What changed

- `extensions/qa-lab/src/suite.ts`
  - Extract `buildQaSuiteSummaryJson(params)` as an exported pure helper. The existing `writeQaSuiteArtifacts` now just formats the JSON and writes to disk. Exporting the builder lets the parity gate (and any future parity wrapper) import the same type instead of reverse-engineering the JSON shape.
  - Add a `run` block to the summary JSON with:
    - `startedAt`, `finishedAt` (ISO strings)
    - `providerMode` (`"mock-openai"` or `"live-frontier"`)
    - `primaryModel`, `primaryProvider`, `primaryModelName` (split)
    - `alternateModel`, `alternateProvider`, `alternateModelName` (split)
    - `fastMode`, `concurrency`
    - `scenarioIds` — the `--scenario-ids` the caller passed, or `null` when the full lane-filtered catalog was used
  - Thread `scenarioIds` from `runQaSuite` → `writeQaSuiteArtifacts` so the summary records exactly which scenarios ran.
- `extensions/qa-lab/src/suite.summary-json.test.ts` (new)
  - 5 unit tests covering the OpenAI lane, Anthropic lane, explicit scenario filter, malformed model ref fallbacks, and that the existing `scenarios` / `counts` fields are preserved alongside the new `run` block.

Backwards-compatible: every existing consumer of `qa-suite-summary.json` sees exactly the same `{ scenarios, counts }` keys they saw before, plus an additional `run` key they can ignore.

## What is NOT in this PR

- **The `qa parity run` CLI wrapper** (run the parity pack twice, emit two labeled summaries, optionally invoke `qa parity-report`) is a separate follow-up. It stacks cleanly on top of this PR — the wrapper can consume the same `buildQaSuiteSummaryJson` helper and rely on the `run.primaryProvider` field to label each summary. That wrapper is being held until #64441 and #64662 merge so it can call `runQaParityReportCommand` directly without a stacked dependency.
- **Label-verification on the parity gate consumer side** (asserting `candidateSummary.run.primaryProvider === params.candidateLabel.split("/")[0]` etc.) belongs in a small follow-up on #64441's `agentic-parity-report.ts`. This PR provides the data; the gate uses it next.

## Validation

```
pnpm test extensions/qa-lab/src/suite.summary-json.test.ts \
          extensions/qa-lab/src/cli.runtime.test.ts \
          extensions/qa-lab/src/scenario-catalog.test.ts
```

→ 34/34 pass.

## Linked issues

- Refs #64227
- Complements #64441 (parity harness) and #64662 (10-scenario expansion). Combined with #64685 (Anthropic `/v1/messages` mock route) the parity gate can now be produced end-to-end from a local worktree without real API keys, with verifiable provider/model labels on both sides.