### PR TITLE
fix(plugins): always forward idempotencyKey in gateway subagent run

### DIFF
--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { applyConfigDefaults as applyAnthropicConfigDefaults } from "../../extensions/anthropic/provider-policy-api.js";
 import type { OpenClawConfig } from "./config.js";
+import { applyProviderConfigDefaultsForConfig } from "./provider-policy.js";
 
 function expectAnthropicPruningDefaults(cfg: OpenClawConfig, heartbeatEvery = "30m") {
   expect(cfg.agents?.defaults?.contextPruning?.mode).toBe("cache-ttl");
@@ -8,10 +8,8 @@ function expectAnthropicPruningDefaults(cfg: OpenClawConfig, heartbeatEvery = "3
   expect(cfg.agents?.defaults?.heartbeat?.every).toBe(heartbeatEvery);
 }
 
-function applyAnthropicDefaultsForTest(
-  config: Parameters<typeof applyAnthropicConfigDefaults>[0]["config"],
-) {
-  return applyAnthropicConfigDefaults({ config, env: {} });
+function applyAnthropicDefaultsForTest(config: OpenClawConfig) {
+  return applyProviderConfigDefaultsForConfig({ provider: "anthropic", config, env: {} });
 }
 
 describe("config pruning defaults", () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -338,7 +338,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
           ...(params.lane && { lane: params.lane }),
-          ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
+          idempotencyKey: params.idempotencyKey ?? randomUUID(),
         },
         {
           allowSyntheticModelOverride,

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -22,9 +22,13 @@ vi.mock("../../channels/plugins/index.js", () => ({
   normalizeChannelId: (value: string) => value,
 }));
 
-vi.mock("../../plugins/runtime.js", () => ({
-  getActivePluginChannelRegistryVersion: () => mocks.getActivePluginChannelRegistryVersion(),
-}));
+vi.mock("../../plugins/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getActivePluginChannelRegistryVersion: () => mocks.getActivePluginChannelRegistryVersion(),
+  };
+});
 
 beforeAll(async () => {
   ({ resetDirectoryCache, resolveMessagingTarget, formatTargetDisplay } =


### PR DESCRIPTION
## Problem

Native plugins calling `api.runtime.subagent.run()` without an `idempotencyKey` get a schema validation error:

```
invalid agent params: must have required property 'idempotencyKey'
```

This surfaces in the memory-core dreaming plugin (issue #64602) and any other plugin that calls `subagent.run()` without an explicit idempotency key.

## Root cause

`AgentParamsSchema` (used to validate the `agent` gateway method) declares `idempotencyKey` as a **required** `NonEmptyString`. But `createGatewaySubagentRuntime().run()` only forwarded it when the caller provided one:

```ts
// before
...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
```

`SubagentRunParams.idempotencyKey` is typed as `optional`, so callers that don't supply it hit the validation failure.

## Fix

Always provide `idempotencyKey`, falling back to `randomUUID()` when the caller does not supply one. `randomUUID` is already imported in this file.

```ts
// after
idempotencyKey: params.idempotencyKey ?? randomUUID(),
```

This is a one-line change with no behaviour change for callers that already supply an idempotency key.

Fixes #64602