### PR TITLE
fix: allow TTS reply media from preferred tmp dir

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../media/store.js", () => ({
   saveMediaSource,
 }));
 
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 describe("createReplyMediaPathNormalizer", () => {
@@ -125,6 +126,25 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(result).toMatchObject({
       mediaUrl: "/Users/peter/.openclaw/media/tool-image-generation/generated.png",
       mediaUrls: ["/Users/peter/.openclaw/media/tool-image-generation/generated.png"],
+    });
+    expect(saveMediaSource).not.toHaveBeenCalled();
+  });
+
+  it("allows generated media under the preferred openclaw temp root", async () => {
+    const mediaPath = path.join(resolvePreferredOpenClawTmpDir(), "tts-test", "voice-1.mp3");
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [mediaPath],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: mediaPath,
+      mediaUrls: [mediaPath],
     });
     expect(saveMediaSource).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -7,6 +7,7 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { saveMediaSource } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
@@ -42,10 +43,13 @@ function isAllowedAbsoluteReplyMediaPath(params: {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
     return true;
   }
-  const volatileRoots = [params.workspaceDir, params.sandboxRoot]
-    .filter((root): root is string => Boolean(root))
-    .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
-  return volatileRoots.some((root) => isPathInside(root, params.candidate));
+  const allowedRoots = [
+    resolvePreferredOpenClawTmpDir(),
+    ...[params.workspaceDir, params.sandboxRoot]
+      .filter((root): root is string => Boolean(root))
+      .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME)),
+  ];
+  return allowedRoots.some((root) => isPathInside(root, params.candidate));
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {


### PR DESCRIPTION
## Summary

Allow reply media normalization to accept generated media under OpenClaw's preferred temp root, so TTS outputs like `/tmp/openclaw/tts-*/voice-*.mp3` are no longer dropped before channel delivery.

## Changes

- allow absolute reply media paths under `resolvePreferredOpenClawTmpDir()`
- add a focused regression test covering preferred temp-root media

## Testing

- `./node_modules/.bin/vitest run src/auto-reply/reply/reply-media-paths.test.ts`

Fixes openclaw/openclaw#64529