### PR TITLE
test: fix stale CI shard regressions

### DIFF
--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -21,6 +21,9 @@ describe("memory-wiki plugin", () => {
     expect(registerMemoryPromptSupplement).toHaveBeenCalledTimes(1);
     expect(registerGatewayMethod.mock.calls.map((call) => call[0])).toEqual([
       "wiki.status",
+      "wiki.importRuns",
+      "wiki.importInsights",
+      "wiki.palace",
       "wiki.init",
       "wiki.doctor",
       "wiki.compile",

--- a/src/config/config.pruning-defaults.test.ts
+++ b/src/config/config.pruning-defaults.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { applyConfigDefaults as applyAnthropicConfigDefaults } from "../../extensions/anthropic/provider-policy-api.js";
 import type { OpenClawConfig } from "./config.js";
+import { applyProviderConfigDefaultsForConfig } from "./provider-policy.js";
 
 function expectAnthropicPruningDefaults(cfg: OpenClawConfig, heartbeatEvery = "30m") {
   expect(cfg.agents?.defaults?.contextPruning?.mode).toBe("cache-ttl");
@@ -8,10 +8,8 @@ function expectAnthropicPruningDefaults(cfg: OpenClawConfig, heartbeatEvery = "3
   expect(cfg.agents?.defaults?.heartbeat?.every).toBe(heartbeatEvery);
 }
 
-function applyAnthropicDefaultsForTest(
-  config: Parameters<typeof applyAnthropicConfigDefaults>[0]["config"],
-) {
-  return applyAnthropicConfigDefaults({ config, env: {} });
+function applyAnthropicDefaultsForTest(config: OpenClawConfig) {
+  return applyProviderConfigDefaultsForConfig({ provider: "anthropic", config, env: {} });
 }
 
 describe("config pruning defaults", () => {

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -23,6 +23,8 @@ vi.mock("../../channels/plugins/index.js", () => ({
 }));
 
 vi.mock("../../plugins/runtime.js", () => ({
+  getActivePluginChannelRegistry: () => null,
+  getActivePluginRegistry: () => null,
   getActivePluginChannelRegistryVersion: () => mocks.getActivePluginChannelRegistryVersion(),
 }));
 


### PR DESCRIPTION
## Summary

- route the Anthropic config-defaults test through the public config policy seam instead of importing the bundled extension surface directly
- update the outbound target-resolver test mock for the current plugin runtime exports
- refresh the memory-wiki gateway method expectation for the newly registered methods

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [X] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [X] CI/CD / infra

## Linked Issue/PR

Follow-up to unblock CI around #62459.

## Root Cause (if applicable)

Recent runtime and memory-wiki changes updated public behavior, but a few tests still asserted the older surface.

## Regression Test Plan (if applicable)

- `pnpm test test/extension-test-boundary.test.ts`
- `pnpm test src/config/config.pruning-defaults.test.ts`
- `pnpm test src/infra/outbound/target-resolver.test.ts`
- `pnpm test extensions/memory-wiki/index.test.ts`
- `pnpm check`

## User-visible / Behavior Changes

None

## Security Impact (required)

None

## Human Verification (required)

- Verified scenarios: targeted failing CI shards reproduced locally and now pass
- Edge cases checked: n/a

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

Low risk; test-only updates aligned to current code paths.
