### PR TITLE
fix: preserve Telegram topic thread IDs for cron delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -389,6 +389,25 @@ describe("resolveDeliveryTarget", () => {
     expect(result.threadId).toBe("thread-2");
   });
 
+  it("keeps session threadId when explicit bare telegram target matches the previous topic route", async () => {
+    setLastSessionEntry({
+      sessionId: "sess-3b",
+      lastChannel: "telegram",
+      lastTo: "telegram:-1001234567890:topic:2996",
+      lastThreadId: "2996",
+    });
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "-1001234567890",
+      sessionKey: "agent:test:main",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("-1001234567890");
+    expect(result.threadId).toBe("2996");
+  });
+
   it("uses single configured channel when neither explicit nor session channel exists", async () => {
     setMainSessionEntry(undefined);
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -6,6 +6,7 @@ import { resolveStorePath } from "../../config/sessions/paths.js";
 import { loadSessionStore } from "../../config/sessions/store-load.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.js";
+import { normalizeTargetForProvider } from "../../infra/outbound/targets-compare.js";
 import { tryResolveLoadedOutboundTarget } from "../../infra/outbound/targets-loaded.js";
 import { resolveSessionDeliveryTarget } from "../../infra/outbound/targets-session.js";
 import type { OutboundChannel } from "../../infra/outbound/targets.js";
@@ -155,11 +156,21 @@ export async function resolveDeliveryTarget(
 
   // Carry threadId when it was explicitly set (from :topic: parsing or config)
   // or when delivering to the same recipient as the session's last conversation.
+  // Normalize target shapes before comparing so plugin grammars like Telegram's
+  // bare-chat vs chat-scoped topic routes still count as the same destination.
   // Session-derived threadIds are dropped when the target differs to prevent
   // stale thread IDs from leaking to a different chat.
+  const explicitToSharesLastRoute = !!(
+    channel &&
+    resolved.to &&
+    resolved.lastTo &&
+    (normalizeTargetForProvider(channel, resolved.to) ?? resolved.to) ===
+      (normalizeTargetForProvider(channel, resolved.lastTo.replace(/:topic:\d+$/, "")) ??
+        resolved.lastTo.replace(/:topic:\d+$/, ""))
+  );
   const threadId =
     resolved.threadId &&
-    (resolved.threadIdExplicit || (resolved.to && resolved.to === resolved.lastTo))
+    (resolved.threadIdExplicit || (resolved.to && resolved.to === resolved.lastTo) || explicitToSharesLastRoute)
       ? resolved.threadId
       : undefined;
 


### PR DESCRIPTION
## Summary
- preserve session-derived Telegram topic thread ids for cron delivery when an explicit bare chat target still matches the session route
- normalize provider-aware target shapes before deciding whether a session thread id is safe to keep
- add a regression test covering bare Telegram chat delivery against a stored topic-scoped session route

## Problem
Cron announce delivery to Telegram forum topics could fail with `TOPIC_CLOSED` even when the job had the correct `sessionKey` topic binding.

The failure happened when cron delivery used a bare Telegram chat target like `-100...`, while the session route was stored in an equivalent topic-scoped/provider-scoped form like `telegram:-100...:topic:2996`.

`resolveDeliveryTarget()` only preserved the session-derived `threadId` when `resolved.to === resolved.lastTo`, so this raw string mismatch caused cron to drop the topic thread id and send to the bare supergroup instead.

## Repro
- sessionKey bound to `agent:main:telegram:group:-1003688383802:topic:2996`
- cron delivery configured with `channel=telegram`, `to=-1003688383802`
- direct explicit topic sends worked
- cron announce delivery failed with `400: Bad Request: TOPIC_CLOSED`

## Fix
Use provider-aware target normalization before deciding whether the explicit delivery target still matches the session route, so equivalent Telegram route shapes still preserve the session thread id.

## Validation
- local repro fixed for the original failing cron job
- additional post-fix sanity check passed on another Telegram topic
- regression test added for the mixed bare-target/topic-route case
