### PR TITLE
fix(process): handle Windows CJK encoding in child process output [AI-assisted]

### DIFF
--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  decodeCapturedOutputBuffer,
+  parseWindowsCodePage,
+  resolveWindowsConsoleEncoding,
+} from "./windows-encoding.js";
+
+describe("parseWindowsCodePage", () => {
+  it("parses English chcp output", () => {
+    expect(parseWindowsCodePage("Active code page: 936")).toBe(936);
+  });
+
+  it("parses Chinese chcp output", () => {
+    expect(parseWindowsCodePage("活动代码页: 65001")).toBe(65001);
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseWindowsCodePage("")).toBeNull();
+  });
+
+  it("returns null when no code page number found", () => {
+    expect(parseWindowsCodePage("no code page")).toBeNull();
+  });
+
+  it("parses Japanese chcp output", () => {
+    expect(parseWindowsCodePage("アクティブ コード ページ: 932")).toBe(932);
+  });
+
+  it("parses Korean chcp output", () => {
+    expect(parseWindowsCodePage("활성 코드 페이지: 949")).toBe(949);
+  });
+
+  it("returns null for non-numeric code page", () => {
+    expect(parseWindowsCodePage("Active code page: abc")).toBeNull();
+  });
+
+  it("returns null for zero code page", () => {
+    expect(parseWindowsCodePage("Active code page: 0")).toBeNull();
+  });
+});
+
+describe("resolveWindowsConsoleEncoding", () => {
+  it("returns null on non-Windows platforms", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    try {
+      expect(resolveWindowsConsoleEncoding()).toBeNull();
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+});
+
+describe("decodeCapturedOutputBuffer", () => {
+  it("returns UTF-8 string on non-Windows platforms", () => {
+    const raw = Buffer.from("hello world");
+    const decoded = decodeCapturedOutputBuffer({ buffer: raw, platform: "darwin" });
+    expect(decoded).toBe("hello world");
+  });
+
+  it("returns UTF-8 string when encoding is utf-8", () => {
+    const raw = Buffer.from("hello world");
+    const decoded = decodeCapturedOutputBuffer({
+      buffer: raw,
+      platform: "win32",
+      windowsEncoding: "utf-8",
+    });
+    expect(decoded).toBe("hello world");
+  });
+
+  it("returns UTF-8 string when encoding is null", () => {
+    const raw = Buffer.from("hello world");
+    const decoded = decodeCapturedOutputBuffer({
+      buffer: raw,
+      platform: "win32",
+      windowsEncoding: null,
+    });
+    expect(decoded).toBe("hello world");
+  });
+
+  it("decodes GBK output on Windows when code page is known", () => {
+    let supportsGbk = true;
+    try {
+      void new TextDecoder("gbk");
+    } catch {
+      supportsGbk = false;
+    }
+
+    const raw = Buffer.from([0xb2, 0xe2, 0xca, 0xd4, 0xa1, 0xab, 0xa3, 0xbb]);
+    const decoded = decodeCapturedOutputBuffer({
+      buffer: raw,
+      platform: "win32",
+      windowsEncoding: "gbk",
+    });
+
+    if (!supportsGbk) {
+      expect(decoded).toContain("�");
+      return;
+    }
+    expect(decoded).toBe("测试～；");
+  });
+
+  it("decodes Shift_JIS output on Windows", () => {
+    let supportsShiftJis = true;
+    try {
+      void new TextDecoder("shift_jis");
+    } catch {
+      supportsShiftJis = false;
+    }
+
+    const raw = Buffer.from([0x82, 0xb1, 0x82, 0xf1, 0x82, 0xc9, 0x82, 0xbf, 0x82, 0xcd]);
+    const decoded = decodeCapturedOutputBuffer({
+      buffer: raw,
+      platform: "win32",
+      windowsEncoding: "shift_jis",
+    });
+
+    if (!supportsShiftJis) {
+      expect(decoded).toContain("�");
+      return;
+    }
+    expect(decoded).toBe("こんにちは");
+  });
+
+  it("falls back to UTF-8 on unsupported encoding", () => {
+    const raw = Buffer.from([0xb2, 0xe2, 0xca, 0xd4]);
+    const decoded = decodeCapturedOutputBuffer({
+      buffer: raw,
+      platform: "win32",
+      windowsEncoding: "nonexistent-encoding",
+    });
+    expect(decoded).toBe(raw.toString("utf8"));
+  });
+
+  it("handles empty buffer", () => {
+    const raw = Buffer.alloc(0);
+    const decoded = decodeCapturedOutputBuffer({ buffer: raw, platform: "win32" });
+    expect(decoded).toBe("");
+  });
+
+  it("handles pure ASCII on Windows with GBK encoding", () => {
+    const raw = Buffer.from("ASCII text");
+    const decoded = decodeCapturedOutputBuffer({
+      buffer: raw,
+      platform: "win32",
+      windowsEncoding: "gbk",
+    });
+    expect(decoded).toBe("ASCII text");
+  });
+
+  it("handles mixed CJK and ASCII in GBK", () => {
+    let supportsGbk = true;
+    try {
+      void new TextDecoder("gbk");
+    } catch {
+      supportsGbk = false;
+    }
+
+    const gbkBytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3]);
+    const asciiBytes = Buffer.from(" hello");
+    const raw = Buffer.concat([gbkBytes, asciiBytes]);
+    const decoded = decodeCapturedOutputBuffer({
+      buffer: raw,
+      platform: "win32",
+      windowsEncoding: "gbk",
+    });
+
+    if (!supportsGbk) {
+      return;
+    }
+    expect(decoded).toBe("你好 hello");
+  });
+});

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -1,0 +1,80 @@
+import { spawnSync } from "node:child_process";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+
+const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
+  65001: "utf-8",
+  54936: "gb18030",
+  936: "gbk",
+  950: "big5",
+  932: "shift_jis",
+  949: "euc-kr",
+  1252: "windows-1252",
+};
+
+let cachedWindowsConsoleEncoding: string | null | undefined;
+
+export function parseWindowsCodePage(raw: string): number | null {
+  if (!raw) {
+    return null;
+  }
+  const match = raw.match(/\b(\d{3,5})\b/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const codePage = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(codePage) || codePage <= 0) {
+    return null;
+  }
+  return codePage;
+}
+
+export function resolveWindowsConsoleEncoding(): string | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+  if (cachedWindowsConsoleEncoding !== undefined) {
+    return cachedWindowsConsoleEncoding;
+  }
+  try {
+    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
+      windowsHide: true,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    const codePage = parseWindowsCodePage(raw);
+    cachedWindowsConsoleEncoding =
+      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
+  } catch {
+    cachedWindowsConsoleEncoding = null;
+  }
+  return cachedWindowsConsoleEncoding;
+}
+
+export function decodeCapturedOutputBuffer(params: {
+  buffer: Buffer;
+  platform?: NodeJS.Platform;
+  windowsEncoding?: string | null;
+}): string {
+  const utf8 = params.buffer.toString("utf8");
+  const platform = params.platform ?? process.platform;
+  if (platform !== "win32") {
+    return utf8;
+  }
+  let encoding = params.windowsEncoding;
+  if (encoding === undefined && process.platform === "win32") {
+    encoding = resolveWindowsConsoleEncoding();
+  }
+  if (!encoding || normalizeLowercaseStringOrEmpty(encoding) === "utf-8") {
+    return utf8;
+  }
+  try {
+    return new TextDecoder(encoding).decode(params.buffer);
+  } catch {
+    return utf8;
+  }
+}
+
+export function resetWindowsConsoleEncodingCache(): void {
+  cachedWindowsConsoleEncoding = undefined;
+}

--- a/src/memory-host-sdk/host/qmd-process.ts
+++ b/src/memory-host-sdk/host/qmd-process.ts
@@ -1,5 +1,9 @@
 import { spawn } from "node:child_process";
 import {
+  decodeCapturedOutputBuffer,
+  resolveWindowsConsoleEncoding,
+} from "../../infra/windows-encoding.js";
+import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
 } from "../../plugin-sdk/windows-spawn.js";
@@ -124,16 +128,25 @@ export async function runCliCommand(params: {
           reject(new Error(`${params.commandSummary} timed out after ${params.timeoutMs}ms`));
         }, params.timeoutMs)
       : null;
-    child.stdout.on("data", (data) => {
+    const windowsEncoding = resolveWindowsConsoleEncoding();
+    child.stdout.on("data", (data: Buffer) => {
       if (discardStdout) {
         return;
       }
-      const next = appendOutputWithCap(stdout, data.toString("utf8"), params.maxOutputChars);
+      const next = appendOutputWithCap(
+        stdout,
+        decodeCapturedOutputBuffer({ buffer: data, windowsEncoding }),
+        params.maxOutputChars,
+      );
       stdout = next.text;
       stdoutTruncated = stdoutTruncated || next.truncated;
     });
-    child.stderr.on("data", (data) => {
-      const next = appendOutputWithCap(stderr, data.toString("utf8"), params.maxOutputChars);
+    child.stderr.on("data", (data: Buffer) => {
+      const next = appendOutputWithCap(
+        stderr,
+        decodeCapturedOutputBuffer({ buffer: data, windowsEncoding }),
+        params.maxOutputChars,
+      );
       stderr = next.text;
       stderrTruncated = stderrTruncated || next.truncated;
     });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { GatewayClient } from "../gateway/client.js";
@@ -19,6 +19,11 @@ import {
   type ExecHostResponse,
 } from "../infra/exec-host.js";
 import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
+import {
+  decodeCapturedOutputBuffer,
+  parseWindowsCodePage,
+  resolveWindowsConsoleEncoding,
+} from "../infra/windows-encoding.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { buildSystemRunApprovalPlan, handleSystemRunInvoke } from "./invoke-system-run.js";
 import type {
@@ -33,16 +38,6 @@ import { invokeRegisteredNodeHostCommand } from "./plugin-node-host.js";
 const OUTPUT_CAP = 200_000;
 const OUTPUT_EVENT_TAIL = 20_000;
 const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
-  65001: "utf-8",
-  54936: "gb18030",
-  936: "gbk",
-  950: "big5",
-  932: "shift_jis",
-  949: "euc-kr",
-  1252: "windows-1252",
-};
-let cachedWindowsConsoleEncoding: string | null | undefined;
 
 const execHostEnforced =
   normalizeLowercaseStringOrEmpty(process.env.OPENCLAW_NODE_EXEC_HOST ?? "") === "app";
@@ -105,64 +100,7 @@ function truncateOutput(raw: string, maxChars: number): { text: string; truncate
   return { text: `... (truncated) ${raw.slice(raw.length - maxChars)}`, truncated: true };
 }
 
-export function parseWindowsCodePage(raw: string): number | null {
-  if (!raw) {
-    return null;
-  }
-  const match = raw.match(/\b(\d{3,5})\b/);
-  if (!match?.[1]) {
-    return null;
-  }
-  const codePage = Number.parseInt(match[1], 10);
-  if (!Number.isFinite(codePage) || codePage <= 0) {
-    return null;
-  }
-  return codePage;
-}
-
-function resolveWindowsConsoleEncoding(): string | null {
-  if (process.platform !== "win32") {
-    return null;
-  }
-  if (cachedWindowsConsoleEncoding !== undefined) {
-    return cachedWindowsConsoleEncoding;
-  }
-  try {
-    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
-      windowsHide: true,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-    const codePage = parseWindowsCodePage(raw);
-    cachedWindowsConsoleEncoding =
-      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
-  } catch {
-    cachedWindowsConsoleEncoding = null;
-  }
-  return cachedWindowsConsoleEncoding;
-}
-
-export function decodeCapturedOutputBuffer(params: {
-  buffer: Buffer;
-  platform?: NodeJS.Platform;
-  windowsEncoding?: string | null;
-}): string {
-  const utf8 = params.buffer.toString("utf8");
-  const platform = params.platform ?? process.platform;
-  if (platform !== "win32") {
-    return utf8;
-  }
-  const encoding = params.windowsEncoding ?? resolveWindowsConsoleEncoding();
-  if (!encoding || normalizeLowercaseStringOrEmpty(encoding) === "utf-8") {
-    return utf8;
-  }
-  try {
-    return new TextDecoder(encoding).decode(params.buffer);
-  } catch {
-    return utf8;
-  }
-}
+export { decodeCapturedOutputBuffer, parseWindowsCodePage } from "../infra/windows-encoding.js";
 
 function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
   const socketPath = file.socket?.path?.trim();

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -5,6 +5,11 @@ import process from "node:process";
 import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
+// keep import: resolveWindowsConsoleEncoding and decodeCapturedOutputBuffer are used below
+import {
+  decodeCapturedOutputBuffer,
+  resolveWindowsConsoleEncoding,
+} from "../infra/windows-encoding.js";
 import { logDebug, logError } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
@@ -135,19 +140,28 @@ export async function runExec(
 ): Promise<{ stdout: string; stderr: string }> {
   const options =
     typeof opts === "number"
-      ? { timeout: opts, encoding: "utf8" as const }
+      ? { timeout: opts }
       : {
           timeout: opts.timeoutMs,
           maxBuffer: opts.maxBuffer,
           cwd: opts.cwd,
-          encoding: "utf8" as const,
         };
+  const windowsEncoding = resolveWindowsConsoleEncoding();
   try {
     const invocation = resolveChildProcessInvocation({ argv: [command, ...args] });
-    const { stdout, stderr } = await execFileAsync(invocation.command, invocation.args, {
+    const result = await execFileAsync(invocation.command, invocation.args, {
       ...options,
+      encoding: "buffer",
       windowsHide: invocation.windowsHide,
       windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    });
+    const stdout = decodeCapturedOutputBuffer({
+      buffer: result.stdout instanceof Buffer ? result.stdout : Buffer.from(result.stdout ?? ""),
+      windowsEncoding,
+    });
+    const stderr = decodeCapturedOutputBuffer({
+      buffer: result.stderr instanceof Buffer ? result.stderr : Buffer.from(result.stderr ?? ""),
+      windowsEncoding,
     });
     if (shouldLogVerbose()) {
       if (stdout.trim()) {
@@ -274,8 +288,8 @@ export async function runCommandWithTimeout(
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
     let settled = false;
     let timedOut = false;
     let noOutputTimedOut = false;
@@ -283,6 +297,7 @@ export async function runCommandWithTimeout(
     let childExitState: { code: number | null; signal: NodeJS.Signals | null } | null = null;
     let closeFallbackTimer: NodeJS.Timeout | null = null;
     let noOutputTimer: NodeJS.Timeout | null = null;
+    const windowsEncoding = resolveWindowsConsoleEncoding();
     const shouldTrackOutputTimeout =
       typeof noOutputTimeoutMs === "number" &&
       Number.isFinite(noOutputTimeoutMs) &&
@@ -337,12 +352,12 @@ export async function runCommandWithTimeout(
       child.stdin.end();
     }
 
-    child.stdout?.on("data", (d) => {
-      stdout += d.toString();
+    child.stdout?.on("data", (d: Buffer) => {
+      stdoutChunks.push(d);
       armNoOutputTimer();
     });
-    child.stderr?.on("data", (d) => {
-      stderr += d.toString();
+    child.stderr?.on("data", (d: Buffer) => {
+      stderrChunks.push(d);
       armNoOutputTimer();
     });
     child.on("error", (err) => {
@@ -376,6 +391,14 @@ export async function runCommandWithTimeout(
       clearTimeout(timer);
       clearNoOutputTimer();
       clearCloseFallbackTimer();
+      const stdout = decodeCapturedOutputBuffer({
+        buffer: Buffer.concat(stdoutChunks),
+        windowsEncoding,
+      });
+      const stderr = decodeCapturedOutputBuffer({
+        buffer: Buffer.concat(stderrChunks),
+        windowsEncoding,
+      });
       const resolvedSignal = childExitState?.signal ?? signal ?? child.signalCode ?? null;
       const resolvedCode = resolveProcessExitCode({
         explicitCode: childExitState?.code ?? code,

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -10,6 +10,7 @@ const execFileMock = vi.hoisted(() =>
     __promisify__: vi.fn(),
   }),
 );
+const resolveWindowsConsoleEncodingMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -20,6 +21,14 @@ vi.mock("node:child_process", async () => {
       execFile: execFileMock as unknown as typeof execFileType,
     },
   );
+});
+
+vi.mock("../infra/windows-encoding.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../infra/windows-encoding.js")>();
+  return {
+    ...original,
+    resolveWindowsConsoleEncoding: resolveWindowsConsoleEncodingMock,
+  };
 });
 
 let runCommandWithTimeout: typeof import("./exec.js").runCommandWithTimeout;
@@ -98,6 +107,7 @@ describe("windows command wrapper behavior", () => {
   beforeEach(() => {
     spawnMock.mockReset();
     execFileMock.mockReset();
+    resolveWindowsConsoleEncodingMock.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -347,6 +357,91 @@ describe("windows command wrapper behavior", () => {
       expect(captured[2].windowsVerbatimArguments).toBeUndefined();
     } finally {
       platformSpy.mockRestore();
+    }
+  });
+
+  it("decodes GBK output in runExec on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    resolveWindowsConsoleEncodingMock.mockReturnValue("gbk");
+
+    const gbkBuffer = Buffer.from([0xb2, 0xe2, 0xca, 0xd4]);
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, result: { stdout: Buffer; stderr: Buffer }) => void,
+      ) => {
+        cb(null, { stdout: gbkBuffer, stderr: Buffer.alloc(0) });
+      },
+    );
+
+    try {
+      const result = await runExec("echo", ["test"], 1000);
+      expect(result.stdout).toBe("\u6d4b\u8bd5");
+    } finally {
+      platformSpy.mockRestore();
+      resolveWindowsConsoleEncodingMock.mockReset();
+    }
+  });
+
+  it("decodes Shift_JIS output in runExec on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    resolveWindowsConsoleEncodingMock.mockReturnValue("shift_jis");
+    let supportsShiftJis = true;
+    try {
+      void new TextDecoder("shift_jis");
+    } catch {
+      supportsShiftJis = false;
+    }
+
+    const shiftJisBuffer = Buffer.from([
+      0x82, 0xb1, 0x82, 0xf1, 0x82, 0xc9, 0x82, 0xbf, 0x82, 0xcd,
+    ]);
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, result: { stdout: Buffer; stderr: Buffer }) => void,
+      ) => {
+        cb(null, { stdout: shiftJisBuffer, stderr: Buffer.alloc(0) });
+      },
+    );
+
+    try {
+      const result = await runExec("echo", ["test"], 1000);
+      if (supportsShiftJis) {
+        expect(result.stdout).toBe("\u3053\u3093\u306b\u3061\u306f");
+      }
+    } finally {
+      platformSpy.mockRestore();
+      resolveWindowsConsoleEncodingMock.mockReset();
+    }
+  });
+
+  it("returns UTF-8 output unchanged on non-Windows in runExec", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    resolveWindowsConsoleEncodingMock.mockReturnValue(null);
+
+    const utf8Buffer = Buffer.from("hello world");
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, result: { stdout: Buffer; stderr: Buffer }) => void,
+      ) => {
+        cb(null, { stdout: utf8Buffer, stderr: Buffer.alloc(0) });
+      },
+    );
+
+    try {
+      const result = await runExec("echo", ["test"], 1000);
+      expect(result.stdout).toBe("hello world");
+    } finally {
+      platformSpy.mockRestore();
+      resolveWindowsConsoleEncodingMock.mockReset();
     }
   });
 });

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -1,5 +1,9 @@
 import { spawn } from "node:child_process";
 import type { Component, SelectItem } from "@mariozechner/pi-tui";
+import {
+  decodeCapturedOutputBuffer,
+  resolveWindowsConsoleEncoding,
+} from "../infra/windows-encoding.js";
 import { createSearchableSelectList } from "./components/selectors.js";
 
 type LocalShellDeps = {
@@ -116,11 +120,18 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
 
       let stdout = "";
       let stderr = "";
-      child.stdout.on("data", (buf) => {
-        stdout = appendWithCap(stdout, buf.toString("utf8"));
+      const windowsEncoding = resolveWindowsConsoleEncoding();
+      child.stdout.on("data", (buf: Buffer) => {
+        stdout = appendWithCap(
+          stdout,
+          decodeCapturedOutputBuffer({ buffer: buf, windowsEncoding }),
+        );
       });
-      child.stderr.on("data", (buf) => {
-        stderr = appendWithCap(stderr, buf.toString("utf8"));
+      child.stderr.on("data", (buf: Buffer) => {
+        stderr = appendWithCap(
+          stderr,
+          decodeCapturedOutputBuffer({ buffer: buf, windowsEncoding }),
+        );
       });
 
       child.on("close", (code, signal) => {


### PR DESCRIPTION
## Summary

- Child process output from `runExec` and `runCommandWithTimeout` was decoded as UTF-8 unconditionally, producing garbled text on Windows systems using CJK codepages (GBK, Big5, Shift_JIS, EUC-KR, GB18030)
- Extract a shared `src/infra/windows-encoding.ts` module with `resolveWindowsConsoleEncoding`, `decodeCapturedOutputBuffer`, `parseWindowsCodePage`, and `resetWindowsConsoleEncodingCache`
- Fix `runExec` to use `encoding: "buffer"` + `decodeCapturedOutputBuffer` instead of `encoding: "utf8"`
- Fix `runCommandWithTimeout` to collect Buffer chunks and decode at resolve time via `Buffer.concat` + `decodeCapturedOutputBuffer`, avoiding per-chunk decoding that splits multi-byte CJK characters across chunk boundaries
- Refactor `invoke.ts` to import from the shared module and re-export `parseWindowsCodePage`/`decodeCapturedOutputBuffer` for backward compatibility
- Apply the same encoding fix to `qmd-process.ts` and `tui-local-shell.ts`

## Motivation

On Windows systems with non-UTF-8 console codepages (e.g., codepage 936 for GBK Chinese, 932 for Shift_JIS Japanese, 949 for EUC-KR Korean), child process output containing CJK characters is garbled because the output bytes are decoded as UTF-8 regardless of the actual encoding. The `node-host/invoke.ts` already had correct encoding-aware decoding via `chcp` detection, but `process/exec.ts`, `memory-host-sdk/host/qmd-process.ts`, and `tui/tui-local-shell.ts` did not.

## Changes

- **New file**: `src/infra/windows-encoding.ts` — shared module with Windows console encoding detection (`chcp`-based) and Buffer-to-String decoding with encoding awareness
- **New file**: `src/infra/windows-encoding.test.ts` — 18 unit tests covering `parseWindowsCodePage`, `resolveWindowsConsoleEncoding`, and `decodeCapturedOutputBuffer` (GBK, Shift_JIS, mixed CJK+ASCII, fallback, empty buffer, etc.)
- **Modified**: `src/process/exec.ts` — `runExec` uses `encoding: "buffer"` + `decodeCapturedOutputBuffer`; `runCommandWithTimeout` collects `Buffer[]` chunks and decodes at resolve time
- **Modified**: `src/node-host/invoke.ts` — removed inline encoding code (~70 lines), imports from shared module, re-exports for backward compat
- **Modified**: `src/memory-host-sdk/host/qmd-process.ts` — uses `decodeCapturedOutputBuffer` instead of `data.toString("utf8")`
- **Modified**: `src/tui/tui-local-shell.ts` — uses `decodeCapturedOutputBuffer` instead of `buf.toString("utf8")`
- **Modified**: `src/process/exec.windows.test.ts` — added 3 integration tests for `runExec` encoding behavior (GBK, Shift_JIS, UTF-8 passthrough)

## Testing

- [x] 18 unit tests in `windows-encoding.test.ts` pass
- [x] 3 integration tests in `exec.windows.test.ts` pass (GBK decode, Shift_JIS decode, UTF-8 passthrough)
- [x] 11 existing Windows command wrapper tests pass
- [x] 8 existing exec general tests pass
- [x] 3 no-output timer tests pass
- [x] 10 invoke sanitize-env tests pass (backward compat verified)
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] Pre-commit hook passes (oxlint, tsgo, all checks)

## Root Cause

`exec.ts` used `encoding: "utf8"` in `execFileAsync` and `d.toString()` in spawn data handlers, which forces UTF-8 decoding regardless of the actual Windows console encoding. The `invoke.ts` module already had the correct approach (detect codepage via `chcp`, decode with `TextDecoder`), but this logic was not shared with other modules.

## User-visible / Behavior Changes

- Windows users with CJK locale codepages will now see correctly decoded child process output instead of garbled mojibake
- No behavior change on non-Windows platforms or Windows with UTF-8 (codepage 65001)

## Security Impact

- No new permissions, secrets, network access, or command execution introduced
- The `chcp` detection reuses the same `spawnSync` pattern already present in `invoke.ts`

## Compatibility / Migration

- Backward compatible: `invoke.ts` re-exports `parseWindowsCodePage` and `decodeCapturedOutputBuffer` from the shared module
- No config changes required

---

[AI-assisted]
- Degree of testing: fully tested (53 tests pass across 5 test files)
- AI used for: Code structure, test design, and PR formatting
- Human verification: All test expectations verified against actual encoding behavior