### PR TITLE
fix(memory-core): fix macOS chokidar glob issue by watching memory dir directly

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -345,7 +345,7 @@ export abstract class MemoryManagerSyncOps {
     const watchPaths = new Set<string>([
       path.join(this.workspaceDir, "MEMORY.md"),
       path.join(this.workspaceDir, "memory.md"),
-      path.join(this.workspaceDir, "memory", "**", "*.md"),
+      path.join(this.workspaceDir, "memory"),
     ]);
     const additionalPaths = normalizeExtraMemoryPaths(this.workspaceDir, this.settings.extraPaths);
     for (const entry of additionalPaths) {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -90,12 +90,22 @@ const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
 
 const log = createSubsystemLogger("memory");
 
-function shouldIgnoreMemoryWatchPath(watchPath: string): boolean {
+function shouldIgnoreMemoryWatchPath(
+  watchPath: string,
+  stats?: { isDirectory?: () => boolean },
+): boolean {
   const normalized = path.normalize(watchPath);
   const parts = normalized
     .split(path.sep)
     .map((segment) => normalizeLowercaseStringOrEmpty(segment));
-  return parts.some((segment) => IGNORED_MEMORY_WATCH_DIR_NAMES.has(segment));
+  if (parts.some((segment) => IGNORED_MEMORY_WATCH_DIR_NAMES.has(segment))) {
+    return true;
+  }
+  if (stats?.isDirectory?.()) {
+    return false;
+  }
+  const extension = normalizeLowercaseStringOrEmpty(path.extname(normalized));
+  return extension.length > 0 && extension !== ".md";
 }
 
 export function runDetachedMemorySync(sync: () => Promise<void>, reason: "interval" | "watch") {
@@ -380,7 +390,7 @@ export abstract class MemoryManagerSyncOps {
     }
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
-      ignored: (watchPath) => shouldIgnoreMemoryWatchPath(watchPath),
+      ignored: (watchPath, stats) => shouldIgnoreMemoryWatchPath(watchPath, stats),
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -93,6 +93,7 @@ const log = createSubsystemLogger("memory");
 function shouldIgnoreMemoryWatchPath(
   watchPath: string,
   stats?: { isDirectory?: () => boolean },
+  multimodalSettings?: ResolvedMemorySearchConfig["multimodal"],
 ): boolean {
   const normalized = path.normalize(watchPath);
   const parts = normalized
@@ -105,7 +106,13 @@ function shouldIgnoreMemoryWatchPath(
     return false;
   }
   const extension = normalizeLowercaseStringOrEmpty(path.extname(normalized));
-  return extension.length > 0 && extension !== ".md";
+  if (extension.length === 0 || extension === ".md") {
+    return false;
+  }
+  if (!multimodalSettings) {
+    return true;
+  }
+  return classifyMemoryMultimodalPath(normalized, multimodalSettings) === null;
 }
 
 export function runDetachedMemorySync(sync: () => Promise<void>, reason: "interval" | "watch") {
@@ -390,7 +397,8 @@ export abstract class MemoryManagerSyncOps {
     }
     this.watcher = chokidar.watch(Array.from(watchPaths), {
       ignoreInitial: true,
-      ignored: (watchPath, stats) => shouldIgnoreMemoryWatchPath(watchPath, stats),
+      ignored: (watchPath, stats) =>
+        shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
       awaitWriteFinish: {
         stabilityThreshold: this.settings.sync.watchDebounceMs,
         pollInterval: 100,

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -123,7 +123,7 @@ describe("memory watcher config", () => {
     manager = result.manager as unknown as MemoryIndexManager;
   }
 
-  it("watches markdown globs and ignores dependency directories", async () => {
+  it("watches the memory directory and ignores non-markdown churn", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
     const cfg = createWatcherConfig();
 
@@ -138,7 +138,7 @@ describe("memory watcher config", () => {
       expect.arrayContaining([
         path.join(workspaceDir, "MEMORY.md"),
         path.join(workspaceDir, "memory.md"),
-        path.join(workspaceDir, "memory", "**", "*.md"),
+        path.join(workspaceDir, "memory"),
         path.join(extraDir, "**", "*.md"),
       ]),
     );
@@ -151,7 +151,12 @@ describe("memory watcher config", () => {
       true,
     );
     expect(ignored?.(path.join(workspaceDir, "memory", ".venv", "lib", "python.md"))).toBe(true);
+    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.tmp"))).toBe(true);
+    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.json"))).toBe(true);
     expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"))).toBe(false);
+    expect(
+      ignored?.(path.join(workspaceDir, "memory", "project"), { isDirectory: () => true }),
+    ).toBe(false);
   });
 
   it("watches multimodal extensions with case-insensitive globs", async () => {

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -9,6 +9,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import type { MemoryIndexManager } from "./index.js";
 import { registerBuiltInMemoryEmbeddingProviders } from "./provider-adapters.js";
 
+type WatchIgnoredFn = (watchPath: string, stats?: { isDirectory?: () => boolean }) => boolean;
+
 const { watchMock } = vi.hoisted(() => ({
   watchMock: vi.fn(() => ({
     on: vi.fn(),
@@ -145,7 +147,7 @@ describe("memory watcher config", () => {
     expect(options.ignoreInitial).toBe(true);
     expect(options.awaitWriteFinish).toEqual({ stabilityThreshold: 25, pollInterval: 100 });
 
-    const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;
+    const ignored = options.ignored as WatchIgnoredFn | undefined;
     expect(ignored).toBeTypeOf("function");
     expect(ignored?.(path.join(workspaceDir, "memory", "node_modules", "pkg", "index.md"))).toBe(
       true,
@@ -182,7 +184,7 @@ describe("memory watcher config", () => {
       ]),
     );
 
-    const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;
+    const ignored = options.ignored as WatchIgnoredFn | undefined;
     expect(ignored).toBeTypeOf("function");
     expect(ignored?.(path.join(extraDir, "nested", "PHOTO.PNG"))).toBe(false);
     expect(ignored?.(path.join(extraDir, "nested", "voice.WAV"))).toBe(false);

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -171,7 +171,7 @@ describe("memory watcher config", () => {
     await expectWatcherManager(cfg);
 
     expect(watchMock).toHaveBeenCalledTimes(1);
-    const [watchedPaths] = watchMock.mock.calls[0] as unknown as [
+    const [watchedPaths, options] = watchMock.mock.calls[0] as unknown as [
       string[],
       Record<string, unknown>,
     ];
@@ -181,5 +181,11 @@ describe("memory watcher config", () => {
         path.join(extraDir, "**", "*.[wW][aA][vV]"),
       ]),
     );
+
+    const ignored = options.ignored as ((watchPath: string) => boolean) | undefined;
+    expect(ignored).toBeTypeOf("function");
+    expect(ignored?.(path.join(extraDir, "nested", "PHOTO.PNG"))).toBe(false);
+    expect(ignored?.(path.join(extraDir, "nested", "voice.WAV"))).toBe(false);
+    expect(ignored?.(path.join(extraDir, "nested", "metadata.json"))).toBe(true);
   });
 });


### PR DESCRIPTION
On some macOS + Node 25 environments, chokidar fails to watch files when using recursive glob patterns like 'memory/**/*.md'. Changing to watch the folder directly resolves the issue while keeping same recursive watch behavior.