### PR TITLE
fix(google): omit unsupported numberOfVideos in Veo requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/webchat: persist agent-run TTS audio replies into webchat history before finalization so tool-generated audio reaches webchat clients again. (#63514) thanks @bittoby
 - macOS/Talk Mode: after granting microphone permission on first enable, continue starting Talk Mode instead of requiring a second toggle. (#62459) Thanks @ggarber.
 - OpenAI/Codex OAuth: stop rewriting the upstream authorize URL scopes so new Codex sign-ins do not fail with `invalid_scope` before returning an authorization code. (#64713) Thanks @fuller-stack-dev.
+- Google/Veo: stop sending the unsupported `numberOfVideos` request field so Gemini Developer API Veo runs do not fail before OpenClaw can complete the intended Google video generation path. (#64723) thanks @velvet-shark
 
 ## 2026.4.10
 

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -67,12 +67,13 @@ describe("google video generation provider", () => {
       audio: true,
     });
 
-    expect(generateVideosMock).toHaveBeenCalledWith(
+    expect(generateVideosMock).toHaveBeenCalledTimes(1);
+    const [request] = generateVideosMock.mock.calls[0] ?? [];
+    expect(request).toEqual(
       expect.objectContaining({
         model: "veo-3.1-fast-generate-preview",
         prompt: "A tiny robot watering a windowsill garden",
         config: expect.objectContaining({
-          numberOfVideos: 1,
           durationSeconds: 4,
           aspectRatio: "16:9",
           resolution: "720p",
@@ -80,6 +81,7 @@ describe("google video generation provider", () => {
         }),
       }),
     );
+    expect(request?.config).not.toHaveProperty("numberOfVideos");
     expect(result.videos).toHaveLength(1);
     expect(result.videos[0]?.mimeType).toBe("video/mp4");
     expect(GoogleGenAIMock).toHaveBeenCalledWith(

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -238,7 +238,6 @@ export function buildGoogleVideoGenerationProvider(): VideoGenerationProvider {
         image: resolveInputImage(req),
         video: resolveInputVideo(req),
         config: {
-          numberOfVideos: 1,
           ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
           ...(resolveAspectRatio({ aspectRatio: req.aspectRatio, size: req.size })
             ? { aspectRatio: resolveAspectRatio({ aspectRatio: req.aspectRatio, size: req.size }) }


### PR DESCRIPTION
## Summary
- stop sending `numberOfVideos: 1` in Google Veo requests
- keep single-video behavior enforced on the OpenClaw side instead of encoding it in the Google payload
- update the Google video provider test to assert the field stays absent while duration rounding and the rest of the config still work

## Why
Google's Gemini Developer API path for the Veo models used here rejects `numberOfVideos` with `400 INVALID_ARGUMENT`:\n\n> `numberOfVideos` isn't supported by this model. Please remove it or refer to the Gemini API documentation for supported usage.

That made Google video generation fail before the request could stay on Veo, and the broader flow could then fall through to another provider. The confusing symptom was asking for Veo and getting a Sora result, but the root cause was the invalid Google request.

Removing the unsupported field preserves OpenClaw's single-video behavior because `maxVideos: 1` is already enforced in provider capabilities and normalization logic.

## Testing
- `pnpm test extensions/google/video-generation-provider.test.ts`