### PR TITLE
fix(hooks): pass workspaceDir in gateway session reset internal hook context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: recover embedded GPT-style runs when reasoning-only or empty turns need bounded continuation, with replay-safe retry gating and incomplete-turn fallback when no visible answer arrives. (#66167) thanks @jalehman
 - Outbound/relay-status: suppress internal relay-status placeholder payloads (`No channel reply.`, `Replied in-thread.`, `Replied in #...`, wiki-update status variants ending in `No channel reply.`) before channel delivery so internal housekeeping text does not leak to users.
 - Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
+- Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
 
 ## 2026.4.12
 
@@ -145,6 +146,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI/Codex OAuth: stop rewriting the upstream authorize URL scopes so new Codex sign-ins do not fail with `invalid_scope` before returning an authorization code. (#64713) Thanks @fuller-stack-dev.
 - Audio transcription: disable pinned DNS only for OpenAI-compatible multipart requests, while still validating hostnames, so OpenAI, Groq, and Mistral transcription works again without weakening other request paths. (#64766) Thanks @GodsBoy.
 - macOS/Talk Mode: after granting microphone permission on first enable, continue starting Talk Mode instead of requiring a second toggle. (#62459) Thanks @ggarber.
+<<<<<<< HEAD
 - Control UI/webchat: persist agent-run TTS audio replies into webchat history and preserve interleaved tool card pairing so generated audio and mixed tool output stay attached to the right messages. (#63514) Thanks @bittoby.
 - WhatsApp: honor the configured default account when the active listener helper is used without an explicit account id, so named default accounts do not get registered under `default`. (#53918) Thanks @yhyatt.
 - ACP/agents: suppress commentary-phase child assistant relay text in ACP parent stream updates, so spawned child runs stop leaking internal progress chatter into the parent session. Thanks @vincentkoc.
@@ -159,6 +161,9 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: scope assistant-side fallback classification and surfaced provider errors to the current attempt instead of stale session history, so cross-provider fallback runs stop inheriting the previous provider's failure. (#62907) Thanks @stainlu.
 - MiniMax/OAuth: write `api: "anthropic-messages"` and `authHeader: true` into the `minimax-portal` config patch during `openclaw configure`, so re-authenticated portal setups keep Bearer auth routing working. (#64964) Thanks @ryanlee666.
 - Agents/tools: stop repeated unavailable-tool retries from escaping loop detection when the model changes arguments, and rewrite over-threshold unknown tool calls into plain assistant text before dispatch. (#65922) Thanks @dutifulbob.
+=======
+- Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
+>>>>>>> 319150b205 (docs(changelog): add session-memory workspace reset note)
 
 ## 2026.4.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,6 @@ Docs: https://docs.openclaw.ai
 - OpenAI/Codex OAuth: stop rewriting the upstream authorize URL scopes so new Codex sign-ins do not fail with `invalid_scope` before returning an authorization code. (#64713) Thanks @fuller-stack-dev.
 - Audio transcription: disable pinned DNS only for OpenAI-compatible multipart requests, while still validating hostnames, so OpenAI, Groq, and Mistral transcription works again without weakening other request paths. (#64766) Thanks @GodsBoy.
 - macOS/Talk Mode: after granting microphone permission on first enable, continue starting Talk Mode instead of requiring a second toggle. (#62459) Thanks @ggarber.
-<<<<<<< HEAD
 - Control UI/webchat: persist agent-run TTS audio replies into webchat history and preserve interleaved tool card pairing so generated audio and mixed tool output stay attached to the right messages. (#63514) Thanks @bittoby.
 - WhatsApp: honor the configured default account when the active listener helper is used without an explicit account id, so named default accounts do not get registered under `default`. (#53918) Thanks @yhyatt.
 - ACP/agents: suppress commentary-phase child assistant relay text in ACP parent stream updates, so spawned child runs stop leaking internal progress chatter into the parent session. Thanks @vincentkoc.
@@ -161,9 +160,6 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: scope assistant-side fallback classification and surfaced provider errors to the current attempt instead of stale session history, so cross-provider fallback runs stop inheriting the previous provider's failure. (#62907) Thanks @stainlu.
 - MiniMax/OAuth: write `api: "anthropic-messages"` and `authHeader: true` into the `minimax-portal` config patch during `openclaw configure`, so re-authenticated portal setups keep Bearer auth routing working. (#64964) Thanks @ryanlee666.
 - Agents/tools: stop repeated unavailable-tool retries from escaping loop detection when the model changes arguments, and rewrite over-threshold unknown tool calls into plain assistant text before dispatch. (#65922) Thanks @dutifulbob.
-=======
-- Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
->>>>>>> 319150b205 (docs(changelog): add session-memory workspace reset note)
 
 ## 2026.4.10
 

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -514,6 +514,8 @@ export async function performGatewaySessionReset(params: {
   })();
   const { entry, legacyKey, canonicalKey } = loadSessionEntry(params.key);
   const hadExistingEntry = Boolean(entry);
+  const agentId = normalizeAgentId(target.agentId ?? resolveDefaultAgentId(cfg));
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const hookEvent = createInternalHookEvent(
     "command",
     params.reason,
@@ -523,6 +525,7 @@ export async function performGatewaySessionReset(params: {
       previousSessionEntry: entry,
       commandSource: params.commandSource,
       cfg,
+      workspaceDir,
     },
   );
   await triggerInternalHook(hookEvent);

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -533,6 +533,49 @@ describe("session-memory hook", () => {
     expect(files.length).toBe(1);
   });
 
+  it("uses agent-specific workspace when workspaceDir is provided for non-default agent (gateway path regression)", async () => {
+    const defaultWorkspace = await createCaseWorkspace("workspace-default");
+    const customAgentWorkspace = await createCaseWorkspace("workspace-custom-agent");
+    const sessionsDir = path.join(customAgentWorkspace, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "custom-agent-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Custom agent conversation" },
+        { role: "assistant", content: "Stored in agent workspace" },
+      ]),
+    });
+
+    // Simulate the gateway internal hook path: workspaceDir is resolved and
+    // passed explicitly in context (fix for #64528).  Without the fix, the
+    // gateway path omitted workspaceDir, causing the handler to fall back to
+    // the default workspace via resolveAgentWorkspaceDir — which for a
+    // default-agent sessionKey would resolve to the shared default workspace.
+    const { files, memoryContent } = await runNewWithPreviousSessionEntry({
+      tempDir: customAgentWorkspace,
+      cfg: {
+        agents: {
+          defaults: { workspace: defaultWorkspace },
+          list: [{ id: "custom-agent", workspace: customAgentWorkspace }],
+        },
+      } satisfies OpenClawConfig,
+      sessionKey: "agent:main:main",
+      workspaceDirOverride: customAgentWorkspace,
+      previousSessionEntry: {
+        sessionId: "custom-agent-session",
+        sessionFile,
+      },
+    });
+
+    expect(files.length).toBe(1);
+    expect(memoryContent).toContain("user: Custom agent conversation");
+    expect(memoryContent).toContain("assistant: Stored in agent workspace");
+    // Verify memory did NOT leak to the default workspace
+    await expect(fs.access(path.join(defaultWorkspace, "memory"))).rejects.toThrow();
+  });
+
   it("handles session files with fewer messages than requested", async () => {
     const sessionContent = createMockSessionContent([
       { role: "user", content: "Only message 1" },


### PR DESCRIPTION
## Summary

- Fixes `performGatewaySessionReset` not passing `workspaceDir` in the internal hook event context, causing the session-memory handler to write daily notes/memory files to the wrong workspace in multi-agent setups
- The plugin hook path (`emitGatewayBeforeResetPluginHook`) in the **same file** already correctly resolves and passes `workspaceDir` — this aligns the internal hook path to match

## Root Cause

`performGatewaySessionReset` creates an `InternalHookEvent` without `workspaceDir` in the context object. The session-memory handler (`handler.ts`) falls back to `resolveAgentWorkspaceDir(cfg, agentId)`, but for default-agent session keys this resolves to the shared default workspace instead of the per-agent workspace. Daily notes and memory files leak across agent boundaries.

## Fix

Resolve `agentId` and `workspaceDir` before creating the hook event (mirroring lines 469–470 of `emitGatewayBeforeResetPluginHook`) and pass `workspaceDir` in the context.

## Test Plan

- [x] Added regression test: "uses agent-specific workspace when workspaceDir is provided for non-default agent (gateway path regression)"
- [x] Verifies memory file lands in the correct agent workspace, NOT the default
- [x] All 18 session-memory handler tests pass

Closes #64528