### PR TITLE
fix(gateway): install env HTTP proxy dispatcher at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - macOS/Talk Mode: after granting microphone permission on first enable, continue starting Talk Mode instead of requiring a second toggle. (#62459) Thanks @ggarber.
 - OpenAI/Codex OAuth: stop rewriting the upstream authorize URL scopes so new Codex sign-ins do not fail with `invalid_scope` before returning an authorization code. (#64713) Thanks @fuller-stack-dev.
 - Google/Veo: stop sending the unsupported `numberOfVideos` request field so Gemini Developer API Veo runs do not fail before OpenClaw can complete the intended Google video generation path. (#64723) thanks @velvet-shark
+- Gateway/proxy: install the env HTTP proxy dispatcher at gateway startup so requests honor `HTTP_PROXY`/`HTTPS_PROXY` environment variables on every fetch path, instead of only the LLM calls that happen to flow through the embedded pi runner. (#64636) Thanks @0xmariowu.
 
 ## 2026.4.10
 

--- a/src/gateway/server.proxy-bootstrap.test.ts
+++ b/src/gateway/server.proxy-bootstrap.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const proxyBootstrapState = vi.hoisted(() => ({
+  events: [] as Array<"bootstrap" | "impl">,
+}));
+
+vi.mock("../infra/net/undici-global-dispatcher.js", () => ({
+  ensureGlobalUndiciEnvProxyDispatcher: vi.fn(() => {
+    proxyBootstrapState.events.push("bootstrap");
+  }),
+}));
+
+vi.mock("./server.impl.js", () => ({
+  startGatewayServer: vi.fn(async () => {
+    proxyBootstrapState.events.push("impl");
+    return { close: vi.fn(async () => undefined) };
+  }),
+  __resetModelCatalogCacheForTest: vi.fn(),
+}));
+
+describe("startGatewayServer proxy bootstrap", () => {
+  beforeEach(() => {
+    proxyBootstrapState.events = [];
+  });
+
+  it("installs the env HTTP proxy dispatcher before loading the gateway impl on every call", async () => {
+    const mod = await import("./server.js");
+
+    await mod.startGatewayServer(4321, { bind: "loopback" });
+    await mod.startGatewayServer(4322, { bind: "loopback" });
+
+    expect(proxyBootstrapState.events).toEqual(["bootstrap", "impl", "bootstrap", "impl"]);
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1,3 +1,5 @@
+import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
+
 export { truncateCloseReason } from "./server/close-reason.js";
 export type { GatewayServer, GatewayServerOptions } from "./server.impl.js";
 async function loadServerImpl() {
@@ -7,6 +9,10 @@ async function loadServerImpl() {
 export async function startGatewayServer(
   ...args: Parameters<typeof import("./server.impl.js").startGatewayServer>
 ): ReturnType<typeof import("./server.impl.js").startGatewayServer> {
+  // Install the env HTTP proxy dispatcher before loading the gateway impl so
+  // every fetch path honors HTTP_PROXY/HTTPS_PROXY, not just LLM calls that
+  // happen to flow through per-request bootstrap sites.
+  ensureGlobalUndiciEnvProxyDispatcher();
   const mod = await loadServerImpl();
   return await mod.startGatewayServer(...args);
 }


### PR DESCRIPTION
## Summary

Move the env HTTP proxy bootstrap from per-request sites to the gateway server entry point so every fetch path honors `HTTP_PROXY` / `HTTPS_PROXY`, not just LLM calls that happen to flow through `pi-embedded-runner`.

Closes #64636.

## Why

`ensureGlobalUndiciEnvProxyDispatcher()` already exists in `src/infra/net/undici-global-dispatcher.ts` and is well-tested. The regression in `2026.4.9` is that it was only called from per-request sites:

- `src/agents/pi-embedded-runner/run/attempt.ts:345`
- `src/agents/minimax-vlm.ts:79`
- `src/plugins/provider-openai-codex-oauth.ts:23`
- `extensions/openai/openai-codex-provider.runtime.ts` (codex auth refresh only)
- `extensions/memory-lancedb/index.ts:175`

There is **no gateway-startup-time call**, which means any fetch path that does not flow through one of those sites — plugin init, codex-harness, browser tools, subagent runners, gateway-side health probes — bypasses the env proxy entirely. The reporter on #64636 sees this as `network connection error` 20 seconds into the first LLM request because the standard `openai-responses` provider does not run the bootstrap before the first request.

The fix is to call `ensureGlobalUndiciEnvProxyDispatcher()` at the top of `startGatewayServer` in `src/gateway/server.ts`, before the dynamic `import("./server.impl.js")`. The function is idempotent and a no-op when no proxy env vars are set, so this is safe for users without a proxy.

## Scope

One concern, three files:

- `src/gateway/server.ts` — add the import + a single call before `loadServerImpl()`. Comment explains the WHY (cross-path coverage), not the WHAT.
- `src/gateway/server.proxy-bootstrap.test.ts` — new boundary test using the same `vi.hoisted()` mock pattern as `src/gateway/server.lazy.test.ts`. Asserts the call order `bootstrap → impl → bootstrap → impl` across two `startGatewayServer` invocations to lock in both ordering and per-call invocation.
- `CHANGELOG.md` — one new entry under `## Unreleased / ### Fixes`.

I deliberately did **not** also call `ensureGlobalUndiciStreamTimeouts()` at startup, even though the two are paired in `pi-embedded-runner/run/attempt.ts`. Installing 30-minute stream timeouts at gateway startup is a separate concern that affects all gateway users, not just proxy users, and belongs in its own PR with its own issue.

## Testing

Locally inside a `node:24` Docker container against a fresh `pnpm install --frozen-lockfile`:

- `pnpm test src/gateway/server.proxy-bootstrap.test.ts` — passes (1 test).
- `pnpm test src/gateway/server.lazy.test.ts` — still passes; the new top-level import does not break the lazy-load invariant the existing test guards.
- `pnpm test src/infra/net/undici-global-dispatcher.test.ts src/infra/net/proxy-fetch.test.ts src/infra/net/proxy-env.test.ts` — all 30 existing proxy/dispatcher tests still pass.
- `pnpm check` is currently failing on `main` for unrelated reasons in `src/video-generation/runtime.ts` (`'inputAudios'` and `'providerOptions'` not on `GenerateVideoParams`). I confirmed the same failure exists on a clean `upstream/main` checkout with no diff applied. The pre-commit hook was run with `FAST_COMMIT=1` to skip the broken repo-wide check; `oxlint` and `oxfmt` still ran on the staged files and reported `0 warnings and 0 errors`.

I do not have a real OpenAI account with `chatgpt 5.4` behind a corporate proxy in the test environment, so this is **not** verified end-to-end against a live proxy server. The fix is verified at the boundary (the global undici dispatcher is now installed before any plugin or LLM request runs) and at the existing proxy infrastructure (which is already covered by 30 unit tests in `src/infra/net/`).

## Known limitation (out of scope)

`ensureGlobalUndiciEnvProxyDispatcher` uses a module-level `lastAppliedProxyBootstrap` flag. A long-lived embedding/test process that calls `startGatewayServer` once with `HTTP_PROXY` set and again after clearing it will keep the previously installed `EnvHttpProxyAgent` active. Real users do not toggle proxy env vars between same-process gateway restarts, but if this becomes a problem, the fix belongs in `undici-global-dispatcher.ts` rather than the call site.

## AI-assisted disclosure

This PR was prepared in a Claude Code session. Testing level: **unit-tested** — new boundary test plus existing neighbor tests run in Docker; not exercised against a live proxy server. I read the relevant source paths (`src/infra/net/undici-global-dispatcher.ts`, `src/infra/net/proxy-env.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`, `src/cli/gateway-cli/run-loop.ts`, `src/gateway/server.ts`, `src/gateway/server.impl.ts`, `extensions/openai/index.ts`, `extensions/openai/openai-codex-provider.runtime.ts`) end-to-end before settling on the placement. `codex review --base upstream/main` was run locally and its findings were addressed before push.