### PR TITLE
Agents: log proxy route summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Tools/video_generate: allow providers and plugins to return URL-only generated video assets so agent delivery and `openclaw capability video generate --output ...` can forward or stream large videos without requiring the full file in memory first. (#61988) Thanks @xieyongliang.
-- Models/providers: surface how configured OpenAI-compatible endpoints are classified in embedded-agent debug logs, so local and proxy routing issues are easier to diagnose. (#64754)
+- Models/providers: surface how configured OpenAI-compatible endpoints are classified in embedded-agent debug logs, so local and proxy routing issues are easier to diagnose. (#64754) Thanks @ImLukeF.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Tools/video_generate: allow providers and plugins to return URL-only generated video assets so agent delivery and `openclaw capability video generate --output ...` can forward or stream large videos without requiring the full file in memory first. (#61988) Thanks @xieyongliang.
+- Models/providers: surface how configured OpenAI-compatible endpoints are classified in embedded-agent debug logs, so local and proxy routing issues are easier to diagnose. (#64754)
 
 ### Fixes
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1733,7 +1733,7 @@ export async function runEmbeddedAttempt(
         });
         log.debug(
           `embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId} ` +
-            `routing=${routingSummary}`,
+            routingSummary,
         );
         cacheTrace?.recordStage("prompt:before", {
           prompt: effectivePrompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -89,6 +89,7 @@ import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
+import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
@@ -1723,7 +1724,17 @@ export async function runEmbeddedAttempt(
           activeSession.agent.streamFn = googlePromptCacheStreamFn;
         }
 
-        log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
+        const routingSummary = describeProviderRequestRoutingSummary({
+          provider: params.provider,
+          api: params.model.api,
+          baseUrl: params.model.baseUrl,
+          capability: "llm",
+          transport: "stream",
+        });
+        log.debug(
+          `embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId} ` +
+            `routing=${routingSummary}`,
+        );
         cacheTrace?.recordStage("prompt:before", {
           prompt: effectivePrompt,
           messages: activeSession.messages,

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -8,6 +8,7 @@ import {
   resolveProviderRequestAttributionHeaders,
   resolveProviderRequestCapabilities,
   resolveProviderRequestPolicy,
+  describeProviderRequestRoutingSummary,
 } from "./provider-attribution.js";
 
 describe("provider attribution", () => {
@@ -301,6 +302,52 @@ describe("provider attribution", () => {
         capability: "llm",
       }),
     ).toBeUndefined();
+  });
+
+  it("summarizes proxy-like, local, and native routing compactly", () => {
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://proxy.example.com/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toBe("provider=openai api=openai-responses endpoint=custom route=proxy-like policy=none");
+
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "qwen",
+        api: "openai-responses",
+        baseUrl: "http://localhost:1234/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toBe("provider=qwen api=openai-responses endpoint=local route=local policy=none");
+
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toBe(
+      "provider=openai api=openai-responses endpoint=openai-public route=native policy=hidden",
+    );
+
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "openrouter",
+        api: "openai-responses",
+        baseUrl: "https://openrouter.ai/api/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toBe(
+      "provider=openrouter api=openai-responses endpoint=openrouter route=proxy-like policy=documented",
+    );
   });
 
   it("models other provider families without enabling hidden attribution", () => {

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -304,7 +304,22 @@ describe("provider attribution", () => {
     ).toBeUndefined();
   });
 
-  it("summarizes proxy-like, local, and native routing compactly", () => {
+  it("summarizes proxy-like, local, invalid, default, and native routing compactly", () => {
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "openai",
+        api: "openai-responses",
+      }),
+    ).toBe("provider=openai api=openai-responses endpoint=default route=default policy=none");
+
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "javascript:alert(1)",
+      }),
+    ).toBe("provider=openai api=openai-responses endpoint=invalid route=invalid policy=none");
+
     expect(
       describeProviderRequestRoutingSummary({
         provider: "openai",
@@ -348,6 +363,16 @@ describe("provider attribution", () => {
     ).toBe(
       "provider=openrouter api=openai-responses endpoint=openrouter route=proxy-like policy=documented",
     );
+
+    expect(
+      describeProviderRequestRoutingSummary({
+        provider: "groq",
+        api: "openai-completions",
+        baseUrl: "https://api.groq.com/openai/v1",
+        transport: "stream",
+        capability: "llm",
+      }),
+    ).toBe("provider=groq api=openai-completions endpoint=groq-native route=native policy=none");
   });
 
   it("models other provider families without enabling hidden attribution", () => {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -616,3 +616,58 @@ export function resolveProviderRequestCapabilities(
     compatibilityFamily,
   };
 }
+
+function describeProviderRequestRoutingPolicy(
+  policy: ProviderRequestPolicyResolution,
+): "hidden" | "documented" | "sdk-hook-only" | "none" {
+  if (!policy.attributionProvider) {
+    return "none";
+  }
+  switch (policy.policy?.verification) {
+    case "vendor-hidden-api-spec":
+      return "hidden";
+    case "vendor-documented":
+      return "documented";
+    case "vendor-sdk-hook-only":
+      return "sdk-hook-only";
+    default:
+      return "none";
+  }
+}
+
+function describeProviderRequestRouteClass(
+  policy: ProviderRequestPolicyResolution,
+): "default" | "native" | "proxy-like" | "local" | "invalid" {
+  if (policy.endpointClass === "default") {
+    return "default";
+  }
+  if (policy.endpointClass === "invalid") {
+    return "invalid";
+  }
+  if (policy.endpointClass === "local") {
+    return "local";
+  }
+  if (policy.usesExplicitProxyLikeEndpoint) {
+    return "proxy-like";
+  }
+  return "native";
+}
+
+export function describeProviderRequestRoutingSummary(
+  input: ProviderRequestPolicyInput,
+  env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
+): string {
+  const policy = resolveProviderRequestPolicy(input, env);
+  const api = normalizeOptionalLowercaseString(input.api) ?? "unknown";
+  const provider = policy.provider ?? "unknown";
+  const routeClass = describeProviderRequestRouteClass(policy);
+  const routingPolicy = describeProviderRequestRoutingPolicy(policy);
+
+  return [
+    `provider=${provider}`,
+    `api=${api}`,
+    `endpoint=${policy.endpointClass}`,
+    `route=${routeClass}`,
+    `policy=${routingPolicy}`,
+  ].join(" ");
+}

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -647,7 +647,7 @@ function describeProviderRequestRouteClass(
   if (policy.endpointClass === "local") {
     return "local";
   }
-  if (policy.usesExplicitProxyLikeEndpoint) {
+  if (policy.endpointClass === "custom" || policy.endpointClass === "openrouter") {
     return "proxy-like";
   }
   return "native";


### PR DESCRIPTION
## Summary
- add a compact provider routing summary helper for native, local, custom, and proxy-like OpenAI-compatible endpoints
- include the resolved routing summary in the embedded runner's existing prompt-start debug log
- add focused attribution tests covering proxy-like, local, native OpenAI, and OpenRouter summaries

## Testing
- `pnpm test src/agents/provider-attribution.test.ts`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts`