### PR TITLE
fix(browser): make headless start override request-local

### DIFF
--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -6,7 +6,7 @@ import { createBrowserProfilesService } from "../profiles-service.js";
 import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
 import { resolveProfileContext } from "./agent.shared.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
-import { getProfileContext, jsonError, toStringOrEmpty } from "./utils.js";
+import { getProfileContext, jsonError, toBoolean, toStringOrEmpty } from "./utils.js";
 
 function handleBrowserRouteError(res: BrowserResponse, err: unknown) {
   const mapped = toBrowserErrorResponse(err);
@@ -135,7 +135,33 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
       res,
       ctx,
       run: async (profileCtx) => {
-        await profileCtx.ensureBrowserAvailable();
+        // Allow runtime headless override via query param (e.g. ?headless=true)
+        const headlessParam = toBoolean(req.query.headless);
+        if (headlessParam) {
+          // Headless mode only works with locally-launched profiles (openclaw driver).
+          // Extension-based profiles (chrome) attach to an existing browser and cannot be made headless.
+          if (profileCtx.profile.driver === "existing-session") {
+            return jsonError(
+              res,
+              400,
+              `Headless mode is not supported with extension-based profile "${profileCtx.profile.name}". Use an openclaw-managed profile instead.`,
+            );
+          }
+        }
+
+        // Scope headless override to this start operation only — don't permanently
+        // mutate shared resolved state, otherwise a subsequent start without
+        // ?headless=true would still launch headless.
+        const current = ctx.state();
+        const previousHeadless = current.resolved.headless;
+        if (headlessParam) {
+          current.resolved.headless = true;
+        }
+        try {
+          await profileCtx.ensureBrowserAvailable();
+        } finally {
+          current.resolved.headless = previousHeadless;
+        }
         res.json({ ok: true, profile: profileCtx.profile.name });
       },
     });

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -138,30 +138,22 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
         // Allow runtime headless override via query param (e.g. ?headless=true)
         const headlessParam = toBoolean(req.query.headless);
         if (headlessParam) {
-          // Headless mode only works with locally-launched profiles (openclaw driver).
-          // Extension-based profiles (chrome) attach to an existing browser and cannot be made headless.
-          if (profileCtx.profile.driver === "existing-session") {
+          const capabilities = getBrowserProfileCapabilities(profileCtx.profile);
+          // Headless mode only works when OpenClaw launches a local browser process.
+          if (
+            profileCtx.profile.driver === "existing-session" ||
+            profileCtx.profile.attachOnly ||
+            capabilities.isRemote
+          ) {
             return jsonError(
               res,
               400,
-              `Headless mode is not supported with extension-based profile "${profileCtx.profile.name}". Use an openclaw-managed profile instead.`,
+              `Headless mode is only supported for locally launched openclaw profiles. Profile "${profileCtx.profile.name}" is attach-only or remote.`,
             );
           }
         }
 
-        // Scope headless override to this start operation only — don't permanently
-        // mutate shared resolved state, otherwise a subsequent start without
-        // ?headless=true would still launch headless.
-        const current = ctx.state();
-        const previousHeadless = current.resolved.headless;
-        if (headlessParam) {
-          current.resolved.headless = true;
-        }
-        try {
-          await profileCtx.ensureBrowserAvailable();
-        } finally {
-          current.resolved.headless = previousHeadless;
-        }
+        await profileCtx.ensureBrowserAvailable({ headless: headlessParam ? true : undefined });
         res.json({ ok: true, profile: profileCtx.profile.name });
       },
     });

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -47,7 +47,7 @@ type AvailabilityDeps = {
 type AvailabilityOps = {
   isHttpReachable: (timeoutMs?: number) => Promise<boolean>;
   isReachable: (timeoutMs?: number) => Promise<boolean>;
-  ensureBrowserAvailable: () => Promise<void>;
+  ensureBrowserAvailable: (opts?: { headless?: boolean }) => Promise<void>;
   stopRunningBrowser: () => Promise<{ stopped: boolean }>;
 };
 
@@ -167,7 +167,7 @@ export function createProfileAvailability({
     );
   };
 
-  const ensureBrowserAvailable = async (): Promise<void> => {
+  const ensureBrowserAvailable = async (options?: { headless?: boolean }): Promise<void> => {
     await reconcileProfileRuntime();
     if (capabilities.usesChromeMcp) {
       if (profile.userDataDir && !fs.existsSync(profile.userDataDir)) {
@@ -210,7 +210,11 @@ export function createProfileAvailability({
             : `Browser attachOnly is enabled and profile "${profile.name}" is not running.`,
         );
       }
-      const launched = await launchOpenClawChrome(current.resolved, profile);
+      const launchConfig =
+        typeof options?.headless === "boolean"
+          ? { ...current.resolved, headless: options.headless }
+          : current.resolved;
+      const launched = await launchOpenClawChrome(launchConfig, profile);
       attachRunning(launched);
       try {
         await waitForCdpReadyAfterLaunch();

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -15,7 +15,7 @@ type SelectionDeps = {
   profile: ResolvedBrowserProfile;
   getProfileState: () => ProfileRuntimeState;
   getSsrFPolicy: () => SsrFPolicy | undefined;
-  ensureBrowserAvailable: () => Promise<void>;
+  ensureBrowserAvailable: (opts?: { headless?: boolean }) => Promise<void>;
   listTabs: () => Promise<BrowserTab[]>;
   openTab: (url: string) => Promise<BrowserTab>;
 };

--- a/extensions/browser/src/browser/server-context.types.ts
+++ b/extensions/browser/src/browser/server-context.types.ts
@@ -27,7 +27,7 @@ export type BrowserServerState = {
 };
 
 type BrowserProfileActions = {
-  ensureBrowserAvailable: () => Promise<void>;
+  ensureBrowserAvailable: (opts?: { headless?: boolean }) => Promise<void>;
   ensureTabAvailable: (targetId?: string) => Promise<BrowserTab>;
   isHttpReachable: (timeoutMs?: number) => Promise<boolean>;
   isReachable: (timeoutMs?: number) => Promise<boolean>;

--- a/extensions/browser/src/cli/browser-cli-examples.ts
+++ b/extensions/browser/src/cli/browser-cli-examples.ts
@@ -1,6 +1,7 @@
 export const browserCoreExamples = [
   "openclaw browser status",
   "openclaw browser start",
+  "openclaw browser start --headless",
   "openclaw browser stop",
   "openclaw browser tabs",
   "openclaw browser open https://example.com",

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -176,11 +176,29 @@ export function registerBrowserManageCommands(
   browser
     .command("start")
     .description("Start the browser (no-op if already running)")
-    .action(async (_opts, cmd) => {
+    .option("--headless", "Launch browser in headless mode (no visible window)")
+    .action(async (opts: { headless?: boolean }, cmd) => {
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
       await runBrowserCommand(async () => {
-        await runBrowserToggle(parent, { profile, path: "/start" });
+        const query: Record<string, string | boolean | undefined> = {
+          ...resolveProfileQuery(profile),
+        };
+        if (opts.headless) {
+          query.headless = "true";
+        }
+        await callBrowserRequest(parent, {
+          method: "POST",
+          path: "/start",
+          query: Object.keys(query).length > 0 ? query : undefined,
+        });
+        const status = await fetchBrowserStatus(parent, profile);
+        if (printJsonResult(parent, status)) {
+          return;
+        }
+        const name = status.profile ?? "openclaw";
+        const headlessLabel = status.headless ? " (headless)" : "";
+        defaultRuntime.log(info(`🦞 browser [${name}] running: ${status.running}${headlessLabel}`));
       });
     });
 

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -197,7 +197,7 @@ export function registerBrowserManageCommands(
           return;
         }
         const name = status.profile ?? "openclaw";
-        const headlessLabel = status.headless ? " (headless)" : "";
+        const headlessLabel = status.headless || opts.headless ? " (headless)" : "";
         defaultRuntime.log(info(`🦞 browser [${name}] running: ${status.running}${headlessLabel}`));
       });
     });

--- a/src/cli/browser-cli-manage.headless-option.test.ts
+++ b/src/cli/browser-cli-manage.headless-option.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerBrowserManageCommands } from "./browser-cli-manage.js";
+import { createBrowserProgram } from "./browser-cli-test-helpers.js";
+
+const mocks = vi.hoisted(() => {
+  const runtimeLog = vi.fn();
+  const runtimeError = vi.fn();
+  const runtimeExit = vi.fn();
+  return {
+    callBrowserRequest: vi.fn(async (_opts: unknown, req: { path?: string }) =>
+      req.path === "/"
+        ? {
+            enabled: true,
+            profile: "openclaw",
+            running: true,
+            pid: 1,
+            cdpPort: 18800,
+            chosenBrowser: "chrome",
+            userDataDir: "/tmp/openclaw",
+            color: "#FF4500",
+            headless: true,
+            attachOnly: false,
+          }
+        : { ok: true },
+    ),
+    runtimeLog,
+    runtimeError,
+    runtimeExit,
+    runtime: {
+      log: runtimeLog,
+      error: runtimeError,
+      exit: runtimeExit,
+    },
+  };
+});
+
+vi.mock("./browser-cli-shared.js", () => ({
+  callBrowserRequest: mocks.callBrowserRequest,
+}));
+
+vi.mock("./cli-utils.js", () => ({
+  runCommandWithRuntime: async (
+    _runtime: unknown,
+    action: () => Promise<void>,
+    onError: (err: unknown) => void,
+  ) => await action().catch(onError),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("browser start --headless", () => {
+  function createProgram() {
+    const { program, browser, parentOpts } = createBrowserProgram();
+    registerBrowserManageCommands(browser, parentOpts);
+    return program;
+  }
+
+  beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
+    mocks.runtimeLog.mockClear();
+  });
+
+  it("passes headless=true query param when --headless flag is provided", async () => {
+    const program = createProgram();
+    await program.parseAsync(["browser", "start", "--headless"], { from: "user" });
+
+    const startCall = mocks.callBrowserRequest.mock.calls.find(
+      (call) => ((call[1] ?? {}) as { path?: string }).path === "/start",
+    ) as [unknown, { path?: string; query?: Record<string, string> }] | undefined;
+
+    expect(startCall).toBeDefined();
+    expect(startCall?.[1]?.query).toMatchObject({ headless: "true" });
+  });
+
+  it("does not pass headless query param without --headless flag", async () => {
+    const program = createProgram();
+    await program.parseAsync(["browser", "start"], { from: "user" });
+
+    const startCall = mocks.callBrowserRequest.mock.calls.find(
+      (call) => ((call[1] ?? {}) as { path?: string }).path === "/start",
+    ) as [unknown, { path?: string; query?: Record<string, string> }] | undefined;
+
+    expect(startCall).toBeDefined();
+    expect(startCall?.[1]?.query).toBeUndefined();
+  });
+
+  it("logs headless indicator in output when browser is headless", async () => {
+    const program = createProgram();
+    await program.parseAsync(["browser", "start", "--headless"], { from: "user" });
+
+    expect(mocks.runtimeLog).toHaveBeenCalled();
+    const logOutput = mocks.runtimeLog.mock.calls.map((c) => c[0]).join("\n");
+    expect(logOutput).toContain("(headless)");
+  });
+});

--- a/src/cli/browser-cli-manage.headless-option.test.ts
+++ b/src/cli/browser-cli-manage.headless-option.test.ts
@@ -6,7 +6,11 @@ const mocks = vi.hoisted(() => {
   const runtimeLog = vi.fn();
   const runtimeError = vi.fn();
   const runtimeExit = vi.fn();
+  let statusHeadless = true;
   return {
+    setStatusHeadless: (value: boolean) => {
+      statusHeadless = value;
+    },
     callBrowserRequest: vi.fn(async (_opts: unknown, req: { path?: string }) =>
       req.path === "/"
         ? {
@@ -18,7 +22,7 @@ const mocks = vi.hoisted(() => {
             chosenBrowser: "chrome",
             userDataDir: "/tmp/openclaw",
             color: "#FF4500",
-            headless: true,
+            headless: statusHeadless,
             attachOnly: false,
           }
         : { ok: true },
@@ -60,6 +64,7 @@ describe("browser start --headless", () => {
   beforeEach(() => {
     mocks.callBrowserRequest.mockClear();
     mocks.runtimeLog.mockClear();
+    mocks.setStatusHeadless(true);
   });
 
   it("passes headless=true query param when --headless flag is provided", async () => {
@@ -93,5 +98,14 @@ describe("browser start --headless", () => {
     expect(mocks.runtimeLog).toHaveBeenCalled();
     const logOutput = mocks.runtimeLog.mock.calls.map((c) => c[0]).join("\n");
     expect(logOutput).toContain("(headless)");
+  });
+
+  it("does not log headless indicator when browser is not headless", async () => {
+    mocks.setStatusHeadless(false);
+    const program = createProgram();
+    await program.parseAsync(["browser", "start"], { from: "user" });
+
+    const logOutput = mocks.runtimeLog.mock.calls.map((c) => c[0]).join("\n");
+    expect(logOutput).not.toContain("(headless)");
   });
 });


### PR DESCRIPTION
Addresses review feedback on #51038.

The previous implementation mutated a shared `headlessOverride` variable and then restored it in a `finally` block. Under concurrent requests this creates a race: if two requests overlap, one can see the other's override value.

**Changes:**
- Pass headless mode as a request-local parameter through the launch chain instead of mutating shared state
- Reject `?headless=true` with HTTP 400 for `attachOnly` and `remote` profiles (headless only makes sense for fresh launches)
- Tests updated accordingly

Signed-off-by: Benedikt Schackenberg <6381261+BenediktSchackenberg@users.noreply.github.com>