### PR TITLE
fix(config): resolve CLI command aliases against parent plugin in plugins.allow (#64748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ Docs: https://docs.openclaw.ai
 - Plugins/memory: restore cached memory capability public artifacts on plugin-registry cache hits so memory-backed artifact surfaces stay visible after warm loads. Thanks @sercada and @vincentkoc.
 - Gateway/cron: preserve requested isolated-agent config across runtime reloads so subagent jobs and heartbeat overrides keep the right workspace and heartbeat settings when the hot-loaded snapshot is stale. Thanks @l0cka and @vincentkoc.
 - Gateway/plugins: always send a non-empty `idempotencyKey` for plugin subagent runs, so dreaming narrative jobs stop failing gateway schema validation. (#65354) Thanks @CodeForgeNet and @vincentkoc.
+- CLI/plugins: honor `memory-wiki` when `plugins.allow` is set for `openclaw wiki`, and register `wiki` as the plugin-owned command alias so doctor/config stop treating it as stale. (#64779) Thanks @feiskyer and @vincentkoc.
 - Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
 - Dreaming/cron: wake managed dreaming jobs immediately instead of waiting for the next heartbeat, so scheduled dreaming runs start when the cron fires. (#65053) Thanks @l0cka and @vincentkoc.
-- CLI/plugins: honor `memory-wiki` when `plugins.allow` is set for `openclaw wiki`, and register `wiki` as the plugin-owned command alias so doctor/config stop treating it as stale. (#64779) Thanks @feiskyer and @vincentkoc.
 
 ## 2026.4.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/plugins: always send a non-empty `idempotencyKey` for plugin subagent runs, so dreaming narrative jobs stop failing gateway schema validation. (#65354) Thanks @CodeForgeNet and @vincentkoc.
 - Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
 - Dreaming/cron: wake managed dreaming jobs immediately instead of waiting for the next heartbeat, so scheduled dreaming runs start when the cron fires. (#65053) Thanks @l0cka and @vincentkoc.
+- CLI/plugins: honor `memory-wiki` when `plugins.allow` is set for `openclaw wiki`, and register `wiki` as the plugin-owned command alias so doctor/config stop treating it as stale. (#64779) Thanks @feiskyer and @vincentkoc.
 
 ## 2026.4.11
 

--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -173,5 +173,6 @@
   },
   "configContracts": {
     "compatibilityMigrationPaths": ["plugins.entries.memory-wiki.config.bridge.readMemoryCore"]
-  }
+  },
+  "commandAliases": [{ "name": "wiki" }]
 }

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -148,4 +148,24 @@ describe("resolveMissingPluginCommandMessage", () => {
     expect(message).toContain("plugins.entries.memory-core.enabled=false");
     expect(message).not.toContain("runtime slash command");
   });
+
+  it("allows CLI commands when their parent plugin is in plugins.allow", () => {
+    const message = resolveMissingPluginCommandMessage("wiki", {
+      plugins: {
+        allow: ["memory-wiki"],
+      },
+    });
+    expect(message).toBeNull();
+  });
+
+  it("blocks CLI commands when parent plugin is NOT in plugins.allow", () => {
+    const message = resolveMissingPluginCommandMessage("wiki", {
+      plugins: {
+        allow: ["telegram"],
+      },
+    });
+    expect(message).not.toBeNull();
+    expect(message).toContain('"memory-wiki"');
+    expect(message).toContain("plugins.allow");
+  });
 });

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -6,6 +6,15 @@ import {
   shouldUseRootHelpFastPath,
 } from "./run-main.js";
 
+const memoryWikiCommandAliasRegistry = {
+  plugins: [
+    {
+      id: "memory-wiki",
+      commandAliases: [{ name: "wiki" }],
+    },
+  ],
+};
+
 describe("rewriteUpdateFlagArgv", () => {
   it("leaves argv unchanged when --update is absent", () => {
     const argv = ["node", "entry.js", "status"];
@@ -150,20 +159,28 @@ describe("resolveMissingPluginCommandMessage", () => {
   });
 
   it("allows CLI commands when their parent plugin is in plugins.allow", () => {
-    const message = resolveMissingPluginCommandMessage("wiki", {
-      plugins: {
-        allow: ["memory-wiki"],
+    const message = resolveMissingPluginCommandMessage(
+      "wiki",
+      {
+        plugins: {
+          allow: ["memory-wiki"],
+        },
       },
-    });
+      { registry: memoryWikiCommandAliasRegistry },
+    );
     expect(message).toBeNull();
   });
 
   it("blocks CLI commands when parent plugin is NOT in plugins.allow", () => {
-    const message = resolveMissingPluginCommandMessage("wiki", {
-      plugins: {
-        allow: ["telegram"],
+    const message = resolveMissingPluginCommandMessage(
+      "wiki",
+      {
+        plugins: {
+          allow: ["telegram"],
+        },
       },
-    });
+      { registry: memoryWikiCommandAliasRegistry },
+    );
     expect(message).not.toBeNull();
     expect(message).toContain('"memory-wiki"');
     expect(message).toContain("plugins.allow");

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -13,6 +13,7 @@ import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { enableConsoleCapture } from "../logging.js";
 import { resolveManifestCommandAliasOwner } from "../plugins/manifest-command-aliases.runtime.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { hasMemoryRuntime } from "../plugins/memory-state.js";
 import { maybeWarnAboutDebugProxyCoverage } from "../proxy-capture/coverage.js";
 import {
@@ -73,6 +74,7 @@ export function shouldUseRootHelpFastPath(argv: string[]): boolean {
 export function resolveMissingPluginCommandMessage(
   pluginId: string,
   config?: OpenClawConfig,
+  options?: { registry?: PluginManifestRegistry },
 ): string | null {
   const normalizedPluginId = normalizeLowercaseStringOrEmpty(pluginId);
   if (!normalizedPluginId) {
@@ -88,6 +90,7 @@ export function resolveMissingPluginCommandMessage(
   const commandAlias = resolveManifestCommandAliasOwner({
     command: normalizedPluginId,
     config,
+    registry: options?.registry,
   });
   const parentPluginId = commandAlias?.pluginId;
   if (parentPluginId) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -118,6 +118,9 @@ export function resolveMissingPluginCommandMessage(
   }
 
   if (allow.length > 0 && !allow.includes(normalizedPluginId)) {
+    if (parentPluginId && allow.includes(parentPluginId)) {
+      return null;
+    }
     return (
       `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
       `\`plugins.allow\` excludes "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +


### PR DESCRIPTION
## Summary

- Problem: `openclaw wiki` CLI guard checks the command name `wiki` directly against `plugins.allow`, ignoring that `wiki` is a command provided by the `memory-wiki` plugin. Separately, `memory-wiki` does not declare `wiki` as a `commandAlias`, so `doctor --fix` treats `wiki` in `plugins.allow` as stale and removes it.
- Why it matters: users who add `wiki` to `plugins.allow` lose it on the next `doctor --fix` run, and the CLI fallback guard can block `openclaw wiki` even when `memory-wiki` is allowed.
- What changed: (1) added `commandAliases: [{ "name": "wiki" }]` to the memory-wiki plugin manifest so config validation and doctor recognize the alias; (2) added a parent-plugin check in the CLI fallback allow guard so commands resolve through their owning plugin.
- What did NOT change: the primary CLI registration path (which already works for bundled plugins) is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64748
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveMissingPluginCommandMessage()` resolves the command alias to its parent plugin for error messages but does not check whether that parent plugin is already in `plugins.allow`. The memory-wiki manifest also lacked a `commandAliases` entry, preventing doctor and config validation from recognizing `wiki` as a valid alias.
- Missing detection / guardrail: the fallback allow check did not resolve command names through their parent plugin.
- Contributing context: the `dreaming` command (memory-core) already had a `commandAliases` entry in its manifest, but `wiki` (memory-wiki) was never added.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cli/run-main.test.ts`
- Scenario the test should lock in: calling `resolveMissingPluginCommandMessage("wiki", { plugins: { allow: ["memory-wiki"] } })` returns `null` (no error).
- Why this is the smallest reliable guardrail: the function is the single decision point for CLI command access.

## User-visible / Behavior Changes

- `openclaw wiki` now works when `memory-wiki` is in `plugins.allow` (no need to also add `wiki`).
- `doctor --fix` no longer removes `wiki` from `plugins.allow` as stale; instead warns that it is a command alias for `memory-wiki`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker), macOS
- Runtime/container: Node 24.x
- Model/provider: N/A (CLI-only)

### Steps

1. Set `plugins.allow: ["memory-wiki"]` in openclaw.json
2. Run `openclaw wiki status`

### Expected

- Command runs successfully.

### Actual

- Before fix: error "plugins.allow excludes wiki" (when CLI registration fails to load)
- After fix: command resolves through parent plugin and runs.

## Evidence

- [x] Failing test/log before + passing after

Unit tests: 17/17 pass including 2 new cases for the allow/deny paths.

## Human Verification (required)

- Verified scenarios: unit tests pass, config validation test suite (18/18) pass, Docker build succeeds
- Edge cases checked: command alias with parent in allow (pass-through), command alias with parent NOT in allow (blocked with correct message), no allow list set (no guard)
- What you did **not** verify: macOS app build, production gateway with memory-wiki installed

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: other plugins with CLI descriptors but no `commandAliases` manifest entry may still hit the same issue.
  - Mitigation: this is an additive fix; other plugins can be updated the same way. The CLI guard fix also helps generically.