### PR TITLE
feat(plugins): add manifest activation and setup descriptors

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -519,9 +519,14 @@ The manifest is the control-plane source of truth. OpenClaw uses it to:
 - validate `plugins.entries.<id>.config`
 - augment Control UI labels/placeholders
 - show install/catalog metadata
+- preserve cheap activation and setup descriptors without loading plugin runtime
 
 For native plugins, the runtime module is the data-plane part. It registers
 actual behavior such as hooks, tools, commands, or provider flows.
+
+Optional manifest `activation` and `setup` blocks stay on the control plane.
+They are metadata-only descriptors for activation planning and setup discovery;
+they do not replace runtime registration, `register(...)`, or `setupEntry`.
 
 ### What the loader caches
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -47,6 +47,10 @@ Use it for:
 - config validation
 - auth and onboarding metadata that should be available without booting plugin
   runtime
+- cheap activation hints that control-plane surfaces can inspect before runtime
+  loads
+- cheap setup descriptors that setup/onboarding surfaces can inspect before
+  runtime loads
 - alias and auto-enable metadata that should resolve before plugin runtime loads
 - shorthand model-family ownership metadata that should auto-activate the
   plugin before runtime loads
@@ -152,6 +156,8 @@ Those belong in your plugin code and `package.json`.
 | `providerAuthAliases`               | No       | `Record<string, string>`         | Provider ids that should reuse another provider id for auth lookup, for example a coding provider that shares the base provider API key and auth profiles.                                                   |
 | `channelEnvVars`                    | No       | `Record<string, string[]>`       | Cheap channel env metadata that OpenClaw can inspect without loading plugin code. Use this for env-driven channel setup or auth surfaces that generic startup/config helpers should see.                     |
 | `providerAuthChoices`               | No       | `object[]`                       | Cheap auth-choice metadata for onboarding pickers, preferred-provider resolution, and simple CLI flag wiring.                                                                                                |
+| `activation`                        | No       | `object`                         | Cheap activation hints for provider, command, channel, route, and capability-triggered loading. Metadata only; plugin runtime still owns actual behavior.                                                    |
+| `setup`                             | No       | `object`                         | Cheap setup/onboarding descriptors that discovery and setup surfaces can inspect without loading plugin runtime.                                                                                             |
 | `contracts`                         | No       | `object`                         | Static bundled capability snapshot for speech, realtime transcription, realtime voice, media-understanding, image-generation, music-generation, video-generation, web-fetch, web search, and tool ownership. |
 | `channelConfigs`                    | No       | `Record<string, object>`         | Manifest-owned channel config metadata merged into discovery and validation surfaces before runtime loads.                                                                                                   |
 | `skills`                            | No       | `string[]`                       | Skill directories to load, relative to the plugin root.                                                                                                                                                      |
@@ -207,6 +213,77 @@ uses this metadata for diagnostics without importing plugin runtime code.
 | `name`       | Yes      | `string`          | Command name that belongs to this plugin.                               |
 | `kind`       | No       | `"runtime-slash"` | Marks the alias as a chat slash command rather than a root CLI command. |
 | `cliCommand` | No       | `string`          | Related root CLI command to suggest for CLI operations, if one exists.  |
+
+## activation reference
+
+Use `activation` when the plugin can cheaply declare which control-plane events
+should activate it later.
+
+This block is metadata only. It does not register runtime behavior, and it does
+not replace `register(...)`, `setupEntry`, or other runtime/plugin entrypoints.
+
+```json
+{
+  "activation": {
+    "onProviders": ["openai"],
+    "onCommands": ["models"],
+    "onChannels": ["web"],
+    "onRoutes": ["gateway-webhook"],
+    "onCapabilities": ["provider", "tool"]
+  }
+}
+```
+
+| Field            | Required | Type                                                 | What it means                                                     |
+| ---------------- | -------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+| `onProviders`    | No       | `string[]`                                           | Provider ids that should activate this plugin when requested.     |
+| `onCommands`     | No       | `string[]`                                           | Command ids that should activate this plugin.                     |
+| `onChannels`     | No       | `string[]`                                           | Channel ids that should activate this plugin.                     |
+| `onRoutes`       | No       | `string[]`                                           | Route kinds that should activate this plugin.                     |
+| `onCapabilities` | No       | `Array<"provider" \| "channel" \| "tool" \| "hook">` | Broad capability hints used by control-plane activation planning. |
+
+## setup reference
+
+Use `setup` when setup and onboarding surfaces need cheap plugin-owned metadata
+before runtime loads.
+
+```json
+{
+  "setup": {
+    "providers": [
+      {
+        "id": "openai",
+        "authMethods": ["api-key"],
+        "envVars": ["OPENAI_API_KEY"]
+      }
+    ],
+    "cliBackends": ["openai-cli"],
+    "configMigrations": ["legacy-openai-auth"],
+    "requiresRuntime": false
+  }
+}
+```
+
+Top-level `cliBackends` stays valid and continues to describe CLI inference
+backends. `setup.cliBackends` is the setup-specific descriptor surface for
+control-plane/setup flows that should stay metadata-only.
+
+### setup.providers reference
+
+| Field         | Required | Type       | What it means                                                                      |
+| ------------- | -------- | ---------- | ---------------------------------------------------------------------------------- |
+| `id`          | Yes      | `string`   | Provider id exposed during setup or onboarding.                                    |
+| `authMethods` | No       | `string[]` | Setup/auth method ids this provider supports without loading full runtime.         |
+| `envVars`     | No       | `string[]` | Env vars that generic setup/status surfaces can check before plugin runtime loads. |
+
+### setup fields
+
+| Field              | Required | Type       | What it means                                                               |
+| ------------------ | -------- | ---------- | --------------------------------------------------------------------------- |
+| `providers`        | No       | `object[]` | Provider setup descriptors exposed during setup and onboarding.             |
+| `cliBackends`      | No       | `string[]` | Setup-time backend ids available without full runtime activation.           |
+| `configMigrations` | No       | `string[]` | Config migration ids owned by this plugin's setup surface.                  |
+| `requiresRuntime`  | No       | `boolean`  | Whether setup still needs plugin runtime execution after descriptor lookup. |
 
 ## uiHints reference
 

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -423,6 +423,60 @@ describe("loadPluginManifestRegistry", () => {
     ]);
   });
 
+  it("preserves activation and setup descriptors from plugin manifests", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, {
+      id: "openai",
+      providers: ["openai"],
+      activation: {
+        onProviders: ["openai"],
+        onCommands: ["models"],
+        onChannels: ["web"],
+        onRoutes: ["gateway-webhook"],
+        onCapabilities: ["provider", "tool"],
+      },
+      setup: {
+        providers: [
+          {
+            id: "openai",
+            authMethods: ["api-key"],
+            envVars: ["OPENAI_API_KEY"],
+          },
+        ],
+        cliBackends: ["openai-cli"],
+        configMigrations: ["legacy-openai-auth"],
+        requiresRuntime: false,
+      },
+      configSchema: { type: "object" },
+    });
+
+    const registry = loadSingleCandidateRegistry({
+      idHint: "openai",
+      rootDir: dir,
+      origin: "bundled",
+    });
+
+    expect(registry.plugins[0]?.activation).toEqual({
+      onProviders: ["openai"],
+      onCommands: ["models"],
+      onChannels: ["web"],
+      onRoutes: ["gateway-webhook"],
+      onCapabilities: ["provider", "tool"],
+    });
+    expect(registry.plugins[0]?.setup).toEqual({
+      providers: [
+        {
+          id: "openai",
+          authMethods: ["api-key"],
+          envVars: ["OPENAI_API_KEY"],
+        },
+      ],
+      cliBackends: ["openai-cli"],
+      configMigrations: ["legacy-openai-auth"],
+      requiresRuntime: false,
+    });
+  });
+
   it("preserves channel env metadata from plugin manifests", () => {
     const dir = makeTempDir();
     writeManifest(dir, {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -18,11 +18,13 @@ import type { PluginManifestCommandAlias } from "./manifest-command-aliases.js";
 import {
   loadPluginManifest,
   type OpenClawPackageManifest,
+  type PluginManifestActivation,
   type PluginManifestConfigContracts,
   type PluginManifest,
   type PluginManifestChannelConfig,
   type PluginManifestContracts,
   type PluginManifestModelSupport,
+  type PluginManifestSetup,
 } from "./manifest.js";
 import { checkMinHostVersion } from "./min-host-version.js";
 import { isPathInside, safeRealpathSync } from "./path-safety.js";
@@ -84,6 +86,8 @@ export type PluginManifestRecord = {
   providerAuthAliases?: Record<string, string>;
   channelEnvVars?: Record<string, string[]>;
   providerAuthChoices?: PluginManifest["providerAuthChoices"];
+  activation?: PluginManifestActivation;
+  setup?: PluginManifestSetup;
   skills: string[];
   settingsFiles?: string[];
   hooks: string[];
@@ -322,6 +326,8 @@ function buildRecord(params: {
     providerAuthAliases: params.manifest.providerAuthAliases,
     channelEnvVars: params.manifest.channelEnvVars,
     providerAuthChoices: params.manifest.providerAuthChoices,
+    activation: params.manifest.activation,
+    setup: params.manifest.setup,
     skills: params.manifest.skills ?? [],
     settingsFiles: [],
     hooks: [],

--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -102,6 +102,54 @@ describe("loadPluginManifest JSON5 tolerance", () => {
     }
   });
 
+  it("normalizes activation and setup descriptor metadata from the manifest", () => {
+    const dir = makeTempDir();
+    const json5Content = `{
+  id: "openai",
+  activation: {
+    onProviders: ["openai", "", "openai-codex"],
+    onCommands: ["models", ""],
+    onChannels: ["web", ""],
+    onRoutes: ["gateway-webhook", ""],
+    onCapabilities: ["provider", "tool", "wat"]
+  },
+  setup: {
+    providers: [
+      { id: "openai", authMethods: ["api-key", ""], envVars: ["OPENAI_API_KEY", ""] },
+      { id: "", authMethods: ["oauth"] }
+    ],
+    cliBackends: ["openai-cli", ""],
+    configMigrations: ["legacy-openai-auth", ""],
+    requiresRuntime: false
+  },
+  configSchema: { type: "object" }
+}`;
+    fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), json5Content, "utf-8");
+    const result = loadPluginManifest(dir, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.activation).toEqual({
+        onProviders: ["openai", "openai-codex"],
+        onCommands: ["models"],
+        onChannels: ["web"],
+        onRoutes: ["gateway-webhook"],
+        onCapabilities: ["provider", "tool"],
+      });
+      expect(result.manifest.setup).toEqual({
+        providers: [
+          {
+            id: "openai",
+            authMethods: ["api-key"],
+            envVars: ["OPENAI_API_KEY"],
+          },
+        ],
+        cliBackends: ["openai-cli"],
+        configMigrations: ["legacy-openai-auth"],
+        requiresRuntime: false,
+      });
+    }
+  });
+
   it("still rejects completely invalid syntax", () => {
     const dir = makeTempDir();
     fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), "not json at all {{{}}", "utf-8");

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -38,6 +38,47 @@ export type PluginManifestModelSupport = {
   modelPatterns?: string[];
 };
 
+export type PluginManifestActivationCapability = "provider" | "channel" | "tool" | "hook";
+
+export type PluginManifestActivation = {
+  /**
+   * Provider ids that should activate this plugin when explicitly requested.
+   * This is metadata only; runtime loading still happens through the loader.
+   */
+  onProviders?: string[];
+  /** Command ids that should activate this plugin. */
+  onCommands?: string[];
+  /** Channel ids that should activate this plugin. */
+  onChannels?: string[];
+  /** Route kinds that should activate this plugin. */
+  onRoutes?: string[];
+  /** Cheap capability hints used by future activation planning. */
+  onCapabilities?: PluginManifestActivationCapability[];
+};
+
+export type PluginManifestSetupProvider = {
+  /** Provider id surfaced during setup/onboarding. */
+  id: string;
+  /** Setup/auth methods that this provider supports. */
+  authMethods?: string[];
+  /** Environment variables that can satisfy setup without runtime loading. */
+  envVars?: string[];
+};
+
+export type PluginManifestSetup = {
+  /** Cheap provider setup metadata exposed before runtime loads. */
+  providers?: PluginManifestSetupProvider[];
+  /** Setup-time backend ids available without full runtime activation. */
+  cliBackends?: string[];
+  /** Config migration ids owned by this plugin's setup surface. */
+  configMigrations?: string[];
+  /**
+   * Whether setup still needs plugin runtime execution after descriptor lookup.
+   * Defaults to false when omitted.
+   */
+  requiresRuntime?: boolean;
+};
+
 export type PluginManifestConfigLiteral = string | number | boolean | null;
 
 export type PluginManifestDangerousConfigFlag = {
@@ -128,6 +169,10 @@ export type PluginManifest = {
    * and non-runtime auth-choice routing before provider runtime loads.
    */
   providerAuthChoices?: PluginManifestProviderAuthChoice[];
+  /** Cheap activation hints exposed before plugin runtime loads. */
+  activation?: PluginManifestActivation;
+  /** Cheap setup/onboarding metadata exposed before plugin runtime loads. */
+  setup?: PluginManifestSetup;
   skills?: string[];
   name?: string;
   description?: string;
@@ -366,6 +411,78 @@ function normalizeManifestModelSupport(value: unknown): PluginManifestModelSuppo
   return Object.keys(modelSupport).length > 0 ? modelSupport : undefined;
 }
 
+function normalizeManifestActivation(value: unknown): PluginManifestActivation | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const onProviders = normalizeTrimmedStringList(value.onProviders);
+  const onCommands = normalizeTrimmedStringList(value.onCommands);
+  const onChannels = normalizeTrimmedStringList(value.onChannels);
+  const onRoutes = normalizeTrimmedStringList(value.onRoutes);
+  const onCapabilities = normalizeTrimmedStringList(value.onCapabilities).filter(
+    (capability): capability is PluginManifestActivationCapability =>
+      capability === "provider" ||
+      capability === "channel" ||
+      capability === "tool" ||
+      capability === "hook",
+  );
+
+  const activation = {
+    ...(onProviders.length > 0 ? { onProviders } : {}),
+    ...(onCommands.length > 0 ? { onCommands } : {}),
+    ...(onChannels.length > 0 ? { onChannels } : {}),
+    ...(onRoutes.length > 0 ? { onRoutes } : {}),
+    ...(onCapabilities.length > 0 ? { onCapabilities } : {}),
+  } satisfies PluginManifestActivation;
+
+  return Object.keys(activation).length > 0 ? activation : undefined;
+}
+
+function normalizeManifestSetupProviders(
+  value: unknown,
+): PluginManifestSetupProvider[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized: PluginManifestSetupProvider[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const id = normalizeOptionalString(entry.id) ?? "";
+    if (!id) {
+      continue;
+    }
+    const authMethods = normalizeTrimmedStringList(entry.authMethods);
+    const envVars = normalizeTrimmedStringList(entry.envVars);
+    normalized.push({
+      id,
+      ...(authMethods.length > 0 ? { authMethods } : {}),
+      ...(envVars.length > 0 ? { envVars } : {}),
+    });
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeManifestSetup(value: unknown): PluginManifestSetup | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const providers = normalizeManifestSetupProviders(value.providers);
+  const cliBackends = normalizeTrimmedStringList(value.cliBackends);
+  const configMigrations = normalizeTrimmedStringList(value.configMigrations);
+  const requiresRuntime =
+    typeof value.requiresRuntime === "boolean" ? value.requiresRuntime : undefined;
+  const setup = {
+    ...(providers ? { providers } : {}),
+    ...(cliBackends.length > 0 ? { cliBackends } : {}),
+    ...(configMigrations.length > 0 ? { configMigrations } : {}),
+    ...(requiresRuntime !== undefined ? { requiresRuntime } : {}),
+  } satisfies PluginManifestSetup;
+  return Object.keys(setup).length > 0 ? setup : undefined;
+}
+
 function normalizeProviderAuthChoices(
   value: unknown,
 ): PluginManifestProviderAuthChoice[] | undefined {
@@ -553,6 +670,8 @@ export function loadPluginManifest(
   const providerAuthAliases = normalizeStringRecord(raw.providerAuthAliases);
   const channelEnvVars = normalizeStringListRecord(raw.channelEnvVars);
   const providerAuthChoices = normalizeProviderAuthChoices(raw.providerAuthChoices);
+  const activation = normalizeManifestActivation(raw.activation);
+  const setup = normalizeManifestSetup(raw.setup);
   const skills = normalizeTrimmedStringList(raw.skills);
   const contracts = normalizeManifestContracts(raw.contracts);
   const configContracts = normalizeManifestConfigContracts(raw.configContracts);
@@ -584,6 +703,8 @@ export function loadPluginManifest(
       providerAuthAliases,
       channelEnvVars,
       providerAuthChoices,
+      activation,
+      setup,
       skills,
       name,
       description,


### PR DESCRIPTION
## Summary

- Problem: phase 1 of the plugin-architecture plan needed manifest-only descriptor seams for future activation/setup work, but `openclaw.plugin.json` could not express them yet.
- Why it matters: setup/control-plane flows should be able to inspect cheap plugin metadata without widening runtime imports or inventing ad hoc side channels later.
- What changed: added optional `activation` and `setup` manifest blocks, normalized them in manifest loading, exposed them in manifest-registry records, documented them, and added tests for normalization plus registry preservation.
- What did NOT change (scope boundary): no activation planner, no runtime loading changes, no `setup-api` migration, and no plugin execution-path behavior changes yet.
- AI-assisted: yes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Plugin authors can now declare optional manifest-only `activation` and `setup` descriptors in `openclaw.plugin.json`. No runtime activation behavior changed yet.

## Diagram (if applicable)

```text
Before:
manifest -> identity/config/auth/contracts metadata only

After:
manifest -> identity/config/auth/contracts metadata + activation/setup descriptors
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin manifest + registry surfaces
- Relevant config (redacted): default repo config

### Steps

1. Add optional `activation` and `setup` blocks to `openclaw.plugin.json`.
2. Load the manifest directly and through `loadPluginManifestRegistry`.
3. Run focused plugin-manifest tests and a full build.

### Expected

- Manifest loading normalizes the new blocks.
- Registry records preserve the normalized metadata.
- Build stays green.

### Actual

- Works as expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Focused verification:
- `pnpm test:serial src/plugins/manifest.json5-tolerance.test.ts src/plugins/manifest-registry.test.ts`
- `pnpm build`
- `pnpm lint -- src/plugins/manifest.ts src/plugins/manifest-registry.ts src/plugins/manifest.json5-tolerance.test.ts src/plugins/manifest-registry.test.ts`

Additional note:
- `pnpm check` still fails on unrelated stale generated drift in `apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift` on this fresh branch off `main`.

## Human Verification (required)

- Verified scenarios: manifest parsing of the new descriptor blocks, registry preservation of the new metadata, docs alignment, targeted lint, and full build.
- Edge cases checked: invalid/empty descriptor entries are dropped during normalization; `requiresRuntime: false` is preserved explicitly.
- What you did **not** verify: no runtime activation planner exists yet, so there was no execution-path behavior to verify beyond manifest/registry surfaces.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: docs or downstream callers could overread these fields as active runtime behavior.
  - Mitigation: docs and architecture notes explicitly mark them as metadata-only, and runtime loading behavior is unchanged in this phase.
