### PR TITLE
qa-lab: (GPT 5.4 Parity vs. Opus Agentic) record provider/model/mode in qa-suite-summary.json

### DIFF
--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -3,9 +3,12 @@ import { buildQaSuiteSummaryJson } from "./suite.js";
 
 describe("buildQaSuiteSummaryJson", () => {
   const baseParams = {
+    // Test scenarios include a `steps: []` field to match the real suite
+    // scenario-result shape so downstream consumers that rely on the shape
+    // (parity gate, report render) stay aligned.
     scenarios: [
-      { name: "Scenario A", status: "pass" as const },
-      { name: "Scenario B", status: "fail" as const, details: "something broke" },
+      { name: "Scenario A", status: "pass" as const, steps: [] },
+      { name: "Scenario B", status: "fail" as const, details: "something broke", steps: [] },
     ],
     startedAt: new Date("2026-04-11T00:00:00.000Z"),
     finishedAt: new Date("2026-04-11T00:05:00.000Z"),
@@ -40,7 +43,18 @@ describe("buildQaSuiteSummaryJson", () => {
       ...baseParams,
       scenarioIds,
     });
-    expect((json.run as { scenarioIds?: readonly string[] }).scenarioIds).toEqual(scenarioIds);
+    expect(json.run.scenarioIds).toEqual(scenarioIds);
+  });
+
+  it("treats an empty scenarioIds array as unspecified (no filter)", () => {
+    // A CLI path that omits --scenario passes an empty array to runQaSuite.
+    // The summary must encode that as null so downstream parity/report
+    // tooling doesn't interpret a full run as an explicit empty selection.
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      scenarioIds: [],
+    });
+    expect(json.run.scenarioIds).toBeNull();
   });
 
   it("records an Anthropic baseline lane cleanly for parity runs", () => {

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { buildQaSuiteSummaryJson } from "./suite.js";
+
+describe("buildQaSuiteSummaryJson", () => {
+  const baseParams = {
+    scenarios: [
+      { name: "Scenario A", status: "pass" as const },
+      { name: "Scenario B", status: "fail" as const, details: "something broke" },
+    ],
+    startedAt: new Date("2026-04-11T00:00:00.000Z"),
+    finishedAt: new Date("2026-04-11T00:05:00.000Z"),
+    providerMode: "mock-openai" as const,
+    primaryModel: "openai/gpt-5.4",
+    alternateModel: "openai/gpt-5.4-alt",
+    fastMode: true,
+    concurrency: 2,
+  };
+
+  it("records provider/model/mode so parity gates can verify labels", () => {
+    const json = buildQaSuiteSummaryJson(baseParams);
+    expect(json.run).toMatchObject({
+      startedAt: "2026-04-11T00:00:00.000Z",
+      finishedAt: "2026-04-11T00:05:00.000Z",
+      providerMode: "mock-openai",
+      primaryModel: "openai/gpt-5.4",
+      primaryProvider: "openai",
+      primaryModelName: "gpt-5.4",
+      alternateModel: "openai/gpt-5.4-alt",
+      alternateProvider: "openai",
+      alternateModelName: "gpt-5.4-alt",
+      fastMode: true,
+      concurrency: 2,
+      scenarioIds: null,
+    });
+  });
+
+  it("includes scenarioIds in run metadata when provided", () => {
+    const scenarioIds = ["approval-turn-tool-followthrough", "subagent-handoff", "memory-recall"];
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      scenarioIds,
+    });
+    expect((json.run as { scenarioIds?: readonly string[] }).scenarioIds).toEqual(scenarioIds);
+  });
+
+  it("records an Anthropic baseline lane cleanly for parity runs", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      primaryModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-sonnet-4-6",
+    });
+    expect(json.run).toMatchObject({
+      primaryModel: "anthropic/claude-opus-4-6",
+      primaryProvider: "anthropic",
+      primaryModelName: "claude-opus-4-6",
+      alternateModel: "anthropic/claude-sonnet-4-6",
+      alternateProvider: "anthropic",
+      alternateModelName: "claude-sonnet-4-6",
+    });
+  });
+
+  it("leaves split fields null when a model ref is malformed", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      primaryModel: "not-a-real-ref",
+      alternateModel: "",
+    });
+    expect(json.run).toMatchObject({
+      primaryModel: "not-a-real-ref",
+      primaryProvider: null,
+      primaryModelName: null,
+      alternateModel: "",
+      alternateProvider: null,
+      alternateModelName: null,
+    });
+  });
+
+  it("keeps scenarios and counts alongside the run metadata", () => {
+    const json = buildQaSuiteSummaryJson(baseParams);
+    expect(json.scenarios).toHaveLength(2);
+    expect(json.counts).toEqual({
+      total: 2,
+      passed: 1,
+      failed: 1,
+    });
+  });
+});

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1328,6 +1328,53 @@ function createQaSuiteReportNotes(params: {
   ];
 }
 
+export type QaSuiteSummaryJsonParams = {
+  scenarios: QaSuiteScenarioResult[];
+  startedAt: Date;
+  finishedAt: Date;
+  providerMode: "mock-openai" | "live-frontier";
+  primaryModel: string;
+  alternateModel: string;
+  fastMode: boolean;
+  concurrency: number;
+  scenarioIds?: readonly string[];
+};
+
+/**
+ * Pure-ish JSON builder for qa-suite-summary.json. Exported so the GPT-5.4
+ * parity gate (agentic-parity-report.ts, #64441) and any future parity
+ * runner can assert-and-trust the provider/model that produced a given
+ * summary instead of blindly accepting the caller's candidateLabel /
+ * baselineLabel. Without the `run` block, a maintainer who swaps candidate
+ * and baseline summary paths could silently produce a mislabeled verdict.
+ */
+export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): Record<string, unknown> {
+  const primarySplit = splitModelRef(params.primaryModel);
+  const alternateSplit = splitModelRef(params.alternateModel);
+  return {
+    scenarios: params.scenarios,
+    counts: {
+      total: params.scenarios.length,
+      passed: params.scenarios.filter((scenario) => scenario.status === "pass").length,
+      failed: params.scenarios.filter((scenario) => scenario.status === "fail").length,
+    },
+    run: {
+      startedAt: params.startedAt.toISOString(),
+      finishedAt: params.finishedAt.toISOString(),
+      providerMode: params.providerMode,
+      primaryModel: params.primaryModel,
+      primaryProvider: primarySplit?.provider ?? null,
+      primaryModelName: primarySplit?.model ?? null,
+      alternateModel: params.alternateModel,
+      alternateProvider: alternateSplit?.provider ?? null,
+      alternateModelName: alternateSplit?.model ?? null,
+      fastMode: params.fastMode,
+      concurrency: params.concurrency,
+      scenarioIds: params.scenarioIds ? [...params.scenarioIds] : null,
+    },
+  };
+}
+
 async function writeQaSuiteArtifacts(params: {
   outputDir: string;
   startedAt: Date;
@@ -1338,6 +1385,7 @@ async function writeQaSuiteArtifacts(params: {
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
+  scenarioIds?: readonly string[];
 }) {
   const report = renderQaMarkdownReport({
     title: "OpenClaw QA Scenario Suite",
@@ -1357,18 +1405,7 @@ async function writeQaSuiteArtifacts(params: {
   await fs.writeFile(reportPath, report, "utf8");
   await fs.writeFile(
     summaryPath,
-    `${JSON.stringify(
-      {
-        scenarios: params.scenarios,
-        counts: {
-          total: params.scenarios.length,
-          passed: params.scenarios.filter((scenario) => scenario.status === "pass").length,
-          failed: params.scenarios.filter((scenario) => scenario.status === "fail").length,
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(buildQaSuiteSummaryJson(params), null, 2)}\n`,
     "utf8",
   );
   return { report, reportPath, summaryPath };
@@ -1527,6 +1564,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
         alternateModel,
         fastMode,
         concurrency,
+        scenarioIds: params?.scenarioIds,
       });
       lab.setLatestReport({
         outputPath: reportPath,
@@ -1670,6 +1708,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       alternateModel,
       fastMode,
       concurrency,
+      scenarioIds: params?.scenarioIds,
     });
     const latestReport = {
       outputPath: reportPath,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1332,12 +1332,41 @@ export type QaSuiteSummaryJsonParams = {
   scenarios: QaSuiteScenarioResult[];
   startedAt: Date;
   finishedAt: Date;
-  providerMode: "mock-openai" | "live-frontier";
+  providerMode: QaProviderMode;
   primaryModel: string;
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
   scenarioIds?: readonly string[];
+};
+
+/**
+ * Strongly-typed shape of `qa-suite-summary.json`. The GPT-5.4 parity gate
+ * (agentic-parity-report.ts, #64441) and any future parity wrapper can
+ * import this type instead of re-declaring the shape, so changes to the
+ * summary schema propagate through to every consumer at type-check time.
+ */
+export type QaSuiteSummaryJson = {
+  scenarios: QaSuiteScenarioResult[];
+  counts: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+  run: {
+    startedAt: string;
+    finishedAt: string;
+    providerMode: QaProviderMode;
+    primaryModel: string;
+    primaryProvider: string | null;
+    primaryModelName: string | null;
+    alternateModel: string;
+    alternateProvider: string | null;
+    alternateModelName: string | null;
+    fastMode: boolean;
+    concurrency: number;
+    scenarioIds: string[] | null;
+  };
 };
 
 /**
@@ -1347,8 +1376,14 @@ export type QaSuiteSummaryJsonParams = {
  * summary instead of blindly accepting the caller's candidateLabel /
  * baselineLabel. Without the `run` block, a maintainer who swaps candidate
  * and baseline summary paths could silently produce a mislabeled verdict.
+ *
+ * `scenarioIds` is only recorded when the caller passed a non-empty array
+ * (an explicit scenario selection). A missing or empty array means "no
+ * filter, full lane-selected catalog", which the summary encodes as `null`
+ * so parity/report tooling doesn't mistake a full run for an explicit
+ * empty selection.
  */
-export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): Record<string, unknown> {
+export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSuiteSummaryJson {
   const primarySplit = splitModelRef(params.primaryModel);
   const alternateSplit = splitModelRef(params.alternateModel);
   return {
@@ -1370,7 +1405,8 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): Recor
       alternateModelName: alternateSplit?.model ?? null,
       fastMode: params.fastMode,
       concurrency: params.concurrency,
-      scenarioIds: params.scenarioIds ? [...params.scenarioIds] : null,
+      scenarioIds:
+        params.scenarioIds && params.scenarioIds.length > 0 ? [...params.scenarioIds] : null,
     },
   };
 }

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1600,7 +1600,13 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
         alternateModel,
         fastMode,
         concurrency,
-        scenarioIds: params?.scenarioIds,
+        // Record the scenario ids that actually ran (post-selectQaSuiteScenarios
+        // normalization) so the summary metadata matches the executed selection,
+        // not the raw caller input. selectQaSuiteScenarios dedupes via Set and
+        // reorders to catalog order, so passing params.scenarioIds directly
+        // would mislabel runs that repeated --scenario flags or used
+        // non-catalog order.
+        scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
       });
       lab.setLatestReport({
         outputPath: reportPath,
@@ -1744,7 +1750,9 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       alternateModel,
       fastMode,
       concurrency,
-      scenarioIds: params?.scenarioIds,
+      // Record the post-selection scenario ids (see the sibling
+      // writeQaSuiteArtifacts call above for the full reasoning).
+      scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
     });
     const latestReport = {
       outputPath: reportPath,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1416,7 +1416,11 @@ async function writeQaSuiteArtifacts(params: {
   startedAt: Date;
   finishedAt: Date;
   scenarios: QaSuiteScenarioResult[];
-  providerMode: "mock-openai" | "live-frontier";
+  // Reuse the canonical QaProviderMode union instead of re-declaring it
+  // inline. Loop 6 already unified `QaSuiteSummaryJsonParams.providerMode`
+  // on this type; keeping the writer in sync prevents drift when model-
+  // selection.ts adds a new provider mode.
+  providerMode: QaProviderMode;
   primaryModel: string;
   alternateModel: string;
   fastMode: boolean;

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1600,13 +1600,16 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
         alternateModel,
         fastMode,
         concurrency,
-        // Record the scenario ids that actually ran (post-selectQaSuiteScenarios
-        // normalization) so the summary metadata matches the executed selection,
-        // not the raw caller input. selectQaSuiteScenarios dedupes via Set and
-        // reorders to catalog order, so passing params.scenarioIds directly
-        // would mislabel runs that repeated --scenario flags or used
-        // non-catalog order.
-        scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
+        // When the caller supplied an explicit non-empty --scenario filter,
+        // record the executed (post-selectQaSuiteScenarios-normalized) ids
+        // so the summary matches what actually ran. When the caller passed
+        // nothing or an empty array ("no filter, full lane catalog"),
+        // preserve the unfiltered = null semantic so the summary stays
+        // distinguishable from an explicit all-scenarios selection.
+        scenarioIds:
+          params?.scenarioIds && params.scenarioIds.length > 0
+            ? selectedCatalogScenarios.map((scenario) => scenario.id)
+            : undefined,
       });
       lab.setLatestReport({
         outputPath: reportPath,
@@ -1750,9 +1753,12 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       alternateModel,
       fastMode,
       concurrency,
-      // Record the post-selection scenario ids (see the sibling
-      // writeQaSuiteArtifacts call above for the full reasoning).
-      scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
+      // Same "filtered → executed list, unfiltered → null" convention as
+      // the concurrent-path writeQaSuiteArtifacts call above.
+      scenarioIds:
+        params?.scenarioIds && params.scenarioIds.length > 0
+          ? selectedCatalogScenarios.map((scenario) => scenario.id)
+          : undefined,
     });
     const latestReport = {
       outputPath: reportPath,


### PR DESCRIPTION
## Summary

Adds a self-describing `run` block to `qa-suite-summary.json` so the parity gate in #64441 (and any future parity runner) can verify — not just trust — the `candidateLabel` / `baselineLabel` a caller passes to `runQaParityReportCommand`.

Independent of #64662, #64679, #64681, #64685 — review it any time. Part of #64227.

Reopened from #64689, which was auto-closed on 2026-04-11 when the 10-PR active cap was hit. The branch and content are the same as #64689's final head, plus a small type-drift fix picked up during review.

## Why

The parity gate reads two summaries and emits a pass/fail verdict based on completion rate, unintended-stop rate, valid-tool-call rate, and fake-success count. Today the summary JSON only contains `{ scenarios, counts }` — nothing identifying which provider or model produced the run. A parity-report call like:

```
pnpm openclaw qa parity-report \
  --candidate-summary qa-parity-candidate.json \
  --baseline-summary qa-parity-baseline.json \
  --candidate-label openai/gpt-5.4 \
  --baseline-label anthropic/claude-opus-4-6
```

has no way to detect whether the two summaries actually came from the claimed providers. If an operator swaps the paths, the verdict is quietly reversed. That's completion gate criterion 5 in #64227 failing silently.

## What changed

`extensions/qa-lab/src/suite.ts`:

- Extracts `buildQaSuiteSummaryJson(params)` as an exported pure helper. The existing `writeQaSuiteArtifacts` now just formats the JSON and writes to disk. Exporting the builder means the parity gate and any future parity wrapper can import the same type instead of reverse-engineering the JSON shape.
- Adds a `run` block to the summary JSON:
  - `startedAt`, `finishedAt` (ISO strings)
  - `providerMode` (`"mock-openai"` or `"live-frontier"`)
  - `primaryModel`, `primaryProvider`, `primaryModelName` (split)
  - `alternateModel`, `alternateProvider`, `alternateModelName` (split)
  - `fastMode`, `concurrency`
  - `scenarioIds` — the `--scenario-ids` the caller passed, or `null` when the full lane-filtered catalog was used
- Threads `scenarioIds` from `runQaSuite` → `writeQaSuiteArtifacts` so the summary records exactly which scenarios ran.
- `writeQaSuiteArtifacts` now takes `providerMode: QaProviderMode` (imported from `./model-selection.ts`) instead of re-declaring the `"mock-openai" | "live-frontier"` literal union inline. Keeps it in sync with `QaSuiteSummaryJsonParams.providerMode`, which already uses the canonical type, and stops this particular drift from coming back the next time someone adds a provider mode.

`extensions/qa-lab/src/suite.summary-json.test.ts` (new):

Five unit tests covering the OpenAI lane, the Anthropic lane, the explicit-scenario-filter path, the malformed-model-ref fallbacks, and that the existing `scenarios` / `counts` fields still come out alongside the new `run` block.

Backwards-compatible: every existing consumer of `qa-suite-summary.json` sees the same `{ scenarios, counts }` keys they saw before, plus an extra `run` key they can ignore.

## Not in this PR

- **The `qa parity run` CLI wrapper** (run the parity pack twice, emit two labeled summaries, optionally invoke `qa parity-report`) stacks cleanly on top of this PR — it can consume the same `buildQaSuiteSummaryJson` helper and rely on `run.primaryProvider` to label each summary. Holding it until #64441 and #64662 merge so it can call `runQaParityReportCommand` directly without a stacked dependency.
- **Label verification on the parity gate consumer side** (asserting `candidateSummary.run.primaryProvider === params.candidateLabel.split("/")[0]`) belongs in a small follow-up on #64441's `agentic-parity-report.ts`. This PR provides the data; the gate uses it next.

## Validation

```
pnpm test extensions/qa-lab/src/suite.summary-json.test.ts \
          extensions/qa-lab/src/cli.runtime.test.ts \
          extensions/qa-lab/src/scenario-catalog.test.ts \
          extensions/qa-lab/src/suite.test.ts
```

→ all green. Rebased on green `main` (HEAD `545490c592` at push time).

## Linked

- Refs #64227
- Complements #64441 (parity harness) and #64662 (10-scenario expansion). Combined with #64685 (Anthropic `/v1/messages` mock route), the parity gate can now be produced end-to-end from a local worktree without real API keys, with verifiable provider/model labels on both sides.
- Supersedes #64689 (auto-closed when the 10-PR active cap was hit).
