### PR TITLE
fix(security): redact secrets in exec approval prompts (#61077)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ Docs: https://docs.openclaw.ai
 - MiniMax/OAuth: write `api: "anthropic-messages"` and `authHeader: true` into the `minimax-portal` config patch during `openclaw configure`, so re-authenticated portal setups keep Bearer auth routing working. (#64964) Thanks @ryanlee666.
 - Agents/tools: stop repeated unavailable-tool retries from escaping loop detection when the model changes arguments, and rewrite over-threshold unknown tool calls into plain assistant text before dispatch. (#65922) Thanks @dutifulbob.
 - Cron/announce delivery: tell isolated cron jobs to return the full response exactly instead of a summary, so structured `--announce` deliveries stop dropping fields nondeterministically. (#65638) Thanks @srinivaspavan9 and @vincentkoc.
+- Security/exec approvals: redact bearer tokens, API keys, and similar secrets in exec approval prompt command text before those prompts are posted back to chat channels, regardless of logging redaction settings. (#61077) Thanks @feiskyer and @vincentkoc.
 
 ## 2026.4.10
 

--- a/src/infra/exec-approval-command-display.test.ts
+++ b/src/infra/exec-approval-command-display.test.ts
@@ -11,6 +11,29 @@ describe("sanitizeExecApprovalDisplayText", () => {
   ])("sanitizes exec approval display text for %j", (input, expected) => {
     expect(sanitizeExecApprovalDisplayText(input)).toBe(expected);
   });
+
+  it("redacts bearer tokens embedded in commands", () => {
+    const cmd =
+      'curl -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.longtoken.sig" https://api.example.com';
+    const result = sanitizeExecApprovalDisplayText(cmd);
+    expect(result).not.toContain("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.longtoken.sig");
+    expect(result).toContain("curl");
+    expect(result).toContain("https://api.example.com");
+  });
+
+  it("redacts API keys in environment variable assignments", () => {
+    const cmd = 'API_SECRET="sk-abc123456789012345678" python script.py';
+    const result = sanitizeExecApprovalDisplayText(cmd);
+    expect(result).not.toContain("sk-abc123456789012345678");
+    expect(result).toContain("python script.py");
+  });
+
+  it("redacts GitHub personal access tokens", () => {
+    const cmd = "git clone https://ghp_1234567890abcdefghij1234567890abcdef@github.com/user/repo";
+    const result = sanitizeExecApprovalDisplayText(cmd);
+    expect(result).not.toContain("ghp_1234567890abcdefghij1234567890abcdef");
+    expect(result).toContain("git clone");
+  });
 });
 
 describe("resolveExecApprovalCommandDisplay", () => {

--- a/src/infra/exec-approval-command-display.ts
+++ b/src/infra/exec-approval-command-display.ts
@@ -10,7 +10,7 @@ function formatCodePointEscape(char: string): string {
 
 export function sanitizeExecApprovalDisplayText(commandText: string): string {
   const escaped = commandText.replace(EXEC_APPROVAL_INVISIBLE_CHAR_REGEX, formatCodePointEscape);
-  return redactSensitiveText(escaped);
+  return redactSensitiveText(escaped, { mode: "tools" });
 }
 
 function normalizePreview(commandText: string, commandPreview?: string | null): string | null {

--- a/src/infra/exec-approval-command-display.ts
+++ b/src/infra/exec-approval-command-display.ts
@@ -1,3 +1,4 @@
+import { redactSensitiveText } from "../logging/redact.js";
 import type { ExecApprovalRequestPayload } from "./exec-approvals.js";
 
 // Escape invisible characters that can spoof approval prompts in common UIs.
@@ -8,7 +9,8 @@ function formatCodePointEscape(char: string): string {
 }
 
 export function sanitizeExecApprovalDisplayText(commandText: string): string {
-  return commandText.replace(EXEC_APPROVAL_INVISIBLE_CHAR_REGEX, formatCodePointEscape);
+  const escaped = commandText.replace(EXEC_APPROVAL_INVISIBLE_CHAR_REGEX, formatCodePointEscape);
+  return redactSensitiveText(escaped);
 }
 
 function normalizePreview(commandText: string, commandPreview?: string | null): string | null {


### PR DESCRIPTION
## Summary

- Problem: exec approval prompts display raw command text including embedded secrets (JWT tokens, API keys, passwords) to chat channels where all participants can see them
- Why it matters: credentials leak to group chats when obfuscation detection triggers an approval prompt
- What changed: `sanitizeExecApprovalDisplayText` now applies `redactSensitiveText` (existing redaction infra) after the invisible-char escape pass
- What did NOT change: approval flow, routing logic, invisible-char sanitization — all untouched

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #61077
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `sanitizeExecApprovalDisplayText` only escaped invisible Unicode characters but never redacted credentials, so raw secrets in exec commands were included verbatim in approval prompt text delivered to chat channels
- Missing detection / guardrail: the existing `redactSensitiveText` infrastructure (Bearer tokens, API keys, ghp_, sk-, PEM blocks, etc.) was not wired into the approval display path
- Contributing context: approval prompts route to the originating channel (including group chats) via `resolveToolDeliveryPayload`, so any secrets in the command text become visible to all channel participants

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/infra/exec-approval-command-display.test.ts`
- Scenario the test should lock in: Bearer tokens, `sk-` prefixed keys, and `ghp_` tokens embedded in commands are redacted before display
- Why this is the smallest reliable guardrail: unit tests on `sanitizeExecApprovalDisplayText` directly verify the redaction without needing a full approval flow

## User-visible / Behavior Changes

Exec approval prompts now mask secrets in displayed commands instead of showing them in plain text.

## Diagram (if applicable)

```text
Before:
[exec obfuscation detected] -> [approval prompt with raw JWT/API key] -> [group chat channel]

After:
[exec obfuscation detected] -> [approval prompt with redacted secrets] -> [group chat channel]
```

## Security Impact (required)

- New permissions/capabilities? No
- Credential/secret handling changes? Yes — secrets in exec commands are now redacted using the existing `redactSensitiveText` patterns before being included in approval prompt text
- New external network calls? No
- Security model changes? No — uses existing redaction infra, no new patterns or config
- Relevant OWASP/CWE? CWE-532 (insertion of sensitive information into log file / display)