### PR TITLE
fix(matrix): trust m.mentions.user_ids as authoritative mention source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,10 @@ Docs: https://docs.openclaw.ai
 - Reply execution: prefer the active runtime snapshot over stale queued reply config during embedded reply and follow-up execution so SecretRef-backed reply turns stop crashing after secrets have already resolved. (#62693) Thanks @mbelinky.
 - Android/manual connect: allow blank port input only for TLS manual gateway endpoints so standard HTTPS Tailscale hosts default to `443` without silently changing cleartext manual connects. (#63134) Thanks @Tyler-RNG.
 - Matrix/agents: hide owner-only `set-profile` from embedded agent channel-action discovery so non-owner runs stop advertising profile updates they cannot execute. (#62662) Thanks @eleqtrizit.
+- iOS/gateway: replace string-matched connection error UI with structured gateway connection problems, preserve actionable pairing/auth failures over later generic disconnect noise, and surface reusable problem banners and details across onboarding, settings, and root status surfaces. (#62650) Thanks @ngutman.
+- Git/env sanitization: block additional Git repository-plumbing env variables such as `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, and `GIT_NAMESPACE` so host-run Git commands cannot be redirected to attacker-chosen repository state through inherited or request-scoped env. (#62002) Thanks @eleqtrizit.
+- Host exec/env sanitization: block additional request-scoped credential and config-path overrides such as `KUBECONFIG`, cloud credential-path env, `CARGO_HOME`, and `HELM_HOME` so host-run tools can no longer be redirected to attacker-chosen config or state. (#59119) Thanks @eleqtrizit.
+- Matrix/mentions: keep room mention gating strict while accepting visible `@displayName` Matrix URI labels, so `requireMention` works for non-OpenClaw Matrix clients again. (#64796) Thanks @hclsys.
 
 ## 2026.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix/mentions: keep room mention gating strict while accepting visible `@displayName` Matrix URI labels, so `requireMention` works for non-OpenClaw Matrix clients again. (#64796) Thanks @hclsys.
+
 ## 2026.4.11
 
 ### Changes
@@ -353,7 +355,6 @@ Docs: https://docs.openclaw.ai
 - iOS/gateway: replace string-matched connection error UI with structured gateway connection problems, preserve actionable pairing/auth failures over later generic disconnect noise, and surface reusable problem banners and details across onboarding, settings, and root status surfaces. (#62650) Thanks @ngutman.
 - Git/env sanitization: block additional Git repository-plumbing env variables such as `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, and `GIT_NAMESPACE` so host-run Git commands cannot be redirected to attacker-chosen repository state through inherited or request-scoped env. (#62002) Thanks @eleqtrizit.
 - Host exec/env sanitization: block additional request-scoped credential and config-path overrides such as `KUBECONFIG`, cloud credential-path env, `CARGO_HOME`, and `HELM_HOME` so host-run tools can no longer be redirected to attacker-chosen config or state. (#59119) Thanks @eleqtrizit.
-- Matrix/mentions: keep room mention gating strict while accepting visible `@displayName` Matrix URI labels, so `requireMention` works for non-OpenClaw Matrix clients again. (#64796) Thanks @hclsys.
 
 ## 2026.4.5
 

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -180,9 +180,9 @@ describe("matrix monitor handler pairing account scope", () => {
       await handler("!room:example.org", makeEvent("$event1"));
       await handler("!room:example.org", makeEvent("$event2"));
       expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
-      expect(JSON.stringify(sendMessageMatrixMock.mock.calls[0]?.[1] ?? {})).toContain(
-        "Pairing request is still pending approval.",
-      );
+      const pairingReminder = sendMessageMatrixMock.mock.calls[0]?.[1];
+      expect(typeof pairingReminder).toBe("string");
+      expect(pairingReminder).toContain("Pairing request is still pending approval.");
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
       await handler("!room:example.org", makeEvent("$event3"));

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -180,7 +180,7 @@ describe("matrix monitor handler pairing account scope", () => {
       await handler("!room:example.org", makeEvent("$event1"));
       await handler("!room:example.org", makeEvent("$event2"));
       expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
-      expect(sendMessageMatrixMock.mock.calls[0]?.[1]).toContain(
+      expect(JSON.stringify(sendMessageMatrixMock.mock.calls[0]?.[1] ?? {})).toContain(
         "Pairing request is still pending approval.",
       );
 
@@ -461,6 +461,30 @@ describe("matrix monitor handler pairing account scope", () => {
           msgtype: "m.text",
           body: "Tom Servo: hello",
           formatted_body: '<a href="https://matrix.to/#/@bot:example.org">Tom Servo</a>: hello',
+        },
+      }),
+    );
+
+    expect(recordInboundSession).toHaveBeenCalled();
+  });
+
+  it("processes room messages mentioned via @displayName in Unicode formatted_body", async () => {
+    const recordInboundSession = vi.fn(async () => {});
+    const { handler } = createMatrixHandlerTestHarness({
+      isDirectMessage: false,
+      getMemberDisplayName: async () => "欢欢",
+      recordInboundSession,
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixRoomMessageEvent({
+        eventId: "$unicode-display-name-mention",
+        content: {
+          msgtype: "m.text",
+          body: "@欢欢 please reply",
+          formatted_body: '<a href="https://matrix.to/#/@bot:example.org">@欢欢</a> please reply',
+          "m.mentions": { user_ids: ["@bot:example.org"] },
         },
       }),
     );

--- a/extensions/matrix/src/matrix/monitor/mentions.test.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.test.ts
@@ -34,10 +34,7 @@ describe("resolveMentions", () => {
       expect(result.hasExplicitMention).toBe(true);
     });
 
-    it("detects mention via m.mentions.user_ids even without visible text mention (#64785)", () => {
-      // MSC3952: m.mentions.user_ids is the authoritative mention source.
-      // Non-OpenClaw Matrix clients (Element, standalone bots) may set
-      // m.mentions without including @bot in the visible message body.
+    it("does not trust m.mentions.user_ids without a visible text or formatted mention", () => {
       const result = resolveMentions({
         content: {
           msgtype: "m.text",
@@ -48,8 +45,8 @@ describe("resolveMentions", () => {
         text: "please reply",
         mentionRegexes,
       });
-      expect(result.wasMentioned).toBe(true);
-      expect(result.hasExplicitMention).toBe(true);
+      expect(result.wasMentioned).toBe(false);
+      expect(result.hasExplicitMention).toBe(false);
     });
 
     it("detects room mention via visible @room text", () => {
@@ -210,6 +207,24 @@ describe("resolveMentions", () => {
         mentionRegexes: [],
       });
       expect(result.wasMentioned).toBe(true);
+    });
+
+    it("detects mention when the visible label is @displayName with Unicode text", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "@欢欢 please reply",
+          formatted_body:
+            '<a href="https://matrix.to/#/@huanhuan:localhost">@欢欢</a> please reply',
+          "m.mentions": { user_ids: ["@huanhuan:localhost"] },
+        },
+        userId: "@huanhuan:localhost",
+        displayName: "欢欢",
+        text: "@欢欢 please reply",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+      expect(result.hasExplicitMention).toBe(true);
     });
 
     it("ignores out-of-range hexadecimal HTML entities in visible labels", () => {

--- a/extensions/matrix/src/matrix/monitor/mentions.test.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.test.ts
@@ -34,19 +34,22 @@ describe("resolveMentions", () => {
       expect(result.hasExplicitMention).toBe(true);
     });
 
-    it("does not trust forged m.mentions.user_ids without a visible mention", () => {
+    it("detects mention via m.mentions.user_ids even without visible text mention (#64785)", () => {
+      // MSC3952: m.mentions.user_ids is the authoritative mention source.
+      // Non-OpenClaw Matrix clients (Element, standalone bots) may set
+      // m.mentions without including @bot in the visible message body.
       const result = resolveMentions({
         content: {
           msgtype: "m.text",
-          body: "hello",
+          body: "please reply",
           "m.mentions": { user_ids: ["@bot:matrix.org"] },
         },
         userId,
-        text: "hello",
+        text: "please reply",
         mentionRegexes,
       });
-      expect(result.wasMentioned).toBe(false);
-      expect(result.hasExplicitMention).toBe(false);
+      expect(result.wasMentioned).toBe(true);
+      expect(result.hasExplicitMention).toBe(true);
     });
 
     it("detects room mention via visible @room text", () => {

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -163,10 +163,13 @@ export function resolveMentions(params: {
         mentionRegexes: params.mentionRegexes,
       })
     : false;
+  // m.mentions.user_ids is the authoritative mention source per MSC3952.
+  // Previously this also required a visible text or formatted_body mention,
+  // which caused messages from non-OpenClaw clients that send proper
+  // m.mentions metadata without an @-mention in the body to be silently
+  // ignored when requireMention was enabled (#64785).
   const metadataBackedUserMention = Boolean(
-    params.userId &&
-    mentionedUsers.has(params.userId) &&
-    (mentionedInFormattedBody || textMentioned),
+    params.userId && mentionedUsers.has(params.userId),
   );
   const metadataBackedRoomMention = Boolean(mentions?.room) && visibleRoomMention;
   const explicitMention =

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -81,6 +81,7 @@ function isVisibleMentionLabel(params: {
     localpart ? extractVisibleMentionText(localpart) : null,
     localpart ? extractVisibleMentionText(`@${localpart}`) : null,
     params.displayName ? extractVisibleMentionText(params.displayName) : null,
+    params.displayName ? extractVisibleMentionText(`@${params.displayName}`) : null,
   ].filter((value): value is string => Boolean(value));
   return candidates.includes(cleaned);
 }
@@ -163,13 +164,13 @@ export function resolveMentions(params: {
         mentionRegexes: params.mentionRegexes,
       })
     : false;
-  // m.mentions.user_ids is the authoritative mention source per MSC3952.
-  // Previously this also required a visible text or formatted_body mention,
-  // which caused messages from non-OpenClaw clients that send proper
-  // m.mentions metadata without an @-mention in the body to be silently
-  // ignored when requireMention was enabled (#64785).
+  // Matrix clients can mention users through m.mentions metadata plus a visible
+  // Matrix URI label in formatted_body. Keep the visible-mention requirement so
+  // hidden metadata-only mentions do not trigger the handler.
   const metadataBackedUserMention = Boolean(
-    params.userId && mentionedUsers.has(params.userId),
+    params.userId &&
+    mentionedUsers.has(params.userId) &&
+    (mentionedInFormattedBody || textMentioned),
   );
   const metadataBackedRoomMention = Boolean(mentions?.room) && visibleRoomMention;
   const explicitMention =


### PR DESCRIPTION
## Summary

`resolveMentions()` in the Matrix extension required BOTH `m.mentions.user_ids` metadata AND a visible text or `formatted_body` mention for a user mention to register. When non-OpenClaw Matrix clients (Element, standalone bots via `matrix-bot-sdk`) send proper `m.mentions` metadata without duplicating the `@bot` text in the message body, the mention was **silently ignored** and `requireMention: true` dropped the message.

This effectively made `requireMention: true` unusable for any Matrix room receiving messages from non-OpenClaw clients — which is most production deployments.

Fixes #64785

## Root cause

```ts
// mentions.ts:166-169 (before fix)
const metadataBackedUserMention = Boolean(
  params.userId &&
  mentionedUsers.has(params.userId) &&
  (mentionedInFormattedBody || textMentioned),  // ← requires BOTH
);
```

Per [MSC3952](https://github.com/matrix-org/matrix-spec-proposals/pull/3952), `m.mentions.user_ids` is the **authoritative** mention source. The visible `@bot` in the body is a display hint for clients that don't support `m.mentions`, not a prerequisite for the mention to be valid.

The conjunction meant that a message like:

```json
{
  "body": "please reply",
  "m.mentions": { "user_ids": ["@bot:matrix.org"] }
}
```

...was NOT detected as a mention because `"please reply"` doesn't contain `@bot`.

## Fix

Drop the `(mentionedInFormattedBody || textMentioned)` conjunction:

```ts
// mentions.ts:166-172 (after fix)
const metadataBackedUserMention = Boolean(
  params.userId && mentionedUsers.has(params.userId),
);
```

Metadata-backed user mentions are now trusted on their own, matching the Matrix spec.

### Why `m.mentions.room` is left unchanged

The `metadataBackedRoomMention` check at line 171 still requires visible `@room` text alongside `m.mentions.room: true`. This is intentional: `@room` mentions have different security implications (spam amplification to all room members), so requiring both metadata AND visible text is a reasonable anti-spam measure. User mentions don't have this concern.

## Tests

Updated `extensions/matrix/src/matrix/monitor/mentions.test.ts`:
- **Before**: "does not trust forged m.mentions.user_ids without a visible mention" → asserted `wasMentioned: false`
- **After**: "detects mention via m.mentions.user_ids even without visible text mention (#64785)" → asserts `wasMentioned: true` + `hasExplicitMention: true`

The existing test for room mentions (requiring both `m.mentions.room` and visible `@room` text) is unchanged.

## Scope

- **Files**: `mentions.ts` (+6/-3), `mentions.test.ts` (+8/-5)
- **Production LOC**: 1 condition removed from 1 boolean expression
- **oxlint clean**
- **Zero competing PRs** (only closed #51106 in adjacent area — different fix scope)

cc @BunsDev — Matrix channel. Credit to @guci314 for the clear reproduction with proper `m.mentions` metadata in #64785.