### PR TITLE
fix(agents): clear sessionFile when rolling a fresh isolated session

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -255,6 +255,64 @@ describe("resolveCronSession", () => {
       });
     });
 
+    it("clears sessionFile when forceNew is true", () => {
+      // Regression: when isolatedSession=true on heartbeats (forceNew: true),
+      // the stale sessionFile on the existing entry was preserved via the
+      // `...entry` spread, so every run kept appending to the same physical
+      // transcript file despite generating a new sessionId. That defeated the
+      // point of "fresh session per run" and poisoned each run with the
+      // in-context history of all prior runs.
+      const result = resolveWithStoredEntry({
+        sessionKey: "agent:main:main:heartbeat",
+        entry: {
+          sessionId: "old-heartbeat-session-id",
+          updatedAt: NOW_MS - 1000,
+          sessionFile: "/tmp/agents/main/sessions/old-heartbeat-session-id.jsonl",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionId).not.toBe("old-heartbeat-session-id");
+      // sessionFile must be cleared so the caller computes a fresh path from
+      // the new sessionId instead of appending to the old transcript.
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
+    it("clears sessionFile when session is stale", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "old-session-id",
+          updatedAt: NOW_MS - 86_400_000,
+          sessionFile: "/tmp/agents/main/sessions/old-session-id.jsonl",
+        },
+        fresh: false,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
+    it("preserves sessionFile when reusing fresh session", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-202",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          sessionFile: "/tmp/agents/main/sessions/existing-session-id-202.jsonl",
+        },
+        fresh: true,
+      });
+
+      expect(result.isNewSession).toBe(false);
+      // The sessionFile field must be preserved when the session is reused
+      // so subsequent writes go to the same transcript.
+      expect(result.sessionEntry.sessionFile).toBe(
+        "/tmp/agents/main/sessions/existing-session-id-202.jsonl",
+      );
+    });
+
     it("creates new sessionId when entry exists but has no sessionId", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -77,12 +77,19 @@ export function resolveCronSession(params: {
     // replies instead of channel top-level messages.
     // deliveryContext must also be cleared because normalizeSessionEntryDelivery
     // repopulates lastThreadId from deliveryContext.threadId on store writes.
+    // sessionFile must also be cleared so resolveSessionFilePath falls through to
+    // resolveSessionTranscriptPathInDir(sessionId, …) and the new session gets a
+    // transcript file named after its new sessionId. Without this clear, the
+    // stale path inherited via `...entry` makes every forceNew run append to the
+    // same physical file forever — defeating the point of isolatedSession and
+    // poisoning each run with the in-context history of all prior runs.
     ...(isNewSession && {
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      sessionFile: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary

- **Problem:** `resolveCronSession` preserves the existing entry's `sessionFile` via `...entry` whenever a new `sessionId` is generated (forceNew or stale). `resolveSessionFilePath` prefers `entry.sessionFile` over `sessionId` when deciding where to write, so every new session keeps appending to the same physical transcript file forever.
- **Why it matters:** For heartbeats configured with `isolatedSession: true` (which is how the docs describe the "fresh session per run" behavior), the transcript file grew unbounded across every run, poisoning each new run with the in-context history of all prior runs — the exact opposite of isolation. `lightContext: true`'s documented ~100K→~2–5K token savings silently regressed as the file grew.
- **What changed:** One-line addition in `src/cron/isolated-agent/session.ts` — `sessionFile: undefined` in the existing `isNewSession` cleanup block (next to `lastChannel`, `lastTo`, `lastThreadId`, `deliveryContext`). The resolver now falls through to `resolveSessionTranscriptPathInDir(sessionId, …)` and produces a new file named after the new sessionId.
- **What did NOT change:** Only the `isNewSession` cleanup block is touched. Non-`forceNew` reuse of fresh sessions continues to preserve `sessionFile` as before. Delivery routing clears, the `...entry` spread of overrides, and every other field stays intact.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Closes #64795
- Related #64196
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The `isNewSession` cleanup block in `resolveCronSession` clears delivery-routing fields but not `sessionFile`. Since the returned entry is built by spreading the old entry first, the stale `sessionFile` is always carried forward, and downstream `resolveSessionFilePath` / `resolveAndPersistSessionFile` both prefer a persisted `sessionFile` over recomputing from `sessionId`. Net effect: the logical session rolls but the physical transcript file never rotates, defeating `isolatedSession: true`.
- **Missing detection / guardrail:** No regression test existed for rotating `sessionFile` when `forceNew` or stale reset generates a new `sessionId`. Existing tests cover delivery-routing clears (`lastChannel`, `deliveryContext`) but not filesystem path isolation.
- **Contributing context:** `sessionFile` was (correctly) added to the `SessionEntry` persistence layer to keep the transcript path stable across reuse of fresh sessions. The `isNewSession` branch inherited the same preservation semantics without carving out forceNew/stale rotation.

## Regression Test Plan

- Coverage level: **Unit test** (pure, no filesystem)
- Target test file: `src/cron/isolated-agent/session.test.ts`
- Scenarios the test locks in:
  1. `clears sessionFile when forceNew is true` — asserts `result.sessionEntry.sessionFile` is `undefined` after `forceNew: true` against an entry with a populated `sessionFile`.
  2. `clears sessionFile when session is stale` — same assertion on the stale-freshness branch (no `forceNew`, but `evaluateSessionFreshness` returns `{ fresh: false }`).
  3. `preserves sessionFile when reusing fresh session` — asserts that a reused fresh session still carries its `sessionFile` unchanged, so this fix doesn't regress the normal reuse path.
- Why: these three cases cover every branch of `resolveCronSession` where the entry's `sessionFile` matters, and they're the smallest pure-unit guardrails that would have caught the original bug.

## User-visible / Behavior Changes

For agents with `isolatedSession: true`, each heartbeat run will now correctly write to a new transcript file named after the current run's sessionId. The old frozen transcript file will be orphaned on disk and cleaned up by the session reaper on its next pass (or can be removed manually).

## Diagram

```text
Before:
[heartbeat t1] -> resolveCronSession(forceNew:true)
                  -> sessionId = uuid-A
                  -> entry = {...oldEntry, sessionFile: oldPath, sessionId: uuid-A}
                  -> transcript writer appends to oldPath

[heartbeat t2] -> resolveCronSession(forceNew:true)
                  -> sessionId = uuid-B (new!)
                  -> entry = {...t1Entry, sessionFile: oldPath, sessionId: uuid-B}
                  -> transcript writer appends to oldPath (same file!)

...many runs...
                  -> file contains all historical messages
                  -> model sees all prior HEARTBEAT replies as in-context history
                  -> few-shot-learns the pattern, reinforces it forever

After:
[heartbeat t1] -> resolveCronSession(forceNew:true)
                  -> sessionId = uuid-A
                  -> entry = {...oldEntry, sessionFile: undefined, sessionId: uuid-A}
                  -> resolver falls through to resolveSessionTranscriptPathInDir
                  -> transcript writer creates/appends uuid-A.jsonl

[heartbeat t2] -> resolveCronSession(forceNew:true)
                  -> sessionId = uuid-B
                  -> entry = {...t1Entry, sessionFile: undefined, sessionId: uuid-B}
                  -> resolver falls through again
                  -> transcript writer creates/appends uuid-B.jsonl  (fresh file!)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

No risk.

## Repro + Verification

### Environment

- OS: Linux (`registry.xlab.now/clankertron:2026.4.10` on Kubernetes, Talos 1.11.2)
- Runtime/container: Node.js via the openclaw container image (upstream base `ghcr.io/openclaw/openclaw`)
- Model/provider: `llamacpp-deep/qwen3.5-35b-a3b` (backed by `llama.cpp` HTTP server, `ctx_size=65536`)
- Integration/channel: Telegram heartbeat target, 15-minute interval
- Relevant config:
  ```json5
  agents: {
    defaults: {
      heartbeat: {
        every: "15m",
        isolatedSession: true,
        lightContext: true,      // or false — both reproduce
        session: "main",         // default
        target: "telegram",
      }
    }
  }
  ```

### Steps (without this fix)

1. Run a heartbeat agent with `isolatedSession: true` for any length of time (multiple heartbeats).
2. `cat /data/agents/main/sessions/sessions.json` and inspect the `agent:main:main:heartbeat` entry.
3. Note that `sessionId` rolls on every run but `sessionFile` is stable.
4. Inspect the transcript file at the path in `sessionFile`.
5. Observe that `grep -c '"type":"session"' <file>` returns `1` — only one session record even though many runs have occurred.
6. Observe that the file grows monotonically and accumulates the history of every heartbeat run.

### Expected

Each `forceNew` heartbeat should produce a new transcript file (or at least a new session record in a rotated file), with no in-context history from prior runs.

### Actual (before fix)

The same transcript file is reused across every run. The model sees ~100K tokens of accumulated prior-run history on every heartbeat. "Fresh session per run" is not achieved for any run past the first.

### Actual (with this fix)

After the first heartbeat post-fix, the store entry's `sessionFile` is cleared on each `forceNew` run. `resolveSessionFilePath` falls through and allocates a new `<sessionId>.jsonl` file. Each run's transcript is isolated.

## Evidence

### Forensic data from a live deployment

`sessions.json` for `agent:main:main:heartbeat` on a live cluster (five hours after the pod restarted):

```json
{
  "sessionId": "8f939e30-e4a3-479f-9eeb-2b21d4aaf57b",
  "sessionFile": "/data/agents/main/sessions/34db8152-a3ac-4e7a-8c4a-9a38d9525339.jsonl",
  "updatedAt": 1775908689677,
  "heartbeatIsolatedBaseSessionKey": "agent:main:main"
}
```

File on disk:

| metric | value |
|---|---|
| filename stem | `34db8152-a3ac-4e7a-8c4a-9a38d9525339` |
| transcript header session id | `cbc883fc-6486-40d2-b0d1-6a102861f5df` (first run ever, `2026-04-10T22:09:51Z`) |
| distinct session records in file | **1** |
| lines | 433 |
| HEARTBEAT_OK ack tokens | 101 |
| oldest message | `2026-04-10T22:09:51Z` |
| newest message | `2026-04-11T11:58:09Z` |

Three distinct UUIDs observable for a single logical session:

- `34db8152…` — filename (set once, never rotated)
- `cbc883fc…` — transcript-file session id (from the very first run)
- `8f939e30…` — current `sessionId` in the store (latest `forceNew`)

### Log correlation (different `sessionId`s, same `sessionFile`)

From context-overflow diagnostics in the same deployment:

```
07:28  sessionId=da41fec7-997f-4a56-b5b5-a56cb3a11c28  sessionFile=…/34db8152-…jsonl
10:43  sessionId=f198e48b-84e6-4695-aabc-c4fed74d7cd1  sessionFile=…/34db8152-…jsonl
10:59  sessionKey=agent:main:main:heartbeat            sessionFile=…/34db8152-…jsonl  messages=97
```

4+ distinct `sessionId` values observed across 5 hours on the same sessionKey and the same `sessionFile`. The other 13 non-heartbeat session entries in the same store all have their filename stem matching their `sessionId` — only the heartbeat entry shows the mismatch, confirming the bug is scoped to the `forceNew` branch.

### Provable from code alone

The bug is also provable purely by code walk:

- `resolveSessionFilePath(sessionId, entry)` at `src/config/sessions/paths.ts:263` prefers `entry.sessionFile` over the sessionId-derived path.
- `resolveAndPersistSessionFile` at `src/config/sessions/session-file.ts:17-27` only consults `fallbackSessionFile` when `!baseEntry.sessionFile`.
- The return entry from `resolveCronSession` is built by spreading `...entry` (which carries `sessionFile`) and the `isNewSession` cleanup block does not include `sessionFile`.
- Therefore, after the first run of any session that ever goes through `resolveCronSession`, the stale `sessionFile` is returned on every subsequent `forceNew`/stale rotation.

## Human Verification (required)

- **Verified scenarios:**
  - Read every caller of `resolveSessionFilePath` and `resolveAndPersistSessionFile` in `src/` to confirm no downstream path re-derives the file from the new `sessionId` after `resolveCronSession` returns.
  - Read the heartbeat-runner flow from `resolveCronSession` through `saveSessionStore` and the downstream transcript writer to confirm no intermediate reset exists.
  - Dumped `sessions.json` from a live cluster and checked all 14 entries — 13 non-heartbeat sessions have correctly matching sessionId↔filename, only the heartbeat entry has the mismatch, confirming the bug is scoped to `forceNew` only.
  - Verified the file header's session id (`cbc883fc`) differs from the store's current `sessionId` (`8f939e30`) and the filename stem (`34db8152`) — three distinct UUIDs for one logical session, exactly as the code predicts.
  - Verified that the same `sessionFile` appears in log lines with four different `sessionId` values over 5 hours.
  - Verified that `sessionFile?: string` in `SessionEntry` type allows the `undefined` assignment; TypeScript is satisfied.
- **Edge cases checked:**
  - First-ever run (no existing entry) — entry is `undefined`, spread is a no-op, `sessionFile` is `undefined` by default, resolver computes from `sessionId`. Unchanged by this fix.
  - Reused fresh session (`!forceNew && fresh`) — the `isNewSession` cleanup block is skipped, `sessionFile` is preserved via the spread. Unchanged and covered by the new `preserves sessionFile when reusing fresh session` test.
  - Stale rotation (`!forceNew && !fresh`) — now also clears `sessionFile` (was broken before). New test covers this.
  - Non-heartbeat `forceNew` callers (webhook cron runs via the same `resolveCronSession`) — they get the same fix, which is also the documented behavior for `sessionTarget: "isolated"`.
- **What I did NOT verify:**
  - Actual vitest run of the new tests. This machine has no `node`/`pnpm` available, so the tests were written by hand against the existing `session.test.ts` conventions (same `resolveWithStoredEntry` helper, same mock shape). I am relying on CI to confirm the suite passes. Targeted test file: `src/cron/isolated-agent/session.test.ts`.
  - End-to-end live reproduction of the fix against our cluster — that requires a rebuild of the downstream `clankertron` image, which I have not done as part of this PR.

## Compatibility / Migration

- Backward compatible? `Yes` — the fix only changes behavior when `isNewSession` is true, which is exactly when the current behavior is wrong. No existing working path is altered.
- Config/env changes? `No`
- Migration needed? `No` for configuration, but operators of affected deployments will have a stale transcript file on disk that is no longer referenced. The session reaper should clean these up on its next pass. Manual cleanup is also safe (`rm` the orphaned file once the sessions store no longer references it).

## Risks and Mitigations

- **Risk:** Orphaned transcript files for existing deployments where the stale `sessionFile` path gets dropped from the store entry on the first post-fix run.
  - **Mitigation:** The files are only orphaned on disk; the session reaper (disk-budget maintenance) will reclaim them on its next pass. No user-visible regression. Operators can also manually delete the old transcript file — it has no operational value after the fix lands.
- **Risk:** Any code path that still reads a session entry's `sessionFile` and expects it to be non-empty may see `undefined` on the first post-fix turn before the downstream `resolveAndPersistSessionFile` runs.
  - **Mitigation:** `SessionEntry.sessionFile` is already declared optional (`sessionFile?: string`) in `src/config/sessions/types.ts`. All call sites I inspected use optional chaining or explicit null-checks. No TypeScript errors surfaced from the change.

## AI-assisted

- [x] Drafted with Claude Code (Claude Opus 4.6, 1M context)
- [ ] Lightly tested — the tests were written but NOT run locally due to a missing Node toolchain on the authoring machine. Relying on CI for the targeted test run.
- [x] I understand what the code does — one-line addition to an existing conditional-clear block, plus three targeted regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)