### PR TITLE
feat(bluesky): add Bluesky DM channel plugin

### DIFF
--- a/docs/channels/bluesky.md
+++ b/docs/channels/bluesky.md
@@ -1,0 +1,188 @@
+---
+summary: "Bluesky DM channel via AT Protocol chat API"
+read_when:
+  - You want OpenClaw to receive DMs on Bluesky
+  - You're setting up a Bluesky bot account
+title: "Bluesky"
+---
+
+# Bluesky
+
+**Status:** Optional bundled plugin (disabled by default until configured).
+
+Bluesky is a decentralized social platform built on the AT Protocol. This channel enables OpenClaw to receive and respond to direct messages via the `chat.bsky.*` lexicons.
+
+## Bundled plugin
+
+Current OpenClaw releases ship Bluesky as a bundled plugin, so normal packaged builds do not need a separate install.
+
+### Older/custom installs
+
+- Onboarding (`openclaw onboard`) and `openclaw channels add` still surface Bluesky from the shared channel catalog.
+- If your build excludes bundled Bluesky, install it manually:
+
+```bash
+openclaw plugins install @openclaw/bluesky
+```
+
+Restart the Gateway after installing or enabling plugins.
+
+## Quick setup
+
+### Interactive (recommended)
+
+```bash
+openclaw configure bluesky
+```
+
+The wizard prompts for your handle and app password, detects existing env vars, and writes the config. You can also reach it via `openclaw onboard` when Bluesky has not been configured yet.
+
+### Environment variables
+
+```bash
+export BLUESKY_HANDLE="yourbot.bsky.social"
+export BLUESKY_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+```
+
+### Config file
+
+```json
+{
+  "channels": {
+    "bluesky": {
+      "handle": "yourbot.bsky.social",
+      "appPassword": "xxxx-xxxx-xxxx-xxxx"
+    }
+  }
+}
+```
+
+Then bind the channel to an agent and restart the Gateway:
+
+```json
+{
+  "bindings": [{ "agentId": "your-agent", "channel": "bluesky" }]
+}
+```
+
+## App Password
+
+Bluesky App Passwords are separate credentials scoped to third-party apps:
+
+1. Go to **Settings → Privacy and Security → App Passwords**
+2. Click **Add App Password**, give it a name
+3. Copy the generated password — it is shown only once
+
+**Never use your main account password.** App Passwords can be revoked individually from Bluesky settings without affecting your account.
+
+## Configuration reference
+
+| Key           | Type    | Default                 | Description                                     |
+| ------------- | ------- | ----------------------- | ----------------------------------------------- |
+| `handle`      | string  | `$BLUESKY_HANDLE`       | Bot account handle (e.g. `yourbot.bsky.social`) |
+| `appPassword` | string  | `$BLUESKY_APP_PASSWORD` | App password (supports SecretRef)               |
+| `pdsUrl`      | string  | `https://bsky.social`   | Personal Data Server URL (self-hosted PDS only) |
+| `enabled`     | boolean | `true`                  | Enable or disable the channel                   |
+| `accounts`    | object  | —                       | Named accounts for multi-account setups         |
+
+## Multiple accounts
+
+Use `accounts` to run separate bots for different agents from the same Gateway:
+
+```json
+{
+  "channels": {
+    "bluesky": {
+      "accounts": {
+        "sales-bot": {
+          "handle": "sales.bsky.social",
+          "appPassword": "xxxx-xxxx-xxxx-xxxx"
+        },
+        "support-bot": {
+          "handle": "support.bsky.social",
+          "appPassword": "yyyy-yyyy-yyyy-yyyy"
+        }
+      }
+    }
+  },
+  "bindings": [
+    { "agentId": "sales-agent", "channel": "bluesky", "accountId": "sales-bot" },
+    { "agentId": "support-agent", "channel": "bluesky", "accountId": "support-bot" }
+  ]
+}
+```
+
+## Self-hosted PDS
+
+If your account is on a self-hosted Personal Data Server, set `pdsUrl`:
+
+```json
+{
+  "channels": {
+    "bluesky": {
+      "handle": "yourbot.example.com",
+      "appPassword": "xxxx-xxxx-xxxx-xxxx",
+      "pdsUrl": "https://pds.example.com"
+    }
+  }
+}
+```
+
+## How it works
+
+### Authentication
+
+The plugin authenticates with the Bluesky PDS using your handle and app password to create an XRPC session. Chat API calls use short-lived service auth tokens scoped to each `chat.bsky.*` lexicon (tokens are cached for 25 minutes and refreshed automatically). A `401` response evicts the cached token and retries the request once.
+
+### Polling
+
+The plugin uses an adaptive polling loop:
+
+- **2 seconds** after a new message arrives (to catch quick replies)
+- Backs off by **1.5×** per idle cycle up to a maximum of **90 seconds**
+- Resets to 2 seconds immediately on any new activity
+
+### Slash commands
+
+Inbound messages starting with `/` are forwarded to the agent as slash commands. Any DM sender can issue slash commands — Bluesky has no server-side allowlist system so the default policy is open.
+
+## Troubleshooting
+
+### `Bluesky: not configured` in `openclaw doctor`
+
+- Check that `BLUESKY_HANDLE` and `BLUESKY_APP_PASSWORD` are set, or that a named account is configured under `channels.bluesky.accounts`
+- When using named accounts without top-level credentials, ensure the account is bound to an agent in `bindings`
+
+### Bot not receiving messages
+
+1. Verify the app password is correct — generate a new one if unsure
+2. Confirm the handle includes the domain (e.g. `yourbot.bsky.social`, not just `yourbot`)
+3. Check that `enabled` is not `false`
+4. Verify the channel is bound to an agent in `bindings`
+5. Check Gateway logs for login errors
+
+### `401` errors at startup
+
+The app password may have been revoked. Generate a new one from Bluesky Settings → Privacy and Security → App Passwords.
+
+Custom PDS users: verify `pdsUrl` is correct and reachable.
+
+## Security
+
+- Use App Passwords — never your main Bluesky account password
+- App Passwords can be revoked individually without affecting your account
+- Credentials are never logged
+- Use environment variables or SecretRef config values; avoid committing credentials to config files
+
+## Limitations
+
+- Direct messages only (no group chats or public posts)
+- No media attachments
+- No server-side allowlist; any DM sender can reach the agent
+
+## Related
+
+- [Channels Overview](/channels) — all supported channels
+- [Pairing](/channels/pairing) — DM authentication and pairing flow
+- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Security](/gateway/security) — access model and hardening

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -14,6 +14,7 @@ Text is supported everywhere; media and reactions vary by channel.
 ## Supported channels
 
 - [BlueBubbles](/channels/bluebubbles) — **Recommended for iMessage**; uses the BlueBubbles macOS server REST API with full feature support (bundled plugin; edit, unsend, effects, reactions, group management — edit currently broken on macOS 26 Tahoe).
+- [Bluesky](/channels/bluesky) — AT Protocol DMs via `chat.bsky.*` lexicons (bundled plugin).
 - [Discord](/channels/discord) — Discord Bot API + Gateway; supports servers, channels, and DMs.
 - [Feishu](/channels/feishu) — Feishu/Lark bot via WebSocket (bundled plugin).
 - [Google Chat](/channels/googlechat) — Google Chat API app via HTTP webhook.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1005,6 +1005,7 @@
                 "group": "Messaging platforms",
                 "pages": [
                   "channels/bluebubbles",
+                  "channels/bluesky",
                   "channels/discord",
                   "channels/feishu",
                   "channels/googlechat",

--- a/extensions/bluesky/README.md
+++ b/extensions/bluesky/README.md
@@ -19,6 +19,20 @@ openclaw plugins install @openclaw/bluesky
 
 ## Quick Setup
 
+### Interactive setup (recommended)
+
+After installing the plugin, run the interactive setup wizard:
+
+```bash
+openclaw configure bluesky
+```
+
+This prompts for your handle and app password, detects existing env vars, and
+writes the config for you. You can also reach it via `openclaw onboard` if
+Bluesky has not been configured yet.
+
+### Manual setup
+
 1. Create a Bluesky App Password at **Settings → Privacy and Security → App Passwords**
    (do **not** use your main account password)
 

--- a/extensions/bluesky/README.md
+++ b/extensions/bluesky/README.md
@@ -1,0 +1,171 @@
+# @openclaw/bluesky
+
+Bluesky DM channel plugin for OpenClaw using the AT Protocol chat API.
+
+## Overview
+
+This extension adds Bluesky as a messaging channel to OpenClaw. It enables your agent to:
+
+- Receive direct messages from Bluesky users via `chat.bsky.*` lexicons
+- Send replies back via the Bluesky chat API
+- Support slash command pass-through
+- Run multiple named accounts from a single gateway
+
+## Installation
+
+```bash
+openclaw plugins install @openclaw/bluesky
+```
+
+## Quick Setup
+
+1. Create a Bluesky App Password at **Settings → Privacy and Security → App Passwords**
+   (do **not** use your main account password)
+
+2. Set environment variables:
+
+   ```bash
+   export BLUESKY_HANDLE="yourbot.bsky.social"
+   export BLUESKY_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+   ```
+
+3. Bind the channel to an agent in your config:
+
+   ```json
+   {
+     "bindings": [{ "agentId": "your-agent", "channel": "bluesky" }]
+   }
+   ```
+
+4. Restart the gateway
+
+## Configuration
+
+### Environment Variables
+
+| Variable               | Description                                                  |
+| ---------------------- | ------------------------------------------------------------ |
+| `BLUESKY_HANDLE`       | Bot account handle (e.g. `yourbot.bsky.social`)              |
+| `BLUESKY_APP_PASSWORD` | App password generated from Bluesky account settings         |
+| `BLUESKY_PDS_URL`      | Personal Data Server URL — defaults to `https://bsky.social` |
+
+### Config File Options
+
+All options can also be set in `openclaw.json` under `channels.bluesky`:
+
+| Key           | Type    | Default                 | Description                             |
+| ------------- | ------- | ----------------------- | --------------------------------------- |
+| `handle`      | string  | `$BLUESKY_HANDLE`       | Bot account handle                      |
+| `appPassword` | string  | `$BLUESKY_APP_PASSWORD` | App password (supports SecretRef)       |
+| `pdsUrl`      | string  | `https://bsky.social`   | Personal Data Server URL                |
+| `enabled`     | boolean | `true`                  | Enable or disable the channel           |
+| `accounts`    | object  | —                       | Named accounts for multi-account setups |
+
+### Single Account (env vars)
+
+```bash
+export BLUESKY_HANDLE="yourbot.bsky.social"
+export BLUESKY_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+```
+
+### Single Account (config file)
+
+```json
+{
+  "channels": {
+    "bluesky": {
+      "handle": "yourbot.bsky.social",
+      "appPassword": "xxxx-xxxx-xxxx-xxxx"
+    }
+  }
+}
+```
+
+### Custom PDS (self-hosted)
+
+```json
+{
+  "channels": {
+    "bluesky": {
+      "handle": "yourbot.example.com",
+      "appPassword": "xxxx-xxxx-xxxx-xxxx",
+      "pdsUrl": "https://pds.example.com"
+    }
+  }
+}
+```
+
+### Multiple Accounts
+
+Use `accounts` to run separate bots for different agents from the same gateway:
+
+```json
+{
+  "channels": {
+    "bluesky": {
+      "accounts": {
+        "sales-bot": {
+          "handle": "sales.bsky.social",
+          "appPassword": "xxxx-xxxx-xxxx-xxxx"
+        },
+        "support-bot": {
+          "handle": "support.bsky.social",
+          "appPassword": "yyyy-yyyy-yyyy-yyyy"
+        }
+      }
+    }
+  },
+  "bindings": [
+    { "agentId": "sales-agent", "channel": "bluesky", "accountId": "sales-bot" },
+    { "agentId": "support-agent", "channel": "bluesky", "accountId": "support-bot" }
+  ]
+}
+```
+
+## How It Works
+
+### Authentication
+
+The plugin authenticates with the Bluesky PDS using your handle and app password to create an
+XRPC session. For chat API calls, it then acquires short-lived service auth tokens scoped to each
+`chat.bsky.*` lexicon method (tokens are cached for 25 minutes and automatically refreshed).
+On a 401 response the cached token is evicted and the request is retried once.
+
+### Polling
+
+The plugin uses an adaptive polling loop with exponential backoff:
+
+- **2 seconds** after a new message arrives (to catch quick replies)
+- Backs off by **1.5×** per idle cycle up to a maximum of **90 seconds**
+- Resets to 2 seconds immediately on any new activity
+
+### Slash Commands
+
+Inbound messages starting with `/` are forwarded to the agent as slash commands.
+
+## Troubleshooting
+
+### `Bluesky: not configured` in `openclaw doctor`
+
+- Check that `BLUESKY_HANDLE` and `BLUESKY_APP_PASSWORD` are set, or that a named account is
+  configured under `channels.bluesky.accounts`
+- When using named accounts without top-level credentials, ensure the account is bound to an agent
+
+### Bot not receiving messages
+
+1. Verify the app password is correct — generate a new one if unsure
+2. Confirm the handle includes the domain (e.g. `yourbot.bsky.social`, not just `yourbot`)
+3. Check that `enabled` is not set to `false`
+4. Verify the channel is bound to an agent in `bindings`
+
+### `401` errors at startup
+
+- The app password may have been revoked; generate a new one from Bluesky settings
+- Custom PDS users: verify `pdsUrl` is correct and reachable
+
+## Security Notes
+
+- Use App Passwords, never your main Bluesky account password
+- App passwords can be revoked individually from Bluesky settings without affecting your account
+- Credentials are never logged
+- Use environment variables or SecretRef config values; avoid committing credentials to config files

--- a/extensions/bluesky/api.ts
+++ b/extensions/bluesky/api.ts
@@ -1,0 +1,2 @@
+export { blueskyPlugin } from "./src/channel.js";
+export { setBlueskyRuntime } from "./src/runtime.js";

--- a/extensions/bluesky/api.ts
+++ b/extensions/bluesky/api.ts
@@ -1,2 +1,3 @@
 export { blueskyPlugin } from "./src/channel.js";
 export { setBlueskyRuntime } from "./src/runtime.js";
+export { blueskySetupAdapter, blueskySetupWizard } from "./src/setup-surface.js";

--- a/extensions/bluesky/index.ts
+++ b/extensions/bluesky/index.ts
@@ -1,0 +1,16 @@
+import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelEntry({
+  id: "bluesky",
+  name: "Bluesky",
+  description: "Bluesky DM channel plugin for OpenClaw",
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./api.js",
+    exportName: "blueskyPlugin",
+  },
+  runtime: {
+    specifier: "./api.js",
+    exportName: "setBlueskyRuntime",
+  },
+});

--- a/extensions/bluesky/openclaw.plugin.json
+++ b/extensions/bluesky/openclaw.plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "bluesky",
+  "channels": ["bluesky"],
+  "channelEnvVars": {
+    "bluesky": ["BLUESKY_HANDLE", "BLUESKY_APP_PASSWORD", "BLUESKY_PDS_URL"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/bluesky/package.json
+++ b/extensions/bluesky/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openclaw/bluesky",
+  "version": "2026.4.10",
+  "description": "Bluesky DM channel plugin for OpenClaw",
+  "type": "module",
+  "dependencies": {
+    "@atproto/api": "^0.13.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "bluesky",
+      "label": "Bluesky",
+      "selectionLabel": "Bluesky (DMs)",
+      "docsPath": "/channels/bluesky",
+      "docsLabel": "bluesky",
+      "blurb": "Connect OpenClaw to Bluesky DMs via the AT Protocol chat API.",
+      "order": 85
+    },
+    "install": {
+      "npmSpec": "@openclaw/bluesky",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/bluesky/src/accounts.ts
+++ b/extensions/bluesky/src/accounts.ts
@@ -1,0 +1,99 @@
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import type {
+  BlueskyAccountConfig,
+  BlueskyChannelConfig,
+  ResolvedBlueskyAccount,
+} from "./types.js";
+
+const DEFAULT_PDS_URL = "https://bsky.social";
+const DEFAULT_ACCOUNT_ID = "default";
+
+function getChannelConfig(cfg: Record<string, unknown>): BlueskyChannelConfig | undefined {
+  const channels = cfg?.channels as Record<string, unknown> | undefined;
+  return channels?.bluesky as BlueskyChannelConfig | undefined;
+}
+
+function mergeAccountConfig(
+  base: BlueskyChannelConfig,
+  override: BlueskyAccountConfig | undefined,
+): BlueskyAccountConfig {
+  return {
+    enabled: override?.enabled ?? base.enabled,
+    handle: override?.handle ?? base.handle,
+    appPassword: override?.appPassword ?? base.appPassword,
+    pdsUrl: override?.pdsUrl ?? base.pdsUrl,
+  };
+}
+
+function resolveAppPassword(accountId: string, merged: BlueskyAccountConfig): string {
+  const envPassword =
+    accountId === DEFAULT_ACCOUNT_ID ? process.env.BLUESKY_APP_PASSWORD?.trim() : undefined;
+  const configured = normalizeResolvedSecretInputString({
+    value: merged.appPassword,
+    path: `channels.bluesky.accounts.${accountId}.appPassword`,
+  });
+  return configured ?? envPassword ?? "";
+}
+
+function resolveHandle(accountId: string, merged: BlueskyAccountConfig): string {
+  return (
+    merged.handle?.trim() ||
+    (accountId === DEFAULT_ACCOUNT_ID ? process.env.BLUESKY_HANDLE?.trim() : undefined) ||
+    ""
+  );
+}
+
+function resolvePdsUrl(accountId: string, merged: BlueskyAccountConfig): string {
+  return (
+    merged.pdsUrl?.trim() ||
+    (accountId === DEFAULT_ACCOUNT_ID ? process.env.BLUESKY_PDS_URL?.trim() : undefined) ||
+    DEFAULT_PDS_URL
+  );
+}
+
+export function listBlueskyAccountIds(cfg: Record<string, unknown>): string[] {
+  const channelCfg = getChannelConfig(cfg);
+  if (!channelCfg) {
+    return [];
+  }
+  const ids = new Set<string>();
+  const hasBase =
+    channelCfg.handle?.trim() ||
+    process.env.BLUESKY_HANDLE ||
+    channelCfg.appPassword ||
+    process.env.BLUESKY_APP_PASSWORD;
+  if (hasBase) {
+    ids.add(DEFAULT_ACCOUNT_ID);
+  }
+  for (const id of Object.keys(channelCfg.accounts ?? {})) {
+    ids.add(id);
+  }
+  return Array.from(ids);
+}
+
+export function resolveBlueskyAccount(
+  cfg: Record<string, unknown>,
+  accountId?: string | null,
+): ResolvedBlueskyAccount {
+  const channelCfg = getChannelConfig(cfg) ?? {};
+  const id = accountId?.trim() || DEFAULT_ACCOUNT_ID;
+  const accountOverride = id === DEFAULT_ACCOUNT_ID ? undefined : (channelCfg.accounts?.[id] ?? {});
+  const merged = mergeAccountConfig(channelCfg, accountOverride);
+
+  const handle = resolveHandle(id, merged);
+  const appPassword = resolveAppPassword(id, merged);
+  const pdsUrl = resolvePdsUrl(id, merged);
+
+  return {
+    accountId: id,
+    enabled: merged.enabled ?? true,
+    configured: Boolean(handle && appPassword),
+    handle,
+    appPassword,
+    pdsUrl,
+  };
+}
+
+export function resolveDefaultBlueskyAccountId(_cfg: Record<string, unknown>): string {
+  return DEFAULT_ACCOUNT_ID;
+}

--- a/extensions/bluesky/src/accounts.ts
+++ b/extensions/bluesky/src/accounts.ts
@@ -94,6 +94,20 @@ export function resolveBlueskyAccount(
   };
 }
 
-export function resolveDefaultBlueskyAccountId(_cfg: Record<string, unknown>): string {
+export function resolveDefaultBlueskyAccountId(cfg: Record<string, unknown>): string {
+  const channelCfg = getChannelConfig(cfg);
+  // If there are no top-level credentials, the named accounts are the real config.
+  // Return the first named account so health/status picks a configured account as the default.
+  const hasTopLevel =
+    channelCfg?.handle?.trim() ||
+    process.env.BLUESKY_HANDLE ||
+    channelCfg?.appPassword ||
+    process.env.BLUESKY_APP_PASSWORD;
+  if (!hasTopLevel) {
+    const firstAccountId = Object.keys(channelCfg?.accounts ?? {})[0];
+    if (firstAccountId) {
+      return firstAccountId;
+    }
+  }
   return DEFAULT_ACCOUNT_ID;
 }

--- a/extensions/bluesky/src/accounts.ts
+++ b/extensions/bluesky/src/accounts.ts
@@ -54,6 +54,11 @@ function resolvePdsUrl(accountId: string, merged: BlueskyAccountConfig): string 
 export function listBlueskyAccountIds(cfg: Record<string, unknown>): string[] {
   const channelCfg = getChannelConfig(cfg);
   if (!channelCfg) {
+    // Env-only config: no channel section but both env credentials are present.
+    // Treat as an implicit default account so the channel starts correctly.
+    if (process.env.BLUESKY_HANDLE?.trim() && process.env.BLUESKY_APP_PASSWORD?.trim()) {
+      return [DEFAULT_ACCOUNT_ID];
+    }
     return [];
   }
   const ids = new Set<string>();
@@ -96,6 +101,11 @@ export function resolveBlueskyAccount(
 
 export function resolveDefaultBlueskyAccountId(cfg: Record<string, unknown>): string {
   const channelCfg = getChannelConfig(cfg);
+  // Explicit user preference takes priority.
+  const explicit = channelCfg?.defaultAccount?.trim();
+  if (explicit) {
+    return explicit;
+  }
   // If there are no top-level credentials, the named accounts are the real config.
   // Return the first named account so health/status picks a configured account as the default.
   const hasTopLevel =

--- a/extensions/bluesky/src/auth.ts
+++ b/extensions/bluesky/src/auth.ts
@@ -1,0 +1,148 @@
+import { BskyAgent } from "@atproto/api";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+
+/**
+ * The DID of the Bluesky central chat service.
+ * All chat.bsky.* lexicon calls must be proxied through this service.
+ */
+export const CHAT_SERVICE_DID = "did:web:api.bsky.chat";
+
+/**
+ * Base URL of the Bluesky chat service used for direct API calls with service tokens.
+ */
+export const CHAT_SERVICE_URL = "https://api.bsky.chat";
+
+type CachedToken = {
+  token: string;
+  /** Absolute ms timestamp after which the token must not be used */
+  expiresAt: number;
+};
+
+/**
+ * Per-agent token cache: `${did}:${lxm}` → CachedToken.
+ * Tokens are valid for 30 min; we cache for 25 min to avoid races.
+ */
+const tokenCache = new Map<string, CachedToken>();
+const TOKEN_TTL_MS = 25 * 60 * 1000;
+
+function tokenCacheKey(did: string, lxm: string): string {
+  return `${did}:${lxm}`;
+}
+
+/**
+ * Obtain a short-lived service auth JWT for a specific chat lexicon method.
+ * Results are cached for 25 minutes (tokens expire at 30 min).
+ */
+export async function getChatServiceToken(agent: BskyAgent, lxm: string): Promise<string> {
+  const did = agent.session?.did;
+  if (!did) {
+    throw new Error("Bluesky agent has no active session; login required before fetching tokens");
+  }
+  const key = tokenCacheKey(did, lxm);
+  const cached = tokenCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.token;
+  }
+
+  logVerbose(`Bluesky: fetching service auth token for ${lxm}`);
+  const res = await agent.api.com.atproto.server.getServiceAuth({
+    aud: CHAT_SERVICE_DID,
+    lxm,
+  });
+  const token = res.data.token;
+  tokenCache.set(key, { token, expiresAt: Date.now() + TOKEN_TTL_MS });
+  return token;
+}
+
+/** Evict all cached tokens for a given DID (call after re-login). */
+export function evictChatServiceTokens(did: string): void {
+  for (const key of tokenCache.keys()) {
+    if (key.startsWith(`${did}:`)) {
+      tokenCache.delete(key);
+    }
+  }
+}
+
+/** Evict the cached token for a specific DID + lexicon method. */
+function evictChatServiceToken(did: string, lxm: string): void {
+  tokenCache.delete(tokenCacheKey(did, lxm));
+}
+
+/**
+ * Make a GET request to a chat.bsky.* lexicon endpoint using a fresh service token.
+ * The token is scoped to the specific lexicon method (lxm).
+ */
+export async function chatApiGet<T>(
+  agent: BskyAgent,
+  lxm: string,
+  params: Record<string, string | number | undefined>,
+): Promise<T> {
+  const did = agent.session?.did ?? "";
+  const url = new URL(`${CHAT_SERVICE_URL}/xrpc/${lxm}`);
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined) {
+      url.searchParams.set(k, String(v));
+    }
+  }
+  const urlStr = url.toString();
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const token = await getChatServiceToken(agent, lxm);
+    const res = await fetch(urlStr, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.status === 401 && attempt === 0) {
+      // Token expired server-side — evict cache and retry once
+      evictChatServiceToken(did, lxm);
+      continue;
+    }
+    if (!res.ok) {
+      const body = await res.text().catch(() => "(unreadable)");
+      throw new Error(`Bluesky chat API GET ${lxm} failed (${res.status}): ${body}`);
+    }
+    return res.json() as Promise<T>;
+  }
+  throw new Error(`Bluesky chat API GET ${lxm} failed after token refresh`);
+}
+
+/**
+ * Make a POST request to a chat.bsky.* lexicon endpoint using a fresh service token.
+ */
+export async function chatApiPost<T>(agent: BskyAgent, lxm: string, body: unknown): Promise<T> {
+  const did = agent.session?.did ?? "";
+  const bodyStr = JSON.stringify(body);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const token = await getChatServiceToken(agent, lxm);
+    const res = await fetch(`${CHAT_SERVICE_URL}/xrpc/${lxm}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: bodyStr,
+    });
+    if (res.status === 401 && attempt === 0) {
+      // Token expired server-side — evict cache and retry once
+      evictChatServiceToken(did, lxm);
+      continue;
+    }
+    if (!res.ok) {
+      const bodyText = await res.text().catch(() => "(unreadable)");
+      throw new Error(`Bluesky chat API POST ${lxm} failed (${res.status}): ${bodyText}`);
+    }
+    return res.json() as Promise<T>;
+  }
+  throw new Error(`Bluesky chat API POST ${lxm} failed after token refresh`);
+}
+
+/** Login to a Bluesky PDS and return an authenticated agent. */
+export async function loginBluesky(params: {
+  handle: string;
+  appPassword: string;
+  pdsUrl: string;
+}): Promise<BskyAgent> {
+  const agent = new BskyAgent({ service: params.pdsUrl });
+  await agent.login({ identifier: params.handle, password: params.appPassword });
+  return agent;
+}

--- a/extensions/bluesky/src/channel.ts
+++ b/extensions/bluesky/src/channel.ts
@@ -12,6 +12,7 @@ import { dispatchBlueskyInboundTurn } from "./inbound-turn.js";
 import { runBlueSkyPollLoop } from "./poll.js";
 import { setBlueskyRuntime } from "./runtime.js";
 import { sendBlueskyMessage } from "./send.js";
+import { blueskySetupAdapter, blueskySetupWizard } from "./setup-surface.js";
 import type { ResolvedBlueskyAccount } from "./types.js";
 
 export { setBlueskyRuntime };
@@ -41,6 +42,9 @@ export const blueskyPlugin: ChannelPlugin<ResolvedBlueskyAccount> = {
     chatTypes: ["direct"],
     media: false,
   },
+
+  setupWizard: blueskySetupWizard,
+  setup: blueskySetupAdapter,
 
   reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
 

--- a/extensions/bluesky/src/channel.ts
+++ b/extensions/bluesky/src/channel.ts
@@ -9,7 +9,7 @@ import {
 import { evictChatServiceTokens, loginBluesky } from "./auth.js";
 import { dispatchBlueskyInboundTurn } from "./inbound-turn.js";
 import { runBlueSkyPollLoop } from "./poll.js";
-import { setBlueskyRuntime } from "./runtime.js";
+import { getBlueskyRuntime, setBlueskyRuntime } from "./runtime.js";
 import { sendBlueskyMessage } from "./send.js";
 import { blueskySetupAdapter, blueskySetupWizard } from "./setup-surface.js";
 import type { ResolvedBlueskyAccount } from "./types.js";
@@ -102,8 +102,7 @@ export const blueskyPlugin: ChannelPlugin<ResolvedBlueskyAccount> = {
         callbacks: {
           onMessage: async (msg) => {
             // Re-read config each turn so live config changes take effect
-            const rt = (await import("./runtime.js")).getBlueskyRuntime();
-            const currentCfg = rt.config.loadConfig();
+            const currentCfg = getBlueskyRuntime().config.loadConfig();
             await dispatchBlueskyInboundTurn({
               account,
               agent,
@@ -133,8 +132,7 @@ export const blueskyPlugin: ChannelPlugin<ResolvedBlueskyAccount> = {
     deliveryMode: "direct",
 
     sendText: async ({ to, text, accountId }) => {
-      const rt = (await import("./runtime.js")).getBlueskyRuntime();
-      const cfg = rt.config.loadConfig();
+      const cfg = getBlueskyRuntime().config.loadConfig();
       const resolvedAccountId =
         accountId ?? resolveDefaultBlueskyAccountId(cfg as Record<string, unknown>);
       const agent = activeAgents.get(resolvedAccountId);

--- a/extensions/bluesky/src/channel.ts
+++ b/extensions/bluesky/src/channel.ts
@@ -1,5 +1,4 @@
 import type { BskyAgent } from "@atproto/api";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/channel-plugin-common";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-plugin-common";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -134,7 +133,10 @@ export const blueskyPlugin: ChannelPlugin<ResolvedBlueskyAccount> = {
     deliveryMode: "direct",
 
     sendText: async ({ to, text, accountId }) => {
-      const resolvedAccountId = accountId ?? DEFAULT_ACCOUNT_ID;
+      const rt = (await import("./runtime.js")).getBlueskyRuntime();
+      const cfg = rt.config.loadConfig();
+      const resolvedAccountId =
+        accountId ?? resolveDefaultBlueskyAccountId(cfg as Record<string, unknown>);
       const agent = activeAgents.get(resolvedAccountId);
       if (!agent) {
         throw new Error(

--- a/extensions/bluesky/src/channel.ts
+++ b/extensions/bluesky/src/channel.ts
@@ -1,0 +1,144 @@
+import type { BskyAgent } from "@atproto/api";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/channel-plugin-common";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-plugin-common";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import {
+  listBlueskyAccountIds,
+  resolveBlueskyAccount,
+  resolveDefaultBlueskyAccountId,
+} from "./accounts.js";
+import { evictChatServiceTokens, loginBluesky } from "./auth.js";
+import { dispatchBlueskyInboundTurn } from "./inbound-turn.js";
+import { runBlueSkyPollLoop } from "./poll.js";
+import { setBlueskyRuntime } from "./runtime.js";
+import { sendBlueskyMessage } from "./send.js";
+import type { ResolvedBlueskyAccount } from "./types.js";
+
+export { setBlueskyRuntime };
+
+const CHANNEL_ID = "bluesky";
+
+/**
+ * Active agents keyed by accountId.
+ * Stored here so the outbound adapter can access them without going through gateway context.
+ */
+const activeAgents = new Map<string, BskyAgent>();
+
+export const blueskyPlugin: ChannelPlugin<ResolvedBlueskyAccount> = {
+  id: CHANNEL_ID,
+
+  meta: {
+    id: CHANNEL_ID,
+    label: "Bluesky",
+    selectionLabel: "Bluesky (DMs)",
+    detailLabel: "Bluesky DM",
+    docsPath: "/channels/bluesky",
+    blurb: "Connect OpenClaw to Bluesky DMs via the AT Protocol chat API.",
+    order: 85,
+  },
+
+  capabilities: {
+    chatTypes: ["direct"],
+    media: false,
+  },
+
+  reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+
+  config: {
+    listAccountIds: (cfg) => listBlueskyAccountIds(cfg as Record<string, unknown>),
+
+    resolveAccount: (cfg, accountId) =>
+      resolveBlueskyAccount(cfg as Record<string, unknown>, accountId),
+
+    defaultAccountId: (cfg) => resolveDefaultBlueskyAccountId(cfg as Record<string, unknown>),
+
+    isConfigured: (account) => account.configured,
+
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      handle: account.handle,
+      pdsUrl: account.pdsUrl,
+      enabled: account.enabled,
+      configured: account.configured,
+    }),
+  },
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const { account, abortSignal, log } = ctx;
+
+      if (!account.configured) {
+        throw new Error(
+          `Bluesky is not configured for account "${account.accountId}" — set channels.bluesky.handle and channels.bluesky.appPassword`,
+        );
+      }
+
+      log?.info?.(`Bluesky [${account.accountId}]: logging in as ${account.handle}`);
+
+      let agent: BskyAgent;
+      try {
+        agent = await loginBluesky({
+          handle: account.handle,
+          appPassword: account.appPassword,
+          pdsUrl: account.pdsUrl,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log?.error?.(`Bluesky [${account.accountId}]: login failed — ${msg}`);
+        throw err;
+      }
+
+      const selfDid = agent.session?.did ?? "";
+      logVerbose(`Bluesky [${account.accountId}]: authenticated as ${selfDid}`);
+      activeAgents.set(account.accountId, agent);
+
+      await runBlueSkyPollLoop({
+        agent,
+        selfDid,
+        abortSignal,
+        callbacks: {
+          onMessage: async (msg) => {
+            // Re-read config each turn so live config changes take effect
+            const rt = (await import("./runtime.js")).getBlueskyRuntime();
+            const currentCfg = rt.config.loadConfig();
+            await dispatchBlueskyInboundTurn({
+              account,
+              agent,
+              msg,
+              cfg: currentCfg,
+              log,
+            });
+          },
+          onError: (err, context) => {
+            log?.error?.(`Bluesky [${account.accountId}]: error in ${context} — ${err.message}`);
+          },
+        },
+      });
+    },
+
+    stopAccount: async (ctx) => {
+      const agent = activeAgents.get(ctx.account.accountId);
+      if (agent?.session?.did) {
+        evictChatServiceTokens(agent.session.did);
+      }
+      activeAgents.delete(ctx.account.accountId);
+      ctx.log?.info?.(`Bluesky [${ctx.account.accountId}]: stopped`);
+    },
+  },
+
+  outbound: {
+    deliveryMode: "direct",
+
+    sendText: async ({ to, text, accountId }) => {
+      const resolvedAccountId = accountId ?? DEFAULT_ACCOUNT_ID;
+      const agent = activeAgents.get(resolvedAccountId);
+      if (!agent) {
+        throw new Error(
+          `Bluesky: no active session for account "${resolvedAccountId}" — is the gateway running?`,
+        );
+      }
+      const { convoId, messageId } = await sendBlueskyMessage(agent, to, text);
+      return { channel: CHANNEL_ID, to: convoId, messageId };
+    },
+  },
+};

--- a/extensions/bluesky/src/inbound-turn.ts
+++ b/extensions/bluesky/src/inbound-turn.ts
@@ -1,0 +1,87 @@
+import type { BskyAgent } from "@atproto/api";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import type { InboundMessage } from "./poll.js";
+import { getBlueskyRuntime } from "./runtime.js";
+import { sendBlueskyMessage } from "./send.js";
+import { buildBlueskySessionKey } from "./session-key.js";
+import type { ResolvedBlueskyAccount } from "./types.js";
+
+type LogSink = {
+  info?: (msg: string) => void;
+  error?: (msg: string) => void;
+};
+
+const CHANNEL_ID = "bluesky";
+
+/**
+ * Dispatch a single inbound Bluesky DM through the OpenClaw agent reply pipeline.
+ *
+ * Routing uses the convoId as the peer identifier so replies are routed back to
+ * the correct conversation. The agent session is keyed by convoId, meaning the
+ * same 1:1 conversation always reaches the same agent session.
+ */
+export async function dispatchBlueskyInboundTurn(params: {
+  account: ResolvedBlueskyAccount;
+  agent: BskyAgent;
+  msg: InboundMessage;
+  cfg?: OpenClawConfig;
+  log?: LogSink;
+}): Promise<void> {
+  const { account, agent, msg, log } = params;
+  const rt = getBlueskyRuntime();
+  const cfg = params.cfg ?? rt.config.loadConfig();
+
+  const route = rt.channel.routing.resolveAgentRoute({
+    cfg,
+    channel: CHANNEL_ID,
+    accountId: account.accountId,
+    peer: {
+      kind: "direct",
+      id: msg.convoId,
+    },
+  });
+
+  const sessionKey = buildBlueskySessionKey({
+    agentId: route.agentId,
+    accountId: account.accountId,
+    convoId: msg.convoId,
+    identityLinks: cfg.session?.identityLinks,
+  });
+
+  const isCommand = msg.text.trim().startsWith("/");
+  const commandBody = isCommand ? msg.text : undefined;
+
+  const msgCtx = rt.channel.reply.finalizeInboundContext({
+    Body: msg.text,
+    RawBody: msg.text,
+    CommandBody: commandBody,
+    From: `${CHANNEL_ID}:${msg.convoId}`,
+    To: `${CHANNEL_ID}:${msg.convoId}`,
+    SessionKey: sessionKey,
+    AccountId: account.accountId,
+    OriginatingChannel: CHANNEL_ID,
+    OriginatingTo: `${CHANNEL_ID}:${msg.convoId}`,
+    ChatType: "direct",
+    SenderId: msg.senderDid,
+    Provider: CHANNEL_ID,
+    Surface: CHANNEL_ID,
+    Timestamp: new Date(msg.sentAt).getTime() || Date.now(),
+  });
+
+  await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx: msgCtx,
+    cfg,
+    dispatcherOptions: {
+      deliver: async (payload: { text?: string; body?: string }) => {
+        const text = payload.text ?? payload.body;
+        if (!text) {
+          return;
+        }
+        await sendBlueskyMessage(agent, msg.convoId, text);
+      },
+      onReplyStart: () => {
+        log?.info?.(`Bluesky: agent reply started for convo ${msg.convoId}`);
+      },
+    },
+  });
+}

--- a/extensions/bluesky/src/inbound-turn.ts
+++ b/extensions/bluesky/src/inbound-turn.ts
@@ -51,10 +51,23 @@ export async function dispatchBlueskyInboundTurn(params: {
   const isCommand = msg.text.trim().startsWith("/");
   const commandBody = isCommand ? msg.text : undefined;
 
+  // Compute command authorization. Bluesky has no allowlist/DM-policy system, so
+  // all DM senders are always allowed. configured:true tells resolveCommandAuthorizedFromAuthorizers
+  // that there is an effective authorizer covering this sender, which returns true
+  // regardless of the useAccessGroups setting. Without this, CommandAuthorized would
+  // be false (default-deny) and slash commands would be silently dropped.
+  const commandAuthorized = rt.channel.commands.shouldComputeCommandAuthorized(msg.text, cfg)
+    ? rt.channel.commands.resolveCommandAuthorizedFromAuthorizers({
+        useAccessGroups: cfg.commands?.useAccessGroups !== false,
+        authorizers: [{ configured: true, allowed: true }],
+      })
+    : undefined;
+
   const msgCtx = rt.channel.reply.finalizeInboundContext({
     Body: msg.text,
     RawBody: msg.text,
     CommandBody: commandBody,
+    CommandAuthorized: commandAuthorized,
     From: `${CHANNEL_ID}:${msg.convoId}`,
     To: `${CHANNEL_ID}:${msg.convoId}`,
     SessionKey: sessionKey,

--- a/extensions/bluesky/src/poll.ts
+++ b/extensions/bluesky/src/poll.ts
@@ -217,16 +217,11 @@ export async function runBlueSkyPollLoop(params: {
 
           if (newMessages.length > 0) {
             hadActivity = true;
-            // Update rev to the latest we fetched
-            const latestRev = newMessages.reduce(
-              (best, m) => (m.messageId > best ? m.messageId : best),
-              prev ?? "",
-            );
             // Use the lastMessage rev from listConvos as the new watermark
             lastRev.set(convo.id, msg.rev);
 
             logVerbose(
-              `Bluesky: ${newMessages.length} new message(s) in convo ${convo.id} (latestRev=${latestRev})`,
+              `Bluesky: ${newMessages.length} new message(s) in convo ${convo.id} (watermark=${msg.rev})`,
             );
 
             for (const inbound of newMessages) {

--- a/extensions/bluesky/src/poll.ts
+++ b/extensions/bluesky/src/poll.ts
@@ -74,21 +74,36 @@ const MAX_FETCH_PAGES = 20;
 /** Maximum pages fetched from listConvos per poll cycle (30 convos/page → up to 300 conversations). */
 const MAX_LIST_PAGES = 10;
 
+type FetchNewMessagesResult = {
+  messages: InboundMessage[];
+  /** The oldest rev we examined (newest-first traversal), set as watermark when page cap hit. */
+  oldestRevSeen: string | undefined;
+  /** True when MAX_FETCH_PAGES was reached while the API still had more pages to return. */
+  hitPageCap: boolean;
+};
+
 /**
  * Fetch all messages in a conversation that are newer than the tracked rev.
  *
  * Paginates `getMessages` (newest-first) until it encounters a message at or
- * before the watermark or exhausts all pages, then returns results in
- * chronological order (oldest first) for in-order dispatch.
+ * before the watermark, exhausts API pages, or reaches MAX_FETCH_PAGES.
+ * Returns results in chronological order (oldest first) for in-order dispatch.
+ *
+ * When `hitPageCap` is true there are unseen messages older than those
+ * returned; callers should advance the watermark to `oldestRevSeen` rather
+ * than the convo's latest rev so the next poll cycle picks up the remainder.
  */
 async function fetchNewMessages(
   agent: BskyAgent,
   convoId: string,
   selfDid: string,
   lastRev: string,
-): Promise<InboundMessage[]> {
+): Promise<FetchNewMessagesResult> {
   const results: InboundMessage[] = [];
   let cursor: string | undefined;
+  let reachedOld = false;
+  let exhaustedApi = false;
+  let oldestRevSeen: string | undefined;
 
   for (let page = 0; page < MAX_FETCH_PAGES; page++) {
     const data = await chatApiGet<GetMessagesResponse>(agent, LXM_GET_MESSAGES, {
@@ -97,7 +112,6 @@ async function fetchNewMessages(
       ...(cursor ? { cursor } : {}),
     });
 
-    let reachedOld = false;
     for (const msg of data.messages) {
       if (!isMessageView(msg)) {
         continue;
@@ -108,6 +122,8 @@ async function fetchNewMessages(
         reachedOld = true;
         break;
       }
+      // Track the oldest rev examined (all messages, including our own outbound).
+      oldestRevSeen = msg.rev;
       // Skip our own outbound messages
       if (msg.sender.did === selfDid) {
         continue;
@@ -121,14 +137,24 @@ async function fetchNewMessages(
       });
     }
 
-    if (reachedOld || !data.cursor) {
+    if (reachedOld) {
+      break;
+    }
+    if (!data.cursor) {
+      exhaustedApi = true;
       break;
     }
     cursor = data.cursor;
   }
 
-  // Reverse to chronological order (oldest first) for in-order dispatch
-  return results.toReversed();
+  return {
+    // Reverse to chronological order (oldest first) for in-order dispatch
+    messages: results.toReversed(),
+    oldestRevSeen,
+    // Page cap: stopped because we ran out of allowed pages, not because we
+    // reached the watermark or ran out of API pages.
+    hitPageCap: !reachedOld && !exhaustedApi,
+  };
 }
 
 /**
@@ -266,15 +292,22 @@ export async function runBlueSkyPollLoop(params: {
           }
 
           // New activity detected — fetch full messages to find exactly what's new
-          const newMessages = await fetchNewMessages(agent, convo.id, selfDid, prev ?? "");
+          const {
+            messages: newMessages,
+            oldestRevSeen,
+            hitPageCap,
+          } = await fetchNewMessages(agent, convo.id, selfDid, prev ?? "");
 
           if (newMessages.length > 0) {
             hadActivity = true;
-            // Use the lastMessage rev from listConvos as the new watermark
-            lastRev.set(convo.id, msg.rev);
+            // When we hit the page cap there are older unseen messages; advance
+            // the watermark only to the oldest rev we examined so the next poll
+            // cycle fetches the remainder rather than skipping it permanently.
+            const newWatermark = hitPageCap && oldestRevSeen ? oldestRevSeen : msg.rev;
+            lastRev.set(convo.id, newWatermark);
 
             logVerbose(
-              `Bluesky: ${newMessages.length} new message(s) in convo ${convo.id} (watermark=${msg.rev})`,
+              `Bluesky: ${newMessages.length} new message(s) in convo ${convo.id} (watermark=${newWatermark}${hitPageCap ? ", page-cap hit" : ""})`,
             );
 
             for (const inbound of newMessages) {

--- a/extensions/bluesky/src/poll.ts
+++ b/extensions/bluesky/src/poll.ts
@@ -1,0 +1,251 @@
+import type { BskyAgent } from "@atproto/api";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { chatApiGet } from "./auth.js";
+
+/** Fastest poll rate — used immediately after a new message arrives. */
+const MIN_POLL_MS = 2_000;
+/** Slowest poll rate — reached after prolonged inactivity. */
+const MAX_POLL_MS = 90_000;
+/** Multiplicative backoff factor applied after each idle poll cycle. */
+const BACKOFF_FACTOR = 1.5;
+
+// AT Protocol lexicon method IDs
+const LXM_LIST_CONVOS = "chat.bsky.convo.listConvos";
+const LXM_GET_MESSAGES = "chat.bsky.convo.getMessages";
+
+type ListConvosResponse = {
+  convos: ConvoView[];
+  cursor?: string;
+};
+
+type ConvoView = {
+  id: string;
+  lastMessage?: MessageView | DeletedMessageView;
+  unreadCount?: number;
+};
+
+type MessageView = {
+  $type: "chat.bsky.convo.defs#messageView";
+  id: string;
+  rev: string;
+  text: string;
+  sender: {
+    did: string;
+  };
+  sentAt: string;
+};
+
+type DeletedMessageView = {
+  $type: "chat.bsky.convo.defs#deletedMessageView";
+  id: string;
+  rev: string;
+};
+
+type GetMessagesResponse = {
+  messages: Array<MessageView | DeletedMessageView>;
+};
+
+type InboundMessage = {
+  convoId: string;
+  messageId: string;
+  text: string;
+  senderDid: string;
+  sentAt: string;
+};
+
+function isMessageView(msg: MessageView | DeletedMessageView | undefined): msg is MessageView {
+  return msg?.$type === "chat.bsky.convo.defs#messageView";
+}
+
+/**
+ * Compute the next poll interval.
+ * Resets to MIN on activity, backs off toward MAX on idle cycles.
+ */
+function nextPollMs(current: number, hadActivity: boolean): number {
+  if (hadActivity) {
+    return MIN_POLL_MS;
+  }
+  return Math.min(Math.round(current * BACKOFF_FACTOR), MAX_POLL_MS);
+}
+
+/**
+ * Fetch all messages in a conversation that are newer than the tracked rev.
+ * Returns at most a handful of recent messages to avoid fetching full history.
+ */
+async function fetchNewMessages(
+  agent: BskyAgent,
+  convoId: string,
+  selfDid: string,
+  lastRev: string,
+): Promise<InboundMessage[]> {
+  const data = await chatApiGet<GetMessagesResponse>(agent, LXM_GET_MESSAGES, {
+    convoId,
+    limit: 10,
+  });
+  const results: InboundMessage[] = [];
+  for (const msg of data.messages) {
+    if (!isMessageView(msg)) {
+      continue;
+    }
+    // Skip if this message is not newer than what we've already seen
+    if (msg.rev <= lastRev) {
+      continue;
+    }
+    // Skip our own outbound messages
+    if (msg.sender.did === selfDid) {
+      continue;
+    }
+    results.push({
+      convoId,
+      messageId: msg.id,
+      text: msg.text,
+      senderDid: msg.sender.did,
+      sentAt: msg.sentAt,
+    });
+  }
+  return results;
+}
+
+export type PollCallbacks = {
+  onMessage: (msg: InboundMessage) => Promise<void>;
+  onError?: (err: Error, context: string) => void;
+};
+
+/**
+ * Run the adaptive polling loop for Bluesky DM conversations.
+ *
+ * Starts by seeding the lastRev map from the current conversation state
+ * so that no historical messages are replayed on startup.
+ * After that, polls at an interval that starts at MIN_POLL_MS immediately
+ * after activity and backs off exponentially to MAX_POLL_MS during idle periods.
+ *
+ * Resolves when the abortSignal fires.
+ */
+export async function runBlueSkyPollLoop(params: {
+  agent: BskyAgent;
+  selfDid: string;
+  abortSignal: AbortSignal;
+  callbacks: PollCallbacks;
+}): Promise<void> {
+  const { agent, selfDid, abortSignal, callbacks } = params;
+
+  if (abortSignal.aborted) {
+    return;
+  }
+
+  // lastRev tracks the most recent message rev per convoId we have processed.
+  const lastRev = new Map<string, string>();
+
+  // --- Seed phase: snapshot current convo state without dispatching ---
+  try {
+    const seedData = await chatApiGet<ListConvosResponse>(agent, LXM_LIST_CONVOS, { limit: 50 });
+    for (const convo of seedData.convos) {
+      const msg = convo.lastMessage;
+      if (msg && "rev" in msg && msg.rev) {
+        lastRev.set(convo.id, msg.rev);
+      }
+    }
+    logVerbose(`Bluesky: seeded ${lastRev.size} conversation(s) for polling`);
+  } catch (err) {
+    callbacks.onError?.(err instanceof Error ? err : new Error(String(err)), "seed");
+  }
+
+  let intervalMs = MIN_POLL_MS;
+
+  return new Promise<void>((resolve) => {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const stop = () => {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = undefined;
+      }
+      resolve();
+    };
+
+    abortSignal.addEventListener("abort", stop, { once: true });
+
+    const poll = async () => {
+      if (abortSignal.aborted) {
+        stop();
+        return;
+      }
+
+      let hadActivity = false;
+
+      try {
+        const data = await chatApiGet<ListConvosResponse>(agent, LXM_LIST_CONVOS, { limit: 30 });
+
+        for (const convo of data.convos) {
+          const msg = convo.lastMessage;
+          if (!msg || !("rev" in msg) || !msg.rev) {
+            continue;
+          }
+
+          const prev = lastRev.get(convo.id);
+
+          // No change in this conversation
+          if (prev !== undefined && msg.rev <= prev) {
+            continue;
+          }
+
+          // New activity detected — fetch full messages to find exactly what's new
+          const newMessages = await fetchNewMessages(agent, convo.id, selfDid, prev ?? "");
+
+          if (newMessages.length > 0) {
+            hadActivity = true;
+            // Update rev to the latest we fetched
+            const latestRev = newMessages.reduce(
+              (best, m) => (m.messageId > best ? m.messageId : best),
+              prev ?? "",
+            );
+            // Use the lastMessage rev from listConvos as the new watermark
+            lastRev.set(convo.id, msg.rev);
+
+            logVerbose(
+              `Bluesky: ${newMessages.length} new message(s) in convo ${convo.id} (latestRev=${latestRev})`,
+            );
+
+            for (const inbound of newMessages) {
+              if (abortSignal.aborted) {
+                stop();
+                return;
+              }
+              try {
+                await callbacks.onMessage(inbound);
+              } catch (err) {
+                callbacks.onError?.(
+                  err instanceof Error ? err : new Error(String(err)),
+                  `dispatch:${inbound.convoId}`,
+                );
+              }
+            }
+          } else {
+            // Rev changed but only our own messages — still update watermark
+            lastRev.set(convo.id, msg.rev);
+          }
+        }
+      } catch (err) {
+        callbacks.onError?.(err instanceof Error ? err : new Error(String(err)), "poll");
+      }
+
+      intervalMs = nextPollMs(intervalMs, hadActivity);
+
+      if (!abortSignal.aborted) {
+        logVerbose(`Bluesky: next poll in ${intervalMs}ms (activity=${hadActivity})`);
+        timeoutHandle = setTimeout(() => {
+          void poll();
+        }, intervalMs);
+      } else {
+        stop();
+      }
+    };
+
+    // Kick off first poll after MIN_POLL_MS
+    timeoutHandle = setTimeout(() => {
+      void poll();
+    }, MIN_POLL_MS);
+  });
+}
+
+export type { InboundMessage };

--- a/extensions/bluesky/src/poll.ts
+++ b/extensions/bluesky/src/poll.ts
@@ -43,6 +43,7 @@ type DeletedMessageView = {
 
 type GetMessagesResponse = {
   messages: Array<MessageView | DeletedMessageView>;
+  cursor?: string;
 };
 
 type InboundMessage = {
@@ -68,9 +69,15 @@ function nextPollMs(current: number, hadActivity: boolean): number {
   return Math.min(Math.round(current * BACKOFF_FACTOR), MAX_POLL_MS);
 }
 
+/** Maximum pages fetched per convo per poll cycle to bound API cost on very active convos. */
+const MAX_FETCH_PAGES = 20;
+
 /**
  * Fetch all messages in a conversation that are newer than the tracked rev.
- * Returns at most a handful of recent messages to avoid fetching full history.
+ *
+ * Paginates `getMessages` (newest-first) until it encounters a message at or
+ * before the watermark or exhausts all pages, then returns results in
+ * chronological order (oldest first) for in-order dispatch.
  */
 async function fetchNewMessages(
   agent: BskyAgent,
@@ -78,32 +85,48 @@ async function fetchNewMessages(
   selfDid: string,
   lastRev: string,
 ): Promise<InboundMessage[]> {
-  const data = await chatApiGet<GetMessagesResponse>(agent, LXM_GET_MESSAGES, {
-    convoId,
-    limit: 10,
-  });
   const results: InboundMessage[] = [];
-  for (const msg of data.messages) {
-    if (!isMessageView(msg)) {
-      continue;
-    }
-    // Skip if this message is not newer than what we've already seen
-    if (msg.rev <= lastRev) {
-      continue;
-    }
-    // Skip our own outbound messages
-    if (msg.sender.did === selfDid) {
-      continue;
-    }
-    results.push({
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_FETCH_PAGES; page++) {
+    const data = await chatApiGet<GetMessagesResponse>(agent, LXM_GET_MESSAGES, {
       convoId,
-      messageId: msg.id,
-      text: msg.text,
-      senderDid: msg.sender.did,
-      sentAt: msg.sentAt,
+      limit: 10,
+      ...(cursor ? { cursor } : {}),
     });
+
+    let reachedOld = false;
+    for (const msg of data.messages) {
+      if (!isMessageView(msg)) {
+        continue;
+      }
+      // Messages are returned newest-first; once we hit one at or before the
+      // watermark, everything further back is already processed — stop paginating.
+      if (msg.rev <= lastRev) {
+        reachedOld = true;
+        break;
+      }
+      // Skip our own outbound messages
+      if (msg.sender.did === selfDid) {
+        continue;
+      }
+      results.push({
+        convoId,
+        messageId: msg.id,
+        text: msg.text,
+        senderDid: msg.sender.did,
+        sentAt: msg.sentAt,
+      });
+    }
+
+    if (reachedOld || !data.cursor) {
+      break;
+    }
+    cursor = data.cursor;
   }
-  return results;
+
+  // Reverse to chronological order (oldest first) for in-order dispatch
+  return results.toReversed();
 }
 
 export type PollCallbacks = {

--- a/extensions/bluesky/src/poll.ts
+++ b/extensions/bluesky/src/poll.ts
@@ -71,6 +71,8 @@ function nextPollMs(current: number, hadActivity: boolean): number {
 
 /** Maximum pages fetched per convo per poll cycle to bound API cost on very active convos. */
 const MAX_FETCH_PAGES = 20;
+/** Maximum pages fetched from listConvos per poll cycle (30 convos/page → up to 300 conversations). */
+const MAX_LIST_PAGES = 10;
 
 /**
  * Fetch all messages in a conversation that are newer than the tracked rev.
@@ -129,6 +131,57 @@ async function fetchNewMessages(
   return results.toReversed();
 }
 
+/**
+ * Fetch all conversations by following the listConvos cursor.
+ *
+ * During poll cycles (lastRev provided), the API returns conversations in
+ * most-recently-active order. When a full page contains only conversations
+ * whose rev is at or before the watermark, all further pages will be older
+ * still and we stop early to avoid unnecessary API calls.
+ *
+ * During the seed phase (lastRev === null), always paginate fully so every
+ * existing conversation is watermarked before the poll loop starts.
+ */
+async function fetchAllConvos(
+  agent: BskyAgent,
+  lastRev: Map<string, string> | null,
+): Promise<ConvoView[]> {
+  const allConvos: ConvoView[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_LIST_PAGES; page++) {
+    const data = await chatApiGet<ListConvosResponse>(agent, LXM_LIST_CONVOS, {
+      limit: 30,
+      ...(cursor ? { cursor } : {}),
+    });
+
+    allConvos.push(...data.convos);
+
+    // During poll cycles: stop early if every convo on this page is unchanged —
+    // older pages will be even staler.
+    if (lastRev !== null) {
+      const allStale = data.convos.every((convo) => {
+        const msg = convo.lastMessage;
+        if (!msg || !("rev" in msg) || !msg.rev) {
+          return true;
+        }
+        const prev = lastRev.get(convo.id);
+        return prev !== undefined && msg.rev <= prev;
+      });
+      if (allStale) {
+        break;
+      }
+    }
+
+    if (!data.cursor) {
+      break;
+    }
+    cursor = data.cursor;
+  }
+
+  return allConvos;
+}
+
 export type PollCallbacks = {
   onMessage: (msg: InboundMessage) => Promise<void>;
   onError?: (err: Error, context: string) => void;
@@ -161,8 +214,8 @@ export async function runBlueSkyPollLoop(params: {
 
   // --- Seed phase: snapshot current convo state without dispatching ---
   try {
-    const seedData = await chatApiGet<ListConvosResponse>(agent, LXM_LIST_CONVOS, { limit: 50 });
-    for (const convo of seedData.convos) {
+    const seedConvos = await fetchAllConvos(agent, null);
+    for (const convo of seedConvos) {
       const msg = convo.lastMessage;
       if (msg && "rev" in msg && msg.rev) {
         lastRev.set(convo.id, msg.rev);
@@ -197,9 +250,9 @@ export async function runBlueSkyPollLoop(params: {
       let hadActivity = false;
 
       try {
-        const data = await chatApiGet<ListConvosResponse>(agent, LXM_LIST_CONVOS, { limit: 30 });
+        const convos = await fetchAllConvos(agent, lastRev);
 
-        for (const convo of data.convos) {
+        for (const convo of convos) {
           const msg = convo.lastMessage;
           if (!msg || !("rev" in msg) || !msg.rev) {
             continue;

--- a/extensions/bluesky/src/runtime.ts
+++ b/extensions/bluesky/src/runtime.ts
@@ -1,0 +1,9 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+
+const { setRuntime: setBlueskyRuntime, getRuntime: getBlueskyRuntime } =
+  createPluginRuntimeStore<PluginRuntime>(
+    "Bluesky runtime not initialized — plugin not registered",
+  );
+
+export { getBlueskyRuntime, setBlueskyRuntime };

--- a/extensions/bluesky/src/send.ts
+++ b/extensions/bluesky/src/send.ts
@@ -1,0 +1,50 @@
+import type { BskyAgent } from "@atproto/api";
+import { chatApiGet, chatApiPost } from "./auth.js";
+
+const LXM_SEND_MESSAGE = "chat.bsky.convo.sendMessage";
+const LXM_GET_CONVO_FOR_MEMBERS = "chat.bsky.convo.getConvoForMembers";
+
+type GetConvoForMembersResponse = {
+  convo: { id: string };
+};
+
+type SendMessageResponse = {
+  id: string;
+  rev: string;
+};
+
+/**
+ * Resolve a conversation ID from a DID when the caller only knows the peer DID.
+ * Bluesky DMs are keyed by convoId; this creates or retrieves the convo for a 1:1 pair.
+ */
+async function resolveConvoId(agent: BskyAgent, target: string): Promise<string> {
+  if (!target.startsWith("did:")) {
+    // Already a convoId
+    return target;
+  }
+  const data = await chatApiGet<GetConvoForMembersResponse>(agent, LXM_GET_CONVO_FOR_MEMBERS, {
+    members: target,
+  });
+  return data.convo.id;
+}
+
+/**
+ * Send a text message to a Bluesky DM conversation.
+ *
+ * @param agent - Authenticated BskyAgent for the sending account.
+ * @param target - Either a convoId or a DID (resolved to convoId automatically).
+ * @param text - The message text to send.
+ * @returns The convoId used and the new message ID.
+ */
+export async function sendBlueskyMessage(
+  agent: BskyAgent,
+  target: string,
+  text: string,
+): Promise<{ convoId: string; messageId: string }> {
+  const convoId = await resolveConvoId(agent, target);
+  const data = await chatApiPost<SendMessageResponse>(agent, LXM_SEND_MESSAGE, {
+    convoId,
+    message: { text },
+  });
+  return { convoId, messageId: data.id };
+}

--- a/extensions/bluesky/src/session-key.ts
+++ b/extensions/bluesky/src/session-key.ts
@@ -1,0 +1,23 @@
+import { buildAgentSessionKey } from "openclaw/plugin-sdk/core";
+
+const CHANNEL_ID = "bluesky";
+
+/**
+ * Build a stable session key for a Bluesky DM conversation.
+ * Keyed by convoId so the same conversation always resolves to the same agent session.
+ */
+export function buildBlueskySessionKey(params: {
+  agentId: string;
+  accountId: string;
+  convoId: string;
+  identityLinks?: Record<string, string[]>;
+}): string {
+  return buildAgentSessionKey({
+    agentId: params.agentId,
+    channel: CHANNEL_ID,
+    accountId: params.accountId,
+    peer: { kind: "direct", id: params.convoId },
+    dmScope: "per-account-channel-peer",
+    identityLinks: params.identityLinks,
+  });
+}

--- a/extensions/bluesky/src/setup-surface.ts
+++ b/extensions/bluesky/src/setup-surface.ts
@@ -1,0 +1,212 @@
+import type { ChannelSetupAdapter } from "openclaw/plugin-sdk/channel-setup";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
+import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
+import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import {
+  createStandardChannelSetupStatus,
+  formatDocsLink,
+  patchTopLevelChannelConfigSection,
+} from "openclaw/plugin-sdk/setup";
+import { resolveBlueskyAccount } from "./accounts.js";
+import type { BlueskyChannelConfig } from "./types.js";
+
+const channel = "bluesky" as const;
+
+const DEFAULT_PDS_URL = "https://bsky.social";
+
+const BLUESKY_SETUP_HELP_LINES = [
+  "Create an App Password at: Settings → Privacy and Security → App Passwords",
+  "Use an App Password — do not use your main Bluesky account password.",
+  "Env vars supported: BLUESKY_HANDLE, BLUESKY_APP_PASSWORD, BLUESKY_PDS_URL.",
+  `Docs: ${formatDocsLink("/channels/bluesky", "channels/bluesky")}`,
+];
+
+function getBlueskyChannelConfig(cfg: Record<string, unknown>): BlueskyChannelConfig | undefined {
+  const channels = cfg?.channels as Record<string, unknown> | undefined;
+  return channels?.bluesky as BlueskyChannelConfig | undefined;
+}
+
+export const blueskySetupAdapter: ChannelSetupAdapter = {
+  resolveAccountId: ({ accountId }) => accountId?.trim() || DEFAULT_ACCOUNT_ID,
+  applyAccountConfig: ({ cfg, input }) => {
+    // inputKey mapping: token → appPassword, name → handle, url → pdsUrl
+    const typedInput = input as { name?: string; token?: string; url?: string };
+    const patch: Record<string, unknown> = {};
+    if (typedInput.name?.trim()) {
+      patch.handle = typedInput.name.trim();
+    }
+    if (typedInput.token?.trim()) {
+      patch.appPassword = typedInput.token.trim();
+    }
+    if (typedInput.url?.trim()) {
+      patch.pdsUrl = typedInput.url.trim();
+    }
+    return patchTopLevelChannelConfigSection({ cfg, channel, enabled: true, patch });
+  },
+};
+
+export const blueskySetupWizard: ChannelSetupWizard = {
+  channel,
+  resolveAccountIdForConfigure: ({ accountOverride, defaultAccountId }) =>
+    accountOverride?.trim() || defaultAccountId,
+  resolveShouldPromptAccountIds: () => false,
+  status: createStandardChannelSetupStatus({
+    channelLabel: "Bluesky",
+    configuredLabel: "configured",
+    unconfiguredLabel: "needs handle and app password",
+    configuredHint: "configured",
+    unconfiguredHint: "needs handle and app password",
+    configuredScore: 1,
+    unconfiguredScore: 0,
+    includeStatusLine: true,
+    resolveConfigured: ({ cfg }) =>
+      resolveBlueskyAccount(cfg as Record<string, unknown>).configured,
+    resolveExtraStatusLines: ({ cfg }) => {
+      const account = resolveBlueskyAccount(cfg as Record<string, unknown>);
+      if (!account.configured) {
+        return [];
+      }
+      return [`Handle: @${account.handle}`, `PDS: ${account.pdsUrl}`];
+    },
+  }),
+  introNote: {
+    title: "Bluesky setup",
+    lines: BLUESKY_SETUP_HELP_LINES,
+  },
+  envShortcut: {
+    prompt: "BLUESKY_HANDLE and BLUESKY_APP_PASSWORD detected. Use env vars?",
+    preferredEnvVar: "BLUESKY_APP_PASSWORD",
+    isAvailable: ({ cfg, accountId }) =>
+      accountId === DEFAULT_ACCOUNT_ID &&
+      Boolean(process.env.BLUESKY_HANDLE?.trim()) &&
+      Boolean(process.env.BLUESKY_APP_PASSWORD?.trim()) &&
+      !resolveBlueskyAccount(cfg as Record<string, unknown>).configured,
+    apply: async ({ cfg }) =>
+      patchTopLevelChannelConfigSection({
+        cfg,
+        channel,
+        enabled: true,
+        clearFields: ["handle", "appPassword"],
+        patch: {},
+      }),
+  },
+  credentials: [
+    {
+      inputKey: "token",
+      providerHint: channel,
+      credentialLabel: "app password",
+      preferredEnvVar: "BLUESKY_APP_PASSWORD",
+      helpTitle: "Bluesky App Password",
+      helpLines: BLUESKY_SETUP_HELP_LINES,
+      envPrompt: "BLUESKY_APP_PASSWORD detected. Use env var?",
+      keepPrompt: "Bluesky app password already configured. Keep it?",
+      inputPrompt: "Bluesky App Password (xxxx-xxxx-xxxx-xxxx)",
+      allowEnv: ({ accountId }) => accountId === DEFAULT_ACCOUNT_ID,
+      inspect: ({ cfg, accountId }) => {
+        const account = resolveBlueskyAccount(cfg as Record<string, unknown>, accountId);
+        const channelCfg = getBlueskyChannelConfig(cfg as Record<string, unknown>);
+        const rawAppPassword =
+          accountId !== DEFAULT_ACCOUNT_ID
+            ? channelCfg?.accounts?.[accountId]?.appPassword
+            : channelCfg?.appPassword;
+        return {
+          accountConfigured: account.configured,
+          hasConfiguredValue: hasConfiguredSecretInput(rawAppPassword),
+          resolvedValue: account.appPassword,
+          envValue:
+            accountId === DEFAULT_ACCOUNT_ID ? process.env.BLUESKY_APP_PASSWORD?.trim() : undefined,
+        };
+      },
+      applyUseEnv: async ({ cfg }) =>
+        patchTopLevelChannelConfigSection({
+          cfg,
+          channel,
+          enabled: true,
+          clearFields: ["appPassword"],
+          patch: {},
+        }),
+      applySet: async ({ cfg, resolvedValue }) =>
+        patchTopLevelChannelConfigSection({
+          cfg,
+          channel,
+          enabled: true,
+          patch: { appPassword: resolvedValue },
+        }),
+    },
+  ],
+  textInputs: [
+    {
+      inputKey: "name",
+      message: "Bluesky handle (e.g. yourbot.bsky.social)",
+      placeholder: "yourbot.bsky.social",
+      required: true,
+      applyEmptyValue: false,
+      helpTitle: "Bluesky handle",
+      helpLines: ["Your bot account handle, including the domain.", "Example: mybot.bsky.social"],
+      currentValue: ({ cfg, accountId }) =>
+        resolveBlueskyAccount(cfg as Record<string, unknown>, accountId).handle,
+      keepPrompt: (value) => `Handle set to @${value}. Keep it?`,
+      validate: ({ value }) => {
+        if (!value.trim()) {
+          return "Handle is required.";
+        }
+        if (!value.includes(".")) {
+          return "Handle must include the domain (e.g. yourbot.bsky.social).";
+        }
+        return undefined;
+      },
+      applySet: async ({ cfg, value }) =>
+        patchTopLevelChannelConfigSection({
+          cfg,
+          channel,
+          enabled: true,
+          patch: { handle: value.trim() },
+        }),
+    },
+    {
+      inputKey: "url",
+      message: "Personal Data Server URL (optional, leave blank for bsky.social)",
+      placeholder: DEFAULT_PDS_URL,
+      required: false,
+      applyEmptyValue: true,
+      helpTitle: "Bluesky PDS URL",
+      helpLines: [
+        "Only set this if you use a self-hosted PDS.",
+        `Leave blank to use the default: ${DEFAULT_PDS_URL}`,
+      ],
+      currentValue: ({ cfg }) => {
+        const channelCfg = getBlueskyChannelConfig(cfg as Record<string, unknown>);
+        return channelCfg?.pdsUrl?.trim() ?? "";
+      },
+      keepPrompt: (value) => `PDS URL set to ${value}. Keep it?`,
+      validate: ({ value }) => {
+        if (!value.trim()) {
+          return undefined;
+        }
+        try {
+          const url = new URL(value.trim());
+          if (url.protocol !== "https:" && url.protocol !== "http:") {
+            return "PDS URL must use https:// or http://";
+          }
+        } catch {
+          return "Invalid PDS URL.";
+        }
+        return undefined;
+      },
+      applySet: async ({ cfg, value }) =>
+        patchTopLevelChannelConfigSection({
+          cfg,
+          channel,
+          enabled: true,
+          clearFields: value.trim() ? undefined : ["pdsUrl"],
+          patch: value.trim() ? { pdsUrl: value.trim() } : {},
+        }),
+    },
+  ],
+  disable: (cfg) =>
+    patchTopLevelChannelConfigSection({
+      cfg,
+      channel,
+      patch: { enabled: false },
+    }),
+};

--- a/extensions/bluesky/src/setup-surface.ts
+++ b/extensions/bluesky/src/setup-surface.ts
@@ -183,9 +183,10 @@ export const blueskySetupWizard: ChannelSetupWizard = {
         "Only set this if you use a self-hosted PDS.",
         `Leave blank to use the default: ${DEFAULT_PDS_URL}`,
       ],
-      currentValue: ({ cfg }) => {
-        const channelCfg = getBlueskyChannelConfig(cfg as Record<string, unknown>);
-        return channelCfg?.pdsUrl?.trim() ?? "";
+      currentValue: ({ cfg, accountId }) => {
+        return (
+          resolveBlueskyAccount(cfg as Record<string, unknown>, accountId).pdsUrl?.trim() ?? ""
+        );
       },
       keepPrompt: (value) => `PDS URL set to ${value}. Keep it?`,
       validate: ({ value }) => {

--- a/extensions/bluesky/src/setup-surface.ts
+++ b/extensions/bluesky/src/setup-surface.ts
@@ -5,6 +5,7 @@ import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
 import {
   createStandardChannelSetupStatus,
   formatDocsLink,
+  patchScopedAccountConfig,
   patchTopLevelChannelConfigSection,
 } from "openclaw/plugin-sdk/setup";
 import { resolveBlueskyAccount } from "./accounts.js";
@@ -28,7 +29,7 @@ function getBlueskyChannelConfig(cfg: Record<string, unknown>): BlueskyChannelCo
 
 export const blueskySetupAdapter: ChannelSetupAdapter = {
   resolveAccountId: ({ accountId }) => accountId?.trim() || DEFAULT_ACCOUNT_ID,
-  applyAccountConfig: ({ cfg, input }) => {
+  applyAccountConfig: ({ cfg, accountId, input }) => {
     // inputKey mapping: token → appPassword, name → handle, url → pdsUrl
     const typedInput = input as { name?: string; token?: string; url?: string };
     const patch: Record<string, unknown> = {};
@@ -41,7 +42,13 @@ export const blueskySetupAdapter: ChannelSetupAdapter = {
     if (typedInput.url?.trim()) {
       patch.pdsUrl = typedInput.url.trim();
     }
-    return patchTopLevelChannelConfigSection({ cfg, channel, enabled: true, patch });
+    return patchScopedAccountConfig({
+      cfg,
+      channelKey: channel,
+      accountId,
+      patch,
+      ensureChannelEnabled: true,
+    });
   },
 };
 
@@ -125,12 +132,13 @@ export const blueskySetupWizard: ChannelSetupWizard = {
           clearFields: ["appPassword"],
           patch: {},
         }),
-      applySet: async ({ cfg, resolvedValue }) =>
-        patchTopLevelChannelConfigSection({
+      applySet: async ({ cfg, accountId, resolvedValue }) =>
+        patchScopedAccountConfig({
           cfg,
-          channel,
-          enabled: true,
+          channelKey: channel,
+          accountId,
           patch: { appPassword: resolvedValue },
+          ensureChannelEnabled: true,
         }),
     },
   ],
@@ -155,12 +163,13 @@ export const blueskySetupWizard: ChannelSetupWizard = {
         }
         return undefined;
       },
-      applySet: async ({ cfg, value }) =>
-        patchTopLevelChannelConfigSection({
+      applySet: async ({ cfg, accountId, value }) =>
+        patchScopedAccountConfig({
           cfg,
-          channel,
-          enabled: true,
+          channelKey: channel,
+          accountId,
           patch: { handle: value.trim() },
+          ensureChannelEnabled: true,
         }),
     },
     {
@@ -193,14 +202,28 @@ export const blueskySetupWizard: ChannelSetupWizard = {
         }
         return undefined;
       },
-      applySet: async ({ cfg, value }) =>
-        patchTopLevelChannelConfigSection({
+      applySet: async ({ cfg, accountId, value }) => {
+        const trimmed = value.trim();
+        if (accountId === DEFAULT_ACCOUNT_ID) {
+          // patchTopLevelChannelConfigSection supports clearFields, needed to
+          // remove pdsUrl from the top-level section when the user clears it.
+          return patchTopLevelChannelConfigSection({
+            cfg,
+            channel,
+            enabled: true,
+            clearFields: trimmed ? undefined : ["pdsUrl"],
+            patch: trimmed ? { pdsUrl: trimmed } : {},
+          });
+        }
+        return patchScopedAccountConfig({
           cfg,
-          channel,
-          enabled: true,
-          clearFields: value.trim() ? undefined : ["pdsUrl"],
-          patch: value.trim() ? { pdsUrl: value.trim() } : {},
-        }),
+          channelKey: channel,
+          accountId,
+          // undefined drops the key from the serialized config, effectively clearing it.
+          patch: { pdsUrl: trimmed || undefined },
+          ensureChannelEnabled: true,
+        });
+      },
     },
   ],
   disable: (cfg) =>

--- a/extensions/bluesky/src/types.ts
+++ b/extensions/bluesky/src/types.ts
@@ -1,0 +1,24 @@
+export type BlueskyChannelConfig = {
+  enabled?: boolean;
+  handle?: string;
+  appPassword?: string;
+  /** Personal Data Server URL — defaults to https://bsky.social */
+  pdsUrl?: string;
+  accounts?: Record<string, BlueskyAccountConfig>;
+};
+
+export type BlueskyAccountConfig = {
+  enabled?: boolean;
+  handle?: string;
+  appPassword?: string;
+  pdsUrl?: string;
+};
+
+export type ResolvedBlueskyAccount = {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
+  handle: string;
+  appPassword: string;
+  pdsUrl: string;
+};

--- a/extensions/bluesky/src/types.ts
+++ b/extensions/bluesky/src/types.ts
@@ -4,6 +4,8 @@ export type BlueskyChannelConfig = {
   appPassword?: string;
   /** Personal Data Server URL — defaults to https://bsky.social */
   pdsUrl?: string;
+  /** Explicit default account id used when no accountId is supplied to outbound sends. */
+  defaultAccount?: string;
   accounts?: Record<string, BlueskyAccountConfig>;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/bluesky:
+    dependencies:
+      '@atproto/api':
+        specifier: ^0.13.0
+        version: 0.13.35
+
   extensions/brave:
     devDependencies:
       '@openclaw/plugin-sdk':
@@ -1342,6 +1348,33 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@atproto/api@0.13.35':
+    resolution: {integrity: sha512-vsEfBj0C333TLjDppvTdTE0IdKlXuljKSveAeI4PPx/l6eUKNnDTsYxvILtXUVzwUlTDmSRqy5O4Ryh78n1b7g==}
+
+  '@atproto/common-web@0.4.19':
+    resolution: {integrity: sha512-3BTi58p5WpT+9/zb6UZrdsXcfPo5P45UJm0E4iwHLILr+jc37CuBj9JReDSZ4U0i9RTrI3ZkfySyZ9bd+LnMsw==}
+
+  '@atproto/lex-data@0.0.14':
+    resolution: {integrity: sha512-53DUa9664SS76nGAMYopWsO10OH0AAdf7P/HSKB6Wzx3iqe6lk/K61QZnKxOG1LreYl5CfvIJU6eNf4txI6GlQ==}
+
+  '@atproto/lex-json@0.0.14':
+    resolution: {integrity: sha512-6lPkDKqe7teEu4WrN5q7400cvZKgYS3uwUMvzG3F9XkgVYhOwSDCtouV/nSLBbpvo3l9OP0kiigtclcNcyekww==}
+
+  '@atproto/lexicon@0.4.14':
+    resolution: {integrity: sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==}
+
+  '@atproto/syntax@0.3.4':
+    resolution: {integrity: sha512-8CNmi5DipOLaVeSMPggMe7FCksVag0aO6XZy9WflbduTKM4dFZVCs4686UeMLfGRXX+X966XgwECHoLYrovMMg==}
+
+  '@atproto/syntax@0.4.3':
+    resolution: {integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==}
+
+  '@atproto/syntax@0.5.3':
+    resolution: {integrity: sha512-gzhlHOJHm5KXdCc17fXi1fXM81ccs5jJfNgCui84ay9JGvczxegpYHNqdMlv+iBuhtBzFIjgx6ChjRxN/kO8kQ==}
+
+  '@atproto/xrpc@0.6.12':
+    resolution: {integrity: sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -4410,6 +4443,9 @@ packages:
     resolution: {integrity: sha512-dK9Z/P83C/rBfTrXXgPD3jZ+aXxx2o/P4rq8+H1JqxbXklitEeJw4CrcwMC5CkON3CX3yy2gaWnIEVYejYh0zQ==}
     engines: {node: '>=14'}
 
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
   await-to-js@3.0.0:
     resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
     engines: {node: '>=6.0.0'}
@@ -5459,6 +5495,9 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
+  iso-datestring-validator@2.2.2:
+    resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -5911,6 +5950,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multiformats@9.9.0:
+    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
   music-metadata@11.12.3:
     resolution: {integrity: sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==}
@@ -6939,6 +6981,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -7050,6 +7096,9 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
+  uint8arrays@3.0.0:
+    resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
+
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
@@ -7072,6 +7121,9 @@ packages:
 
   unhomoglyph@1.0.6:
     resolution: {integrity: sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg==}
+
+  unicode-segmenter@0.14.5:
+    resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -7426,6 +7478,59 @@ snapshots:
       is-potential-custom-element-name: 1.0.1
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@atproto/api@0.13.35':
+    dependencies:
+      '@atproto/common-web': 0.4.19
+      '@atproto/lexicon': 0.4.14
+      '@atproto/syntax': 0.3.4
+      '@atproto/xrpc': 0.6.12
+      await-lock: 2.2.2
+      multiformats: 9.9.0
+      tlds: 1.261.0
+      zod: 3.25.76
+
+  '@atproto/common-web@0.4.19':
+    dependencies:
+      '@atproto/lex-data': 0.0.14
+      '@atproto/lex-json': 0.0.14
+      '@atproto/syntax': 0.5.3
+      zod: 3.25.76
+
+  '@atproto/lex-data@0.0.14':
+    dependencies:
+      multiformats: 9.9.0
+      tslib: 2.8.1
+      uint8arrays: 3.0.0
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.0.14':
+    dependencies:
+      '@atproto/lex-data': 0.0.14
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.4.14':
+    dependencies:
+      '@atproto/common-web': 0.4.19
+      '@atproto/syntax': 0.4.3
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/syntax@0.3.4': {}
+
+  '@atproto/syntax@0.4.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/syntax@0.5.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.6.12':
+    dependencies:
+      '@atproto/lexicon': 0.4.14
+      zod: 3.25.76
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -11083,6 +11188,8 @@ snapshots:
   audio-type@2.4.1:
     optional: true
 
+  await-lock@2.2.2: {}
+
   await-to-js@3.0.0: {}
 
   axios@1.15.0:
@@ -12223,6 +12330,8 @@ snapshots:
 
   isexe@4.0.0: {}
 
+  iso-datestring-validator@2.2.2: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -12714,6 +12823,8 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  multiformats@9.9.0: {}
 
   music-metadata@11.12.3:
     dependencies:
@@ -13983,6 +14094,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tlds@1.261.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -14078,6 +14191,10 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
+  uint8arrays@3.0.0:
+    dependencies:
+      multiformats: 9.9.0
+
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -14094,6 +14211,8 @@ snapshots:
   undici@8.0.2: {}
 
   unhomoglyph@1.0.6: {}
+
+  unicode-segmenter@0.14.5: {}
 
   unist-util-is@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a new bundled Bluesky channel plugin so OpenClaw can receive and respond to Bluesky DMs via the `chat.bsky.*` AT Protocol lexicons.

- **Problem:** No Bluesky channel support; users on Bluesky had no way to connect an OpenClaw agent to their DMs.
- **Why it matters:** Bluesky is a growing decentralised social platform with an open DM API; adding it follows the same pattern as other bundled channels (Nostr, Zalo, etc.).
- **What changed:** New `extensions/bluesky` package — AT Proto auth with service token caching, adaptive polling loop, inbound dispatch with open-DM slash command authorization, outbound send, multi-account support, interactive setup wizard, and full docs.
- **What did NOT change:** Core gateway, routing, or plugin SDK contracts — the plugin is self-contained and communicates only through `openclaw/plugin-sdk/*`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — new plugin, no prior behaviour to regress. No unit tests added; the plugin surface is covered by manual verification below and the existing plugin contract/SDK tests that all bundled channel plugins satisfy.

- If no new test is added, why not: no test infrastructure exists yet for network-polling channel plugins; a future test could mock `chatApiGet` to exercise the polling and dispatch paths.

## User-visible / Behavior Changes

- New channel: `bluesky` is now available in `openclaw onboard`, `openclaw configure bluesky`, and `openclaw channels status`.
- Config keys: `channels.bluesky.handle`, `channels.bluesky.appPassword`, `channels.bluesky.pdsUrl`, `channels.bluesky.accounts` (multi-account).
- Env shortcuts: `BLUESKY_HANDLE`, `BLUESKY_APP_PASSWORD`.

## Diagram (if applicable)

```text
Before:
[Bluesky DM] -> (no handler)

After:
[Bluesky DM] -> poll loop -> inbound dispatch -> agent -> sendBlueskyMessage -> [Bluesky DM reply]
```

## Security Impact (required)

- New permissions/capabilities? **No** — plugin uses existing `ChannelPlugin` contract.
- Secrets/tokens handling changed? **Yes** — app password stored under `channels.bluesky.appPassword`; supports SecretRef. Short-lived service auth JWTs are cached in-process (25 min TTL, evicted on 401). Credentials are never logged.
- New/changed network calls? **Yes** — outbound HTTPS to `bsky.social` (or configured `pdsUrl`) for login and to `api.bsky.chat` for all `chat.bsky.*` lexicon calls.
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- Risk: App password exposure if config file is world-readable. Mitigation: recommend SecretRef or env vars; existing Gateway config file permission guidance applies.

## Repro + Verification

### Environment

- OS: Linux (Raspberry Pi / Raspberry Pi OS)
- Runtime/container: Node 22, bun
- Model/provider: default
- Integration/channel: Bluesky
- Relevant config (redacted):
  ```json
  { "channels": { "bluesky": { "handle": "<bot>.bsky.social", "appPassword": "xxxx-xxxx-xxxx-xxxx" } }, "bindings": [{ "agentId": "<agent>", "channel": "bluesky" }] }
  ```

### Steps

1. Run `openclaw configure bluesky`, enter handle and app password
2. Restart the Gateway
3. Send a DM to the bot account from another Bluesky account
4. Send a slash command DM (e.g. `/status`)

### Expected

- Regular DM: agent receives message and replies within the poll interval
- Slash command: command executes and response is sent back to the DM conversation

### Actual

- Regular DM: ✅ agent responds
- Slash command: ✅ command executes and response returned (required fixing `configured:true` in the command authorizer — see `fix(bluesky): authorize DM slash commands` commit)

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording — verified live against a real Bluesky bot account
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: interactive setup wizard prompts and writes config; Gateway starts and authenticates; inbound regular DM dispatched to agent and reply sent; inbound slash command dispatched and response returned; polling backs off correctly during idle periods.
- Edge cases checked: bot ignores its own outbound messages (self-DID filter); 401 on chat API evicts token and retries once; named accounts resolve correctly when no top-level credentials are set.
- What you did **not** verify: multi-account (two named accounts simultaneously);  `openclaw onboard` full flow from scratch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — plugin is disabled by default until `channels.bluesky` is configured; no existing channel or core code changed.
- Config/env changes? **Yes** — new `channels.bluesky.*` keys (all optional/additive).
- Migration needed? **No**

## Risks and Mitigations

- Risk: Polling adds steady background HTTPS traffic to `bsky.social` per configured account.
  - Mitigation: Adaptive backoff caps at 90 s idle; a single idle bot makes ~40 requests/hour at max backoff — well within Bluesky's rate limits.
- Risk: No allowlist — any Bluesky user who can DM the bot can issue slash commands.
  - Mitigation: Documented limitation. Matches Bluesky's open-DM model; a future pairing/allowlist seam could be added when the AT Protocol exposes one.

<img width="301" height="635" alt="Screenshot 2026-04-11 at 22 30 37" src="https://github.com/user-attachments/assets/2766b484-7166-4df7-9f3c-90b0afcfc52c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)