### PR TITLE
fix: surface_error failover now throws FailoverError to prevent UI hang

### DIFF
--- a/src/agents/pi-embedded-runner/run/assistant-failover.surface-error-throws.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.surface-error-throws.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleAssistantFailover } from "./assistant-failover.js";
+
+/**
+ * Regression tests for #64793: surface_error decisions must throw a
+ * FailoverError so the error propagates to the UI instead of silently
+ * completing as "continue_normal" and leaving the WebSocket client hanging.
+ */
+
+function createBaseParams(
+  overrides: Partial<Parameters<typeof handleAssistantFailover>[0]> = {},
+): Parameters<typeof handleAssistantFailover>[0] {
+  return {
+    initialDecision: { action: "surface_error", reason: "timeout" },
+    aborted: false,
+    fallbackConfigured: false,
+    failoverFailure: false,
+    failoverReason: "timeout",
+    timedOut: true,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    allowSameModelIdleTimeoutRetry: false,
+    assistantProfileFailureReason: null,
+    lastProfileId: "profile-1",
+    modelId: "minimax-m2.5",
+    provider: "nvidia",
+    activeErrorContext: { provider: "nvidia", model: "minimax-m2.5" },
+    lastAssistant: undefined,
+    config: undefined,
+    sessionKey: "session-1",
+    authFailure: false,
+    rateLimitFailure: false,
+    billingFailure: false,
+    cloudCodeAssistFormatError: false,
+    isProbeSession: false,
+    overloadProfileRotations: 0,
+    overloadProfileRotationLimit: 3,
+    previousRetryFailoverReason: null,
+    logAssistantFailoverDecision: vi.fn(),
+    warn: vi.fn(),
+    maybeMarkAuthProfileFailure: vi.fn().mockResolvedValue(undefined),
+    maybeEscalateRateLimitProfileFallback: vi.fn(),
+    maybeBackoffBeforeOverloadFailover: vi.fn().mockResolvedValue(undefined),
+    advanceAuthProfile: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  };
+}
+
+describe("handleAssistantFailover — surface_error produces throw", () => {
+  it("returns throw action with FailoverError for timeout surface_error", async () => {
+    const params = createBaseParams();
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      throw new Error("Expected throw action");
+    }
+    expect(outcome.error).toBeDefined();
+    expect(outcome.error.message).toContain("timed out");
+    expect(outcome.error.reason).toBe("timeout");
+    expect(outcome.error.status).toBe(408);
+    expect(outcome.error.provider).toBe("nvidia");
+    expect(outcome.error.model).toBe("minimax-m2.5");
+  });
+
+  it("logs surface_error before throwing", async () => {
+    const logFn = vi.fn();
+    const params = createBaseParams({
+      logAssistantFailoverDecision: logFn,
+    });
+    await handleAssistantFailover(params);
+
+    expect(logFn).toHaveBeenCalledWith("surface_error");
+  });
+
+  it("returns throw action with billing message for billing failures", async () => {
+    const params = createBaseParams({
+      initialDecision: { action: "surface_error", reason: "billing" },
+      failoverReason: "billing",
+      timedOut: false,
+      billingFailure: true,
+    });
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      throw new Error("Expected throw action");
+    }
+    expect(outcome.error.reason).toBe("billing");
+    expect(outcome.error.status).toBe(402);
+  });
+
+  it("returns throw action with rate_limit message", async () => {
+    const params = createBaseParams({
+      initialDecision: { action: "surface_error", reason: "rate_limit" },
+      failoverReason: "rate_limit",
+      timedOut: false,
+      rateLimitFailure: true,
+    });
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      throw new Error("Expected throw action");
+    }
+    expect(outcome.error.message).toContain("rate limited");
+    expect(outcome.error.reason).toBe("rate_limit");
+    expect(outcome.error.status).toBe(429);
+  });
+
+  it("returns throw action with auth message for auth failures", async () => {
+    const params = createBaseParams({
+      initialDecision: { action: "surface_error", reason: "auth" },
+      failoverReason: "auth",
+      timedOut: false,
+      authFailure: true,
+    });
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      throw new Error("Expected throw action");
+    }
+    expect(outcome.error.message).toContain("unauthorized");
+    expect(outcome.error.reason).toBe("auth");
+    expect(outcome.error.status).toBe(401);
+  });
+
+  it("falls back to generic message when no specific failure is detected", async () => {
+    const params = createBaseParams({
+      initialDecision: { action: "surface_error", reason: "unknown" },
+      failoverReason: "unknown",
+      timedOut: false,
+    });
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      throw new Error("Expected throw action");
+    }
+    expect(outcome.error.message).toBe("LLM request failed.");
+    expect(outcome.error.reason).toBe("unknown");
+  });
+
+  it("still allows idle timeout retry before throwing", async () => {
+    const params = createBaseParams({
+      idleTimedOut: true,
+      allowSameModelIdleTimeoutRetry: true,
+    });
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("retry");
+    if (outcome.action !== "retry") {
+      throw new Error("Expected retry action");
+    }
+    expect(outcome.retryKind).toBe("same_model_idle_timeout");
+  });
+
+  it("preserves continue_normal for non-error decisions", async () => {
+    const params = createBaseParams({
+      initialDecision: { action: "continue_normal" },
+      failoverReason: null,
+      timedOut: false,
+    });
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("continue_normal");
+  });
+
+  it("uses null failover reason when decision.reason is null and not timed out", async () => {
+    const params = createBaseParams({
+      initialDecision: { action: "surface_error", reason: null },
+      failoverReason: null,
+      timedOut: false,
+    });
+    const outcome = await handleAssistantFailover(params);
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      throw new Error("Expected throw action");
+    }
+    // When reason is null and not timed out, should use "unknown"
+    expect(outcome.error.reason).toBe("unknown");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -223,6 +223,44 @@ export async function handleAssistantFailover(params: {
       return sameModelIdleTimeoutRetry();
     }
     params.logAssistantFailoverDecision("surface_error");
+    // Surface the error as a throw so the caller can propagate it to the UI.
+    // Previously this fell through to "continue_normal", which silently
+    // swallowed the error and left the UI hanging when the WebSocket
+    // connection was torn down before any final event could be sent.
+    const surfaceMessage = params.timedOut
+      ? "LLM request timed out."
+      : params.billingFailure
+        ? formatBillingErrorMessage(
+            params.activeErrorContext.provider,
+            params.activeErrorContext.model,
+          )
+        : params.rateLimitFailure
+          ? "LLM request rate limited."
+          : params.authFailure
+            ? "LLM request unauthorized."
+            : (params.lastAssistant
+                ? formatAssistantErrorText(params.lastAssistant, {
+                    cfg: params.config,
+                    sessionKey: params.sessionKey,
+                    provider: params.activeErrorContext.provider,
+                    model: params.activeErrorContext.model,
+                  })
+                : undefined) ||
+              params.lastAssistant?.errorMessage?.trim() ||
+              "LLM request failed.";
+    const surfaceReason: FailoverReason = decision.reason ?? (params.timedOut ? "timeout" : "unknown");
+    const status = resolveFailoverStatus(surfaceReason) ?? (isTimeoutErrorMessage(surfaceMessage) ? 408 : undefined);
+    return {
+      action: "throw",
+      overloadProfileRotations,
+      error: new FailoverError(surfaceMessage, {
+        reason: surfaceReason,
+        provider: params.activeErrorContext.provider,
+        model: params.activeErrorContext.model,
+        profileId: params.lastProfileId,
+        status,
+      }),
+    };
   }
 
   return {

--- a/src/agents/pi-embedded-runner/run/failover-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.test.ts
@@ -111,6 +111,40 @@ describe("resolveRunFailoverDecision", () => {
       action: "continue_normal",
     });
   });
+
+  it("surfaces error for timeout when no fallback is configured and rotation is exhausted", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        fallbackConfigured: false,
+        failoverFailure: false,
+        failoverReason: "timeout",
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: "timeout",
+    });
+  });
+
+  it("surfaces error for timeout when no fallback is configured and not rotated", () => {
+    // When timedOut=true and not during compaction, shouldRotateAssistant returns true.
+    // With profileRotated=true and no fallback, we get surface_error.
+    const decision = resolveRunFailoverDecision({
+      stage: "assistant",
+      aborted: false,
+      fallbackConfigured: false,
+      failoverFailure: false,
+      failoverReason: null,
+      timedOut: true,
+      timedOutDuringCompaction: false,
+      profileRotated: true,
+    });
+    expect(decision.action).toBe("surface_error");
+  });
 });
 
 describe("mergeRetryFailoverReason", () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2093,6 +2093,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
 
       let agentRunStarted = false;
+      let terminalEventSent = false;
       void dispatchInboundMessage({
         ctx,
         cfg,
@@ -2155,6 +2156,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                 runId: clientRunId,
                 sessionKey,
               });
+              terminalEventSent = true;
             } else {
               const combinedReply = buildTranscriptReplyText(
                 deliveredReplies
@@ -2198,9 +2200,14 @@ export const chatHandlers: GatewayRequestHandlers = {
                 sessionKey,
                 message,
               });
+              terminalEventSent = true;
             }
           } else {
             void emitUserTranscriptUpdate();
+            // Agent run was started — the streaming infrastructure sends its
+            // own terminal events, so mark as sent to avoid the .finally()
+            // safety net from emitting a spurious error broadcast.
+            terminalEventSent = true;
           }
           setGatewayDedupeEntry({
             dedupe: context.dedupe,
@@ -2244,8 +2251,26 @@ export const chatHandlers: GatewayRequestHandlers = {
             sessionKey,
             errorMessage: String(err),
           });
+          terminalEventSent = true;
         })
         .finally(() => {
+          // Safety net: if neither the .then() nor .catch() branch managed to
+          // send a terminal chat event (e.g. due to a connection abort race),
+          // emit an error event so the UI never hangs indefinitely.
+          if (!terminalEventSent) {
+            try {
+              broadcastChatError({
+                context,
+                runId: clientRunId,
+                sessionKey,
+                errorMessage:
+                  "Agent run ended without sending a final response. " +
+                  "This may indicate a timeout or connection interruption.",
+              });
+            } catch {
+              // Best-effort — if broadcast itself fails the run is already over.
+            }
+          }
           context.chatAbortControllers.delete(clientRunId);
         });
     } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #64793

When an LLM request times out and the failover policy decides to `surface_error`, the `handleAssistantFailover` function previously fell through to return `{ action: "continue_normal" }`, silently swallowing the error. This caused the WebSocket connection to abort before any `final` or `error` event could be broadcast to the UI, leaving the client spinner hanging indefinitely.

- **`assistant-failover.ts`**: `surface_error` decisions now return `{ action: "throw" }` with a properly constructed `FailoverError`, ensuring the error propagates through the promise chain to `broadcastChatError`
- **`chat.ts`**: Added a `terminalEventSent` safety net in the `.finally()` handler — if neither `.then()` nor `.catch()` managed to broadcast a terminal event (e.g. due to a connection abort race), a fallback error event is emitted
- **Tests**: Added 9 regression tests covering timeout, billing, rate-limit, auth, generic failure, idle-timeout retry, and continue_normal preservation scenarios; extended `failover-policy.test.ts` with 2 timeout surface_error policy assertions

## Test plan

- [x] `assistant-failover.surface-error-throws.test.ts` — 9 tests pass
- [x] `failover-policy.test.ts` — all assertions pass with new timeout cases
- [ ] Manual: deploy with a slow LLM provider (e.g. minimax-m2.5 via NVIDIA API), trigger timeout, verify UI displays error instead of hanging
- [ ] Verify existing retry/fallback behavior is preserved (idle timeout retry, profile rotation, model fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)