### PR TITLE
fix: avoid heartbeat preempting active reply runs

### DIFF
--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createReplyOperation } from "../auto-reply/reply/reply-run-registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -89,6 +90,62 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         expect(result.reason).toBe("requests-in-flight");
       }
       expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("returns requests-in-flight when a reply run is still active for the session", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            heartbeat: { every: "30m" },
+            model: { primary: "test/model" },
+          },
+        },
+        channels: {
+          telegram: {
+            enabled: true,
+            token: "fake",
+            allowFrom: ["123"],
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      enqueueSystemEvent("Exec completed (test-id, code 0) :: test output", {
+        sessionKey,
+      });
+
+      const op = createReplyOperation({
+        sessionKey,
+        sessionId: "session-active-reply",
+        resetTriggered: false,
+      });
+      op.setPhase("running");
+
+      try {
+        const result = await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getQueueSize: () => 0,
+            nowMs: () => Date.now(),
+            getReplyFromConfig: replySpy,
+          } as HeartbeatDeps,
+        });
+
+        expect(result.status).toBe("skipped");
+        if (result.status === "skipped") {
+          expect(result.reason).toBe("requests-in-flight");
+        }
+        expect(replySpy).not.toHaveBeenCalled();
+      } finally {
+        op.complete();
+      }
     });
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -13,6 +13,7 @@ import {
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
 import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner.js";
+import { resolveActiveReplyRunSessionId } from "../auto-reply/reply/reply-run-registry.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
@@ -725,6 +726,20 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: preflight.skipReason };
   }
   const { entry, sessionKey, storePath, suppressOriginatingContext } = preflight.session;
+
+  // A reply run can remain active for this session even after the command lane
+  // itself has drained, for example while the active assistant turn is still
+  // finishing provider/output cleanup. In that window, a heartbeat/system-event
+  // wake would race the user-visible reply and can effectively swallow it.
+  // Skip and let heartbeat-wake retry shortly instead of preempting the turn.
+  if (resolveActiveReplyRunSessionId(sessionKey)) {
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: "requests-in-flight",
+      durationMs: Date.now() - startedAt,
+    });
+    return { status: "skipped", reason: "requests-in-flight" };
+  }
 
   // Check the resolved session lane — if it is busy, skip to avoid interrupting
   // an active streaming turn.  The wake-layer retry (heartbeat-wake.ts) will


### PR DESCRIPTION
## Summary
- skip heartbeat execution when the target session still has an active reply run, even if the command lane has already drained
- cover the regression with a heartbeat runner test that simulates a live reply run plus a queued system event

## Testing
- node scripts/test-projects.mjs src/infra/heartbeat-runner.skips-busy-session-lane.test.ts

## Issue
- fixes #64810