### PR TITLE
fix(agents): increase default idle timeout for reasoning models

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1217,6 +1217,7 @@ export async function runEmbeddedAttempt(
       const idleTimeoutMs = resolveLlmIdleTimeoutMs({
         cfg: params.config,
         trigger: params.trigger,
+        reasoning: params.model.reasoning,
       });
       if (idleTimeoutMs > 0) {
         activeSession.agent.streamFn = streamWithIdleTimeout(

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
   DEFAULT_LLM_IDLE_TIMEOUT_MS,
+  DEFAULT_REASONING_LLM_IDLE_TIMEOUT_MS,
   resolveLlmIdleTimeoutMs,
   streamWithIdleTimeout,
 } from "./llm-idle-timeout.js";
@@ -84,6 +85,37 @@ describe("resolveLlmIdleTimeoutMs", () => {
   it("keeps an explicit cron idle timeout when configured", () => {
     const cfg = { agents: { defaults: { llm: { idleTimeoutSeconds: 45 } } } } as OpenClawConfig;
     expect(resolveLlmIdleTimeoutMs({ cfg, trigger: "cron" })).toBe(45_000);
+  });
+
+  it("returns reasoning default for reasoning models when no timeout is configured", () => {
+    expect(resolveLlmIdleTimeoutMs({ reasoning: true })).toBe(
+      DEFAULT_REASONING_LLM_IDLE_TIMEOUT_MS,
+    );
+  });
+
+  it("returns standard default for non-reasoning models", () => {
+    expect(resolveLlmIdleTimeoutMs({ reasoning: false })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+  });
+
+  it("prefers explicit idleTimeoutSeconds over reasoning default", () => {
+    const cfg = { agents: { defaults: { llm: { idleTimeoutSeconds: 90 } } } } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs({ cfg, reasoning: true })).toBe(90_000);
+  });
+
+  it("prefers agents.defaults.timeoutSeconds over reasoning default", () => {
+    const cfg = { agents: { defaults: { timeoutSeconds: 240 } } } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs({ cfg, reasoning: true })).toBe(240_000);
+  });
+
+  it("keeps idleTimeoutSeconds=0 disabled even for reasoning models", () => {
+    const cfg = { agents: { defaults: { llm: { idleTimeoutSeconds: 0 } } } } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs({ cfg, reasoning: true })).toBe(0);
+  });
+
+  it("uses reasoning default for cron trigger with reasoning model when no timeout is configured", () => {
+    expect(resolveLlmIdleTimeoutMs({ trigger: "cron", reasoning: true })).toBe(
+      DEFAULT_REASONING_LLM_IDLE_TIMEOUT_MS,
+    );
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -12,6 +12,14 @@ import type { EmbeddedRunTrigger } from "./params.js";
 export const DEFAULT_LLM_IDLE_TIMEOUT_MS = 60_000;
 
 /**
+ * Default idle timeout for reasoning/thinking models in milliseconds.
+ * Reasoning models (e.g. glm-5.1, o1, o3) take significantly longer
+ * to produce the first token due to extended chain-of-thought processing.
+ * Default: 180 seconds (3x the standard timeout).
+ */
+export const DEFAULT_REASONING_LLM_IDLE_TIMEOUT_MS = 180_000;
+
+/**
  * Maximum safe timeout value (approximately 24.8 days).
  */
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
@@ -23,6 +31,8 @@ const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 export function resolveLlmIdleTimeoutMs(params?: {
   cfg?: OpenClawConfig;
   trigger?: EmbeddedRunTrigger;
+  /** Whether the target model is a reasoning/thinking model. */
+  reasoning?: boolean;
 }): number {
   const raw = params?.cfg?.agents?.defaults?.llm?.idleTimeoutSeconds;
   // 0 means explicitly disabled (no timeout).
@@ -40,6 +50,12 @@ export function resolveLlmIdleTimeoutMs(params?: {
     agentTimeoutSeconds > 0
   ) {
     return Math.min(Math.floor(agentTimeoutSeconds) * 1000, MAX_SAFE_TIMEOUT_MS);
+  }
+
+  // Reasoning models need a longer default timeout because chain-of-thought
+  // processing can delay the first token well beyond the standard 60s window.
+  if (params?.reasoning) {
+    return DEFAULT_REASONING_LLM_IDLE_TIMEOUT_MS;
   }
 
   if (params?.trigger === "cron") {


### PR DESCRIPTION
## Summary

- Reasoning models (glm-5.1, o1, o3 등) are timing out on embedded agent runs because the default 60s LLM idle timeout is too short for their extended chain-of-thought processing
- Auto-detect reasoning models via the existing `reasoning` flag on model definitions and apply a 180s default timeout (3x standard)
- Explicit user config (`llm.idleTimeoutSeconds`, `agents.defaults.timeoutSeconds`) still takes priority

## Test plan

- [x] Added unit tests for reasoning model timeout resolution
- [x] Verified existing tests still pass (26/26)
- [x] Confirmed GLM-5.1 API responds normally (TTFB ~7s for simple prompts, can exceed 60s for complex ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)