### PR TITLE
docs(parity): (GPT 5.4 Parity vs. Opus Agentic) catch up 10-PR program state with architecture diagrams

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -1,0 +1,85 @@
+name: Parity gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "extensions/qa-lab/**"
+      - "qa/scenarios/**"
+      - "src/agents/**"
+      - "src/context-engine/**"
+      - ".github/workflows/parity-gate.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: parity-gate-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  parity-gate:
+    name: Run the GPT-5.4 / Opus 4.6 parity gate against the qa-lab mock
+    if: ${{ github.event.pull_request.draft != true }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    env:
+      # Fence the gate off from any real provider credentials. The qa-lab
+      # mock server + auth staging (PR N) should be enough to produce a
+      # meaningful verdict without touching a real API. If any of these
+      # leak into the job env, fail hard instead of silently running
+      # against a live provider and burning real budget.
+      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
+      OPENCLAW_LIVE_OPENAI_KEY: ""
+      OPENCLAW_LIVE_ANTHROPIC_KEY: ""
+      OPENCLAW_LIVE_GEMINI_KEY: ""
+      OPENCLAW_LIVE_SETUP_TOKEN_VALUE: ""
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run GPT-5.4 lane
+        run: |
+          pnpm openclaw qa suite \
+            --parity-pack agentic \
+            --model openai/gpt-5.4 \
+            --output-dir .artifacts/qa-e2e/gpt54
+
+      - name: Run Opus 4.6 lane
+        run: |
+          pnpm openclaw qa suite \
+            --parity-pack agentic \
+            --model anthropic/claude-opus-4-6 \
+            --output-dir .artifacts/qa-e2e/opus46
+
+      - name: Generate parity report
+        run: |
+          pnpm openclaw qa parity-report \
+            --repo-root . \
+            --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
+            --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+            --candidate-label openai/gpt-5.4 \
+            --baseline-label anthropic/claude-opus-4-6 \
+            --output-dir .artifacts/qa-e2e/parity
+
+      - name: Upload parity artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-gate-${{ github.event.pull_request.number || github.sha }}
+          path: .artifacts/qa-e2e/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -21,7 +21,7 @@ jobs:
   parity-gate:
     name: Run the mock structural GPT-5.4 / Opus 4.6 parity gate
     if: ${{ github.event.pull_request.draft != true }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 20
     env:
       # Fence the gate off from any real provider credentials. The qa-lab

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - "extensions/qa-lab/**"
+      - "extensions/qa-channel/**"
       - "qa/scenarios/**"
       - "src/agents/**"
       - "src/context-engine/**"

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -8,6 +8,7 @@ on:
       - "qa/scenarios/**"
       - "src/agents/**"
       - "src/context-engine/**"
+      - "src/gateway/**"
       - ".github/workflows/parity-gate.yml"
 
 permissions:

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   parity-gate:
-    name: Run the GPT-5.4 / Opus 4.6 parity gate against the qa-lab mock
+    name: Run the mock structural GPT-5.4 / Opus 4.6 parity gate
     if: ${{ github.event.pull_request.draft != true }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
@@ -51,16 +51,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run GPT-5.4 lane
+      - name: Run GPT-5.4 mock lane
         run: |
           pnpm openclaw qa suite \
+            --provider-mode mock-openai \
             --parity-pack agentic \
             --model openai/gpt-5.4 \
             --output-dir .artifacts/qa-e2e/gpt54
 
-      - name: Run Opus 4.6 lane
+      - name: Run Opus 4.6 mock lane
         run: |
           pnpm openclaw qa suite \
+            --provider-mode mock-openai \
             --parity-pack agentic \
             --model anthropic/claude-opus-4-6 \
             --output-dir .artifacts/qa-e2e/opus46

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -58,6 +58,7 @@ jobs:
             --provider-mode mock-openai \
             --parity-pack agentic \
             --model openai/gpt-5.4 \
+            --alt-model openai/gpt-5.4-alt \
             --output-dir .artifacts/qa-e2e/gpt54
 
       - name: Run Opus 4.6 mock lane
@@ -66,6 +67,7 @@ jobs:
             --provider-mode mock-openai \
             --parity-pack agentic \
             --model anthropic/claude-opus-4-6 \
+            --alt-model anthropic/claude-sonnet-4-6 \
             --output-dir .artifacts/qa-e2e/opus46
 
       - name: Generate parity report

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,14 +1,14 @@
-# GPT-5.4 / Codex Parity Maintainer Notes
+# GPT-5.4 / Codex parity maintainer notes
 
-This note explains how to review the GPT-5.4 / Codex parity program without losing the original six-contract architecture. The program ships as ten runtime/test merge units (PRs A, B, C, D, E, F, H, J, K, L) plus a separate documentation catch-up (PR M #64837 — this page). Wave 1 — the four initial PRs A, B, C, D — established the runtime contract, parity harness, and first-wave scenario pack and is now merged. Wave 2 — the six follow-up PRs E, F, H, J, K, L — doubles the parity pack, auto-activates strict-agentic on GPT-5, tightens tool-call enforcement, covers the baseline provider for offline runs, and self-describes each run in its summary artifact. PR F was closed as superseded after its three fixes were resolved upstream independently, so wave 2 lands as five code PRs plus PR M.
+This is the review-oriented companion to [`gpt54-codex-agentic-parity.md`](/help/gpt54-codex-agentic-parity). The goal here is to make the program legible as merge units without losing the underlying six-contract architecture, so someone picking up a PR knows what it's supposed to own and what it deliberately doesn't.
 
-## Program status
+The program ends up as ten runtime/test merge units plus a separate documentation pass (PR M, this note). Wave 1 — PRs A, B, C, D — is merged and landed the runtime contract, the parity harness, and the first-wave scenario pack. Wave 2 — PRs E, F, H, J, K, L — is the refinement round: it doubles the parity pack, makes strict-agentic the real default for GPT-5, adds tool-call enforcement, brings the mock server up to dual-provider coverage, and teaches each summary artifact to describe itself. PR F was closed after each of its three fixes landed on `main` through unrelated commits during the review window, so wave 2 effectively merges as five code PRs plus this docs pass.
 
-Sections below describe each PR's scope, including wave-2 PRs that have not yet merged. This doc is merged as PR M after the wave-2 code PRs. Until then, "Owns" blocks for wave-2 PRs describe the intended end state of each slice.
+Sections below describe each PR's scope including the wave-2 ones that haven't merged yet. "Owns" blocks for wave-2 PRs describe their intended end state, not what's on `main` today.
 
 ## Merge units
 
-### PR A: strict-agentic execution
+### PR A — strict-agentic execution
 
 Owns:
 
@@ -17,14 +17,9 @@ Owns:
 - `update_plan` as non-terminal progress tracking
 - explicit blocked states instead of plan-only silent stops
 
-Does not own:
+Does not own: auth/runtime failure classification, permission truthfulness, replay/continuation redesign, parity benchmarking.
 
-- auth/runtime failure classification
-- permission truthfulness
-- replay/continuation redesign
-- parity benchmarking
-
-### PR B: runtime truthfulness
+### PR B — runtime truthfulness
 
 Owns:
 
@@ -32,13 +27,9 @@ Owns:
 - typed provider/runtime failure classification
 - truthful `/elevated full` availability and blocked reasons
 
-Does not own:
+Does not own: tool schema normalization, replay/liveness state, benchmark gating.
 
-- tool schema normalization
-- replay/liveness state
-- benchmark gating
-
-### PR C: execution correctness
+### PR C — execution correctness
 
 Owns:
 
@@ -47,13 +38,9 @@ Owns:
 - replay-invalid surfacing
 - paused, blocked, and abandoned long-task state visibility
 
-Does not own:
+Does not own: self-elected continuation, generic Codex dialect behavior outside provider hooks, benchmark gating.
 
-- self-elected continuation
-- generic Codex dialect behavior outside provider hooks
-- benchmark gating
-
-### PR D: first-wave parity harness
+### PR D — first-wave parity harness
 
 Owns:
 
@@ -61,31 +48,23 @@ Owns:
 - parity documentation baseline
 - parity report and release-gate mechanics
 
-Does not own:
+Does not own: second-wave scenarios, dual-provider mock routing, runtime behavior changes outside QA-lab.
 
-- second-wave scenarios
-- dual-provider mock routing
-- runtime behavior changes outside QA-lab
-
-### PR E: second-wave parity pack
+### PR E — second-wave parity pack
 
 Owns:
 
 - five additional parity scenarios (`subagent-handoff`, `subagent-fanout-synthesis`, `memory-recall`, `thread-memory-isolation`, `config-restart-capability-flip`)
 - parity report header parametrization so non-default model pairs render accurate labels
-- parity gate failure when any required scenario fails on either candidate or baseline, so “both models fail” no longer leaks through the relative metric comparison
+- parity gate failure when a required scenario fails on either candidate or baseline, so "both models fail" no longer slips through the relative metric comparison
 
-Does not own:
+Does not own: dual-provider mock routing (PR K), self-describing run metadata (PR L), tool-call assertions (PR J).
 
-- dual-provider mock routing (PR K)
-- self-describing run metadata (PR L)
-- tool-call assertions (PR J)
+### PR F — post-parity main stabilization (closed as superseded)
 
-### PR F: post-parity main stabilization (closed as superseded)
+Had three inherited red-CI fixes against `target-resolver.test.ts`, `memory-wiki/index.test.ts`, and `config.pruning-defaults.test.ts`. All three got resolved upstream through unrelated commits during the review window, so the PR was closed after verification and no review action is needed.
 
-Owned three inherited red-CI fixes against `target-resolver.test.ts`, `memory-wiki/index.test.ts`, and `config.pruning-defaults.test.ts`. All three failures were resolved upstream through independent commits while the parity loop was in progress, and the PR was closed as superseded after verification. No review action needed.
-
-### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
+### PR H — strict-agentic auto-activation + blocked-exit liveness
 
 Owns:
 
@@ -93,50 +72,38 @@ Owns:
 - explicit `"blocked"` liveness state at the strict-agentic blocked exit
 - regression coverage pinning both behaviors
 
-Does not own:
+Does not own: the `executionContract` mechanism itself (PR A), non-GPT-5 provider defaults.
 
-- the `executionContract` mechanism itself (that's PR A)
-- non-GPT-5 provider defaults
-
-### PR J: parity scenario tool-call enforcement
+### PR J — parity scenario tool-call enforcement
 
 Owns:
 
-- tool-call assertions on the `source-docs-discovery-report` and `subagent-handoff` parity scenarios
+- tool-call assertions on `source-docs-discovery-report` and `subagent-handoff`
 - `/debug/requests` seam consumption from scenario YAML flows
-- matching on scenario-unique prompt substrings to keep assertions scoped to their own scenario
+- matching on scenario-unique prompt substrings so neighboring scenarios can't accidentally satisfy each other's assertions
 
-Does not own:
+Does not own: the `/debug/requests` store itself (part of the mock server), tool schemas or tool execution.
 
-- the `/debug/requests` store itself (part of the mock server)
-- tool schemas or tool execution
-
-### PR K: Anthropic `/v1/messages` mock route
+### PR K — Anthropic `/v1/messages` mock route
 
 Owns:
 
 - the `/v1/messages` route on the qa-lab mock server
 - Anthropic messages → shared `ResponsesInputItem[]` conversion
-- empty-model and streaming-request edge cases (empty string defaults to `claude-opus-4-6`; `stream: true` returns a 400 so the failure mode is visible)
+- the empty-model and streaming-request edge cases (empty-string defaults to `claude-opus-4-6`; `stream: true` returns a 400 so the failure mode is visible)
 
-Does not own:
+Does not own: real Anthropic API compatibility beyond what the scenario dispatcher reads, live Anthropic credential wiring.
 
-- real Anthropic API compatibility beyond what the scenario dispatcher reads
-- live Anthropic credential wiring
-
-### PR L: qa-suite-summary.json run metadata
+### PR L — `qa-suite-summary.json` run metadata
 
 Owns:
 
 - the `run` block in `qa-suite-summary.json` (`primaryProvider`, `primaryModel`, `providerMode`, `scenarioIds`)
 - reuse of the canonical `QaProviderMode` union in `writeQaSuiteArtifacts` instead of a re-declared string-literal union
 
-Does not own:
+Does not own: parity report consumption of the run block (PR D's report helper), scenario catalog filtering.
 
-- parity report consumption of the run block (that's PR D's report helper)
-- scenario catalog filtering
-
-### PR M: documentation catch-up
+### PR M — parity documentation catch-up
 
 Owns:
 
@@ -146,12 +113,7 @@ Owns:
 - the goal-to-evidence matrix update covering all 10 PRs
 - the program-status disclaimer that marks wave-2 sections as forward-looking until each wave-2 PR merges
 
-Does not own:
-
-- any runtime, test, or scenario registry change (documentation-only PR)
-- the `QA_AGENTIC_PARITY_SCENARIOS` registry expansion (PR E owns that)
-- the CLI flag reference (PR M describes `--model` / `--alt-model` as they exist on `main`; PR M does not change the CLI surface)
-- any architecture change to the mock server, parity report, or strict-agentic contract
+Does not own: any runtime, test, or scenario registry change (docs-only), the `QA_AGENTIC_PARITY_SCENARIOS` registry expansion (PR E owns that), the CLI flag reference itself (PR M describes `--model` / `--alt-model` as they exist on `main` but doesn't change the CLI surface), the mock server, the parity report, or the strict-agentic contract.
 
 ## Mapping back to the original six contracts
 
@@ -166,18 +128,16 @@ Does not own:
 
 ## Review order
 
-1. PR A
-2. PR B
-3. PR C
-4. PR D
-5. PR H (runtime follow-up, parallelizable with D)
-6. PR E (parity pack expansion, depends on D)
-7. PR K (Anthropic mock route, parallelizable with E/J)
-8. PR J (tool-call enforcement, depends on E)
-9. PR L (run metadata, parallelizable with J)
-10. PR M (documentation catch-up, depends on E/H/J/K/L)
+Wave 1 landed in A → B → C → D order. For wave 2, the dependencies are:
 
-PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed. PRs E/H/J/K/L are independent refinements that can land in any order as long as their individual dependency callouts are respected. PR M is documentation-only and can land in parallel with the last code PR.
+1. PR H is a runtime follow-up, independent of the parity harness work — review it any time.
+2. PR E depends on PR D being merged (it extends the parity pack registry).
+3. PR K is independent of E/H/J/L.
+4. PR J depends on PR E because it asserts against scenarios the second-wave pack registers.
+5. PR L is independent of J.
+6. PR M is docs-only and should land last so its references point to merged content.
+
+PRs H, K, and L can be reviewed in parallel. PR E should land before PR J. PR M should be the tail.
 
 ## What to look for
 
@@ -189,15 +149,15 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 
 ### PR B
 
-- auth/proxy/runtime failures stop collapsing into generic “model failed” handling
-- `/elevated full` is only described as available when it is actually available
+- auth/proxy/runtime failures don't collapse into a generic "model failed" handler
+- `/elevated full` is only described as available when it actually is
 - blocked reasons are visible to both the model and the user-facing runtime
 
 ### PR C
 
 - strict OpenAI/Codex tool registration behaves predictably
-- parameter-free tools do not fail strict schema checks
-- replay and compaction outcomes preserve truthful liveness state
+- parameter-free tools don't fail strict schema checks
+- replay and compaction outcomes keep truthful liveness state
 
 ### PR D
 
@@ -206,17 +166,13 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
 
-Expected artifacts from PR D:
-
-- `qa-suite-report.md` / `qa-suite-summary.json` for each model run
-- `qa-agentic-parity-report.md` with aggregate and scenario-level comparison
-- `qa-agentic-parity-summary.json` with a machine-readable verdict
+Expected artifacts: `qa-suite-report.md` / `qa-suite-summary.json` for each model run, `qa-agentic-parity-report.md` with aggregate and scenario-level comparison, `qa-agentic-parity-summary.json` with a machine-readable verdict.
 
 ### PR E
 
-- the parity pack is now ten scenarios, not five
-- the parity report Markdown header reflects the candidate and baseline labels instead of a hardcoded legacy string
-- a required scenario that fails on either side fails the gate, even if both sides fail the same scenario (this closes the relative-metric loophole)
+- the parity pack is ten scenarios, not five
+- the parity report Markdown header reflects the candidate and baseline labels, not a hardcoded legacy string
+- a required scenario that fails on either side fails the gate, even when both sides fail the same scenario — this closes the relative-metric loophole
 - the five new scenarios exercise delegation, fanout synthesis, memory recall, thread-memory isolation, and a capability flip across config restart
 
 ### PR H
@@ -228,16 +184,16 @@ Expected artifacts from PR D:
 
 ### PR J
 
-- the `source-docs-discovery-report` scenario gates on a real `read` tool call via `/debug/requests`, not just the prose shape of the reply
-- the `subagent-handoff` scenario gates on a real `sessions_spawn` call before accepting the three labeled sections
-- both assertions use a scenario-unique prompt substring so neighboring scenarios (for example `subagent-fanout-synthesis`) cannot accidentally satisfy them
+- `source-docs-discovery-report` gates on a real `read` tool call via `/debug/requests`, not just the prose shape of the reply
+- `subagent-handoff` gates on a real `sessions_spawn` call before accepting the three labeled sections
+- both assertions match on a scenario-unique prompt substring so neighboring scenarios (for example `subagent-fanout-synthesis`, which also contains "delegate" and produces its own `sessions_spawn` request) can't accidentally satisfy them
 
 ### PR K
 
-- the `/v1/messages` mock route routes through the same scenario dispatcher as `/v1/responses` so one scenario plan drives both providers
+- `/v1/messages` routes through the same scenario dispatcher as `/v1/responses` so one scenario plan drives both providers
 - streaming requests return a 400 with an Anthropic-shaped error body, not a silent non-streaming fallback
 - empty-string `model` is treated the same as absent and defaults to `claude-opus-4-6`
-- `/debug/requests` snapshots record the same `plannedToolName` / `allInputText` / `toolOutput` fields that the OpenAI route exposes, so a single parity run can diff assertions across both lanes
+- `/debug/requests` snapshots record the same `plannedToolName` / `allInputText` / `toolOutput` fields on the Anthropic route that the OpenAI route already exposes, so a single parity run can diff assertions across both lanes
 
 ### PR L
 
@@ -249,24 +205,24 @@ Expected artifacts from PR D:
 
 - the parity docs cover all ten PRs, not just the first four
 - the three new mermaid diagrams are present (dual-provider mock, parity run orchestration, tool-call assertion seam)
-- the end-to-end parity runbook is reproducible offline
+- the end-to-end parity runbook uses the real CLI flags and calls out which steps depend on unmerged wave-2 PRs
 - the goal-to-evidence matrix matches the ten-PR program
 
 ## Release gate
 
-Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
+Don't claim GPT-5.4 parity or superiority over Opus 4.6 until:
 
-- PR A, PR B, PR C, and PR H are merged (runtime contract enforced by default for GPT-5)
-- PR D and PR E run the ten-scenario parity pack cleanly on both providers
-- PR J tool-call assertions pass on the tool-mediated scenarios
-- PR K offline dual-provider mock is exercised in CI
-- PR L run metadata is present in both summary artifacts
-- runtime-truthfulness regression suites remain green
+- PRs A, B, C, and H are merged (runtime contract enforced by default for GPT-5)
+- PRs D and E run the ten-scenario parity pack cleanly on both providers
+- PR J's tool-call assertions pass on the tool-mediated scenarios
+- PR K's offline dual-provider mock is exercised in CI
+- PR L's run metadata is present in both summary artifacts
+- runtime-truthfulness regression suites stay green
 - the parity report shows no fake-success cases and no regression in stop behavior
 
 ```mermaid
 flowchart LR
-    A["PR A-C merged"] --> B["Run GPT-5.4 parity pack"]
+    A["Runtime PRs merged"] --> B["Run GPT-5.4 parity pack"]
     A --> C["Run Opus 4.6 parity pack"]
     B --> D["qa-suite-summary.json"]
     C --> E["qa-suite-summary.json"]
@@ -275,25 +231,22 @@ flowchart LR
     F --> G["Markdown report + JSON verdict"]
     G --> H{"Pass?"}
     H -- "yes" --> I["Parity claim allowed"]
-    H -- "no" --> J["Keep runtime fixes / review loop open"]
+    H -- "no" --> J["Keep runtime fixes in play"]
 ```
 
-The parity harness is not the only evidence source. Keep this split explicit in review:
-
-- PR D owns the scenario-based GPT-5.4 vs Opus 4.6 comparison
-- PR B deterministic suites still own auth/proxy/DNS and full-access truthfulness evidence
+The parity harness isn't the only evidence source. Keep the split explicit in review: PRs D and E own the scenario-based GPT-5.4 vs Opus 4.6 comparison, and PR B's deterministic suites still own auth, proxy, DNS, and `/elevated full` truthfulness.
 
 ## Goal-to-evidence map
 
-| Completion gate item                     | Primary owners            | Review artifact                                                                                                       |
-| ---------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| No plan-only stalls                      | PR A + PR H               | strict-agentic runtime tests, `approval-turn-tool-followthrough`, PR H auto-activation regression                     |
-| No fake progress or fake tool completion | PR A + PR D + PR J        | parity fake-success count, scenario-level report details, `/debug/requests` tool-call assertions                      |
-| No false `/elevated full` guidance       | PR B                      | deterministic runtime-truthfulness suites                                                                             |
-| Replay/liveness failures remain explicit | PR C + PR H               | lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                                     |
-| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, full ten-scenario coverage on both providers offline |
+| Completion gate criterion                | Primary owners            | Review artifact                                                                                                   |
+| ---------------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| No plan-only stalls                      | PR A + PR H               | strict-agentic runtime tests, `approval-turn-tool-followthrough`, PR H auto-activation regression                 |
+| No fake progress or fake tool completion | PR A + PR D + PR J        | parity fake-success count, scenario-level report details, `/debug/requests` tool-call assertions                  |
+| No false `/elevated full` guidance       | PR B                      | deterministic runtime-truthfulness suites                                                                         |
+| Replay/liveness failures remain explicit | PR C + PR H               | lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                                 |
+| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, ten-scenario coverage on both providers, offline |
 
-## Reviewer shorthand: before vs after
+## Reviewer shorthand
 
 | User-visible problem before                                 | Review signal after                                                                               |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -205,7 +205,7 @@ Expected artifacts: `qa-suite-report.md` / `qa-suite-summary.json` for each mode
 
 - the parity docs cover all ten PRs, not just the first four
 - the three new mermaid diagrams are present (dual-provider mock, parity run orchestration, tool-call assertion seam)
-- the end-to-end parity runbook uses the real CLI flags and calls out which steps depend on unmerged wave-2 PRs
+- the end-to-end parity runbook clearly separates the mock structural gate from the live-frontier proof run
 - the goal-to-evidence matrix matches the ten-PR program
 
 ## Release gate
@@ -235,6 +235,12 @@ flowchart LR
 ```
 
 The parity harness isn't the only evidence source. Keep the split explicit in review: PRs D and E own the scenario-based GPT-5.4 vs Opus 4.6 comparison, and PR B's deterministic suites still own auth, proxy, DNS, and `/elevated full` truthfulness.
+
+## Mock gate vs live proof
+
+- The workflow in `.github/workflows/parity-gate.yml` is the **mock structural gate**. It should run `openclaw qa suite --provider-mode mock-openai ...` for both lanes and verify harness structure, scenario registration, artifact generation, and fail-fast semantics without touching real credentials.
+- The final product claim still requires a **live-frontier proof run**. That run should use `--provider-mode live-frontier` for both GPT-5.4 and Opus 4.6, then feed the resulting summaries into `openclaw qa parity-report`.
+- Reviewers should reject any wording that treats the mock structural gate as the final parity proof by itself.
 
 ## Goal-to-evidence map
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,10 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as ten merge units without losing the original six-contract architecture. The program shipped as four initial PRs (A through D) that established the runtime contract, parity harness, and first-wave scenario pack, plus six follow-up PRs (E, F, H, J, K, L) that doubled the parity pack, auto-activated strict-agentic on GPT-5, tightened tool-call enforcement, covered the baseline provider for offline runs, and self-described each run in its summary artifact.
+This note explains how to review the GPT-5.4 / Codex parity program without losing the original six-contract architecture. The program ships as ten runtime/test merge units (PRs A, B, C, D, E, F, H, J, K, L) plus a separate documentation catch-up (PR M #64837 — this page). Wave 1 — the four initial PRs A, B, C, D — established the runtime contract, parity harness, and first-wave scenario pack and is now merged. Wave 2 — the six follow-up PRs E, F, H, J, K, L — doubles the parity pack, auto-activates strict-agentic on GPT-5, tightens tool-call enforcement, covers the baseline provider for offline runs, and self-describes each run in its summary artifact. PR F was closed as superseded after its three fixes were resolved upstream independently, so wave 2 lands as five code PRs plus PR M.
+
+## Program status
+
+Sections below describe each PR's scope, including wave-2 PRs that have not yet merged. This doc is merged as PR M after the wave-2 code PRs. Until then, "Owns" blocks for wave-2 PRs describe the intended end state of each slice.
 
 ## Merge units
 
@@ -140,6 +144,14 @@ Owns:
 - three new mermaid diagrams (dual-provider mock, parity run orchestration, tool-call assertion seam)
 - the end-to-end parity runbook section
 - the goal-to-evidence matrix update covering all 10 PRs
+- the program-status disclaimer that marks wave-2 sections as forward-looking until each wave-2 PR merges
+
+Does not own:
+
+- any runtime, test, or scenario registry change (documentation-only PR)
+- the `QA_AGENTIC_PARITY_SCENARIOS` registry expansion (PR E owns that)
+- the CLI flag reference (PR M describes `--model` / `--alt-model` as they exist on `main`; PR M does not change the CLI surface)
+- any architecture change to the mock server, parity report, or strict-agentic contract
 
 ## Mapping back to the original six contracts
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,6 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as four merge units without losing the original six-contract architecture.
+This note explains how to review the GPT-5.4 / Codex parity program as ten merge units without losing the original six-contract architecture. The program shipped as four initial PRs (A through D) that established the runtime contract, parity harness, and first-wave scenario pack, plus six follow-up PRs (E, F, H, J, K, L) that doubled the parity pack, auto-activated strict-agentic on GPT-5, tightened tool-call enforcement, covered the baseline provider for offline runs, and self-described each run in its summary artifact.
 
 ## Merge units
 
@@ -49,29 +49,108 @@ Does not own:
 - generic Codex dialect behavior outside provider hooks
 - benchmark gating
 
-### PR D: parity harness
+### PR D: first-wave parity harness
 
 Owns:
 
-- first-wave GPT-5.4 vs Opus 4.6 scenario pack
-- parity documentation
+- first-wave GPT-5.4 vs Opus 4.6 scenario pack (five scenarios)
+- parity documentation baseline
 - parity report and release-gate mechanics
 
 Does not own:
 
+- second-wave scenarios
+- dual-provider mock routing
 - runtime behavior changes outside QA-lab
-- auth/proxy/DNS simulation inside the harness
+
+### PR E: second-wave parity pack
+
+Owns:
+
+- five additional parity scenarios (`subagent-handoff`, `subagent-fanout-synthesis`, `memory-recall`, `thread-memory-isolation`, `config-restart-capability-flip`)
+- parity report header parametrization so non-default model pairs render accurate labels
+- parity gate failure when any required scenario fails on either candidate or baseline, so “both models fail” no longer leaks through the relative metric comparison
+
+Does not own:
+
+- dual-provider mock routing (PR K)
+- self-describing run metadata (PR L)
+- tool-call assertions (PR J)
+
+### PR F: post-parity main stabilization (closed as superseded)
+
+Owned three inherited red-CI fixes against `target-resolver.test.ts`, `memory-wiki/index.test.ts`, and `config.pruning-defaults.test.ts`. All three failures were resolved upstream through independent commits while the parity loop was in progress, and the PR was closed as superseded after verification. No review action needed.
+
+### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
+
+Owns:
+
+- auto-activation of the strict-agentic contract for unconfigured GPT-5-family `openai` and `openai-codex` runs
+- explicit `"blocked"` liveness state at the strict-agentic blocked exit
+- regression coverage pinning both behaviors
+
+Does not own:
+
+- the `executionContract` mechanism itself (that's PR A)
+- non-GPT-5 provider defaults
+
+### PR J: parity scenario tool-call enforcement
+
+Owns:
+
+- tool-call assertions on the `source-docs-discovery-report` and `subagent-handoff` parity scenarios
+- `/debug/requests` seam consumption from scenario YAML flows
+- matching on scenario-unique prompt substrings to keep assertions scoped to their own scenario
+
+Does not own:
+
+- the `/debug/requests` store itself (part of the mock server)
+- tool schemas or tool execution
+
+### PR K: Anthropic `/v1/messages` mock route
+
+Owns:
+
+- the `/v1/messages` route on the qa-lab mock server
+- Anthropic messages → shared `ResponsesInputItem[]` conversion
+- empty-model and streaming-request edge cases (empty string defaults to `claude-opus-4-6`; `stream: true` returns a 400 so the failure mode is visible)
+
+Does not own:
+
+- real Anthropic API compatibility beyond what the scenario dispatcher reads
+- live Anthropic credential wiring
+
+### PR L: qa-suite-summary.json run metadata
+
+Owns:
+
+- the `run` block in `qa-suite-summary.json` (`primaryProvider`, `primaryModel`, `providerMode`, `scenarioIds`)
+- reuse of the canonical `QaProviderMode` union in `writeQaSuiteArtifacts` instead of a re-declared string-literal union
+
+Does not own:
+
+- parity report consumption of the run block (that's PR D's report helper)
+- scenario catalog filtering
+
+### PR M: documentation catch-up
+
+Owns:
+
+- the 10-PR rewrite of `docs/help/gpt54-codex-agentic-parity.md` and `docs/help/gpt54-codex-agentic-parity-maintainers.md`
+- three new mermaid diagrams (dual-provider mock, parity run orchestration, tool-call assertion seam)
+- the end-to-end parity runbook section
+- the goal-to-evidence matrix update covering all 10 PRs
 
 ## Mapping back to the original six contracts
 
-| Original contract                        | Merge unit |
-| ---------------------------------------- | ---------- |
-| Provider transport/auth correctness      | PR B       |
-| Tool contract/schema compatibility       | PR C       |
-| Same-turn execution                      | PR A       |
-| Permission truthfulness                  | PR B       |
-| Replay/continuation/liveness correctness | PR C       |
-| Benchmark/release gate                   | PR D       |
+| Original contract                        | Merge units                             |
+| ---------------------------------------- | --------------------------------------- |
+| Provider transport/auth correctness      | PR B                                    |
+| Tool contract/schema compatibility       | PR C                                    |
+| Same-turn execution                      | PR A + PR H                             |
+| Permission truthfulness                  | PR B                                    |
+| Replay/continuation/liveness correctness | PR C + PR H                             |
+| Benchmark/release gate                   | PR D + PR E + PR J + PR K + PR L + PR M |
 
 ## Review order
 
@@ -79,8 +158,14 @@ Does not own:
 2. PR B
 3. PR C
 4. PR D
+5. PR H (runtime follow-up, parallelizable with D)
+6. PR E (parity pack expansion, depends on D)
+7. PR K (Anthropic mock route, parallelizable with E/J)
+8. PR J (tool-call enforcement, depends on E)
+9. PR L (run metadata, parallelizable with J)
+10. PR M (documentation catch-up, depends on E/H/J/K/L)
 
-PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed.
+PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed. PRs E/H/J/K/L are independent refinements that can land in any order as long as their individual dependency callouts are respected. PR M is documentation-only and can land in parallel with the last code PR.
 
 ## What to look for
 
@@ -104,7 +189,7 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 
 ### PR D
 
-- the scenario pack is understandable and reproducible
+- the first-wave scenario pack is understandable and reproducible
 - the pack includes a mutating replay-safety lane, not only read-only flows
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
@@ -115,12 +200,55 @@ Expected artifacts from PR D:
 - `qa-agentic-parity-report.md` with aggregate and scenario-level comparison
 - `qa-agentic-parity-summary.json` with a machine-readable verdict
 
+### PR E
+
+- the parity pack is now ten scenarios, not five
+- the parity report Markdown header reflects the candidate and baseline labels instead of a hardcoded legacy string
+- a required scenario that fails on either side fails the gate, even if both sides fail the same scenario (this closes the relative-metric loophole)
+- the five new scenarios exercise delegation, fanout synthesis, memory recall, thread-memory isolation, and a capability flip across config restart
+
+### PR H
+
+- unconfigured GPT-5-family `openai` / `openai-codex` runs auto-activate strict-agentic without per-agent configuration
+- the strict-agentic blocked exit emits an explicit `"blocked"` liveness state on the final turn
+- `executionContract: "default"` still opts out, and explicit `executionContract: "strict-agentic"` is always honored
+- the regression test title matches the asserted liveness state
+
+### PR J
+
+- the `source-docs-discovery-report` scenario gates on a real `read` tool call via `/debug/requests`, not just the prose shape of the reply
+- the `subagent-handoff` scenario gates on a real `sessions_spawn` call before accepting the three labeled sections
+- both assertions use a scenario-unique prompt substring so neighboring scenarios (for example `subagent-fanout-synthesis`) cannot accidentally satisfy them
+
+### PR K
+
+- the `/v1/messages` mock route routes through the same scenario dispatcher as `/v1/responses` so one scenario plan drives both providers
+- streaming requests return a 400 with an Anthropic-shaped error body, not a silent non-streaming fallback
+- empty-string `model` is treated the same as absent and defaults to `claude-opus-4-6`
+- `/debug/requests` snapshots record the same `plannedToolName` / `allInputText` / `toolOutput` fields that the OpenAI route exposes, so a single parity run can diff assertions across both lanes
+
+### PR L
+
+- each `qa-suite-summary.json` carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`
+- `writeQaSuiteArtifacts` reuses the canonical `QaProviderMode` union instead of a re-declared string-literal union
+- parity consumers can verify the provider, model, and mode of each input summary without relying on filenames
+
+### PR M
+
+- the parity docs cover all ten PRs, not just the first four
+- the three new mermaid diagrams are present (dual-provider mock, parity run orchestration, tool-call assertion seam)
+- the end-to-end parity runbook is reproducible offline
+- the goal-to-evidence matrix matches the ten-PR program
+
 ## Release gate
 
 Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
 
-- PR A, PR B, and PR C are merged
-- PR D runs the first-wave parity pack cleanly
+- PR A, PR B, PR C, and PR H are merged (runtime contract enforced by default for GPT-5)
+- PR D and PR E run the ten-scenario parity pack cleanly on both providers
+- PR J tool-call assertions pass on the tool-mediated scenarios
+- PR K offline dual-provider mock is exercised in CI
+- PR L run metadata is present in both summary artifacts
 - runtime-truthfulness regression suites remain green
 - the parity report shows no fake-success cases and no regression in stop behavior
 
@@ -145,20 +273,23 @@ The parity harness is not the only evidence source. Keep this split explicit in 
 
 ## Goal-to-evidence map
 
-| Completion gate item                     | Primary owner | Review artifact                                                     |
-| ---------------------------------------- | ------------- | ------------------------------------------------------------------- |
-| No plan-only stalls                      | PR A          | strict-agentic runtime tests and `approval-turn-tool-followthrough` |
-| No fake progress or fake tool completion | PR A + PR D   | parity fake-success count plus scenario-level report details        |
-| No false `/elevated full` guidance       | PR B          | deterministic runtime-truthfulness suites                           |
-| Replay/liveness failures remain explicit | PR C + PR D   | lifecycle/replay suites plus `compaction-retry-mutating-tool`       |
-| GPT-5.4 matches or beats Opus 4.6        | PR D          | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`  |
+| Completion gate item                     | Primary owners            | Review artifact                                                                                                       |
+| ---------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| No plan-only stalls                      | PR A + PR H               | strict-agentic runtime tests, `approval-turn-tool-followthrough`, PR H auto-activation regression                     |
+| No fake progress or fake tool completion | PR A + PR D + PR J        | parity fake-success count, scenario-level report details, `/debug/requests` tool-call assertions                      |
+| No false `/elevated full` guidance       | PR B                      | deterministic runtime-truthfulness suites                                                                             |
+| Replay/liveness failures remain explicit | PR C + PR H               | lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                                     |
+| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, full ten-scenario coverage on both providers offline |
 
 ## Reviewer shorthand: before vs after
 
-| User-visible problem before                                 | Review signal after                                                                     |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| GPT-5.4 stopped after planning                              | PR A shows act-or-block behavior instead of commentary-only completion                  |
-| Tool use felt brittle with strict OpenAI/Codex schemas      | PR C keeps tool registration and parameter-free invocation predictable                  |
-| `/elevated full` hints were sometimes misleading            | PR B ties guidance to actual runtime capability and blocked reasons                     |
-| Long tasks could disappear into replay/compaction ambiguity | PR C emits explicit paused, blocked, abandoned, and replay-invalid state                |
-| Parity claims were anecdotal                                | PR D produces a report plus JSON verdict with the same scenario coverage on both models |
+| User-visible problem before                                 | Review signal after                                                                               |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| GPT-5.4 stopped after planning                              | PR A + PR H: GPT-5 runs auto-activate act-or-block instead of commentary-only completion          |
+| Tool use felt brittle with strict OpenAI/Codex schemas      | PR C keeps tool registration and parameter-free invocation predictable                            |
+| `/elevated full` hints were sometimes misleading            | PR B ties guidance to actual runtime capability and blocked reasons                               |
+| Long tasks could disappear into replay/compaction ambiguity | PR C + PR H emit explicit paused, blocked, abandoned, and replay-invalid state                    |
+| Parity claims were anecdotal                                | PR D + PR E produce a ten-scenario report plus JSON verdict with the same coverage on both models |
+| Parity scenarios could pass with prose alone                | PR J adds `/debug/requests` tool-call assertions on the tool-mediated scenarios                   |
+| Baseline parity needed live Anthropic credentials           | PR K adds an Anthropic `/v1/messages` route on the qa-lab mock so the gate runs offline           |
+| Parity consumers had to trust file paths for provenance     | PR L records `run.primaryProvider` / `run.primaryModel` / `run.providerMode` in each summary      |

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -204,12 +204,14 @@ Use this lane in CI and in reproducible local smoke runs:
 pnpm openclaw qa suite \
   --provider-mode mock-openai \
   --model openai/gpt-5.4 \
+  --alt-model openai/gpt-5.4-alt \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/gpt54
 
 pnpm openclaw qa suite \
   --provider-mode mock-openai \
   --model anthropic/claude-opus-4-6 \
+  --alt-model anthropic/claude-sonnet-4-6 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/opus46
 
@@ -221,6 +223,9 @@ pnpm openclaw qa parity-report \
 ```
 
 This is what the parity-gate workflow should run. It keeps the job fenced away from real provider credentials and proves the harness structure is sound.
+The explicit `--alt-model` values matter: they keep `model-switch-tool-continuity`
+inside the intended provider lane instead of silently falling back to the CLI
+default alternate model.
 
 ### Live-frontier proof run
 
@@ -230,12 +235,14 @@ Use this lane only when you want the release-evidence comparison against real fr
 pnpm openclaw qa suite \
   --provider-mode live-frontier \
   --model openai/gpt-5.4 \
+  --alt-model openai/gpt-5.4-mini \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/gpt54-live
 
 pnpm openclaw qa suite \
   --provider-mode live-frontier \
   --model anthropic/claude-opus-4-6 \
+  --alt-model anthropic/claude-sonnet-4-6 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/opus46-live
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,13 +8,13 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in four reviewable slices.
+This parity program fixes those gaps in ten reviewable slices. PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that doubled the parity pack, tightened the runtime contract, added tool-call enforcement to the gate, expanded the mock server to cover both providers for offline parity runs, and self-described each run in its summary artifact.
 
 ## What changed
 
 ### PR A: strict-agentic execution
 
-This slice adds an opt-in `strict-agentic` execution contract for embedded Pi GPT-5 runs.
+This slice adds the `strict-agentic` execution contract for embedded Pi GPT-5 runs.
 
 When enabled, OpenClaw stops accepting plan-only turns as “good enough” completion. If the model only says what it intends to do and does not actually use tools or make progress, OpenClaw retries with an act-now steer and then fails closed with an explicit blocked state instead of silently ending the task.
 
@@ -42,7 +42,7 @@ This slice improves two kinds of correctness:
 
 The tool-compat work reduces schema friction for strict OpenAI/Codex tool registration, especially around parameter-free tools and strict object-root expectations. The replay/liveness work makes long-running tasks more observable, so paused, blocked, and abandoned states are visible instead of disappearing into generic failure text.
 
-### PR D: parity harness
+### PR D: first-wave parity harness
 
 This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be exercised through the same scenarios and compared using shared evidence.
 
@@ -63,6 +63,46 @@ That command writes:
 - a human-readable Markdown report
 - a machine-readable JSON verdict
 - an explicit `pass` / `fail` gate result
+
+### PR E: second-wave parity scenarios
+
+This slice doubles the parity pack from the first-wave five scenarios to ten. The new scenarios exercise delegation, fanout synthesis, memory recall after a context switch, thread-memory isolation, and a live capability flip across a config restart. They run through the same `openclaw qa parity-report` gate and the same `QA_AGENTIC_PARITY_SCENARIOS` registration so the verdict covers the full pack without a CLI flag change.
+
+PR E also rewrites the parity report Markdown header to use the candidate and baseline labels passed to `buildQaAgenticParityComparison`, so reports generated for non-default model pairs no longer carry a hard-coded “GPT-5.4 / Opus 4.6” title.
+
+Criterion 5 of the release gate (GPT-5.4 matches or beats Opus 4.6 on the agreed metrics) now requires green outcomes across all ten scenarios on both sides.
+
+### PR F: post-parity main stabilization (subsumed by upstream main)
+
+This slice was a stabilization PR that addressed three inherited red-CI failures on main during the parity program. All three failures were resolved upstream through independent commits while the parity loop was in progress, so the PR was closed as superseded after verification. No follow-up work is needed from this slice.
+
+### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
+
+This slice takes the PR A `strict-agentic` contract from an opt-in default to an automatic default for GPT-5-family OpenAI and OpenAI-Codex runs. Unconfigured runs on those providers now auto-activate strict-agentic and emit an explicit `"blocked"` liveness state at the strict-agentic blocked exit, instead of silently reporting a generic completion. Runs that set `executionContract: "default"` still opt out, and explicit `executionContract: "strict-agentic"` is always honored.
+
+This closes the remaining hole in criterion 1 (“GPT-5.4 no longer stalls after planning”): users no longer need to know about the contract for the runtime to enforce it.
+
+### PR J: parity scenario tool-call enforcement
+
+This slice adds tool-call assertions to the `source-docs-discovery-report` and `subagent-handoff` parity scenarios. Both scenarios previously asserted the textual shape of the agent's prose reply; the assertions now also read the mock server's `/debug/requests` log and require that the scenario actually invoked the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply.
+
+This closes the remaining hole in criterion 2 (“no fake progress or fake tool completion”): a model that hallucinates a report without reading files or delegates without actually spawning a subagent can no longer satisfy the scenario with prose alone.
+
+### PR K: Anthropic `/v1/messages` mock route
+
+This slice adds an Anthropic Messages API route to the qa-lab mock server so the parity baseline lane (`anthropic/claude-opus-4-6`) can run through the same scenario dispatcher without requiring real Anthropic API credentials. The route converts the Anthropic request shape into the shared `ResponsesInputItem[]` representation, dispatches through the same scenario logic the OpenAI `/v1/responses` route uses, and shapes the response back into an Anthropic Messages body.
+
+The route rejects streaming requests with an explicit Anthropic-shaped 400 (the runner always uses non-streaming in mock mode) and treats an empty-string `model` as absent, defaulting to `claude-opus-4-6` so the echoed model label matches what parity consumers expect.
+
+This closes the remaining hole in infrastructure for criterion 5: operators can now run the parity gate end-to-end offline against both providers.
+
+### PR L: qa-suite-summary.json run metadata
+
+This slice records `run.primaryProvider`, `run.primaryModel`, `run.providerMode`, and `run.scenarioIds` in each `qa-suite-summary.json` artifact. Parity consumers can now verify the provider, model, and mode of each input summary when reading the report, which means the parity report can distinguish two “qa-suite-summary.json” files by provenance instead of relying on filenames.
+
+The writer-side parameter type now reuses the canonical `QaProviderMode` union instead of re-declaring the string-literal union inline, so a future addition to the mode list propagates automatically.
+
+This closes the remaining self-description hole for criterion 5: the report no longer has to trust file paths to know which provider produced which summary.
 
 ## Why this improves GPT-5.4 in practice
 
@@ -127,9 +167,55 @@ flowchart LR
     I -- "no" --> K["Keep runtime/review loop open"]
 ```
 
+## Dual-provider mock architecture
+
+The qa-lab mock server now exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans.
+
+```mermaid
+flowchart LR
+    A[QA suite runner] -- "candidate: gpt-5.4" --> B["POST /v1/responses"]
+    A -- "baseline: claude-opus-4-6" --> C["POST /v1/messages"]
+    B --> D[buildResponsesPayload]
+    C --> E[convertAnthropicMessagesToResponsesInput]
+    E --> D
+    D --> F[Scenario dispatcher]
+    F --> G["/debug/requests log"]
+    F --> H[Scenario-specific response]
+    H --> B
+    H --> C
+```
+
+## Parity run orchestration
+
+The release gate consumes two `qa-suite-summary.json` artifacts (one per provider) and produces the Markdown report plus the machine-readable verdict. Each summary file now carries a self-describing `run` block, so the parity consumer can label the inputs without relying on filenames.
+
+```mermaid
+flowchart TD
+    A[runQaSuite candidate=openai/gpt-5.4] --> B[qa-suite-summary.json<br/>run.primaryProvider=openai]
+    C[runQaSuite baseline=anthropic/claude-opus-4-6] --> D[qa-suite-summary.json<br/>run.primaryProvider=anthropic]
+    B --> E[runQaParityReportCommand]
+    D --> E
+    E --> F[qa-agentic-parity-report.md]
+    E --> G[qa-agentic-parity-summary.json<br/>pass/fail verdict]
+    E --> H[process.exitCode 1 on fail]
+```
+
+## Tool-call assertion seam
+
+Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. The tool-call assertion seam closes that gap by requiring the scenario to actually invoke the expected tool before the prose is accepted.
+
+```mermaid
+flowchart LR
+    A[Scenario YAML qa-flow] -- "runAgentPrompt" --> B[Embedded Pi runner]
+    B -- "Responses API call" --> C[mock-openai-server]
+    C -- "record plannedToolName" --> D["/debug/requests store"]
+    A -- "fetchJson /debug/requests" --> D
+    A -- "assert plannedToolName matches" --> E[Pass or Fail]
+```
+
 ## Scenario pack
 
-The first-wave parity pack currently covers five scenarios:
+The parity pack covers ten scenarios after the second-wave expansion:
 
 ### `approval-turn-tool-followthrough`
 
@@ -141,7 +227,7 @@ Checks that tool-using work remains coherent across model/runtime switching boun
 
 ### `source-docs-discovery-report`
 
-Checks that the model can read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping early.
+Checks that the model can read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping early. The scenario also requires a real `read` tool call to land before the prose reply is accepted.
 
 ### `image-understanding-attachment`
 
@@ -151,19 +237,78 @@ Checks that mixed-mode tasks involving attachments remain actionable and do not 
 
 Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
 
+### `subagent-handoff`
+
+Checks that a bounded delegation actually spawns a subagent via the `sessions_spawn` tool and folds the subagent's result back into the main flow, instead of producing a prose report that claims delegation occurred without a real subagent call.
+
+### `subagent-fanout-synthesis`
+
+Checks that a fanout across multiple subagents synthesizes results honestly and labels which sub-result contributed to which part of the final answer.
+
+### `memory-recall`
+
+Checks that a task can pull a prior detail back after an intervening context switch, instead of implicitly asking the user to restate it.
+
+### `thread-memory-isolation`
+
+Checks that memory recorded against one thread does not leak into an unrelated thread, so the runtime's isolation contract matches what the model behaves as if.
+
+### `config-restart-capability-flip`
+
+Checks that a live capability change survives a config restart on the agent and is visible to the next run without a stale feature flag cached in the agent's state.
+
 ## Scenario matrix
 
 | Scenario                           | What it tests                           | Good GPT-5.4 behavior                                                          | Failure signal                                                                 |
 | ---------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | `approval-turn-tool-followthrough` | Short approval turns after a plan       | Starts the first concrete tool action immediately instead of restating intent  | plan-only follow-up, no tool activity, or blocked turn without a real blocker  |
 | `model-switch-tool-continuity`     | Runtime/model switching under tool use  | Preserves task context and continues acting coherently                         | resets into commentary, loses tool context, or stops after switch              |
-| `source-docs-discovery-report`     | Source reading + synthesis + action     | Finds sources, uses tools, and produces a useful report without stalling       | thin summary, missing tool work, or incomplete-turn stop                       |
+| `source-docs-discovery-report`     | Source reading + synthesis + tool call  | Reads source via a real `read` tool call and produces a useful report          | thin summary, no `read` tool call recorded, or incomplete-turn stop            |
 | `image-understanding-attachment`   | Attachment-driven agentic work          | Interprets the attachment, connects it to tools, and continues the task        | vague narration, attachment ignored, or no concrete next action                |
 | `compaction-retry-mutating-tool`   | Mutating work under compaction pressure | Performs a real write and keeps replay-unsafety explicit after the side effect | mutating write happens but replay safety is implied, missing, or contradictory |
+| `subagent-handoff`                 | Bounded delegation to a subagent        | Spawns a real subagent via `sessions_spawn` and folds the result back          | prose report claims delegation but no `sessions_spawn` call recorded           |
+| `subagent-fanout-synthesis`        | Multi-subagent fanout synthesis         | Spawns multiple subagents and attributes each sub-result honestly              | merges results without attribution or fabricates fanout evidence               |
+| `memory-recall`                    | Recall after a context switch           | Pulls the prior detail back without asking the user to restate it              | implicitly restates the context by asking the user for the same detail         |
+| `thread-memory-isolation`          | Cross-thread memory isolation           | Keeps memory scoped to the right thread and does not leak                      | a detail from thread A surfaces in thread B                                    |
+| `config-restart-capability-flip`   | Live capability change across restart   | Next run sees the new capability instead of the cached feature flag            | stale capability survives the restart and leaks into the next run              |
+
+## Running the parity gate end-to-end
+
+The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers.
+
+1. Run the suite against the candidate provider/model:
+
+   ```bash
+   pnpm openclaw qa suite \
+     --primary-model openai/gpt-5.4 \
+     --parity-pack agentic \
+     --output-dir .artifacts/qa-e2e/gpt54
+   ```
+
+2. Run the suite against the baseline provider/model:
+
+   ```bash
+   pnpm openclaw qa suite \
+     --primary-model anthropic/claude-opus-4-6 \
+     --parity-pack agentic \
+     --output-dir .artifacts/qa-e2e/opus46
+   ```
+
+3. Generate the parity report and read the verdict:
+
+   ```bash
+   pnpm openclaw qa parity-report \
+     --repo-root . \
+     --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
+     --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+     --output-dir .artifacts/qa-e2e/parity
+   ```
+
+Each `qa-suite-summary.json` now carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
 
 ## Release gate
 
-GPT-5.4 can only be considered at parity or better when the merged runtime passes the parity pack and the runtime-truthfulness regressions at the same time.
+GPT-5.4 can only be considered at parity or better when the merged runtime passes the full ten-scenario parity pack and the runtime-truthfulness regressions at the same time.
 
 Required outcomes:
 
@@ -171,29 +316,31 @@ Required outcomes:
 - no fake completion without real execution
 - no incorrect `/elevated full` guidance
 - no silent replay or compaction abandonment
-- parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline
+- parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline across all ten scenarios
 
-For the first-wave harness, the gate compares:
+The gate compares:
 
 - completion rate
 - unintended-stop rate
 - valid-tool-call rate
 - fake-success count
+- required-scenario outcomes (any required scenario that fails on either side fails the gate, even if the baseline also failed)
+- tool-call assertions on the scenarios that require a real tool invocation (`read` for `source-docs-discovery-report`, `sessions_spawn` for `subagent-handoff`)
 
 Parity evidence is intentionally split across two layers:
 
-- PR D proves same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
+- PRs D and E prove same-scenario GPT-5.4 vs Opus 4.6 behavior through the ten-scenario QA-lab pack
 - PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
 
 ## Goal-to-evidence matrix
 
-| Completion gate item                                     | Owning PR   | Evidence source                                                    | Pass signal                                                                              |
-| -------------------------------------------------------- | ----------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 no longer stalls after planning                  | PR A        | `approval-turn-tool-followthrough` plus PR A runtime suites        | approval turns trigger real work or an explicit blocked state                            |
-| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D | parity report scenario outcomes and fake-success count             | no suspicious pass results and no commentary-only completion                             |
-| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B        | deterministic truthfulness suites                                  | blocked reasons and full-access hints stay runtime-accurate                              |
-| Replay/liveness failures stay explicit                   | PR C + PR D | PR C lifecycle/replay suites plus `compaction-retry-mutating-tool` | mutating work keeps replay-unsafety explicit instead of silently disappearing            |
-| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json` | same scenario coverage and no regression on completion, stop behavior, or valid tool use |
+| Completion gate item                                     | Owning PRs                | Evidence source                                                                                                  | Pass signal                                                                                                            |
+| -------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| GPT-5.4 no longer stalls after planning                  | PR A + PR H               | PR A runtime suites, `approval-turn-tool-followthrough`, PR H auto-activation regression                         | unconfigured GPT-5 runs auto-activate strict-agentic and approval turns trigger real work or an explicit blocked state |
+| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR J        | parity report scenario outcomes, fake-success count, `/debug/requests` tool-call assertions                      | no suspicious pass results and a real `read` / `sessions_spawn` call is recorded before prose is accepted              |
+| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B                      | deterministic truthfulness suites                                                                                | blocked reasons and full-access hints stay runtime-accurate                                                            |
+| Replay/liveness failures stay explicit                   | PR C + PR H               | PR C lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                           | mutating work keeps replay-unsafety explicit and the strict-agentic blocked exit emits `"blocked"`                     |
+| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, self-describing `run` block, dual-provider mock | full ten-scenario coverage on both providers with no regression on the agreed metrics, verifiable offline              |
 
 ## How to read the parity verdict
 
@@ -204,16 +351,24 @@ Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readabl
 - “shared/base CI issue” is not itself a parity result. If CI noise outside PR D blocks a run, the verdict should wait for a clean merged-runtime execution instead of being inferred from branch-era logs.
 - Auth, proxy, DNS, and `/elevated full` truthfulness still come from PR B’s deterministic suites, so the final release claim needs both: a passing PR D parity verdict and green PR B truthfulness coverage.
 
-## Who should enable `strict-agentic`
+## Strict-agentic defaults and overrides
 
-Use `strict-agentic` when:
+After PR H landed, the strict-agentic contract is now the automatic default for GPT-5-family `openai` and `openai-codex` runs. Operators no longer need to configure `executionContract: "strict-agentic"` to get act-now enforcement on those providers — an unconfigured GPT-5 run automatically activates the contract and emits an explicit `"blocked"` liveness state at the strict-agentic blocked exit.
 
-- the agent is expected to act immediately when a next step is obvious
-- GPT-5.4 or Codex-family models are the primary runtime
+Override behavior:
+
+- **Auto-activated (default for GPT-5 on `openai` / `openai-codex`)**: no configuration required. The runtime enforces act-or-block on plan-only turns and surfaces a `"blocked"` liveness state on the blocked exit.
+- **Explicit opt-out**: set `executionContract: "default"` on the agent config to keep the pre-PR-H looser behavior. This is the escape hatch for prompt-testing workflows or third-party agents that rely on plan-only completion.
+- **Explicit opt-in for other providers**: set `executionContract: "strict-agentic"` to run the contract on Anthropic or any other provider. The auto-activation rule only fires for GPT-5-family OpenAI / OpenAI-Codex runs; other providers still require the explicit config.
+
+Keep the default auto-activation behavior when:
+
+- you want the runtime to guarantee act-or-block on GPT-5 flows without per-agent configuration
+- you are comparing GPT-5.4 against Opus 4.6 through the parity pack and want the contract enforced on the candidate side
 - you prefer explicit blocked states over “helpful” recap-only replies
 
-Keep the default contract when:
+Opt out (`executionContract: "default"`) when:
 
-- you want the existing looser behavior
-- you are not using GPT-5-family models
-- you are testing prompts rather than runtime enforcement
+- you are running prompt-engineering workflows that deliberately test plan-only turns
+- you are testing a third-party skill that expects the pre-PR-H behavior
+- you are using a non-GPT-5 model that should not be gated by the contract

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -189,15 +189,26 @@ The pack is `QA_AGENTIC_PARITY_SCENARIOS` in `extensions/qa-lab/src/agentic-pari
 
 ## Running the harness end-to-end
 
-The harness is three commands. The CLI flags are `--model` / `--alt-model` on `openclaw qa suite` and `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`. The baseline lane only runs fully offline once PR K lands the Anthropic mock route — until then it needs real Anthropic credentials.
+There are two distinct parity runs:
+
+- the **mock structural gate**, which is CI-safe and proves the harness wiring, scenario registration, artifact generation, and pass/fail semantics
+- the **live-frontier proof run**, which is the release-evidence lane for the real GPT-5.4 vs Opus 4.6 claim
+
+Treat them differently. The mock gate is necessary, but it is not the final product claim by itself.
+
+### Mock structural gate
+
+Use this lane in CI and in reproducible local smoke runs:
 
 ```bash
 pnpm openclaw qa suite \
+  --provider-mode mock-openai \
   --model openai/gpt-5.4 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/gpt54
 
 pnpm openclaw qa suite \
+  --provider-mode mock-openai \
   --model anthropic/claude-opus-4-6 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/opus46
@@ -207,6 +218,32 @@ pnpm openclaw qa parity-report \
   --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
   --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
   --output-dir .artifacts/qa-e2e/parity
+```
+
+This is what the parity-gate workflow should run. It keeps the job fenced away from real provider credentials and proves the harness structure is sound.
+
+### Live-frontier proof run
+
+Use this lane only when you want the release-evidence comparison against real frontier providers:
+
+```bash
+pnpm openclaw qa suite \
+  --provider-mode live-frontier \
+  --model openai/gpt-5.4 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/gpt54-live
+
+pnpm openclaw qa suite \
+  --provider-mode live-frontier \
+  --model anthropic/claude-opus-4-6 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/opus46-live
+
+pnpm openclaw qa parity-report \
+  --repo-root . \
+  --candidate-summary .artifacts/qa-e2e/gpt54-live/qa-suite-summary.json \
+  --baseline-summary .artifacts/qa-e2e/opus46-live/qa-suite-summary.json \
+  --output-dir .artifacts/qa-e2e/parity-live
 ```
 
 `openclaw qa parity-report` writes the Markdown report and a JSON verdict, and exits nonzero on a gate failure so CI can block the release. After PR L lands, `qa-suite-summary.json` carries the `run` block that the parity report uses to label each input; until then, the report still works but trusts the caller's `--candidate-label` / `--baseline-label`.

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,7 +8,25 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in ten reviewable slices. PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that doubled the parity pack, tightened the runtime contract, added tool-call enforcement to the gate, expanded the mock server to cover both providers for offline parity runs, and self-described each run in its summary artifact.
+This parity program ships as ten reviewable slices plus a documentation follow-up (this page). PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that double the parity pack, tighten the runtime contract, add tool-call enforcement to the gate, expand the mock server to cover both providers for offline parity runs, and self-describe each run in its summary artifact.
+
+## Program status
+
+Sections that describe "after PR X" behavior are forward-looking and reflect the post-merge end state of the program, not what is currently on `main`. Reviewers and operators should read the wave-2 sections below through that lens until each wave-2 PR merges.
+
+| PR          | Title                                                  | Status                                                                 |
+| ----------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
+| PR A #64241 | strict-agentic execution                               | merged                                                                 |
+| PR B #64439 | runtime truthfulness                                   | merged                                                                 |
+| PR C #64300 | execution correctness                                  | merged                                                                 |
+| PR D #64441 | first-wave parity harness                              | merged                                                                 |
+| PR F #64675 | post-parity main stabilization                         | closed as superseded (all three fixes resolved upstream independently) |
+| PR E #64662 | second-wave parity scenarios                           | open                                                                   |
+| PR H #64679 | strict-agentic auto-activation + blocked-exit liveness | open                                                                   |
+| PR J #64681 | parity scenario tool-call enforcement                  | open                                                                   |
+| PR K #64685 | Anthropic `/v1/messages` mock route                    | open                                                                   |
+| PR L #64789 | `qa-suite-summary.json` run metadata                   | open                                                                   |
+| PR M #64837 | parity documentation catch-up (this page)              | open                                                                   |
 
 ## What changed
 
@@ -169,20 +187,22 @@ flowchart LR
 
 ## Dual-provider mock architecture
 
-The qa-lab mock server now exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans.
+After PR K #64685 merges, the qa-lab mock server exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans. Today (pre-PR-K on `main`) only the `/v1/responses` route exists.
 
 ```mermaid
 flowchart LR
-    A[QA suite runner] -- "candidate: gpt-5.4" --> B["POST /v1/responses"]
-    A -- "baseline: claude-opus-4-6" --> C["POST /v1/messages"]
-    B --> D[buildResponsesPayload]
-    C --> E[convertAnthropicMessagesToResponsesInput]
-    E --> D
-    D --> F[Scenario dispatcher]
-    F --> G["/debug/requests log"]
-    F --> H[Scenario-specific response]
-    H --> B
-    H --> C
+    Runner[QA suite runner]
+    Runner -- "candidate: gpt-5.4" --> ResponsesRoute["POST /v1/responses"]
+    Runner -- "baseline: claude-opus-4-6" --> MessagesRoute["POST /v1/messages"]
+    ResponsesRoute -- "OpenAI request body" --> Payload[buildResponsesPayload]
+    MessagesRoute -- "Anthropic request body" --> Adapter[convertAnthropicMessagesToResponsesInput]
+    Adapter -- "shared ResponsesInputItem[]" --> Payload
+    Payload --> Dispatcher[Scenario dispatcher]
+    Dispatcher --> DebugLog["/debug/requests log"]
+    Dispatcher --> OpenAIResponse[OpenAI-shaped response]
+    Dispatcher --> AnthropicResponse[Anthropic-shaped response]
+    OpenAIResponse -- "HTTP 200 JSON" --> Runner
+    AnthropicResponse -- "HTTP 200 JSON" --> Runner
 ```
 
 ## Parity run orchestration
@@ -202,20 +222,23 @@ flowchart TD
 
 ## Tool-call assertion seam
 
-Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. The tool-call assertion seam closes that gap by requiring the scenario to actually invoke the expected tool before the prose is accepted.
+Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. After PR J #64681 merges, the `source-docs-discovery-report` and `subagent-handoff` scenarios also read the mock server's `/debug/requests` log and require the scenario to actually invoke the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply is accepted. Today (pre-PR-J on `main`) these scenarios only assert the prose shape.
 
 ```mermaid
 flowchart LR
-    A[Scenario YAML qa-flow] -- "runAgentPrompt" --> B[Embedded Pi runner]
-    B -- "Responses API call" --> C[mock-openai-server]
-    C -- "record plannedToolName" --> D["/debug/requests store"]
-    A -- "fetchJson /debug/requests" --> D
-    A -- "assert plannedToolName matches" --> E[Pass or Fail]
+    Scenario[Scenario YAML qa-flow] -- "runAgentPrompt" --> Runner[Embedded Pi runner]
+    Runner -- "Responses API call" --> Mock[mock-openai-server]
+    Mock -- "record plannedToolName" --> DebugStore["/debug/requests store"]
+    Scenario -- "fetchJson /debug/requests" --> DebugStore
+    DebugStore -- "plannedToolName" --> Scenario
+    Scenario -- "assert matches expected tool" --> Verdict[Pass or Fail]
 ```
 
 ## Scenario pack
 
-The parity pack covers ten scenarios after the second-wave expansion:
+Wave 1 (PR D #64441, merged) registers the first five scenarios in the parity pack. Wave 2 (PR E #64662, open) registers the next five. The `QA_AGENTIC_PARITY_SCENARIOS` array in `extensions/qa-lab/src/agentic-parity.ts` is the single source of truth; reviewers can count the entries there to see which scenarios are currently wired into the gate.
+
+**Wave 1 scenarios (live on main):**
 
 ### `approval-turn-tool-followthrough`
 
@@ -236,6 +259,8 @@ Checks that mixed-mode tasks involving attachments remain actionable and do not 
 ### `compaction-retry-mutating-tool`
 
 Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
+
+**Wave 2 scenarios (registered in the pack after PR E #64662 merges; the scenario files already live under `qa/scenarios/` and run standalone):**
 
 ### `subagent-handoff`
 
@@ -274,13 +299,15 @@ Checks that a live capability change survives a config restart on the agent and 
 
 ## Running the parity gate end-to-end
 
-The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers.
+The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers. The shell commands below use the real CLI flag names (`--model` / `--alt-model` on `openclaw qa suite`, `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`).
+
+The baseline lane only runs end-to-end against the qa-lab mock server after PR K #64685 merges the Anthropic `/v1/messages` route. Until then, the baseline lane requires real Anthropic credentials.
 
 1. Run the suite against the candidate provider/model:
 
    ```bash
    pnpm openclaw qa suite \
-     --primary-model openai/gpt-5.4 \
+     --model openai/gpt-5.4 \
      --parity-pack agentic \
      --output-dir .artifacts/qa-e2e/gpt54
    ```
@@ -289,7 +316,7 @@ The parity gate is a three-step flow. Each step is reproducible against the qa-l
 
    ```bash
    pnpm openclaw qa suite \
-     --primary-model anthropic/claude-opus-4-6 \
+     --model anthropic/claude-opus-4-6 \
      --parity-pack agentic \
      --output-dir .artifacts/qa-e2e/opus46
    ```
@@ -304,7 +331,7 @@ The parity gate is a three-step flow. Each step is reproducible against the qa-l
      --output-dir .artifacts/qa-e2e/parity
    ```
 
-Each `qa-suite-summary.json` now carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
+After PR L #64789 merges, each `qa-suite-summary.json` carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. Until PR L merges, the summary only carries `{ scenarios, counts }` and the parity report trusts the caller-supplied labels. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
 
 ## Release gate
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -344,7 +344,7 @@ Parity evidence is intentionally split across two layers:
 
 ## How to read the parity verdict
 
-Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the first-wave parity pack.
+Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the ten-scenario parity pack.
 
 - `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and did not regress on the agreed aggregate metrics.
 - `fail` means at least one hard gate tripped: weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, or mismatched scenario coverage.

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -1,155 +1,73 @@
-# GPT-5.4 / Codex Agentic Parity in OpenClaw
+# GPT-5.4 / Codex agentic parity in OpenClaw
 
-OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Codex-style models were still underperforming in a few practical ways:
+OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Codex-style models kept running into a handful of practical gaps that showed up in real sessions:
 
-- they could stop after planning instead of doing the work
-- they could use strict OpenAI/Codex tool schemas incorrectly
-- they could ask for `/elevated full` even when full access was impossible
-- they could lose long-running task state during replay or compaction
-- parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
+- they would stop after planning instead of doing the work
+- strict OpenAI/Codex tool schemas got rejected in confusing ways
+- `/elevated full` guidance was sometimes wrong
+- long-running tasks could lose state during replay or compaction
+- parity claims against Claude Opus 4.6 were anecdotal rather than something you could rerun
 
-This parity program ships as ten reviewable slices plus a documentation follow-up (this page). PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that double the parity pack, tighten the runtime contract, add tool-call enforcement to the gate, expand the mock server to cover both providers for offline parity runs, and self-describe each run in its summary artifact.
+The fixes landed in two waves, mostly because of the repo's 10-PR active cap. The first wave (PRs A through D) put the runtime contract in place and shipped the first parity harness. The second wave (E, H, J, K, L, plus this documentation pass as PR M) extends the harness from five to ten scenarios, tightens the runtime contract so it's on by default for GPT-5, adds tool-call enforcement to the gate, brings the mock server up to parity so the baseline lane can run offline, and teaches each summary artifact to describe itself. PR F started life as a stabilization slice but was closed after all three of its fixes landed upstream through unrelated commits during the review window.
 
-## Program status
+## Where things stand
 
-Sections that describe "after PR X" behavior are forward-looking and reflect the post-merge end state of the program, not what is currently on `main`. Reviewers and operators should read the wave-2 sections below through that lens until each wave-2 PR merges.
+| PR                                                     | Status              |
+| ------------------------------------------------------ | ------------------- |
+| #64241 strict-agentic execution (PR A)                 | merged              |
+| #64439 runtime truthfulness (PR B)                     | merged              |
+| #64300 execution correctness (PR C)                    | merged              |
+| #64441 first-wave parity harness (PR D)                | merged              |
+| #64675 post-parity main stabilization (PR F)           | closed (superseded) |
+| #64679 strict-agentic auto-activation (PR H)           | open                |
+| #64662 second-wave parity scenarios (PR E)             | open                |
+| #64685 Anthropic `/v1/messages` mock route (PR K)      | open                |
+| #64681 parity scenario tool-call enforcement (PR J)    | open                |
+| #64789 `qa-suite-summary.json` run metadata (PR L)     | open                |
+| #64837 parity documentation catch-up (PR M, this page) | open                |
 
-| PR          | Title                                                  | Status                                                                 |
-| ----------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
-| PR A #64241 | strict-agentic execution                               | merged                                                                 |
-| PR B #64439 | runtime truthfulness                                   | merged                                                                 |
-| PR C #64300 | execution correctness                                  | merged                                                                 |
-| PR D #64441 | first-wave parity harness                              | merged                                                                 |
-| PR F #64675 | post-parity main stabilization                         | closed as superseded (all three fixes resolved upstream independently) |
-| PR E #64662 | second-wave parity scenarios                           | open                                                                   |
-| PR H #64679 | strict-agentic auto-activation + blocked-exit liveness | open                                                                   |
-| PR J #64681 | parity scenario tool-call enforcement                  | open                                                                   |
-| PR K #64685 | Anthropic `/v1/messages` mock route                    | open                                                                   |
-| PR L #64789 | `qa-suite-summary.json` run metadata                   | open                                                                   |
-| PR M #64837 | parity documentation catch-up (this page)              | open                                                                   |
+A few sections below describe behavior that's still "after PR X" — I've kept those framings where the shape of the program is easier to see if you read the end state, and flagged them inline so nobody tries to run commands that rely on unmerged code.
 
-## What changed
+## The runtime contract
 
-### PR A: strict-agentic execution
+PR A introduced a `strict-agentic` execution contract for embedded Pi GPT-5 runs. When it's active, OpenClaw stops accepting a plan-only turn as "good enough": if the model describes what it's going to do and then stops without actually touching a tool, the runtime retries with an act-now steer and then fails closed with an explicit blocked state instead of quietly returning the plan text as a completed turn. It's the single biggest fix on the "GPT-5.4 stalled after planning" complaint.
 
-This slice adds the `strict-agentic` execution contract for embedded Pi GPT-5 runs.
+PR B made OpenClaw honest about two separate things: why a provider or runtime call actually failed, and whether `/elevated full` was actually available on the current runtime. That gives GPT-5.4 (and the user) real signals for missing scopes, auth refresh failures, 403 HTML auth errors, proxy issues, DNS or timeout failures, and blocked full-access modes. The model stops hallucinating the wrong remediation or asking for a permission mode the runtime can't grant.
 
-When enabled, OpenClaw stops accepting plan-only turns as “good enough” completion. If the model only says what it intends to do and does not actually use tools or make progress, OpenClaw retries with an act-now steer and then fails closed with an explicit blocked state instead of silently ending the task.
+PR C covered two kinds of correctness. On the tool side, it cut the friction that strict OpenAI/Codex tool registration used to hit — parameter-free tools, strict object-root expectations, schema normalization. On the liveness side, it made paused, blocked, and abandoned states visible in the runtime meta instead of collapsing them into a generic failure text that looked the same as success.
 
-This improves the GPT-5.4 experience most on:
+PR H (still open) is the piece that takes the strict-agentic contract from opt-in to the real default. An unconfigured GPT-5-family `openai` or `openai-codex` run now activates the contract automatically, and the strict-agentic blocked exit sets an explicit `"blocked"` liveness state on the final turn. Setting `executionContract: "default"` still opts out, and an explicit `strict-agentic` setting is honored on any provider. The intent here is that users shouldn't have to know about the contract for the runtime to enforce it — the fixed-by-default path is the one that closes criterion 1 of the release gate for real.
 
-- short “ok do it” follow-ups
-- code tasks where the first step is obvious
-- flows where `update_plan` should be progress tracking rather than filler text
+## The parity harness
 
-### PR B: runtime truthfulness
+PR D shipped the first-wave parity pack: five QA-lab scenarios that exercise GPT-5.4 and Opus 4.6 against the same workloads so "which one is better at agentic work" stops being a vibe check. Running the suite twice and feeding both summaries into `openclaw qa parity-report` produces a Markdown report and a machine-readable pass/fail verdict. PR D is the proof layer — it doesn't change runtime behavior by itself.
 
-This slice makes OpenClaw tell the truth about two things:
+PR E (open) doubles the pack from five to ten. The new scenarios cover delegation, fanout synthesis, memory recall across a context switch, thread-memory isolation, and a live capability flip across a config restart. PR E also parametrizes the parity report's Markdown header so non-default model pairs render with the labels you actually passed, and closes a parity-gate loophole where a required scenario that failed on both candidate and baseline would still come out as `pass: true` because the downstream metric comparisons were purely relative.
 
-- why the provider/runtime call failed
-- whether `/elevated full` is actually available
+PR K (open) adds an Anthropic `/v1/messages` route to the qa-lab mock server so the baseline lane can run offline through the same scenario dispatcher the OpenAI `/v1/responses` route already uses. Without it, running the baseline lane requires real Anthropic credentials — which is fine for production but blocks reproducible CI and local parity runs. The route rejects streaming requests with an explicit Anthropic-shaped 400 (since the runner only runs non-streaming in mock mode), and treats an empty-string `body.model` the same as absent, defaulting to `claude-opus-4-6`.
 
-That means GPT-5.4 gets better runtime signals for missing scope, auth refresh failures, HTML 403 auth failures, proxy issues, DNS or timeout failures, and blocked full-access modes. The model is less likely to hallucinate the wrong remediation or keep asking for a permission mode the runtime cannot provide.
+PR L (open) is the self-description layer. Each `qa-suite-summary.json` now carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`, so the parity report can verify the provider and model behind each input instead of trusting the caller-supplied labels. The writer-side parameter type was also switched to the canonical `QaProviderMode` union, which prevents the kind of type drift that keeps creeping back in when two places both declare the same literal union.
 
-### PR C: execution correctness
+## Tool-call enforcement
 
-This slice improves two kinds of correctness:
+Some parity scenarios used to gate on the textual shape of the agent's prose reply. That's necessary but not sufficient — a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. PR J (open) wires `/debug/requests` into the scenario YAML flows so `source-docs-discovery-report` (must actually invoke `read`) and `subagent-handoff` (must actually invoke `sessions_spawn`) fail when the required tool call isn't recorded before the prose reply. The assertions match on scenario-unique prompt substrings so neighboring scenarios like `subagent-fanout-synthesis`, which also produces its own `sessions_spawn` call, can't accidentally satisfy them.
 
-- provider-owned OpenAI/Codex tool-schema compatibility
-- replay and long-task liveness surfacing
+## Why this matters for users
 
-The tool-compat work reduces schema friction for strict OpenAI/Codex tool registration, especially around parameter-free tools and strict object-root expectations. The replay/liveness work makes long-running tasks more observable, so paused, blocked, and abandoned states are visible instead of disappearing into generic failure text.
+Before this work, GPT-5.4 on OpenClaw could feel less agentic than Opus in real coding sessions because the runtime tolerated a few behaviors that are especially bad for GPT-5-style models: commentary-only turns, schema friction on tools, vague permission feedback, and silent replay or compaction breakage. None of those are things you can prompt-engineer around cleanly.
 
-### PR D: first-wave parity harness
+The goal here isn't to make GPT-5.4 imitate Opus. It's to give GPT-5.4 a runtime contract that actually rewards real progress, cleans up the tool and permission semantics so the model can reason about them, and turns failure modes into explicit machine- and human-readable states. The experience moves from "the model had a good plan but stopped" to "the model either acted, or OpenClaw surfaced the exact reason it couldn't".
 
-This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be exercised through the same scenarios and compared using shared evidence.
-
-The parity pack is the proof layer. It does not change runtime behavior by itself.
-
-After you have two `qa-suite-summary.json` artifacts, generate the release-gate comparison with:
-
-```bash
-pnpm openclaw qa parity-report \
-  --repo-root . \
-  --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
-  --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
-  --output-dir .artifacts/qa-e2e/parity
-```
-
-That command writes:
-
-- a human-readable Markdown report
-- a machine-readable JSON verdict
-- an explicit `pass` / `fail` gate result
-
-### PR E: second-wave parity scenarios
-
-This slice doubles the parity pack from the first-wave five scenarios to ten. The new scenarios exercise delegation, fanout synthesis, memory recall after a context switch, thread-memory isolation, and a live capability flip across a config restart. They run through the same `openclaw qa parity-report` gate and the same `QA_AGENTIC_PARITY_SCENARIOS` registration so the verdict covers the full pack without a CLI flag change.
-
-PR E also rewrites the parity report Markdown header to use the candidate and baseline labels passed to `buildQaAgenticParityComparison`, so reports generated for non-default model pairs no longer carry a hard-coded “GPT-5.4 / Opus 4.6” title.
-
-Criterion 5 of the release gate (GPT-5.4 matches or beats Opus 4.6 on the agreed metrics) now requires green outcomes across all ten scenarios on both sides.
-
-### PR F: post-parity main stabilization (subsumed by upstream main)
-
-This slice was a stabilization PR that addressed three inherited red-CI failures on main during the parity program. All three failures were resolved upstream through independent commits while the parity loop was in progress, so the PR was closed as superseded after verification. No follow-up work is needed from this slice.
-
-### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
-
-This slice takes the PR A `strict-agentic` contract from an opt-in default to an automatic default for GPT-5-family OpenAI and OpenAI-Codex runs. Unconfigured runs on those providers now auto-activate strict-agentic and emit an explicit `"blocked"` liveness state at the strict-agentic blocked exit, instead of silently reporting a generic completion. Runs that set `executionContract: "default"` still opt out, and explicit `executionContract: "strict-agentic"` is always honored.
-
-This closes the remaining hole in criterion 1 (“GPT-5.4 no longer stalls after planning”): users no longer need to know about the contract for the runtime to enforce it.
-
-### PR J: parity scenario tool-call enforcement
-
-This slice adds tool-call assertions to the `source-docs-discovery-report` and `subagent-handoff` parity scenarios. Both scenarios previously asserted the textual shape of the agent's prose reply; the assertions now also read the mock server's `/debug/requests` log and require that the scenario actually invoked the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply.
-
-This closes the remaining hole in criterion 2 (“no fake progress or fake tool completion”): a model that hallucinates a report without reading files or delegates without actually spawning a subagent can no longer satisfy the scenario with prose alone.
-
-### PR K: Anthropic `/v1/messages` mock route
-
-This slice adds an Anthropic Messages API route to the qa-lab mock server so the parity baseline lane (`anthropic/claude-opus-4-6`) can run through the same scenario dispatcher without requiring real Anthropic API credentials. The route converts the Anthropic request shape into the shared `ResponsesInputItem[]` representation, dispatches through the same scenario logic the OpenAI `/v1/responses` route uses, and shapes the response back into an Anthropic Messages body.
-
-The route rejects streaming requests with an explicit Anthropic-shaped 400 (the runner always uses non-streaming in mock mode) and treats an empty-string `model` as absent, defaulting to `claude-opus-4-6` so the echoed model label matches what parity consumers expect.
-
-This closes the remaining hole in infrastructure for criterion 5: operators can now run the parity gate end-to-end offline against both providers.
-
-### PR L: qa-suite-summary.json run metadata
-
-This slice records `run.primaryProvider`, `run.primaryModel`, `run.providerMode`, and `run.scenarioIds` in each `qa-suite-summary.json` artifact. Parity consumers can now verify the provider, model, and mode of each input summary when reading the report, which means the parity report can distinguish two “qa-suite-summary.json” files by provenance instead of relying on filenames.
-
-The writer-side parameter type now reuses the canonical `QaProviderMode` union instead of re-declaring the string-literal union inline, so a future addition to the mode list propagates automatically.
-
-This closes the remaining self-description hole for criterion 5: the report no longer has to trust file paths to know which provider produced which summary.
-
-## Why this improves GPT-5.4 in practice
-
-Before this work, GPT-5.4 on OpenClaw could feel less agentic than Opus in real coding sessions because the runtime tolerated behaviors that are especially harmful for GPT-5-style models:
-
-- commentary-only turns
-- schema friction around tools
-- vague permission feedback
-- silent replay or compaction breakage
-
-The goal is not to make GPT-5.4 imitate Opus. The goal is to give GPT-5.4 a runtime contract that rewards real progress, supplies cleaner tool and permission semantics, and turns failure modes into explicit machine- and human-readable states.
-
-That changes the user experience from:
-
-- “the model had a good plan but stopped”
-
-to:
-
-- “the model either acted, or OpenClaw surfaced the exact reason it could not”
-
-## Before vs after for GPT-5.4 users
-
-| Before this program                                                                            | After PR A-D                                                                             |
-| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 could stop after a reasonable plan without taking the next tool step                   | PR A turns “plan only” into “act now or surface a blocked state”                         |
-| Strict tool schemas could reject parameter-free or OpenAI/Codex-shaped tools in confusing ways | PR C makes provider-owned tool registration and invocation more predictable              |
-| `/elevated full` guidance could be vague or wrong in blocked runtimes                          | PR B gives GPT-5.4 and the user truthful runtime and permission hints                    |
-| Replay or compaction failures could feel like the task silently disappeared                    | PR C surfaces paused, blocked, abandoned, and replay-invalid outcomes explicitly         |
-| “GPT-5.4 feels worse than Opus” was mostly anecdotal                                           | PR D turns that into the same scenario pack, the same metrics, and a hard pass/fail gate |
+| Symptom before                                                | After the program                                                            |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| GPT-5.4 stopped after a reasonable plan without taking action | PR A + PR H: act-or-block by default on unconfigured GPT-5 runs              |
+| Strict tool schemas rejected parameter-free or Codex tools    | PR C: provider-owned tool registration stays predictable                     |
+| `/elevated full` guidance was vague or wrong                  | PR B: guidance ties to actual runtime capability                             |
+| Replay or compaction failures looked like silent task loss    | PR C + PR H: explicit paused, blocked, abandoned, replay-invalid state       |
+| "GPT-5.4 feels worse than Opus" was anecdotal                 | PR D + PR E: same ten scenarios on both models, JSON verdict, pass/fail gate |
+| Parity scenarios could pass with prose alone                  | PR J: `/debug/requests` assertions on the tool-mediated lanes                |
+| Baseline parity needed live Anthropic credentials             | PR K: Anthropic mock route on the qa-lab server                              |
+| Parity report had to trust caller-supplied labels             | PR L: self-describing `run` block on every summary artifact                  |
 
 ## Architecture
 
@@ -172,7 +90,7 @@ flowchart TD
 
 ```mermaid
 flowchart LR
-    A["Merged runtime slices (PR A-C)"] --> B["Run GPT-5.4 parity pack"]
+    A["Merged runtime slices"] --> B["Run GPT-5.4 parity pack"]
     A --> C["Run Opus 4.6 parity pack"]
     B --> D["qa-suite-summary.json"]
     C --> E["qa-suite-summary.json"]
@@ -182,12 +100,12 @@ flowchart LR
     F --> H["qa-agentic-parity-summary.json"]
     H --> I{"Gate pass?"}
     I -- "yes" --> J["Evidence-backed parity claim"]
-    I -- "no" --> K["Keep runtime/review loop open"]
+    I -- "no" --> K["Keep runtime fixes in play"]
 ```
 
 ## Dual-provider mock architecture
 
-After PR K #64685 merges, the qa-lab mock server exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans. Today (pre-PR-K on `main`) only the `/v1/responses` route exists.
+After PR K lands, the qa-lab mock server exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both feed into the same scenario dispatcher, so each parity scenario has one response plan and both providers exercise it. Today only `/v1/responses` exists on `main`.
 
 ```mermaid
 flowchart LR
@@ -207,7 +125,7 @@ flowchart LR
 
 ## Parity run orchestration
 
-The release gate consumes two `qa-suite-summary.json` artifacts (one per provider) and produces the Markdown report plus the machine-readable verdict. Each summary file now carries a self-describing `run` block, so the parity consumer can label the inputs without relying on filenames.
+The release gate consumes two `qa-suite-summary.json` artifacts — one per provider — and produces the Markdown report plus the pass/fail verdict. After PR L lands, each summary file also carries its own `run` block so the parity consumer can verify the inputs without relying on filenames.
 
 ```mermaid
 flowchart TD
@@ -222,7 +140,7 @@ flowchart TD
 
 ## Tool-call assertion seam
 
-Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. After PR J #64681 merges, the `source-docs-discovery-report` and `subagent-handoff` scenarios also read the mock server's `/debug/requests` log and require the scenario to actually invoke the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply is accepted. Today (pre-PR-J on `main`) these scenarios only assert the prose shape.
+After PR J lands, the scenarios that depend on a real tool call read the mock server's `/debug/requests` log and fail if the expected tool wasn't actually invoked before the prose reply. Before PR J, these scenarios only check the prose shape.
 
 ```mermaid
 flowchart LR
@@ -236,51 +154,23 @@ flowchart LR
 
 ## Scenario pack
 
-Wave 1 (PR D #64441, merged) registers the first five scenarios in the parity pack. Wave 2 (PR E #64662, open) registers the next five. The `QA_AGENTIC_PARITY_SCENARIOS` array in `extensions/qa-lab/src/agentic-parity.ts` is the single source of truth; reviewers can count the entries there to see which scenarios are currently wired into the gate.
+The pack is `QA_AGENTIC_PARITY_SCENARIOS` in `extensions/qa-lab/src/agentic-parity.ts`. PR D registers the first five; PR E adds the other five. The scenario markdown files themselves already live under `qa/scenarios/` and can run standalone — PR E is just the pack registration and gate wiring.
 
-**Wave 1 scenarios (live on main):**
+**Wave 1 (live on `main`):**
 
-### `approval-turn-tool-followthrough`
+- `approval-turn-tool-followthrough` — the model shouldn't stop at "I'll do that" after a short approval. It should take the first concrete action in the same turn.
+- `model-switch-tool-continuity` — tool-using work should stay coherent across a model or runtime switch instead of resetting into commentary.
+- `source-docs-discovery-report` — the model should read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping. After PR J, this scenario also requires a real `read` tool call to land before the prose reply is accepted.
+- `image-understanding-attachment` — mixed-mode tasks with attachments should stay actionable and not collapse into vague narration.
+- `compaction-retry-mutating-tool` — a task with a real mutating write should keep replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state.
 
-Checks that the model does not stop at “I’ll do that” after a short approval. It should take the first concrete action in the same turn.
+**Wave 2 (registered in the pack after PR E lands):**
 
-### `model-switch-tool-continuity`
-
-Checks that tool-using work remains coherent across model/runtime switching boundaries instead of resetting into commentary or losing execution context.
-
-### `source-docs-discovery-report`
-
-Checks that the model can read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping early. The scenario also requires a real `read` tool call to land before the prose reply is accepted.
-
-### `image-understanding-attachment`
-
-Checks that mixed-mode tasks involving attachments remain actionable and do not collapse into vague narration.
-
-### `compaction-retry-mutating-tool`
-
-Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
-
-**Wave 2 scenarios (registered in the pack after PR E #64662 merges; the scenario files already live under `qa/scenarios/` and run standalone):**
-
-### `subagent-handoff`
-
-Checks that a bounded delegation actually spawns a subagent via the `sessions_spawn` tool and folds the subagent's result back into the main flow, instead of producing a prose report that claims delegation occurred without a real subagent call.
-
-### `subagent-fanout-synthesis`
-
-Checks that a fanout across multiple subagents synthesizes results honestly and labels which sub-result contributed to which part of the final answer.
-
-### `memory-recall`
-
-Checks that a task can pull a prior detail back after an intervening context switch, instead of implicitly asking the user to restate it.
-
-### `thread-memory-isolation`
-
-Checks that memory recorded against one thread does not leak into an unrelated thread, so the runtime's isolation contract matches what the model behaves as if.
-
-### `config-restart-capability-flip`
-
-Checks that a live capability change survives a config restart on the agent and is visible to the next run without a stale feature flag cached in the agent's state.
+- `subagent-handoff` — a bounded delegation should actually spawn a subagent via `sessions_spawn` and fold the result back into the main flow. After PR J, this scenario also requires the `sessions_spawn` call to land before the prose reply.
+- `subagent-fanout-synthesis` — a fanout across multiple subagents should synthesize results honestly and label which sub-result contributed where.
+- `memory-recall` — the model should pull a prior detail back after an intervening context switch instead of implicitly asking the user to restate it.
+- `thread-memory-isolation` — memory recorded against one thread shouldn't leak into an unrelated thread.
+- `config-restart-capability-flip` — a live capability change should survive a config restart and be visible to the next run without a stale feature flag cached in the agent's state.
 
 ## Scenario matrix
 
@@ -297,105 +187,58 @@ Checks that a live capability change survives a config restart on the agent and 
 | `thread-memory-isolation`          | Cross-thread memory isolation           | Keeps memory scoped to the right thread and does not leak                      | a detail from thread A surfaces in thread B                                    |
 | `config-restart-capability-flip`   | Live capability change across restart   | Next run sees the new capability instead of the cached feature flag            | stale capability survives the restart and leaks into the next run              |
 
-## Running the parity gate end-to-end
+## Running the harness end-to-end
 
-The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers. The shell commands below use the real CLI flag names (`--model` / `--alt-model` on `openclaw qa suite`, `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`).
+The harness is three commands. The CLI flags are `--model` / `--alt-model` on `openclaw qa suite` and `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`. The baseline lane only runs fully offline once PR K lands the Anthropic mock route — until then it needs real Anthropic credentials.
 
-The baseline lane only runs end-to-end against the qa-lab mock server after PR K #64685 merges the Anthropic `/v1/messages` route. Until then, the baseline lane requires real Anthropic credentials.
+```bash
+pnpm openclaw qa suite \
+  --model openai/gpt-5.4 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/gpt54
 
-1. Run the suite against the candidate provider/model:
+pnpm openclaw qa suite \
+  --model anthropic/claude-opus-4-6 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/opus46
 
-   ```bash
-   pnpm openclaw qa suite \
-     --model openai/gpt-5.4 \
-     --parity-pack agentic \
-     --output-dir .artifacts/qa-e2e/gpt54
-   ```
+pnpm openclaw qa parity-report \
+  --repo-root . \
+  --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
+  --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+  --output-dir .artifacts/qa-e2e/parity
+```
 
-2. Run the suite against the baseline provider/model:
-
-   ```bash
-   pnpm openclaw qa suite \
-     --model anthropic/claude-opus-4-6 \
-     --parity-pack agentic \
-     --output-dir .artifacts/qa-e2e/opus46
-   ```
-
-3. Generate the parity report and read the verdict:
-
-   ```bash
-   pnpm openclaw qa parity-report \
-     --repo-root . \
-     --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
-     --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
-     --output-dir .artifacts/qa-e2e/parity
-   ```
-
-After PR L #64789 merges, each `qa-suite-summary.json` carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. Until PR L merges, the summary only carries `{ scenarios, counts }` and the parity report trusts the caller-supplied labels. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
+`openclaw qa parity-report` writes the Markdown report and a JSON verdict, and exits nonzero on a gate failure so CI can block the release. After PR L lands, `qa-suite-summary.json` carries the `run` block that the parity report uses to label each input; until then, the report still works but trusts the caller's `--candidate-label` / `--baseline-label`.
 
 ## Release gate
 
-GPT-5.4 can only be considered at parity or better when the merged runtime passes the full ten-scenario parity pack and the runtime-truthfulness regressions at the same time.
+GPT-5.4 can only be called at parity or better when the merged runtime passes the ten-scenario parity pack and the runtime-truthfulness regressions at the same time. The gate compares completion rate, unintended-stop rate, valid-tool-call rate, and fake-success count across candidate and baseline. After PR E, it also requires every required parity scenario to pass on _both_ sides (not just match each other) and honors the `/debug/requests` tool-call assertions from PR J on the tool-mediated scenarios.
 
-Required outcomes:
-
-- no plan-only stall when the next tool action is clear
-- no fake completion without real execution
-- no incorrect `/elevated full` guidance
-- no silent replay or compaction abandonment
-- parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline across all ten scenarios
-
-The gate compares:
-
-- completion rate
-- unintended-stop rate
-- valid-tool-call rate
-- fake-success count
-- required-scenario outcomes (any required scenario that fails on either side fails the gate, even if the baseline also failed)
-- tool-call assertions on the scenarios that require a real tool invocation (`read` for `source-docs-discovery-report`, `sessions_spawn` for `subagent-handoff`)
-
-Parity evidence is intentionally split across two layers:
-
-- PRs D and E prove same-scenario GPT-5.4 vs Opus 4.6 behavior through the ten-scenario QA-lab pack
-- PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
+Evidence lives in two layers on purpose. The parity harness (PRs D + E) proves same-scenario GPT-5.4 vs Opus 4.6 behavior. The deterministic runtime-truthfulness suites from PR B still own auth, proxy, DNS, and `/elevated full` truthfulness outside the harness, because those failure modes are better tested by contract than by scenario.
 
 ## Goal-to-evidence matrix
 
-| Completion gate item                                     | Owning PRs                | Evidence source                                                                                                  | Pass signal                                                                                                            |
-| -------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| GPT-5.4 no longer stalls after planning                  | PR A + PR H               | PR A runtime suites, `approval-turn-tool-followthrough`, PR H auto-activation regression                         | unconfigured GPT-5 runs auto-activate strict-agentic and approval turns trigger real work or an explicit blocked state |
-| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR J        | parity report scenario outcomes, fake-success count, `/debug/requests` tool-call assertions                      | no suspicious pass results and a real `read` / `sessions_spawn` call is recorded before prose is accepted              |
-| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B                      | deterministic truthfulness suites                                                                                | blocked reasons and full-access hints stay runtime-accurate                                                            |
-| Replay/liveness failures stay explicit                   | PR C + PR H               | PR C lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                           | mutating work keeps replay-unsafety explicit and the strict-agentic blocked exit emits `"blocked"`                     |
-| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, self-describing `run` block, dual-provider mock | full ten-scenario coverage on both providers with no regression on the agreed metrics, verifiable offline              |
+| Completion gate criterion                                | Owning PRs                | Evidence                                                                                                         | Pass signal                                                                                                             |
+| -------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| GPT-5.4 no longer stalls after planning                  | PR A + PR H               | strict-agentic runtime suites, `approval-turn-tool-followthrough`, PR H auto-activation regression               | unconfigured GPT-5 runs auto-activate strict-agentic and approval turns either act or surface an explicit blocked state |
+| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR J        | parity report scenario outcomes, fake-success count, `/debug/requests` tool-call assertions                      | no suspicious pass results; a real `read` or `sessions_spawn` call is recorded before prose is accepted                 |
+| No false `/elevated full` guidance                       | PR B                      | deterministic truthfulness suites                                                                                | blocked reasons and full-access hints stay runtime-accurate                                                             |
+| Replay/liveness failures stay explicit                   | PR C + PR H               | lifecycle/replay suites, strict-agentic blocked-exit liveness regression                                         | mutating work keeps replay-unsafety explicit; the strict-agentic blocked exit emits `"blocked"`                         |
+| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, self-describing `run` block, dual-provider mock | full ten-scenario coverage on both providers with no regression on the agreed metrics, verifiable offline               |
 
-## How to read the parity verdict
+## Reading the parity verdict
 
-Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the ten-scenario parity pack.
+`qa-agentic-parity-summary.json` is the final machine-readable decision for the ten-scenario parity pack. `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and didn't regress on the agreed aggregate metrics. `fail` means at least one hard gate tripped — weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, mismatched scenario coverage, or a required scenario that failed on either side.
 
-- `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and did not regress on the agreed aggregate metrics.
-- `fail` means at least one hard gate tripped: weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, or mismatched scenario coverage.
-- “shared/base CI issue” is not itself a parity result. If CI noise outside PR D blocks a run, the verdict should wait for a clean merged-runtime execution instead of being inferred from branch-era logs.
-- Auth, proxy, DNS, and `/elevated full` truthfulness still come from PR B’s deterministic suites, so the final release claim needs both: a passing PR D parity verdict and green PR B truthfulness coverage.
+"Shared/base CI issue" isn't a parity result. If CI noise outside the harness blocks a run, the verdict should wait for a clean merged-runtime execution instead of being inferred from branch-era logs. Auth, proxy, DNS, and `/elevated full` truthfulness still come from PR B's deterministic suites, so the final release claim needs both a passing parity verdict and green truthfulness coverage.
 
 ## Strict-agentic defaults and overrides
 
-After PR H landed, the strict-agentic contract is now the automatic default for GPT-5-family `openai` and `openai-codex` runs. Operators no longer need to configure `executionContract: "strict-agentic"` to get act-now enforcement on those providers — an unconfigured GPT-5 run automatically activates the contract and emits an explicit `"blocked"` liveness state at the strict-agentic blocked exit.
+Once PR H lands, the strict-agentic contract is the automatic default for GPT-5-family `openai` and `openai-codex` runs. Operators don't need to set `executionContract: "strict-agentic"` to get act-now enforcement — an unconfigured GPT-5 run picks it up automatically and emits a `"blocked"` liveness state at the strict-agentic blocked exit.
 
-Override behavior:
+Three configurations to know about:
 
-- **Auto-activated (default for GPT-5 on `openai` / `openai-codex`)**: no configuration required. The runtime enforces act-or-block on plan-only turns and surfaces a `"blocked"` liveness state on the blocked exit.
-- **Explicit opt-out**: set `executionContract: "default"` on the agent config to keep the pre-PR-H looser behavior. This is the escape hatch for prompt-testing workflows or third-party agents that rely on plan-only completion.
-- **Explicit opt-in for other providers**: set `executionContract: "strict-agentic"` to run the contract on Anthropic or any other provider. The auto-activation rule only fires for GPT-5-family OpenAI / OpenAI-Codex runs; other providers still require the explicit config.
-
-Keep the default auto-activation behavior when:
-
-- you want the runtime to guarantee act-or-block on GPT-5 flows without per-agent configuration
-- you are comparing GPT-5.4 against Opus 4.6 through the parity pack and want the contract enforced on the candidate side
-- you prefer explicit blocked states over “helpful” recap-only replies
-
-Opt out (`executionContract: "default"`) when:
-
-- you are running prompt-engineering workflows that deliberately test plan-only turns
-- you are testing a third-party skill that expects the pre-PR-H behavior
-- you are using a non-GPT-5 model that should not be gated by the contract
+- **Auto-activated** (default for GPT-5 on `openai` / `openai-codex`). No configuration required. Use this for the common case where you want the runtime to guarantee act-or-block on GPT-5 flows, and especially when running GPT-5.4 through the parity pack.
+- **Explicit opt-out** (`executionContract: "default"`). Keeps the pre-PR-H looser behavior. This is the escape hatch for prompt-engineering workflows that deliberately test plan-only turns or third-party skills that expect the older semantics.
+- **Explicit opt-in for other providers** (`executionContract: "strict-agentic"`). Runs the contract on Anthropic or any other provider. The auto-activation rule only fires for GPT-5-family OpenAI and OpenAI-Codex runs, so if you want strict-agentic somewhere else you still have to turn it on.


### PR DESCRIPTION
## Summary

Documentation-only catch-up. Brings `docs/help/gpt54-codex-agentic-parity.md` and `docs/help/gpt54-codex-agentic-parity-maintainers.md` up to the full ten-PR state of the parity program, adds three new architecture diagrams, an end-to-end runbook, and an updated goal-to-evidence matrix.

Zero runtime, test, scenario registry, CLI, or architecture changes. Part of #64227.

## Why this exists

The earlier parity docs were written for the first-wave 4-PR plan (A, B, C, D). Once the refinement wave started landing on branches (E, H, J, K, L), the docs were stuck describing a much smaller program than what was actually in flight. Reviewers couldn't tell from a single page what was merged, what was open, or how the pieces fit together — so I'm treating "the full story is legible from the docs" as part of the criterion 5 deliverable and splitting it out here so it doesn't have to wait on whichever wave-2 PR is the last to merge.

## What changed

### `docs/help/gpt54-codex-agentic-parity.md`

- Rewrote the intro to explain the two waves and the 10-PR cap backstory honestly.
- Added a `Where things stand` table listing the full program with per-PR merge status.
- Restructured `What changed` around "the runtime contract" (PRs A, B, C, H), "the parity harness" (PRs D, E, K, L), and "tool-call enforcement" (PR J) instead of a flat list of ten subsections.
- Kept the before/after table but extended it to cover the wave-2 symptoms (prose-only scenarios, baseline credentials, provenance).
- Added three new mermaid diagrams: the dual-provider mock architecture, the parity run orchestration, and the tool-call assertion seam.
- Added a `Running the harness end-to-end` section with the three-step flow using the real CLI flags (`--model` / `--alt-model` on `qa suite`, `--candidate-summary` / `--baseline-summary` on `qa parity-report`), plus a clear note that the baseline lane only runs fully offline after PR K lands.
- Updated `Release gate` and `Goal-to-evidence matrix` so the five criteria map across all ten PRs.
- Rewrote the strict-agentic section around the three real configurations (auto-activated default, explicit opt-out, explicit opt-in for other providers) instead of a bulleted "who should enable" list.
- Kept every section that describes unmerged behavior tagged inline with "after PR X lands" so nobody tries to run commands that depend on code that isn't on `main` yet.

### `docs/help/gpt54-codex-agentic-parity-maintainers.md`

- Rewrote the intro to explain the two-wave shape.
- Added per-PR `Owns` / `Does not own` subsections for E, F, H, J, K, L, and M.
- Updated `Mapping back to the original six contracts` so "Same-turn execution" is PR A + PR H, "Replay/continuation/liveness correctness" is PR C + PR H, and "Benchmark/release gate" spans PR D + PR E + PR J + PR K + PR L + PR M.
- Rewrote `Review order` around the real dependency graph (H independent; E depends on D; K independent; J depends on E; L independent; M last) instead of a flat enumerated list.
- Added `What to look for` subsections for each new PR.
- Updated `Release gate` to require PR H merged, PR D + PR E clean on both providers, PR J tool-call assertions passing, PR K's dual-provider mock exercised in CI, and PR L's run metadata present on both summaries.
- Updated the goal-to-evidence map and reviewer shorthand table to match the ten-PR program.

## Test plan

- [x] `wc -l docs/help/gpt54-codex-agentic-parity.md` — consolidated from the earlier 401-line draft into a tighter rewrite
- [x] `wc -l docs/help/gpt54-codex-agentic-parity-maintainers.md` — similar consolidation
- [x] `rg 'flowchart' docs/help/gpt54-codex-agentic-parity.md` — 5 flowcharts (2 original architecture/release diagrams + 3 new)
- [x] Every mermaid node label that contains a leading `/` (for example `/v1/responses`, `/debug/requests`) is wrapped in quotes so it doesn't collide with mermaid's parallelogram shape
- [x] Runbook commands use the real CLI flag names (`--model` / `--alt-model`), not the earlier draft's `--primary-model`
- [ ] Maintainer spot-check that each new PR subsection matches its owning PR's scope (depends on review)

## Scope the way a reviewer should see it

- **What PR M owns:** prose, tables, mermaid, runbook wording, matrix wording, program-status disclaimer.
- **What PR M does not own:** anything runtime/test/scenario/CLI/architecture — if the doc describes a behavior, the owning PR is the one that implements it. The CLI flag reference matches what's on `main` today (`--model`), not a speculative future flag.
