### PR TITLE
fix(tui): clear stale streaming status for completed unbound runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI: clear stale `streaming` status when a run finishes without binding as the active run, including empty local `/btw` completions, so completed turns return to `idle` instead of spinning indefinitely. (#64825)
 - OpenAI/Codex OAuth: stop rewriting the upstream authorize URL scopes so new Codex sign-ins do not fail with `invalid_scope` before returning an authorization code. (#64713) Thanks @fuller-stack-dev.
 - Audio transcription: disable pinned DNS only for OpenAI-compatible multipart requests, while still validating hostnames, so OpenAI, Groq, and Mistral transcription works again without weakening other request paths. (#64766) Thanks @GodsBoy.
 - macOS/Talk Mode: after granting microphone permission on first enable, continue starting Talk Mode instead of requiring a second toggle. (#62459) Thanks @ggarber.

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -331,6 +331,61 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
   });
 
+  it("sets aborted status when a local BTW run aborts after rendering delta text", () => {
+    const { state, chatLog, noteLocalBtwRunId, setActivityStatus, handleChatEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: null },
+      });
+
+    noteLocalBtwRunId("run-btw");
+    handleChatEvent({
+      runId: "run-btw",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "partial" },
+    });
+
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith("partial", "run-btw");
+    expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
+
+    handleChatEvent({
+      runId: "run-btw",
+      sessionKey: state.currentSessionKey,
+      state: "aborted",
+    } satisfies ChatEvent);
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenLastCalledWith("aborted");
+  });
+
+  it("sets error status when a local BTW run errors after rendering delta text", () => {
+    const { state, chatLog, noteLocalBtwRunId, setActivityStatus, handleChatEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: null },
+      });
+
+    noteLocalBtwRunId("run-btw");
+    handleChatEvent({
+      runId: "run-btw",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "partial" },
+    });
+
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith("partial", "run-btw");
+    expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
+
+    handleChatEvent({
+      runId: "run-btw",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "boom",
+    } satisfies ChatEvent);
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenLastCalledWith("error");
+  });
+
   it("does not cross-match canonical session keys from different agents", () => {
     const { chatLog, handleChatEvent } = createHandlersHarness({
       state: {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -304,6 +304,33 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
   });
 
+  it("clears streaming status when a local BTW run finishes after rendering delta text", () => {
+    const { state, chatLog, noteLocalBtwRunId, setActivityStatus, handleChatEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: null },
+      });
+
+    noteLocalBtwRunId("run-btw");
+    handleChatEvent({
+      runId: "run-btw",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "partial" },
+    });
+
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith("partial", "run-btw");
+    expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
+
+    handleChatEvent({
+      runId: "run-btw",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    } satisfies ChatEvent);
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
+  });
+
   it("does not cross-match canonical session keys from different agents", () => {
     const { chatLog, handleChatEvent } = createHandlersHarness({
       state: {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -138,7 +138,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || (!state.activeChatRunId && sessionRuns.size === 0)) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
@@ -254,6 +254,9 @@ export function createEventHandlers(context: EventHandlerContext) {
       if (!evt.message && isLocalBtwRun) {
         forgetLocalBtwRunId?.(evt.runId);
         noteFinalizedRun(evt.runId);
+        if (!state.activeChatRunId && sessionRuns.size === 0) {
+          setActivityStatus("idle");
+        }
         tui.requestRender();
         return;
       }

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -153,7 +153,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || (!state.activeChatRunId && sessionRuns.size === 0)) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the TUI can stay stuck on `streaming` after a run finishes if that run never bound as `activeChatRunId`.
- Why it matters: completed turns look hung until the user manually clears the status, even though the reply/rendered state is already done.
- What changed: `finalizeRun()` now falls back to the terminal status when no tracked runs remain, and empty local `/btw` finals use the same idle recovery path.
- What did NOT change (scope boundary): concurrent-run status handling and history refresh behavior stay as-is.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64825
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: chat deltas always set `streaming`, but the terminal status transition only fired when `wasActiveRun` was `true`; local `/btw` runs can stream without ever binding as the active run, and their empty final path never had a fallback idle transition.
- Missing detection / guardrail: there was no regression test for a local `/btw` run that renders delta text and then finishes with an empty final event.
- Contributing context (if known): `handleChatEvent()` intentionally skips binding `activeChatRunId` for local `/btw` runs, so the edge case only appears on that unbound completion path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/tui/tui-event-handlers.test.ts`
- Scenario the test should lock in: a local `/btw` run emits a visible delta, then completes with an empty final event, and the TUI status returns from `streaming` to `idle`.
- Why this is the smallest reliable guardrail: it exercises the exact handler/state transition without needing a live model or interactive TUI session.
- Existing test that already covers this (if any): the concurrent-run tests in the same file already cover the “do not clear another active run” side of this state machine.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Completed TUI turns that finish on the unbound local `/btw` path now return the status bar to `idle` instead of leaving it stuck on `streaming`.

## Diagram (if applicable)

```text
Before:
local /btw run -> delta sets streaming -> empty final arrives unbound -> status stays streaming

After:
local /btw run -> delta sets streaming -> empty final arrives unbound -> status returns to idle
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: Node 22.17.1
- Model/provider: N/A
- Integration/channel (if any): TUI local `/btw` event-handler path
- Relevant config (redacted): none

### Steps

1. Mark a run as local `/btw` so it does not bind `activeChatRunId`.
2. Send a chat delta for that run so the handler renders text and sets `streaming`.
3. Send the empty final event for the same run.

### Expected

- The TUI status returns to `idle` once the final event is processed.

### Actual

- Before this change, the status remained stuck on `streaming`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the handler seam locally before the fix (`statusCalls: ["streaming"]`) and after the fix (`statusCalls: ["streaming", "idle"]`); ran `pnpm test src/tui/tui-event-handlers.test.ts`, `pnpm build`, and `pnpm check`.
- Edge cases checked: the existing concurrent-run regression in `src/tui/tui-event-handlers.test.ts` still passes, so another active run does not get forced to `idle`.
- What you did **not** verify: a live interactive TUI session against a real provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a terminal status fallback could clear `streaming` too early if another run were still in flight.
  - Mitigation: the new path only fires when no tracked runs remain, and the existing concurrent-run regression test stays green.
