### PR TITLE
fix(tui): recover footer state after stale run final

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -530,6 +530,23 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.updateAssistant).toHaveBeenLastCalledWith("continued", "run-active");
   });
 
+  it("recovers the footer when the last tracked run finalizes under a stale active run id", () => {
+    const { state, chatLog, setActivityStatus, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-stale" },
+    });
+
+    handleChatEvent({
+      runId: "run-complete",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("done", "run-complete");
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
   it("suppresses non-local empty final placeholders during concurrent runs", () => {
     const { state, chatLog, loadHistory, handleChatEvent } =
       createConcurrentRunHarness("local stream");

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -134,11 +134,18 @@ export function createEventHandlers(context: EventHandlerContext) {
     runId: string;
     wasActiveRun: boolean;
     status: "idle" | "error";
+    allowStaleFooterRecovery?: boolean;
   }) => {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
+    const shouldRecoverExternalCompletion =
+      Boolean(params.allowStaleFooterRecovery) && sessionRuns.size === 0;
+    if (shouldRecoverExternalCompletion) {
+      // External chat finals are safe to use for stale footer recovery once no runs remain.
+      state.activeChatRunId = null;
+    }
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || shouldRecoverExternalCompletion) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
@@ -250,6 +257,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     if (evt.state === "final") {
       const isLocalBtwRun = isLocalBtwRunId?.(evt.runId) ?? false;
+      const isLocalRun = isLocalRunId?.(evt.runId) ?? false;
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message && isLocalBtwRun) {
         forgetLocalBtwRunId?.(evt.runId);
@@ -262,7 +270,12 @@ export function createEventHandlers(context: EventHandlerContext) {
           allowLocalWithoutDisplayableFinal: true,
         });
         chatLog.dropAssistant(evt.runId);
-        finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
+        finalizeRun({
+          runId: evt.runId,
+          wasActiveRun,
+          status: "idle",
+          allowStaleFooterRecovery: !isLocalRun,
+        });
         tui.requestRender();
         return;
       }
@@ -272,7 +285,12 @@ export function createEventHandlers(context: EventHandlerContext) {
         if (text) {
           chatLog.addSystem(text);
         }
-        finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
+        finalizeRun({
+          runId: evt.runId,
+          wasActiveRun,
+          status: "idle",
+          allowStaleFooterRecovery: !isLocalRun,
+        });
         tui.requestRender();
         return;
       }
@@ -301,6 +319,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         runId: evt.runId,
         wasActiveRun,
         status: stopReason === "error" ? "error" : "idle",
+        allowStaleFooterRecovery: !isLocalRun,
       });
     }
     if (evt.state === "aborted") {


### PR DESCRIPTION
## Summary
Closes #64825.

A non-local chat final could leave the TUI footer stuck in `streaming` when `activeChatRunId` had gone stale, because `finalizeRun()` only settled the footer when the finishing run was still marked active. This lets external final events recover the footer once no tracked runs remain, and adds a regression test that preserves the existing local-run defer behavior from `#53115`.

## Validation
- `pnpm exec vitest run src/tui/tui-event-handlers.test.ts src/tui/tui-session-actions.test.ts`
- `pnpm exec oxlint src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`

`pnpm check` still fails on `main` with the existing repo-wide 442-error oxlint baseline, unchanged by this PR.
