### PR TITLE
fix(tools): tolerate duplicate sessionKey/label in sessions_send

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -103,7 +103,10 @@ export function createSessionsSendTool(opts?: {
       const sessionKeyParam = readStringParam(params, "sessionKey");
       const labelParam = normalizeOptionalString(readStringParam(params, "label"));
       const labelAgentIdParam = normalizeOptionalString(readStringParam(params, "agentId"));
-      if (sessionKeyParam && labelParam) {
+      // When sessionKey and label are both provided but equal, treat it as
+      // sessionKey-only.  LLMs / UI layers sometimes mirror the value into
+      // both fields unintentionally (see #64699).
+      if (sessionKeyParam && labelParam && sessionKeyParam !== labelParam) {
         return jsonResult({
           runId: crypto.randomUUID(),
           status: "error",


### PR DESCRIPTION
## Summary

When calling `sessions_send`, LLMs and UI layers (ClawX, Control UI) sometimes mirror the same value into both `sessionKey` and `label`. This triggers the mutual-exclusion guard even though the intent is unambiguous.

## Changes

Relax the check: only reject when both params are provided AND they differ. When they are equal, treat the call as sessionKey-only (the more specific routing path).

## Testing

- When `sessionKey` and `label` are the same → uses sessionKey, no error
- When `sessionKey` and `label` differ → still rejects with existing error
- When only one is provided → unchanged behavior

Fixes #64699