### PR TITLE
fix(tui): recover activity status when no runs are in flight

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -138,7 +138,11 @@ export function createEventHandlers(context: EventHandlerContext) {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    // Always transition to the target status when no other runs are in flight.
+    // This recovers from edge cases where activeChatRunId was cleared early
+    // (e.g. by a concurrent event) causing wasActiveRun to be false even
+    // though the run genuinely finished — leaving the UI stuck on "streaming".
+    if (params.wasActiveRun || (sessionRuns.size === 0 && !state.activeChatRunId)) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
@@ -153,7 +157,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || (sessionRuns.size === 0 && !state.activeChatRunId)) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();


### PR DESCRIPTION
## Summary

The TUI status bar can get stuck on `streaming` indefinitely after a chat turn completes. This happens when `state.activeChatRunId` is cleared by a concurrent event before the `final` event arrives, causing `wasActiveRun` to be `false` in `finalizeRun` — the `setActivityStatus("idle")` call is skipped and the spinner never stops.

## Changes

Add a recovery condition to both `finalizeRun` and `terminateRun`: when `wasActiveRun` is false but there are provably no other runs in flight (`sessionRuns.size === 0` and `activeChatRunId` is null), still transition the activity status.

This is safe because it only fires when the state machine has confirmed no other work is active — it cannot interfere with legitimate in-flight runs.

## Testing

- Normal case: `wasActiveRun === true` → unchanged behavior
- Edge case: `wasActiveRun === false`, no runs in flight → status recovers to idle
- Concurrent runs: `sessionRuns.size > 0` → no premature status change

Fixes #64825