### PR TITLE
fix(discord): recognize voice messages as audio by filename extension

### DIFF
--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -555,6 +555,17 @@ function inferPlaceholder(attachment: APIAttachment): string {
   if (mime.startsWith("audio/")) {
     return "<media:audio>";
   }
+  // Fallback: infer media type from filename extension when content_type is
+  // missing or generic.  Discord voice messages (OGG/Opus) sometimes arrive
+  // without a correct content_type, so this ensures they are still recognised
+  // as audio and can trigger transcription.
+  const name = normalizeLowercaseStringOrEmpty(attachment.filename);
+  if (name && /\.(aac|flac|m4a|mp3|oga|ogg|opus|wav|wma)$/.test(name)) {
+    return "<media:audio>";
+  }
+  if (name && /\.(mp4|mov|avi|mkv|webm)$/.test(name)) {
+    return "<media:video>";
+  }
   return "<media:document>";
 }
 


### PR DESCRIPTION
## Summary

Discord voice messages (OGG/Opus) sometimes arrive with a missing or generic `content_type`, causing `inferPlaceholder` to classify them as `<media:document>` instead of `<media:audio>`. This prevents the audio transcription pipeline (`tools.media.audio`) from triggering.

## Changes

Add a filename extension fallback in `inferPlaceholder`, matching the same pattern already used by `isImageAttachment`. When `content_type` does not match a known media prefix, check the attachment filename for common audio extensions (`.ogg`, `.opus`, `.mp3`, `.wav`, etc.) and video extensions before falling through to `<media:document>`.

## Testing

- Voice message with `content_type: audio/ogg` → still works (MIME check)
- Voice message with empty `content_type` but filename `voice-message.ogg` → now recognized as `<media:audio>`
- Regular document with `.pdf` extension → still `<media:document>`

Fixes #64803