### PR TITLE
fix(plugins): treat command aliases as valid in plugins.allow

### DIFF
--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -171,6 +171,7 @@
       }
     }
   },
+  "commandAliases": ["wiki"],
   "configContracts": {
     "compatibilityMigrationPaths": ["plugins.entries.memory-wiki.config.bridge.readMemoryCore"]
   }

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -15,6 +15,7 @@ type StalePluginConfigHit = {
 
 type StalePluginRegistryState = {
   knownIds: Set<string>;
+  commandAliases: Set<string>;
   hasDiscoveryErrors: boolean;
 };
 
@@ -30,6 +31,13 @@ function collectPluginRegistryState(
   });
   return {
     knownIds: new Set(registry.plugins.map((plugin) => plugin.id)),
+    commandAliases: new Set(
+      registry.plugins.flatMap((plugin) =>
+        Array.isArray((plugin as Record<string, unknown>).commandAliases)
+          ? ((plugin as Record<string, unknown>).commandAliases as string[])
+          : [],
+      ),
+    ),
     hasDiscoveryErrors: registry.diagnostics.some((diag) => diag.level === "error"),
   };
 }
@@ -50,7 +58,7 @@ export function scanStalePluginConfig(
     return [];
   }
 
-  const { knownIds } = collectPluginRegistryState(cfg, env);
+  const { knownIds, commandAliases } = collectPluginRegistryState(cfg, env);
   const hits: StalePluginConfigHit[] = [];
 
   const allow = Array.isArray(plugins.allow) ? plugins.allow : [];
@@ -59,7 +67,7 @@ export function scanStalePluginConfig(
       continue;
     }
     const pluginId = normalizePluginId(rawPluginId);
-    if (!pluginId || knownIds.has(pluginId)) {
+    if (!pluginId || knownIds.has(pluginId) || commandAliases.has(pluginId)) {
       continue;
     }
     hits.push({
@@ -74,7 +82,7 @@ export function scanStalePluginConfig(
     return hits;
   }
   for (const rawPluginId of Object.keys(entries)) {
-    if (knownIds.has(normalizePluginId(rawPluginId))) {
+    if (knownIds.has(normalizePluginId(rawPluginId)) || commandAliases.has(normalizePluginId(rawPluginId))) {
       continue;
     }
     hits.push({


### PR DESCRIPTION
## Summary

When a plugin declares `commandAliases` in its manifest (e.g. memory-wiki declares `["wiki"]`), users can reference the alias in `plugins.allow` and in CLI commands. However, `openclaw doctor` flags these aliases as stale/unknown plugin references because the stale-plugin-config check only looks at canonical plugin IDs from the registry.

## Changes

- **`extensions/memory-wiki/openclaw.plugin.json`**: Add `commandAliases: ["wiki"]` field to the manifest
- **`src/commands/doctor/shared/stale-plugin-config.ts`**: 
  - Add `commandAliases` to `StalePluginRegistryState` type
  - Collect command aliases from all plugin manifests in `collectPluginRegistryState`
  - Check against aliases in both the `plugins.allow` and `plugins.entries` scans

## Testing

- Plugin referenced by canonical ID → still valid ✓
- Plugin referenced by command alias (e.g. `wiki`) → now valid ✓
- Unknown plugin ID → still flagged as stale ✓

Fixes #64748