### PR TITLE
daemon: recover launch agent restart + prefer restart wake path

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -251,7 +251,7 @@ final class AppState {
         self.launchAtLogin = false
         self.onboardingSeen = onboardingSeen
         self.debugPaneEnabled = UserDefaults.standard.bool(forKey: debugPaneEnabledKey)
-        let savedVoiceWake = UserDefaults.standard.bool(forKey: swabbleEnabledKey)
+        let savedVoiceWake = UserDefaults.standard.object(forKey: swabbleEnabledKey) as? Bool ?? true
         self.swabbleEnabled = voiceWakeSupported ? savedVoiceWake : false
         self.swabbleTriggerWords = UserDefaults.standard
             .stringArray(forKey: swabbleTriggersKey) ?? defaultVoiceWakeTriggers
@@ -327,13 +327,6 @@ final class AppState {
                 let current = await LaunchAgentManager.status()
                 await MainActor.run { [weak self] in self?.launchAtLogin = current }
             }
-        }
-
-        if self.swabbleEnabled, !PermissionManager.voiceWakePermissionsGranted() {
-            self.swabbleEnabled = false
-        }
-        if self.talkEnabled, !PermissionManager.voiceWakePermissionsGranted() {
-            self.talkEnabled = false
         }
 
         if !self.isPreview {

--- a/apps/macos/Sources/OpenClaw/AudioInputDeviceObserver.swift
+++ b/apps/macos/Sources/OpenClaw/AudioInputDeviceObserver.swift
@@ -13,6 +13,11 @@ final class AudioInputDeviceObserver {
         return self.deviceUID(for: deviceID)
     }
 
+    static func setDefaultInputDeviceUID(_ uid: String) -> Bool {
+        guard let deviceID = self.deviceID(forUID: uid) else { return false }
+        return self.setDefaultInputDeviceID(deviceID)
+    }
+
     static func aliveInputDeviceUIDs() -> Set<String> {
         let systemObject = AudioObjectID(kAudioObjectSystemObject)
         var address = AudioObjectPropertyAddress(
@@ -74,6 +79,41 @@ final class AudioInputDeviceObserver {
             &deviceID)
         guard status == noErr, deviceID != 0 else { return nil }
         return deviceID
+    }
+
+    private static func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool {
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var newID = deviceID
+        let size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectSetPropertyData(systemObject, &address, 0, nil, size, &newID)
+        return status == noErr
+    }
+
+    private static func deviceID(forUID uid: String) -> AudioObjectID? {
+        let systemObject = AudioObjectID(kAudioObjectSystemObject)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        var status = AudioObjectGetPropertyDataSize(systemObject, &address, 0, nil, &size)
+        guard status == noErr, size > 0 else { return nil }
+
+        let count = Int(size) / MemoryLayout<AudioObjectID>.size
+        var deviceIDs = [AudioObjectID](repeating: 0, count: count)
+        status = AudioObjectGetPropertyData(systemObject, &address, 0, nil, &size, &deviceIDs)
+        guard status == noErr else { return nil }
+
+        for deviceID in deviceIDs {
+            if self.deviceUID(for: deviceID) == uid {
+                return deviceID
+            }
+        }
+        return nil
     }
 
     func start(onChange: @escaping @Sendable () -> Void) {

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -175,8 +175,11 @@ actor TalkModeRuntime {
         self.recognitionGeneration &+= 1
         let generation = self.recognitionGeneration
 
-        let locale = await MainActor.run { AppStateStore.shared.voiceWakeLocaleID }
+        let (locale, selectedMicID) = await MainActor.run { (AppStateStore.shared.voiceWakeLocaleID, AppStateStore.shared.voiceWakeMicID) }
         self.recognizer = SFSpeechRecognizer(locale: Locale(identifier: locale))
+        if !selectedMicID.isEmpty {
+            _ = AudioInputDeviceObserver.setDefaultInputDeviceUID(selectedMicID)
+        }
         guard let recognizer, recognizer.isAvailable else {
             self.logger.error("talk recognizer unavailable")
             return
@@ -332,6 +335,27 @@ actor TalkModeRuntime {
         await MainActor.run { TalkModeController.shared.updatePhase(.thinking) }
         await self.stopRecognition()
         await self.sendAndSpeak(text)
+    }
+
+    func handleExternalTranscript(_ transcript: String) async -> Bool {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+
+        let wasEnabled = self.isEnabled
+
+        if !wasEnabled {
+            await MainActor.run {
+                AppStateStore.shared.talkEnabled = true
+                TalkOverlayController.shared.present()
+            }
+            self.isEnabled = true
+            self.isPaused = false
+        }
+
+        self.phase = .thinking
+        await MainActor.run { TalkModeController.shared.updatePhase(.thinking) }
+        await self.sendAndSpeak(trimmed)
+        return true
     }
 
     // MARK: - Gateway + TTS
@@ -810,9 +834,11 @@ extension TalkModeRuntime {
 
     private func fetchTalkConfig() async -> TalkModeGatewayConfigState {
         let env = ProcessInfo.processInfo.environment
-        let envVoice = env["ELEVENLABS_VOICE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let envVoice = (env["ELEVENLABS_VOICE_ID"] ?? Self.readGatewayEnvLocal("ELEVENLABS_VOICE_ID"))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let sagVoice = env["SAG_VOICE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let envApiKey = env["ELEVENLABS_API_KEY"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let envApiKey = (env["ELEVENLABS_API_KEY"] ?? Self.readGatewayEnvLocal("ELEVENLABS_API_KEY"))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
             let snap: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
@@ -884,13 +910,15 @@ extension TalkModeRuntime {
 
     private func shouldInterrupt(transcript: String, hasConfidence: Bool) async -> Bool {
         let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 3 else { return false }
+        guard trimmed.count >= 2 else { return false }
         if self.isLikelyEcho(of: trimmed) { return false }
         let now = Date()
-        if let lastSpeechEnergyAt, now.timeIntervalSince(lastSpeechEnergyAt) > 0.35 {
-            return false
+        guard let lastSpeechEnergyAt else { return hasConfidence }
+        let recentSpeech = now.timeIntervalSince(lastSpeechEnergyAt) <= 1.0
+        if recentSpeech, trimmed.count >= 4 {
+            return true
         }
-        return hasConfidence
+        return hasConfidence && recentSpeech
     }
 
     private func isLikelyEcho(of transcript: String) -> Bool {
@@ -900,6 +928,20 @@ extension TalkModeRuntime {
             return spoken.contains(probe)
         }
         return spoken.contains(probe)
+    }
+
+    private static func readGatewayEnvLocal(_ key: String) -> String? {
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".openclaw/secrets/gateway-env.local")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        for rawLine in text.split(whereSeparator: \Character.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard line.hasPrefix("\(key)=") else { continue }
+            let value = String(line.dropFirst(key.count + 1)).trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        }
+        return nil
     }
 
     private static func resolveSpeed(speed: Double?, rateWPM: Int?, logger: Logger) -> Double? {

--- a/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
@@ -45,6 +45,11 @@ enum VoiceWakeForwarder {
         transcript: String,
         options: ForwardOptions = ForwardOptions()) async -> Result<Void, VoiceWakeForwardError>
     {
+        if await TalkModeRuntime.shared.handleExternalTranscript(transcript) {
+            self.logger.info("voice wake handoff to talk runtime ok")
+            return .success(())
+        }
+
         let payload = Self.prefixedTranscript(transcript)
         let deliver = options.channel.shouldDeliver(options.deliver)
         let result = await GatewayConnection.shared.sendAgent(GatewayAgentInvocation(

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -160,6 +160,10 @@ actor VoiceWakeRuntime {
             self.recognitionRequest?.taskHint = .dictation
             guard let request = self.recognitionRequest else { return }
 
+            if let micID = config.micID, !micID.isEmpty {
+                _ = AudioInputDeviceObserver.setDefaultInputDeviceUID(micID)
+            }
+
             // Lazily create the engine here so app launch doesn't grab audio resources / trigger Bluetooth HFP.
             if self.audioEngine == nil {
                 self.audioEngine = AVAudioEngine()

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -50,6 +50,7 @@ Common commands
 - Calendar show colors: `gog calendar colors`
 - Drive search: `gog drive search "query" --max 10`
 - Contacts: `gog contacts list --max 20`
+- For comprehensive Contacts search/export tasks where completeness matters, use the dedicated `google-contacts` skill instead of relying on `gog contacts search` alone.
 - Sheets get: `gog sheets get <sheetId> "Tab!A1:D10" --json`
 - Sheets update: `gog sheets update <sheetId> "Tab!A1:B2" --values-json '[["A","B"],["1","2"]]' --input USER_ENTERED`
 - Sheets append: `gog sheets append <sheetId> "Tab!A:C" --values-json '[["x","y","z"]]' --insert INSERT_ROWS`

--- a/skills/google-contacts/SKILL.md
+++ b/skills/google-contacts/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: google-contacts
+description: Work with Google Contacts via gog when agents need to search, export, or audit contacts and must return a complete result set. Use when a user wants all matching contacts, a filtered contact export, contact counts, CSV/JSON outputs, or when `gog contacts search` appears incomplete or capped.
+---
+
+# Google Contacts
+
+Use this skill for reliable Google Contacts retrieval via `gog`, especially when completeness matters.
+
+## Quick rule
+
+If the user wants **all** contacts matching a query, do **not** trust `gog contacts search` as the final answer.
+
+Read `references/contacts-search-limits.md` and use `scripts/fetch_contacts.py` to paginate `gog contacts list` and filter locally.
+
+## Workflow
+
+1. Confirm the account to query.
+   - Prefer an explicit `--account`.
+   - If the user already specified the account in prior context, keep using it.
+
+2. Decide whether completeness matters.
+   - If the user wants a spot check or a few likely matches, `gog contacts search` is acceptable.
+   - If the user wants **all** matches, counts, exports, or is debugging missing contacts, use the paginated workflow.
+
+3. Use the paginated workflow.
+   - Run `scripts/fetch_contacts.py`.
+   - Search `name,email,phone` unless the task clearly calls for narrower matching.
+   - Write JSON/CSV outputs when the user asks for an artifact or when the result set is large.
+
+4. Report clearly.
+   - Say that the workflow paginated the full contact list and filtered locally.
+   - Include total contacts scanned and total matches found.
+   - If relevant, note that this avoids the capped behavior of `gog contacts search`.
+
+## Commands
+
+### Quick comprehensive search
+
+```bash
+python3 /absolute/path/to/google-contacts/scripts/fetch_contacts.py \
+  --account admin@focus.ceo \
+  --query pkb \
+  --json-out /tmp/pkb_contacts.json \
+  --csv-out /tmp/pkb_contacts.csv
+```
+
+### Narrower field matching
+
+```bash
+python3 /absolute/path/to/google-contacts/scripts/fetch_contacts.py \
+  --account admin@focus.ceo \
+  --query smith \
+  --fields name,email
+```
+
+## Outputs
+
+The script prints a JSON summary to stdout and can also write:
+
+- JSON array of matching contacts
+- CSV with `resource,name,email,phone`
+
+## Important behavior notes
+
+- `gog contacts list` supports pagination with `nextPageToken`; use that for exhaustive retrieval.
+- Dedupe by `resource` so contacts seen across pages do not double-count.
+- For scripting, always prefer `--json --no-input` behavior through the bundled script.
+- If the user is comparing counts against the Google Contacts UI, mention that this skill intentionally avoids `gog contacts search` caps by enumerating the full list first.
+
+## References
+
+- Search/result-cap behavior and workaround: `references/contacts-search-limits.md`

--- a/skills/google-contacts/references/contacts-search-limits.md
+++ b/skills/google-contacts/references/contacts-search-limits.md
@@ -1,0 +1,62 @@
+# Google Contacts search limits and reliable workaround
+
+## Problem
+
+`gog contacts search <query>` can return an incomplete subset of matches for broad queries like `pkb`.
+
+In the observed failure mode:
+
+- `gog contacts search pkb` returned only 30 results
+- the account actually had many more matches
+- agents can falsely conclude the result set is complete if they trust `search`
+
+## Reliable approach
+
+Do not rely on `gog contacts search` when the user expects comprehensive results.
+
+Instead:
+
+1. page through `gog contacts list --json --no-input --max 1000`
+2. follow `nextPageToken` until exhausted
+3. filter locally against `name`, `email`, and/or `phone`
+4. dedupe by `resource`
+5. write JSON/CSV if the user wants an artifact
+
+## Why this works
+
+`gog contacts list` exposes pagination and can enumerate the full reachable contact corpus for the account. Local filtering avoids the result cap behavior of `search`.
+
+## Recommended script
+
+Use `scripts/fetch_contacts.py` in this skill.
+
+Example:
+
+```bash
+python3 /absolute/path/to/google-contacts/scripts/fetch_contacts.py \
+  --account admin@focus.ceo \
+  --query pkb \
+  --json-out /tmp/pkb_contacts.json \
+  --csv-out /tmp/pkb_contacts.csv
+```
+
+## Output behavior
+
+The script prints a JSON summary to stdout with:
+
+- query
+- fields searched
+- pages fetched
+- total contacts scanned
+- match count
+
+If requested, it also writes:
+
+- JSON array of matching contacts
+- CSV with `resource,name,email,phone`
+
+## Agent guidance
+
+- Prefer `gog contacts search` only for small spot checks where completeness is not critical.
+- Prefer paginated list + local filter whenever the user asks for all matches, suspects missing contacts, or wants a report/export.
+- Always mention that the workaround is deliberate, so future agents do not regress to `search` and hit the same cap again.

--- a/skills/google-contacts/scripts/fetch_contacts.py
+++ b/skills/google-contacts/scripts/fetch_contacts.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_gog(account: str, page: str | None, page_size: int) -> dict:
+    cmd = [
+        'gog', 'contacts', 'list',
+        '--json', '--no-input',
+        '--max', str(page_size),
+        '--account', account,
+    ]
+    if page:
+        cmd += ['--page', page]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr or proc.stdout or f'gog failed: {proc.returncode}')
+    return json.loads(proc.stdout)
+
+
+def contact_matches(contact: dict, needle: str, fields: list[str]) -> bool:
+    needle = needle.lower()
+    for field in fields:
+        value = (contact.get(field) or '').lower()
+        if needle in value:
+            return True
+    return False
+
+
+def fetch_all_matching(account: str, needle: str, page_size: int, fields: list[str], verbose: bool) -> tuple[list[dict], int, int]:
+    page = None
+    seen = set()
+    matches: list[dict] = []
+    total_contacts = 0
+    pages = 0
+
+    while True:
+        payload = run_gog(account, page, page_size)
+        contacts = payload.get('contacts', [])
+        pages += 1
+        total_contacts += len(contacts)
+
+        for contact in contacts:
+            if not contact_matches(contact, needle, fields):
+                continue
+            resource = contact.get('resource') or json.dumps(contact, sort_keys=True)
+            if resource in seen:
+                continue
+            seen.add(resource)
+            matches.append(contact)
+
+        page = payload.get('nextPageToken')
+        if verbose:
+            print(
+                f'page={pages} contacts={len(contacts)} total={total_contacts} matches={len(matches)} next={bool(page)}',
+                file=sys.stderr,
+            )
+        if not page:
+            break
+
+    matches.sort(key=lambda c: (c.get('name') or '').lower())
+    return matches, total_contacts, pages
+
+
+def write_outputs(matches: list[dict], json_path: Path | None, csv_path: Path | None) -> None:
+    rows = [
+        {
+            'resource': row.get('resource', ''),
+            'name': row.get('name', ''),
+            'email': row.get('email', ''),
+            'phone': row.get('phone', ''),
+        }
+        for row in matches
+    ]
+
+    if json_path:
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        with json_path.open('w') as f:
+            json.dump(matches, f, indent=2)
+            f.write('\n')
+
+    if csv_path:
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        with csv_path.open('w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=['resource', 'name', 'email', 'phone'])
+            writer.writeheader()
+            writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Paginate gog contacts list and filter locally to avoid gog contacts search result caps.'
+    )
+    parser.add_argument('--account', required=True, help='Google account to query via gog')
+    parser.add_argument('--query', required=True, help='Case-insensitive substring to match')
+    parser.add_argument('--page-size', type=int, default=1000, help='Contacts per gog page (default: 1000)')
+    parser.add_argument('--fields', default='name,email,phone', help='Comma-separated fields to search')
+    parser.add_argument('--json-out', help='Optional path for JSON output')
+    parser.add_argument('--csv-out', help='Optional path for CSV output')
+    parser.add_argument('--quiet', action='store_true', help='Suppress progress logs')
+    args = parser.parse_args()
+
+    fields = [f.strip() for f in args.fields.split(',') if f.strip()]
+    matches, total_contacts, pages = fetch_all_matching(
+        account=args.account,
+        needle=args.query,
+        page_size=args.page_size,
+        fields=fields,
+        verbose=not args.quiet,
+    )
+
+    write_outputs(
+        matches,
+        Path(args.json_out) if args.json_out else None,
+        Path(args.csv_out) if args.csv_out else None,
+    )
+
+    summary = {
+        'query': args.query,
+        'fields': fields,
+        'pages': pages,
+        'totalContactsScanned': total_contacts,
+        'matches': len(matches),
+    }
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/skills/pickle-contacts/SKILL.md
+++ b/skills/pickle-contacts/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: pickle-contacts
+description: Create pickleball invite lists from a Google Contacts export/merged CSV by filtering tagged contacts (e.g., CKS), extracting ladder ratings (LR: or embedded numeric ratings), applying rating ranges, and outputting a CSV including First Name, Last Name, Rating, Phone, and Email.
+---
+
+# Pickleball Contacts
+
+Use this skill to reliably generate an **invite list CSV** from a contacts export/merged CSV when Davo asks things like:
+
+- “Create a file of my Google Contacts with `pkb` and `CKS` in their name, with ratings between X and Y.”
+- “Generate today’s Creekside invite list.”
+
+This skill is intentionally **contacts-only**. Bulk/drip SMS is handled separately by the `texts-with-approval` skill.
+
+## Inputs (source of truth)
+
+Typically a CSV exported/maintained from Google Contacts and then augmented with tags/ratings, e.g.:
+
+- `~/.openclaw/workspace/temp/pkb_contacts_merged_YYYY-MM-DD-vN.csv`
+
+Expected columns (current workflow):
+
+- `First Name`
+- `Old Last Name`
+- `Last Name`
+- `Phone`
+- `Email`
+
+If the user asks to export from Google Contacts first, use the `google-contacts` skill to generate a comprehensive export, then run this process on the exported file.
+
+## Workflow (invite list)
+
+1. **Filter invite candidates**
+
+- Include only rows whose `Last Name` contains `CKS` (case-sensitive).
+- Important: filter on `Last Name` (not `Old Last Name`).
+
+2. **Extract rating (numeric)**
+
+- Prefer `LR:<number>` anywhere in the row.
+- Else find the first token matching `([345]\.\d+)` anywhere in the row.
+- If no rating is found, record as a failure.
+
+3. **Apply rating range**
+
+- Default range: **3.4 to 4.7** (inclusive), unless the user specifies otherwise.
+
+4. **Normalize First Name**
+
+- Output first name = first word of the `First Name` field, capitalized.
+
+5. **Include contact fields**
+
+- Copy `Phone` and `Email` into output.
+
+6. **Optional discard list**
+
+- If user provides a list of already-signed-up people, discard them using light fuzzy matching.
+
+## Outputs
+
+- Invite list CSV: `First Name, Last Name, Rating, Phone, Email`
+- Failures CSV: rows where rating extraction failed
+
+## Script
+
+Use:
+
+- `scripts/extract_invite_list.py`
+
+Example:
+
+```bash
+python3 skills/pickle-contacts/scripts/extract_invite_list.py \
+  --in ~/.openclaw/workspace/temp/pkb_contacts_merged_2026-03-26-v4.csv \
+  --out ~/.openclaw/workspace/temp/pkb_invite_list_2026-03-26_with_contact.csv \
+  --failures ~/.openclaw/workspace/temp/pkb_invite_list_2026-03-26_with_contact_failures.csv \
+  --min 3.4 --max 4.7 \
+  --tag CKS \
+  --discard "Alyson Wells, Vickie Freshour, Vlad G, Weston McKinney, Chase Highley, Steven Jackson, M Gerst"
+```
+
+## References
+
+- `references/invite-list-process.md`

--- a/skills/pickle-contacts/references/invite-list-process.md
+++ b/skills/pickle-contacts/references/invite-list-process.md
@@ -1,0 +1,62 @@
+# Pickleball invite list extraction (CKS)
+
+## Source of truth
+
+A contacts CSV exported/maintained from Google Contacts and then augmented with tags/ratings. Example:
+
+- `~/.openclaw/workspace/temp/pkb_contacts_merged_YYYY-MM-DD-vN.csv`
+
+Expected columns (current workflow):
+
+- `First Name`
+- `Old Last Name`
+- `Last Name`
+- `Phone`
+- `Email`
+
+## Step-by-step
+
+1. **Select invite candidates**
+
+- Include only rows where `Last Name` contains the exact substring `CKS` (case-sensitive).
+- Important: use `Last Name`, not `Old Last Name`.
+
+2. **Extract rating**
+
+- Prefer `LR:<number>` if present anywhere in the row text.
+  - Example: `LR:4.15` -> `4.15`
+- If no `LR:` exists, find the first rating-like token that matches:
+  - starts with `3`, `4`, or `5`
+  - contains a decimal point
+  - regex: `([345]\.\d+)`
+- If no rating can be found, flag the row as a failure.
+
+3. **Range filter**
+
+- Drop any rating < **3.4** or > **4.7** (inclusive range filter by default).
+
+4. **Output fields**
+
+- `First Name`: first word of the `First Name` field, capitalized.
+- `Last Name`: keep as-is (this includes tags like `CKS`).
+- `Rating`: parsed numeric rating.
+- `Phone`, `Email`: copied from the same row.
+
+5. **Optional: discard already-signed-up people**
+   When Davo provides a short list of already-signed-up names, discard those candidates via lightweight fuzzy name matching.
+
+## Script
+
+Use `scripts/extract_invite_list.py`.
+
+Example:
+
+```bash
+python3 /path/to/skills/pickle-contacts/scripts/extract_invite_list.py \
+  --in ~/.openclaw/workspace/temp/pkb_contacts_merged_2026-03-26-v4.csv \
+  --out ~/.openclaw/workspace/temp/pkb_invite_list_2026-03-26_with_contact.csv \
+  --failures ~/.openclaw/workspace/temp/pkb_invite_list_2026-03-26_with_contact_failures.csv \
+  --min 3.4 --max 4.7 \
+  --tag CKS \
+  --discard "Alyson Wells, Vickie Freshour, Vlad G, Weston McKinney, Chase Highley, Steven Jackson, M Gerst"
+```

--- a/skills/pickle-contacts/scripts/extract_invite_list.py
+++ b/skills/pickle-contacts/scripts/extract_invite_list.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Extract a pickleball invite list from a Google Contacts export/merge CSV.
+
+Designed for Davo's workflow:
+- Source of truth: a CSV like `pkb_contacts_merged_YYYY-MM-DD-vN.csv`
+- Filter: only rows whose `Last Name` contains the exact substring `CKS` (case-sensitive)
+- Rating extraction:
+  1) Prefer `LR:<number>` anywhere in First Name / Old Last Name / Last Name
+  2) Else find the first `[3-5].<digit+>` anywhere
+- Keep rating in inclusive range [minRating, maxRating]
+- First name output: first word of `First Name` field, capitalized
+- Include Phone + Email in output
+- Optionally discard already-signed-up people via fuzzy name match
+
+Outputs:
+- Invite list CSV: First Name, Last Name, Rating, Phone, Email
+- Failures CSV: rows where rating couldn't be extracted
+"""
+
+import argparse
+import csv
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Iterable
+
+
+LR_RE = re.compile(r"\bLR:\s*([0-9]+(?:\.[0-9]+)?)", re.I)
+ALT_RE = re.compile(r"([345]\.\d+)")
+
+
+def norm(s: str) -> str:
+    s = (s or "").lower()
+    s = re.sub(r"[^a-z0-9 ]+", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def similarity(a: str, b: str) -> float:
+    a = norm(a)
+    b = norm(b)
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def extract_rating(*fields: str) -> float | None:
+    hay = " ".join([f for f in fields if f])
+    m = LR_RE.search(hay)
+    if m:
+        return float(m.group(1))
+    m2 = ALT_RE.search(hay)
+    if m2:
+        return float(m2.group(1))
+    return None
+
+
+def first_word_capitalized(first_name_field: str) -> str:
+    first_name_field = (first_name_field or "").strip()
+    if not first_name_field:
+        return ""
+    return first_name_field.split()[0].capitalize()
+
+
+def load_discard_list(text: str | None) -> list[str]:
+    if not text:
+        return []
+    # allow comma-separated or newline-separated
+    parts = re.split(r"[\n,]+", text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def should_discard(contact_first_name_field: str, discard_names: Iterable[str], threshold: float) -> bool:
+    for dn in discard_names:
+        if norm(dn) in norm(contact_first_name_field):
+            return True
+        if similarity(dn, contact_first_name_field) >= threshold:
+            return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="in_path", required=True, help="Input contacts CSV")
+    ap.add_argument("--out", dest="out_path", required=True, help="Output invite list CSV")
+    ap.add_argument("--failures", dest="fail_path", required=True, help="Output failures CSV")
+    ap.add_argument("--min", dest="min_rating", type=float, default=3.4)
+    ap.add_argument("--max", dest="max_rating", type=float, default=4.7)
+    ap.add_argument(
+        "--tag",
+        dest="tag",
+        default="CKS",
+        help="Case-sensitive substring required in Last Name (default: CKS)",
+    )
+    ap.add_argument(
+        "--discard",
+        dest="discard",
+        default="",
+        help="Comma/newline separated names to discard (already signed up)",
+    )
+    ap.add_argument(
+        "--discard-threshold",
+        dest="discard_threshold",
+        type=float,
+        default=0.72,
+        help="Fuzzy similarity threshold for discard matching",
+    )
+
+    args = ap.parse_args()
+
+    in_path = Path(args.in_path)
+    out_path = Path(args.out_path)
+    fail_path = Path(args.fail_path)
+
+    discard_names = load_discard_list(args.discard)
+
+    kept_rows: list[dict] = []
+    fail_rows: list[dict] = []
+
+    with in_path.open(newline="") as f:
+        r = csv.DictReader(f)
+        for row in r:
+            last = row.get("Last Name", "") or ""
+            if args.tag not in last:
+                continue
+
+            rating = extract_rating(
+                row.get("First Name", "") or "",
+                row.get("Old Last Name", "") or "",
+                row.get("Last Name", "") or "",
+            )
+
+            if rating is None:
+                fail_rows.append(
+                    {
+                        "Reason": "no rating found",
+                        "First Name": row.get("First Name", ""),
+                        "Last Name": row.get("Last Name", ""),
+                        "Email": row.get("Email", ""),
+                        "Phone": row.get("Phone", ""),
+                        "Raw": " ".join(
+                            [
+                                row.get("First Name", "") or "",
+                                row.get("Old Last Name", "") or "",
+                                row.get("Last Name", "") or "",
+                            ]
+                        ).strip(),
+                    }
+                )
+                continue
+
+            if rating < args.min_rating or rating > args.max_rating:
+                continue
+
+            first_field = (row.get("First Name") or "").strip()
+            if not first_field:
+                fail_rows.append(
+                    {
+                        "Reason": "missing first name",
+                        "First Name": "",
+                        "Last Name": row.get("Last Name", ""),
+                        "Email": row.get("Email", ""),
+                        "Phone": row.get("Phone", ""),
+                        "Raw": "(empty First Name)",
+                    }
+                )
+                continue
+
+            if discard_names and should_discard(first_field, discard_names, args.discard_threshold):
+                continue
+
+            kept_rows.append(
+                {
+                    "First Name": first_word_capitalized(first_field),
+                    "Last Name": last,
+                    "Rating": rating,
+                    "Phone": (row.get("Phone") or "").strip(),
+                    "Email": (row.get("Email") or "").strip(),
+                }
+            )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fail_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with out_path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["First Name", "Last Name", "Rating", "Phone", "Email"])
+        w.writeheader()
+        for rr in sorted(kept_rows, key=lambda x: (-x["Rating"], x["Last Name"], x["First Name"])):
+            w.writerow(rr)
+
+    with fail_path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["Reason", "First Name", "Last Name", "Email", "Phone", "Raw"])
+        w.writeheader()
+        w.writerows(fail_rows)
+
+    print(f"kept={len(kept_rows)} failures={len(fail_rows)} out={out_path} fail={fail_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/texts-with-approval/references/dedupe-ledger.md
+++ b/skills/texts-with-approval/references/dedupe-ledger.md
@@ -1,0 +1,41 @@
+# Dedupe + ledger for bulk texting
+
+## Why
+
+Bulk sends must be idempotent. If a process restarts or is re-run, recipients must not get duplicates.
+
+## Required artifacts
+
+- **Queue file**: deterministic list of recipients for this campaign
+  - deduped by normalized phone before any send begins
+  - fields: phoneDigits, phoneRaw, firstName, messageVariantId, messageText
+- **Sent ledger** (append-only JSONL or CSV)
+  - key: campaignId + phoneDigits
+  - fields: ts, campaignId, phoneDigits, phoneRaw, status, error
+- **Delay window config**
+  - e.g. `delayMinSec=20`, `delayMaxSec=50`
+
+## Algorithm
+
+1. Generate queue from source list and dedupe by normalized phone.
+2. Load ledger and build `alreadySent` set for the current `campaignId` where status=="sent".
+3. Iterate queue in order:
+   - if phoneDigits in alreadySent: append ledger row with `skipped-already-sent`, then skip
+   - append ledger row with `queued`
+   - attempt send
+   - append ledger row with status `sent` or `failed`
+   - sleep a randomized duration inside the configured delay window before the next send
+
+## Failure handling
+
+- Track consecutive failures.
+- If N consecutive failures (configurable):
+  - sleep 10 minutes
+  - retry one failed
+  - widen delay window
+  - continue
+
+## Notes
+
+- Do not rely on AppleScript exit code as delivery confirmation; it only indicates Messages accepted the command.
+- Ledger is the only durable truth for dedupe.

--- a/skills/texts-with-approval/scripts/bulk_sms_with_ledger.py
+++ b/skills/texts-with-approval/scripts/bulk_sms_with_ledger.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import random
+import subprocess
+import time
+from pathlib import Path
+
+
+def digits(s: str) -> str:
+    return ''.join(ch for ch in (s or '') if ch.isdigit())
+
+
+def norm_phone(s: str) -> str:
+    d = digits(s)
+    return d[-10:] if len(d) >= 10 else d
+
+
+def load_queue_from_csv(csv_path: Path, message_template: str, limit: int | None = None):
+    seen = set()
+    queue = []
+    with csv_path.open(newline='') as f:
+        for row in csv.DictReader(f):
+            phone_raw = (row.get('Phone') or '').strip()
+            phone_digits = norm_phone(phone_raw)
+            first = (row.get('First Name') or '').strip()
+            if not phone_digits or not first:
+                continue
+            if phone_digits in seen:
+                continue
+            seen.add(phone_digits)
+            queue.append({
+                'phoneDigits': phone_digits,
+                'phoneRaw': phone_raw,
+                'firstName': first,
+                'messageText': message_template.replace('[FIRSTNAME]', first),
+            })
+            if limit is not None and len(queue) >= limit:
+                break
+    return queue
+
+
+def append_ledger(ledger_path: Path, rec: dict):
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open('a') as f:
+        f.write(json.dumps(rec) + '\n')
+
+
+def already_sent(ledger_path: Path, campaign_id: str):
+    sent = set()
+    if not ledger_path.exists():
+        return sent
+    for line in ledger_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        rec = json.loads(line)
+        if rec.get('campaignId') == campaign_id and rec.get('status') == 'sent':
+            sent.add(rec['phoneDigits'])
+    return sent
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--input-csv', required=True)
+    ap.add_argument('--queue-jsonl', required=True)
+    ap.add_argument('--ledger-jsonl', required=True)
+    ap.add_argument('--campaign-id', required=True)
+    ap.add_argument('--message-template', required=True)
+    ap.add_argument('--script', required=True)
+    ap.add_argument('--delay-min-sec', type=float, default=20)
+    ap.add_argument('--delay-max-sec', type=float, default=50)
+    ap.add_argument('--service', default='sms')
+    ap.add_argument('--limit', type=int, default=None)
+    args = ap.parse_args()
+
+    queue_path = Path(args.queue_jsonl)
+    ledger_path = Path(args.ledger_jsonl)
+    queue = load_queue_from_csv(Path(args.input_csv), args.message_template, args.limit)
+    queue_path.write_text(''.join(json.dumps(x) + '\n' for x in queue))
+
+    sent_set = already_sent(ledger_path, args.campaign_id)
+
+    for item in queue:
+        base = {
+            'ts': time.time(),
+            'campaignId': args.campaign_id,
+            'phoneDigits': item['phoneDigits'],
+            'phoneRaw': item['phoneRaw'],
+            'firstName': item['firstName'],
+        }
+        if item['phoneDigits'] in sent_set:
+            append_ledger(ledger_path, {**base, 'status': 'skipped-already-sent'})
+            continue
+
+        append_ledger(ledger_path, {**base, 'status': 'queued'})
+        p = subprocess.run([
+            'osascript', args.script, item['phoneRaw'], item['messageText'], args.service
+        ], capture_output=True, text=True)
+
+        status = 'sent' if p.returncode == 0 else 'failed'
+        append_ledger(ledger_path, {
+            **base,
+            'status': status,
+            'stderr': (p.stderr or '')[:200],
+            'stdout': (p.stdout or '')[:200],
+        })
+        if status == 'sent':
+            sent_set.add(item['phoneDigits'])
+
+        time.sleep(random.uniform(args.delay_min_sec, args.delay_max_sec))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -473,6 +473,8 @@ export function buildAgentSystemPrompt(params: {
           "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
           "Use config.schema.lookup with a specific dot path to inspect only the relevant config subtree before making config changes or answering config-field questions; avoid guessing field names/types.",
           "Actions: config.schema.lookup, config.get, config.apply (validate + write full config, then restart), config.patch (partial update, merges with existing), update.run (update deps or git, then restart).",
+          "For agent-triggered restarts/config writes, prefer the built-in config.apply/config.patch/update.run path over raw service restarts so OpenClaw can route the post-restart wake correctly.",
+          "Before an agent-triggered restart, send a brief warning to the user; include sessionKey and a human-readable note so the post-restart ping lands in the same conversation.",
           "After restart, OpenClaw pings the last active session automatically.",
         ].join("\n")
       : "",

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -156,6 +156,30 @@ describe("runServiceRestart token drift", () => {
     expect(payload.message).toContain("unmanaged process");
   });
 
+  it("rechecks service state when a not-loaded restart path re-registers the service", async () => {
+    const postRestartCheck = vi.fn(async () => {});
+    service.isLoaded.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+      onNotLoaded: async () => ({
+        result: "restarted",
+        message: "Gateway service restarted.",
+        serviceLoaded: true,
+      }),
+      postRestartCheck,
+    });
+
+    expect(postRestartCheck).toHaveBeenCalledTimes(1);
+    expect(service.isLoaded).toHaveBeenCalledTimes(2);
+    const payload = readJsonLog<{ service?: { loaded?: boolean }; message?: string }>();
+    expect(payload.message).toBe("Gateway service restarted.");
+    expect(payload.service?.loaded).toBe(true);
+  });
+
   it("skips restart health checks when restart is only scheduled", async () => {
     const postRestartCheck = vi.fn(async () => {});
     service.restart.mockResolvedValue({ outcome: "scheduled" });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -35,6 +35,7 @@ type NotLoadedActionResult = {
   result: "stopped" | "restarted";
   message?: string;
   warnings?: string[];
+  serviceLoaded?: boolean;
 };
 
 type NotLoadedActionContext = {
@@ -450,8 +451,8 @@ export async function runServiceRestart(params: {
         }
       }
     }
-    let restarted = loaded;
-    if (loaded) {
+    let restarted = handledNotLoaded?.serviceLoaded ?? loaded;
+    if (restarted) {
       try {
         restarted = await params.service.isLoaded({ env: process.env });
       } catch {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -20,6 +20,7 @@ type RestartParams = {
 };
 
 const service = {
+  label: "LaunchAgent",
   readCommand: vi.fn(),
   restart: vi.fn(),
 };
@@ -47,6 +48,9 @@ const probeGateway = vi.fn<
 >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
+const launchAgentPlistExists = vi.fn<(env: NodeJS.ProcessEnv) => Promise<boolean>>(
+  async () => false,
+);
 
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
@@ -78,6 +82,10 @@ vi.mock("../../daemon/service.js", () => ({
   resolveGatewayService: () => service,
 }));
 
+vi.mock("../../daemon/launchd.js", () => ({
+  launchAgentPlistExists: (env: NodeJS.ProcessEnv) => launchAgentPlistExists(env),
+}));
+
 vi.mock("./restart-health.js", () => ({
   DEFAULT_RESTART_HEALTH_ATTEMPTS: 120,
   DEFAULT_RESTART_HEALTH_DELAY_MS: 500,
@@ -105,8 +113,12 @@ describe("runDaemonRestart health checks", () => {
     runPostRestartCheck?: boolean;
   } = {}) {
     runServiceRestart.mockImplementation(
-      async (params: RestartParams & { onNotLoaded?: () => Promise<unknown> }) => {
-        await params.onNotLoaded?.();
+      async (
+        params: RestartParams & {
+          onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
+        },
+      ) => {
+        await params.onNotLoaded?.({ stdout: process.stdout });
         if (runPostRestartCheck) {
           await params.postRestartCheck?.({
             json: Boolean(params.opts?.json),
@@ -143,6 +155,7 @@ describe("runDaemonRestart health checks", () => {
     probeGateway.mockReset();
     isRestartEnabled.mockReset();
     loadConfig.mockReset();
+    launchAgentPlistExists.mockReset();
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
@@ -176,6 +189,7 @@ describe("runDaemonRestart health checks", () => {
     isRestartEnabled.mockReturnValue(true);
     signalVerifiedGatewayPidSync.mockImplementation(() => {});
     formatGatewayPidList.mockImplementation((pids) => pids.join(", "));
+    launchAgentPlistExists.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -244,9 +258,13 @@ describe("runDaemonRestart health checks", () => {
 
   it("signals an unmanaged gateway process on stop", async () => {
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200, 4200, 4300]);
-    runServiceStop.mockImplementation(async (params: { onNotLoaded?: () => Promise<unknown> }) => {
-      await params.onNotLoaded?.();
-    });
+    runServiceStop.mockImplementation(
+      async (params: {
+        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
+      }) => {
+        await params.onNotLoaded?.({ stdout: process.stdout });
+      },
+    );
 
     await runDaemonStop({ json: true });
 
@@ -268,6 +286,41 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("restarts a booted-out launch agent when the plist still exists", async () => {
+    launchAgentPlistExists.mockResolvedValue(true);
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+    runServiceRestart.mockImplementation(
+      async (
+        params: RestartParams & {
+          onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
+        },
+      ) => {
+        await params.onNotLoaded?.({ stdout: process.stdout });
+        await params.postRestartCheck?.({
+          json: Boolean(params.opts?.json),
+          stdout: process.stdout,
+          warnings: [],
+          fail: (message: string) => {
+            throw new Error(message);
+          },
+        });
+        return true;
+      },
+    );
+
+    await runDaemonRestart({ json: true });
+
+    expect(launchAgentPlistExists).toHaveBeenCalled();
+    expect(service.restart).toHaveBeenCalledTimes(1);
+    expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
+    expect(waitForGatewayHealthyListener).not.toHaveBeenCalled();
   });
 
   it("fails unmanaged restart when multiple gateway listeners are present", async () => {
@@ -295,9 +348,13 @@ describe("runDaemonRestart health checks", () => {
 
   it("skips unmanaged signaling for pids that are not live gateway processes", async () => {
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
-    runServiceStop.mockImplementation(async (params: { onNotLoaded?: () => Promise<unknown> }) => {
-      await params.onNotLoaded?.();
-    });
+    runServiceStop.mockImplementation(
+      async (params: {
+        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
+      }) => {
+        await params.onNotLoaded?.({ stdout: process.stdout });
+      },
+    );
 
     await runDaemonStop({ json: true });
 

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,5 +1,6 @@
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { launchAgentPlistExists } from "../../daemon/launchd.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
@@ -163,12 +164,28 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     renderStartHints: renderGatewayServiceStartHints,
     opts,
     checkTokenDrift: true,
-    onNotLoaded: async () => {
+    onNotLoaded: async ({ stdout }) => {
       const handled = await restartGatewayWithoutServiceManager(restartPort);
       if (handled) {
         restartedWithoutServiceManager = true;
+        return handled;
       }
-      return handled;
+      if (service.label === "LaunchAgent" && (await launchAgentPlistExists(process.env))) {
+        const restartResult = await service.restart({ env: process.env, stdout });
+        if (restartResult.outcome === "scheduled") {
+          return {
+            result: "restarted" as const,
+            message: "restart scheduled, gateway will restart momentarily",
+            serviceLoaded: true,
+          };
+        }
+        return {
+          result: "restarted" as const,
+          message: "Gateway service restarted.",
+          serviceLoaded: true,
+        };
+      }
+      return null;
     },
     postRestartCheck: async ({ warnings, fail, stdout }) => {
       if (restartedWithoutServiceManager) {

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -124,6 +124,21 @@ describe("restart sentinel", () => {
     );
   });
 
+  it("omits doctor hint on successful restart wake pings", () => {
+    const payload = {
+      kind: "config-patch" as const,
+      status: "ok" as const,
+      ts: Date.now(),
+      message: "Restart completed",
+      doctorHint: "Run openclaw doctor",
+      stats: { mode: "config.patch" },
+    };
+
+    expect(formatRestartSentinelMessage(payload)).toBe(
+      ["Gateway restart config-patch ok (config.patch)", "Restart completed"].join("\n"),
+    );
+  });
+
   it("trims log tails", () => {
     const text = "a".repeat(9000);
     const trimmed = trimLogTail(text, 8000);

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -121,7 +121,7 @@ export function formatRestartSentinelMessage(payload: RestartSentinelPayload): s
   if (reason && reason !== message) {
     lines.push(`Reason: ${reason}`);
   }
-  if (payload.doctorHint?.trim()) {
+  if (payload.status !== "ok" && payload.doctorHint?.trim()) {
     lines.push(payload.doctorHint.trim());
   }
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- teach agents to prefer the built-in restart/config path with sessionKey + note
- stop successful restart wake pings from suggesting Doctor
- recover unloaded macOS LaunchAgents during  instead of bailing out with not-loaded hints

## Why
This makes agent-triggered restarts resume the same conversation more reliably and fixes the frustrating macOS case where  failed after launchd had booted the agent out.

## Testing
-  ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace
-  ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace
- local rebuild + live verification that the gateway comes back healthy under the pinned Node 24 runtime
