### PR TITLE
fix(tui): recover activity status when no runs are in flight

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -138,7 +138,11 @@ export function createEventHandlers(context: EventHandlerContext) {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    // Always transition to the target status when no other runs are in flight.
+    // This recovers from edge cases where activeChatRunId was cleared early
+    // (e.g. by a concurrent event) causing wasActiveRun to be false even
+    // though the run genuinely finished — leaving the UI stuck on "streaming".
+    if (params.wasActiveRun || (sessionRuns.size === 0 && !state.activeChatRunId)) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
@@ -153,7 +157,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || (sessionRuns.size === 0 && !state.activeChatRunId)) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();


### PR DESCRIPTION
## Summary
The TUI status bar can get stuck on `streaming` indefinitely after a chat turn completes. When `activeChatRunId` is cleared by a concurrent event before the final event arrives, `wasActiveRun` is false and `setActivityStatus("idle")` is never called.

## Changes
Add a recovery condition to `finalizeRun` and `terminateRun`: when `wasActiveRun` is false but no other runs are in flight (`sessionRuns.size === 0` and `activeChatRunId` is null), still transition the activity status. Safe because it only fires when no work is active.

Fixes #64825