### PR TITLE
fix(slack): route subagent completion messages back to originating thread

### DIFF
--- a/extensions/slack/api.ts
+++ b/extensions/slack/api.ts
@@ -1,5 +1,6 @@
 export { slackPlugin } from "./src/channel.js";
 export { slackSetupPlugin } from "./src/channel.setup.js";
+export { handleSlackSubagentDeliveryTarget } from "./src/subagent-hooks.js";
 export * from "./src/account-inspect.js";
 export * from "./src/accounts.js";
 export * from "./src/action-threading.js";

--- a/extensions/slack/index.ts
+++ b/extensions/slack/index.ts
@@ -4,6 +4,12 @@ import {
 } from "openclaw/plugin-sdk/channel-entry-contract";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
 
+let slackSubagentHooksPromise: Promise<typeof import("./src/subagent-hooks.js")> | null = null;
+function loadSlackSubagentHooksModule(): Promise<typeof import("./src/subagent-hooks.js")> {
+  slackSubagentHooksPromise ??= import("./src/subagent-hooks.js");
+  return slackSubagentHooksPromise;
+}
+
 function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
   const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
     specifier: "./runtime-api.js",
@@ -29,5 +35,11 @@ export default defineBundledChannelEntry({
     specifier: "./runtime-api.js",
     exportName: "setSlackRuntime",
   },
-  registerFull: registerSlackPluginHttpRoutes,
+  registerFull(api: OpenClawPluginApi) {
+    registerSlackPluginHttpRoutes(api);
+    api.on("subagent_delivery_target", async (event) => {
+      const { handleSlackSubagentDeliveryTarget } = await loadSlackSubagentHooksModule();
+      return handleSlackSubagentDeliveryTarget(event);
+    });
+  },
 });

--- a/extensions/slack/src/subagent-hooks.test.ts
+++ b/extensions/slack/src/subagent-hooks.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { handleSlackSubagentDeliveryTarget } from "./subagent-hooks.js";
+
+describe("handleSlackSubagentDeliveryTarget", () => {
+  const baseEvent = {
+    childSessionKey: "agent:worker:slack:channel:C123:thread:1234567890.123456",
+    requesterSessionKey: "agent:router:slack:channel:C123:thread:1234567890.123456",
+    expectsCompletionMessage: true,
+    requesterOrigin: {
+      channel: "slack",
+      accountId: "default",
+      to: "channel:C123",
+      threadId: "1234567890.123456",
+    },
+  };
+
+  it("returns origin with threadId when requester is Slack with thread", () => {
+    const result = handleSlackSubagentDeliveryTarget(baseEvent);
+    expect(result).toEqual({
+      origin: {
+        channel: "slack",
+        accountId: "default",
+        to: "channel:C123",
+        threadId: "1234567890.123456",
+      },
+    });
+  });
+
+  it("returns undefined when expectsCompletionMessage is false", () => {
+    const result = handleSlackSubagentDeliveryTarget({
+      ...baseEvent,
+      expectsCompletionMessage: false,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when channel is not slack", () => {
+    const result = handleSlackSubagentDeliveryTarget({
+      ...baseEvent,
+      requesterOrigin: {
+        ...baseEvent.requesterOrigin,
+        channel: "discord",
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when threadId is missing", () => {
+    const result = handleSlackSubagentDeliveryTarget({
+      ...baseEvent,
+      requesterOrigin: {
+        ...baseEvent.requesterOrigin,
+        threadId: undefined,
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when threadId is empty string", () => {
+    const result = handleSlackSubagentDeliveryTarget({
+      ...baseEvent,
+      requesterOrigin: {
+        ...baseEvent.requesterOrigin,
+        threadId: "",
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("handles numeric threadId", () => {
+    const result = handleSlackSubagentDeliveryTarget({
+      ...baseEvent,
+      requesterOrigin: {
+        ...baseEvent.requesterOrigin,
+        threadId: 1234567890,
+      },
+    });
+    expect(result).toEqual({
+      origin: {
+        channel: "slack",
+        accountId: "default",
+        to: "channel:C123",
+        threadId: 1234567890,
+      },
+    });
+  });
+
+  it("returns undefined when requesterOrigin is missing", () => {
+    const result = handleSlackSubagentDeliveryTarget({
+      ...baseEvent,
+      requesterOrigin: undefined,
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/slack/src/subagent-hooks.ts
+++ b/extensions/slack/src/subagent-hooks.ts
@@ -1,0 +1,49 @@
+import type {
+  PluginHookSubagentDeliveryTargetEvent,
+  PluginHookSubagentDeliveryTargetResult,
+} from "openclaw/plugin-sdk/plugin-types";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-api-types";
+
+/**
+ * Route subagent completion messages back into the originating Slack thread.
+ *
+ * When a subagent is spawned from within a Slack thread, the requester origin
+ * already carries the correct `threadId` (Slack thread_ts). This hook reads
+ * it back so the completion message is delivered into the same thread instead
+ * of the main channel.
+ */
+export function handleSlackSubagentDeliveryTarget(
+  event: PluginHookSubagentDeliveryTargetEvent,
+): PluginHookSubagentDeliveryTargetResult {
+  if (!event.expectsCompletionMessage) {
+    return undefined;
+  }
+
+  const requesterChannel = event.requesterOrigin?.channel?.toLowerCase()?.trim();
+  if (requesterChannel !== "slack") {
+    return undefined;
+  }
+
+  const threadId = event.requesterOrigin?.threadId;
+  if (threadId == null || String(threadId).trim() === "") {
+    return undefined;
+  }
+
+  const accountId = event.requesterOrigin?.accountId?.trim() || undefined;
+  const to = event.requesterOrigin?.to?.trim() || undefined;
+
+  return {
+    origin: {
+      channel: "slack" as const,
+      ...(accountId ? { accountId } : {}),
+      ...(to ? { to } : {}),
+      threadId,
+    },
+  };
+}
+
+export function registerSlackSubagentHooks(api: OpenClawPluginApi): void {
+  api.on("subagent_delivery_target", (event) =>
+    handleSlackSubagentDeliveryTarget(event),
+  );
+}


### PR DESCRIPTION
## Summary
Subagent completion messages go to main channel instead of originating Slack thread. Slack extension lacks `subagent_delivery_target` hook (Discord/Feishu have it).

## Changes
- New `handleSlackSubagentDeliveryTarget` reads threadId from requesterOrigin
- Register hook in Slack plugin entry via `registerFull`
- Unit tests for all edge cases

Fixes #64454