### PR TITLE
fix: canonicalize topic session transcript fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/sessions: keep topic-scoped session initialization on the canonical topic transcript path when inbound turns omit `MessageThreadId`, so one topic session no longer alternates between bare and topic-qualified transcript files. (#64869) thanks @jalehman.
+
 ## 2026.4.11-beta.1
 
 ### Changes

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -16,11 +16,12 @@ import {
   registerSessionBindingAdapter,
 } from "../../infra/outbound/session-binding-service.js";
 import { enqueueSystemEvent, resetSystemEventsForTest } from "../../infra/system-events.js";
-import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
+import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 import { drainFormattedSystemEvents } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
@@ -560,6 +561,35 @@ describe("initSessionState thread forking", () => {
     expect(path.basename(sessionFile ?? "")).toBe(
       `${result.sessionEntry.sessionId}-topic-456.jsonl`,
     );
+  });
+
+  it("records topic-specific session files from SessionKey when MessageThreadId is absent", async () => {
+    const root = await makeCaseDir("openclaw-topic-session-key-");
+    const storePath = path.join(root, "sessions.json");
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    setActivePluginRegistry(createSessionConversationTestRegistry());
+    try {
+      const result = await initSessionState({
+        ctx: {
+          Body: "Hello topic",
+          SessionKey: "agent:main:telegram:group:123:topic:456",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      const sessionFile = result.sessionEntry.sessionFile;
+      expect(sessionFile).toBeTruthy();
+      expect(path.basename(sessionFile ?? "")).toBe(
+        `${result.sessionEntry.sessionId}-topic-456.jsonl`,
+      );
+    } finally {
+      resetPluginRuntimeStateForTest();
+    }
   });
 });
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -21,6 +21,7 @@ import { resolveAndPersistSessionFile } from "../../config/sessions/session-file
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import { loadSessionStore, updateSessionStore } from "../../config/sessions/store.js";
+import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import {
   DEFAULT_RESET_TRIGGERS,
   type GroupKeyResolution,
@@ -620,8 +621,15 @@ export async function initSessionState(params: {
       }
     }
   }
+  const threadIdFromSessionKey = parseSessionThreadInfo(
+    sessionCtxForState.SessionKey ?? sessionKey,
+  ).threadId;
   const fallbackSessionFile = !sessionEntry.sessionFile
-    ? resolveSessionTranscriptPath(sessionEntry.sessionId, agentId, ctx.MessageThreadId)
+    ? resolveSessionTranscriptPath(
+        sessionEntry.sessionId,
+        agentId,
+        ctx.MessageThreadId ?? threadIdFromSessionKey,
+      )
     : undefined;
   const resolvedSessionFile = await resolveAndPersistSessionFile({
     sessionId: sessionEntry.sessionId,


### PR DESCRIPTION
## What
Fix OpenClaw session initialization so topic-scoped sessions keep using the topic-qualified transcript path even when an inbound turn does not carry `MessageThreadId`.

## Why
We traced LCM session-history loss to OpenClaw alternating between `<session-id>.jsonl` and `<session-id>-topic-<n>.jsonl` for the same Telegram topic session. That made one logical session look like two transcript files and triggered session-file rotation handling downstream.

## Changes
- Parse thread id from `SessionKey` during session init fallback
- Keep topic-qualified transcript paths without `MessageThreadId`
- Add regression coverage for topic session init fallback

## Testing
- `pnpm -C /Users/phaedrus/Projects/openclaw exec vitest run src/auto-reply/reply/session.test.ts -t "records topic-specific session files" --reporter=verbose`
- `pnpm -C /Users/phaedrus/Projects/openclaw exec vitest run src/auto-reply/reply/session.test.ts --reporter=dot`
