### PR TITLE
Fix main-session workspace reload after on-disk bootstrap/context updates

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -38,7 +38,7 @@ describe("getOrLoadBootstrapFiles", () => {
     vi.clearAllMocks();
   });
 
-  it("loads from disk on first call and caches", async () => {
+  it("loads from disk on first call and seeds the session snapshot", async () => {
     const result = await getOrLoadBootstrapFiles({
       workspaceDir: "/ws",
       sessionKey: "session-1",
@@ -48,12 +48,24 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(mockLoad()).toHaveBeenCalledTimes(1);
   });
 
-  it("returns cached result on second call", async () => {
+  it("reuses the cached snapshot object when bootstrap content is unchanged", async () => {
     await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
     const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
 
     expect(result).toBe(files);
-    expect(mockLoad()).toHaveBeenCalledTimes(1);
+    expect(mockLoad()).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes the session snapshot when bootstrap content changes", async () => {
+    const files2 = [makeFile("AGENTS.md", "# Agent v2")];
+    mockLoad().mockResolvedValueOnce(files).mockResolvedValueOnce(files2);
+
+    const r1 = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    const r2 = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+
+    expect(r1).toBe(files);
+    expect(r2).toBe(files2);
+    expect(mockLoad()).toHaveBeenCalledTimes(2);
   });
 
   it("different session keys get independent caches", async () => {
@@ -94,22 +106,37 @@ describe("clearBootstrapSnapshot", () => {
   });
 
   it("clears a single session entry", async () => {
+    const files2 = [makeFile("AGENTS.md", "content")];
+    mockLoad()
+      .mockResolvedValueOnce([makeFile("AGENTS.md", "content")])
+      .mockResolvedValueOnce(files2);
+
     await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk" });
     clearBootstrapSnapshot("sk");
 
-    // Next call should hit disk again.
-    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk" });
+    // Next call should rebuild the session snapshot instead of reusing the cached object.
+    const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk" });
+    expect(result).toBe(files2);
     expect(mockLoad()).toHaveBeenCalledTimes(2);
   });
 
   it("does not affect other sessions", async () => {
+    const sk1Files = [makeFile("AGENTS.md", "content-1")];
+    const sk2Files = [makeFile("AGENTS.md", "content-2")];
+    const sk2FilesReload = [makeFile("AGENTS.md", "content-2")];
+    mockLoad()
+      .mockResolvedValueOnce(sk1Files)
+      .mockResolvedValueOnce(sk2Files)
+      .mockResolvedValueOnce(sk2FilesReload);
+
     await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk1" });
     await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk2" });
 
     clearBootstrapSnapshot("sk1");
 
-    // sk2 should still be cached.
-    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk2" });
-    expect(mockLoad()).toHaveBeenCalledTimes(2); // sk1 x1, sk2 x1
+    // sk2 should still retain its prior session snapshot because its content is unchanged.
+    const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk2" });
+    expect(result).toBe(sk2Files);
+    expect(mockLoad()).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -2,16 +2,37 @@ import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./work
 
 const cache = new Map<string, WorkspaceBootstrapFile[]>();
 
+function bootstrapFileEquals(
+  current: WorkspaceBootstrapFile,
+  next: WorkspaceBootstrapFile,
+): boolean {
+  return (
+    current.name === next.name &&
+    current.path === next.path &&
+    current.missing === next.missing &&
+    current.content === next.content
+  );
+}
+
+function bootstrapSnapshotEquals(
+  current: WorkspaceBootstrapFile[],
+  next: WorkspaceBootstrapFile[],
+): boolean {
+  if (current.length !== next.length) {
+    return false;
+  }
+  return current.every((file, index) => bootstrapFileEquals(file, next[index]));
+}
+
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
 }): Promise<WorkspaceBootstrapFile[]> {
+  const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const existing = cache.get(params.sessionKey);
-  if (existing) {
+  if (existing && bootstrapSnapshotEquals(existing, files)) {
     return existing;
   }
-
-  const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
   cache.set(params.sessionKey, files);
   return files;
 }


### PR DESCRIPTION
Objective
Fix a long-lived session bug where on-disk workspace bootstrap/context updates were not reflected in subsequent turns for the same session unless the bootstrap snapshot was explicitly cleared or the session was reset.

Deploy-source proof
This change is for `openclaw/openclaw` and is based on the local reproduction and validation branch `aimqwest_codex/0358-main-session-workspace-reload` pushed to `aimqwest/openclaw`. There is no deployment claim in this PR; the source proof is the code diff plus the local validation artifacts listed below.

Problem
`getOrLoadBootstrapFiles` cached workspace bootstrap files forever per `sessionKey`. After the first turn, later turns in the same long-lived session reused that cached snapshot without checking whether `AGENTS.md`, `SOUL.md`, `MEMORY.md`, `TOOLS.md`, or other bootstrap files had changed on disk.

Root cause
The session bootstrap cache was keyed only by `sessionKey` and treated the first loaded file set as authoritative for the life of that session. `loadWorkspaceBootstrapFiles` already has file-identity-aware reads, but `bootstrap-cache.ts` never reloaded the file set to see whether it had changed.

Fix
- reload the workspace bootstrap file set on each access for an existing session key
- compare the fresh file list to the cached snapshot
- reuse the cached snapshot object only when the file set is unchanged
- replace the cached snapshot when content/path/missing-state differs

This keeps the session-local snapshot stable when nothing changed, while allowing same-session bootstrap refresh after on-disk workspace updates.

Tests
- updated `src/agents/bootstrap-cache.test.ts`
- added regression coverage for unchanged content reusing the cached snapshot object
- added regression coverage for changed bootstrap content refreshing the session snapshot
- preserved coverage for session isolation and explicit snapshot clearing

Why scope is intentionally narrow
This PR only adjusts bootstrap snapshot refresh semantics and the directly related unit tests. It does not change workspace file discovery rules, hook behavior, session routing, or any product-specific workspace content.

Files changed
- `src/agents/bootstrap-cache.ts`
- `src/agents/bootstrap-cache.test.ts`

Validation
- `pnpm exec vitest run --config vitest.config.ts src/agents/bootstrap-cache.test.ts src/agents/workspace.bootstrap-cache.test.ts` — pass
- `pnpm build` — pass
- `git diff --check` — pass
- `pnpm check` — blocked by unrelated existing lint failures in `src/channels/plugins/config-writes.ts` on this checkout; see evidence file
- local same-session sentinel validation on a live OpenClaw runtime — pass

Evidence files
- `/tmp/codex0357_live_reload_baseline.json`
- `/tmp/codex0357_live_reload_after_add.json`
- `/tmp/codex0357_live_reload_after_remove.json`
- `/tmp/codex0357_hotreload_same_session.json`
- `/tmp/codex0358_pnpm_check.txt`

Scope statement
Focused runtime bug fix only. No AIMQWEST-private workspace content, no docs bundle, no unrelated refactors.

AI assistance
- AI-assisted: yes
- Testing: targeted tests + build + live runtime reproduction/verification
