### PR TITLE
fix: convert local media paths to gateway URLs in WhatsApp reply pipeline

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
 const saveMediaSource = vi.hoisted(() => vi.fn());
+const ensureMediaHosted = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/sandbox.js", () => ({
   ensureSandboxWorkspaceForSession,
@@ -12,16 +13,33 @@ vi.mock("../../media/store.js", () => ({
   saveMediaSource,
 }));
 
+vi.mock("../../media/host.js", () => ({
+  ensureMediaHosted,
+}));
+
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
     saveMediaSource.mockReset();
+    ensureMediaHosted.mockReset();
+    // Default: ensureMediaHosted converts local paths to gateway URLs
+    ensureMediaHosted.mockImplementation(async (source: string) => ({
+      url: `https://tailnet-host.example/media/${path.basename(source)}`,
+      id: path.basename(source),
+      size: 1024,
+    }));
     vi.unstubAllEnvs();
   });
 
-  it("resolves workspace-relative media against the agent workspace", async () => {
+  it("resolves workspace-relative media against the agent workspace and converts to gateway URL", async () => {
+    const resolvedPath = path.join("/tmp/agent-workspace", "out", "photo.png");
+    ensureMediaHosted.mockResolvedValue({
+      url: `https://tailnet-host.example/media/photo.png`,
+      id: "photo.png",
+      size: 1024,
+    });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -32,13 +50,14 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: ["./out/photo.png"],
     });
 
+    expect(ensureMediaHosted).toHaveBeenCalledWith(resolvedPath, { startServer: false });
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/agent-workspace", "out", "photo.png"),
-      mediaUrls: [path.join("/tmp/agent-workspace", "out", "photo.png")],
+      mediaUrl: "https://tailnet-host.example/media/photo.png",
+      mediaUrls: ["https://tailnet-host.example/media/photo.png"],
     });
   });
 
-  it("maps sandbox-relative media back to the host sandbox workspace", async () => {
+  it("maps sandbox-relative media back to the host sandbox workspace and converts to gateway URLs", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -53,11 +72,12 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: ["./out/photo.png", "file:///workspace/screens/final.png"],
     });
 
+    expect(ensureMediaHosted).toHaveBeenCalledTimes(2);
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
+      mediaUrl: expect.stringContaining("https://"),
       mediaUrls: [
-        path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-        path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
+        expect.stringContaining("https://"),
+        expect.stringContaining("https://"),
       ],
     });
   });
@@ -106,11 +126,16 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(saveMediaSource).not.toHaveBeenCalled();
   });
 
-  it("keeps managed generated media under the shared media root", async () => {
+  it("converts managed generated media under the shared media root to gateway URL", async () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
+    });
+    ensureMediaHosted.mockResolvedValue({
+      url: "https://tailnet-host.example/media/generated.png",
+      id: "generated.png",
+      size: 2048,
     });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
@@ -122,11 +147,15 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: ["/Users/peter/.openclaw/media/tool-image-generation/generated.png"],
     });
 
-    expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/tool-image-generation/generated.png",
-      mediaUrls: ["/Users/peter/.openclaw/media/tool-image-generation/generated.png"],
-    });
     expect(saveMediaSource).not.toHaveBeenCalled();
+    expect(ensureMediaHosted).toHaveBeenCalledWith(
+      "/Users/peter/.openclaw/media/tool-image-generation/generated.png",
+      { startServer: false },
+    );
+    expect(result).toMatchObject({
+      mediaUrl: "https://tailnet-host.example/media/generated.png",
+      mediaUrls: ["https://tailnet-host.example/media/generated.png"],
+    });
   });
 
   it("drops absolute file URLs outside managed reply media roots", async () => {
@@ -150,9 +179,14 @@ describe("createReplyMediaPathNormalizer", () => {
     });
   });
 
-  it("persists volatile agent-state media from the workspace into host outbound media", async () => {
+  it("persists volatile agent-state media from the workspace and converts to gateway URL", async () => {
     saveMediaSource.mockResolvedValue({
       path: "/Users/peter/.openclaw/media/outbound/persisted.png",
+    });
+    ensureMediaHosted.mockResolvedValue({
+      url: "https://tailnet-host.example/media/persisted.png",
+      id: "persisted.png",
+      size: 4096,
     });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
@@ -171,9 +205,85 @@ describe("createReplyMediaPathNormalizer", () => {
       undefined,
       "outbound",
     );
+    expect(ensureMediaHosted).toHaveBeenCalledWith(
+      "/Users/peter/.openclaw/media/outbound/persisted.png",
+      { startServer: false },
+    );
     expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/outbound/persisted.png",
-      mediaUrls: ["/Users/peter/.openclaw/media/outbound/persisted.png"],
+      mediaUrl: "https://tailnet-host.example/media/persisted.png",
+      mediaUrls: ["https://tailnet-host.example/media/persisted.png"],
+    });
+  });
+
+  it("preserves HTTP URLs without calling ensureMediaHosted", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["https://cdn.example.com/image.png"],
+    });
+
+    expect(ensureMediaHosted).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      mediaUrl: "https://cdn.example.com/image.png",
+      mediaUrls: ["https://cdn.example.com/image.png"],
+    });
+  });
+
+  it("falls back to local path when ensureMediaHosted fails (graceful degradation)", async () => {
+    ensureMediaHosted.mockRejectedValue(new Error("Media hosting requires the webhook server"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["./out/audio.ogg"],
+    });
+
+    const expectedPath = path.join("/tmp/agent-workspace", "out", "audio.ogg");
+    expect(ensureMediaHosted).toHaveBeenCalledWith(expectedPath, { startServer: false });
+    expect(result).toMatchObject({
+      mediaUrl: expectedPath,
+      mediaUrls: [expectedPath],
+    });
+  });
+
+  it("converts multiple mixed local/remote media correctly", async () => {
+    ensureMediaHosted.mockImplementation(async (source: string) => ({
+      url: `https://tailnet-host.example/media/${path.basename(source)}`,
+      id: path.basename(source),
+      size: 1024,
+    }));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [
+        "https://cdn.example.com/remote.png",
+        "./local-photo.jpg",
+      ],
+    });
+
+    // Only the local path should trigger ensureMediaHosted
+    expect(ensureMediaHosted).toHaveBeenCalledTimes(1);
+    expect(ensureMediaHosted).toHaveBeenCalledWith(
+      path.join("/tmp/agent-workspace", "local-photo.jpg"),
+      { startServer: false },
+    );
+    expect(result).toMatchObject({
+      mediaUrl: "https://cdn.example.com/remote.png",
+      mediaUrls: [
+        "https://cdn.example.com/remote.png",
+        "https://tailnet-host.example/media/local-photo.jpg",
+      ],
     });
   });
 });

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -7,6 +7,7 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { ensureMediaHosted } from "../../media/host.js";
 import { saveMediaSource } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
@@ -64,6 +65,30 @@ function isLikelyLocalMediaSource(media: string): boolean {
 
 function getPayloadMediaList(payload: ReplyPayload): string[] {
   return resolveSendableOutboundReplyParts(payload).mediaUrls;
+}
+
+/**
+ * Convert a local filesystem media path to a gateway-accessible URL.
+ *
+ * Paths that are already HTTP(S) URLs are returned unchanged. Local paths are
+ * hosted through the media server so that external transports (WhatsApp, etc.)
+ * can fetch them over the network.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/64665
+ */
+async function convertLocalPathToGatewayUrl(mediaPath: string): Promise<string> {
+  if (HTTP_URL_RE.test(mediaPath)) {
+    return mediaPath;
+  }
+  try {
+    const hosted = await ensureMediaHosted(mediaPath, { startServer: false });
+    return hosted.url;
+  } catch (err) {
+    logVerbose(
+      `media path→URL conversion failed for ${mediaPath}, returning local path: ${String(err)}`,
+    );
+    return mediaPath;
+  }
 }
 
 export function createReplyMediaPathNormalizer(params: {
@@ -219,10 +244,19 @@ export function createReplyMediaPathNormalizer(params: {
       };
     }
 
+    // Convert local filesystem paths to gateway-accessible URLs so that
+    // external transports (WhatsApp, Telegram, etc.) can fetch the media
+    // over HTTP instead of receiving unusable local paths.
+    // Fixes: https://github.com/openclaw/openclaw/issues/64665
+    const gatewayUrls: string[] = [];
+    for (const media of normalizedMedia) {
+      gatewayUrls.push(await convertLocalPathToGatewayUrl(media));
+    }
+
     return {
       ...payload,
-      mediaUrl: normalizedMedia[0],
-      mediaUrls: normalizedMedia,
+      mediaUrl: gatewayUrls[0],
+      mediaUrls: gatewayUrls,
     };
   };
 }


### PR DESCRIPTION
## Summary

- Fix silent media drop on WhatsApp outbound by converting local filesystem paths to gateway-accessible HTTPS URLs via `ensureMediaHosted()` before outbound payload assembly
- Add `convertLocalPathToGatewayUrl()` helper in the reply media path normalizer that bridges local paths through the media server; HTTP URLs pass through unchanged
- Graceful degradation: if the media server is unavailable, falls back to the local path with a verbose log instead of crashing

## Problem

Media saved to local disk paths (e.g. `/Users/peter/.openclaw/media/outbound/persisted.png`) was never converted to gateway-accessible URLs before reaching `resolveSendableOutboundReplyParts`. The WhatsApp sender evaluated `hasMedia: Boolean(options.mediaUrl)` as `false` because filesystem paths are not servable URLs, silently dropping all outbound media with no error surfaced to the user or model.

Full trace documented in #64665.

## Test plan

- [x] Existing tests updated to verify gateway URL conversion occurs after path normalization
- [x] New test: HTTP URLs pass through without calling `ensureMediaHosted`
- [x] New test: graceful fallback to local path when `ensureMediaHosted` fails
- [x] New test: mixed local/remote media URLs handled correctly (only local paths converted)
- [ ] Manual verification: send media via WhatsApp channel and confirm `hasMedia: true` in gateway logs

Fixes #64665

🤖 Generated with [Claude Code](https://claude.com/claude-code)