### PR TITLE
fix(cron): clear sessionFile on forceNew so isolated runs don't share transcripts

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -255,6 +255,57 @@ describe("resolveCronSession", () => {
       });
     });
 
+    it("clears sessionFile when forceNew is true so fresh isolated runs do not reuse the prior transcript", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-802",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          sessionFile: "stable-heartbeat-transcript.jsonl",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      // sessionFile must be cleared so resolveSessionFilePath recomputes the
+      // transcript path from the new sessionId. Without this, heartbeat
+      // isolatedSession: true and cron sessionTarget: "isolated" silently
+      // append every run to the same physical transcript file.
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
+    it("clears sessionFile when session is stale", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "old-session-id",
+          updatedAt: NOW_MS - 86_400_000, // 1 day ago
+          sessionFile: "stale-transcript.jsonl",
+        },
+        fresh: false,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
+    it("preserves sessionFile when reusing a fresh session", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-803",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          sessionFile: "persistent-transcript.jsonl",
+        },
+        fresh: true,
+      });
+
+      expect(result.isNewSession).toBe(false);
+      // On reuse we must NOT clear sessionFile — the whole point of reuse is
+      // that the transcript keeps accumulating in the same file.
+      expect(result.sessionEntry.sessionFile).toBe("persistent-transcript.jsonl");
+    });
+
     it("creates new sessionId when entry exists but has no sessionId", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -77,12 +77,17 @@ export function resolveCronSession(params: {
     // replies instead of channel top-level messages.
     // deliveryContext must also be cleared because normalizeSessionEntryDelivery
     // repopulates lastThreadId from deliveryContext.threadId on store writes.
+    // sessionFile must also be cleared so that resolveSessionFilePath recomputes
+    // the transcript path from the new sessionId. Leaving the stale sessionFile
+    // in place makes every forced-new run append to the previous transcript,
+    // which defeats heartbeat.isolatedSession and cron sessionTarget: "isolated".
     ...(isNewSession && {
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      sessionFile: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary

- Add `sessionFile: undefined` to the `isNewSession` cleanup block in `resolveCronSession` so that forced-new isolated runs don't inherit and keep writing to the previous transcript file.
- Add three targeted tests in `src/cron/isolated-agent/session.test.ts` covering forceNew, stale-session, and fresh-reuse paths.

Fixes #64795.

## Root cause

`resolveCronSession` in `src/cron/isolated-agent/session.ts` rolls a new `sessionId` when `forceNew: true` (or when the stored session is stale), but it builds the returned entry by spreading the previous entry first:

```ts
const sessionEntry: SessionEntry = {
  ...entry,                 // ← spreads sessionFile from prior entry
  sessionId,                // ← overridden with the new uuid
  updatedAt: params.nowMs,
  systemSent,
  ...(isNewSession && {
    lastChannel: undefined,
    lastTo: undefined,
    lastAccountId: undefined,
    lastThreadId: undefined,
    deliveryContext: undefined,
    // sessionFile was NOT here — it survives into the new entry
  }),
};
```

Downstream, `resolveSessionFilePath` in `src/config/sessions/paths.ts:263` prefers a persisted `entry.sessionFile` over recomputing a fresh path from `sessionId`:

```ts
export function resolveSessionFilePath(
  sessionId: string,
  entry?: { sessionFile?: string },
  opts?: SessionFilePathOptions,
): string {
  const sessionsDir = resolveSessionsDir(opts);
  const candidate = entry?.sessionFile?.trim();
  if (candidate) {
    try {
      return resolvePathWithinSessionsDir(sessionsDir, candidate, { agentId: opts?.agentId });
    } catch { /* … */ }
  }
  return resolveSessionTranscriptPathInDir(sessionId, sessionsDir);
}
```

So the returned entry ends up with a **new `sessionId`** but the **old `sessionFile`**. Every forced-new run appends to the same physical transcript file as the previous run, indefinitely.

## Impact

This defeats two documented features:

1. **`agents.defaults.heartbeat.isolatedSession: true`** — `docs/gateway/heartbeat.md` promises "each heartbeat runs in a fresh session with no prior conversation history" and quotes `~100K tokens down to ~2-5K per run`. Neither holds while the stale `sessionFile` survives — every heartbeat turn reads the full accumulated transcript on context load.

2. **Cron `sessionTarget: "isolated"`** — isolated cron runs take the same `forceNew: true` path via `resolveCronSession`, so the same transcript pollution affects cron jobs configured for full isolation.

The silent failure mode is particularly painful because it looks like heartbeat `isolatedSession` is working (new `sessionId`, new store entry, no `forceNew` warnings) while the underlying transcript file continues to accumulate every prior run's history.

## Fix

One field added to the existing `isNewSession` cleanup block, with a comment explaining the downstream interaction with `resolveSessionFilePath`:

```diff
     ...(isNewSession && {
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      sessionFile: undefined,
     }),
```

With `sessionFile` cleared on the `isNewSession` branch, `resolveSessionFilePath` falls through `candidate = entry?.sessionFile?.trim()` (which is now undefined) and computes the path from the new `sessionId` via `resolveSessionTranscriptPathInDir`. This is the exact intent of the existing cleanup block: strip anything that leaked from the prior session into a fresh one.

## Test coverage

Added to the existing `describe("session reuse for webhooks/cron")` block in `src/cron/isolated-agent/session.test.ts`:

- **`clears sessionFile when forceNew is true`** — covers the heartbeat isolatedSession and isolated cron paths.
- **`clears sessionFile when session is stale`** — covers the freshness-expiry path for direct-style cron/webhook sessions.
- **`preserves sessionFile when reusing a fresh session`** — locks in the negative: reuse must keep the transcript, because the whole point of reuse is that the transcript keeps accumulating.

## Verification

- ✅ `npx vitest run src/cron/isolated-agent/session.test.ts` — **13/13 pass** (the 3 new ones included).
- ✅ `npx vitest run src/cron/isolated-agent/session.test.ts src/config/sessions/sessions.test.ts src/config/sessions/store.lock.test.ts src/config/sessions/transcript.test.ts` — **41/41 pass** across the four related test files, no regressions in transcript/store code.

## What this does NOT change

- No changes to `heartbeat-runner.ts` or its `forceNew: true` call — the fix is purely in the session-roll helper so every caller benefits (isolated cron, heartbeat, webhook).
- No changes to `resolveSessionFilePath` — it still honors a persisted `sessionFile` when present, which is the correct behavior for non-isolated session reuse.
- No config schema or docs changes — the documented behavior is now actually what the code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)