### PR TITLE
Add proxy capture stack and QA Lab inspector

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -1,4 +1,5 @@
 import * as carbonGateway from "@buape/carbon/gateway";
+import { randomUUID } from "node:crypto";
 import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import * as httpsProxyAgent from "https-proxy-agent";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
@@ -6,6 +7,8 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+import { resolveEffectiveDebugProxyUrl } from "../../../../src/proxy-capture/env.js";
+import { captureHttpExchange, captureWsEvent } from "../../../../src/proxy-capture/runtime.js";
 import * as undici from "undici";
 import * as ws from "ws";
 import { validateDiscordProxyUrl } from "../proxy-fetch.js";
@@ -240,6 +243,7 @@ function createGatewayPlugin(params: {
     webSocketCtor?: DiscordGatewayWebSocketCtor;
   };
 }): carbonGateway.GatewayPlugin {
+  const wsFlowId = randomUUID();
   class SafeGatewayPlugin extends carbonGateway.GatewayPlugin {
     private gatewayInfoUsedFallback = false;
 
@@ -280,6 +284,44 @@ function createGatewayPlugin(params: {
       // already our proxy path and behaves predictably for lifecycle cleanup.
       const WebSocketCtor = params.testing?.webSocketCtor ?? ws.default;
       const socket = new WebSocketCtor(url, params.wsAgent ? { agent: params.wsAgent } : undefined);
+      captureWsEvent({
+        url,
+        direction: "local",
+        kind: "ws-open",
+        flowId: wsFlowId,
+        meta: { subsystem: "discord-gateway" },
+      });
+      socket.on?.("message", (data: unknown) => {
+        captureWsEvent({
+          url,
+          direction: "inbound",
+          kind: "ws-frame",
+          flowId: wsFlowId,
+          payload: Buffer.isBuffer(data) ? data : Buffer.from(String(data)),
+          meta: { subsystem: "discord-gateway" },
+        });
+      });
+      socket.on?.("close", (code: number, reason: Buffer) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "ws-close",
+          flowId: wsFlowId,
+          closeCode: code,
+          payload: reason,
+          meta: { subsystem: "discord-gateway" },
+        });
+      });
+      socket.on?.("error", (error: Error) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "error",
+          flowId: wsFlowId,
+          errorText: error.message,
+          meta: { subsystem: "discord-gateway" },
+        });
+      });
       if ("binaryType" in socket) {
         try {
           socket.binaryType = "arraybuffer";
@@ -309,7 +351,7 @@ export function createDiscordGatewayPlugin(params: {
   };
 }): carbonGateway.GatewayPlugin {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
-  const proxy = params.discordConfig?.proxy?.trim();
+  const proxy = resolveEffectiveDebugProxyUrl(params.discordConfig?.proxy);
   const options = {
     reconnect: { maxAttempts: 50 },
     intents,
@@ -319,7 +361,19 @@ export function createDiscordGatewayPlugin(params: {
   if (!proxy) {
     return createGatewayPlugin({
       options,
-      fetchImpl: (input, init) => fetch(input, init as RequestInit),
+      fetchImpl: async (input, init) => {
+        const response = await fetch(input, init as RequestInit);
+        captureHttpExchange({
+          url: input,
+          method: (init?.method as string | undefined) ?? "GET",
+          requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
+          requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+          response,
+          flowId: randomUUID(),
+          meta: { subsystem: "discord-gateway-metadata" },
+        });
+        return response;
+      },
       runtime: params.runtime,
       testing: params.__testing
         ? {
@@ -342,7 +396,22 @@ export function createDiscordGatewayPlugin(params: {
 
     return createGatewayPlugin({
       options,
-      fetchImpl: (input, init) => (params.__testing?.undiciFetch ?? undici.fetch)(input, init),
+      fetchImpl: async (input, init) => {
+        const response = (await (params.__testing?.undiciFetch ?? undici.fetch)(
+          input,
+          init,
+        )) as unknown as Response;
+        captureHttpExchange({
+          url: input,
+          method: (init?.method as string | undefined) ?? "GET",
+          requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
+          requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+          response,
+          flowId: randomUUID(),
+          meta: { subsystem: "discord-gateway-metadata" },
+        });
+        return response;
+      },
       fetchInit: { dispatcher: fetchAgent },
       wsAgent,
       runtime: params.runtime,

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -4,11 +4,15 @@ import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import * as httpsProxyAgent from "https-proxy-agent";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  captureHttpExchange,
+  captureWsEvent,
+  resolveEffectiveDebugProxyUrl,
+  resolveDebugProxySettings,
+} from "openclaw/plugin-sdk/proxy-capture";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
-import { resolveEffectiveDebugProxyUrl } from "../../../../src/proxy-capture/env.js";
-import { captureHttpExchange, captureWsEvent } from "../../../../src/proxy-capture/runtime.js";
 import * as undici from "undici";
 import * as ws from "ws";
 import { validateDiscordProxyUrl } from "../proxy-fetch.js";
@@ -243,7 +247,6 @@ function createGatewayPlugin(params: {
     webSocketCtor?: DiscordGatewayWebSocketCtor;
   };
 }): carbonGateway.GatewayPlugin {
-  const wsFlowId = randomUUID();
   class SafeGatewayPlugin extends carbonGateway.GatewayPlugin {
     private gatewayInfoUsedFallback = false;
 
@@ -279,6 +282,7 @@ function createGatewayPlugin(params: {
       if (!url) {
         throw new Error("Gateway URL is required");
       }
+      const wsFlowId = randomUUID();
       // Avoid Node's undici-backed global WebSocket here. We have seen late
       // close-path crashes during Discord gateway teardown; the ws transport is
       // already our proxy path and behaves predictably for lifecycle cleanup.
@@ -352,6 +356,7 @@ export function createDiscordGatewayPlugin(params: {
 }): carbonGateway.GatewayPlugin {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
   const proxy = resolveEffectiveDebugProxyUrl(params.discordConfig?.proxy);
+  const debugProxySettings = resolveDebugProxySettings();
   const options = {
     reconnect: { maxAttempts: 50 },
     intents,
@@ -363,15 +368,17 @@ export function createDiscordGatewayPlugin(params: {
       options,
       fetchImpl: async (input, init) => {
         const response = await fetch(input, init as RequestInit);
-        captureHttpExchange({
-          url: input,
-          method: (init?.method as string | undefined) ?? "GET",
-          requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
-          requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
-          response,
-          flowId: randomUUID(),
-          meta: { subsystem: "discord-gateway-metadata" },
-        });
+        if (!debugProxySettings.enabled) {
+          captureHttpExchange({
+            url: input,
+            method: (init?.method as string | undefined) ?? "GET",
+            requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
+            requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+            response,
+            flowId: randomUUID(),
+            meta: { subsystem: "discord-gateway-metadata" },
+          });
+        }
         return response;
       },
       runtime: params.runtime,

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -3,11 +3,14 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   GatewayIntents,
   baseRegisterClientSpy,
+  captureHttpExchangeSpy,
+  captureWsEventSpy,
   GatewayPlugin,
   globalFetchMock,
   HttpsProxyAgent,
   getLastAgent,
   restProxyAgentSpy,
+  resolveDebugProxySettingsMock,
   undiciFetchMock,
   undiciProxyAgentSpy,
   resetLastAgent,
@@ -21,6 +24,9 @@ const {
   const globalFetchMock = vi.fn();
   const baseRegisterClientSpy = vi.fn();
   const webSocketSpy = vi.fn();
+  const captureHttpExchangeSpy = vi.fn();
+  const captureWsEventSpy = vi.fn();
+  const resolveDebugProxySettingsMock = vi.fn(() => ({ enabled: false }));
 
   const GatewayIntents = {
     Guilds: 1 << 0,
@@ -66,6 +72,9 @@ const {
     HttpsProxyAgent,
     getLastAgent: () => HttpsProxyAgent.lastCreated,
     restProxyAgentSpy,
+    captureHttpExchangeSpy,
+    captureWsEventSpy,
+    resolveDebugProxySettingsMock,
     undiciFetchMock,
     undiciProxyAgentSpy,
     resetLastAgent: () => {
@@ -104,6 +113,14 @@ vi.mock("ws", () => ({
   default: function MockWebSocket(url: string, options?: { agent?: unknown }) {
     webSocketSpy(url, options);
   },
+}));
+
+vi.mock("openclaw/plugin-sdk/proxy-capture", () => ({
+  captureHttpExchange: captureHttpExchangeSpy,
+  captureWsEvent: captureWsEventSpy,
+  resolveEffectiveDebugProxyUrl: (configuredProxyUrl?: string) =>
+    configuredProxyUrl?.trim() || process.env.OPENCLAW_DEBUG_PROXY_URL,
+  resolveDebugProxySettings: resolveDebugProxySettingsMock,
 }));
 
 describe("createDiscordGatewayPlugin", () => {
@@ -213,6 +230,9 @@ describe("createDiscordGatewayPlugin", () => {
     undiciProxyAgentSpy.mockClear();
     wsProxyAgentSpy.mockClear();
     webSocketSpy.mockClear();
+    captureHttpExchangeSpy.mockClear();
+    captureWsEventSpy.mockClear();
+    resolveDebugProxySettingsMock.mockReset().mockReturnValue({ enabled: false });
     resetLastAgent();
   });
 
@@ -247,6 +267,25 @@ describe("createDiscordGatewayPlugin", () => {
 
     expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", undefined);
     expect(wsProxyAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("allocates a fresh websocket flow id for each gateway socket", () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg/?attempt=1");
+    createWebSocket("wss://gateway.discord.gg/?attempt=2");
+
+    const openCalls = captureWsEventSpy.mock.calls.filter(
+      ([event]) => event?.kind === "ws-open",
+    );
+    expect(openCalls).toHaveLength(2);
+    expect(openCalls[0]?.[0]?.flowId).not.toBe(openCalls[1]?.[0]?.flowId);
   });
 
   it("maps plain-text Discord 503 responses to fetch failed", async () => {
@@ -322,6 +361,19 @@ describe("createDiscordGatewayPlugin", () => {
       }),
     );
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-capture gateway metadata fetches when global fetch patching is enabled", async () => {
+    resolveDebugProxySettingsMock.mockReturnValue({ enabled: true });
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    await registerGatewayClientWithMetadata({ plugin, fetchMock: globalFetchMock });
+
+    expect(captureHttpExchangeSpy).not.toHaveBeenCalled();
   });
 
   it("accepts IPv6 loopback proxy URLs for gateway metadata and websocket setup", async () => {

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -30,6 +30,7 @@ describe("resolveDiscordRestFetch", () => {
   });
 
   beforeEach(() => {
+    vi.unstubAllEnvs();
     undiciFetchMock.mockReset();
     proxyAgentSpy.mockReset();
   });
@@ -99,5 +100,22 @@ describe("resolveDiscordRestFetch", () => {
 
     expect(proxyAgentSpy).toHaveBeenCalledWith("http://[::1]:8080");
     expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("uses debug proxy env when no discord proxy URL is configured", async () => {
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", "http://127.0.0.1:7777");
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+    undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const fetcher = resolveDiscordRestFetch(undefined, runtime);
+    await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://127.0.0.1:7777");
+    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
   });
 });

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -1,9 +1,8 @@
 import { wrapFetchWithAbortSignal } from "openclaw/plugin-sdk/fetch-runtime";
+import { captureHttpExchange, resolveEffectiveDebugProxyUrl } from "openclaw/plugin-sdk/proxy-capture";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { randomUUID } from "node:crypto";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
-import { resolveEffectiveDebugProxyUrl } from "../../../../src/proxy-capture/env.js";
-import { captureHttpExchange } from "../../../../src/proxy-capture/runtime.js";
 import { withValidatedDiscordProxy } from "../proxy-fetch.js";
 
 export function resolveDiscordRestFetch(

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -1,20 +1,35 @@
 import { wrapFetchWithAbortSignal } from "openclaw/plugin-sdk/fetch-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { randomUUID } from "node:crypto";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
+import { resolveEffectiveDebugProxyUrl } from "../../../../src/proxy-capture/env.js";
+import { captureHttpExchange } from "../../../../src/proxy-capture/runtime.js";
 import { withValidatedDiscordProxy } from "../proxy-fetch.js";
 
 export function resolveDiscordRestFetch(
   proxyUrl: string | undefined,
   runtime: RuntimeEnv,
 ): typeof fetch {
-  const fetcher = withValidatedDiscordProxy(proxyUrl, runtime, (proxy) => {
+  const effectiveProxyUrl = resolveEffectiveDebugProxyUrl(proxyUrl);
+  const fetcher = withValidatedDiscordProxy(effectiveProxyUrl, runtime, (proxy) => {
     const agent = new ProxyAgent(proxy);
     return wrapFetchWithAbortSignal(
       ((input: RequestInfo | URL, init?: RequestInit) =>
-        undiciFetch(input as string | URL, {
+        (undiciFetch(input as string | URL, {
           ...(init as Record<string, unknown>),
           dispatcher: agent,
-        }) as unknown as Promise<Response>) as typeof fetch,
+        }) as unknown as Promise<Response>).then((response) => {
+          captureHttpExchange({
+            url: input instanceof URL ? input.toString() : String(input),
+            method: init?.method ?? "GET",
+            requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
+            requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+            response,
+            flowId: randomUUID(),
+            meta: { subsystem: "discord-rest" },
+          });
+          return response;
+        })) as typeof fetch,
     );
   });
   if (!fetcher) {

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -1,12 +1,12 @@
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
+import {
+  captureWsEvent,
+  createDebugProxyWebSocketAgent,
+  resolveDebugProxySettings,
+} from "openclaw/plugin-sdk/proxy-capture";
 import { z } from "openclaw/plugin-sdk/zod";
 import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
-import {
-  createDebugProxyWebSocketAgent,
-  resolveDebugProxySettings,
-} from "../../../../src/proxy-capture/env.js";
-import { captureWsEvent } from "../../../../src/proxy-capture/runtime.js";
 import { MattermostPostSchema, type MattermostPost } from "./client.js";
 import { rawDataToString } from "./monitor-helpers.js";
 import type { ChannelAccountSnapshot, RuntimeEnv } from "./runtime-api.js";

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -1,6 +1,12 @@
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import { z } from "openclaw/plugin-sdk/zod";
+import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
+import {
+  createDebugProxyWebSocketAgent,
+  resolveDebugProxySettings,
+} from "../../../../src/proxy-capture/env.js";
+import { captureWsEvent } from "../../../../src/proxy-capture/runtime.js";
 import { MattermostPostSchema, type MattermostPost } from "./client.js";
 import { rawDataToString } from "./monitor-helpers.js";
 import type { ChannelAccountSnapshot, RuntimeEnv } from "./runtime-api.js";
@@ -100,8 +106,10 @@ type CreateMattermostConnectOnceOpts = {
   healthCheckIntervalMs?: number;
 };
 
-export const defaultMattermostWebSocketFactory: MattermostWebSocketFactory = (url) =>
-  new WebSocket(url) as MattermostWebSocketLike;
+export const defaultMattermostWebSocketFactory: MattermostWebSocketFactory = (url) => {
+  const agent = createDebugProxyWebSocketAgent(resolveDebugProxySettings());
+  return new WebSocket(url, agent ? { agent } : undefined) as MattermostWebSocketLike;
+};
 
 export function parsePostedPayload(
   payload: MattermostEventPayload,
@@ -137,6 +145,7 @@ export function createMattermostConnectOnce(
   const webSocketFactory = opts.webSocketFactory ?? defaultMattermostWebSocketFactory;
   const healthCheckIntervalMs = opts.healthCheckIntervalMs ?? 30_000;
   return async () => {
+    const flowId = randomUUID();
     const ws = webSocketFactory(opts.wsUrl);
     const onAbort = () => ws.terminate();
     opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
@@ -228,18 +237,32 @@ export function createMattermostConnectOnce(
 
         ws.on("open", () => {
           opened = true;
+          captureWsEvent({
+            url: opts.wsUrl,
+            direction: "local",
+            kind: "ws-open",
+            flowId,
+            meta: { subsystem: "mattermost-websocket" },
+          });
           opts.statusSink?.({
             connected: true,
             lastConnectedAt: Date.now(),
             lastError: null,
           });
-          ws.send(
-            JSON.stringify({
-              seq: opts.nextSeq(),
-              action: "authentication_challenge",
-              data: { token: opts.botToken },
-            }),
-          );
+          const authPayload = JSON.stringify({
+            seq: opts.nextSeq(),
+            action: "authentication_challenge",
+            data: { token: opts.botToken },
+          });
+          captureWsEvent({
+            url: opts.wsUrl,
+            direction: "outbound",
+            kind: "ws-frame",
+            flowId,
+            payload: authPayload,
+            meta: { subsystem: "mattermost-websocket", eventType: "authentication_challenge" },
+          });
+          ws.send(authPayload);
 
           // Periodically check if the bot account was modified (e.g. disable/enable).
           // After such a cycle the WebSocket silently stops delivering events even
@@ -252,6 +275,14 @@ export function createMattermostConnectOnce(
         });
 
         ws.on("message", async (data) => {
+          captureWsEvent({
+            url: opts.wsUrl,
+            direction: "inbound",
+            kind: "ws-frame",
+            flowId,
+            payload: Buffer.isBuffer(data) ? data : Buffer.from(String(data)),
+            meta: { subsystem: "mattermost-websocket" },
+          });
           const raw = rawDataToString(data);
           const payload = parseMattermostEventPayload(raw);
           if (!payload) {
@@ -285,6 +316,15 @@ export function createMattermostConnectOnce(
         });
 
         ws.on("close", (code, reason) => {
+          captureWsEvent({
+            url: opts.wsUrl,
+            direction: "local",
+            kind: "ws-close",
+            flowId,
+            closeCode: code,
+            payload: reason,
+            meta: { subsystem: "mattermost-websocket" },
+          });
           stopHealthChecks();
           const message = reasonToString(reason);
           opts.statusSink?.({
@@ -303,6 +343,14 @@ export function createMattermostConnectOnce(
         });
 
         ws.on("error", (err) => {
+          captureWsEvent({
+            url: opts.wsUrl,
+            direction: "local",
+            kind: "error",
+            flowId,
+            errorText: String(err),
+            meta: { subsystem: "mattermost-websocket" },
+          });
           opts.runtime.error?.(`mattermost websocket error: ${String(err)}`);
           opts.statusSink?.({
             lastError: String(err),

--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -1,4 +1,6 @@
-import { writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -12,10 +14,26 @@ const TEST_CFG = {} as OpenClawConfig;
 
 describe("listMicrosoftVoices", () => {
   const originalFetch = globalThis.fetch;
+  const proxyEnvKeys = [
+    "OPENCLAW_DEBUG_PROXY_ENABLED",
+    "OPENCLAW_DEBUG_PROXY_DB_PATH",
+    "OPENCLAW_DEBUG_PROXY_BLOB_DIR",
+    "OPENCLAW_DEBUG_PROXY_SESSION_ID",
+  ] as const;
+  let priorProxyEnv: Partial<Record<(typeof proxyEnvKeys)[number], string | undefined>> = {};
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
+    for (const key of proxyEnvKeys) {
+      const value = priorProxyEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    priorProxyEnv = {};
   });
 
   it("maps Microsoft voice metadata into speech voice options", async () => {
@@ -60,6 +78,47 @@ describe("listMicrosoftVoices", () => {
       ) as unknown as typeof globalThis.fetch;
 
     await expect(listMicrosoftVoices()).rejects.toThrow("Microsoft voices API error (503)");
+  });
+
+  it("records voice discovery exchanges in debug proxy capture mode", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "microsoft-voices-capture-"));
+    priorProxyEnv = Object.fromEntries(
+      proxyEnvKeys.map((key) => [key, process.env[key]]),
+    ) as typeof priorProxyEnv;
+    process.env.OPENCLAW_DEBUG_PROXY_ENABLED = "1";
+    process.env.OPENCLAW_DEBUG_PROXY_DB_PATH = path.join(tempDir, "capture.sqlite");
+    process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR = path.join(tempDir, "blobs");
+    process.env.OPENCLAW_DEBUG_PROXY_SESSION_ID = "ms-voices-session";
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([{ ShortName: "en-US-AvaNeural" }]), { status: 200 }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const { getDebugProxyCaptureStore } = await import("../../src/proxy-capture/store.sqlite.js");
+    const store = getDebugProxyCaptureStore(
+      process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+      process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+    );
+    store.upsertSession({
+      id: "ms-voices-session",
+      startedAt: Date.now(),
+      mode: "test",
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      dbPath: process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+      blobDir: process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+    });
+
+    await listMicrosoftVoices();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const events = store.getSessionEvents("ms-voices-session", 10);
+    expect(
+      events.some((event) => event.kind === "request" && event.host === "speech.platform.bing.com"),
+    ).toBe(true);
+    expect(
+      events.some((event) => event.kind === "response" && event.host === "speech.platform.bing.com"),
+    ).toBe(true);
   });
 });
 

--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -120,6 +120,52 @@ describe("listMicrosoftVoices", () => {
       events.some((event) => event.kind === "response" && event.host === "speech.platform.bing.com"),
     ).toBe(true);
   });
+
+  it("does not double-capture voice discovery when the global fetch patch is installed", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "microsoft-voices-global-"));
+    priorProxyEnv = Object.fromEntries(
+      proxyEnvKeys.map((key) => [key, process.env[key]]),
+    ) as typeof priorProxyEnv;
+    process.env.OPENCLAW_DEBUG_PROXY_ENABLED = "1";
+    process.env.OPENCLAW_DEBUG_PROXY_DB_PATH = path.join(tempDir, "capture.sqlite");
+    process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR = path.join(tempDir, "blobs");
+    process.env.OPENCLAW_DEBUG_PROXY_SESSION_ID = "ms-voices-global-session";
+
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify([{ ShortName: "en-US-AvaNeural" }]), { status: 200 })) as unknown as typeof globalThis.fetch;
+
+    const { getDebugProxyCaptureStore } = await import("../../src/proxy-capture/store.sqlite.js");
+    const { finalizeDebugProxyCapture, initializeDebugProxyCapture } = await import(
+      "../../src/proxy-capture/runtime.js"
+    );
+    const store = getDebugProxyCaptureStore(
+      process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+      process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+    );
+    store.upsertSession({
+      id: "ms-voices-global-session",
+      startedAt: Date.now(),
+      mode: "test",
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      dbPath: process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+      blobDir: process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+    });
+    initializeDebugProxyCapture("test");
+
+    try {
+      await listMicrosoftVoices();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const events = store
+        .getSessionEvents("ms-voices-global-session", 10)
+        .filter((event) => event.host === "speech.platform.bing.com");
+      expect(events).toHaveLength(2);
+      expect(events.map((event) => event.kind).sort()).toEqual(["request", "response"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      finalizeDebugProxyCapture();
+    }
+  });
 });
 
 describe("isCjkDominant", () => {

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -13,6 +13,7 @@ import type {
 } from "openclaw/plugin-sdk/speech";
 import { asBoolean, asFiniteNumber, asObject, trimToUndefined } from "openclaw/plugin-sdk/speech";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { captureHttpExchange } from "../../src/proxy-capture/runtime.js";
 import { edgeTTS, inferEdgeExtension } from "./tts.js";
 
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
@@ -129,13 +130,24 @@ const DEFAULT_CHINESE_EDGE_VOICE = "zh-CN-XiaoxiaoNeural";
 const DEFAULT_CHINESE_EDGE_LANG = "zh-CN";
 
 export async function listMicrosoftVoices(): Promise<SpeechVoiceOption[]> {
-  const response = await fetch(
+  const url =
     "https://speech.platform.bing.com/consumer/speech/synthesize/readaloud/voices/list" +
-      `?trustedclienttoken=${TRUSTED_CLIENT_TOKEN}`,
-    {
-      headers: buildMicrosoftVoiceHeaders(),
+    `?trustedclienttoken=${TRUSTED_CLIENT_TOKEN}`;
+  const headers = buildMicrosoftVoiceHeaders();
+  const response = await fetch(url, {
+    headers,
+  });
+  captureHttpExchange({
+    url,
+    method: "GET",
+    requestHeaders: headers,
+    response,
+    transport: "http",
+    meta: {
+      provider: "microsoft",
+      capability: "speech-voices",
     },
-  );
+  });
   if (!response.ok) {
     throw new Error(`Microsoft voices API error (${response.status})`);
   }

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -11,9 +11,9 @@ import type {
   SpeechProviderPlugin,
   SpeechVoiceOption,
 } from "openclaw/plugin-sdk/speech";
+import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
 import { asBoolean, asFiniteNumber, asObject, trimToUndefined } from "openclaw/plugin-sdk/speech";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import { captureHttpExchange } from "../../src/proxy-capture/runtime.js";
 import { edgeTTS, inferEdgeExtension } from "./tts.js";
 
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -11,7 +11,10 @@ import type {
   SpeechProviderPlugin,
   SpeechVoiceOption,
 } from "openclaw/plugin-sdk/speech";
-import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
+import {
+  captureHttpExchange,
+  isDebugProxyGlobalFetchPatchInstalled,
+} from "openclaw/plugin-sdk/proxy-capture";
 import { asBoolean, asFiniteNumber, asObject, trimToUndefined } from "openclaw/plugin-sdk/speech";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { edgeTTS, inferEdgeExtension } from "./tts.js";
@@ -137,17 +140,19 @@ export async function listMicrosoftVoices(): Promise<SpeechVoiceOption[]> {
   const response = await fetch(url, {
     headers,
   });
-  captureHttpExchange({
-    url,
-    method: "GET",
-    requestHeaders: headers,
-    response,
-    transport: "http",
-    meta: {
-      provider: "microsoft",
-      capability: "speech-voices",
-    },
-  });
+  if (!isDebugProxyGlobalFetchPatchInstalled()) {
+    captureHttpExchange({
+      url,
+      method: "GET",
+      requestHeaders: headers,
+      response,
+      transport: "http",
+      meta: {
+        provider: "microsoft",
+        capability: "speech-voices",
+      },
+    });
+  }
   if (!response.ok) {
     throw new Error(`Microsoft voices API error (${response.status})`);
   }

--- a/extensions/openai/realtime-transcription-provider.ts
+++ b/extensions/openai/realtime-transcription-provider.ts
@@ -4,11 +4,14 @@ import type {
   RealtimeTranscriptionSession,
   RealtimeTranscriptionSessionCreateRequest,
 } from "openclaw/plugin-sdk/realtime-transcription";
+import {
+  captureWsEvent,
+  createDebugProxyWebSocketAgent,
+  resolveDebugProxySettings,
+} from "openclaw/plugin-sdk/proxy-capture";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
-import { createDebugProxyWebSocketAgent, resolveDebugProxySettings } from "../../src/proxy-capture/env.js";
-import { captureWsEvent } from "../../src/proxy-capture/runtime.js";
 import {
   asFiniteNumber,
   readRealtimeErrorDetail,

--- a/extensions/openai/realtime-transcription-provider.ts
+++ b/extensions/openai/realtime-transcription-provider.ts
@@ -5,7 +5,10 @@ import type {
   RealtimeTranscriptionSessionCreateRequest,
 } from "openclaw/plugin-sdk/realtime-transcription";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
+import { createDebugProxyWebSocketAgent, resolveDebugProxySettings } from "../../src/proxy-capture/env.js";
+import { captureWsEvent } from "../../src/proxy-capture/runtime.js";
 import {
   asFiniteNumber,
   readRealtimeErrorDetail,
@@ -64,6 +67,7 @@ class OpenAIRealtimeTranscriptionSession implements RealtimeTranscriptionSession
   private closed = false;
   private reconnectAttempts = 0;
   private pendingTranscript = "";
+  private readonly flowId = randomUUID();
 
   constructor(private readonly config: OpenAIRealtimeTranscriptionSessionConfig) {}
 
@@ -98,11 +102,15 @@ class OpenAIRealtimeTranscriptionSession implements RealtimeTranscriptionSession
 
   private async doConnect(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      this.ws = new WebSocket("wss://api.openai.com/v1/realtime?intent=transcription", {
+      const url = "wss://api.openai.com/v1/realtime?intent=transcription";
+      const debugProxy = resolveDebugProxySettings();
+      const proxyAgent = createDebugProxyWebSocketAgent(debugProxy);
+      this.ws = new WebSocket(url, {
         headers: {
           Authorization: `Bearer ${this.config.apiKey}`,
           "OpenAI-Beta": "realtime=v1",
         },
+        ...(proxyAgent ? { agent: proxyAgent } : {}),
       });
 
       const connectTimeout = setTimeout(() => {
@@ -113,6 +121,16 @@ class OpenAIRealtimeTranscriptionSession implements RealtimeTranscriptionSession
         clearTimeout(connectTimeout);
         this.connected = true;
         this.reconnectAttempts = 0;
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "ws-open",
+          flowId: this.flowId,
+          meta: {
+            provider: "openai",
+            capability: "realtime-transcription",
+          },
+        });
         this.sendEvent({
           type: "transcription_session.update",
           session: {
@@ -132,6 +150,17 @@ class OpenAIRealtimeTranscriptionSession implements RealtimeTranscriptionSession
       });
 
       this.ws.on("message", (data: Buffer) => {
+        captureWsEvent({
+          url,
+          direction: "inbound",
+          kind: "ws-frame",
+          flowId: this.flowId,
+          payload: data,
+          meta: {
+            provider: "openai",
+            capability: "realtime-transcription",
+          },
+        });
         try {
           this.handleEvent(JSON.parse(data.toString()) as RealtimeEvent);
         } catch (error) {
@@ -140,6 +169,17 @@ class OpenAIRealtimeTranscriptionSession implements RealtimeTranscriptionSession
       });
 
       this.ws.on("error", (error) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "error",
+          flowId: this.flowId,
+          errorText: error instanceof Error ? error.message : String(error),
+          meta: {
+            provider: "openai",
+            capability: "realtime-transcription",
+          },
+        });
         if (!this.connected) {
           clearTimeout(connectTimeout);
           reject(error);
@@ -148,7 +188,22 @@ class OpenAIRealtimeTranscriptionSession implements RealtimeTranscriptionSession
         this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
       });
 
-      this.ws.on("close", () => {
+      this.ws.on("close", (code, reasonBuffer) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "ws-close",
+          flowId: this.flowId,
+          closeCode: typeof code === "number" ? code : undefined,
+          meta: {
+            provider: "openai",
+            capability: "realtime-transcription",
+            reason:
+              Buffer.isBuffer(reasonBuffer) && reasonBuffer.length > 0
+                ? reasonBuffer.toString("utf8")
+                : undefined,
+          },
+        });
         this.connected = false;
         if (this.closed) {
           return;
@@ -215,7 +270,19 @@ class OpenAIRealtimeTranscriptionSession implements RealtimeTranscriptionSession
 
   private sendEvent(event: unknown): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(event));
+      const payload = JSON.stringify(event);
+      captureWsEvent({
+        url: "wss://api.openai.com/v1/realtime?intent=transcription",
+        direction: "outbound",
+        kind: "ws-frame",
+        flowId: this.flowId,
+        payload,
+        meta: {
+          provider: "openai",
+          capability: "realtime-transcription",
+        },
+      });
+      this.ws.send(payload);
     }
   }
 }

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -5,11 +5,14 @@ import type {
   RealtimeVoiceProviderPlugin,
   RealtimeVoiceTool,
 } from "openclaw/plugin-sdk/realtime-voice";
+import {
+  captureWsEvent,
+  createDebugProxyWebSocketAgent,
+  resolveDebugProxySettings,
+} from "openclaw/plugin-sdk/proxy-capture";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
-import { createDebugProxyWebSocketAgent, resolveDebugProxySettings } from "../../src/proxy-capture/env.js";
-import { captureWsEvent } from "../../src/proxy-capture/runtime.js";
 import {
   asFiniteNumber,
   readRealtimeErrorDetail,

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -6,7 +6,10 @@ import type {
   RealtimeVoiceTool,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
+import { createDebugProxyWebSocketAgent, resolveDebugProxySettings } from "../../src/proxy-capture/env.js";
+import { captureWsEvent } from "../../src/proxy-capture/runtime.js";
 import {
   asFiniteNumber,
   readRealtimeErrorDetail,
@@ -125,6 +128,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private latestMediaTimestamp = 0;
   private lastAssistantItemId: string | null = null;
   private toolCallBuffers = new Map<string, { name: string; callId: string; args: string }>();
+  private readonly flowId = randomUUID();
 
   constructor(private readonly config: OpenAIRealtimeVoiceBridgeConfig) {}
 
@@ -214,7 +218,12 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private async doConnect(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       const { url, headers } = this.resolveConnectionParams();
-      this.ws = new WebSocket(url, { headers });
+      const debugProxy = resolveDebugProxySettings();
+      const proxyAgent = createDebugProxyWebSocketAgent(debugProxy);
+      this.ws = new WebSocket(url, {
+        headers,
+        ...(proxyAgent ? { agent: proxyAgent } : {}),
+      });
 
       const connectTimeout = setTimeout(() => {
         reject(new Error("OpenAI realtime connection timeout"));
@@ -224,6 +233,16 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         clearTimeout(connectTimeout);
         this.connected = true;
         this.reconnectAttempts = 0;
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "ws-open",
+          flowId: this.flowId,
+          meta: {
+            provider: "openai",
+            capability: "realtime-voice",
+          },
+        });
         this.sendSessionUpdate();
         for (const chunk of this.pendingAudio.splice(0)) {
           this.sendAudio(chunk);
@@ -233,6 +252,17 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       });
 
       this.ws.on("message", (data: Buffer) => {
+        captureWsEvent({
+          url,
+          direction: "inbound",
+          kind: "ws-frame",
+          flowId: this.flowId,
+          payload: data,
+          meta: {
+            provider: "openai",
+            capability: "realtime-voice",
+          },
+        });
         try {
           this.handleEvent(JSON.parse(data.toString()) as RealtimeEvent);
         } catch (error) {
@@ -241,6 +271,17 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       });
 
       this.ws.on("error", (error) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "error",
+          flowId: this.flowId,
+          errorText: error instanceof Error ? error.message : String(error),
+          meta: {
+            provider: "openai",
+            capability: "realtime-voice",
+          },
+        });
         if (!this.connected) {
           clearTimeout(connectTimeout);
           reject(error);
@@ -248,7 +289,22 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
       });
 
-      this.ws.on("close", () => {
+      this.ws.on("close", (code, reasonBuffer) => {
+        captureWsEvent({
+          url,
+          direction: "local",
+          kind: "ws-close",
+          flowId: this.flowId,
+          closeCode: typeof code === "number" ? code : undefined,
+          meta: {
+            provider: "openai",
+            capability: "realtime-voice",
+            reason:
+              Buffer.isBuffer(reasonBuffer) && reasonBuffer.length > 0
+                ? reasonBuffer.toString("utf8")
+                : undefined,
+          },
+        });
         this.connected = false;
         if (this.intentionallyClosed) {
           this.config.onClose?.("completed");
@@ -475,7 +531,19 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
   private sendEvent(event: unknown): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(event));
+      const payload = JSON.stringify(event);
+      captureWsEvent({
+        url: this.resolveConnectionParams().url,
+        direction: "outbound",
+        kind: "ws-frame",
+        flowId: this.flowId,
+        payload,
+        meta: {
+          provider: "openai",
+          capability: "realtime-voice",
+        },
+      });
+      this.ws.send(payload);
     }
   }
 }

--- a/extensions/openai/tts.test.ts
+++ b/extensions/openai/tts.test.ts
@@ -252,5 +252,48 @@ describe("openai tts", () => {
         events.some((event) => event.kind === "response" && event.host === "api.openai.com"),
       ).toBe(true);
     });
+
+    it("does not double-capture TTS exchanges when the global fetch patch is installed", async () => {
+      const tempDir = mkdtempSync(path.join(os.tmpdir(), "openai-tts-patched-capture-"));
+      priorProxyEnv = Object.fromEntries(
+        proxyEnvKeys.map((key) => [key, process.env[key]]),
+      ) as typeof priorProxyEnv;
+      process.env.OPENCLAW_DEBUG_PROXY_ENABLED = "1";
+      process.env.OPENCLAW_DEBUG_PROXY_DB_PATH = path.join(tempDir, "capture.sqlite");
+      process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR = path.join(tempDir, "blobs");
+      process.env.OPENCLAW_DEBUG_PROXY_SESSION_ID = "tts-patched-session";
+
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response(Buffer.from("audio-bytes"), { status: 200 })) as
+        unknown as typeof globalThis.fetch;
+
+      const runtime = await import("../../src/proxy-capture/runtime.js");
+      const { getDebugProxyCaptureStore } = await import("../../src/proxy-capture/store.sqlite.js");
+      runtime.initializeDebugProxyCapture("test");
+
+      await openaiTTS({
+        text: "hello",
+        apiKey: "test-key",
+        baseUrl: "https://api.openai.com/v1",
+        model: "gpt-4o-mini-tts",
+        voice: "alloy",
+        responseFormat: "mp3",
+        timeoutMs: 5_000,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      runtime.finalizeDebugProxyCapture();
+
+      const store = getDebugProxyCaptureStore(
+        process.env.OPENCLAW_DEBUG_PROXY_DB_PATH!,
+        process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR!,
+      );
+      const events = store
+        .getSessionEvents("tts-patched-session", 10)
+        .filter((event) => event.host === "api.openai.com");
+      expect(events).toHaveLength(2);
+      expect(events.map((event) => event.kind).sort()).toEqual(["request", "response"]);
+      store.close();
+    });
   });
 });

--- a/extensions/openai/tts.test.ts
+++ b/extensions/openai/tts.test.ts
@@ -1,3 +1,6 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isValidOpenAIModel,
@@ -10,10 +13,26 @@ import {
 
 describe("openai tts", () => {
   const originalFetch = globalThis.fetch;
+  const proxyEnvKeys = [
+    "OPENCLAW_DEBUG_PROXY_ENABLED",
+    "OPENCLAW_DEBUG_PROXY_DB_PATH",
+    "OPENCLAW_DEBUG_PROXY_BLOB_DIR",
+    "OPENCLAW_DEBUG_PROXY_SESSION_ID",
+  ] as const;
+  let priorProxyEnv: Partial<Record<(typeof proxyEnvKeys)[number], string | undefined>> = {};
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
+    for (const key of proxyEnvKeys) {
+      const value = priorProxyEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    priorProxyEnv = {};
   });
 
   describe("isValidOpenAIVoice", () => {
@@ -182,6 +201,56 @@ describe("openai tts", () => {
       ).rejects.toThrow("OpenAI TTS API error (503)");
 
       expect(streamed.getReadCount()).toBeLessThan(200);
+    });
+
+    it("records TTS exchanges in debug proxy capture mode", async () => {
+      const tempDir = mkdtempSync(path.join(os.tmpdir(), "openai-tts-capture-"));
+      priorProxyEnv = Object.fromEntries(
+        proxyEnvKeys.map((key) => [key, process.env[key]]),
+      ) as typeof priorProxyEnv;
+      process.env.OPENCLAW_DEBUG_PROXY_ENABLED = "1";
+      process.env.OPENCLAW_DEBUG_PROXY_DB_PATH = path.join(tempDir, "capture.sqlite");
+      process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR = path.join(tempDir, "blobs");
+      process.env.OPENCLAW_DEBUG_PROXY_SESSION_ID = "tts-session";
+
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response(Buffer.from("audio-bytes"), { status: 200 })) as
+        unknown as typeof globalThis.fetch;
+
+      const { getDebugProxyCaptureStore } = await import("../../src/proxy-capture/store.sqlite.js");
+      const store = getDebugProxyCaptureStore(
+        process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+        process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+      );
+      store.upsertSession({
+        id: "tts-session",
+        startedAt: Date.now(),
+        mode: "test",
+        sourceScope: "openclaw",
+        sourceProcess: "openclaw",
+        dbPath: process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+        blobDir: process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+      });
+
+      await openaiTTS({
+        text: "hello",
+        apiKey: "test-key",
+        baseUrl: "https://api.openai.com/v1",
+        model: "gpt-4o-mini-tts",
+        voice: "alloy",
+        responseFormat: "mp3",
+        timeoutMs: 5_000,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const events = store.getSessionEvents("tts-session", 10);
+      expect(events.some((event) => event.kind === "request" && event.host === "api.openai.com")).toBe(
+        true,
+      );
+      expect(
+        events.some((event) => event.kind === "response" && event.host === "api.openai.com"),
+      ).toBe(true);
     });
   });
 });

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -4,6 +4,7 @@ import {
   trimToUndefined,
   truncateErrorDetail,
 } from "openclaw/plugin-sdk/speech";
+import { captureHttpExchange } from "../../src/proxy-capture/runtime.js";
 
 export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 
@@ -130,21 +131,35 @@ export async function openaiTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
+    const requestHeaders = {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    };
+    const requestBody = JSON.stringify({
+      model,
+      input: text,
+      voice,
+      response_format: responseFormat,
+      ...(speed != null && { speed }),
+      ...(effectiveInstructions != null && { instructions: effectiveInstructions }),
+    });
     const response = await fetch(`${baseUrl}/audio/speech`, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model,
-        input: text,
-        voice,
-        response_format: responseFormat,
-        ...(speed != null && { speed }),
-        ...(effectiveInstructions != null && { instructions: effectiveInstructions }),
-      }),
+      headers: requestHeaders,
+      body: requestBody,
       signal: controller.signal,
+    });
+    captureHttpExchange({
+      url: `${baseUrl}/audio/speech`,
+      method: "POST",
+      requestHeaders,
+      requestBody,
+      response,
+      transport: "http",
+      meta: {
+        provider: "openai",
+        capability: "tts",
+      },
     });
 
     if (!response.ok) {

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -4,7 +4,10 @@ import {
   trimToUndefined,
   truncateErrorDetail,
 } from "openclaw/plugin-sdk/speech";
-import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
+import {
+  captureHttpExchange,
+  isDebugProxyGlobalFetchPatchInstalled,
+} from "openclaw/plugin-sdk/proxy-capture";
 
 export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 
@@ -149,18 +152,20 @@ export async function openaiTTS(params: {
       body: requestBody,
       signal: controller.signal,
     });
-    captureHttpExchange({
-      url: `${baseUrl}/audio/speech`,
-      method: "POST",
-      requestHeaders,
-      requestBody,
-      response,
-      transport: "http",
-      meta: {
-        provider: "openai",
-        capability: "tts",
-      },
-    });
+    if (!isDebugProxyGlobalFetchPatchInstalled()) {
+      captureHttpExchange({
+        url: `${baseUrl}/audio/speech`,
+        method: "POST",
+        requestHeaders,
+        requestBody,
+        response,
+        transport: "http",
+        meta: {
+          provider: "openai",
+          capability: "tts",
+        },
+      });
+    }
 
     if (!response.ok) {
       const detail = await extractOpenAiErrorDetail(response);

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -4,7 +4,7 @@ import {
   trimToUndefined,
   truncateErrorDetail,
 } from "openclaw/plugin-sdk/speech";
-import { captureHttpExchange } from "../../src/proxy-capture/runtime.js";
+import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
 
 export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -271,6 +271,76 @@ describe("qa-lab server", () => {
     expect(await rootResponse.text()).toContain("Control UI");
   });
 
+  it("reports startup reachability for proxy and gateway", async () => {
+    const proxy = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+      res.end("proxy");
+    });
+    await new Promise<void>((resolve, reject) => {
+      proxy.once("error", reject);
+      proxy.listen(0, "127.0.0.1", () => resolve());
+    });
+    cleanups.push(
+      async () =>
+        await new Promise<void>((resolve, reject) =>
+          proxy.close((error) => (error ? reject(error) : resolve())),
+        ),
+    );
+
+    const gateway = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+      res.end("gateway");
+    });
+    await new Promise<void>((resolve, reject) => {
+      gateway.once("error", reject);
+      gateway.listen(0, "127.0.0.1", () => resolve());
+    });
+    cleanups.push(
+      async () =>
+        await new Promise<void>((resolve, reject) =>
+          gateway.close((error) => (error ? reject(error) : resolve())),
+        ),
+    );
+
+    const proxyAddress = proxy.address();
+    const gatewayAddress = gateway.address();
+    if (
+      !proxyAddress ||
+      typeof proxyAddress === "string" ||
+      !gatewayAddress ||
+      typeof gatewayAddress === "string"
+    ) {
+      throw new Error("expected startup probe addresses");
+    }
+
+    process.env.OPENCLAW_DEBUG_PROXY_URL = `http://127.0.0.1:${proxyAddress.port}`;
+    const lab = await startQaLabServer({
+      host: "127.0.0.1",
+      port: 0,
+      controlUiUrl: `http://127.0.0.1:${gatewayAddress.port}/`,
+    });
+    cleanups.push(async () => {
+      delete process.env.OPENCLAW_DEBUG_PROXY_URL;
+      await lab.stop();
+    });
+
+    const response = await fetchWithRetry(`${lab.baseUrl}/api/capture/startup-status`);
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      status: {
+        proxy: { ok: boolean; url: string };
+        gateway: { ok: boolean; url: string };
+        qaLab: { ok: boolean; url: string };
+      };
+    };
+    expect(payload.status.proxy.ok).toBe(true);
+    expect(payload.status.proxy.url).toBe(`http://127.0.0.1:${proxyAddress.port}/`);
+    expect(payload.status.gateway.ok).toBe(true);
+    expect(payload.status.gateway.url).toBe(`http://127.0.0.1:${gatewayAddress.port}/`);
+    expect(payload.status.qaLab.ok).toBe(true);
+    expect(payload.status.qaLab.url).toBe(lab.baseUrl);
+  });
+
   it("serves the built QA UI bundle when available", async () => {
     const uiDistDir = await mkdtemp(path.join(os.tmpdir(), "qa-lab-ui-dist-"));
     cleanups.push(async () => {
@@ -566,6 +636,167 @@ describe("qa-lab server", () => {
     expect(outcomes.run.scenarios.map((scenario) => scenario.id)).toEqual([
       "channel-chat-baseline",
       "cron-one-minute-ping",
+    ]);
+  });
+
+  it("serves proxy capture sessions, events, and query rows", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "qa-lab-capture-"));
+    cleanups.push(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+    process.env.OPENCLAW_DEBUG_PROXY_DB_PATH = path.join(tempDir, "capture.sqlite");
+    process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR = path.join(tempDir, "blobs");
+    const { getDebugProxyCaptureStore } = await import("../../../src/proxy-capture/store.sqlite.js");
+    const store = getDebugProxyCaptureStore(
+      process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+      process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+    );
+    store.upsertSession({
+      id: "qa-capture-session",
+      startedAt: Date.now(),
+      mode: "proxy-run",
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      dbPath: process.env.OPENCLAW_DEBUG_PROXY_DB_PATH,
+      blobDir: process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR,
+    });
+    store.recordEvent({
+      sessionId: "qa-capture-session",
+      ts: Date.now(),
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      protocol: "https",
+      direction: "outbound",
+      kind: "request",
+      flowId: "flow-1",
+      method: "POST",
+      host: "api.example.com",
+      path: "/v1/send",
+      dataText: '{"hello":"world"}',
+      dataSha256: "abc",
+      metaJson: JSON.stringify({
+        provider: "openai",
+        api: "responses",
+        model: "gpt-5.4",
+        captureOrigin: "shared-fetch",
+      }),
+    });
+    store.recordEvent({
+      sessionId: "qa-capture-session",
+      ts: Date.now() + 1,
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      protocol: "https",
+      direction: "outbound",
+      kind: "request",
+      flowId: "flow-2",
+      method: "POST",
+      host: "api.example.com",
+      path: "/v1/send",
+      dataText: '{"hello":"world"}',
+      dataSha256: "abc",
+      metaJson: JSON.stringify({
+        provider: "openai",
+        api: "responses",
+        model: "gpt-5.4",
+        captureOrigin: "shared-fetch",
+      }),
+    });
+    store.recordEvent({
+      sessionId: "qa-capture-session",
+      ts: Date.now() + 2,
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      protocol: "https",
+      direction: "outbound",
+      kind: "request",
+      flowId: "flow-3",
+      method: "POST",
+      host: "127.0.0.1:11434",
+      path: "/api/chat",
+      metaJson: JSON.stringify({
+        provider: "ollama",
+        model: "kimi-k2.5:cloud",
+        captureOrigin: "shared-fetch",
+      }),
+    });
+
+    const lab = await startQaLabServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      delete process.env.OPENCLAW_DEBUG_PROXY_DB_PATH;
+      delete process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR;
+      await lab.stop();
+    });
+
+    const sessions = (await (
+      await fetchWithRetry(`${lab.baseUrl}/api/capture/sessions`)
+    ).json()) as { sessions: Array<{ id: string }> };
+    expect(sessions.sessions.some((session) => session.id === "qa-capture-session")).toBe(true);
+
+    const events = (await (
+      await fetchWithRetry(`${lab.baseUrl}/api/capture/events?sessionId=qa-capture-session`)
+    ).json()) as {
+      events: Array<{ flowId: string; provider?: string; model?: string; captureOrigin?: string }>;
+    };
+    expect(events.events.some((event) => event.flowId === "flow-1")).toBe(true);
+    expect(events.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          flowId: "flow-1",
+          provider: "openai",
+          model: "gpt-5.4",
+          captureOrigin: "shared-fetch",
+        }),
+        expect.objectContaining({
+          flowId: "flow-3",
+          provider: "ollama",
+          model: "kimi-k2.5:cloud",
+        }),
+      ]),
+    );
+
+    const coverage = (await (
+      await fetchWithRetry(`${lab.baseUrl}/api/capture/coverage?sessionId=qa-capture-session`)
+    ).json()) as {
+      coverage: {
+        totalEvents: number;
+        unlabeledEventCount: number;
+        providers: Array<{ value: string; count: number }>;
+        models: Array<{ value: string; count: number }>;
+        localPeers: Array<{ value: string; count: number }>;
+      };
+    };
+    expect(coverage.coverage.totalEvents).toBe(3);
+    expect(coverage.coverage.unlabeledEventCount).toBe(0);
+    expect(coverage.coverage.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: "openai", count: 2 }),
+        expect.objectContaining({ value: "ollama", count: 1 }),
+      ]),
+    );
+    expect(coverage.coverage.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: "gpt-5.4", count: 2 }),
+        expect.objectContaining({ value: "kimi-k2.5:cloud", count: 1 }),
+      ]),
+    );
+    expect(coverage.coverage.localPeers).toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: "127.0.0.1:11434", count: 1 })]),
+    );
+
+    const query = (await (
+      await fetchWithRetry(
+        `${lab.baseUrl}/api/capture/query?sessionId=qa-capture-session&preset=double-sends`,
+      )
+    ).json()) as { rows: Array<{ host: string; duplicateCount: number }> };
+    expect(query.rows).toEqual([
+      expect.objectContaining({
+        host: "api.example.com",
+        duplicateCount: 2,
+      }),
     ]);
   });
 });

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -385,6 +385,38 @@ describe("qa-lab server", () => {
     expect(version2.version).not.toBe(version1.version);
   });
 
+  it("does not serve sibling files outside the UI dist root", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "qa-lab-ui-boundary-"));
+    cleanups.push(async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    });
+    const uiDistDir = path.join(rootDir, "dist");
+    const siblingDir = path.join(rootDir, "dist-other");
+    await mkdir(uiDistDir, { recursive: true });
+    await mkdir(siblingDir, { recursive: true });
+    await writeFile(
+      path.join(uiDistDir, "index.html"),
+      "<!doctype html><html><body>bundle-root</body></html>",
+      "utf8",
+    );
+    await writeFile(path.join(siblingDir, "secret.txt"), "sibling-secret", "utf8");
+
+    const lab = await startQaLabServer({
+      host: "127.0.0.1",
+      port: 0,
+      uiDistDir,
+    });
+    cleanups.push(async () => {
+      await lab.stop();
+    });
+
+    const response = await fetchWithRetry(`${lab.baseUrl}/../dist-other/secret.txt`);
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("bundle-root");
+    expect(body).not.toContain("sibling-secret");
+  });
+
   it("uses the explicit repo root for ui assets and runner model discovery", async () => {
     const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-lab-repo-root-"));
     cleanups.push(async () => {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -477,8 +477,9 @@ function tryResolveUiAsset(
   }
   const safePath = pathname === "/" ? "/index.html" : pathname;
   const decoded = decodeURIComponent(safePath);
-  const candidate = path.normalize(path.join(distDir, decoded));
-  if (!candidate.startsWith(distDir)) {
+  const candidate = path.resolve(distDir, `.${decoded.startsWith("/") ? decoded : `/${decoded}`}`);
+  const relative = path.relative(distDir, candidate);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
     return null;
   }
   if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -13,10 +13,12 @@ import type { Duplex } from "node:stream";
 import tls from "node:tls";
 import { fileURLToPath } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  getDebugProxyCaptureStore,
+  resolveDebugProxySettings,
+  type CaptureQueryPreset,
+} from "openclaw/plugin-sdk/proxy-capture";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
-import { getDebugProxyCaptureStore } from "../../../src/proxy-capture/store.sqlite.js";
-import { resolveDebugProxySettings } from "../../../src/proxy-capture/env.js";
-import type { CaptureQueryPreset } from "../../../src/proxy-capture/types.js";
 import { closeQaHttpServer, handleQaBusRequest, writeError, writeJson } from "./bus-server.js";
 import { createQaBusState, type QaBusState } from "./bus-state.js";
 import { createQaRunnerRuntime } from "./harness-runtime.js";

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -14,6 +14,9 @@ import tls from "node:tls";
 import { fileURLToPath } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+import { getDebugProxyCaptureStore } from "../../../src/proxy-capture/store.sqlite.js";
+import { resolveDebugProxySettings } from "../../../src/proxy-capture/env.js";
+import type { CaptureQueryPreset } from "../../../src/proxy-capture/types.js";
 import { closeQaHttpServer, handleQaBusRequest, writeError, writeJson } from "./bus-server.js";
 import { createQaBusState, type QaBusState } from "./bus-state.js";
 import { createQaRunnerRuntime } from "./harness-runtime.js";
@@ -48,6 +51,106 @@ export type {
   QaLabServerHandle,
   QaLabServerStartParams,
 } from "./lab-server.types.js";
+
+function parseCaptureMeta(metaJson: unknown): Record<string, unknown> | null {
+  if (typeof metaJson !== "string" || metaJson.trim().length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(metaJson) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function readCaptureMetaString(meta: Record<string, unknown> | null, key: string): string | undefined {
+  const value = meta?.[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function mapCaptureEventForQa(row: Record<string, unknown>) {
+  const meta = parseCaptureMeta(row.metaJson);
+  return {
+    ...row,
+    payloadPreview: typeof row.dataText === "string" ? row.dataText : undefined,
+    provider: readCaptureMetaString(meta, "provider"),
+    api: readCaptureMetaString(meta, "api"),
+    model: readCaptureMetaString(meta, "model"),
+    captureOrigin: readCaptureMetaString(meta, "captureOrigin"),
+  };
+}
+
+type QaStartupProbeStatus = {
+  label: string;
+  url: string;
+  ok: boolean;
+  error?: string;
+};
+
+function defaultPortForProtocol(protocol: string): number {
+  if (protocol === "https:") {
+    return 443;
+  }
+  if (protocol === "http:") {
+    return 80;
+  }
+  return 0;
+}
+
+async function probeTcpReachability(rawUrl: string, timeoutMs = 700): Promise<QaStartupProbeStatus> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return {
+      label: rawUrl,
+      url: rawUrl,
+      ok: false,
+      error: "invalid url",
+    };
+  }
+  const host = parsed.hostname;
+  const port = parsed.port ? Number(parsed.port) : defaultPortForProtocol(parsed.protocol);
+  if (!host || !Number.isFinite(port) || port <= 0) {
+    return {
+      label: parsed.origin,
+      url: parsed.toString(),
+      ok: false,
+      error: "missing host or port",
+    };
+  }
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const socket = net.createConnection({ host, port });
+      const onError = (error: Error) => {
+        socket.destroy();
+        reject(error);
+      };
+      socket.setTimeout(timeoutMs, () => {
+        socket.destroy(new Error("timeout"));
+      });
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+      socket.once("error", onError);
+      socket.once("timeout", () => onError(new Error("timeout")));
+    });
+    return {
+      label: parsed.host,
+      url: parsed.toString(),
+      ok: true,
+    };
+  } catch (error) {
+    return {
+      label: parsed.host,
+      url: parsed.toString(),
+      ok: false,
+      error: formatErrorMessage(error),
+    };
+  }
+}
 
 function countQaLabScenarioRun(scenarios: QaLabScenarioOutcome[]) {
   return {
@@ -440,6 +543,8 @@ export async function startQaLabServer(
   params?: QaLabServerStartParams,
 ): Promise<QaLabServerHandle> {
   const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
+  const captureSettings = resolveDebugProxySettings();
+  const captureStore = getDebugProxyCaptureStore(captureSettings.dbPath, captureSettings.blobDir);
   const state = createQaBusState();
   let latestReport: QaLabLatestReport | null = null;
   let latestScenarioRun: QaLabScenarioRun | null = null;
@@ -597,6 +702,98 @@ export async function startQaLabServer(
       }
       if (req.method === "GET" && url.pathname === "/api/outcomes") {
         writeJson(res, 200, { run: latestScenarioRun });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/capture/sessions") {
+        writeJson(res, 200, {
+          sessions: captureStore.listSessions(50),
+        });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/capture/startup-status") {
+        const proxyUrl = captureSettings.proxyUrl || "http://127.0.0.1:7799";
+        const gatewayUrl = controlUiUrl || "http://127.0.0.1:18789/";
+        const [proxy, gateway] = await Promise.all([
+          probeTcpReachability(proxyUrl),
+          probeTcpReachability(gatewayUrl),
+        ]);
+        writeJson(res, 200, {
+          status: {
+            proxy: {
+              ...proxy,
+              label: "Proxy",
+            },
+            gateway: {
+              ...gateway,
+              label: "Gateway",
+            },
+            qaLab: {
+              label: "QA Lab",
+              url: publicBaseUrl,
+              ok: true,
+            },
+          },
+        });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/capture/events") {
+        const sessionId = url.searchParams.get("sessionId")?.trim();
+        writeJson(res, 200, {
+          events: sessionId ? captureStore.getSessionEvents(sessionId, 200).map(mapCaptureEventForQa) : [],
+        });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/capture/coverage") {
+        const sessionId = url.searchParams.get("sessionId")?.trim();
+        if (!sessionId) {
+          writeError(res, 400, "Missing sessionId");
+          return;
+        }
+        writeJson(res, 200, {
+          coverage: captureStore.summarizeSessionCoverage(sessionId),
+        });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/capture/query") {
+        const preset = url.searchParams.get("preset")?.trim() as CaptureQueryPreset | null;
+        const sessionId = url.searchParams.get("sessionId")?.trim() || undefined;
+        if (!preset) {
+          writeError(res, 400, "Missing preset");
+          return;
+        }
+        writeJson(res, 200, {
+          rows: captureStore.queryPreset(preset, sessionId),
+        });
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/capture/blob") {
+        const blobId = url.searchParams.get("id")?.trim();
+        if (!blobId) {
+          writeError(res, 400, "Missing blob id");
+          return;
+        }
+        const content = captureStore.readBlob(blobId);
+        if (content == null) {
+          writeError(res, 404, "Blob not found");
+          return;
+        }
+        writeJson(res, 200, { id: blobId, content });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/api/capture/delete-sessions") {
+        const body = (await readJson(req)) as { sessionIds?: unknown };
+        const sessionIds = Array.isArray(body.sessionIds)
+          ? body.sessionIds.filter((value): value is string => typeof value === "string")
+          : [];
+        writeJson(res, 200, {
+          result: captureStore.deleteSessions(sessionIds),
+        });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/api/capture/purge") {
+        writeJson(res, 200, {
+          result: captureStore.purgeAll(),
+        });
         return;
       }
       if (req.method === "POST" && url.pathname === "/api/reset") {

--- a/extensions/qa-lab/web/src/app.ts
+++ b/extensions/qa-lab/web/src/app.ts
@@ -7,6 +7,12 @@ import {
   type RunnerSelection,
   type Snapshot,
   type TabId,
+  type CaptureEventsEnvelope,
+  type CaptureCoverageEnvelope,
+  type CaptureQueryEnvelope,
+  type CaptureSessionsEnvelope,
+  type CaptureStartupStatusEnvelope,
+  type CaptureSavedView,
   type UiState,
   renderQaLabUi,
 } from "./ui-render.js";
@@ -40,6 +46,42 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
   return (await response.json()) as T;
 }
 
+function countCaptureDimension(events: UiState["captureEvents"], pick: (event: UiState["captureEvents"][number]) => string | undefined) {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    const value = pick(event)?.trim();
+    if (!value) {
+      continue;
+    }
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((left, right) => right.count - left.count || left.value.localeCompare(right.value));
+}
+
+function summarizeCaptureCoverageFromEvents(
+  sessionIds: string[],
+  events: UiState["captureEvents"],
+): UiState["captureCoverage"] {
+  const unlabeledEventCount = events.filter(
+    (event) => !event.provider?.trim() && !event.api?.trim() && !event.model?.trim(),
+  ).length;
+  return {
+    sessionId: sessionIds.join(","),
+    totalEvents: events.length,
+    unlabeledEventCount,
+    providers: countCaptureDimension(events, (event) => event.provider),
+    apis: countCaptureDimension(events, (event) => event.api),
+    models: countCaptureDimension(events, (event) => event.model),
+    hosts: countCaptureDimension(events, (event) => event.host),
+    localPeers: countCaptureDimension(events, (event) => {
+      const host = event.host?.trim();
+      return host && /^(127\.0\.0\.1|localhost)(:\d+)?$/i.test(host) ? host : undefined;
+    }),
+  };
+}
+
 function defaultModelsForProviderMode(
   mode: RunnerSelection["providerMode"],
   bootstrap?: Bootstrap | null,
@@ -71,6 +113,46 @@ function detectTheme(): "light" | "dark" {
   return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
 }
 
+function detectSidebarCollapsed(): boolean {
+  return localStorage.getItem("qa-lab-sidebar-collapsed") === "1";
+}
+
+function detectSidebarPanel(): UiState["sidebarPanel"] {
+  const stored = localStorage.getItem("qa-lab-sidebar-panel");
+  return stored === "config" || stored === "run" ? stored : "scenarios";
+}
+
+const CAPTURE_SAVED_VIEWS_KEY = "qa-lab-capture-saved-views";
+
+function loadCaptureSavedViews(): CaptureSavedView[] {
+  try {
+    const raw = localStorage.getItem(CAPTURE_SAVED_VIEWS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as CaptureSavedView[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistCaptureSavedViews(savedViews: CaptureSavedView[]) {
+  localStorage.setItem(CAPTURE_SAVED_VIEWS_KEY, JSON.stringify(savedViews));
+}
+
+function isEditableElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    target.isContentEditable ||
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement
+  );
+}
+
 export async function createQaLabApp(root: HTMLDivElement) {
   const state: UiState = {
     theme: detectTheme(),
@@ -78,6 +160,53 @@ export async function createQaLabApp(root: HTMLDivElement) {
     snapshot: null,
     latestReport: null,
     scenarioRun: null,
+    captureSessions: [],
+    captureEvents: [],
+    captureQueryPreset: "none",
+    captureQueryRows: [],
+    captureKindFilter: [],
+    captureProviderFilter: [],
+    captureHostFilter: [],
+    captureSearchText: "",
+    captureHeaderMode: "key",
+    captureViewMode: "list",
+    captureGroupMode: "none",
+    captureTimelineLaneMode: "domain",
+    captureTimelineLaneSort: "most-events",
+    captureTimelinePreviousLaneSort: null,
+    captureTimelineLaneSearch: "",
+    captureTimelineZoom: 100,
+    captureTimelineSparklineMode: "session-relative",
+    captureTimelineWindowStartPct: null,
+    captureTimelineWindowEndPct: null,
+    captureTimelineBrushAnchorPct: null,
+    captureTimelineBrushCurrentPct: null,
+    captureTimelineFocusSelectedFlow: false,
+    captureTimelineFocusedLaneMode: "all",
+    captureTimelineFocusedLaneThreshold: "any",
+    captureDetailPlacement: "right",
+    captureDetailSplitPct: 34,
+    captureDetailSplitDragging: false,
+    captureDetailView: "overview",
+    capturePreferredDetailView: null,
+    captureFlowDetailLayout: null,
+    capturePayloadDetailLayout: null,
+    capturePayloadExtent: "preview",
+    capturePayloadEventSort: "stream",
+    capturePayloadEventFilter: "",
+    captureErrorsOnly: false,
+    captureCoverage: null,
+    captureStartupStatus: null,
+    captureControlsExpanded: false,
+    captureSummaryExpanded: false,
+    captureSavedViews: loadCaptureSavedViews(),
+    captureSelectedSessionsExpanded: false,
+    sidebarCollapsed: detectSidebarCollapsed(),
+    sidebarPanel: detectSidebarPanel(),
+    captureCollapsedLaneIds: [],
+    capturePinnedLaneIds: [],
+    selectedCaptureSessionIds: [],
+    selectedCaptureEventKey: null,
     selectedConversationId: null,
     selectedThreadId: null,
     selectedScenarioId: null,
@@ -105,6 +234,13 @@ export async function createQaLabApp(root: HTMLDivElement) {
   let renderDeferred = false;
   let previousRunnerStatus: string | null = null;
   let currentUiVersion: string | null = null;
+  let syncingCaptureTimelineScroll = false;
+  let sparklineSweepActive = false;
+  let sparklineSweepAnchorStartPct: number | null = null;
+  let sparklineSweepAnchorEndPct: number | null = null;
+  let sparklineSweepCurrentStartPct: number | null = null;
+  let sparklineSweepCurrentEndPct: number | null = null;
+  let captureGlobalListenersBound = false;
 
   function stateFingerprint(): string {
     const msgs = state.snapshot?.messages;
@@ -126,6 +262,53 @@ export async function createQaLabApp(root: HTMLDivElement) {
       rp: state.latestReport?.generatedAt,
       cs: state.bootstrap?.runnerCatalog.status,
       cl: state.bootstrap?.runnerCatalog.real.length ?? 0,
+      cps: state.captureSessions.length,
+      cse: state.captureSessions[0]?.eventCount ?? 0,
+      cei: state.selectedCaptureSessionIds.join(","),
+      cec: state.captureEvents.length,
+      ceh: state.captureEvents[0]?.host ?? null,
+      ccp: state.captureQueryPreset,
+      ccq: state.captureQueryRows.length,
+      ccv: state.captureCoverage?.totalEvents ?? 0,
+      ccpv: state.captureCoverage?.providers[0]?.value ?? null,
+      ccss: state.captureStartupStatus?.proxy.ok ?? null,
+      ccsg: state.captureStartupStatus?.gateway.ok ?? null,
+      ccce: state.captureControlsExpanded,
+      ccse: state.captureSummaryExpanded,
+      ccsx: state.captureSelectedSessionsExpanded,
+      ccsv: state.captureSavedViews.map((view) => `${view.id}:${view.name}`).join("|"),
+      scc: state.sidebarCollapsed,
+      scp: state.sidebarPanel,
+      cck: state.captureKindFilter.join(","),
+      ccpf: state.captureProviderFilter.join(","),
+      cchf: state.captureHostFilter.join(","),
+      cchm: state.captureHeaderMode,
+      ccgm: state.captureGroupMode,
+      cctl: state.captureTimelineLaneMode,
+      ccts: state.captureTimelineLaneSort,
+      cctps: state.captureTimelinePreviousLaneSort,
+      cctq: state.captureTimelineLaneSearch,
+      cctz: state.captureTimelineZoom,
+      cctsm: state.captureTimelineSparklineMode,
+      cctws: state.captureTimelineWindowStartPct,
+      cctwe: state.captureTimelineWindowEndPct,
+      cctba: state.captureTimelineBrushAnchorPct,
+      cctbc: state.captureTimelineBrushCurrentPct,
+      cctff: state.captureTimelineFocusSelectedFlow,
+      cctfm: state.captureTimelineFocusedLaneMode,
+      cctft: state.captureTimelineFocusedLaneThreshold,
+      ccdp: state.captureDetailPlacement,
+      ccds: state.captureDetailSplitPct,
+      ccdsd: state.captureDetailSplitDragging,
+      ccdv: state.captureDetailView,
+      ccpdv: state.capturePreferredDetailView,
+      ccdfl: state.captureFlowDetailLayout,
+      ccdpl: state.capturePayloadDetailLayout,
+      ccdpe: state.capturePayloadExtent,
+      ccpes: state.capturePayloadEventSort,
+      ccpef: state.capturePayloadEventFilter,
+      ccli: state.captureCollapsedLaneIds.join(","),
+      ccpi: state.capturePinnedLaneIds.join(","),
       er: state.error,
     });
   }
@@ -172,6 +355,78 @@ export async function createQaLabApp(root: HTMLDivElement) {
         };
       }
       state.error = null;
+    } catch (error) {
+      state.error = formatErrorMessage(error);
+    }
+
+    try {
+      const sessions = await getJson<CaptureSessionsEnvelope>("/api/capture/sessions");
+      const startupStatusPromise = getJson<CaptureStartupStatusEnvelope>("/api/capture/startup-status");
+      state.captureSessions = sessions.sessions;
+      const availableSessionIds = new Set(sessions.sessions.map((session) => session.id));
+      state.selectedCaptureSessionIds = state.selectedCaptureSessionIds.filter((id) =>
+        availableSessionIds.has(id),
+      );
+      if (state.selectedCaptureSessionIds.length === 0) {
+        state.selectedCaptureSessionIds = sessions.sessions[0]?.id ? [sessions.sessions[0].id] : [];
+      }
+      const startupStatusResult = await Promise.allSettled([startupStatusPromise]);
+      state.captureStartupStatus =
+        startupStatusResult[0]?.status === "fulfilled" ? startupStatusResult[0].value.status : null;
+      if (state.selectedCaptureSessionIds.length > 0) {
+        const eventsPromises = state.selectedCaptureSessionIds.map((sessionId) =>
+          getJson<CaptureEventsEnvelope>(`/api/capture/events?sessionId=${encodeURIComponent(sessionId)}`),
+        );
+        const singleSessionId =
+          state.selectedCaptureSessionIds.length === 1 ? state.selectedCaptureSessionIds[0] : null;
+        const coveragePromise = singleSessionId
+          ? getJson<CaptureCoverageEnvelope>(`/api/capture/coverage?sessionId=${encodeURIComponent(singleSessionId)}`)
+          : Promise.resolve<CaptureCoverageEnvelope | null>(null);
+        const queryPromise =
+          state.captureQueryPreset === "none"
+            ? Promise.resolve<CaptureQueryEnvelope>({ rows: [] })
+            : singleSessionId
+              ? getJson<CaptureQueryEnvelope>(
+                  `/api/capture/query?sessionId=${encodeURIComponent(
+                    singleSessionId,
+                  )}&preset=${encodeURIComponent(state.captureQueryPreset)}`,
+                )
+              : Promise.resolve<CaptureQueryEnvelope>({ rows: [] });
+        const [eventsResult, coverageResult, queryResult] = await Promise.allSettled([
+          Promise.all(eventsPromises),
+          coveragePromise,
+          queryPromise,
+        ]);
+        if (eventsResult.status !== "fulfilled") {
+          throw eventsResult.reason;
+        }
+        state.captureEvents = eventsResult.value
+          .flatMap((envelope) => envelope.events)
+          .sort((left, right) => right.ts - left.ts || String(right.id ?? "").localeCompare(String(left.id ?? "")));
+        state.captureCoverage =
+          coverageResult.status === "fulfilled" && coverageResult.value
+            ? coverageResult.value.coverage
+            : summarizeCaptureCoverageFromEvents(state.selectedCaptureSessionIds, state.captureEvents);
+        state.captureQueryRows = queryResult.status === "fulfilled" ? queryResult.value.rows : [];
+        if (
+          !state.selectedCaptureEventKey ||
+          !state.captureEvents.some(
+            (event) =>
+              `${event.id ?? "no-id"}:${event.flowId}:${event.ts}:${event.kind}` ===
+              state.selectedCaptureEventKey,
+          )
+        ) {
+          const first = state.captureEvents[0];
+          state.selectedCaptureEventKey = first
+            ? `${first.id ?? "no-id"}:${first.flowId}:${first.ts}:${first.kind}`
+            : null;
+        }
+      } else {
+        state.captureEvents = [];
+        state.captureCoverage = null;
+        state.captureQueryRows = [];
+        state.selectedCaptureEventKey = null;
+      }
     } catch (error) {
       state.error = formatErrorMessage(error);
     }
@@ -381,6 +636,65 @@ export async function createQaLabApp(root: HTMLDivElement) {
     render();
   }
 
+  function toggleSidebar() {
+    state.sidebarCollapsed = !state.sidebarCollapsed;
+    localStorage.setItem("qa-lab-sidebar-collapsed", state.sidebarCollapsed ? "1" : "0");
+    render();
+  }
+
+  function setSidebarPanel(panel: UiState["sidebarPanel"]) {
+    state.sidebarPanel = panel;
+    localStorage.setItem("qa-lab-sidebar-panel", panel);
+    if (state.sidebarCollapsed) {
+      state.sidebarCollapsed = false;
+      localStorage.setItem("qa-lab-sidebar-collapsed", "0");
+    }
+    render();
+  }
+
+  function applyCaptureSavedView(view: CaptureSavedView) {
+    state.selectedCaptureSessionIds = [...view.sessionIds];
+    state.captureKindFilter = [...view.kindFilter];
+    state.captureProviderFilter = [...view.providerFilter];
+    state.captureHostFilter = [...view.hostFilter];
+    state.captureSearchText = view.searchText;
+    state.captureHeaderMode = view.headerMode;
+    state.captureViewMode = view.viewMode;
+    state.captureGroupMode = view.groupMode;
+    state.captureTimelineLaneMode = view.timelineLaneMode;
+    state.captureTimelineLaneSort = view.timelineLaneSort;
+    state.captureTimelineZoom = view.timelineZoom;
+    state.captureTimelineSparklineMode = view.timelineSparklineMode;
+    state.captureErrorsOnly = view.errorsOnly;
+    state.captureDetailPlacement = view.detailPlacement;
+    state.capturePayloadDetailLayout = view.payloadLayout;
+    state.capturePayloadExtent = view.payloadExtent;
+    state.selectedCaptureEventKey = null;
+  }
+
+  function buildCaptureSavedView(name: string): CaptureSavedView {
+    return {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      name,
+      sessionIds: [...state.selectedCaptureSessionIds],
+      kindFilter: [...state.captureKindFilter],
+      providerFilter: [...state.captureProviderFilter],
+      hostFilter: [...state.captureHostFilter],
+      searchText: state.captureSearchText,
+      headerMode: state.captureHeaderMode,
+      viewMode: state.captureViewMode,
+      groupMode: state.captureGroupMode,
+      timelineLaneMode: state.captureTimelineLaneMode,
+      timelineLaneSort: state.captureTimelineLaneSort,
+      timelineZoom: state.captureTimelineZoom,
+      timelineSparklineMode: state.captureTimelineSparklineMode,
+      errorsOnly: state.captureErrorsOnly,
+      detailPlacement: state.captureDetailPlacement,
+      payloadLayout: state.capturePayloadDetailLayout,
+      payloadExtent: state.capturePayloadExtent,
+    };
+  }
+
   /* ---------- Chat scroll tracking ---------- */
 
   function trackChatScroll() {
@@ -471,6 +785,17 @@ export async function createQaLabApp(root: HTMLDivElement) {
       .querySelector<HTMLElement>("[data-action='toggle-theme']")
       ?.addEventListener("click", toggleTheme);
     root
+      .querySelector<HTMLElement>("[data-action='toggle-sidebar']")
+      ?.addEventListener("click", toggleSidebar);
+    root.querySelectorAll<HTMLElement>("[data-sidebar-panel]").forEach((node) => {
+      node.addEventListener("click", () => {
+        const panel = node.dataset.sidebarPanel;
+        if (panel === "config" || panel === "run" || panel === "scenarios") {
+          setSidebarPanel(panel);
+        }
+      });
+    });
+    root
       .querySelector<HTMLElement>("[data-action='self-check']")
       ?.addEventListener("click", () => void runSelfCheck());
     root
@@ -552,6 +877,597 @@ export async function createQaLabApp(root: HTMLDivElement) {
       }));
     });
 
+    root.querySelector<HTMLSelectElement>("#capture-session")?.addEventListener("change", (e) => {
+      state.selectedCaptureSessionIds = readMultiSelect(e.currentTarget as HTMLSelectElement);
+      state.selectedCaptureEventKey = null;
+      void refresh();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-save-view")?.addEventListener("click", () => {
+      const name = window.prompt("Saved view name");
+      const trimmed = name?.trim();
+      if (!trimmed) {
+        return;
+      }
+      state.captureSavedViews = [buildCaptureSavedView(trimmed), ...state.captureSavedViews].slice(0, 12);
+      persistCaptureSavedViews(state.captureSavedViews);
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-saved-view")?.addEventListener("change", (e) => {
+      const id = (e.currentTarget as HTMLSelectElement).value;
+      const view = state.captureSavedViews.find((candidate) => candidate.id === id);
+      if (!view) {
+        return;
+      }
+      applyCaptureSavedView(view);
+      void refresh();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-delete-view")?.addEventListener("click", () => {
+      const select = root.querySelector<HTMLSelectElement>("#capture-saved-view");
+      const id = select?.value?.trim();
+      if (!id) {
+        return;
+      }
+      state.captureSavedViews = state.captureSavedViews.filter((view) => view.id !== id);
+      persistCaptureSavedViews(state.captureSavedViews);
+      render();
+    });
+    root.querySelectorAll<HTMLButtonElement>("[data-capture-session-remove]").forEach((node) => {
+      node.addEventListener("click", () => {
+        const sessionId = node.dataset.captureSessionRemove?.trim();
+        if (!sessionId) {
+          return;
+        }
+        state.selectedCaptureSessionIds = state.selectedCaptureSessionIds.filter((id) => id !== sessionId);
+        state.selectedCaptureEventKey = null;
+        void refresh();
+      });
+    });
+    root.querySelector<HTMLButtonElement>("#capture-toggle-selected-sessions")?.addEventListener("click", () => {
+      state.captureSelectedSessionsExpanded = !state.captureSelectedSessionsExpanded;
+      render();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-delete-selected-sessions")?.addEventListener("click", async () => {
+      if (state.selectedCaptureSessionIds.length === 0) {
+        return;
+      }
+      const confirmed = window.confirm(
+        `Delete ${state.selectedCaptureSessionIds.length} selected capture session${
+          state.selectedCaptureSessionIds.length === 1 ? "" : "s"
+        }?`,
+      );
+      if (!confirmed) {
+        return;
+      }
+      await postJson("/api/capture/delete-sessions", { sessionIds: state.selectedCaptureSessionIds });
+      state.selectedCaptureSessionIds = [];
+      state.selectedCaptureEventKey = null;
+      await refresh();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-purge-all")?.addEventListener("click", async () => {
+      const confirmed = window.confirm("Purge all captured sessions, events, and blobs?");
+      if (!confirmed) {
+        return;
+      }
+      await postJson("/api/capture/purge", {});
+      state.selectedCaptureSessionIds = [];
+      state.selectedCaptureEventKey = null;
+      await refresh();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-preset")?.addEventListener("change", (e) => {
+      state.captureQueryPreset = (e.currentTarget as HTMLSelectElement).value as UiState["captureQueryPreset"];
+      void refresh();
+    });
+    const readMultiSelect = (select: HTMLSelectElement) =>
+      [...select.selectedOptions].map((option) => option.value).filter(Boolean);
+    root.querySelector<HTMLSelectElement>("#capture-kind-filter")?.addEventListener("change", (e) => {
+      state.captureKindFilter = readMultiSelect(e.currentTarget as HTMLSelectElement);
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-provider-filter")?.addEventListener("change", (e) => {
+      state.captureProviderFilter = readMultiSelect(e.currentTarget as HTMLSelectElement);
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-host-filter")?.addEventListener("change", (e) => {
+      state.captureHostFilter = readMultiSelect(e.currentTarget as HTMLSelectElement);
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-header-mode")?.addEventListener("change", (e) => {
+      const value = (e.currentTarget as HTMLSelectElement).value;
+      state.captureHeaderMode = value === "all" || value === "hidden" ? value : "key";
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-view-mode")?.addEventListener("change", (e) => {
+      state.captureViewMode = (e.currentTarget as HTMLSelectElement).value === "timeline" ? "timeline" : "list";
+      state.captureCollapsedLaneIds = [];
+      state.capturePinnedLaneIds = [];
+      state.captureTimelineWindowStartPct = null;
+      state.captureTimelineWindowEndPct = null;
+      state.captureTimelineBrushAnchorPct = null;
+      state.captureTimelineBrushCurrentPct = null;
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-group-mode")?.addEventListener("change", (e) => {
+      const value = (e.currentTarget as HTMLSelectElement).value;
+      state.captureGroupMode = value === "flow" || value === "host-path" || value === "burst" ? value : "none";
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-timeline-lane-mode")?.addEventListener("change", (e) => {
+      const value = (e.currentTarget as HTMLSelectElement).value;
+      state.captureTimelineLaneMode =
+        value === "provider" || value === "flow" ? value : "domain";
+      state.captureTimelinePreviousLaneSort = null;
+      state.captureCollapsedLaneIds = [];
+      state.capturePinnedLaneIds = [];
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-timeline-lane-sort")?.addEventListener("change", (e) => {
+      const value = (e.currentTarget as HTMLSelectElement).value;
+      const nextSort =
+        value === "most-errors" || value === "severity" || value === "alphabetical"
+          ? value
+          : "most-events";
+      if (nextSort !== state.captureTimelineLaneSort) {
+        state.captureTimelinePreviousLaneSort = state.captureTimelineLaneSort;
+      }
+      state.captureTimelineLaneSort =
+        nextSort;
+      render();
+    });
+    root.querySelector<HTMLInputElement>("#capture-timeline-lane-search")?.addEventListener("input", (e) => {
+      state.captureTimelineLaneSearch = (e.currentTarget as HTMLInputElement).value ?? "";
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-timeline-zoom")?.addEventListener("change", (e) => {
+      const value = Number((e.currentTarget as HTMLSelectElement).value);
+      state.captureTimelineZoom =
+        value === 75 || value === 150 || value === 200 || value === 300 ? value : 100;
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-timeline-sparkline-mode")?.addEventListener("change", (e) => {
+      state.captureTimelineSparklineMode =
+        (e.currentTarget as HTMLSelectElement).value === "lane-relative"
+          ? "lane-relative"
+          : "session-relative";
+      render();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-timeline-clear-window")?.addEventListener("click", () => {
+      state.captureTimelineWindowStartPct = null;
+      state.captureTimelineWindowEndPct = null;
+      state.captureTimelineBrushAnchorPct = null;
+      state.captureTimelineBrushCurrentPct = null;
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLInputElement>("#capture-timeline-focus-flow")?.addEventListener("change", (e) => {
+      state.captureTimelineFocusSelectedFlow = (e.currentTarget as HTMLInputElement).checked;
+      if (!state.captureTimelineFocusSelectedFlow) {
+        state.captureTimelineFocusedLaneMode = "all";
+        state.captureTimelineFocusedLaneThreshold = "any";
+      }
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-timeline-focused-lane-mode")?.addEventListener("change", (e) => {
+      const value = (e.currentTarget as HTMLSelectElement).value;
+      state.captureTimelineFocusedLaneMode =
+        value === "only-matching" || value === "collapse-background" ? value : "all";
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-timeline-focused-lane-threshold")?.addEventListener("change", (e) => {
+      const value = (e.currentTarget as HTMLSelectElement).value;
+      state.captureTimelineFocusedLaneThreshold =
+        value === "events-2" || value === "percent-10" || value === "percent-25" ? value : "any";
+      render();
+    });
+    root.querySelector<HTMLSelectElement>("#capture-detail-placement")?.addEventListener("change", (e) => {
+      state.captureDetailPlacement =
+        (e.currentTarget as HTMLSelectElement).value === "bottom" ? "bottom" : "right";
+      render();
+    });
+    root.querySelector<HTMLElement>("[data-capture-detail-splitter]")?.addEventListener("mousedown", (event) => {
+      if (event.button !== 0 || state.captureDetailPlacement !== "right") {
+        return;
+      }
+      const splitRoot = root.querySelector<HTMLElement>("[data-capture-detail-split-root]");
+      if (!splitRoot) {
+        return;
+      }
+      const rect = splitRoot.getBoundingClientRect();
+      state.captureDetailSplitDragging = true;
+      render();
+      const handleMove = (moveEvent: MouseEvent) => {
+        const localX = moveEvent.clientX - rect.left;
+        const nextPct = ((rect.width - localX) / rect.width) * 100;
+        state.captureDetailSplitPct = Math.max(22, Math.min(55, Number(nextPct.toFixed(2))));
+        render();
+      };
+      const handleUp = () => {
+        state.captureDetailSplitDragging = false;
+        window.removeEventListener("mousemove", handleMove);
+        window.removeEventListener("mouseup", handleUp);
+        render();
+      };
+      window.addEventListener("mousemove", handleMove);
+      window.addEventListener("mouseup", handleUp);
+      event.preventDefault();
+    });
+    root.querySelector<HTMLElement>("[data-capture-detail-splitter]")?.addEventListener("dblclick", () => {
+      state.captureDetailSplitPct = 34;
+      state.captureDetailSplitDragging = false;
+      render();
+    });
+    root.querySelectorAll<HTMLInputElement>('input[name="capture-detail-view"]').forEach((node) => {
+      node.addEventListener("change", () => {
+        if (!node.checked) {
+          return;
+        }
+        const value = node.value;
+        state.captureDetailView =
+          value === "flow" || value === "payload" || value === "headers" ? value : "overview";
+        state.capturePreferredDetailView = state.captureDetailView;
+        render();
+      });
+    });
+    root.querySelectorAll<HTMLInputElement>('input[name="capture-flow-layout"]').forEach((node) => {
+      node.addEventListener("change", () => {
+        if (!node.checked) {
+          return;
+        }
+        state.captureFlowDetailLayout = node.value === "pair-first" ? "pair-first" : "nav-first";
+        render();
+      });
+    });
+    root.querySelectorAll<HTMLInputElement>('input[name="capture-payload-layout"]').forEach((node) => {
+      node.addEventListener("change", () => {
+        if (!node.checked) {
+          return;
+        }
+        state.capturePayloadDetailLayout = node.value === "raw" ? "raw" : "formatted";
+        render();
+      });
+    });
+    root.querySelectorAll<HTMLInputElement>('input[name="capture-payload-extent"]').forEach((node) => {
+      node.addEventListener("change", () => {
+        if (!node.checked) {
+          return;
+        }
+        state.capturePayloadExtent = node.value === "full" ? "full" : "preview";
+        render();
+      });
+    });
+    root.querySelectorAll<HTMLInputElement>('input[name="capture-payload-event-sort"]').forEach((node) => {
+      node.addEventListener("change", () => {
+        if (!node.checked) {
+          return;
+        }
+        state.capturePayloadEventSort =
+          node.value === "name" || node.value === "size" ? node.value : "stream";
+        render();
+      });
+    });
+    root.querySelector<HTMLInputElement>("#capture-payload-event-filter")?.addEventListener("input", (e) => {
+      state.capturePayloadEventFilter = (e.currentTarget as HTMLInputElement).value ?? "";
+      render();
+    });
+    root.querySelector<HTMLInputElement>("#capture-search-filter")?.addEventListener("input", (e) => {
+      state.captureSearchText = (e.currentTarget as HTMLInputElement).value ?? "";
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLInputElement>("#capture-errors-only")?.addEventListener("change", (e) => {
+      state.captureErrorsOnly = (e.currentTarget as HTMLInputElement).checked;
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-summary-toggle")?.addEventListener("click", () => {
+      state.captureSummaryExpanded = !state.captureSummaryExpanded;
+      render();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-controls-toggle")?.addEventListener("click", () => {
+      state.captureControlsExpanded = !state.captureControlsExpanded;
+      render();
+    });
+    root.querySelector<HTMLButtonElement>("#capture-clear-filters")?.addEventListener("click", () => {
+      state.captureKindFilter = [];
+      state.captureProviderFilter = [];
+      state.captureHostFilter = [];
+      state.captureSearchText = "";
+      state.captureHeaderMode = "key";
+      state.captureViewMode = "list";
+      state.captureGroupMode = "none";
+      state.captureTimelineLaneMode = "domain";
+      state.captureTimelineLaneSort = "most-events";
+      state.captureTimelinePreviousLaneSort = null;
+      state.captureTimelineLaneSearch = "";
+      state.captureTimelineZoom = 100;
+      state.captureTimelineSparklineMode = "session-relative";
+      state.captureTimelineWindowStartPct = null;
+      state.captureTimelineWindowEndPct = null;
+      state.captureTimelineBrushAnchorPct = null;
+      state.captureTimelineBrushCurrentPct = null;
+      state.captureTimelineFocusSelectedFlow = false;
+      state.captureTimelineFocusedLaneMode = "all";
+      state.captureTimelineFocusedLaneThreshold = "any";
+      state.captureErrorsOnly = false;
+      state.captureCollapsedLaneIds = [];
+      state.capturePinnedLaneIds = [];
+      state.selectedCaptureEventKey = null;
+      render();
+    });
+    root.querySelectorAll<HTMLElement>("[data-capture-lane-toggle]").forEach((node) => {
+      node.addEventListener("click", () => {
+        const laneId = node.dataset.captureLaneToggle;
+        if (!laneId) {
+          return;
+        }
+        const collapsed = new Set(state.captureCollapsedLaneIds);
+        if (collapsed.has(laneId)) {
+          collapsed.delete(laneId);
+        } else {
+          collapsed.add(laneId);
+        }
+        state.captureCollapsedLaneIds = [...collapsed];
+        render();
+      });
+    });
+    root.querySelectorAll<HTMLElement>("[data-capture-lane-pin]").forEach((node) => {
+      node.addEventListener("click", () => {
+        const laneId = node.dataset.captureLanePin;
+        if (!laneId) {
+          return;
+        }
+        const pinned = new Set(state.capturePinnedLaneIds);
+        if (pinned.has(laneId)) {
+          pinned.delete(laneId);
+        } else {
+          pinned.add(laneId);
+        }
+        state.capturePinnedLaneIds = [...pinned];
+        render();
+      });
+    });
+    root.querySelectorAll<HTMLElement>("[data-capture-event]").forEach((node) => {
+      node.addEventListener("click", () => {
+        state.selectedCaptureEventKey = node.dataset.captureEvent ?? null;
+        render();
+      });
+    });
+    root.querySelectorAll<HTMLButtonElement>("[data-copy-text]").forEach((node) => {
+      node.addEventListener("click", async () => {
+        const text = node.dataset.copyText ?? "";
+        if (!text) {
+          return;
+        }
+        await navigator.clipboard.writeText(text).catch(() => undefined);
+      });
+    });
+    root.querySelectorAll<HTMLElement>("[data-capture-sparkline-window]").forEach((node) => {
+      const readWindow = () => {
+        const start = Number(node.dataset.captureWindowStart ?? "NaN");
+        const end = Number(node.dataset.captureWindowEnd ?? "NaN");
+        return Number.isFinite(start) && Number.isFinite(end) ? { start, end } : null;
+      };
+      node.addEventListener("mousedown", (event) => {
+        if (event.button !== 0) {
+          return;
+        }
+        const windowRange = readWindow();
+        if (!windowRange) {
+          return;
+        }
+        sparklineSweepActive = true;
+        sparklineSweepAnchorStartPct = windowRange.start;
+        sparklineSweepAnchorEndPct = windowRange.end;
+        sparklineSweepCurrentStartPct = windowRange.start;
+        sparklineSweepCurrentEndPct = windowRange.end;
+        state.captureTimelineBrushAnchorPct = windowRange.start;
+        state.captureTimelineBrushCurrentPct = windowRange.end;
+        render();
+      });
+      node.addEventListener("mouseenter", () => {
+        if (!sparklineSweepActive) {
+          return;
+        }
+        const windowRange = readWindow();
+        if (!windowRange) {
+          return;
+        }
+        sparklineSweepCurrentStartPct = windowRange.start;
+        sparklineSweepCurrentEndPct = windowRange.end;
+        const previewStart = Math.min(
+          sparklineSweepAnchorStartPct ?? windowRange.start,
+          windowRange.start,
+        );
+        const previewEnd = Math.max(
+          sparklineSweepAnchorEndPct ?? windowRange.end,
+          windowRange.end,
+        );
+        state.captureTimelineBrushAnchorPct = previewStart;
+        state.captureTimelineBrushCurrentPct = previewEnd;
+        render();
+      });
+    });
+    const timelineViewports = [...root.querySelectorAll<HTMLElement>(".capture-timeline-viewport")];
+    timelineViewports.forEach((node) => {
+      node.addEventListener("scroll", () => {
+        if (syncingCaptureTimelineScroll) {
+          return;
+        }
+        syncingCaptureTimelineScroll = true;
+        const nextLeft = node.scrollLeft;
+        for (const other of timelineViewports) {
+          if (other !== node && other.scrollLeft !== nextLeft) {
+            other.scrollLeft = nextLeft;
+          }
+        }
+        syncingCaptureTimelineScroll = false;
+      });
+    });
+    root.querySelectorAll<HTMLElement>("[data-capture-timeline-brush-surface]").forEach((node) => {
+      node.addEventListener("mousedown", (event) => {
+        if (event.button !== 0) {
+          return;
+        }
+        const viewport = node;
+        const trackWidth = Number(viewport.dataset.captureTimelineTrackWidth ?? "0");
+        if (!Number.isFinite(trackWidth) || trackWidth <= 0) {
+          return;
+        }
+        const percentFromEvent = (clientX: number) => {
+          const rect = viewport.getBoundingClientRect();
+          const localX = clientX - rect.left + viewport.scrollLeft;
+          return Math.min(100, Math.max(0, (localX / trackWidth) * 100));
+        };
+        const anchorPct = percentFromEvent(event.clientX);
+        state.captureTimelineBrushAnchorPct = anchorPct;
+        state.captureTimelineBrushCurrentPct = anchorPct;
+        render();
+        const handleMove = (moveEvent: MouseEvent) => {
+          state.captureTimelineBrushCurrentPct = percentFromEvent(moveEvent.clientX);
+          render();
+        };
+        const handleUp = () => {
+          const anchor = state.captureTimelineBrushAnchorPct;
+          const current = state.captureTimelineBrushCurrentPct;
+          if (anchor != null && current != null) {
+            const start = Math.min(anchor, current);
+            const end = Math.max(anchor, current);
+            if (end - start >= 1) {
+              state.captureTimelineWindowStartPct = start;
+              state.captureTimelineWindowEndPct = end;
+              state.selectedCaptureEventKey = null;
+            }
+          }
+          state.captureTimelineBrushAnchorPct = null;
+          state.captureTimelineBrushCurrentPct = null;
+          window.removeEventListener("mousemove", handleMove);
+          window.removeEventListener("mouseup", handleUp);
+          render();
+        };
+        window.addEventListener("mousemove", handleMove);
+        window.addEventListener("mouseup", handleUp);
+      });
+    });
+    if (!captureGlobalListenersBound) {
+      captureGlobalListenersBound = true;
+      window.addEventListener("mouseup", (event) => {
+        if (!sparklineSweepActive) {
+          return;
+        }
+        const anchorStart = sparklineSweepAnchorStartPct;
+        const anchorEnd = sparklineSweepAnchorEndPct;
+        const currentStart = sparklineSweepCurrentStartPct;
+        const currentEnd = sparklineSweepCurrentEndPct;
+        sparklineSweepActive = false;
+        sparklineSweepAnchorStartPct = null;
+        sparklineSweepAnchorEndPct = null;
+        sparklineSweepCurrentStartPct = null;
+        sparklineSweepCurrentEndPct = null;
+        if (
+          anchorStart == null ||
+          anchorEnd == null ||
+          currentStart == null ||
+          currentEnd == null
+        ) {
+          state.captureTimelineBrushAnchorPct = null;
+          state.captureTimelineBrushCurrentPct = null;
+          render();
+          return;
+        }
+        const start = Math.min(anchorStart, currentStart);
+        const end = Math.max(anchorEnd, currentEnd);
+        const width = Math.max(0.01, end - start);
+        const expand = event.shiftKey ? width : 0;
+        state.captureTimelineWindowStartPct = Math.max(0, Math.min(100, start - expand));
+        state.captureTimelineWindowEndPct = Math.max(0, Math.min(100, end + expand));
+        state.captureTimelineBrushAnchorPct = null;
+        state.captureTimelineBrushCurrentPct = null;
+        state.selectedCaptureEventKey = null;
+        render();
+      });
+      root.addEventListener("keydown", (event) => {
+        if (state.activeTab !== "capture") {
+          return;
+        }
+        if (isEditableElement(event.target)) {
+          return;
+        }
+        if (event.key === "1" || event.key === "2" || event.key === "3" || event.key === "4") {
+          const radios = [
+            ...root.querySelectorAll<HTMLInputElement>('input[name="capture-detail-view"]'),
+          ].filter((node) => !node.disabled);
+          const index = Number(event.key) - 1;
+          const target = radios[index];
+          if (target) {
+            event.preventDefault();
+            target.checked = true;
+            state.captureDetailView =
+              target.value === "flow" || target.value === "payload" || target.value === "headers"
+                ? target.value
+                : "overview";
+            state.capturePreferredDetailView = state.captureDetailView;
+            render();
+          }
+          return;
+        }
+        if (state.captureViewMode !== "timeline") {
+          return;
+        }
+        if (
+          event.key !== "ArrowLeft" &&
+          event.key !== "ArrowRight" &&
+          event.key !== "Home" &&
+          event.key !== "End" &&
+          event.key !== "Escape"
+        ) {
+          return;
+        }
+        if (event.key === "Escape") {
+          if (state.captureTimelineWindowStartPct != null || state.captureTimelineBrushAnchorPct != null) {
+            event.preventDefault();
+            state.captureTimelineWindowStartPct = null;
+            state.captureTimelineWindowEndPct = null;
+            state.captureTimelineBrushAnchorPct = null;
+            state.captureTimelineBrushCurrentPct = null;
+            state.selectedCaptureEventKey = null;
+            render();
+          }
+          return;
+        }
+        const markers = [
+          ...root.querySelectorAll<HTMLElement>(".capture-timeline [data-capture-event]"),
+        ];
+        if (markers.length === 0) {
+          return;
+        }
+        const currentIndex = markers.findIndex(
+          (node) => (node.dataset.captureEvent ?? null) === state.selectedCaptureEventKey,
+        );
+        let nextIndex = currentIndex >= 0 ? currentIndex : 0;
+        if (event.key === "Home") {
+          nextIndex = 0;
+        } else if (event.key === "End") {
+          nextIndex = markers.length - 1;
+        } else if (event.key === "ArrowLeft") {
+          nextIndex = currentIndex <= 0 ? 0 : currentIndex - 1;
+        } else if (event.key === "ArrowRight") {
+          nextIndex = currentIndex < 0 ? 0 : Math.min(markers.length - 1, currentIndex + 1);
+        }
+        const next = markers[nextIndex];
+        if (!next) {
+          return;
+        }
+        event.preventDefault();
+        state.selectedCaptureEventKey = next.dataset.captureEvent ?? null;
+        render();
+      });
+    }
+
     /* Composer form */
     root.querySelector<HTMLSelectElement>("#conversation-kind")?.addEventListener("change", (e) => {
       state.composer.conversationKind =
@@ -611,6 +1527,15 @@ export async function createQaLabApp(root: HTMLDivElement) {
       const el = root.querySelector<HTMLElement>(`#${CSS.escape(focusedId)}`);
       if (el && "focus" in el) {
         el.focus();
+      }
+    }
+
+    if (state.activeTab === "capture" && state.captureViewMode === "timeline" && state.selectedCaptureEventKey) {
+      const selectedTimelineMarker = root.querySelector<HTMLElement>(
+        `.capture-timeline [data-capture-event="${CSS.escape(state.selectedCaptureEventKey)}"]`,
+      );
+      if (selectedTimelineMarker) {
+        selectedTimelineMarker.scrollIntoView({ block: "nearest", inline: "center" });
       }
     }
 

--- a/extensions/qa-lab/web/src/styles.css
+++ b/extensions/qa-lab/web/src/styles.css
@@ -359,6 +359,36 @@ select {
   border-right: 1px solid var(--border);
   background: var(--bg-sidebar);
   overflow: hidden;
+  transition: width 140ms ease, min-width 140ms ease, border-color 140ms ease;
+}
+
+.app-shell--sidebar-collapsed .sidebar {
+  width: 0;
+  min-width: 0;
+  border-right-color: transparent;
+}
+
+.sidebar-panel-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-sidebar) 88%, var(--bg-elevated));
+}
+
+.sidebar-panel-tab {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-panel-tab.active {
+  background: var(--accent-soft);
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--border));
+  color: var(--accent);
+}
+
+.sidebar-panel-body {
+  min-height: 0;
 }
 
 .sidebar-section {
@@ -536,6 +566,7 @@ select {
   flex-direction: column;
   gap: 8px;
   flex-shrink: 0;
+  background: color-mix(in srgb, var(--bg-sidebar) 92%, var(--bg-elevated));
 }
 
 .sidebar-actions .btn-primary {
@@ -1554,6 +1585,1435 @@ select {
   color: var(--text-secondary);
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.capture-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 14px;
+  align-items: start;
+}
+
+.capture-controls-shell {
+  margin-bottom: 14px;
+}
+
+.capture-controls-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-surface);
+}
+
+.capture-controls-summary,
+.capture-controls-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.capture-controls-panel {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-surface) 92%, var(--bg-elevated));
+}
+
+.capture-controls-grid {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.capture-summary-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 8px;
+}
+
+.capture-summary-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.capture-summary--compact .capture-summary-card {
+  padding: 8px 10px;
+}
+
+.capture-summary--compact .capture-summary-label {
+  margin-bottom: 4px;
+}
+
+.capture-summary--compact .capture-summary-value {
+  font-size: 13px;
+}
+
+.capture-summary-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+}
+
+.capture-summary-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+
+.capture-summary-meta {
+  margin-top: 6px;
+}
+
+.capture-summary-note {
+  margin-top: 4px;
+  line-height: 1.35;
+}
+
+.capture-chip-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.capture-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 6px;
+  padding: 3px 7px;
+  background: var(--accent-soft);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.capture-chip-muted {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.capture-chip-danger {
+  background: color-mix(in srgb, var(--danger) 14%, var(--bg-surface));
+  color: var(--danger);
+  border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--border));
+}
+
+.capture-active-filters {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: -2px 0 14px;
+}
+
+.capture-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  min-height: 38px;
+}
+
+.capture-checkbox input {
+  width: auto;
+  margin: 0;
+}
+
+.capture-search-field {
+  min-width: 260px;
+}
+
+.capture-search-field input {
+  min-width: 260px;
+}
+
+.capture-session-filter select {
+  min-width: 280px;
+  max-height: 94px;
+}
+
+.capture-selected-sessions-shell {
+  display: grid;
+  gap: 8px;
+  max-width: 420px;
+}
+
+.capture-selected-sessions-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.capture-selected-sessions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  max-width: 420px;
+}
+
+.capture-selected-session-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+  padding: 4px 8px;
+  border-radius: 7px;
+  background: var(--accent-soft);
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+  color: var(--text-secondary);
+}
+
+.capture-selected-session-chip-label {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 1180px) {
+  .capture-controls-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+.capture-selected-session-chip-x {
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-tertiary);
+}
+
+.capture-clear-filters {
+  min-height: 38px;
+}
+
+.capture-timeline {
+  --capture-timeline-label-width: minmax(180px, 220px);
+  --capture-timeline-track-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.capture-body {
+  display: grid;
+  gap: 16px;
+  align-items: start;
+}
+
+.capture-body--detail-right {
+  grid-template-columns:
+    minmax(0, calc(100% - var(--capture-detail-pane-width, 34%) - 12px))
+    12px
+    minmax(320px, var(--capture-detail-pane-width, 34%));
+}
+
+.capture-body--detail-bottom {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.capture-main-panel,
+.capture-detail-pane {
+  display: grid;
+  gap: 12px;
+}
+
+.capture-events-scroll {
+  max-height: 620px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-surface) 86%, var(--bg-elevated));
+}
+
+.capture-detail-pane {
+  position: sticky;
+  top: 12px;
+}
+
+.capture-detail-splitter {
+  position: relative;
+  align-self: stretch;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 78%, transparent);
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.capture-detail-splitter::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 8%, transparent),
+    color-mix(in srgb, var(--accent) 20%, transparent),
+    color-mix(in srgb, var(--accent) 8%, transparent)
+  );
+}
+
+.capture-detail-splitter:hover,
+.capture-detail-splitter:active,
+.capture-detail-splitter.dragging {
+  background: color-mix(in srgb, var(--accent) 38%, var(--border));
+}
+
+.capture-detail-splitter-label {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-surface) 92%, var(--bg-elevated));
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.capture-detail-splitter:hover .capture-detail-splitter-label,
+.capture-detail-splitter.dragging .capture-detail-splitter-label {
+  opacity: 1;
+}
+
+.capture-timeline-axis-grid {
+  display: grid;
+  grid-template-columns: var(--capture-timeline-label-width) minmax(0, 1fr);
+  gap: 12px;
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  padding-block: 4px 6px;
+  background: color-mix(in srgb, var(--bg-surface) 94%, var(--bg-elevated));
+  backdrop-filter: blur(10px);
+}
+
+.capture-timeline-axis-spacer {
+  min-width: 0;
+}
+
+.capture-timeline-viewport {
+  overflow-x: auto;
+  overflow-y: visible;
+  scrollbar-gutter: stable both-edges;
+  padding-bottom: 4px;
+}
+
+.capture-timeline-axis {
+  position: relative;
+  height: 34px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 2px;
+  width: var(--capture-timeline-track-width);
+  min-width: var(--capture-timeline-track-width);
+}
+
+.capture-timeline-axis::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 8px;
+  height: 1px;
+  background: color-mix(in srgb, var(--border) 82%, transparent);
+}
+
+.capture-timeline-axis-tick {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.capture-timeline-axis-tick-start {
+  transform: translateX(0);
+  align-items: flex-start;
+}
+
+.capture-timeline-axis-tick-end {
+  transform: translateX(-100%);
+  align-items: flex-end;
+}
+
+.capture-timeline-axis-tick-line {
+  width: 1px;
+  height: 12px;
+  background: color-mix(in srgb, var(--border) 86%, transparent);
+}
+
+.capture-timeline-axis-tick-label {
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.capture-timeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  margin: 0 0 10px calc(var(--capture-timeline-label-width) + 12px);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.capture-timeline-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.capture-timeline-legend-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+  background: color-mix(in srgb, var(--accent) 36%, var(--border));
+}
+
+.capture-timeline-legend-dot-request {
+  background: color-mix(in srgb, var(--accent) 54%, var(--border));
+}
+
+.capture-timeline-legend-dot-response {
+  background: color-mix(in srgb, var(--success) 46%, var(--border));
+}
+
+.capture-timeline-legend-dot-error {
+  background: color-mix(in srgb, var(--danger) 56%, var(--border));
+}
+
+.capture-timeline-legend-dot-ws {
+  background: color-mix(in srgb, var(--warning) 58%, var(--border));
+}
+
+.capture-timeline-legend-line {
+  width: 16px;
+  height: 2px;
+  background: color-mix(in srgb, var(--accent) 42%, var(--border));
+}
+
+.capture-timeline-legend-window {
+  width: 16px;
+  height: 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border));
+}
+
+.capture-timeline-brush-surface {
+  cursor: crosshair;
+  user-select: none;
+}
+
+.capture-timeline-lane {
+  display: grid;
+  grid-template-columns: var(--capture-timeline-label-width) minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.capture-timeline-lane-label {
+  min-width: 0;
+  padding-block: 4px;
+}
+
+.capture-timeline-lane.selected .capture-timeline-lane-label {
+  padding-left: 8px;
+  border-left: 3px solid color-mix(in srgb, var(--accent) 58%, var(--border));
+}
+
+.capture-timeline-lane-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.capture-timeline-lane-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.capture-timeline-lane-chevron {
+  color: var(--text-tertiary);
+  font-size: 12px;
+  width: 10px;
+}
+
+.capture-timeline-lane-pin {
+  border: 0;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.capture-timeline-lane-pin.pinned {
+  color: var(--warning);
+}
+
+.capture-timeline-lane-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.capture-timeline-lane-meta {
+  margin-top: 3px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.capture-timeline-lane-focus-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.capture-timeline-lane-compact-meta {
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0;
+  max-height: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease, max-height 120ms ease, margin-top 120ms ease;
+}
+
+.capture-timeline-lane:hover .capture-timeline-lane-compact-meta,
+.capture-timeline-lane:focus-within .capture-timeline-lane-compact-meta,
+.capture-timeline-lane.selected .capture-timeline-lane-compact-meta {
+  opacity: 1;
+  max-height: 24px;
+  margin-top: 4px;
+}
+
+.capture-timeline-lane-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin-top: 6px;
+}
+
+.capture-timeline-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 22px;
+  padding: 2px 7px 2px 5px;
+  border-radius: 7px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.capture-timeline-stat-danger {
+  border-color: color-mix(in srgb, var(--danger) 28%, var(--border));
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 9%, var(--bg-surface));
+}
+
+.capture-timeline-stat-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  background: var(--bg-elevated);
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.capture-timeline-stat-key-request {
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-surface));
+  color: var(--accent);
+}
+
+.capture-timeline-stat-key-response {
+  background: color-mix(in srgb, var(--success) 14%, var(--bg-surface));
+  color: var(--success);
+}
+
+.capture-timeline-stat-key-error {
+  background: color-mix(in srgb, var(--danger) 16%, var(--bg-surface));
+  color: var(--danger);
+}
+
+.capture-timeline-stat-key-focus {
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-surface));
+  color: var(--accent);
+}
+
+.capture-timeline-stat-key-background {
+  background: color-mix(in srgb, var(--text-tertiary) 10%, var(--bg-surface));
+  color: var(--text-tertiary);
+}
+
+.capture-timeline-stat-value {
+  color: var(--text-secondary);
+}
+
+.capture-timeline-inline-chip {
+  padding-inline: 6px;
+  min-height: 22px;
+}
+
+.capture-chip-focus {
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-surface));
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  color: var(--accent);
+}
+
+.capture-chip-severity {
+  background: color-mix(in srgb, var(--warning) 18%, var(--bg-surface));
+  border-color: color-mix(in srgb, var(--warning) 28%, var(--border));
+  color: color-mix(in srgb, var(--warning) 86%, black 8%);
+}
+
+.capture-chip-movement.up {
+  background: color-mix(in srgb, var(--success) 16%, var(--bg-surface));
+  border-color: color-mix(in srgb, var(--success) 28%, var(--border));
+  color: var(--success);
+}
+
+.capture-chip-movement.down {
+  background: color-mix(in srgb, var(--danger) 14%, var(--bg-surface));
+  border-color: color-mix(in srgb, var(--danger) 24%, var(--border));
+  color: var(--danger);
+}
+
+.capture-timeline-lane-severity {
+  margin-top: 5px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.capture-timeline-lane-movement-copy {
+  color: var(--text-tertiary);
+}
+
+.capture-timeline-sparkline {
+  display: grid;
+  grid-template-columns: repeat(18, minmax(0, 1fr));
+  align-items: end;
+  gap: 2px;
+  height: 20px;
+  margin-top: 6px;
+  padding: 4px 0;
+}
+
+.capture-timeline-sparkline-bar {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  min-height: 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 42%, var(--border));
+  opacity: 0.9;
+  cursor: pointer;
+}
+
+.capture-timeline-sparkline-bar:hover {
+  opacity: 1;
+  background: color-mix(in srgb, var(--accent) 66%, var(--border));
+}
+
+.capture-timeline-lane-track {
+  position: relative;
+  min-height: 42px;
+  width: var(--capture-timeline-track-width);
+  min-width: var(--capture-timeline-track-width);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--bg-elevated) 88%, transparent), transparent),
+    color-mix(in srgb, var(--bg-surface) 86%, var(--bg-elevated));
+}
+
+.capture-timeline-lane-track.selected {
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.capture-timeline-lane-track.collapsed {
+  min-height: 18px;
+  border-style: dashed;
+}
+
+.capture-timeline-window {
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border));
+  pointer-events: none;
+}
+
+.capture-timeline-axis .capture-timeline-window {
+  top: 0;
+  bottom: 0;
+}
+
+.capture-timeline-window-draft {
+  background: color-mix(in srgb, var(--warning) 22%, transparent);
+  border-style: dashed;
+}
+
+.capture-timeline-guide {
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  width: 1px;
+  transform: translateX(-50%);
+  background: color-mix(in srgb, var(--border) 74%, transparent);
+  pointer-events: none;
+}
+
+.capture-timeline-quick-preview {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  transform: translateX(-50%);
+  width: min(320px, calc(100% - 24px));
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-surface) 94%, var(--bg-elevated));
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.12);
+  z-index: 2;
+}
+
+.capture-timeline-quick-preview-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.capture-timeline-quick-preview-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.capture-timeline-quick-preview-meta {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  word-break: break-word;
+}
+
+.capture-timeline-quick-preview-snippet,
+.capture-timeline-quick-preview-error {
+  margin-top: 8px;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.capture-timeline-quick-preview-error {
+  color: var(--danger);
+}
+
+.capture-timeline-track-line {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  top: 18px;
+  height: 2px;
+  transform: translateY(-1px);
+  background: var(--border);
+}
+
+.capture-timeline-flow-link {
+  position: absolute;
+  height: 2px;
+  transform-origin: left center;
+  background: color-mix(in srgb, var(--accent) 34%, var(--border));
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.capture-timeline-flow-link.selected {
+  height: 3px;
+  background: color-mix(in srgb, var(--accent) 72%, white 8%);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+  opacity: 1;
+}
+
+.capture-timeline-flow-link.paired {
+  background: color-mix(in srgb, var(--success) 58%, var(--border));
+  opacity: 0.9;
+}
+
+.capture-timeline-flow-link.dimmed {
+  opacity: 0.16;
+}
+
+.capture-timeline-marker {
+  position: absolute;
+  top: 18px;
+  width: 12px;
+  height: 12px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 2px solid var(--bg-surface);
+  background: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 40%, var(--border));
+  cursor: pointer;
+}
+
+.capture-timeline-marker-mini {
+  width: 8px;
+  height: 8px;
+  border-width: 1px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--border) 88%, transparent);
+}
+
+.capture-timeline-marker:hover {
+  transform: translate(-50%, -50%) scale(1.12);
+}
+
+.capture-timeline-marker.selected {
+  width: 16px;
+  height: 16px;
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.capture-timeline-marker.paired {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--success) 65%, transparent);
+}
+
+.capture-timeline-marker.dimmed {
+  opacity: 0.22;
+}
+
+@media (max-width: 900px) {
+  .capture-timeline-axis-grid,
+  .capture-timeline-lane {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .capture-timeline-axis-spacer {
+    display: none;
+  }
+
+  .capture-body--detail-right {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .capture-detail-splitter {
+    display: none;
+  }
+}
+
+.capture-timeline-marker-response {
+  background: var(--success);
+}
+
+.capture-timeline-marker-error {
+  background: var(--danger);
+}
+
+.capture-timeline-marker-request {
+  background: var(--accent);
+}
+
+.capture-timeline-marker-ws-frame,
+.capture-timeline-marker-ws-open,
+.capture-timeline-marker-ws-close {
+  background: var(--warning);
+}
+
+.capture-group {
+  margin-bottom: 14px;
+}
+
+.capture-group-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-surface) 88%, var(--bg-elevated));
+}
+
+.capture-group-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.capture-group-meta {
+  margin-top: 3px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.capture-event-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+}
+
+.capture-event-card-compact {
+  align-items: start;
+}
+
+.capture-event-card-rail {
+  display: flex;
+  align-items: flex-start;
+  padding-top: 2px;
+}
+
+.capture-event-card-body {
+  min-width: 0;
+}
+
+.capture-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.capture-glyph-req {
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-surface));
+  color: var(--accent);
+}
+
+.capture-glyph-res {
+  background: color-mix(in srgb, var(--success) 14%, var(--bg-surface));
+  color: var(--success);
+}
+
+.capture-glyph-err {
+  background: color-mix(in srgb, var(--danger) 14%, var(--bg-surface));
+  color: var(--danger);
+}
+
+.capture-glyph-ws {
+  background: color-mix(in srgb, var(--warning) 14%, var(--bg-surface));
+  color: var(--warning);
+}
+
+.capture-glyph-warn {
+  background: color-mix(in srgb, var(--warning) 14%, var(--bg-surface));
+  color: var(--warning);
+}
+
+.capture-event-card:hover {
+  background: var(--bg-hover);
+  border-color: var(--border);
+}
+
+.capture-event-card.selected {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.capture-event-card.paired {
+  border-color: color-mix(in srgb, var(--success) 42%, var(--border));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--success) 18%, transparent);
+}
+
+.capture-event-card-header {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.capture-event-card-title-row,
+.capture-event-card-meta-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.capture-event-card-target {
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.capture-event-card-preview {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  background: var(--bg-inset);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.capture-group-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.events-view label select[multiple] {
+  min-width: 180px;
+  max-width: 280px;
+  padding: 6px;
+}
+
+.capture-pair-badge {
+  margin-top: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--success);
+}
+
+.capture-detail {
+  margin-top: 16px;
+}
+
+.capture-detail-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.capture-detail-view-switch {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.capture-subview-switch {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.capture-detail-view-option {
+  position: relative;
+}
+
+.capture-detail-view-option input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.capture-detail-view-option span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  gap: 6px;
+}
+
+.capture-detail-radio-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.capture-payload-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 10px 14px;
+  margin: 10px 0 12px;
+}
+
+.capture-payload-filter-field {
+  min-width: 240px;
+}
+
+.capture-inline-section-compact {
+  padding-top: 8px;
+}
+
+.capture-detail-view-option input:checked + span {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.capture-detail-view-body {
+  display: grid;
+  gap: 12px;
+}
+
+.capture-detail-view-hint {
+  font-style: normal;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.capture-startup-state {
+  display: grid;
+  gap: 12px;
+}
+
+.capture-startup-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.capture-startup-copy {
+  max-width: 72ch;
+}
+
+.capture-startup-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.capture-startup-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.capture-startup-status-url {
+  color: var(--text-secondary);
+}
+
+.capture-startup-command {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-surface) 90%, var(--bg-elevated));
+}
+
+.capture-startup-pre {
+  margin-top: 0;
+  white-space: pre-wrap;
+}
+
+.capture-detail-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.capture-pair-card {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  margin-top: 8px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--success) 34%, var(--border));
+  background: color-mix(in srgb, var(--success) 7%, var(--bg-surface));
+}
+
+.capture-pair-card:hover {
+  background: color-mix(in srgb, var(--success) 12%, var(--bg-hover));
+}
+
+.capture-pair-card-top {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.capture-pair-card-target {
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.capture-nav-row {
+  display: grid;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.capture-nav-button,
+.capture-nav-placeholder {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.capture-nav-button:hover {
+  background: var(--bg-hover);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+}
+
+.capture-nav-button-pair {
+  border-color: color-mix(in srgb, var(--success) 34%, var(--border));
+  background: color-mix(in srgb, var(--success) 7%, var(--bg-surface));
+}
+
+.capture-nav-button-pair:hover {
+  background: color-mix(in srgb, var(--success) 12%, var(--bg-hover));
+}
+
+.capture-nav-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.capture-nav-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.capture-nav-placeholder {
+  color: var(--text-tertiary);
+  background: color-mix(in srgb, var(--bg-surface) 88%, var(--bg-elevated));
+}
+
+.capture-detail-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.capture-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.capture-detail-mini-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.capture-detail-grid,
+.capture-detail-sections-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.capture-kv-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.capture-kv-row {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-surface) 86%, var(--bg-elevated));
+}
+
+.capture-kv-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.capture-kv-value {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.capture-detail-section {
+  margin-top: 12px;
+}
+
+.capture-inline-section + .capture-inline-section {
+  margin-top: 12px;
+}
+
+.capture-sse-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.capture-detail-payload {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.capture-detail-payload--full .capture-pre {
+  max-height: none;
+}
+
+.capture-detail-raw {
+  margin-top: 12px;
+}
+
+.capture-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.capture-mono {
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
+  word-break: break-word;
+}
+
+.capture-pre {
+  max-height: 320px;
+  margin-top: 6px;
+  overflow: auto;
+}
+
+.capture-detail-payload .capture-pre {
+  max-height: min(56vh, 760px);
+}
+
+.capture-pre-json {
+  background: color-mix(in srgb, var(--accent-soft) 18%, var(--bg-surface));
+}
+
+.capture-error {
+  color: var(--danger);
+  margin-top: 4px;
+}
+
+.capture-detail-note {
+  margin-top: 6px;
+}
+
+.capture-chip-warn {
+  background: color-mix(in srgb, var(--warning, #d97706) 14%, var(--bg-surface));
+  color: var(--warning, #b45309);
+  border: 1px solid color-mix(in srgb, var(--warning, #d97706) 30%, var(--border));
+}
+
+.capture-chip-strong {
+  background: color-mix(in srgb, var(--accent) 20%, var(--bg-surface));
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+}
+
+@media (max-width: 1180px) {
+  .capture-body--detail-right {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .capture-detail-pane {
+    position: static;
+  }
 }
 
 /* --- Utility --- */

--- a/extensions/qa-lab/web/src/ui-render.ts
+++ b/extensions/qa-lab/web/src/ui-render.ts
@@ -158,7 +158,120 @@ export type OutcomesEnvelope = {
   run: ScenarioRun | null;
 };
 
-export type TabId = "chat" | "results" | "report" | "events";
+export type CaptureSessionSummary = {
+  id: string;
+  startedAt: number;
+  endedAt?: number;
+  mode: string;
+  sourceProcess: string;
+  proxyUrl?: string;
+  eventCount: number;
+};
+
+export type CaptureEventView = {
+  id?: number;
+  ts: number;
+  protocol: string;
+  direction: string;
+  kind: string;
+  flowId: string;
+  method?: string;
+  host?: string;
+  path?: string;
+  status?: number;
+  closeCode?: number;
+  contentType?: string;
+  headersJson?: string;
+  dataText?: string;
+  payloadPreview?: string;
+  dataBlobId?: string;
+  errorText?: string;
+  provider?: string;
+  api?: string;
+  model?: string;
+  captureOrigin?: string;
+};
+
+export type CaptureQueryPreset =
+  | "none"
+  | "double-sends"
+  | "retry-storms"
+  | "cache-busting"
+  | "ws-duplicate-frames"
+  | "missing-ack"
+  | "error-bursts";
+
+export type CaptureSessionsEnvelope = {
+  sessions: CaptureSessionSummary[];
+};
+
+export type CaptureEventsEnvelope = {
+  events: CaptureEventView[];
+};
+
+export type CaptureQueryEnvelope = {
+  rows: Array<Record<string, string | number | null>>;
+};
+
+export type CaptureObservedDimension = {
+  value: string;
+  count: number;
+};
+
+export type CaptureCoverageSummary = {
+  sessionId: string;
+  totalEvents: number;
+  unlabeledEventCount: number;
+  providers: CaptureObservedDimension[];
+  apis: CaptureObservedDimension[];
+  models: CaptureObservedDimension[];
+  hosts: CaptureObservedDimension[];
+  localPeers: CaptureObservedDimension[];
+};
+
+export type CaptureCoverageEnvelope = {
+  coverage: CaptureCoverageSummary;
+};
+
+export type CaptureStartupProbeStatus = {
+  label: string;
+  url: string;
+  ok: boolean;
+  error?: string;
+};
+
+export type CaptureStartupStatus = {
+  proxy: CaptureStartupProbeStatus;
+  gateway: CaptureStartupProbeStatus;
+  qaLab: CaptureStartupProbeStatus;
+};
+
+export type CaptureStartupStatusEnvelope = {
+  status: CaptureStartupStatus;
+};
+
+export type CaptureSavedView = {
+  id: string;
+  name: string;
+  sessionIds: string[];
+  kindFilter: string[];
+  providerFilter: string[];
+  hostFilter: string[];
+  searchText: string;
+  headerMode: "key" | "all" | "hidden";
+  viewMode: "list" | "timeline";
+  groupMode: "none" | "flow" | "host-path" | "burst";
+  timelineLaneMode: "domain" | "provider" | "flow";
+  timelineLaneSort: "most-events" | "most-errors" | "severity" | "alphabetical";
+  timelineZoom: 75 | 100 | 150 | 200 | 300;
+  timelineSparklineMode: "session-relative" | "lane-relative";
+  errorsOnly: boolean;
+  detailPlacement: "right" | "bottom";
+  payloadLayout: "formatted" | "raw" | null;
+  payloadExtent: "preview" | "full";
+};
+
+export type TabId = "chat" | "results" | "report" | "events" | "capture";
 
 export type UiState = {
   theme: "light" | "dark";
@@ -166,6 +279,53 @@ export type UiState = {
   snapshot: Snapshot | null;
   latestReport: ReportEnvelope["report"];
   scenarioRun: ScenarioRun | null;
+  captureSessions: CaptureSessionSummary[];
+  captureEvents: CaptureEventView[];
+  captureQueryPreset: CaptureQueryPreset;
+  captureQueryRows: Array<Record<string, string | number | null>>;
+  captureKindFilter: string[];
+  captureProviderFilter: string[];
+  captureHostFilter: string[];
+  captureSearchText: string;
+  captureHeaderMode: "key" | "all" | "hidden";
+  captureViewMode: "list" | "timeline";
+  captureGroupMode: "none" | "flow" | "host-path" | "burst";
+  captureTimelineLaneMode: "domain" | "provider" | "flow";
+  captureTimelineLaneSort: "most-events" | "most-errors" | "severity" | "alphabetical";
+  captureTimelinePreviousLaneSort: "most-events" | "most-errors" | "severity" | "alphabetical" | null;
+  captureTimelineLaneSearch: string;
+  captureTimelineZoom: 75 | 100 | 150 | 200 | 300;
+  captureTimelineSparklineMode: "session-relative" | "lane-relative";
+  captureTimelineWindowStartPct: number | null;
+  captureTimelineWindowEndPct: number | null;
+  captureTimelineBrushAnchorPct: number | null;
+  captureTimelineBrushCurrentPct: number | null;
+  captureTimelineFocusSelectedFlow: boolean;
+  captureTimelineFocusedLaneMode: "all" | "only-matching" | "collapse-background";
+  captureTimelineFocusedLaneThreshold: "any" | "events-2" | "percent-10" | "percent-25";
+  captureDetailPlacement: "right" | "bottom";
+  captureDetailSplitPct: number;
+  captureDetailSplitDragging: boolean;
+  captureDetailView: "overview" | "flow" | "payload" | "headers";
+  capturePreferredDetailView: "overview" | "flow" | "payload" | "headers" | null;
+  captureFlowDetailLayout: "nav-first" | "pair-first" | null;
+  capturePayloadDetailLayout: "formatted" | "raw" | null;
+  capturePayloadExtent: "preview" | "full";
+  capturePayloadEventSort: "stream" | "name" | "size";
+  capturePayloadEventFilter: string;
+  captureErrorsOnly: boolean;
+  captureCoverage: CaptureCoverageSummary | null;
+  captureStartupStatus: CaptureStartupStatus | null;
+  captureControlsExpanded: boolean;
+  captureSummaryExpanded: boolean;
+  captureSavedViews: CaptureSavedView[];
+  captureSelectedSessionsExpanded: boolean;
+  sidebarCollapsed: boolean;
+  sidebarPanel: "scenarios" | "config" | "run";
+  captureCollapsedLaneIds: string[];
+  capturePinnedLaneIds: string[];
+  selectedCaptureSessionIds: string[];
+  selectedCaptureEventKey: string | null;
   selectedConversationId: string | null;
   selectedThreadId: string | null;
   selectedScenarioId: string | null;
@@ -206,12 +366,483 @@ function formatIso(iso?: string) {
   });
 }
 
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
 function esc(text: string) {
   return text
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
+}
+
+function parseJsonObject(raw?: string): Record<string, unknown> | null {
+  if (!raw || raw.trim().length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderCaptureKeyValueGrid(rows: Array<{ label: string; value: string }>): string {
+  if (rows.length === 0) {
+    return '<div class="empty-state">No structured fields available.</div>';
+  }
+  return `<div class="capture-kv-grid">
+    ${rows
+      .map(
+        (row) => `<div class="capture-kv-row">
+          <div class="capture-kv-label">${esc(row.label)}</div>
+          <div class="capture-kv-value capture-mono">${esc(row.value)}</div>
+        </div>`,
+      )
+      .join("")}
+  </div>`;
+}
+
+function isImportantCaptureHeader(label: string): boolean {
+  return /content-type|content-length|accept|cache-control|etag|last-modified|retry-after|location|date|server|x-request-id|openai-processing-ms|cf-cache-status|vary|age|host|user-agent/i.test(
+    label,
+  );
+}
+
+function renderCaptureHeaders(raw: string | undefined, mode: UiState["captureHeaderMode"]): string {
+  if (mode === "hidden") {
+    return '<div class="empty-state">Headers are hidden. Switch to key or all to inspect them.</div>';
+  }
+  const parsed = parseJsonObject(raw);
+  if (!parsed) {
+    return '<div class="empty-state">No captured headers for this event.</div>';
+  }
+  const sourceEntries =
+    mode === "key"
+      ? Object.entries(parsed).filter(([label]) => isImportantCaptureHeader(label))
+      : Object.entries(parsed);
+  const groups: Array<{
+    key: string;
+    label: string;
+    match: (header: string) => boolean;
+  }> = [
+    { key: "auth", label: "Auth & Session", match: (header) => isSensitiveCaptureField(header) },
+    {
+      key: "content",
+      label: "Content",
+      match: (header) => /content-|accept|encoding|transfer-encoding/i.test(header),
+    },
+    {
+      key: "cache",
+      label: "Caching & Validation",
+      match: (header) => /cache|etag|if-|last-modified|vary|expires|age/i.test(header),
+    },
+    {
+      key: "routing",
+      label: "Routing & Network",
+      match: (header) => /host|origin|referer|x-forwarded|forwarded|cf-|traceparent|tracestate|via/i.test(header),
+    },
+  ];
+  const remaining = new Map(sourceEntries);
+  const renderedGroups = groups
+    .map((group) => {
+      const rows = Array.from(remaining.entries())
+        .filter(([label]) => group.match(label))
+        .map(([label, value]) => {
+          remaining.delete(label);
+          return { label, value: formatCaptureFieldValue(value, label) };
+        })
+        .filter((row) => row.value.length > 0)
+        .sort((left, right) => left.label.localeCompare(right.label));
+      if (rows.length === 0) {
+        return "";
+      }
+      return `<section class="capture-inline-section">
+        <div class="capture-summary-label">${esc(group.label)}</div>
+        ${renderCaptureKeyValueGrid(rows)}
+      </section>`;
+    })
+    .filter(Boolean);
+  const otherRows = Array.from(remaining.entries())
+    .map(([label, value]) => ({
+      label,
+      value: formatCaptureFieldValue(value, label),
+    }))
+    .filter((row) => row.value.length > 0)
+    .sort((left, right) => left.label.localeCompare(right.label));
+  if (otherRows.length > 0) {
+    renderedGroups.push(`<section class="capture-inline-section">
+      <div class="capture-summary-label">Other</div>
+      ${renderCaptureKeyValueGrid(otherRows)}
+    </section>`);
+  }
+  return renderedGroups.join("") || '<div class="empty-state">No captured headers for this event.</div>';
+}
+
+function isSensitiveCaptureField(label: string): boolean {
+  return /authorization|proxy-authorization|cookie|set-cookie|api[-_]?key|x[-_]?api[-_]?key|token|secret|password|session/i.test(
+    label,
+  );
+}
+
+function redactCaptureScalar(value: string, label?: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (label && isSensitiveCaptureField(label)) {
+    if (/^bearer\s+/i.test(trimmed)) {
+      return "Bearer [redacted]";
+    }
+    return "[redacted]";
+  }
+  if (trimmed.length > 400) {
+    return `${trimmed.slice(0, 280)}\n…\n${trimmed.slice(-80)}`;
+  }
+  return trimmed;
+}
+
+function redactCaptureValue(value: unknown, label?: string): unknown {
+  if (typeof value === "string") {
+    return redactCaptureScalar(value, label);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactCaptureValue(entry, label));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    out[key] = redactCaptureValue(entry, key);
+  }
+  return out;
+}
+
+function formatCaptureFieldValue(value: unknown, label?: string): string {
+  const redacted = redactCaptureValue(value, label);
+  if (typeof redacted === "string") {
+    return redacted;
+  }
+  if (redacted == null) {
+    return "";
+  }
+  if (Array.isArray(redacted)) {
+    return redacted
+      .map((entry) => (typeof entry === "string" ? entry : JSON.stringify(entry)))
+      .filter(Boolean)
+      .join(", ");
+  }
+  return JSON.stringify(redacted, null, 2);
+}
+
+function renderCaptureFormPayload(payload: string): string {
+  const params = new URLSearchParams(payload.trim());
+  const rows = Array.from(params.entries()).map(([label, value]) => ({
+    label,
+    value: redactCaptureScalar(value, label),
+  }));
+  return rows.length > 0
+    ? renderCaptureKeyValueGrid(rows)
+    : `<pre class="report-pre capture-pre">${esc(redactCaptureScalar(payload))}</pre>`;
+}
+
+function renderCaptureSsePayload(
+  payload: string,
+  options?: {
+    sort?: UiState["capturePayloadEventSort"];
+    filterText?: string;
+  },
+): { body: string; eventCount: number; visibleCount: number } {
+  const frames = payload
+    .split(/\n\n+/)
+    .map((frame) => frame.trim())
+    .filter(Boolean)
+    .slice(0, 48)
+    .map((frame, index) => {
+      const rows = frame
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const separatorIndex = line.indexOf(":");
+          const label = separatorIndex >= 0 ? line.slice(0, separatorIndex).trim() || "field" : "line";
+          const value = separatorIndex >= 0 ? line.slice(separatorIndex + 1).trim() : line;
+          return { label, value: redactCaptureScalar(value, label) };
+        });
+      const eventName = rows.find((row) => row.label === "event")?.value || "message";
+      const dataText = rows
+        .filter((row) => row.label === "data")
+        .map((row) => row.value)
+        .join("\n");
+      const searchable = [eventName, dataText, ...rows.flatMap((row) => [row.label, row.value])]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return {
+        id: index,
+        index,
+        eventName,
+        rows,
+        byteLength: new TextEncoder().encode(frame).length,
+        searchable,
+      };
+    });
+  const normalizedFilter = options?.filterText?.trim().toLowerCase() ?? "";
+  const filteredFrames =
+    normalizedFilter.length === 0
+      ? frames
+      : frames.filter((frame) => frame.searchable.includes(normalizedFilter));
+  const sortMode = options?.sort ?? "stream";
+  const sortedFrames = [...filteredFrames].sort((left, right) => {
+    if (sortMode === "name") {
+      return left.eventName.localeCompare(right.eventName) || left.index - right.index;
+    }
+    if (sortMode === "size") {
+      return right.byteLength - left.byteLength || left.index - right.index;
+    }
+    return left.index - right.index;
+  });
+  if (frames.length === 0) {
+    return {
+      body: `<pre class="report-pre capture-pre">${esc(redactCaptureScalar(payload))}</pre>`,
+      eventCount: 0,
+      visibleCount: 0,
+    };
+  }
+  return {
+    body:
+      sortedFrames.length === 0
+        ? '<div class="empty-state">No SSE frames match the current payload filter.</div>'
+        : `<div class="capture-sse-stack">
+            ${sortedFrames
+              .map(
+                (frame) => `<section class="capture-inline-section capture-inline-section-compact">
+                  <div class="capture-summary-header">
+                    <div class="capture-summary-label">Event ${frame.index + 1}</div>
+                    <div class="capture-detail-mini-meta">
+                      <span class="capture-chip">${esc(frame.eventName)}</span>
+                      <span class="capture-chip capture-chip-muted">${frame.byteLength.toLocaleString()} bytes</span>
+                    </div>
+                  </div>
+                  ${renderCaptureKeyValueGrid(frame.rows)}
+                </section>`,
+              )
+              .join("")}
+          </div>`,
+    eventCount: frames.length,
+    visibleCount: sortedFrames.length,
+  };
+}
+
+function renderCapturePayload(
+  payload: string | undefined,
+  contentType?: string,
+  options?: {
+    payloadEventSort?: UiState["capturePayloadEventSort"];
+    payloadEventFilter?: string;
+  },
+): {
+  body: string;
+  mode: string;
+  byteLength: number;
+  looksStructured: boolean;
+  itemCount?: number;
+  visibleItemCount?: number;
+} {
+  if (!payload?.length) {
+    return {
+      body: '<div class="empty-state">No inline payload preview for this event.</div>',
+      mode: "none",
+      byteLength: 0,
+      looksStructured: false,
+    };
+  }
+  const trimmed = payload.trim();
+  const byteLength = new TextEncoder().encode(payload).length;
+  if (contentType?.includes("application/x-www-form-urlencoded")) {
+    return {
+      body: renderCaptureFormPayload(payload),
+      mode: "form",
+      byteLength,
+      looksStructured: true,
+    };
+  }
+  if (contentType?.includes("text/event-stream") || /^event:|^data:/m.test(trimmed)) {
+    const sse = renderCaptureSsePayload(payload, {
+      sort: options?.payloadEventSort,
+      filterText: options?.payloadEventFilter,
+    });
+    return {
+      body: sse.body,
+      mode: "sse",
+      byteLength,
+      looksStructured: true,
+      itemCount: sse.eventCount,
+      visibleItemCount: sse.visibleCount,
+    };
+  }
+  const isJsonLike =
+    contentType?.includes("json") ||
+    trimmed.startsWith("{") ||
+    trimmed.startsWith("[");
+  if (isJsonLike) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      return {
+        body: `<pre class="report-pre capture-pre capture-pre-json">${esc(
+          JSON.stringify(redactCaptureValue(parsed), null, 2),
+        )}</pre>`,
+        mode: "json",
+        byteLength,
+        looksStructured: true,
+      };
+    } catch {
+      // fall through to plain text
+    }
+  }
+  return {
+    body: `<pre class="report-pre capture-pre">${esc(redactCaptureScalar(payload))}</pre>`,
+    mode: "text",
+    byteLength,
+    looksStructured: false,
+  };
+}
+
+function renderCaptureCommandBlock(label: string, command: string): string {
+  return `<div class="capture-startup-command">
+    <div class="capture-summary-header">
+      <div class="capture-summary-label">${esc(label)}</div>
+      <button
+        class="btn-sm capture-copy-button"
+        type="button"
+        data-copy-text="${esc(command)}"
+      >Copy</button>
+    </div>
+    <pre class="report-pre capture-pre capture-startup-pre">${esc(command)}</pre>
+  </div>`;
+}
+
+function renderCaptureStartupStatusRow(status: CaptureStartupProbeStatus | null): string {
+  if (!status) {
+    return '<div class="capture-startup-status-row text-dimmed text-sm">Status unavailable.</div>';
+  }
+  return `<div class="capture-startup-status-row text-sm">
+    <span class="capture-chip ${status.ok ? "capture-chip-strong" : "capture-chip-danger"}">${
+      status.ok ? "reachable" : "unreachable"
+    }</span>
+    <span class="capture-startup-status-url capture-mono">${esc(status.url)}</span>
+    ${status.ok ? "" : `<span class="text-dimmed">${esc(status.error || "connection failed")}</span>`}
+  </div>`;
+}
+
+function renderCaptureStartupInstructions(status: CaptureStartupStatus | null): string {
+  const proxyStart = "pnpm proxy:start --port 7799";
+  const gatewayStart = `OPENCLAW_DEBUG_PROXY_ENABLED=1 \\
+OPENCLAW_DEBUG_PROXY_REQUIRE=1 \\
+OPENCLAW_DEBUG_PROXY_URL=http://127.0.0.1:7799 \\
+pnpm openclaw gateway --port 18789 --bind loopback`;
+  const qaStart = "pnpm qa:lab:ui --port 43124 --control-ui-url http://127.0.0.1:18789/";
+  const caInstall = "pnpm proxy:install-ca";
+  const caTrust = "sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /Users/thoffman/.openclaw/debug-proxy/certs/root-ca.pem";
+  return `<div class="capture-startup-state">
+    <div class="capture-startup-title">Proxy capture is not running yet.</div>
+    <div class="text-dimmed text-sm capture-startup-copy">
+      Start the proxy, then the gateway through that proxy, then QA Lab. Each command is copyable.
+    </div>
+    <div class="capture-startup-grid">
+      <div>
+        ${renderCaptureStartupStatusRow(status?.proxy ?? null)}
+        ${renderCaptureCommandBlock("1. Start proxy", proxyStart)}
+      </div>
+      <div>
+        ${renderCaptureStartupStatusRow(status?.gateway ?? null)}
+        ${renderCaptureCommandBlock("2. Start gateway through proxy", gatewayStart)}
+      </div>
+      <div>
+        ${renderCaptureStartupStatusRow(status?.qaLab ?? null)}
+        ${renderCaptureCommandBlock("3. Start QA Lab", qaStart)}
+      </div>
+      <div>
+        <div class="capture-startup-status-row text-dimmed text-sm">
+          Install the debug CA once on macOS if you want HTTPS/WSS clients to trust the proxy.
+        </div>
+        ${renderCaptureCommandBlock("4. Generate/install debug CA helper", caInstall)}
+        ${renderCaptureCommandBlock("5. macOS system trust (if needed)", caTrust)}
+      </div>
+    </div>
+  </div>`;
+}
+
+function captureEventKey(event: Pick<CaptureEventView, "id" | "flowId" | "ts" | "kind">): string {
+  return `${event.id ?? "no-id"}:${event.flowId}:${event.ts}:${event.kind}`;
+}
+
+function captureEventGlyph(event: Pick<CaptureEventView, "kind" | "direction">): { label: string; cls: string } {
+  switch (event.kind) {
+    case "request":
+      return { label: "REQ", cls: "req" };
+    case "response":
+      return { label: "RES", cls: "res" };
+    case "error":
+      return { label: "ERR", cls: "err" };
+    case "ws-frame":
+      return { label: "WS", cls: "ws" };
+    case "ws-open":
+      return { label: "W+", cls: "ws" };
+    case "ws-close":
+      return { label: "W-", cls: "ws" };
+    case "tls-handshake":
+      return { label: "TLS", cls: "sys" };
+    case "connect":
+      return { label: "CON", cls: "sys" };
+    case "retry-link":
+      return { label: "RTY", cls: "warn" };
+    default:
+      return { label: event.direction === "inbound" ? "IN" : "OUT", cls: "sys" };
+  }
+}
+
+function findPairedCaptureEvent(
+  event: CaptureEventView | null,
+  candidates: CaptureEventView[],
+): { counterpart: CaptureEventView | null; role: "request" | "response" | null } {
+  if (!event?.flowId || (event.kind !== "request" && event.kind !== "response")) {
+    return { counterpart: null, role: null };
+  }
+  const flowEvents = candidates
+    .filter(
+      (candidate) =>
+        candidate.flowId === event.flowId &&
+        (candidate.kind === "request" || candidate.kind === "response") &&
+        captureEventKey(candidate) !== captureEventKey(event),
+    )
+    .sort((left, right) => left.ts - right.ts || captureEventKey(left).localeCompare(captureEventKey(right)));
+  if (event.kind === "request") {
+    return {
+      counterpart: flowEvents.find((candidate) => candidate.kind === "response" && candidate.ts >= event.ts) ?? null,
+      role: "response",
+    };
+  }
+  const requests = flowEvents.filter((candidate) => candidate.kind === "request" && candidate.ts <= event.ts);
+  return {
+    counterpart: requests.at(-1) ?? null,
+    role: "request",
+  };
 }
 
 function attachmentSourceUrl(attachment: Attachment): string | null {
@@ -342,6 +973,7 @@ function renderHeader(state: UiState): string {
       </div>
       <div class="header-right">
         ${controlUrl ? `<a class="header-link" href="${esc(controlUrl)}" target="_blank" rel="noreferrer">Control UI</a>` : ""}
+        <button class="btn-ghost btn-sm" data-action="toggle-sidebar">${state.sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}</button>
         <button class="btn-ghost btn-sm" data-action="refresh"${state.busy ? " disabled" : ""}>Refresh</button>
         <button class="btn-ghost btn-sm" data-action="reset"${state.busy ? " disabled" : ""}>Reset</button>
         <button class="theme-toggle" data-action="toggle-theme" title="Toggle theme">${state.theme === "dark" ? "\u2600" : "\u263E"}</button>
@@ -395,71 +1027,78 @@ function renderSidebar(state: UiState): string {
   const selectedIds = new Set(selection?.scenarioIds ?? []);
 
   return `
-    <aside class="sidebar">
-      <!-- Configuration -->
-      <div class="sidebar-section">
-        <div class="sidebar-section-title"><h3>Configuration</h3></div>
-        <div class="config-field">
-          <span class="config-label">Provider lane</span>
-          <select id="provider-mode"${isRunning ? " disabled" : ""}>
-            <option value="mock-openai"${selection?.providerMode === "mock-openai" ? " selected" : ""}>Synthetic (mock)</option>
-            <option value="live-frontier"${selection?.providerMode === "live-frontier" ? " selected" : ""}>Real frontier providers</option>
-          </select>
-        </div>
-        ${renderModelSelect({
-          id: "primary-model",
-          label: "Primary model",
-          value: selection?.primaryModel ?? "",
-          options: modelOptions,
-          disabled: isRunning,
-        })}
-        ${renderModelSelect({
-          id: "alternate-model",
-          label: "Alternate model",
-          value: selection?.alternateModel ?? "",
-          options: modelOptions,
-          disabled: isRunning,
-        })}
-        ${
-          selection?.providerMode === "live-frontier"
-            ? `<div class="config-hint">${esc(
-                state.bootstrap?.runnerCatalog.status === "loading"
-                  ? "Loading model catalog\u2026"
-                  : state.bootstrap?.runnerCatalog.status === "failed"
-                    ? "Catalog unavailable; using manual input."
-                    : `${realModels.length} models available`,
-              )}</div>`
-            : ""
-        }
+    <aside class="sidebar${state.sidebarCollapsed ? " is-collapsed" : ""}">
+      <div class="sidebar-panel-tabs">
+        <button class="btn-sm btn-ghost sidebar-panel-tab${state.sidebarPanel === "scenarios" ? " active" : ""}" data-sidebar-panel="scenarios">Scenarios</button>
+        <button class="btn-sm btn-ghost sidebar-panel-tab${state.sidebarPanel === "config" ? " active" : ""}" data-sidebar-panel="config">Config</button>
+        <button class="btn-sm btn-ghost sidebar-panel-tab${state.sidebarPanel === "run" ? " active" : ""}" data-sidebar-panel="run">Run</button>
       </div>
-
-      <!-- Scenarios -->
-      <div class="sidebar-section sidebar-scenarios">
-        <div class="sidebar-section-title">
-          <h3>Scenarios (${selectedIds.size}/${scenarios.length})</h3>
-          <div class="btn-group">
-            <button class="btn-sm btn-ghost" data-action="select-all-scenarios"${isRunning ? " disabled" : ""}>All</button>
-            <button class="btn-sm btn-ghost" data-action="clear-scenarios"${isRunning ? " disabled" : ""}>None</button>
-          </div>
-        </div>
-        <div class="scenario-scroll">
-          ${scenarios
-            .map((s) => {
-              const outcome = findScenarioOutcome(state, s);
-              const status = outcome?.status ?? "pending";
-              return `
-                <label class="scenario-item">
-                  <input type="checkbox" data-scenario-toggle-id="${esc(s.id)}"${selectedIds.has(s.id) ? " checked" : ""}${isRunning ? " disabled" : ""} />
-                  <span class="${statusDotClass(status)}"></span>
-                  <div class="scenario-item-info">
-                    <span class="scenario-item-title">${esc(s.title)}</span>
-                    <span class="scenario-item-meta">${esc(s.surface)} · ${esc(s.id)}</span>
+      ${
+        state.sidebarPanel === "config"
+          ? `<div class="sidebar-section sidebar-panel-body">
+              <div class="sidebar-section-title"><h3>Configuration</h3></div>
+              <div class="config-field">
+                <span class="config-label">Provider lane</span>
+                <select id="provider-mode"${isRunning ? " disabled" : ""}>
+                  <option value="mock-openai"${selection?.providerMode === "mock-openai" ? " selected" : ""}>Synthetic (mock)</option>
+                  <option value="live-frontier"${selection?.providerMode === "live-frontier" ? " selected" : ""}>Real frontier providers</option>
+                </select>
+              </div>
+              ${renderModelSelect({
+                id: "primary-model",
+                label: "Primary model",
+                value: selection?.primaryModel ?? "",
+                options: modelOptions,
+                disabled: isRunning,
+              })}
+              ${renderModelSelect({
+                id: "alternate-model",
+                label: "Alternate model",
+                value: selection?.alternateModel ?? "",
+                options: modelOptions,
+                disabled: isRunning,
+              })}
+              ${
+                selection?.providerMode === "live-frontier"
+                  ? `<div class="config-hint">${esc(
+                      state.bootstrap?.runnerCatalog.status === "loading"
+                        ? "Loading model catalog\u2026"
+                        : state.bootstrap?.runnerCatalog.status === "failed"
+                          ? "Catalog unavailable; using manual input."
+                          : `${realModels.length} models available`,
+                    )}</div>`
+                  : ""
+              }
+            </div>`
+          : state.sidebarPanel === "run"
+            ? `<div class="sidebar-panel-body">${run || runner ? renderRunStatus(state) : '<div class="sidebar-section"><div class="text-dimmed text-sm">No run data yet.</div></div>'}</div>`
+            : `<div class="sidebar-section sidebar-scenarios sidebar-panel-body">
+                <div class="sidebar-section-title">
+                  <h3>Scenarios (${selectedIds.size}/${scenarios.length})</h3>
+                  <div class="btn-group">
+                    <button class="btn-sm btn-ghost" data-action="select-all-scenarios"${isRunning ? " disabled" : ""}>All</button>
+                    <button class="btn-sm btn-ghost" data-action="clear-scenarios"${isRunning ? " disabled" : ""}>None</button>
                   </div>
-                </label>`;
-            })
-            .join("")}
-        </div>
-      </div>
+                </div>
+                <div class="scenario-scroll">
+                  ${scenarios
+                    .map((s) => {
+                      const outcome = findScenarioOutcome(state, s);
+                      const status = outcome?.status ?? "pending";
+                      return `
+                        <label class="scenario-item">
+                          <input type="checkbox" data-scenario-toggle-id="${esc(s.id)}"${selectedIds.has(s.id) ? " checked" : ""}${isRunning ? " disabled" : ""} />
+                          <span class="${statusDotClass(status)}"></span>
+                          <div class="scenario-item-info">
+                            <span class="scenario-item-title">${esc(s.title)}</span>
+                            <span class="scenario-item-meta">${esc(s.surface)} · ${esc(s.id)}</span>
+                          </div>
+                        </label>`;
+                    })
+                    .join("")}
+                </div>
+              </div>`
+      }
 
       <!-- Actions -->
       <div class="sidebar-actions">
@@ -471,9 +1110,6 @@ function renderSidebar(state: UiState): string {
           <button data-action="kickoff"${isRunning || state.busy ? " disabled" : ""}>Kickoff</button>
         </div>
       </div>
-
-      <!-- Run status -->
-      ${run || runner ? renderRunStatus(state) : ""}
     </aside>`;
 }
 
@@ -516,6 +1152,7 @@ function renderTabBar(state: UiState): string {
     { id: "results", label: "Results" },
     { id: "report", label: "Report" },
     { id: "events", label: "Events" },
+    { id: "capture", label: "Capture" },
   ];
   return `
     <nav class="tab-bar">
@@ -909,6 +1546,1831 @@ function renderEventsView(state: UiState): string {
     </div>`;
 }
 
+function renderCaptureView(state: UiState): string {
+  const sessionIds =
+    state.selectedCaptureSessionIds.length > 0
+      ? state.selectedCaptureSessionIds
+      : state.captureSessions[0]?.id
+        ? [state.captureSessions[0].id]
+        : [];
+  const sessions = state.captureSessions;
+  const rows = state.captureQueryRows;
+  const events = state.captureEvents;
+  const availableKinds = [
+    ...new Set(events.map((event) => event.kind).filter((value): value is string => Boolean(value))),
+  ].sort();
+  const availableProviders = [
+    ...new Set(events.map((event) => event.provider).filter((value): value is string => Boolean(value))),
+  ].sort();
+  const availableHosts = [
+    ...new Set(events.map((event) => event.host).filter((value): value is string => Boolean(value))),
+  ].sort();
+  const normalizedSearch = state.captureSearchText.trim().toLowerCase();
+  const activeFilters: string[] = [];
+  if (state.captureKindFilter.length > 0) {
+    activeFilters.push(`kind: ${state.captureKindFilter.join(", ")}`);
+  }
+  if (state.captureProviderFilter.length > 0) {
+    activeFilters.push(`provider: ${state.captureProviderFilter.join(", ")}`);
+  }
+  if (state.captureHostFilter.length > 0) {
+    activeFilters.push(`host: ${state.captureHostFilter.join(", ")}`);
+  }
+  if (normalizedSearch) {
+    activeFilters.push(`search: ${state.captureSearchText.trim()}`);
+  }
+  if (state.captureHeaderMode !== "key") {
+    activeFilters.push(`headers: ${state.captureHeaderMode}`);
+  }
+  if (state.captureViewMode === "list" && state.captureGroupMode !== "none") {
+    activeFilters.push(`group: ${state.captureGroupMode}`);
+  }
+  if (state.captureViewMode === "timeline") {
+    activeFilters.push(`lanes: ${state.captureTimelineLaneMode}`);
+    activeFilters.push(`lane sort: ${state.captureTimelineLaneSort}`);
+    activeFilters.push(`zoom: ${state.captureTimelineZoom}%`);
+    if (state.captureTimelineFocusSelectedFlow) {
+      activeFilters.push("focus selected flow");
+      if (state.captureTimelineFocusedLaneMode !== "all") {
+        activeFilters.push(`focused lanes: ${state.captureTimelineFocusedLaneMode}`);
+      }
+      if (state.captureTimelineFocusedLaneThreshold !== "any") {
+        activeFilters.push(`focus threshold: ${state.captureTimelineFocusedLaneThreshold}`);
+      }
+    }
+    if (state.captureTimelineLaneSearch.trim()) {
+      activeFilters.push(`lane search: ${state.captureTimelineLaneSearch.trim()}`);
+    }
+    if (state.capturePinnedLaneIds.length > 0) {
+      activeFilters.push(`pinned lanes: ${state.capturePinnedLaneIds.length}`);
+    }
+    if (state.captureTimelineSparklineMode !== "session-relative") {
+      activeFilters.push(`sparkline: ${state.captureTimelineSparklineMode}`);
+    }
+  }
+  if (state.captureErrorsOnly) {
+    activeFilters.push("errors only");
+  }
+  const baseFilteredEvents = events.filter((event) => {
+    if (state.captureKindFilter.length > 0 && !state.captureKindFilter.includes(event.kind)) {
+      return false;
+    }
+    if (state.captureProviderFilter.length > 0 && !state.captureProviderFilter.includes(event.provider || "")) {
+      return false;
+    }
+    if (state.captureHostFilter.length > 0 && !state.captureHostFilter.includes(event.host || "")) {
+      return false;
+    }
+    if (state.captureErrorsOnly && !event.errorText && (event.status ?? 0) < 400) {
+      return false;
+    }
+    if (normalizedSearch) {
+      const haystack = [
+        event.kind,
+        event.protocol,
+        event.direction,
+        event.provider,
+        event.api,
+        event.model,
+        event.method,
+        event.host,
+        event.path,
+        event.status == null ? "" : String(event.status),
+        event.errorText,
+        event.payloadPreview,
+        event.flowId,
+        event.closeCode == null ? "" : String(event.closeCode),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(normalizedSearch)) {
+        return false;
+      }
+    }
+    return true;
+  });
+  const minTs = baseFilteredEvents.length > 0 ? Math.min(...baseFilteredEvents.map((event) => event.ts)) : 0;
+  const maxTs = baseFilteredEvents.length > 0 ? Math.max(...baseFilteredEvents.map((event) => event.ts)) : 0;
+  const totalSpanMs = Math.max(1, maxTs - minTs);
+  const activeWindowStartPct =
+    state.captureTimelineWindowStartPct != null && state.captureTimelineWindowEndPct != null
+      ? Math.min(state.captureTimelineWindowStartPct, state.captureTimelineWindowEndPct)
+      : null;
+  const activeWindowEndPct =
+    state.captureTimelineWindowStartPct != null && state.captureTimelineWindowEndPct != null
+      ? Math.max(state.captureTimelineWindowStartPct, state.captureTimelineWindowEndPct)
+      : null;
+  const draftWindowStartPct =
+    state.captureTimelineBrushAnchorPct != null && state.captureTimelineBrushCurrentPct != null
+      ? Math.min(state.captureTimelineBrushAnchorPct, state.captureTimelineBrushCurrentPct)
+      : null;
+  const draftWindowEndPct =
+    state.captureTimelineBrushAnchorPct != null && state.captureTimelineBrushCurrentPct != null
+      ? Math.max(state.captureTimelineBrushAnchorPct, state.captureTimelineBrushCurrentPct)
+      : null;
+  const activeWindowStartTs =
+    activeWindowStartPct == null ? null : minTs + totalSpanMs * (activeWindowStartPct / 100);
+  const activeWindowEndTs =
+    activeWindowEndPct == null ? null : minTs + totalSpanMs * (activeWindowEndPct / 100);
+  const activeWindowLabel =
+    activeWindowStartTs == null || activeWindowEndTs == null
+      ? null
+      : `${formatTime(activeWindowStartTs)} → ${formatTime(activeWindowEndTs)} · ${formatDuration(
+          Math.max(0, activeWindowEndTs - activeWindowStartTs),
+        )}`;
+  if (activeWindowLabel && state.captureViewMode === "timeline") {
+    activeFilters.push(`window: ${activeWindowLabel}`);
+  }
+  const filteredEvents =
+    state.captureViewMode === "timeline" && activeWindowStartPct != null && activeWindowEndPct != null
+      ? baseFilteredEvents.filter((event) => {
+          const percent = ((event.ts - minTs) / totalSpanMs) * 100;
+          return percent >= activeWindowStartPct && percent <= activeWindowEndPct;
+        })
+      : baseFilteredEvents;
+  const analysisEnabled = state.captureQueryPreset !== "none";
+  const selectedSessions = sessions.filter((session) => sessionIds.includes(session.id));
+  const singleSelectedSession = selectedSessions.length === 1 ? selectedSessions[0] ?? null : null;
+  const selectedSessionEventCount = selectedSessions.reduce((sum, session) => sum + session.eventCount, 0);
+  const selectedEvent =
+    filteredEvents.find((event) => {
+      const key = captureEventKey(event);
+      return key === state.selectedCaptureEventKey;
+    }) ?? filteredEvents[0] ?? null;
+  const selectedEventKey = selectedEvent == null ? null : captureEventKey(selectedEvent);
+  const kindCounts = new Map<string, number>();
+  for (const event of filteredEvents) {
+    kindCounts.set(event.kind, (kindCounts.get(event.kind) ?? 0) + 1);
+  }
+  const topKinds = [...kindCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+  const topProviders = state.captureCoverage?.providers.slice(0, 4) ?? [];
+  const topModels = state.captureCoverage?.models.slice(0, 3) ?? [];
+  const selectedFlowId = selectedEvent?.flowId?.trim() || "";
+  const selectedFlowEvents =
+    selectedFlowId.length > 0
+      ? events
+          .filter((event) => event.flowId === selectedFlowId)
+          .sort((left, right) => left.ts - right.ts || captureEventKey(left).localeCompare(captureEventKey(right)))
+      : [];
+  const selectedFlowIndex =
+    selectedEvent == null ? -1 : selectedFlowEvents.findIndex((event) => captureEventKey(event) === captureEventKey(selectedEvent));
+  const previousFlowEvent = selectedFlowIndex > 0 ? selectedFlowEvents[selectedFlowIndex - 1] : null;
+  const nextFlowEvent =
+    selectedFlowIndex >= 0 && selectedFlowIndex < selectedFlowEvents.length - 1
+      ? selectedFlowEvents[selectedFlowIndex + 1]
+      : null;
+  const selectedPairing = findPairedCaptureEvent(selectedEvent, events);
+  const pairedEvent = selectedPairing.counterpart;
+  const pairedEventKey = pairedEvent ? captureEventKey(pairedEvent) : null;
+  const pairedEventVisible =
+    pairedEventKey != null && filteredEvents.some((event) => captureEventKey(event) === pairedEventKey);
+  const pairingLatencyMs =
+    selectedEvent && pairedEvent ? Math.max(0, Math.abs(pairedEvent.ts - selectedEvent.ts)) : null;
+  const previousFlowEventVisible =
+    previousFlowEvent != null && filteredEvents.some((event) => captureEventKey(event) === captureEventKey(previousFlowEvent));
+  const nextFlowEventVisible =
+    nextFlowEvent != null && filteredEvents.some((event) => captureEventKey(event) === captureEventKey(nextFlowEvent));
+  const timelineTrackWidthPx = Math.round(960 * (state.captureTimelineZoom / 100));
+  const timelineWidthStyle = `--capture-timeline-track-width:${timelineTrackWidthPx}px`;
+  const renderTimelineWindow = (startPct: number | null, endPct: number | null, className: string): string => {
+    if (startPct == null || endPct == null) {
+      return "";
+    }
+    const left = Math.max(0, Math.min(100, startPct));
+    const width = Math.max(0, Math.min(100, endPct) - left);
+    return `<div class="${className}" style="left:${left.toFixed(2)}%;width:${width.toFixed(2)}%"></div>`;
+  };
+  const timelineAxisTicks = Array.from({ length: 5 }, (_, index) => {
+    const pct = (index / 4) * 100;
+    const ts = minTs + (totalSpanMs * pct) / 100;
+    return {
+      pct,
+      label: formatTime(ts),
+      edgeClass:
+        index === 0 ? "capture-timeline-axis-tick-start" : index === 4 ? "capture-timeline-axis-tick-end" : "",
+    };
+  });
+  const renderLaneSparkline = (eventsForLane: CaptureEventView[], laneId: string) => {
+    if (eventsForLane.length === 0) {
+      return "";
+    }
+    const binCount = 18;
+    const bins = Array.from({ length: binCount }, () => 0);
+    const laneMinTs = eventsForLane.reduce((min, event) => Math.min(min, event.ts), eventsForLane[0]?.ts ?? minTs);
+    const laneMaxTs = eventsForLane.reduce((max, event) => Math.max(max, event.ts), eventsForLane[0]?.ts ?? maxTs);
+    const laneSpanMs = Math.max(1, laneMaxTs - laneMinTs);
+    for (const event of eventsForLane) {
+      const spanStart = state.captureTimelineSparklineMode === "lane-relative" ? laneMinTs : minTs;
+      const spanMs = state.captureTimelineSparklineMode === "lane-relative" ? laneSpanMs : totalSpanMs;
+      const rawIndex = spanMs <= 0 ? 0 : Math.floor(((event.ts - spanStart) / spanMs) * binCount);
+      const index = Math.max(0, Math.min(binCount - 1, rawIndex));
+      bins[index] += 1;
+    }
+    const maxBin = Math.max(...bins, 1);
+    return `<div class="capture-timeline-sparkline">
+      ${bins
+        .map((count, index) => {
+          const height = Math.max(12, Math.round((count / maxBin) * 100));
+          const spanStartTs =
+            state.captureTimelineSparklineMode === "lane-relative"
+              ? laneMinTs + (laneSpanMs * index) / binCount
+              : minTs + (totalSpanMs * index) / binCount;
+          const spanEndTs =
+            state.captureTimelineSparklineMode === "lane-relative"
+              ? laneMinTs + (laneSpanMs * (index + 1)) / binCount
+              : minTs + (totalSpanMs * (index + 1)) / binCount;
+          const startPct = ((spanStartTs - minTs) / Math.max(1, totalSpanMs)) * 100;
+          const endPct = ((spanEndTs - minTs) / Math.max(1, totalSpanMs)) * 100;
+          const binLabel = `${laneId} · ${formatTime(spanStartTs)} → ${formatTime(spanEndTs)} · ${count} events`;
+          return `<button
+            class="capture-timeline-sparkline-bar"
+            data-capture-sparkline-window="${esc(laneId)}:${index}"
+            data-capture-window-start="${startPct.toFixed(4)}"
+            data-capture-window-end="${endPct.toFixed(4)}"
+            type="button"
+            title="${esc(`${binLabel} · click/drag: custom window · Shift+drag: wider context`)}"
+            style="height:${height}%"
+          ></button>`;
+        })
+        .join("")}
+    </div>`;
+  };
+  const computeLaneSeverity = (eventsForLane: CaptureEventView[]) => {
+    const total = eventsForLane.length;
+    const errorCount = eventsForLane.filter(
+      (event) => Boolean(event.errorText) || (event.status ?? 0) >= 400,
+    ).length;
+    const focusedCount = selectedFlowId
+      ? eventsForLane.filter((event) => event.flowId === selectedFlowId).length
+      : 0;
+    const recencyScore =
+      total === 0
+        ? 0
+        : eventsForLane.reduce((max, event) => Math.max(max, event.ts), 0) / Math.max(1, maxTs);
+    const errorShare = total > 0 ? errorCount / total : 0;
+    const focusedShare = total > 0 ? focusedCount / total : 0;
+    return errorCount * 10 + errorShare * 30 + focusedShare * 35 + recencyScore * 8 + Math.min(total, 40) * 0.2;
+  };
+  const describeLaneSeverity = (eventsForLane: CaptureEventView[]) => {
+    const total = eventsForLane.length;
+    const errorCount = eventsForLane.filter(
+      (event) => Boolean(event.errorText) || (event.status ?? 0) >= 400,
+    ).length;
+    const focusedCount = selectedFlowId
+      ? eventsForLane.filter((event) => event.flowId === selectedFlowId).length
+      : 0;
+    const newestTs = total === 0 ? 0 : eventsForLane.reduce((max, event) => Math.max(max, event.ts), 0);
+    const recencyMinutes = newestTs > 0 ? Math.max(0, Math.round((maxTs - newestTs) / 60000)) : null;
+    const focusedPercent = total > 0 ? Math.round((focusedCount / total) * 100) : 0;
+    const errorPercent = total > 0 ? Math.round((errorCount / total) * 100) : 0;
+    const reasons: string[] = [];
+    if (errorCount > 0) {
+      reasons.push(`${errorCount} errors (${errorPercent}%)`);
+    }
+    if (selectedFlowId && focusedCount > 0) {
+      reasons.push(`focused flow ${focusedPercent}%`);
+    }
+    if (recencyMinutes != null) {
+      reasons.push(recencyMinutes === 0 ? "active now" : `${recencyMinutes}m old`);
+    }
+    if (total > 0) {
+      reasons.push(`${total} events`);
+    }
+    return {
+      score: computeLaneSeverity(eventsForLane),
+      summary: reasons.join(" · "),
+    };
+  };
+  const unsortedTimelineLanes = Array.from(
+    filteredEvents.reduce<
+      Map<
+        string,
+        {
+          id: string;
+          label: string;
+          meta: string;
+          events: CaptureEventView[];
+        }
+      >
+    >((lanes, event) => {
+      const providerLabel = event.provider || "unlabeled";
+      const flowLabel = event.flowId || "(no flow id)";
+      const laneConfig =
+        state.captureTimelineLaneMode === "provider"
+          ? {
+              id: providerLabel,
+              label: providerLabel,
+              meta: [event.host, event.api, event.model].filter(Boolean).join(" · "),
+            }
+          : state.captureTimelineLaneMode === "flow"
+            ? {
+                id: flowLabel,
+                label: flowLabel,
+                meta: [event.provider, event.host, event.path].filter(Boolean).join(" · "),
+              }
+            : {
+                id: event.host || "(no host)",
+                label: event.host || "(no host)",
+                meta: [event.provider, event.model].filter(Boolean).join(", "),
+              };
+      const laneId = laneConfig.id;
+      const existing = lanes.get(laneId);
+      if (existing) {
+        existing.events.push(event);
+        return lanes;
+      }
+      lanes.set(laneId, { id: laneId, label: laneConfig.label, meta: laneConfig.meta, events: [event] });
+      return lanes;
+    }, new Map()),
+  ).map(([, lane]) => lane);
+  const sortTimelineLanes = (
+    lanes: Array<{ id: string; label: string; meta: string; events: CaptureEventView[] }>,
+    mode: UiState["captureTimelineLaneSort"],
+  ) =>
+    [...lanes].sort((a, b) => {
+      const aErrorCount = a.events.filter((event) => Boolean(event.errorText) || (event.status ?? 0) >= 400).length;
+      const bErrorCount = b.events.filter((event) => Boolean(event.errorText) || (event.status ?? 0) >= 400).length;
+      if (mode === "severity") {
+        return (
+          computeLaneSeverity(b.events) - computeLaneSeverity(a.events) ||
+          bErrorCount - aErrorCount ||
+          b.events.length - a.events.length ||
+          a.label.localeCompare(b.label)
+        );
+      }
+      if (mode === "most-errors") {
+        return (
+          bErrorCount - aErrorCount ||
+          b.events.length - a.events.length ||
+          a.label.localeCompare(b.label)
+        );
+      }
+      if (mode === "alphabetical") {
+        return a.label.localeCompare(b.label);
+      }
+      return b.events.length - a.events.length || bErrorCount - aErrorCount || a.label.localeCompare(b.label);
+    });
+  const timelineLanes = sortTimelineLanes(unsortedTimelineLanes, state.captureTimelineLaneSort);
+  const previousTimelineLanes =
+    state.captureTimelinePreviousLaneSort == null
+      ? null
+      : sortTimelineLanes(unsortedTimelineLanes, state.captureTimelinePreviousLaneSort);
+  const previousLanePosition = new Map<string, number>(
+    (previousTimelineLanes ?? []).map((lane, index) => [lane.id, index]),
+  );
+  const laneSearch = state.captureTimelineLaneSearch.trim().toLowerCase();
+  const collapsedLaneIds = new Set(state.captureCollapsedLaneIds);
+  const pinnedLaneIds = new Set(state.capturePinnedLaneIds);
+  const focusedLaneMode =
+    state.captureTimelineFocusSelectedFlow && selectedFlowId
+      ? state.captureTimelineFocusedLaneMode
+      : "all";
+  const focusedLaneThreshold =
+    state.captureTimelineFocusSelectedFlow && selectedFlowId
+      ? state.captureTimelineFocusedLaneThreshold
+      : "any";
+  const laneMeetsFocusedThreshold = (focusedCount: number, laneTotal: number) => {
+    if (focusedLaneThreshold === "events-2") {
+      return focusedCount >= 2;
+    }
+    if (focusedLaneThreshold === "percent-10") {
+      return laneTotal > 0 && focusedCount / laneTotal >= 0.1;
+    }
+    if (focusedLaneThreshold === "percent-25") {
+      return laneTotal > 0 && focusedCount / laneTotal >= 0.25;
+    }
+    return focusedCount > 0;
+  };
+  const visibleTimelineLanes = timelineLanes.filter((lane) => {
+    const focusedCount = selectedFlowId
+      ? lane.events.filter((event) => event.flowId === selectedFlowId).length
+      : 0;
+    if (
+      focusedLaneMode === "only-matching" &&
+      !laneMeetsFocusedThreshold(focusedCount, lane.events.length) &&
+      !pinnedLaneIds.has(lane.id)
+    ) {
+      return false;
+    }
+    if (pinnedLaneIds.size > 0 && pinnedLaneIds.has(lane.id)) {
+      return true;
+    }
+    if (!laneSearch) {
+      return pinnedLaneIds.size === 0 || !pinnedLaneIds.has(lane.id);
+    }
+    const haystack = [lane.label, lane.meta]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(laneSearch);
+  });
+  const summaryChips = [
+    sessionIds.length > 1 ? `sessions: ${sessionIds.length}` : null,
+    analysisEnabled ? `analysis: ${state.captureQueryPreset}` : "raw only",
+    state.captureViewMode === "timeline"
+      ? `timeline: ${state.captureTimelineLaneMode}`
+      : "view: list",
+    state.captureViewMode === "timeline" ? `sort: ${state.captureTimelineLaneSort}` : null,
+    state.captureViewMode === "timeline" ? `zoom: ${state.captureTimelineZoom}%` : null,
+    activeFilters.length > 0 ? `filters: ${activeFilters.length}` : null,
+    normalizedSearch ? `search` : null,
+  ].filter((value): value is string => Boolean(value));
+  const summaryMeta = [
+    `${filteredEvents.length} visible`,
+    selectedSessions.length > 0 ? `${selectedSessionEventCount} stored` : null,
+    state.captureViewMode === "timeline" && activeWindowLabel ? `window ${activeWindowLabel}` : null,
+    state.captureViewMode === "timeline"
+      ? `${visibleTimelineLanes.length}/${timelineLanes.length} lanes${pinnedLaneIds.size > 0 ? ` · ${pinnedLaneIds.size} pinned` : ""}`
+      : null,
+    state.captureTimelineFocusSelectedFlow && selectedEvent?.flowId
+      ? `focus ${selectedEvent.flowId}`
+      : null,
+  ].filter((value): value is string => Boolean(value));
+  const groupedEvents =
+    state.captureGroupMode === "none" || state.captureGroupMode === "burst"
+      ? [{ id: "__all__", label: "All Events", meta: "", events: filteredEvents }]
+      : Array.from(
+          filteredEvents.reduce<
+            Map<
+              string,
+              { id: string; label: string; meta: string; events: CaptureEventView[] }
+            >
+          >((groups, event) => {
+            const key =
+              state.captureGroupMode === "flow"
+                ? event.flowId || "(no flow)"
+                : [event.host || "(no host)", event.path || "/"].join(" ");
+            const label =
+              state.captureGroupMode === "flow"
+                ? event.flowId || "(no flow id)"
+                : [event.host || "(no host)", event.path || "/"].join(" ");
+            const existing = groups.get(key);
+            if (existing) {
+              existing.events.push(event);
+              return groups;
+            }
+            groups.set(key, {
+              id: key,
+              label,
+              meta:
+                state.captureGroupMode === "flow"
+                  ? [event.host, event.path].filter(Boolean).join(" ")
+                  : event.flowId || "",
+              events: [event],
+            });
+            return groups;
+          }, new Map()),
+        ).map(([, group]) => group);
+  const clusterEventBursts = (eventsForGroup: CaptureEventView[]) => {
+    const sorted = [...eventsForGroup].sort(
+      (left, right) => left.ts - right.ts || captureEventKey(left).localeCompare(captureEventKey(right)),
+    );
+    const clusters: Array<{
+      key: string;
+      representative: CaptureEventView;
+      events: CaptureEventView[];
+      count: number;
+      startTs: number;
+      endTs: number;
+    }> = [];
+    for (const event of sorted) {
+      const previous = clusters.at(-1);
+      const sameShape =
+        previous &&
+        previous.representative.kind === event.kind &&
+        previous.representative.direction === event.direction &&
+        (previous.representative.provider || "") === (event.provider || "") &&
+        (previous.representative.host || "") === (event.host || "") &&
+        (previous.representative.path || "") === (event.path || "") &&
+        (previous.representative.method || "") === (event.method || "") &&
+        (previous.representative.status || 0) === (event.status || 0) &&
+        event.ts - previous.endTs <= 1500;
+      if (!sameShape) {
+        clusters.push({
+          key: captureEventKey(event),
+          representative: event,
+          events: [event],
+          count: 1,
+          startTs: event.ts,
+          endTs: event.ts,
+        });
+        continue;
+      }
+      previous.events.push(event);
+      previous.count += 1;
+      previous.endTs = event.ts;
+      previous.representative = event;
+    }
+    return clusters;
+  };
+  const selectedHeaders = parseJsonObject(selectedEvent?.headersJson);
+  const selectedHeaderCount = selectedHeaders ? Object.keys(selectedHeaders).length : 0;
+  const selectedSensitiveHeaderCount = selectedHeaders
+    ? Object.keys(selectedHeaders).filter((label) => isSensitiveCaptureField(label)).length
+    : 0;
+  const selectedPayload = renderCapturePayload(selectedEvent?.dataText, selectedEvent?.contentType, {
+    payloadEventSort: state.capturePayloadEventSort,
+    payloadEventFilter: state.capturePayloadEventFilter,
+  });
+  const selectedMetaRows = selectedEvent
+    ? [
+        { label: "provider", value: selectedEvent.provider ?? "unlabeled" },
+        { label: "model", value: selectedEvent.model ?? "n/a" },
+        { label: "api", value: selectedEvent.api ?? "n/a" },
+        { label: "peer host", value: selectedEvent.host ?? "n/a" },
+        { label: "path", value: selectedEvent.path ?? "n/a" },
+        { label: "flow id", value: selectedEvent.flowId },
+        { label: "capture origin", value: selectedEvent.captureOrigin ?? "runtime/default" },
+        { label: "content-type", value: selectedEvent.contentType ?? "n/a" },
+      ].filter((row) => row.value.trim().length > 0)
+    : [];
+  const rawPayloadBody = selectedEvent?.dataText?.length
+    ? `<pre class="report-pre capture-pre">${esc(redactCaptureScalar(selectedEvent.dataText))}</pre>`
+    : '<div class="empty-state">No inline payload preview for this event.</div>';
+  const availableDetailViews: Array<{
+    value: UiState["captureDetailView"];
+    label: string;
+    available: boolean;
+    recommended: boolean;
+  }> = [
+    { value: "overview", label: "Overview", available: true, recommended: false },
+    {
+      value: "flow",
+      label: "Flow",
+      available: selectedFlowEvents.length > 0 || pairedEvent != null,
+      recommended:
+        (selectedEvent?.kind === "request" || selectedEvent?.kind === "response") &&
+        (selectedFlowEvents.length > 1 || pairedEvent != null),
+    },
+    {
+      value: "payload",
+      label: "Payload",
+      available: Boolean(selectedEvent?.dataText?.length || selectedEvent?.dataBlobId),
+      recommended: Boolean(selectedPayload.byteLength > 0),
+    },
+    {
+      value: "headers",
+      label: "Headers",
+      available: selectedHeaderCount > 0,
+      recommended: !selectedPayload.byteLength && selectedHeaderCount > 0,
+    },
+  ];
+  if (!availableDetailViews.some((view) => view.recommended && view.available)) {
+    availableDetailViews[0]!.recommended = true;
+  }
+  const preferredDetailView = state.capturePreferredDetailView;
+  const effectiveDetailView = availableDetailViews.some(
+    (view) => view.value === preferredDetailView && view.available,
+  )
+    ? (preferredDetailView ?? "overview")
+    : availableDetailViews.some((view) => view.value === state.captureDetailView && view.available)
+      ? state.captureDetailView
+      : (availableDetailViews.find((view) => view.recommended && view.available)?.value ?? "overview");
+  const effectiveFlowLayout =
+    state.captureFlowDetailLayout ??
+    ((selectedEvent?.kind === "request" || selectedEvent?.kind === "response") && pairedEvent ? "pair-first" : "nav-first");
+  const effectivePayloadLayout =
+    state.capturePayloadDetailLayout ??
+    (selectedPayload.looksStructured ? "formatted" : "raw");
+  const effectivePayloadExtent = state.capturePayloadExtent;
+  const flowSections = {
+    navigation:
+      selectedFlowEvents.length > 0
+        ? `<section class="capture-detail-section">
+            <div class="capture-summary-header">
+              <div class="capture-summary-label">Flow Navigation</div>
+              <div class="capture-detail-mini-meta">
+                <span class="capture-chip">${selectedFlowIndex + 1} / ${selectedFlowEvents.length}</span>
+                <span class="capture-chip capture-chip-muted">${esc(selectedEvent?.flowId || "")}</span>
+              </div>
+            </div>
+            <div class="capture-nav-row">
+              ${
+                previousFlowEvent
+                  ? `<button class="capture-nav-button" data-capture-event="${esc(captureEventKey(previousFlowEvent))}" type="button">
+                      <span class="capture-nav-label">Previous on flow</span>
+                      <span class="capture-nav-meta">${esc(previousFlowEvent.kind)} · ${esc(new Date(previousFlowEvent.ts).toLocaleTimeString())}${
+                        previousFlowEventVisible ? "" : " · outside current view"
+                      }</span>
+                    </button>`
+                  : '<div class="capture-nav-placeholder">No earlier event on this flow.</div>'
+              }
+              ${
+                nextFlowEvent
+                  ? `<button class="capture-nav-button" data-capture-event="${esc(captureEventKey(nextFlowEvent))}" type="button">
+                      <span class="capture-nav-label">Next on flow</span>
+                      <span class="capture-nav-meta">${esc(nextFlowEvent.kind)} · ${esc(new Date(nextFlowEvent.ts).toLocaleTimeString())}${
+                        nextFlowEventVisible ? "" : " · outside current view"
+                      }</span>
+                    </button>`
+                  : '<div class="capture-nav-placeholder">No later event on this flow.</div>'
+              }
+            </div>
+          </section>`
+        : '<div class="empty-state">This event does not have a usable flow.</div>',
+    pair:
+      pairedEvent
+        ? `<section class="capture-detail-section">
+            <div class="capture-summary-header">
+              <div class="capture-summary-label">Paired ${esc(selectedPairing.role || "counterpart")}</div>
+              <div class="capture-detail-mini-meta">
+                ${pairingLatencyMs != null ? `<span class="capture-chip">${formatDuration(pairingLatencyMs)}</span>` : ""}
+                ${
+                  pairedEventVisible
+                    ? '<span class="capture-chip capture-chip-strong">visible now</span>'
+                    : '<span class="capture-chip capture-chip-muted">outside current window/filter</span>'
+                }
+              </div>
+            </div>
+            <button class="capture-pair-card" data-capture-event="${esc(captureEventKey(pairedEvent))}" type="button">
+              <div class="capture-pair-card-top">
+                <strong>${esc(pairedEvent.kind)}</strong>
+                <span class="text-dimmed text-sm">${esc(new Date(pairedEvent.ts).toLocaleTimeString())}</span>
+                ${pairedEvent.status ? `<span class="text-dimmed text-sm">status ${pairedEvent.status}</span>` : ""}
+              </div>
+              <div class="capture-pair-card-target">${esc(
+                [pairedEvent.method, pairedEvent.host, pairedEvent.path].filter(Boolean).join(" ") || pairedEvent.flowId,
+              )}</div>
+              <div class="text-dimmed text-sm">${esc(
+                [pairedEvent.provider, pairedEvent.model, pairedEvent.api].filter(Boolean).join(" · ") || "same flow",
+              )}</div>
+            </button>
+          </section>`
+        : selectedEvent?.kind === "request" || selectedEvent?.kind === "response"
+          ? `<section class="capture-detail-section">
+              <div class="capture-summary-label">Paired ${
+                esc(selectedEvent.kind === "request" ? "response" : "request")
+              }</div>
+              <div class="empty-state">No unambiguous counterpart was found on this flow.</div>
+            </section>`
+          : "",
+  };
+  const renderDetailView = () => {
+    if (!selectedEvent) {
+      return "";
+    }
+    if (effectiveDetailView === "flow") {
+      return `
+        <div class="capture-detail-stack">
+          <div class="capture-subview-switch" role="radiogroup" aria-label="Flow layout">
+            <label class="capture-detail-view-option">
+              <input type="radio" name="capture-flow-layout" value="nav-first"${
+                effectiveFlowLayout === "nav-first" ? " checked" : ""
+              } />
+              <span>Nav first</span>
+            </label>
+            <label class="capture-detail-view-option">
+              <input type="radio" name="capture-flow-layout" value="pair-first"${
+                effectiveFlowLayout === "pair-first" ? " checked" : ""
+              } />
+              <span>Pair first</span>
+            </label>
+          </div>
+          ${effectiveFlowLayout === "pair-first" ? flowSections.pair + flowSections.navigation : flowSections.navigation + flowSections.pair}
+        </div>`;
+    }
+    if (effectiveDetailView === "payload") {
+      return `
+        <section class="capture-detail-section">
+          <div class="capture-subview-switch" role="radiogroup" aria-label="Payload layout">
+            <label class="capture-detail-view-option">
+              <input type="radio" name="capture-payload-layout" value="formatted"${
+                effectivePayloadLayout === "formatted" ? " checked" : ""
+              } />
+              <span>Formatted</span>
+            </label>
+            <label class="capture-detail-view-option">
+              <input type="radio" name="capture-payload-layout" value="raw"${
+                effectivePayloadLayout === "raw" ? " checked" : ""
+              } />
+              <span>Raw preview</span>
+            </label>
+          </div>
+          <div class="capture-subview-switch" role="radiogroup" aria-label="Payload extent">
+            <label class="capture-detail-view-option">
+              <input type="radio" name="capture-payload-extent" value="preview"${
+                effectivePayloadExtent === "preview" ? " checked" : ""
+              } />
+              <span>Preview</span>
+            </label>
+            <label class="capture-detail-view-option">
+              <input type="radio" name="capture-payload-extent" value="full"${
+                effectivePayloadExtent === "full" ? " checked" : ""
+              } />
+              <span>Full inline</span>
+            </label>
+          </div>
+          <div class="capture-summary-header">
+            <div class="capture-summary-label">Payload</div>
+            <div class="capture-detail-mini-meta">
+              <span class="capture-chip">${esc(selectedPayload.mode)}</span>
+              <span class="capture-chip">${esc(selectedEvent.contentType || "unknown content-type")}</span>
+              ${selectedPayload.byteLength > 0 ? `<span class="capture-chip">${selectedPayload.byteLength.toLocaleString()} bytes previewed</span>` : ""}
+              ${
+                selectedPayload.mode === "sse" && selectedPayload.itemCount != null
+                  ? `<span class="capture-chip capture-chip-muted">${selectedPayload.visibleItemCount ?? selectedPayload.itemCount}/${selectedPayload.itemCount} frames</span>`
+                  : ""
+              }
+              ${selectedEvent.dataBlobId ? '<span class="capture-chip capture-chip-strong">blob-backed</span>' : ""}
+            </div>
+          </div>
+          ${
+            selectedPayload.mode === "sse"
+              ? `<div class="capture-payload-toolbar">
+                  <div class="capture-detail-radio-row" role="radiogroup" aria-label="Payload event sort">
+                    <label class="capture-detail-view-option">
+                      <input type="radio" name="capture-payload-event-sort" value="stream"${
+                        state.capturePayloadEventSort === "stream" ? " checked" : ""
+                      } />
+                      <span>Stream order</span>
+                    </label>
+                    <label class="capture-detail-view-option">
+                      <input type="radio" name="capture-payload-event-sort" value="name"${
+                        state.capturePayloadEventSort === "name" ? " checked" : ""
+                      } />
+                      <span>Name</span>
+                    </label>
+                    <label class="capture-detail-view-option">
+                      <input type="radio" name="capture-payload-event-sort" value="size"${
+                        state.capturePayloadEventSort === "size" ? " checked" : ""
+                      } />
+                      <span>Largest first</span>
+                    </label>
+                  </div>
+                  <label class="capture-search-field capture-payload-filter-field">Filter
+                    <input
+                      id="capture-payload-event-filter"
+                      type="search"
+                      value="${esc(state.capturePayloadEventFilter)}"
+                      placeholder="event name, field, payload text..."
+                      spellcheck="false"
+                    />
+                  </label>
+                </div>`
+              : ""
+          }
+          <div class="capture-detail-payload capture-detail-payload--${effectivePayloadExtent}">
+            ${effectivePayloadLayout === "raw" ? rawPayloadBody : selectedPayload.body}
+            ${
+              effectivePayloadLayout !== "raw" && selectedPayload.looksStructured
+                ? '<div class="text-dimmed text-sm capture-detail-note">Structured payloads are pretty-printed and secret-like fields are redacted for the UI.</div>'
+                : ""
+            }
+          </div>
+        </section>
+        ${
+          selectedEvent.dataBlobId
+            ? `<section class="capture-detail-section">
+                <div class="capture-summary-header">
+                  <div class="capture-summary-label">Stored Blob</div>
+                  <div class="capture-detail-mini-meta">
+                    <span class="capture-chip">full payload</span>
+                  </div>
+                </div>
+                <div class="capture-detail-actions">
+                  <span class="capture-mono">${esc(selectedEvent.dataBlobId)}</span>
+                  <a class="btn-sm" href="/api/capture/blob?id=${encodeURIComponent(selectedEvent.dataBlobId)}" target="_blank" rel="noreferrer">Open blob</a>
+                </div>
+                <div class="text-dimmed text-sm capture-detail-note">Blob access is intentionally raw and may contain unredacted content.</div>
+              </section>`
+            : ""
+        }`;
+    }
+    if (effectiveDetailView === "headers") {
+      return `
+        <section class="capture-detail-section">
+          <div class="capture-summary-header">
+            <div class="capture-summary-label">Headers</div>
+            <div class="capture-detail-mini-meta">
+              <span class="capture-chip">${selectedHeaderCount} captured</span>
+              ${selectedSensitiveHeaderCount > 0 ? `<span class="capture-chip capture-chip-warn">${selectedSensitiveHeaderCount} redacted</span>` : ""}
+              <span class="capture-chip capture-chip-muted">${esc(state.captureHeaderMode)}</span>
+            </div>
+          </div>
+          ${renderCaptureHeaders(selectedEvent.headersJson, state.captureHeaderMode)}
+          ${
+            state.captureHeaderMode !== "hidden" && selectedSensitiveHeaderCount > 0
+              ? '<div class="text-dimmed text-sm capture-detail-note">Sensitive header values are redacted in the UI.</div>'
+              : ""
+          }
+        </section>
+        ${
+          selectedHeaders && state.captureHeaderMode !== "hidden"
+            ? `<details class="capture-detail-raw">
+                <summary class="text-dimmed text-sm">Redacted headers JSON</summary>
+                <pre class="report-pre capture-pre capture-pre-json">${esc(
+                  JSON.stringify(redactCaptureValue(selectedHeaders), null, 2),
+                )}</pre>
+              </details>`
+            : ""
+        }`;
+    }
+    return `
+      <div class="capture-detail-stack">
+        <section class="capture-detail-section">
+          <div class="capture-summary-label">Overview</div>
+          ${renderCaptureKeyValueGrid([
+            { label: "time", value: new Date(selectedEvent.ts).toLocaleString() },
+            { label: "target", value: [selectedEvent.method, selectedEvent.host, selectedEvent.path].filter(Boolean).join(" ") || "n/a" },
+            { label: "provider route", value: [selectedEvent.provider, selectedEvent.model, selectedEvent.api].filter(Boolean).join(" · ") || "unlabeled" },
+            { label: "capture origin", value: selectedEvent.captureOrigin || "runtime/default" },
+          ])}
+        </section>
+        <section class="capture-detail-section">
+          <div class="capture-summary-label">Fields</div>
+          ${renderCaptureKeyValueGrid(selectedMetaRows)}
+        </section>
+        ${
+          selectedEvent.errorText
+            ? `<section class="capture-detail-section"><div class="capture-summary-label">Error</div><div class="capture-error">${esc(selectedEvent.errorText)}</div></section>`
+            : ""
+        }
+      </div>`;
+  };
+  return `
+    <div class="events-view">
+      <div class="events-header">
+        <span class="events-header-title">Proxy Capture</span>
+        <span class="text-dimmed text-sm">${sessions.length} sessions · ${filteredEvents.length}/${events.length} events shown</span>
+      </div>
+      <div class="text-dimmed text-sm" style="margin-bottom:14px">
+        Raw traffic always appears in <strong>Recent Events</strong>. The preset only controls the optional analysis panel.
+      </div>
+      <div class="capture-controls-shell">
+        <div class="capture-controls-toolbar">
+          <div class="capture-controls-summary">
+            <span class="capture-chip capture-chip-muted">${selectedSessions.length || 0} session${selectedSessions.length === 1 ? "" : "s"}</span>
+            <span class="capture-chip capture-chip-muted">${state.captureViewMode}</span>
+            ${
+              state.captureQueryPreset !== "none"
+                ? `<span class="capture-chip capture-chip-muted">analysis: ${esc(state.captureQueryPreset)}</span>`
+                : `<span class="capture-chip capture-chip-muted">raw only</span>`
+            }
+            <span class="capture-chip capture-chip-muted">${activeFilters.length} filter${activeFilters.length === 1 ? "" : "s"}</span>
+            ${
+              state.captureViewMode === "timeline"
+                ? `<span class="capture-chip capture-chip-muted">lanes: ${esc(state.captureTimelineLaneMode)}</span>`
+                : ""
+            }
+          </div>
+          <div class="capture-controls-actions">
+            ${
+              selectedSessions.length > 0
+                ? `<button class="btn-sm" type="button" id="capture-summary-toggle">
+                    ${state.captureSummaryExpanded ? "Hide summary" : "Show summary"}
+                  </button>`
+                : ""
+            }
+            ${
+              activeFilters.length > 0
+                ? `<button
+                    id="capture-clear-filters"
+                    class="secondary-button capture-clear-filters"
+                    type="button"
+                  >Clear filters</button>`
+                : ""
+            }
+            <button class="btn-sm" type="button" id="capture-controls-toggle">
+              ${state.captureControlsExpanded ? "Collapse controls" : "Show controls"}
+            </button>
+          </div>
+        </div>
+        ${
+          state.captureControlsExpanded
+            ? `<div class="capture-controls-panel">
+      <div class="capture-controls-grid">
+        <label class="capture-session-filter">Session
+          <select id="capture-session" multiple size="${Math.min(3, Math.max(2, sessions.length || 2))}">
+            ${sessions
+              .map(
+                (session) => `<option value="${esc(session.id)}"${
+                  sessionIds.includes(session.id) ? " selected" : ""
+                }>${esc(new Date(session.startedAt).toLocaleString())} · ${esc(session.mode)} · ${session.eventCount} events</option>`,
+              )
+              .join("")}
+          </select>
+        </label>
+        <div class="capture-inline-actions">
+          <label class="capture-saved-view-filter">Saved view
+            <select id="capture-saved-view">
+              <option value="">apply saved view…</option>
+              ${state.captureSavedViews
+                .map((view) => `<option value="${esc(view.id)}">${esc(view.name)}</option>`)
+                .join("")}
+            </select>
+          </label>
+          <button id="capture-save-view" class="btn-sm" type="button">Save view</button>
+          <button
+            id="capture-delete-view"
+            class="btn-sm"
+            type="button"${state.captureSavedViews.length === 0 ? " disabled" : ""}
+          >Delete view</button>
+        </div>
+        ${
+          selectedSessions.length > 0
+            ? `<div class="capture-selected-sessions-shell">
+                <div class="capture-selected-sessions-summary">
+                  <span class="capture-chip capture-chip-muted">${selectedSessions.length} selected</span>
+                  ${
+                    selectedSessions.length > 1
+                      ? `<button
+                          id="capture-toggle-selected-sessions"
+                          class="btn-sm"
+                          type="button"
+                        >${state.captureSelectedSessionsExpanded ? "Hide selected" : "Manage selected"}</button>`
+                      : ""
+                  }
+                </div>
+                ${
+                  state.captureSelectedSessionsExpanded || selectedSessions.length === 1
+                    ? `<div class="capture-selected-sessions">
+                        ${selectedSessions
+                          .map(
+                            (session) => `<button
+                              type="button"
+                              class="capture-selected-session-chip"
+                              data-capture-session-remove="${esc(session.id)}"
+                              title="Remove ${esc(new Date(session.startedAt).toLocaleString())}"
+                            >
+                              <span class="capture-selected-session-chip-label">${esc(new Date(session.startedAt).toLocaleString())}</span>
+                              <span class="capture-selected-session-chip-x">×</span>
+                            </button>`,
+                          )
+                          .join("")}
+                      </div>`
+                    : ""
+                }
+              </div>`
+            : ""
+        }
+        <div class="capture-inline-actions">
+          <button
+            id="capture-delete-selected-sessions"
+            class="btn-sm"
+            type="button"${selectedSessions.length === 0 ? " disabled" : ""}
+          >Delete selected data</button>
+          <button
+            id="capture-purge-all"
+            class="btn-sm"
+            type="button"${sessions.length === 0 ? " disabled" : ""}
+          >Purge all data</button>
+        </div>
+        <label>Analysis
+          <select id="capture-preset">
+            ${(
+              [
+                "none",
+                "double-sends",
+                "retry-storms",
+                "cache-busting",
+                "ws-duplicate-frames",
+                "missing-ack",
+                "error-bursts",
+              ] as CaptureQueryPreset[]
+            )
+              .map(
+                (preset) =>
+                  `<option value="${preset}"${
+                    preset === state.captureQueryPreset ? " selected" : ""
+                  }>${preset === "none" ? "none (show raw events only)" : preset}</option>`,
+              )
+              .join("")}
+          </select>
+        </label>
+        <label>Kind
+          <select id="capture-kind-filter" multiple size="${Math.min(6, Math.max(3, availableKinds.length || 3))}">
+            ${availableKinds
+              .map(
+                (kind) =>
+                  `<option value="${esc(kind)}"${
+                    state.captureKindFilter.includes(kind) ? " selected" : ""
+                  }>${esc(kind)}</option>`,
+              )
+              .join("")}
+          </select>
+        </label>
+        <label>Provider
+          <select id="capture-provider-filter" multiple size="${Math.min(6, Math.max(3, availableProviders.length || 3))}">
+            ${availableProviders
+              .map(
+                (provider) =>
+                  `<option value="${esc(provider)}"${
+                    state.captureProviderFilter.includes(provider) ? " selected" : ""
+                  }>${esc(provider)}</option>`,
+              )
+              .join("")}
+          </select>
+        </label>
+        <label>Host
+          <select id="capture-host-filter" multiple size="${Math.min(6, Math.max(3, availableHosts.length || 3))}">
+            ${availableHosts
+              .map(
+                (host) =>
+                  `<option value="${esc(host)}"${
+                    state.captureHostFilter.includes(host) ? " selected" : ""
+                  }>${esc(host)}</option>`,
+              )
+              .join("")}
+          </select>
+        </label>
+        <label>View
+          <select id="capture-view-mode">
+            <option value="list"${state.captureViewMode === "list" ? " selected" : ""}>list</option>
+            <option value="timeline"${state.captureViewMode === "timeline" ? " selected" : ""}>timeline</option>
+          </select>
+        </label>
+        ${
+          state.captureViewMode === "timeline"
+            ? `
+        <label>Timeline Lanes
+          <select id="capture-timeline-lane-mode">
+            <option value="domain"${state.captureTimelineLaneMode === "domain" ? " selected" : ""}>domain</option>
+            <option value="provider"${state.captureTimelineLaneMode === "provider" ? " selected" : ""}>provider</option>
+            <option value="flow"${state.captureTimelineLaneMode === "flow" ? " selected" : ""}>flow</option>
+          </select>
+        </label>
+        <label>Lane Sort
+          <select id="capture-timeline-lane-sort">
+            <option value="most-events"${state.captureTimelineLaneSort === "most-events" ? " selected" : ""}>most events</option>
+            <option value="most-errors"${state.captureTimelineLaneSort === "most-errors" ? " selected" : ""}>most errors</option>
+            <option value="severity"${state.captureTimelineLaneSort === "severity" ? " selected" : ""}>severity</option>
+            <option value="alphabetical"${state.captureTimelineLaneSort === "alphabetical" ? " selected" : ""}>alphabetical</option>
+          </select>
+        </label>
+        <label class="capture-search-field">Lane Search
+          <input
+            id="capture-timeline-lane-search"
+            type="search"
+            value="${esc(state.captureTimelineLaneSearch)}"
+            placeholder="provider, host, flow..."
+            spellcheck="false"
+          />
+        </label>
+        <label>Timeline Zoom
+          <select id="capture-timeline-zoom">
+            <option value="75"${state.captureTimelineZoom === 75 ? " selected" : ""}>75%</option>
+            <option value="100"${state.captureTimelineZoom === 100 ? " selected" : ""}>100%</option>
+            <option value="150"${state.captureTimelineZoom === 150 ? " selected" : ""}>150%</option>
+            <option value="200"${state.captureTimelineZoom === 200 ? " selected" : ""}>200%</option>
+            <option value="300"${state.captureTimelineZoom === 300 ? " selected" : ""}>300%</option>
+          </select>
+        </label>
+        <label>Sparkline
+          <select id="capture-timeline-sparkline-mode">
+            <option value="session-relative"${state.captureTimelineSparklineMode === "session-relative" ? " selected" : ""}>session-relative</option>
+            <option value="lane-relative"${state.captureTimelineSparklineMode === "lane-relative" ? " selected" : ""}>lane-relative</option>
+          </select>
+        </label>
+        <button
+          id="capture-timeline-clear-window"
+          class="secondary-button capture-clear-filters"
+          type="button"${
+            activeWindowStartPct == null && draftWindowStartPct == null ? " disabled" : ""
+          }
+        >Clear window</button>
+        <label class="capture-checkbox">
+          <input
+            id="capture-timeline-focus-flow"
+            type="checkbox"${
+              state.captureTimelineFocusSelectedFlow ? " checked" : ""
+            }${selectedEvent?.flowId ? "" : " disabled"}
+          />
+          <span>focus selected flow</span>
+        </label>
+        <label>Focused Lanes
+          <select id="capture-timeline-focused-lane-mode"${state.captureTimelineFocusSelectedFlow && selectedEvent?.flowId ? "" : " disabled"}>
+            <option value="all"${state.captureTimelineFocusedLaneMode === "all" ? " selected" : ""}>show all</option>
+            <option value="only-matching"${state.captureTimelineFocusedLaneMode === "only-matching" ? " selected" : ""}>only matching</option>
+            <option value="collapse-background"${state.captureTimelineFocusedLaneMode === "collapse-background" ? " selected" : ""}>collapse background</option>
+          </select>
+        </label>
+        <label>Focus Threshold
+          <select id="capture-timeline-focused-lane-threshold"${state.captureTimelineFocusSelectedFlow && selectedEvent?.flowId ? "" : " disabled"}>
+            <option value="any"${state.captureTimelineFocusedLaneThreshold === "any" ? " selected" : ""}>any presence</option>
+            <option value="events-2"${state.captureTimelineFocusedLaneThreshold === "events-2" ? " selected" : ""}>2+ events</option>
+            <option value="percent-10"${state.captureTimelineFocusedLaneThreshold === "percent-10" ? " selected" : ""}>10%+ of lane</option>
+            <option value="percent-25"${state.captureTimelineFocusedLaneThreshold === "percent-25" ? " selected" : ""}>25%+ of lane</option>
+          </select>
+        </label>`
+            : `
+        <label>Group
+          <select id="capture-group-mode">
+            <option value="none"${state.captureGroupMode === "none" ? " selected" : ""}>flat stream</option>
+            <option value="burst"${state.captureGroupMode === "burst" ? " selected" : ""}>burst clusters</option>
+            <option value="flow"${state.captureGroupMode === "flow" ? " selected" : ""}>flow id</option>
+            <option value="host-path"${state.captureGroupMode === "host-path" ? " selected" : ""}>host + path</option>
+          </select>
+        </label>`
+        }
+        <label>Detail Pane
+          <select id="capture-detail-placement">
+            <option value="right"${state.captureDetailPlacement === "right" ? " selected" : ""}>right</option>
+            <option value="bottom"${state.captureDetailPlacement === "bottom" ? " selected" : ""}>bottom</option>
+          </select>
+        </label>
+        <label>Headers
+          <select id="capture-header-mode">
+            <option value="key"${state.captureHeaderMode === "key" ? " selected" : ""}>key only</option>
+            <option value="all"${state.captureHeaderMode === "all" ? " selected" : ""}>all</option>
+            <option value="hidden"${state.captureHeaderMode === "hidden" ? " selected" : ""}>hidden</option>
+          </select>
+        </label>
+        <label class="capture-search-field">Search
+          <input
+            id="capture-search-filter"
+            type="search"
+            value="${esc(state.captureSearchText)}"
+            placeholder="host, path, method, status, payload..."
+            spellcheck="false"
+          />
+        </label>
+        <label class="capture-checkbox">
+          <input id="capture-errors-only" type="checkbox"${state.captureErrorsOnly ? " checked" : ""} />
+          <span>errors only</span>
+        </label>
+      </div></div>`
+            : ""
+        }
+      </div>
+      ${
+        state.captureControlsExpanded && activeFilters.length > 0
+          ? `<div class="capture-active-filters">
+              <span class="capture-summary-label" style="margin:0">Active Filters</span>
+              <div class="capture-chip-row">
+                ${activeFilters.map((filter) => `<span class="capture-chip capture-chip-muted">${esc(filter)}</span>`).join("")}
+              </div>
+            </div>`
+          : ""
+      }
+      ${
+        selectedSessions.length > 0 && state.captureSummaryExpanded
+          ? `<div class="capture-summary capture-summary--expanded">
+              <div class="capture-summary-card">
+                <div class="capture-summary-label">Session</div>
+                <div class="capture-summary-value">${
+                  singleSelectedSession
+                    ? esc(new Date(singleSelectedSession.startedAt).toLocaleString())
+                    : `${selectedSessions.length} sessions selected`
+                }</div>
+                <div class="text-dimmed text-sm">${
+                  singleSelectedSession
+                    ? `${esc(singleSelectedSession.mode)} · ${singleSelectedSession.eventCount} stored events`
+                    : `${selectedSessionEventCount} stored events across ${selectedSessions.length} sessions`
+                }</div>
+              </div>
+              <div class="capture-summary-card">
+                <div class="capture-summary-label">What You’re Seeing</div>
+                <div class="capture-chip-row">
+                  ${summaryChips.map((chip) => `<span class="capture-chip">${esc(chip)}</span>`).join("")}
+                </div>
+                ${
+                  summaryMeta.length > 0
+                    ? `<div class="capture-summary-meta text-dimmed text-sm">${summaryMeta.map((part) => esc(part)).join(" · ")}</div>`
+                    : ""
+                }
+                ${
+                  state.captureQueryPreset !== "none" && sessionIds.length > 1
+                    ? '<div class="capture-summary-note text-dimmed text-sm">Analysis presets currently run on a single session only. Raw traffic below is merged across the selected sessions.</div>'
+                    : ""
+                }
+                ${
+                  state.captureViewMode === "timeline"
+                    ? '<div class="capture-summary-note text-dimmed text-sm">Keys: 1-4 views · ←/→ markers · Home/End jump · Esc clears brush · drag sparkline bins · Shift+drag widens.</div>'
+                    : ""
+                }
+              </div>
+              <div class="capture-summary-card">
+                <div class="capture-summary-label">Visible Event Kinds</div>
+                <div class="capture-chip-row">
+                  ${
+                    topKinds.length > 0
+                      ? topKinds
+                          .map(
+                            ([kind, count]) =>
+                              `<span class="capture-chip">${esc(kind)} · ${count}</span>`,
+                          )
+                          .join("")
+                      : '<span class="text-dimmed text-sm">No events match the current filters.</span>'
+                  }
+                </div>
+              </div>
+              <div class="capture-summary-card">
+                <div class="capture-summary-label">Observed Providers</div>
+                <div class="capture-chip-row">
+                  ${
+                    topProviders.length > 0
+                      ? topProviders
+                          .map(
+                            (provider) =>
+                              `<span class="capture-chip">${esc(provider.value)} · ${provider.count}</span>`,
+                          )
+                          .join("")
+                      : '<span class="text-dimmed text-sm">No provider metadata captured for this session yet.</span>'
+                  }
+                </div>
+                ${
+                  topModels.length > 0
+                    ? `<div class="capture-summary-meta text-dimmed text-sm">Top models: ${topModels
+                        .map((model) => `${esc(model.value)} (${model.count})`)
+                        .join(", ")}</div>`
+                    : ""
+                }
+                ${
+                  state.captureCoverage
+                    ? `<div class="capture-summary-meta text-dimmed text-sm">${state.captureCoverage.totalEvents} total events · ${state.captureCoverage.unlabeledEventCount} unlabeled by provider/model/api</div>`
+                    : ""
+                }
+              </div>
+            </div>`
+          : ""
+      }
+      <div class="results-view"${analysisEnabled ? ' style="grid-template-columns: minmax(420px, 1.7fr) minmax(280px, 0.9fr);"' : ""}>
+        <div class="results-inspector">
+          <div
+            class="capture-body capture-body--detail-${state.captureDetailPlacement}"
+            data-capture-detail-split-root
+            style="--capture-detail-pane-width:${state.captureDetailSplitPct.toFixed(2)}%;"
+          >
+            <section class="capture-main-panel">
+              <div class="inspector-section-title">${state.captureViewMode === "timeline" ? "Timeline" : "Recent Events"}</div>
+              <div class="events-scroll capture-events-scroll">
+                ${
+                  events.length === 0
+                    ? `<div style="padding:20px">${renderCaptureStartupInstructions(state.captureStartupStatus)}</div>`
+                    : filteredEvents.length === 0
+                      ? '<div class="empty-state" style="padding:20px">No events match the current filters or search text.</div>'
+                      : state.captureViewMode === "timeline"
+                        ? `<div class="capture-timeline" style="${timelineWidthStyle}">
+                        <div class="capture-timeline-legend">
+                          <span class="capture-timeline-legend-item"><span class="capture-timeline-legend-dot capture-timeline-legend-dot-request"></span>request</span>
+                          <span class="capture-timeline-legend-item"><span class="capture-timeline-legend-dot capture-timeline-legend-dot-response"></span>response</span>
+                          <span class="capture-timeline-legend-item"><span class="capture-timeline-legend-dot capture-timeline-legend-dot-error"></span>error</span>
+                          <span class="capture-timeline-legend-item"><span class="capture-timeline-legend-dot capture-timeline-legend-dot-ws"></span>ws</span>
+                          <span class="capture-timeline-legend-item"><span class="capture-timeline-legend-line"></span>flow trail</span>
+                          ${
+                            activeWindowStartPct != null && activeWindowEndPct != null
+                              ? '<span class="capture-timeline-legend-item"><span class="capture-timeline-legend-window"></span>active window</span>'
+                              : ""
+                          }
+                        </div>
+                        <div class="capture-timeline-axis-grid">
+                          <div class="capture-timeline-axis-spacer"></div>
+                          <div class="capture-timeline-viewport capture-timeline-brush-surface" data-capture-timeline-brush-surface="axis" data-capture-timeline-track-width="${timelineTrackWidthPx}">
+                            <div class="capture-timeline-axis">
+                              ${renderTimelineWindow(activeWindowStartPct, activeWindowEndPct, "capture-timeline-window")}
+                              ${renderTimelineWindow(draftWindowStartPct, draftWindowEndPct, "capture-timeline-window capture-timeline-window-draft")}
+                              ${timelineAxisTicks
+                                .map(
+                                  (tick) => `<div class="capture-timeline-axis-tick ${tick.edgeClass}" style="left:${tick.pct.toFixed(2)}%">
+                                    <span class="capture-timeline-axis-tick-line"></span>
+                                    <span class="capture-timeline-axis-tick-label">${esc(tick.label)}</span>
+                                  </div>`,
+                                )
+                                .join("")}
+                            </div>
+                          </div>
+                        </div>
+                        ${visibleTimelineLanes.length === 0
+                          ? '<div class="empty-state" style="padding:20px">No timeline lanes match the current lane search.</div>'
+                          : visibleTimelineLanes
+                          .map((lane) => {
+                            const laneErrorCount = lane.events.filter(
+                              (event) => Boolean(event.errorText) || (event.status ?? 0) >= 400,
+                            ).length;
+                            const laneRequestCount = lane.events.filter((event) => event.kind === "request").length;
+                            const laneResponseCount = lane.events.filter((event) => event.kind === "response").length;
+                            const collapsed = collapsedLaneIds.has(lane.id);
+                            const pinned = pinnedLaneIds.has(lane.id);
+                            const sortedLaneEvents = [...lane.events].sort((left, right) => left.ts - right.ts);
+                            const markerGapPx = 16;
+                            const rowStridePx = 18;
+                            const baselineTopPx = 18;
+                            const rowRightEdges: number[] = [];
+                            const packedMarkers = sortedLaneEvents.map((event) => {
+                              const key = captureEventKey(event);
+                              const leftPct = ((event.ts - minTs) / totalSpanMs) * 100;
+                              const leftPx = (leftPct / 100) * timelineTrackWidthPx;
+                              let rowIndex = 0;
+                              while (
+                                rowIndex < rowRightEdges.length &&
+                                rowRightEdges[rowIndex] > leftPx - markerGapPx
+                              ) {
+                                rowIndex += 1;
+                              }
+                              rowRightEdges[rowIndex] = leftPx + markerGapPx;
+                              const topPx = baselineTopPx + rowIndex * rowStridePx;
+                              return { event, key, leftPct, leftPx, rowIndex, topPx };
+                            });
+                            const laneRowCount = Math.max(
+                              1,
+                              packedMarkers.reduce((max, marker) => Math.max(max, marker.rowIndex + 1), 1),
+                            );
+                            const laneTrackHeightPx = collapsed ? 18 : Math.max(42, baselineTopPx + (laneRowCount - 1) * rowStridePx + 18);
+                            const selectedLaneEvent =
+                              lane.events.find((event) => {
+                                const key = captureEventKey(event);
+                                return key === selectedEventKey;
+                              }) ?? null;
+                            const selectedFlowId = selectedLaneEvent?.flowId || selectedEvent?.flowId || "";
+                            const focusSelectedFlow =
+                              state.captureTimelineFocusSelectedFlow && selectedFlowId.length > 0;
+                            const laneFocusedEventCount = focusSelectedFlow
+                              ? lane.events.filter((event) => event.flowId === selectedFlowId).length
+                              : 0;
+                            const laneBackgroundEventCount = focusSelectedFlow
+                              ? lane.events.length - laneFocusedEventCount
+                              : 0;
+                            const laneFocusedPercent =
+                              focusSelectedFlow && lane.events.length > 0
+                                ? Math.round((laneFocusedEventCount / lane.events.length) * 100)
+                                : 0;
+                            const laneSelected = selectedLaneEvent != null;
+                            const laneSeverity = describeLaneSeverity(lane.events);
+                            const laneMeetsThreshold = focusSelectedFlow
+                              ? laneMeetsFocusedThreshold(laneFocusedEventCount, lane.events.length)
+                              : false;
+                            const autoCollapsed =
+                              focusSelectedFlow &&
+                              focusedLaneMode === "collapse-background" &&
+                              !laneMeetsThreshold;
+                            const laneCompactMetaParts = [
+                              focusSelectedFlow
+                                ? `${laneFocusedPercent}% focus${laneBackgroundEventCount > 0 ? ` · ${laneBackgroundEventCount} bg` : ""}`
+                                : null,
+                              laneErrorCount > 0 ? `${laneErrorCount} err` : null,
+                              state.captureTimelineLaneSort === "severity" ? laneSeverity.summary : null,
+                              autoCollapsed ? "auto-collapsed" : null,
+                            ].filter((value): value is string => Boolean(value));
+                            const previousIndex = previousLanePosition.get(lane.id);
+                            const currentIndex = timelineLanes.findIndex((candidate) => candidate.id === lane.id);
+                            const laneMovement =
+                              previousIndex == null
+                                ? null
+                                : previousIndex - currentIndex;
+                            const laneIsCollapsed = collapsed || autoCollapsed;
+                            const flowLinks = laneIsCollapsed
+                              ? ""
+                              : Array.from(
+                                  packedMarkers.reduce<Map<string, typeof packedMarkers>>((flows, marker) => {
+                                    const flowId = marker.event.flowId?.trim();
+                                    if (!flowId) {
+                                      return flows;
+                                    }
+                                    const existing = flows.get(flowId) ?? [];
+                                    existing.push(marker);
+                                    flows.set(flowId, existing);
+                                    return flows;
+                                  }, new Map()),
+                                )
+                                  .flatMap(([, markers]) => {
+                                    if (markers.length < 2) {
+                                      return [];
+                                    }
+                                    return markers.slice(1).map((marker, index) => {
+                                      const previous = markers[index];
+                                      const dx = marker.leftPx - previous.leftPx;
+                                      const dy = marker.topPx - previous.topPx;
+                                      const length = Math.sqrt(dx * dx + dy * dy);
+                                      const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
+                                      const selected =
+                                        selectedFlowId.length > 0 && marker.event.flowId === selectedFlowId;
+                                      const dimmed = focusSelectedFlow && marker.event.flowId !== selectedFlowId;
+                                      const paired =
+                                        pairedEventKey != null && captureEventKey(marker.event) === pairedEventKey;
+                                      return `<div
+                                        class="capture-timeline-flow-link${selected ? " selected" : ""}${dimmed ? " dimmed" : ""}${paired ? " paired" : ""}"
+                                        style="left:${previous.leftPct.toFixed(2)}%;top:${previous.topPx}px;width:${length.toFixed(2)}px;transform:translateY(-50%) rotate(${angle.toFixed(2)}deg)"
+                                      ></div>`;
+                                    });
+                                  })
+                                  .join("");
+                            const laneGuides = timelineAxisTicks
+                              .slice(1, -1)
+                              .map(
+                                (tick) => `<div
+                                  class="capture-timeline-guide"
+                                  style="left:${tick.pct.toFixed(2)}%"
+                                  aria-hidden="true"
+                                ></div>`,
+                              )
+                              .join("");
+                            const markers = packedMarkers
+                              .map(({ event, key, leftPct, topPx }) => {
+                                const selected = selectedEventKey != null && key === selectedEventKey;
+                                const kindClass = `capture-timeline-marker-${event.kind.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`;
+                                const dimmed = focusSelectedFlow && event.flowId !== selectedFlowId;
+                                const paired = pairedEventKey != null && key === pairedEventKey;
+                                const label = [
+                                  formatTime(event.ts),
+                                  event.provider,
+                                  event.model,
+                                  event.kind,
+                                  event.method,
+                                  event.host,
+                                  event.path,
+                                  event.status ? `status ${event.status}` : "",
+                                  event.errorText ?? "",
+                                ]
+                                  .filter(Boolean)
+                                  .join(" · ");
+                                return `<button
+                                  class="capture-timeline-marker ${kindClass}${selected ? " selected" : ""}${dimmed ? " dimmed" : ""}${paired ? " paired" : ""}"
+                                  data-capture-event="${esc(key)}"
+                                  type="button"
+                                  style="left:${leftPct.toFixed(2)}%;top:${topPx}px"
+                                  title="${esc(label)}"
+                                ></button>`;
+                              })
+                              .join("");
+                            const collapsedMarkers = laneIsCollapsed
+                              ? packedMarkers
+                                  .map(({ event, key, leftPct }) => {
+                                    const selected = selectedEventKey != null && key === selectedEventKey;
+                                    const kindClass = `capture-timeline-marker-${event.kind
+                                      .replace(/[^a-z0-9]+/gi, "-")
+                                      .toLowerCase()}`;
+                                    const dimmed = focusSelectedFlow && event.flowId !== selectedFlowId;
+                                    const paired = pairedEventKey != null && key === pairedEventKey;
+                                    return `<button
+                                      class="capture-timeline-marker capture-timeline-marker-mini ${kindClass}${
+                                        selected ? " selected" : ""
+                                      }${dimmed ? " dimmed" : ""}${paired ? " paired" : ""}"
+                                      data-capture-event="${esc(key)}"
+                                      type="button"
+                                      style="left:${leftPct.toFixed(2)}%;top:${baselineTopPx}px"
+                                      title="${esc(
+                                        [formatTime(event.ts), event.kind, event.host, event.path]
+                                          .filter(Boolean)
+                                          .join(" · "),
+                                      )}"
+                                    ></button>`;
+                                  })
+                                  .join("")
+                              : "";
+                            const selectedLaneLeft =
+                              selectedLaneEvent == null
+                                ? 50
+                                : Math.min(
+                                    84,
+                                    Math.max(
+                                      16,
+                                      ((selectedLaneEvent.ts - minTs) / totalSpanMs) * 100,
+                                    ),
+                                  );
+                            const quickPreview =
+                              selectedLaneEvent && !laneIsCollapsed
+                                ? `<div class="capture-timeline-quick-preview" style="left:${selectedLaneLeft.toFixed(2)}%">
+                                    <div class="capture-timeline-quick-preview-row">
+                                      <span class="capture-chip">${esc(selectedLaneEvent.kind)}</span>
+                                      ${
+                                        selectedLaneEvent.provider
+                                          ? `<span class="capture-chip">${esc(selectedLaneEvent.provider)}</span>`
+                                          : ""
+                                      }
+                                      ${
+                                        selectedLaneEvent.status
+                                          ? `<span class="capture-chip capture-chip-muted">status ${selectedLaneEvent.status}</span>`
+                                          : ""
+                                      }
+                                    </div>
+                                    <div class="capture-timeline-quick-preview-title">${esc(
+                                      [selectedLaneEvent.method, selectedLaneEvent.host, selectedLaneEvent.path]
+                                        .filter(Boolean)
+                                        .join(" ") || selectedLaneEvent.flowId,
+                                    )}</div>
+                                    <div class="capture-timeline-quick-preview-meta">${esc(
+                                      [
+                                        new Date(selectedLaneEvent.ts).toLocaleTimeString(),
+                                        selectedLaneEvent.model,
+                                        selectedLaneEvent.api,
+                                      ]
+                                        .filter(Boolean)
+                                        .join(" · "),
+                                    )}</div>
+                                    ${
+                                      selectedLaneEvent.errorText
+                                        ? `<div class="capture-timeline-quick-preview-error">${esc(selectedLaneEvent.errorText)}</div>`
+                                        : selectedLaneEvent.payloadPreview
+                                          ? `<div class="capture-timeline-quick-preview-snippet">${esc(selectedLaneEvent.payloadPreview)}</div>`
+                                          : ""
+                                    }
+                                  </div>`
+                                : "";
+                            return `<div class="capture-timeline-lane${laneSelected ? " selected" : ""}">
+                                <div class="capture-timeline-lane-label${laneSelected ? " selected" : ""}">
+                                  <div class="capture-timeline-lane-toolbar">
+                                    <button class="capture-timeline-lane-toggle" data-capture-lane-toggle="${esc(lane.id)}" type="button">
+                                      <span class="capture-timeline-lane-chevron">${laneIsCollapsed ? "▸" : "▾"}</span>
+                                      <span class="capture-timeline-lane-title">${esc(lane.label)}</span>
+                                    </button>
+                                    <button class="capture-timeline-lane-pin${pinned ? " pinned" : ""}" data-capture-lane-pin="${esc(lane.id)}" type="button" title="${pinned ? "Unpin lane" : "Pin lane"}">
+                                      ${pinned ? "★" : "☆"}
+                                    </button>
+                                  </div>
+                                  <div class="capture-timeline-lane-meta">${lane.events.length} event${lane.events.length === 1 ? "" : "s"}${
+                                    lane.meta ? ` · ${esc(lane.meta)}` : ""
+                                  }</div>
+                                  ${
+                                    focusSelectedFlow && laneSelected
+                                      ? `<div class="capture-timeline-lane-focus-meta">
+                                          <span class="capture-mono">${esc(selectedFlowId)}</span>
+                                          <span>·</span>
+                                          <span>${laneFocusedEventCount}/${lane.events.length} events focused</span>
+                                          <span>·</span>
+                                          <span>${laneFocusedPercent}% of lane</span>
+                                          ${
+                                            laneBackgroundEventCount > 0
+                                              ? `<span>·</span><span>${laneBackgroundEventCount} background</span>`
+                                              : ""
+                                          }
+                                          ${
+                                            focusSelectedFlow && !laneMeetsThreshold
+                                              ? `<span>·</span><span>below threshold</span>`
+                                              : ""
+                                          }
+                                        </div>`
+                                      : ""
+                                  }
+                                  ${
+                                    autoCollapsed && laneSelected
+                                      ? '<div class="capture-timeline-lane-meta">Auto-collapsed because the focused flow is not present in this lane.</div>'
+                                      : ""
+                                  }
+                                  ${
+                                    !laneSelected && laneCompactMetaParts.length > 0
+                                      ? `<div class="capture-timeline-lane-compact-meta">${esc(laneCompactMetaParts.join(" · "))}</div>`
+                                      : ""
+                                  }
+                                  ${renderLaneSparkline(lane.events, lane.id)}
+                                  <div class="capture-timeline-lane-stats">
+                                    <span class="capture-timeline-stat" title="requests">
+                                      <span class="capture-timeline-stat-key capture-timeline-stat-key-request">R</span>
+                                      <span class="capture-timeline-stat-value">${laneRequestCount}</span>
+                                    </span>
+                                    <span class="capture-timeline-stat" title="responses">
+                                      <span class="capture-timeline-stat-key capture-timeline-stat-key-response">S</span>
+                                      <span class="capture-timeline-stat-value">${laneResponseCount}</span>
+                                    </span>
+                                    ${
+                                      laneMovement == null || laneMovement === 0
+                                        ? ""
+                                        : `<span class="capture-chip capture-chip-movement capture-timeline-inline-chip ${
+                                            laneMovement > 0 ? "up" : "down"
+                                          }">${laneMovement > 0 ? `up ${laneMovement}` : `down ${Math.abs(laneMovement)}`}</span>`
+                                    }
+                                    ${
+                                      state.captureTimelineLaneSort === "severity"
+                                        ? `<span class="capture-chip capture-chip-severity capture-timeline-inline-chip">severity ${laneSeverity.score.toFixed(1)}</span>`
+                                        : ""
+                                    }
+                                    ${
+                                      focusSelectedFlow
+                                        ? `<span class="capture-timeline-stat" title="focused flow events">
+                                            <span class="capture-timeline-stat-key capture-timeline-stat-key-focus">F</span>
+                                            <span class="capture-timeline-stat-value">${laneFocusedEventCount}</span>
+                                          </span>`
+                                        : ""
+                                    }
+                                    ${
+                                      focusSelectedFlow && laneBackgroundEventCount > 0
+                                        ? `<span class="capture-timeline-stat" title="background events">
+                                            <span class="capture-timeline-stat-key capture-timeline-stat-key-background">B</span>
+                                            <span class="capture-timeline-stat-value">${laneBackgroundEventCount}</span>
+                                          </span>`
+                                        : ""
+                                    }
+                                    ${
+                                      laneErrorCount > 0
+                                        ? `<span class="capture-timeline-stat capture-timeline-stat-danger" title="errors">
+                                            <span class="capture-timeline-stat-key capture-timeline-stat-key-error">!</span>
+                                            <span class="capture-timeline-stat-value">${laneErrorCount}</span>
+                                          </span>`
+                                        : ""
+                                    }
+                                  </div>
+                                  ${
+                                    laneSelected && (state.captureTimelineLaneSort === "severity" || laneMovement != null)
+                                      ? `<div class="capture-timeline-lane-severity">${
+                                          laneMovement == null || laneMovement === 0
+                                            ? ""
+                                            : `<span class="capture-timeline-lane-movement-copy">${
+                                                laneMovement > 0
+                                                  ? `Moved up ${laneMovement} from ${state.captureTimelinePreviousLaneSort}`
+                                                  : `Moved down ${Math.abs(laneMovement)} from ${state.captureTimelinePreviousLaneSort}`
+                                              }</span>${
+                                                state.captureTimelineLaneSort === "severity" ? " · " : ""
+                                              }`
+                                        }${
+                                          state.captureTimelineLaneSort === "severity"
+                                            ? esc(laneSeverity.summary)
+                                            : ""
+                                        }</div>`
+                                      : ""
+                                  }
+                                </div>
+                                <div class="capture-timeline-viewport">
+                                  <div class="capture-timeline-lane-track${laneIsCollapsed ? " collapsed" : ""}${laneSelected ? " selected" : ""}" style="height:${laneTrackHeightPx}px">
+                                    ${renderTimelineWindow(activeWindowStartPct, activeWindowEndPct, "capture-timeline-window")}
+                                    ${renderTimelineWindow(draftWindowStartPct, draftWindowEndPct, "capture-timeline-window capture-timeline-window-draft")}
+                                    ${laneGuides}
+                                    <div class="capture-timeline-track-line" style="top:${baselineTopPx}px"></div>
+                                    ${flowLinks}
+                                    ${quickPreview}
+                                    ${laneIsCollapsed ? collapsedMarkers : markers}
+                                  </div>
+                                </div>
+                              </div>`;
+                          })
+                          .join("")}
+                      </div>`
+                        : groupedEvents
+                          .map((group) => {
+                            const groupMeta = [
+                              `${group.events.length} event${group.events.length === 1 ? "" : "s"}`,
+                              group.meta,
+                            ]
+                              .filter(Boolean)
+                              .join(" · ");
+                            const rows =
+                              state.captureGroupMode === "burst"
+                                ? clusterEventBursts(group.events)
+                                    .map((cluster) => {
+                                      const event = cluster.representative;
+                                      const key = cluster.key;
+                                      const selected =
+                                        selectedEvent != null &&
+                                        key === captureEventKey(selectedEvent);
+                                      const paired = pairedEventKey != null && key === pairedEventKey;
+                                      const glyph = captureEventGlyph(event);
+                                      return `
+                                        <button class="capture-event-card capture-event-card-compact${selected ? " selected" : ""}${paired ? " paired" : ""}" data-capture-event="${esc(key)}" type="button">
+                                          <div class="capture-event-card-rail">
+                                            <span class="capture-glyph capture-glyph-${glyph.cls}">${esc(glyph.label)}</span>
+                                          </div>
+                                          <div class="capture-event-card-body">
+                                            <div class="capture-event-card-header">
+                                              <div class="capture-event-card-title-row">
+                                                <strong>${esc(event.host || event.provider || event.kind)}</strong>
+                                                <span class="text-dimmed text-sm">${esc(
+                                                  [event.method, event.path].filter(Boolean).join(" ") || event.kind,
+                                                )}</span>
+                                              </div>
+                                              <div class="capture-event-card-meta-row">
+                                                <span class="text-dimmed text-sm">${cluster.count} events</span>
+                                                <span class="text-dimmed text-sm">${esc(formatTime(cluster.startTs))} → ${esc(formatTime(cluster.endTs))}</span>
+                                                ${event.status ? `<span class="text-dimmed text-sm">status ${event.status}</span>` : ""}
+                                              </div>
+                                            </div>
+                                            ${
+                                              event.provider || event.model
+                                                ? `<div class="text-dimmed text-sm">${esc(
+                                                    [event.provider, event.model].filter(Boolean).join(" · "),
+                                                  )}</div>`
+                                                : ""
+                                            }
+                                            ${paired ? '<div class="capture-pair-badge">paired counterpart</div>' : ""}
+                                            ${
+                                              event.payloadPreview
+                                                ? `<div class="capture-event-card-preview">${esc(event.payloadPreview)}</div>`
+                                                : ""
+                                            }
+                                          </div>
+                                        </button>`;
+                                    })
+                                    .join("")
+                                : group.events
+                                    .map((event) => {
+                                const key = captureEventKey(event);
+                                const selected =
+                                  selectedEvent != null &&
+                                  key === captureEventKey(selectedEvent);
+                                const paired = pairedEventKey != null && key === pairedEventKey;
+                                const glyph = captureEventGlyph(event);
+                                return `
+                                  <button class="capture-event-card capture-event-card-compact${selected ? " selected" : ""}${paired ? " paired" : ""}" data-capture-event="${esc(key)}" type="button">
+                                    <div class="capture-event-card-rail">
+                                      <span class="capture-glyph capture-glyph-${glyph.cls}">${esc(glyph.label)}</span>
+                                    </div>
+                                    <div class="capture-event-card-body">
+                                      <div class="capture-event-card-header">
+                                        <div class="capture-event-card-title-row">
+                                          <strong>${esc(event.host || event.provider || event.kind)}</strong>
+                                          <span class="text-dimmed text-sm">${esc(
+                                            [event.method, event.path].filter(Boolean).join(" ") || event.kind,
+                                          )}</span>
+                                        </div>
+                                        <div class="capture-event-card-meta-row">
+                                          <span class="text-dimmed text-sm">${esc(new Date(event.ts).toLocaleTimeString())}</span>
+                                          ${event.status ? `<span class="text-dimmed text-sm">status ${event.status}</span>` : ""}
+                                          ${event.closeCode ? `<span class="text-dimmed text-sm">close ${event.closeCode}</span>` : ""}
+                                          <span class="text-dimmed text-sm">${esc(event.direction)} · ${esc(event.protocol)}</span>
+                                        </div>
+                                      </div>
+                                    ${paired ? '<div class="capture-pair-badge">paired counterpart</div>' : ""}
+                                    ${
+                                      event.provider || event.api || event.captureOrigin
+                                        ? `<div class="text-dimmed text-sm">${esc(
+                                            [event.provider, event.api, event.captureOrigin].filter(Boolean).join(" · "),
+                                          )}</div>`
+                                        : ""
+                                    }
+                                    ${
+                                      event.payloadPreview
+                                        ? `<div class="capture-event-card-preview">${esc(event.payloadPreview)}</div>`
+                                        : ""
+                                    }
+                                    ${event.errorText ? `<div class="capture-error" style="margin-top:8px">${esc(event.errorText)}</div>` : ""}
+                                    </div>
+                                  </button>`;
+                              })
+                              .join("");
+                            return state.captureGroupMode === "none"
+                              ? rows
+                              : `<section class="capture-group">
+                                  <div class="capture-group-header">
+                                    <div class="capture-group-title">${esc(group.label)}</div>
+                                    <div class="capture-group-meta">${esc(groupMeta)}</div>
+                                  </div>
+                                  ${rows}
+                                </section>`;
+                          })
+                          .join("")
+                }
+              </div>
+            </section>
+            ${
+              state.captureDetailPlacement === "right"
+                ? `<div class="capture-detail-splitter${state.captureDetailSplitDragging ? " dragging" : ""}" data-capture-detail-splitter role="separator" aria-orientation="vertical" aria-label="Resize detail pane">
+                    <span class="capture-detail-splitter-label">${Math.round(state.captureDetailSplitPct)}%</span>
+                  </div>`
+                : ""
+            }
+            <aside class="capture-detail-pane">
+              <div class="inspector-section-title">Selected Event</div>
+              ${
+                selectedEvent == null
+                  ? '<div class="empty-state">Select an event to inspect its details.</div>'
+                  : `
+                  <div class="capture-detail-card">
+                    <div class="capture-detail-view-switch" role="radiogroup" aria-label="Detail view">
+                      ${availableDetailViews
+                        .filter((view) => view.available)
+                        .map(
+                          (view) => `<label class="capture-detail-view-option">
+                            <input type="radio" name="capture-detail-view" value="${view.value}"${
+                              effectiveDetailView === view.value ? " checked" : ""
+                            } />
+                            <span>${view.label}${view.recommended ? ' <em class="capture-detail-view-hint">recommended</em>' : ""}</span>
+                          </label>`,
+                        )
+                        .join("")}
+                    </div>
+                    <div class="capture-detail-meta">
+                      <span class="capture-chip">${esc(selectedEvent.kind)}</span>
+                      <span class="capture-chip">${esc(selectedEvent.direction)}</span>
+                      <span class="capture-chip">${esc(selectedEvent.protocol)}</span>
+                      ${selectedEvent.provider ? `<span class="capture-chip">${esc(selectedEvent.provider)}</span>` : ""}
+                      ${selectedEvent.api ? `<span class="capture-chip">${esc(selectedEvent.api)}</span>` : ""}
+                      ${selectedEvent.model ? `<span class="capture-chip">${esc(selectedEvent.model)}</span>` : ""}
+                      ${selectedEvent.status ? `<span class="capture-chip">status ${selectedEvent.status}</span>` : ""}
+                      ${selectedEvent.closeCode ? `<span class="capture-chip">close ${selectedEvent.closeCode}</span>` : ""}
+                    </div>
+                    <div class="capture-detail-view-body">
+                      ${renderDetailView()}
+                    </div>
+                  </div>`
+              }
+            </aside>
+          </div>
+        </div>
+        <div class="results-sidebar"${analysisEnabled ? "" : ' style="display:none"'}>
+          <div class="inspector-section-title">Analysis Results</div>
+          <div class="text-dimmed text-sm" style="margin-bottom:10px">
+            ${
+              analysisEnabled
+                ? `Preset: ${esc(state.captureQueryPreset)}`
+                : "Analysis disabled. Select a preset to group the raw events."
+            }
+          </div>
+          <div class="events-scroll" style="max-height: 520px">
+            ${
+              rows.length === 0
+                  ? '<div class="empty-state" style="padding:20px">This session has raw traffic, but nothing matched the selected analysis preset.</div>'
+                  : rows
+                    .map(
+                      (row) => `<pre class="report-pre" style="margin:0 0 10px 0">${esc(JSON.stringify(row, null, 2))}</pre>`,
+                    )
+                    .join("")
+            }
+          </div>
+        </div>
+      </div>
+    </div>`;
+}
+
 /* ===== Render: Active tab switch ===== */
 
 function renderActiveTab(state: UiState): string {
@@ -921,6 +3383,8 @@ function renderActiveTab(state: UiState): string {
       return renderReportView(state);
     case "events":
       return renderEventsView(state);
+    case "capture":
+      return renderCaptureView(state);
     default:
       return renderChatView(state);
   }
@@ -930,7 +3394,7 @@ function renderActiveTab(state: UiState): string {
 
 export function renderQaLabUi(state: UiState): string {
   return `
-    <div class="app-shell" data-theme="${state.theme}">
+    <div class="app-shell${state.sidebarCollapsed ? " app-shell--sidebar-collapsed" : ""}" data-theme="${state.theme}">
       ${renderHeader(state)}
       <div class="layout">
         ${renderSidebar(state)}

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -103,6 +103,8 @@ beforeAll(async () => {
 beforeEach(() => {
   vi.unstubAllEnvs();
   for (const key of [
+    "OPENCLAW_DEBUG_PROXY_ENABLED",
+    "OPENCLAW_DEBUG_PROXY_URL",
     "ALL_PROXY",
     "all_proxy",
     "HTTP_PROXY",
@@ -116,6 +118,10 @@ beforeEach(() => {
   }
   loggerInfo.mockReset();
   loggerDebug.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 function resolveTelegramFetchOrThrow(
@@ -358,6 +364,22 @@ describe("resolveTelegramFetch", () => {
       expect.objectContaining({
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,
+      }),
+    );
+  });
+
+  it("uses the OpenClaw debug proxy URL when no explicit proxy fetch is provided", async () => {
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", "http://127.0.0.1:7777");
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetch(undefined);
+    await resolved("https://api.telegram.org/botTOKEN/getMe");
+
+    expect(ProxyAgentCtor).toHaveBeenCalledTimes(1);
+    expect(ProxyAgentCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: "http://127.0.0.1:7777",
       }),
     );
   });

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -1,4 +1,5 @@
 import * as dns from "node:dns";
+import { randomUUID } from "node:crypto";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -10,11 +11,13 @@ import {
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { Agent, EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
+import { resolveEffectiveDebugProxyUrl } from "../../../src/proxy-capture/env.js";
+import { captureHttpExchange } from "../../../src/proxy-capture/runtime.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
   resolveTelegramDnsResultOrderDecision,
 } from "./network-config.js";
-import { getProxyUrlFromFetch } from "./proxy.js";
+import { getProxyUrlFromFetch, makeProxyFetch } from "./proxy.js";
 
 const log = createSubsystemLogger("telegram/network");
 
@@ -495,15 +498,20 @@ export function resolveTelegramTransport(
     dnsDecision,
   });
 
-  const explicitProxyUrl = proxyFetch ? getProxyUrlFromFetch(proxyFetch) : undefined;
+  const effectiveProxyFetch =
+    proxyFetch ?? (() => {
+      const debugProxyUrl = resolveEffectiveDebugProxyUrl(undefined);
+      return debugProxyUrl ? makeProxyFetch(debugProxyUrl) : undefined;
+    })();
+  const explicitProxyUrl = effectiveProxyFetch ? getProxyUrlFromFetch(effectiveProxyFetch) : undefined;
   const undiciSourceFetch = resolveWrappedFetch(undiciFetch as unknown as typeof fetch);
   const sourceFetch = explicitProxyUrl
     ? undiciSourceFetch
-    : proxyFetch
-      ? resolveWrappedFetch(proxyFetch)
+    : effectiveProxyFetch
+      ? resolveWrappedFetch(effectiveProxyFetch)
       : undiciSourceFetch;
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
-  if (proxyFetch && !explicitProxyUrl) {
+  if (effectiveProxyFetch && !explicitProxyUrl) {
     return { fetch: sourceFetch, sourceFetch };
   }
 
@@ -544,10 +552,20 @@ export function resolveTelegramTransport(
     let err: unknown;
 
     try {
-      return await sourceFetch(
+      const response = await sourceFetch(
         input,
         withDispatcherIfMissing(init, transportAttempts[startIndex].createDispatcher()),
       );
+      captureHttpExchange({
+        url: input instanceof URL ? input.toString() : String(input),
+        method: init?.method ?? "GET",
+        requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
+        requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+        response,
+        flowId: randomUUID(),
+        meta: { subsystem: "telegram-fetch" },
+      });
+      return response;
     } catch (caught) {
       err = caught;
     }
@@ -569,6 +587,15 @@ export function resolveTelegramTransport(
           input,
           withDispatcherIfMissing(init, nextAttempt.createDispatcher()),
         );
+        captureHttpExchange({
+          url: input instanceof URL ? input.toString() : String(input),
+          method: init?.method ?? "GET",
+          requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
+          requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+          response,
+          flowId: randomUUID(),
+          meta: { subsystem: "telegram-fetch", fallbackAttempt: nextIndex },
+        });
         stickyAttemptIndex = nextIndex;
         return response;
       } catch (caught) {

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -8,11 +8,10 @@ import {
   resolveFetch,
   type PinnedDispatcherPolicy,
 } from "openclaw/plugin-sdk/fetch-runtime";
+import { captureHttpExchange, resolveEffectiveDebugProxyUrl } from "openclaw/plugin-sdk/proxy-capture";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { Agent, EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
-import { resolveEffectiveDebugProxyUrl } from "../../../src/proxy-capture/env.js";
-import { captureHttpExchange } from "../../../src/proxy-capture/runtime.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
   resolveTelegramDnsResultOrderDecision,

--- a/package.json
+++ b/package.json
@@ -361,6 +361,10 @@
       "types": "./dist/plugin-sdk/logging-core.d.ts",
       "default": "./dist/plugin-sdk/logging-core.js"
     },
+    "./plugin-sdk/proxy-capture": {
+      "types": "./dist/plugin-sdk/proxy-capture.d.ts",
+      "default": "./dist/plugin-sdk/proxy-capture.js"
+    },
     "./plugin-sdk/markdown-table-runtime": {
       "types": "./dist/plugin-sdk/markdown-table-runtime.d.ts",
       "default": "./dist/plugin-sdk/markdown-table-runtime.js"
@@ -1200,6 +1204,11 @@
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
+    "proxy:coverage": "node scripts/run-node.mjs proxy coverage",
+    "proxy:gateway": "node scripts/run-node.mjs proxy run -- node scripts/run-node.mjs gateway",
+    "proxy:install-ca": "node --import tsx scripts/proxy-install-ca.mjs",
+    "proxy:run": "node scripts/run-node.mjs proxy run",
+    "proxy:start": "node scripts/run-node.mjs proxy start",
     "qa:e2e": "node --import tsx scripts/qa-e2e.ts",
     "qa:lab:build": "vite build --config extensions/qa-lab/web/vite.config.ts",
     "qa:lab:ui": "pnpm openclaw qa ui",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -8,6 +8,7 @@
   "runtime",
   "runtime-doctor",
   "runtime-env",
+  "proxy-capture",
   "runtime-secret-resolution",
   "setup",
   "setup-adapter-runtime",

--- a/scripts/proxy-install-ca.mjs
+++ b/scripts/proxy-install-ca.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import { resolveSystemBin } from "../src/infra/resolve-system-bin.js";
+import { ensureDebugProxyCa } from "../src/proxy-capture/ca.js";
+import { resolveDebugProxySettings } from "../src/proxy-capture/env.js";
+
+const printOnly = process.argv.includes("--print-only");
+
+async function installCa() {
+  const settings = resolveDebugProxySettings();
+  const ca = await ensureDebugProxyCa(settings.certDir);
+  process.stdout.write(`Debug proxy CA: ${ca.certPath}\n`);
+  if (printOnly) {
+    process.stdout.write("Created or reused the debug proxy CA without changing system trust.\n");
+    return;
+  }
+
+  if (process.platform !== "darwin") {
+    process.stdout.write(
+      "Automatic CA trust is only implemented for macOS. Use the printed CA path to trust it manually on this platform.\n",
+    );
+    return;
+  }
+
+  const security = resolveSystemBin("security");
+  if (!security) {
+    throw new Error("security CLI is required on macOS to trust the debug proxy CA");
+  }
+
+  const result = spawnSync(
+    security,
+    [
+      "add-trusted-cert",
+      "-d",
+      "-r",
+      "trustRoot",
+      "-k",
+      "/Library/Keychains/System.keychain",
+      ca.certPath,
+    ],
+    {
+      stdio: "inherit",
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(`security add-trusted-cert failed with exit code ${result.status ?? 1}`);
+  }
+  process.stdout.write("Trusted the OpenClaw debug proxy CA in System.keychain.\n");
+}
+
+void installCa().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -12,9 +12,11 @@
  *
  * @see https://developers.openai.com/api/docs/guides/websocket-mode
  */
-
 import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
 import WebSocket, { type ClientOptions } from "ws";
+import { createDebugProxyWebSocketAgent, resolveDebugProxySettings } from "../proxy-capture/env.js";
+import { captureWsEvent } from "../proxy-capture/runtime.js";
 import { buildOpenAIWebSocketWarmUpPayload } from "./openai-ws-request.js";
 import {
   buildProviderRequestTlsClientOptions,
@@ -347,6 +349,7 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
   private readonly socketFactory: (url: string, options: ClientOptions) => WebSocket;
   private readonly headers?: Record<string, string>;
   private readonly request?: ModelProviderRequestTransportOverrides;
+  private readonly flowId: string;
 
   constructor(options: OpenAIWebSocketManagerOptions = {}) {
     super();
@@ -357,6 +360,7 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
       options.socketFactory ?? ((url, socketOptions) => new WebSocket(url, socketOptions));
     this.headers = options.headers;
     this.request = options.request;
+    this.flowId = randomUUID();
   }
 
   // ─── Public API ────────────────────────────────────────────────────────────
@@ -401,7 +405,16 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
         `OpenAIWebSocketManager: cannot send — connection is not open (readyState=${this.ws?.readyState ?? "no socket"})`,
       );
     }
-    this.ws.send(JSON.stringify(event));
+    const payload = JSON.stringify(event);
+    captureWsEvent({
+      url: this.wsUrl,
+      direction: "outbound",
+      kind: "ws-frame",
+      flowId: this.flowId,
+      payload,
+      meta: { eventType: event.type },
+    });
+    this.ws.send(payload);
   }
 
   /**
@@ -469,8 +482,10 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
         request: this.request,
         allowPrivateNetwork: this.request?.allowPrivateNetwork === true,
       });
+      const debugAgent = createDebugProxyWebSocketAgent(resolveDebugProxySettings());
       const socket = this.socketFactory(this.wsUrl, {
         headers: requestConfig.headers,
+        ...(debugAgent ? { agent: debugAgent } : {}),
         ...buildProviderRequestTlsClientOptions(requestConfig),
       });
 
@@ -480,6 +495,12 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
         this.retryCount = 0;
         this._connectionState = "open";
         this._lastCloseInfo = null;
+        captureWsEvent({
+          url: this.wsUrl,
+          direction: "local",
+          kind: "ws-open",
+          flowId: this.flowId,
+        });
         resolve();
         this.emit("open");
       };
@@ -494,6 +515,13 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
         if (this.listenerCount("error") > 0) {
           this.emit("error", err);
         }
+        captureWsEvent({
+          url: this.wsUrl,
+          direction: "local",
+          kind: "error",
+          flowId: this.flowId,
+          errorText: err.message,
+        });
         if (this._connectionState === "connecting" || this._connectionState === "reconnecting") {
           this._connectionState = "closed";
         }
@@ -508,6 +536,14 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
           retryable: isRetryableWebSocketClose(code),
         } satisfies OpenAIWebSocketCloseInfo;
         this._lastCloseInfo = closeInfo;
+        captureWsEvent({
+          url: this.wsUrl,
+          direction: "local",
+          kind: "ws-close",
+          flowId: this.flowId,
+          closeCode: code,
+          payload: reasonStr,
+        });
         this.emit("close", code, reasonStr);
 
         if (!this.closed && closeInfo.retryable) {
@@ -518,6 +554,13 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
       };
 
       const onMessage = (data: WebSocket.RawData) => {
+        captureWsEvent({
+          url: this.wsUrl,
+          direction: "inbound",
+          kind: "ws-frame",
+          flowId: this.flowId,
+          payload: Buffer.isBuffer(data) ? data : Buffer.from(String(data)),
+        });
         this._handleMessage(data);
       };
 

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Model } from "./model-types.js";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+vi.mock("./provider-request-config.js", () => ({
+  buildProviderRequestDispatcherPolicy: vi.fn(() => ({ mode: "direct" })),
+  getModelProviderRequestTransport: vi.fn(() => undefined),
+  mergeModelProviderRequestOverrides: vi.fn((current, overrides) => ({ ...current, ...overrides })),
+  resolveProviderRequestPolicyConfig: vi.fn(() => ({ allowPrivateNetwork: false })),
+}));
+
+describe("buildGuardedModelFetch", () => {
+  beforeEach(() => {
+    fetchWithSsrFGuardMock.mockReset().mockResolvedValue({
+      response: new Response("ok", { status: 200 }),
+      finalUrl: "https://api.openai.com/v1/responses",
+      release: vi.fn(async () => undefined),
+    });
+    delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;
+    delete process.env.OPENCLAW_DEBUG_PROXY_URL;
+  });
+
+  it("pushes provider capture metadata into the shared guarded fetch seam", async () => {
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    const fetcher = buildGuardedModelFetch(model);
+    await fetcher("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"input":"hello"}',
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/responses",
+        capture: {
+          meta: {
+            provider: "openai",
+            api: "openai-responses",
+            model: "gpt-5.4",
+          },
+        },
+      }),
+    );
+  });
+});

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Model } from "./model-types.js";
 
-const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+const {
+  fetchWithSsrFGuardMock,
+  mergeModelProviderRequestOverridesMock,
+  resolveProviderRequestPolicyConfigMock,
+} = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
+  mergeModelProviderRequestOverridesMock: vi.fn((current, overrides) => ({ ...current, ...overrides })),
+  resolveProviderRequestPolicyConfigMock: vi.fn(() => ({ allowPrivateNetwork: false })),
 }));
 
 vi.mock("../infra/net/fetch-guard.js", () => ({
@@ -12,8 +18,8 @@ vi.mock("../infra/net/fetch-guard.js", () => ({
 vi.mock("./provider-request-config.js", () => ({
   buildProviderRequestDispatcherPolicy: vi.fn(() => ({ mode: "direct" })),
   getModelProviderRequestTransport: vi.fn(() => undefined),
-  mergeModelProviderRequestOverrides: vi.fn((current, overrides) => ({ ...current, ...overrides })),
-  resolveProviderRequestPolicyConfig: vi.fn(() => ({ allowPrivateNetwork: false })),
+  mergeModelProviderRequestOverrides: mergeModelProviderRequestOverridesMock,
+  resolveProviderRequestPolicyConfig: resolveProviderRequestPolicyConfigMock,
 }));
 
 describe("buildGuardedModelFetch", () => {
@@ -23,6 +29,8 @@ describe("buildGuardedModelFetch", () => {
       finalUrl: "https://api.openai.com/v1/responses",
       release: vi.fn(async () => undefined),
     });
+    mergeModelProviderRequestOverridesMock.mockClear();
+    resolveProviderRequestPolicyConfigMock.mockClear().mockReturnValue({ allowPrivateNetwork: false });
     delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;
     delete process.env.OPENCLAW_DEBUG_PROXY_URL;
   });
@@ -55,5 +63,29 @@ describe("buildGuardedModelFetch", () => {
         },
       }),
     );
+  });
+
+  it("does not force explicit debug proxy overrides onto plain HTTP model transports", async () => {
+    process.env.OPENCLAW_DEBUG_PROXY_ENABLED = "1";
+    process.env.OPENCLAW_DEBUG_PROXY_URL = "http://127.0.0.1:7799";
+
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "kimi-k2.5:cloud",
+      provider: "ollama",
+      api: "ollama-chat",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    } as unknown as Model<"ollama-chat">;
+
+    const fetcher = buildGuardedModelFetch(model);
+    await fetcher("http://127.0.0.1:11434/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"messages":[]}',
+    });
+
+    expect(mergeModelProviderRequestOverridesMock).toHaveBeenCalledWith(undefined, {
+      proxy: undefined,
+    });
   });
 });

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -1,8 +1,10 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { resolveDebugProxySettings } from "../proxy-capture/env.js";
 import {
   buildProviderRequestDispatcherPolicy,
   getModelProviderRequestTransport,
+  mergeModelProviderRequestOverrides,
   resolveProviderRequestPolicyConfig,
 } from "./provider-request-config.js";
 
@@ -55,7 +57,16 @@ function buildManagedResponse(response: Response, release: () => Promise<void>):
 }
 
 function resolveModelRequestPolicy(model: Model<Api>) {
-  const request = getModelProviderRequestTransport(model);
+  const debugProxy = resolveDebugProxySettings();
+  const request = mergeModelProviderRequestOverrides(getModelProviderRequestTransport(model), {
+    proxy:
+      debugProxy.enabled && debugProxy.proxyUrl
+        ? {
+            mode: "explicit-proxy",
+            url: debugProxy.proxyUrl,
+          }
+        : undefined,
+  });
   return resolveProviderRequestPolicyConfig({
     provider: model.provider,
     api: model.api,
@@ -94,6 +105,13 @@ export function buildGuardedModelFetch(model: Model<Api>): typeof fetch {
     const result = await fetchWithSsrFGuard({
       url,
       init: requestInit ?? init,
+      capture: {
+        meta: {
+          provider: model.provider,
+          api: model.api,
+          model: model.id,
+        },
+      },
       dispatcherPolicy,
       // Provider transport intentionally keeps the secure default and never
       // replays unsafe request bodies across cross-origin redirects.

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -58,14 +58,23 @@ function buildManagedResponse(response: Response, release: () => Promise<void>):
 
 function resolveModelRequestPolicy(model: Model<Api>) {
   const debugProxy = resolveDebugProxySettings();
+  const allowExplicitDebugProxy =
+    debugProxy.enabled &&
+    debugProxy.proxyUrl &&
+    (() => {
+      try {
+        return new URL(model.baseUrl).protocol === "https:";
+      } catch {
+        return false;
+      }
+    })();
   const request = mergeModelProviderRequestOverrides(getModelProviderRequestTransport(model), {
-    proxy:
-      debugProxy.enabled && debugProxy.proxyUrl
-        ? {
-            mode: "explicit-proxy",
-            url: debugProxy.proxyUrl,
-          }
-        : undefined,
+    proxy: allowExplicitDebugProxy
+      ? {
+          mode: "explicit-proxy",
+          url: debugProxy.proxyUrl,
+        }
+      : undefined,
   });
   return resolveProviderRequestPolicyConfig({
     provider: model.provider,

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -135,6 +135,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       exportName: "registerQaCli",
     },
     {
+      commandNames: ["proxy"],
+      loadModule: () => import("../proxy-cli.js"),
+      exportName: "registerProxyCli",
+    },
+    {
       commandNames: ["hooks"],
       loadModule: () => import("../hooks-cli.js"),
       exportName: "registerHooksCli",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -88,6 +88,11 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "proxy",
+    description: "Run the OpenClaw debug proxy and inspect captured traffic",
+    hasSubcommands: true,
+  },
+  {
     name: "hooks",
     description: "Manage internal agent hooks",
     hasSubcommands: true,

--- a/src/cli/proxy-cli.runtime.test.ts
+++ b/src/cli/proxy-cli.runtime.test.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { serverStopSpy, spawnMock } = vi.hoisted(() => ({
+  serverStopSpy: vi.fn(async () => undefined),
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock("../proxy-capture/proxy-server.js", () => ({
+  startDebugProxyServer: vi.fn(async () => ({
+    proxyUrl: "http://127.0.0.1:7799",
+    stop: serverStopSpy,
+  })),
+}));
+
+describe("proxy cli runtime", () => {
+  const envKeys = [
+    "OPENCLAW_DEBUG_PROXY_DB_PATH",
+    "OPENCLAW_DEBUG_PROXY_BLOB_DIR",
+    "OPENCLAW_DEBUG_PROXY_CERT_DIR",
+    "OPENCLAW_DEBUG_PROXY_SESSION_ID",
+    "OPENCLAW_DEBUG_PROXY_ENABLED",
+  ] as const;
+  const savedEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+  let tempDir = "";
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-cli-runtime-"));
+    process.env.OPENCLAW_DEBUG_PROXY_DB_PATH = path.join(tempDir, "capture.sqlite");
+    process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR = path.join(tempDir, "blobs");
+    process.env.OPENCLAW_DEBUG_PROXY_CERT_DIR = path.join(tempDir, "certs");
+    delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;
+    delete process.env.OPENCLAW_DEBUG_PROXY_SESSION_ID;
+    serverStopSpy.mockClear();
+    spawnMock.mockReset();
+  });
+
+  afterEach(async () => {
+    const { closeDebugProxyCaptureStore } = await import("../proxy-capture/store.sqlite.js");
+    closeDebugProxyCaptureStore();
+    vi.resetModules();
+    for (const key of envKeys) {
+      const value = savedEnv[key];
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("stops the proxy server and ends the session when child spawn fails", async () => {
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter();
+      queueMicrotask(() => {
+        child.emit("error", new Error("spawn failed"));
+      });
+      return child;
+    });
+
+    const { runDebugProxyRunCommand } = await import("./proxy-cli.runtime.js");
+    const { getDebugProxyCaptureStore } = await import("../proxy-capture/store.sqlite.js");
+
+    await expect(
+      runDebugProxyRunCommand({
+        commandArgs: ["does-not-exist"],
+      }),
+    ).rejects.toThrow("spawn failed");
+
+    expect(serverStopSpy).toHaveBeenCalledTimes(1);
+
+    const store = getDebugProxyCaptureStore(
+      process.env.OPENCLAW_DEBUG_PROXY_DB_PATH!,
+      process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR!,
+    );
+    const [session] = store.listSessions(5);
+    expect(session?.mode).toBe("proxy-run");
+    expect(session?.endedAt).toEqual(expect.any(Number));
+  });
+});

--- a/src/cli/proxy-cli.runtime.ts
+++ b/src/cli/proxy-cli.runtime.ts
@@ -17,6 +17,17 @@ import type { CaptureQueryPreset } from "../proxy-capture/types.js";
 
 export async function runDebugProxyStartCommand(opts: { host?: string; port?: number }) {
   const settings = resolveDebugProxySettings();
+  const store = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir);
+  store.upsertSession({
+    id: settings.sessionId,
+    startedAt: Date.now(),
+    mode: "proxy-start",
+    sourceScope: "openclaw",
+    sourceProcess: "openclaw",
+    proxyUrl: settings.proxyUrl,
+    dbPath: settings.dbPath,
+    blobDir: settings.blobDir,
+  });
   initializeDebugProxyCapture("proxy-start", settings);
   const ca = await ensureDebugProxyCa(settings.certDir);
   const server = await startDebugProxyServer({
@@ -32,7 +43,12 @@ export async function runDebugProxyStartCommand(opts: { host?: string; port?: nu
     process.off("SIGINT", onSignal);
     process.off("SIGTERM", onSignal);
     await server.stop();
-    finalizeDebugProxyCapture(settings);
+    if (settings.enabled) {
+      finalizeDebugProxyCapture(settings);
+    } else {
+      store.endSession(settings.sessionId);
+      closeDebugProxyCaptureStore();
+    }
     process.exit(0);
   };
   const onSignal = () => {

--- a/src/cli/proxy-cli.runtime.ts
+++ b/src/cli/proxy-cli.runtime.ts
@@ -1,0 +1,144 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import process from "node:process";
+import { ensureDebugProxyCa } from "../proxy-capture/ca.js";
+import { buildDebugProxyCoverageReport } from "../proxy-capture/coverage.js";
+import { resolveDebugProxySettings, applyDebugProxyEnv } from "../proxy-capture/env.js";
+import { startDebugProxyServer } from "../proxy-capture/proxy-server.js";
+import {
+  finalizeDebugProxyCapture,
+  initializeDebugProxyCapture,
+} from "../proxy-capture/runtime.js";
+import {
+  closeDebugProxyCaptureStore,
+  getDebugProxyCaptureStore,
+} from "../proxy-capture/store.sqlite.js";
+import type { CaptureQueryPreset } from "../proxy-capture/types.js";
+
+export async function runDebugProxyStartCommand(opts: { host?: string; port?: number }) {
+  const settings = resolveDebugProxySettings();
+  initializeDebugProxyCapture("proxy-start", settings);
+  const ca = await ensureDebugProxyCa(settings.certDir);
+  const server = await startDebugProxyServer({
+    host: opts.host,
+    port: opts.port,
+    settings,
+  });
+  process.stdout.write(`Debug proxy: ${server.proxyUrl}\n`);
+  process.stdout.write(`CA cert: ${ca.certPath}\n`);
+  process.stdout.write(`Capture DB: ${settings.dbPath}\n`);
+  process.stdout.write("Press Ctrl+C to stop.\n");
+  const shutdown = async () => {
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+    await server.stop();
+    finalizeDebugProxyCapture(settings);
+    process.exit(0);
+  };
+  const onSignal = () => {
+    void shutdown();
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+  await new Promise(() => undefined);
+}
+
+export async function runDebugProxyRunCommand(opts: {
+  host?: string;
+  port?: number;
+  commandArgs: string[];
+}) {
+  if (opts.commandArgs.length === 0) {
+    throw new Error("proxy run requires a command after --");
+  }
+  const sessionId = randomUUID();
+  const baseSettings = resolveDebugProxySettings();
+  const settings = {
+    ...baseSettings,
+    sessionId,
+  };
+  getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).upsertSession({
+    id: sessionId,
+    startedAt: Date.now(),
+    mode: "proxy-run",
+    sourceScope: "openclaw",
+    sourceProcess: "openclaw",
+    proxyUrl: undefined,
+    dbPath: settings.dbPath,
+    blobDir: settings.blobDir,
+  });
+  const server = await startDebugProxyServer({
+    host: opts.host,
+    port: opts.port,
+    settings,
+  });
+  const [command, ...args] = opts.commandArgs;
+  const childEnv = applyDebugProxyEnv(process.env, {
+    proxyUrl: server.proxyUrl,
+    sessionId,
+    dbPath: settings.dbPath,
+    blobDir: settings.blobDir,
+    certDir: settings.certDir,
+  });
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      env: childEnv,
+      cwd: process.cwd(),
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      process.exitCode = signal ? 1 : (code ?? 1);
+      resolve();
+    });
+  });
+  await server.stop();
+  getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).endSession(sessionId);
+}
+
+export async function runDebugProxySessionsCommand(opts: { limit?: number }) {
+  const settings = resolveDebugProxySettings();
+  const sessions = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).listSessions(
+    opts.limit ?? 20,
+  );
+  process.stdout.write(`${JSON.stringify(sessions, null, 2)}\n`);
+  closeDebugProxyCaptureStore();
+}
+
+export async function runDebugProxyQueryCommand(opts: {
+  preset: CaptureQueryPreset;
+  sessionId?: string;
+}) {
+  const settings = resolveDebugProxySettings();
+  const rows = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).queryPreset(
+    opts.preset,
+    opts.sessionId,
+  );
+  process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+  closeDebugProxyCaptureStore();
+}
+
+export async function runDebugProxyCoverageCommand() {
+  process.stdout.write(`${JSON.stringify(buildDebugProxyCoverageReport(), null, 2)}\n`);
+  closeDebugProxyCaptureStore();
+}
+
+export async function runDebugProxyPurgeCommand() {
+  const settings = resolveDebugProxySettings();
+  const result = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).purgeAll();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  closeDebugProxyCaptureStore();
+}
+
+export async function readDebugProxyBlobCommand(opts: { blobId: string }) {
+  const settings = resolveDebugProxySettings();
+  const content = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).readBlob(
+    opts.blobId,
+  );
+  if (content == null) {
+    closeDebugProxyCaptureStore();
+    throw new Error(`Unknown blob: ${opts.blobId}`);
+  }
+  process.stdout.write(content);
+  closeDebugProxyCaptureStore();
+}

--- a/src/cli/proxy-cli.runtime.ts
+++ b/src/cli/proxy-cli.runtime.ts
@@ -96,20 +96,23 @@ export async function runDebugProxyRunCommand(opts: {
     blobDir: settings.blobDir,
     certDir: settings.certDir,
   });
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, {
-      stdio: "inherit",
-      env: childEnv,
-      cwd: process.cwd(),
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(command, args, {
+        stdio: "inherit",
+        env: childEnv,
+        cwd: process.cwd(),
+      });
+      child.once("error", reject);
+      child.once("exit", (code, signal) => {
+        process.exitCode = signal ? 1 : (code ?? 1);
+        resolve();
+      });
     });
-    child.once("error", reject);
-    child.once("exit", (code, signal) => {
-      process.exitCode = signal ? 1 : (code ?? 1);
-      resolve();
-    });
-  });
-  await server.stop();
-  getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).endSession(sessionId);
+  } finally {
+    await server.stop();
+    getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).endSession(sessionId);
+  }
 }
 
 export async function runDebugProxySessionsCommand(opts: { limit?: number }) {

--- a/src/cli/proxy-cli.test.ts
+++ b/src/cli/proxy-cli.test.ts
@@ -1,0 +1,21 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerProxyCli } from "./proxy-cli.js";
+
+describe("proxy cli", () => {
+  it("registers the debug proxy subcommands", () => {
+    const program = new Command();
+    registerProxyCli(program);
+
+    const proxy = program.commands.find((command) => command.name() === "proxy");
+    expect(proxy?.commands.map((command) => command.name())).toEqual([
+      "start",
+      "run",
+      "coverage",
+      "sessions",
+      "query",
+      "blob",
+      "purge",
+    ]);
+  });
+});

--- a/src/cli/proxy-cli.ts
+++ b/src/cli/proxy-cli.ts
@@ -1,0 +1,102 @@
+import type { Command } from "commander";
+import type { CaptureQueryPreset } from "../proxy-capture/types.js";
+
+type ProxyCliRuntime = typeof import("./proxy-cli.runtime.js");
+
+let proxyCliRuntimePromise: Promise<ProxyCliRuntime> | undefined;
+
+async function loadProxyCliRuntime(): Promise<ProxyCliRuntime> {
+  proxyCliRuntimePromise ??= import("./proxy-cli.runtime.js");
+  return await proxyCliRuntimePromise;
+}
+
+function parseOptionalNumber(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function registerProxyCli(program: Command) {
+  const proxy = program
+    .command("proxy")
+    .description("Run the OpenClaw debug proxy and inspect captured traffic");
+
+  proxy
+    .command("start")
+    .description("Start the local explicit debug proxy")
+    .option("--host <host>", "Bind host", "127.0.0.1")
+    .option("--port <port>", "Bind port", parseOptionalNumber)
+    .action(async (opts: { host?: string; port?: number }) => {
+      const runtime = await loadProxyCliRuntime();
+      await runtime.runDebugProxyStartCommand(opts);
+    });
+
+  proxy
+    .command("run")
+    .description("Run a child command with OpenClaw debug proxy capture enabled")
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .option("--host <host>", "Bind host", "127.0.0.1")
+    .option("--port <port>", "Bind port", parseOptionalNumber)
+    .argument("[cmd...]", "Command to run after --")
+    .action(async (cmd: string[], opts: { host?: string; port?: number }) => {
+      const runtime = await loadProxyCliRuntime();
+      await runtime.runDebugProxyRunCommand({
+        host: opts.host,
+        port: opts.port,
+        commandArgs: cmd,
+      });
+    });
+
+  proxy
+    .command("coverage")
+    .description("Report current debug proxy transport coverage and remaining gaps")
+    .action(async () => {
+      const runtime = await loadProxyCliRuntime();
+      await runtime.runDebugProxyCoverageCommand();
+    });
+
+  proxy
+    .command("sessions")
+    .description("List recent capture sessions")
+    .option("--limit <count>", "Maximum sessions to show", parseOptionalNumber)
+    .action(async (opts: { limit?: number }) => {
+      const runtime = await loadProxyCliRuntime();
+      await runtime.runDebugProxySessionsCommand(opts);
+    });
+
+  proxy
+    .command("query")
+    .description("Run a built-in query preset against captured traffic")
+    .requiredOption(
+      "--preset <name>",
+      "Query preset: double-sends, retry-storms, cache-busting, ws-duplicate-frames, missing-ack, error-bursts",
+    )
+    .option("--session <id>", "Restrict to a capture session id")
+    .action(async (opts: { preset: CaptureQueryPreset; session?: string }) => {
+      const runtime = await loadProxyCliRuntime();
+      await runtime.runDebugProxyQueryCommand({
+        preset: opts.preset,
+        sessionId: opts.session,
+      });
+    });
+
+  proxy
+    .command("blob")
+    .description("Read a captured payload blob by id")
+    .requiredOption("--id <blobId>", "Blob id")
+    .action(async (opts: { id: string }) => {
+      const runtime = await loadProxyCliRuntime();
+      await runtime.readDebugProxyBlobCommand({ blobId: opts.id });
+    });
+
+  proxy
+    .command("purge")
+    .description("Delete all captured traffic metadata and blobs")
+    .action(async () => {
+      const runtime = await loadProxyCliRuntime();
+      await runtime.runDebugProxyPurgeCommand();
+    });
+}

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -8,11 +8,17 @@ import { resolveStateDir } from "../config/paths.js";
 import { normalizeEnv } from "../infra/env.js";
 import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
+import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { enableConsoleCapture } from "../logging.js";
 import { resolveManifestCommandAliasOwner } from "../plugins/manifest-command-aliases.runtime.js";
 import { hasMemoryRuntime } from "../plugins/memory-state.js";
+import { maybeWarnAboutDebugProxyCoverage } from "../proxy-capture/coverage.js";
+import {
+  finalizeDebugProxyCapture,
+  initializeDebugProxyCapture,
+} from "../proxy-capture/runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -168,6 +174,12 @@ export async function runCli(argv: string[] = process.argv) {
     loadCliDotEnv({ quiet: true });
   }
   normalizeEnv();
+  initializeDebugProxyCapture("cli");
+  process.once("exit", () => {
+    finalizeDebugProxyCapture();
+  });
+  ensureGlobalUndiciEnvProxyDispatcher();
+  maybeWarnAboutDebugProxyCoverage();
   if (shouldEnsureCliPath(normalizedArgv)) {
     ensureOpenClawCliOnPath();
   }

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,5 +1,6 @@
 import type { Dispatcher } from "undici";
 import { logWarn } from "../../logger.js";
+import { captureHttpExchange } from "../../proxy-capture/runtime.js";
 import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
 import { hasProxyEnvConfigured } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
@@ -36,6 +37,12 @@ export type GuardedFetchOptions = {
   url: string;
   fetchImpl?: FetchLike;
   init?: RequestInit;
+  capture?:
+    | false
+    | {
+        flowId?: string;
+        meta?: Record<string, unknown>;
+      };
   maxRedirects?: number;
   /**
    * Allow replaying unsafe request methods and bodies across cross-origin redirects.
@@ -349,6 +356,24 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       const response = shouldUseRuntimeFetch
         ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
         : await defaultFetch(parsedUrl.toString(), init);
+
+      if (params.capture !== false) {
+        captureHttpExchange({
+          url: parsedUrl.toString(),
+          method: currentInit?.method ?? "GET",
+          requestHeaders: currentInit?.headers as Headers | Record<string, string> | undefined,
+          requestBody:
+            (currentInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,
+          response,
+          transport: "http",
+          flowId: params.capture?.flowId,
+          meta: {
+            captureOrigin: "guarded-fetch",
+            ...(params.auditContext ? { auditContext: params.auditContext } : {}),
+            ...(params.capture?.meta ?? {}),
+          },
+        });
+      }
 
       if (isRedirectStatus(response.status)) {
         const location = response.headers.get("location");

--- a/src/plugin-sdk/proxy-capture.ts
+++ b/src/plugin-sdk/proxy-capture.ts
@@ -1,8 +1,13 @@
-export { resolveDebugProxySettings } from "../proxy-capture/env.js";
+export {
+  createDebugProxyWebSocketAgent,
+  resolveDebugProxySettings,
+  resolveEffectiveDebugProxyUrl,
+} from "../proxy-capture/env.js";
 export {
   DebugProxyCaptureStore,
   getDebugProxyCaptureStore,
 } from "../proxy-capture/store.sqlite.js";
+export { captureHttpExchange, captureWsEvent } from "../proxy-capture/runtime.js";
 export type {
   CaptureEventRecord,
   CaptureQueryPreset,

--- a/src/plugin-sdk/proxy-capture.ts
+++ b/src/plugin-sdk/proxy-capture.ts
@@ -7,7 +7,11 @@ export {
   DebugProxyCaptureStore,
   getDebugProxyCaptureStore,
 } from "../proxy-capture/store.sqlite.js";
-export { captureHttpExchange, captureWsEvent } from "../proxy-capture/runtime.js";
+export {
+  captureHttpExchange,
+  captureWsEvent,
+  isDebugProxyGlobalFetchPatchInstalled,
+} from "../proxy-capture/runtime.js";
 export type {
   CaptureEventRecord,
   CaptureQueryPreset,

--- a/src/plugin-sdk/proxy-capture.ts
+++ b/src/plugin-sdk/proxy-capture.ts
@@ -1,0 +1,11 @@
+export { resolveDebugProxySettings } from "../proxy-capture/env.js";
+export {
+  DebugProxyCaptureStore,
+  getDebugProxyCaptureStore,
+} from "../proxy-capture/store.sqlite.js";
+export type {
+  CaptureEventRecord,
+  CaptureQueryPreset,
+  CaptureQueryRow,
+  CaptureSessionSummary,
+} from "../proxy-capture/types.js";

--- a/src/proxy-capture/blob-store.ts
+++ b/src/proxy-capture/blob-store.ts
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { gzipSync, gunzipSync } from "node:zlib";
+import type { CaptureBlobRecord } from "./types.js";
+
+function ensureDir(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+export function writeCaptureBlob(params: {
+  blobDir: string;
+  data: Buffer;
+  contentType?: string;
+}): CaptureBlobRecord {
+  ensureDir(params.blobDir);
+  const sha256 = createHash("sha256").update(params.data).digest("hex");
+  const blobId = sha256.slice(0, 24);
+  const outputPath = path.join(params.blobDir, `${blobId}.bin.gz`);
+  if (!fs.existsSync(outputPath)) {
+    fs.writeFileSync(outputPath, gzipSync(params.data));
+  }
+  return {
+    blobId,
+    path: outputPath,
+    encoding: "gzip",
+    sizeBytes: params.data.byteLength,
+    sha256,
+    ...(params.contentType ? { contentType: params.contentType } : {}),
+  };
+}
+
+export function readCaptureBlobText(blobPath: string): string {
+  return gunzipSync(fs.readFileSync(blobPath)).toString("utf8");
+}

--- a/src/proxy-capture/ca.ts
+++ b/src/proxy-capture/ca.ts
@@ -1,0 +1,40 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { resolveSystemBin } from "../infra/resolve-system-bin.js";
+
+const execFileAsync = promisify(execFile);
+
+export async function ensureDebugProxyCa(certDir: string): Promise<{
+  certPath: string;
+  keyPath: string;
+}> {
+  fs.mkdirSync(certDir, { recursive: true });
+  const certPath = path.join(certDir, "root-ca.pem");
+  const keyPath = path.join(certDir, "root-ca-key.pem");
+  if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
+    return { certPath, keyPath };
+  }
+  const openssl = resolveSystemBin("openssl");
+  if (!openssl) {
+    throw new Error("openssl is required to generate debug proxy certificates");
+  }
+  await execFileAsync(openssl, [
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-sha256",
+    "-days",
+    "7",
+    "-nodes",
+    "-keyout",
+    keyPath,
+    "-out",
+    certPath,
+    "-subj",
+    "/CN=OpenClaw Debug Proxy",
+  ]);
+  return { certPath, keyPath };
+}

--- a/src/proxy-capture/coverage.test.ts
+++ b/src/proxy-capture/coverage.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { buildDebugProxyCoverageReport } from "./coverage.js";
+
+describe("debug proxy coverage report", () => {
+  it("summarizes captured and partial transport seams", () => {
+    const report = buildDebugProxyCoverageReport();
+
+    expect(report.summary.total).toBe(report.entries.length);
+    expect(report.summary.captured).toBeGreaterThan(0);
+    expect(report.summary.proxyOnly).toBeGreaterThan(0);
+    expect(report.entries.some((entry) => entry.id === "provider-transport-fetch")).toBe(true);
+    expect(report.entries.some((entry) => entry.id === "feishu-client-http")).toBe(true);
+  });
+});

--- a/src/proxy-capture/coverage.ts
+++ b/src/proxy-capture/coverage.ts
@@ -1,0 +1,199 @@
+import process from "node:process";
+import { resolveDebugProxySettings, type DebugProxySettings } from "./env.js";
+import type { CaptureProtocol } from "./types.js";
+
+export type DebugProxyCoverageStatus = "captured" | "proxy-only" | "uncovered";
+
+export type DebugProxyCoverageEntry = {
+  id: string;
+  label: string;
+  modulePath: string;
+  protocols: CaptureProtocol[];
+  status: DebugProxyCoverageStatus;
+  notes: string;
+};
+
+export type DebugProxyCoverageSummary = {
+  total: number;
+  captured: number;
+  proxyOnly: number;
+  uncovered: number;
+};
+
+const DEBUG_PROXY_COVERAGE_ENTRIES: readonly DebugProxyCoverageEntry[] = [
+  {
+    id: "provider-transport-fetch",
+    label: "Provider HTTP transport",
+    modulePath: "src/agents/provider-transport-fetch.ts",
+    protocols: ["http", "https", "sse"],
+    status: "captured",
+    notes:
+      "Central provider fetch seam routes through explicit proxy overrides and records request/response payloads.",
+  },
+  {
+    id: "openai-ws-manager",
+    label: "OpenAI websocket manager",
+    modulePath: "src/agents/openai-ws-connection.ts",
+    protocols: ["ws", "wss"],
+    status: "captured",
+    notes:
+      "Central OpenAI websocket path records open/frame/close/error events with proxy agent support.",
+  },
+  {
+    id: "discord-rest",
+    label: "Discord REST monitor fetch",
+    modulePath: "extensions/discord/src/monitor/rest-fetch.ts",
+    protocols: ["http", "https"],
+    status: "captured",
+    notes: "Discord monitor REST calls inherit the debug proxy and record HTTP exchanges.",
+  },
+  {
+    id: "discord-gateway",
+    label: "Discord gateway monitor",
+    modulePath: "extensions/discord/src/monitor/gateway-plugin.ts",
+    protocols: ["https", "wss"],
+    status: "captured",
+    notes:
+      "Gateway metadata fetches and websocket lifecycle events are captured for monitor traffic.",
+  },
+  {
+    id: "telegram-fetch",
+    label: "Telegram fetch resolver",
+    modulePath: "extensions/telegram/src/fetch.ts",
+    protocols: ["http", "https"],
+    status: "captured",
+    notes:
+      "Telegram API fetch fallback picks up debug proxy env and records outbound/inbound exchanges.",
+  },
+  {
+    id: "mattermost-ws",
+    label: "Mattermost monitor websocket",
+    modulePath: "extensions/mattermost/src/mattermost/monitor-websocket.ts",
+    protocols: ["ws", "wss"],
+    status: "captured",
+    notes: "Mattermost websocket monitor uses the debug proxy agent and records frame activity.",
+  },
+  {
+    id: "openai-realtime-voice",
+    label: "OpenAI realtime voice bridge",
+    modulePath: "extensions/openai/realtime-voice-provider.ts",
+    protocols: ["wss"],
+    status: "captured",
+    notes:
+      "Realtime voice bridge now routes through the debug proxy agent and records websocket frames.",
+  },
+  {
+    id: "openai-realtime-transcription",
+    label: "OpenAI realtime transcription",
+    modulePath: "extensions/openai/realtime-transcription-provider.ts",
+    protocols: ["wss"],
+    status: "captured",
+    notes:
+      "Realtime transcription sessions now route through the debug proxy agent and record websocket frames.",
+  },
+  {
+    id: "openai-tts",
+    label: "OpenAI text-to-speech",
+    modulePath: "extensions/openai/tts.ts",
+    protocols: ["https"],
+    status: "captured",
+    notes:
+      "Direct OpenAI TTS fetches record request/response payloads while inheriting proxy env routing.",
+  },
+  {
+    id: "microsoft-voices",
+    label: "Microsoft voice discovery",
+    modulePath: "extensions/microsoft/speech-provider.ts",
+    protocols: ["https"],
+    status: "captured",
+    notes:
+      "Microsoft voice listing fetches record HTTP exchanges and follow process-wide proxy routing.",
+  },
+  {
+    id: "feishu-client-http",
+    label: "Feishu SDK HTTP client",
+    modulePath: "extensions/feishu/src/client.ts",
+    protocols: ["https"],
+    status: "proxy-only",
+    notes:
+      "Feishu SDK traffic can inherit ambient proxying, but decrypted request/response capture is not yet wired at the SDK seam.",
+  },
+  {
+    id: "feishu-client-ws",
+    label: "Feishu SDK websocket client",
+    modulePath: "extensions/feishu/src/client.ts",
+    protocols: ["wss"],
+    status: "proxy-only",
+    notes:
+      "Feishu websocket creation can inherit ambient proxying, but websocket frame capture is not yet wired.",
+  },
+];
+
+let warnedCoverageSessionKey: string | null = null;
+
+export function listDebugProxyCoverageEntries(): DebugProxyCoverageEntry[] {
+  return DEBUG_PROXY_COVERAGE_ENTRIES.map((entry) => ({
+    ...entry,
+    protocols: [...entry.protocols],
+  }));
+}
+
+export function summarizeDebugProxyCoverage(
+  entries: readonly DebugProxyCoverageEntry[] = DEBUG_PROXY_COVERAGE_ENTRIES,
+): DebugProxyCoverageSummary {
+  let captured = 0;
+  let proxyOnly = 0;
+  let uncovered = 0;
+  for (const entry of entries) {
+    if (entry.status === "captured") {
+      captured += 1;
+      continue;
+    }
+    if (entry.status === "proxy-only") {
+      proxyOnly += 1;
+      continue;
+    }
+    uncovered += 1;
+  }
+  return {
+    total: entries.length,
+    captured,
+    proxyOnly,
+    uncovered,
+  };
+}
+
+export function buildDebugProxyCoverageReport() {
+  const entries = listDebugProxyCoverageEntries();
+  return {
+    summary: summarizeDebugProxyCoverage(entries),
+    entries,
+  };
+}
+
+export function maybeWarnAboutDebugProxyCoverage(
+  settings: DebugProxySettings = resolveDebugProxySettings(),
+  warn: (message: string) => void = (message) => process.stderr.write(`${message}\n`),
+): void {
+  if (!settings.enabled || !settings.required) {
+    return;
+  }
+  const sessionKey = `${settings.sessionId}:${settings.proxyUrl ?? ""}`;
+  if (warnedCoverageSessionKey === sessionKey) {
+    return;
+  }
+  warnedCoverageSessionKey = sessionKey;
+
+  const report = buildDebugProxyCoverageReport();
+  const { summary } = report;
+  const partial = report.entries.filter((entry) => entry.status !== "captured");
+  if (partial.length === 0) {
+    return;
+  }
+  warn(
+    `[openclaw proxy] debug proxy coverage: ${summary.captured}/${summary.total} captured, ${summary.proxyOnly} proxy-only, ${summary.uncovered} uncovered.`,
+  );
+  warn(
+    `[openclaw proxy] remaining gaps: ${partial.map((entry) => entry.id).join(", ")}. Run \`openclaw proxy coverage\` for details.`,
+  );
+}

--- a/src/proxy-capture/env.test.ts
+++ b/src/proxy-capture/env.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  OPENCLAW_DEBUG_PROXY_ENABLED,
+  OPENCLAW_DEBUG_PROXY_SESSION_ID,
+  resolveDebugProxySettings,
+} from "./env.js";
+
+describe("resolveDebugProxySettings", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("keeps an implicit debug proxy session id stable within one process", async () => {
+    const mod = await import("./env.js");
+    const env = {
+      [OPENCLAW_DEBUG_PROXY_ENABLED]: "1",
+    } satisfies NodeJS.ProcessEnv;
+
+    const first = mod.resolveDebugProxySettings(env);
+    const second = mod.resolveDebugProxySettings(env);
+
+    expect(first.sessionId).toBe(second.sessionId);
+  });
+
+  it("prefers an explicit session id from the environment", () => {
+    const settings = resolveDebugProxySettings({
+      [OPENCLAW_DEBUG_PROXY_ENABLED]: "1",
+      [OPENCLAW_DEBUG_PROXY_SESSION_ID]: "session-explicit",
+    });
+
+    expect(settings.sessionId).toBe("session-explicit");
+  });
+});

--- a/src/proxy-capture/env.ts
+++ b/src/proxy-capture/env.ts
@@ -1,0 +1,93 @@
+import { randomUUID } from "node:crypto";
+import type { Agent } from "node:http";
+import process from "node:process";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import {
+  resolveDebugProxyBlobDir,
+  resolveDebugProxyCertDir,
+  resolveDebugProxyDbPath,
+} from "./paths.js";
+
+export const OPENCLAW_DEBUG_PROXY_ENABLED = "OPENCLAW_DEBUG_PROXY_ENABLED";
+export const OPENCLAW_DEBUG_PROXY_URL = "OPENCLAW_DEBUG_PROXY_URL";
+export const OPENCLAW_DEBUG_PROXY_DB_PATH = "OPENCLAW_DEBUG_PROXY_DB_PATH";
+export const OPENCLAW_DEBUG_PROXY_BLOB_DIR = "OPENCLAW_DEBUG_PROXY_BLOB_DIR";
+export const OPENCLAW_DEBUG_PROXY_CERT_DIR = "OPENCLAW_DEBUG_PROXY_CERT_DIR";
+export const OPENCLAW_DEBUG_PROXY_SESSION_ID = "OPENCLAW_DEBUG_PROXY_SESSION_ID";
+export const OPENCLAW_DEBUG_PROXY_REQUIRE = "OPENCLAW_DEBUG_PROXY_REQUIRE";
+
+export type DebugProxySettings = {
+  enabled: boolean;
+  required: boolean;
+  proxyUrl?: string;
+  dbPath: string;
+  blobDir: string;
+  certDir: string;
+  sessionId: string;
+  sourceProcess: string;
+};
+
+let cachedImplicitSessionId: string | undefined;
+
+function isTruthy(value: string | undefined): boolean {
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+export function resolveDebugProxySettings(
+  env: NodeJS.ProcessEnv = process.env,
+): DebugProxySettings {
+  const enabled = isTruthy(env[OPENCLAW_DEBUG_PROXY_ENABLED]);
+  const explicitSessionId = env[OPENCLAW_DEBUG_PROXY_SESSION_ID]?.trim() || undefined;
+  const sessionId = explicitSessionId ?? (cachedImplicitSessionId ??= randomUUID());
+  return {
+    enabled,
+    required: isTruthy(env[OPENCLAW_DEBUG_PROXY_REQUIRE]),
+    proxyUrl: env[OPENCLAW_DEBUG_PROXY_URL]?.trim() || undefined,
+    dbPath: env[OPENCLAW_DEBUG_PROXY_DB_PATH]?.trim() || resolveDebugProxyDbPath(env),
+    blobDir: env[OPENCLAW_DEBUG_PROXY_BLOB_DIR]?.trim() || resolveDebugProxyBlobDir(env),
+    certDir: env[OPENCLAW_DEBUG_PROXY_CERT_DIR]?.trim() || resolveDebugProxyCertDir(env),
+    sessionId,
+    sourceProcess: "openclaw",
+  };
+}
+
+export function applyDebugProxyEnv(
+  env: NodeJS.ProcessEnv,
+  params: {
+    proxyUrl: string;
+    sessionId: string;
+    dbPath?: string;
+    blobDir?: string;
+    certDir?: string;
+  },
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    [OPENCLAW_DEBUG_PROXY_ENABLED]: "1",
+    [OPENCLAW_DEBUG_PROXY_REQUIRE]: "1",
+    [OPENCLAW_DEBUG_PROXY_URL]: params.proxyUrl,
+    [OPENCLAW_DEBUG_PROXY_DB_PATH]: params.dbPath ?? resolveDebugProxyDbPath(env),
+    [OPENCLAW_DEBUG_PROXY_BLOB_DIR]: params.blobDir ?? resolveDebugProxyBlobDir(env),
+    [OPENCLAW_DEBUG_PROXY_CERT_DIR]: params.certDir ?? resolveDebugProxyCertDir(env),
+    [OPENCLAW_DEBUG_PROXY_SESSION_ID]: params.sessionId,
+    HTTP_PROXY: params.proxyUrl,
+    HTTPS_PROXY: params.proxyUrl,
+    ALL_PROXY: params.proxyUrl,
+  };
+}
+
+export function createDebugProxyWebSocketAgent(settings: DebugProxySettings): Agent | undefined {
+  if (!settings.enabled || !settings.proxyUrl) {
+    return undefined;
+  }
+  return new HttpsProxyAgent(settings.proxyUrl);
+}
+
+export function resolveEffectiveDebugProxyUrl(configuredProxyUrl?: string): string | undefined {
+  const explicit = configuredProxyUrl?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const settings = resolveDebugProxySettings();
+  return settings.enabled ? settings.proxyUrl : undefined;
+}

--- a/src/proxy-capture/paths.ts
+++ b/src/proxy-capture/paths.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+export function resolveDebugProxyRootDir(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), "debug-proxy");
+}
+
+export function resolveDebugProxyDbPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveDebugProxyRootDir(env), "capture.sqlite");
+}
+
+export function resolveDebugProxyBlobDir(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveDebugProxyRootDir(env), "blobs");
+}
+
+export function resolveDebugProxyCertDir(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveDebugProxyRootDir(env), "certs");
+}

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { parseConnectTarget } from "./proxy-server.js";
+
+describe("parseConnectTarget", () => {
+  it("parses bracketed IPv6 CONNECT targets safely", () => {
+    expect(parseConnectTarget("[::1]:8443")).toEqual({
+      hostname: "::1",
+      port: 8443,
+    });
+  });
+
+  it("parses unbracketed host:port CONNECT targets", () => {
+    expect(parseConnectTarget("api.openai.com:443")).toEqual({
+      hostname: "api.openai.com",
+      port: 443,
+    });
+  });
+
+  it("rejects invalid CONNECT ports", () => {
+    expect(() => parseConnectTarget("[::1]:99999")).toThrow("Invalid CONNECT target port");
+  });
+});

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import net from "node:net";
+import { URL } from "node:url";
+import { ensureDebugProxyCa } from "./ca.js";
+import type { DebugProxySettings } from "./env.js";
+import { getDebugProxyCaptureStore } from "./store.sqlite.js";
+
+type DebugProxyServerHandle = {
+  proxyUrl: string;
+  stop: () => Promise<void>;
+};
+
+function normalizeTargetUrl(req: IncomingMessage): URL {
+  if (req.url?.startsWith("http://") || req.url?.startsWith("https://")) {
+    return new URL(req.url);
+  }
+  const host = req.headers.host ?? "127.0.0.1";
+  return new URL(`http://${host}${req.url ?? "/"}`);
+}
+
+async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function startDebugProxyServer(params: {
+  host?: string;
+  port?: number;
+  settings: DebugProxySettings;
+}): Promise<DebugProxyServerHandle> {
+  await ensureDebugProxyCa(params.settings.certDir);
+  const store = getDebugProxyCaptureStore(params.settings.dbPath, params.settings.blobDir);
+  const host = params.host?.trim() || "127.0.0.1";
+
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const flowId = randomUUID();
+    const target = normalizeTargetUrl(req);
+    const body = await readBody(req);
+    store.recordEvent({
+      sessionId: params.settings.sessionId,
+      ts: Date.now(),
+      sourceScope: "openclaw",
+      sourceProcess: params.settings.sourceProcess,
+      protocol: target.protocol === "https:" ? "https" : "http",
+      direction: "outbound",
+      kind: "request",
+      flowId,
+      method: req.method,
+      host: target.host,
+      path: `${target.pathname}${target.search}`,
+      headersJson: JSON.stringify(req.headers),
+      dataText: body.subarray(0, 8192).toString("utf8"),
+    });
+    const upstream = (target.protocol === "https:" ? httpsRequest : httpRequest)(
+      target,
+      {
+        method: req.method,
+        headers: req.headers,
+      },
+      (upstreamRes) => {
+        const chunks: Buffer[] = [];
+        upstreamRes.on("data", (chunk) => {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          chunks.push(buffer);
+          res.write(buffer);
+        });
+        upstreamRes.on("end", () => {
+          const responseBody = Buffer.concat(chunks);
+          store.recordEvent({
+            sessionId: params.settings.sessionId,
+            ts: Date.now(),
+            sourceScope: "openclaw",
+            sourceProcess: params.settings.sourceProcess,
+            protocol: target.protocol === "https:" ? "https" : "http",
+            direction: "inbound",
+            kind: "response",
+            flowId,
+            method: req.method,
+            host: target.host,
+            path: `${target.pathname}${target.search}`,
+            status: upstreamRes.statusCode ?? undefined,
+            headersJson: JSON.stringify(upstreamRes.headers),
+            dataText: responseBody.subarray(0, 8192).toString("utf8"),
+          });
+          res.end();
+        });
+        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+      },
+    );
+    upstream.on("error", (error) => {
+      store.recordEvent({
+        sessionId: params.settings.sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: params.settings.sourceProcess,
+        protocol: target.protocol === "https:" ? "https" : "http",
+        direction: "local",
+        kind: "error",
+        flowId,
+        method: req.method,
+        host: target.host,
+        path: `${target.pathname}${target.search}`,
+        errorText: error.message,
+      });
+      res.statusCode = 502;
+      res.end(error.message);
+    });
+    if (body.byteLength > 0) {
+      upstream.write(body);
+    }
+    upstream.end();
+  });
+
+  server.on("connect", (req, clientSocket, head) => {
+    const flowId = randomUUID();
+    const [hostnameRaw, portRaw] = (req.url ?? "").split(":");
+    const hostname = hostnameRaw || "127.0.0.1";
+    const port = Number(portRaw || 443);
+    store.recordEvent({
+      sessionId: params.settings.sessionId,
+      ts: Date.now(),
+      sourceScope: "openclaw",
+      sourceProcess: params.settings.sourceProcess,
+      protocol: "connect",
+      direction: "local",
+      kind: "connect",
+      flowId,
+      host: hostname,
+      path: req.url ?? "",
+      headersJson: JSON.stringify(req.headers),
+    });
+    const upstreamSocket = net.connect(port, hostname, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) {
+        upstreamSocket.write(head);
+      }
+      clientSocket.pipe(upstreamSocket);
+      upstreamSocket.pipe(clientSocket);
+    });
+    upstreamSocket.on("error", (error) => {
+      store.recordEvent({
+        sessionId: params.settings.sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: params.settings.sourceProcess,
+        protocol: "connect",
+        direction: "local",
+        kind: "error",
+        flowId,
+        host: hostname,
+        path: req.url ?? "",
+        errorText: error.message,
+      });
+      clientSocket.end();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(params.port ?? 0, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to resolve debug proxy server address");
+  }
+  return {
+    proxyUrl: `http://${host}:${address.port}`,
+    stop: async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  };
+}

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -13,6 +13,38 @@ type DebugProxyServerHandle = {
   stop: () => Promise<void>;
 };
 
+export function parseConnectTarget(rawTarget: string | undefined): {
+  hostname: string;
+  port: number;
+} {
+  const trimmed = rawTarget?.trim() ?? "";
+  if (!trimmed) {
+    return { hostname: "127.0.0.1", port: 443 };
+  }
+
+  const bracketedMatch = trimmed.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (bracketedMatch) {
+    const hostname = bracketedMatch[1]?.trim() || "127.0.0.1";
+    const port = Number(bracketedMatch[2] || 443);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error("Invalid CONNECT target port");
+    }
+    return { hostname, port };
+  }
+
+  const lastColon = trimmed.lastIndexOf(":");
+  if (lastColon <= 0 || lastColon === trimmed.length - 1) {
+    return { hostname: trimmed, port: 443 };
+  }
+  const hostname = trimmed.slice(0, lastColon).trim() || "127.0.0.1";
+  const portText = trimmed.slice(lastColon + 1).trim();
+  const port = Number(portText);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error("Invalid CONNECT target port");
+  }
+  return { hostname, port };
+}
+
 function normalizeTargetUrl(req: IncomingMessage): URL {
   if (req.url?.startsWith("http://") || req.url?.startsWith("https://")) {
     return new URL(req.url);
@@ -119,9 +151,29 @@ export async function startDebugProxyServer(params: {
 
   server.on("connect", (req, clientSocket, head) => {
     const flowId = randomUUID();
-    const [hostnameRaw, portRaw] = (req.url ?? "").split(":");
-    const hostname = hostnameRaw || "127.0.0.1";
-    const port = Number(portRaw || 443);
+    let hostname = "127.0.0.1";
+    let port = 443;
+    try {
+      const parsed = parseConnectTarget(req.url);
+      hostname = parsed.hostname;
+      port = parsed.port;
+    } catch (error) {
+      store.recordEvent({
+        sessionId: params.settings.sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: params.settings.sourceProcess,
+        protocol: "connect",
+        direction: "local",
+        kind: "error",
+        flowId,
+        host: hostname,
+        path: req.url ?? "",
+        errorText: error instanceof Error ? error.message : String(error),
+      });
+      clientSocket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
+      return;
+    }
     store.recordEvent({
       sessionId: params.settings.sessionId,
       ts: Date.now(),

--- a/src/proxy-capture/query.ts
+++ b/src/proxy-capture/query.ts
@@ -1,0 +1,16 @@
+import { resolveDebugProxySettings } from "./env.js";
+import { getDebugProxyCaptureStore } from "./store.sqlite.js";
+import type { CaptureQueryPreset } from "./types.js";
+
+export function listDebugProxySessions(limit?: number) {
+  const settings = resolveDebugProxySettings();
+  return getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).listSessions(limit);
+}
+
+export function queryDebugProxyPreset(preset: CaptureQueryPreset, sessionId?: string) {
+  const settings = resolveDebugProxySettings();
+  return getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).queryPreset(
+    preset,
+    sessionId,
+  );
+}

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("debug proxy runtime", () => {
+  const envKeys = [
+    "OPENCLAW_DEBUG_PROXY_ENABLED",
+    "OPENCLAW_DEBUG_PROXY_DB_PATH",
+    "OPENCLAW_DEBUG_PROXY_BLOB_DIR",
+    "OPENCLAW_DEBUG_PROXY_SESSION_ID",
+    "OPENCLAW_DEBUG_PROXY_SOURCE_PROCESS",
+  ] as const;
+  const savedEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+  const originalFetch = globalThis.fetch;
+  let tempDir = "";
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-runtime-"));
+    process.env.OPENCLAW_DEBUG_PROXY_ENABLED = "1";
+    process.env.OPENCLAW_DEBUG_PROXY_DB_PATH = path.join(tempDir, "capture.sqlite");
+    process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR = path.join(tempDir, "blobs");
+    process.env.OPENCLAW_DEBUG_PROXY_SESSION_ID = "runtime-test-session";
+    process.env.OPENCLAW_DEBUG_PROXY_SOURCE_PROCESS = "runtime-test";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const key of envKeys) {
+      const value = savedEnv[key];
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it("captures ambient global fetch calls when debug proxy mode is enabled", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('{"ok":true}', { status: 200 }),
+    ) as typeof fetch;
+
+    const runtime = await import("./runtime.js");
+    const storeModule = await import("./store.sqlite.js");
+    runtime.initializeDebugProxyCapture("test");
+    await globalThis.fetch("https://api.minimax.io/anthropic/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"input":"hello"}',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    runtime.finalizeDebugProxyCapture();
+
+    const store = storeModule.getDebugProxyCaptureStore(
+      process.env.OPENCLAW_DEBUG_PROXY_DB_PATH!,
+      process.env.OPENCLAW_DEBUG_PROXY_BLOB_DIR!,
+    );
+    const events = store.getSessionEvents("runtime-test-session", 20);
+    expect(events.some((event) => event.host === "api.minimax.io")).toBe(true);
+    expect(events.some((event) => event.kind === "request")).toBe(true);
+    expect(events.some((event) => event.kind === "response")).toBe(true);
+    store.close();
+  });
+});

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -15,6 +15,10 @@ type GlobalFetchPatchedState = {
   originalFetch: typeof globalThis.fetch;
 };
 
+type GlobalFetchPatchTarget = typeof globalThis & {
+  [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
+};
+
 function protocolFromUrl(rawUrl: string): CaptureProtocol {
   try {
     const url = new URL(rawUrl);
@@ -50,9 +54,7 @@ function installDebugProxyGlobalFetchPatch(settings: DebugProxySettings): void {
   if (typeof globalThis.fetch !== "function") {
     return;
   }
-  const patched = globalThis as typeof globalThis & {
-    [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
-  };
+  const patched = globalThis as GlobalFetchPatchTarget;
   if (patched[DEBUG_PROXY_FETCH_PATCH_KEY]) {
     return;
   }
@@ -121,15 +123,17 @@ function installDebugProxyGlobalFetchPatch(settings: DebugProxySettings): void {
 }
 
 function uninstallDebugProxyGlobalFetchPatch(): void {
-  const patched = globalThis as typeof globalThis & {
-    [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
-  };
+  const patched = globalThis as GlobalFetchPatchTarget;
   const state = patched[DEBUG_PROXY_FETCH_PATCH_KEY];
   if (!state) {
     return;
   }
   globalThis.fetch = state.originalFetch;
   delete patched[DEBUG_PROXY_FETCH_PATCH_KEY];
+}
+
+export function isDebugProxyGlobalFetchPatchInstalled(): boolean {
+  return Boolean((globalThis as GlobalFetchPatchTarget)[DEBUG_PROXY_FETCH_PATCH_KEY]);
 }
 
 export function initializeDebugProxyCapture(mode: string, resolved?: DebugProxySettings): void {

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -1,0 +1,326 @@
+import { randomUUID } from "node:crypto";
+import { URL } from "node:url";
+import { resolveDebugProxySettings, type DebugProxySettings } from "./env.js";
+import {
+  closeDebugProxyCaptureStore,
+  getDebugProxyCaptureStore,
+  persistEventPayload,
+  safeJsonString,
+} from "./store.sqlite.js";
+import type { CaptureProtocol } from "./types.js";
+
+const DEBUG_PROXY_FETCH_PATCH_KEY = Symbol.for("openclaw.debugProxy.fetchPatch");
+
+type GlobalFetchPatchedState = {
+  originalFetch: typeof globalThis.fetch;
+};
+
+function protocolFromUrl(rawUrl: string): CaptureProtocol {
+  try {
+    const url = new URL(rawUrl);
+    switch (url.protocol) {
+      case "https:":
+        return "https";
+      case "wss:":
+        return "wss";
+      case "ws:":
+        return "ws";
+      default:
+        return "http";
+    }
+  } catch {
+    return "http";
+  }
+}
+
+function resolveUrlString(input: RequestInfo | URL): string | null {
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  if (typeof input === "string") {
+    return input;
+  }
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return input.url;
+  }
+  return null;
+}
+
+function installDebugProxyGlobalFetchPatch(settings: DebugProxySettings): void {
+  if (typeof globalThis.fetch !== "function") {
+    return;
+  }
+  const patched = globalThis as typeof globalThis & {
+    [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
+  };
+  if (patched[DEBUG_PROXY_FETCH_PATCH_KEY]) {
+    return;
+  }
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  patched[DEBUG_PROXY_FETCH_PATCH_KEY] = { originalFetch };
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = resolveUrlString(input);
+    try {
+      const response = await originalFetch(input, init);
+      if (url && /^https?:/i.test(url)) {
+        captureHttpExchange({
+          url,
+          method:
+            (typeof Request !== "undefined" && input instanceof Request
+              ? input.method
+              : undefined) ??
+            init?.method ??
+            "GET",
+          requestHeaders:
+            (typeof Request !== "undefined" && input instanceof Request
+              ? input.headers
+              : undefined) ?? (init?.headers as Headers | Record<string, string> | undefined),
+          requestBody:
+            (typeof Request !== "undefined" && input instanceof Request
+              ? (input as Request & { body?: BodyInit | null }).body
+              : undefined) ??
+            (init as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ??
+            null,
+          response,
+          transport: "http",
+          meta: {
+            captureOrigin: "global-fetch",
+            source: settings.sourceProcess,
+          },
+        });
+      }
+      return response;
+    } catch (error) {
+      if (url && /^https?:/i.test(url)) {
+        const store = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir);
+        const parsed = new URL(url);
+        store.recordEvent({
+          sessionId: settings.sessionId,
+          ts: Date.now(),
+          sourceScope: "openclaw",
+          sourceProcess: settings.sourceProcess,
+          protocol: protocolFromUrl(url),
+          direction: "local",
+          kind: "error",
+          flowId: randomUUID(),
+          method:
+            (typeof Request !== "undefined" && input instanceof Request
+              ? input.method
+              : undefined) ??
+            init?.method ??
+            "GET",
+          host: parsed.host,
+          path: `${parsed.pathname}${parsed.search}`,
+          errorText: error instanceof Error ? error.message : String(error),
+          metaJson: safeJsonString({ captureOrigin: "global-fetch" }),
+        });
+      }
+      throw error;
+    }
+  }) as typeof globalThis.fetch;
+}
+
+function uninstallDebugProxyGlobalFetchPatch(): void {
+  const patched = globalThis as typeof globalThis & {
+    [DEBUG_PROXY_FETCH_PATCH_KEY]?: GlobalFetchPatchedState;
+  };
+  const state = patched[DEBUG_PROXY_FETCH_PATCH_KEY];
+  if (!state) {
+    return;
+  }
+  globalThis.fetch = state.originalFetch;
+  delete patched[DEBUG_PROXY_FETCH_PATCH_KEY];
+}
+
+export function initializeDebugProxyCapture(mode: string, resolved?: DebugProxySettings): void {
+  const settings = resolved ?? resolveDebugProxySettings();
+  if (!settings.enabled) {
+    return;
+  }
+  getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).upsertSession({
+    id: settings.sessionId,
+    startedAt: Date.now(),
+    mode,
+    sourceScope: "openclaw",
+    sourceProcess: settings.sourceProcess,
+    proxyUrl: settings.proxyUrl,
+    dbPath: settings.dbPath,
+    blobDir: settings.blobDir,
+  });
+  installDebugProxyGlobalFetchPatch(settings);
+}
+
+export function finalizeDebugProxyCapture(resolved?: DebugProxySettings): void {
+  const settings = resolved ?? resolveDebugProxySettings();
+  if (!settings.enabled) {
+    return;
+  }
+  getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).endSession(settings.sessionId);
+  uninstallDebugProxyGlobalFetchPatch();
+  closeDebugProxyCaptureStore();
+}
+
+export function captureHttpExchange(params: {
+  url: string;
+  method: string;
+  requestHeaders?: Headers | Record<string, string> | undefined;
+  requestBody?: BodyInit | Buffer | string | null;
+  response: Response;
+  transport?: "http" | "sse";
+  flowId?: string;
+  meta?: Record<string, unknown>;
+}): void {
+  const settings = resolveDebugProxySettings();
+  if (!settings.enabled) {
+    return;
+  }
+  const store = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir);
+  const flowId = params.flowId ?? randomUUID();
+  const url = new URL(params.url);
+  const requestBody =
+    typeof params.requestBody === "string" || Buffer.isBuffer(params.requestBody)
+      ? params.requestBody
+      : null;
+  const requestPayload = persistEventPayload(store, {
+    data: requestBody,
+    contentType:
+      params.requestHeaders instanceof Headers
+        ? (params.requestHeaders.get("content-type") ?? undefined)
+        : params.requestHeaders?.["content-type"],
+  });
+  store.recordEvent({
+    sessionId: settings.sessionId,
+    ts: Date.now(),
+    sourceScope: "openclaw",
+    sourceProcess: settings.sourceProcess,
+    protocol: params.transport ?? protocolFromUrl(params.url),
+    direction: "outbound",
+    kind: "request",
+    flowId,
+    method: params.method,
+    host: url.host,
+    path: `${url.pathname}${url.search}`,
+    contentType:
+      params.requestHeaders instanceof Headers
+        ? (params.requestHeaders.get("content-type") ?? undefined)
+        : params.requestHeaders?.["content-type"],
+    headersJson: safeJsonString(
+      params.requestHeaders instanceof Headers
+        ? Object.fromEntries(params.requestHeaders.entries())
+        : params.requestHeaders,
+    ),
+    metaJson: safeJsonString(params.meta),
+    ...requestPayload,
+  });
+  const cloneable =
+    params.response &&
+    typeof params.response.clone === "function" &&
+    typeof params.response.arrayBuffer === "function";
+  if (!cloneable) {
+    store.recordEvent({
+      sessionId: settings.sessionId,
+      ts: Date.now(),
+      sourceScope: "openclaw",
+      sourceProcess: settings.sourceProcess,
+      protocol: params.transport ?? protocolFromUrl(params.url),
+      direction: "inbound",
+      kind: "response",
+      flowId,
+      method: params.method,
+      host: url.host,
+      path: `${url.pathname}${url.search}`,
+      status: params.response.status,
+      contentType:
+        typeof params.response.headers?.get === "function"
+          ? (params.response.headers.get("content-type") ?? undefined)
+          : undefined,
+      headersJson:
+        params.response.headers && typeof params.response.headers.entries === "function"
+          ? safeJsonString(Object.fromEntries(params.response.headers.entries()))
+          : undefined,
+      metaJson: safeJsonString({ ...params.meta, bodyCapture: "unavailable" }),
+    });
+    return;
+  }
+  void params.response
+    .clone()
+    .arrayBuffer()
+    .then((buffer) => {
+      const responsePayload = persistEventPayload(store, {
+        data: Buffer.from(buffer),
+        contentType: params.response.headers.get("content-type") ?? undefined,
+      });
+      store.recordEvent({
+        sessionId: settings.sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: settings.sourceProcess,
+        protocol: params.transport ?? protocolFromUrl(params.url),
+        direction: "inbound",
+        kind: "response",
+        flowId,
+        method: params.method,
+        host: url.host,
+        path: `${url.pathname}${url.search}`,
+        status: params.response.status,
+        contentType: params.response.headers.get("content-type") ?? undefined,
+        headersJson: safeJsonString(Object.fromEntries(params.response.headers.entries())),
+        metaJson: safeJsonString(params.meta),
+        ...responsePayload,
+      });
+    })
+    .catch((error) => {
+      store.recordEvent({
+        sessionId: settings.sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: settings.sourceProcess,
+        protocol: params.transport ?? protocolFromUrl(params.url),
+        direction: "local",
+        kind: "error",
+        flowId,
+        method: params.method,
+        host: url.host,
+        path: `${url.pathname}${url.search}`,
+        errorText: error instanceof Error ? error.message : String(error),
+      });
+    });
+}
+
+export function captureWsEvent(params: {
+  url: string;
+  direction: "outbound" | "inbound" | "local";
+  kind: "ws-open" | "ws-frame" | "ws-close" | "error";
+  flowId: string;
+  payload?: string | Buffer;
+  closeCode?: number;
+  errorText?: string;
+  meta?: Record<string, unknown>;
+}): void {
+  const settings = resolveDebugProxySettings();
+  if (!settings.enabled) {
+    return;
+  }
+  const store = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir);
+  const url = new URL(params.url);
+  const payload = persistEventPayload(store, {
+    data: params.payload,
+    contentType: "application/json",
+  });
+  store.recordEvent({
+    sessionId: settings.sessionId,
+    ts: Date.now(),
+    sourceScope: "openclaw",
+    sourceProcess: settings.sourceProcess,
+    protocol: protocolFromUrl(params.url),
+    direction: params.direction,
+    kind: params.kind,
+    flowId: params.flowId,
+    host: url.host,
+    path: `${url.pathname}${url.search}`,
+    closeCode: params.closeCode,
+    errorText: params.errorText,
+    metaJson: safeJsonString(params.meta),
+    ...payload,
+  });
+}

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { DebugProxyCaptureStore, persistEventPayload } from "./store.sqlite.js";
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function makeStore() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-"));
+  cleanupDirs.push(root);
+  return new DebugProxyCaptureStore(path.join(root, "capture.sqlite"), path.join(root, "blobs"));
+}
+
+describe("DebugProxyCaptureStore", () => {
+  it("stores sessions, blobs, and duplicate-send query results", () => {
+    const store = makeStore();
+    store.upsertSession({
+      id: "session-1",
+      startedAt: Date.now(),
+      mode: "proxy-run",
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      dbPath: store.dbPath,
+      blobDir: store.blobDir,
+    });
+    const firstPayload = persistEventPayload(store, {
+      data: '{"ok":true}',
+      contentType: "application/json",
+    });
+    store.recordEvent({
+      sessionId: "session-1",
+      ts: 1,
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      protocol: "https",
+      direction: "outbound",
+      kind: "request",
+      flowId: "flow-1",
+      method: "POST",
+      host: "api.example.com",
+      path: "/v1/send",
+      ...firstPayload,
+    });
+    store.recordEvent({
+      sessionId: "session-1",
+      ts: 2,
+      sourceScope: "openclaw",
+      sourceProcess: "openclaw",
+      protocol: "https",
+      direction: "outbound",
+      kind: "request",
+      flowId: "flow-2",
+      method: "POST",
+      host: "api.example.com",
+      path: "/v1/send",
+      ...firstPayload,
+    });
+
+    expect(store.listSessions(10)).toHaveLength(1);
+    expect(store.queryPreset("double-sends", "session-1")).toEqual([
+      expect.objectContaining({
+        host: "api.example.com",
+        path: "/v1/send",
+        method: "POST",
+        duplicateCount: 2,
+      }),
+    ]);
+    expect(store.readBlob(firstPayload.dataBlobId ?? "")).toContain('"ok":true');
+  });
+});

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -77,4 +77,46 @@ describe("DebugProxyCaptureStore", () => {
     ]);
     expect(store.readBlob(firstPayload.dataBlobId ?? "")).toContain('"ok":true');
   });
+
+  it("keeps shared blobs when deleting one of multiple referencing sessions", () => {
+    const store = makeStore();
+    const sharedPayload = persistEventPayload(store, {
+      data: '{"shared":true}',
+      contentType: "application/json",
+    });
+
+    for (const sessionId of ["session-a", "session-b"]) {
+      store.upsertSession({
+        id: sessionId,
+        startedAt: Date.now(),
+        mode: "proxy-run",
+        sourceScope: "openclaw",
+        sourceProcess: "openclaw",
+        dbPath: store.dbPath,
+        blobDir: store.blobDir,
+      });
+      store.recordEvent({
+        sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: "openclaw",
+        protocol: "https",
+        direction: "outbound",
+        kind: "request",
+        flowId: `flow-${sessionId}`,
+        method: "POST",
+        host: "api.example.com",
+        path: "/v1/shared",
+        ...sharedPayload,
+      });
+    }
+
+    const result = store.deleteSessions(["session-a"]);
+
+    expect(result.sessions).toBe(1);
+    expect(result.events).toBe(1);
+    expect(result.blobs).toBe(0);
+    expect(store.readBlob(sharedPayload.dataBlobId ?? "")).toContain('"shared":true');
+    expect(store.listSessions(10).map((session) => session.id)).toEqual(["session-b"]);
+  });
 });

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -410,10 +410,30 @@ export class DebugProxyCaptureStore {
     this.db
       .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
       .run(...uniqueSessionIds);
+    const candidateBlobIds = blobRows
+      .map((row) => row.blobId?.trim())
+      .filter((blobId): blobId is string => Boolean(blobId));
+    const remainingBlobRefs =
+      candidateBlobIds.length > 0
+        ? new Set(
+            (
+              this.db
+                .prepare(
+                  `SELECT DISTINCT data_blob_id AS blobId
+                   FROM capture_events
+                   WHERE data_blob_id IN (${candidateBlobIds.map(() => "?").join(", ")})
+                     AND data_blob_id IS NOT NULL`,
+                )
+                .all(...candidateBlobIds) as Array<{ blobId?: string | null }>
+            )
+              .map((row) => row.blobId?.trim())
+              .filter((blobId): blobId is string => Boolean(blobId)),
+          )
+        : new Set<string>();
     let blobs = 0;
     for (const row of blobRows) {
       const blobId = row.blobId?.trim();
-      if (!blobId) {
+      if (!blobId || remainingBlobRefs.has(blobId)) {
         continue;
       }
       const blobPath = path.join(this.blobDir, `${blobId}.bin.gz`);

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -1,0 +1,470 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { readCaptureBlobText, writeCaptureBlob } from "./blob-store.js";
+import type {
+  CaptureBlobRecord,
+  CaptureEventRecord,
+  CaptureObservedDimension,
+  CaptureQueryPreset,
+  CaptureQueryRow,
+  CaptureSessionCoverageSummary,
+  CaptureSessionRecord,
+  CaptureSessionSummary,
+} from "./types.js";
+
+function ensureParentDir(filePath: string) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function openDatabase(dbPath: string): DatabaseSync {
+  ensureParentDir(dbPath);
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 5000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS capture_sessions (
+      id TEXT PRIMARY KEY,
+      started_at INTEGER NOT NULL,
+      ended_at INTEGER,
+      mode TEXT NOT NULL,
+      source_scope TEXT NOT NULL,
+      source_process TEXT NOT NULL,
+      proxy_url TEXT,
+      db_path TEXT NOT NULL,
+      blob_dir TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS capture_events (
+      id INTEGER PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      ts INTEGER NOT NULL,
+      source_scope TEXT NOT NULL,
+      source_process TEXT NOT NULL,
+      protocol TEXT NOT NULL,
+      direction TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      flow_id TEXT NOT NULL,
+      method TEXT,
+      host TEXT,
+      path TEXT,
+      status INTEGER,
+      close_code INTEGER,
+      content_type TEXT,
+      headers_json TEXT,
+      data_text TEXT,
+      data_blob_id TEXT,
+      data_sha256 TEXT,
+      error_text TEXT,
+      meta_json TEXT
+    );
+    CREATE INDEX IF NOT EXISTS capture_events_session_ts_idx ON capture_events(session_id, ts);
+    CREATE INDEX IF NOT EXISTS capture_events_flow_idx ON capture_events(flow_id, ts);
+  `);
+  return db;
+}
+
+function serializeJson(value: unknown): string | null {
+  return value == null ? null : JSON.stringify(value);
+}
+
+function parseMetaJson(metaJson: unknown): Record<string, unknown> | null {
+  if (typeof metaJson !== "string" || metaJson.trim().length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(metaJson) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeObservedValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function sortObservedCounts(counts: Map<string, number>): CaptureObservedDimension[] {
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .toSorted((left, right) => right.count - left.count || left.value.localeCompare(right.value));
+}
+
+export class DebugProxyCaptureStore {
+  readonly db: DatabaseSync;
+
+  constructor(
+    readonly dbPath: string,
+    readonly blobDir: string,
+  ) {
+    this.db = openDatabase(dbPath);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  upsertSession(session: CaptureSessionRecord): void {
+    this.db
+      .prepare(
+        `INSERT INTO capture_sessions (
+          id, started_at, ended_at, mode, source_scope, source_process, proxy_url, db_path, blob_dir
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          ended_at=excluded.ended_at,
+          proxy_url=excluded.proxy_url,
+          source_process=excluded.source_process`,
+      )
+      .run(
+        session.id,
+        session.startedAt,
+        session.endedAt ?? null,
+        session.mode,
+        session.sourceScope,
+        session.sourceProcess,
+        session.proxyUrl ?? null,
+        session.dbPath,
+        session.blobDir,
+      );
+  }
+
+  endSession(sessionId: string, endedAt = Date.now()): void {
+    this.db
+      .prepare(`UPDATE capture_sessions SET ended_at = ? WHERE id = ?`)
+      .run(endedAt, sessionId);
+  }
+
+  persistPayload(data: Buffer, contentType?: string): CaptureBlobRecord {
+    return writeCaptureBlob({ blobDir: this.blobDir, data, contentType });
+  }
+
+  recordEvent(event: CaptureEventRecord): void {
+    this.db
+      .prepare(
+        `INSERT INTO capture_events (
+          session_id, ts, source_scope, source_process, protocol, direction, kind, flow_id,
+          method, host, path, status, close_code, content_type, headers_json,
+          data_text, data_blob_id, data_sha256, error_text, meta_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        event.sessionId,
+        event.ts,
+        event.sourceScope,
+        event.sourceProcess,
+        event.protocol,
+        event.direction,
+        event.kind,
+        event.flowId,
+        event.method ?? null,
+        event.host ?? null,
+        event.path ?? null,
+        event.status ?? null,
+        event.closeCode ?? null,
+        event.contentType ?? null,
+        event.headersJson ?? null,
+        event.dataText ?? null,
+        event.dataBlobId ?? null,
+        event.dataSha256 ?? null,
+        event.errorText ?? null,
+        event.metaJson ?? null,
+      );
+  }
+
+  listSessions(limit = 50): CaptureSessionSummary[] {
+    return this.db
+      .prepare(
+        `SELECT
+           s.id,
+           s.started_at AS startedAt,
+           s.ended_at AS endedAt,
+           s.mode,
+           s.source_process AS sourceProcess,
+           s.proxy_url AS proxyUrl,
+           COUNT(e.id) AS eventCount
+         FROM capture_sessions s
+         LEFT JOIN capture_events e ON e.session_id = s.id
+         GROUP BY s.id
+         ORDER BY s.started_at DESC
+         LIMIT ?`,
+      )
+      .all(limit) as CaptureSessionSummary[];
+  }
+
+  getSessionEvents(sessionId: string, limit = 500): Array<Record<string, unknown>> {
+    return this.db
+      .prepare(
+        `SELECT
+           id, session_id AS sessionId, ts, source_scope AS sourceScope, source_process AS sourceProcess,
+           protocol, direction, kind, flow_id AS flowId, method, host, path, status, close_code AS closeCode,
+           content_type AS contentType, headers_json AS headersJson, data_text AS dataText,
+           data_blob_id AS dataBlobId, data_sha256 AS dataSha256, error_text AS errorText, meta_json AS metaJson
+         FROM capture_events
+         WHERE session_id = ?
+         ORDER BY ts DESC, id DESC
+         LIMIT ?`,
+      )
+      .all(sessionId, limit) as Array<Record<string, unknown>>;
+  }
+
+  summarizeSessionCoverage(sessionId: string): CaptureSessionCoverageSummary {
+    const rows = this.db
+      .prepare(
+        `SELECT host, meta_json AS metaJson
+         FROM capture_events
+         WHERE session_id = ?`,
+      )
+      .all(sessionId) as Array<{ host?: string | null; metaJson?: string | null }>;
+    const providers = new Map<string, number>();
+    const apis = new Map<string, number>();
+    const models = new Map<string, number>();
+    const hosts = new Map<string, number>();
+    const localPeers = new Map<string, number>();
+    let unlabeledEventCount = 0;
+    for (const row of rows) {
+      const meta = parseMetaJson(row.metaJson);
+      const provider = normalizeObservedValue(meta?.provider);
+      const api = normalizeObservedValue(meta?.api);
+      const model = normalizeObservedValue(meta?.model);
+      const host = normalizeObservedValue(row.host);
+      if (!provider && !api && !model) {
+        unlabeledEventCount += 1;
+      }
+      if (provider) {
+        providers.set(provider, (providers.get(provider) ?? 0) + 1);
+      }
+      if (api) {
+        apis.set(api, (apis.get(api) ?? 0) + 1);
+      }
+      if (model) {
+        models.set(model, (models.get(model) ?? 0) + 1);
+      }
+      if (host) {
+        hosts.set(host, (hosts.get(host) ?? 0) + 1);
+        if (
+          host === "127.0.0.1:11434" ||
+          host.startsWith("127.0.0.1:") ||
+          host.startsWith("localhost:")
+        ) {
+          localPeers.set(host, (localPeers.get(host) ?? 0) + 1);
+        }
+      }
+    }
+    return {
+      sessionId,
+      totalEvents: rows.length,
+      unlabeledEventCount,
+      providers: sortObservedCounts(providers),
+      apis: sortObservedCounts(apis),
+      models: sortObservedCounts(models),
+      hosts: sortObservedCounts(hosts),
+      localPeers: sortObservedCounts(localPeers),
+    };
+  }
+
+  readBlob(blobId: string): string | null {
+    const row = this.db
+      .prepare(`SELECT data_blob_id AS blobId FROM capture_events WHERE data_blob_id = ? LIMIT 1`)
+      .get(blobId) as { blobId?: string } | undefined;
+    if (!row?.blobId) {
+      return null;
+    }
+    const blobPath = path.join(this.blobDir, `${row.blobId}.bin.gz`);
+    return fs.existsSync(blobPath) ? readCaptureBlobText(blobPath) : null;
+  }
+
+  queryPreset(preset: CaptureQueryPreset, sessionId?: string): CaptureQueryRow[] {
+    const sessionWhere = sessionId ? "AND session_id = ?" : "";
+    const args = sessionId ? [sessionId] : [];
+    switch (preset) {
+      case "double-sends":
+        return this.db
+          .prepare(
+            `SELECT host, path, method, COUNT(*) AS duplicateCount
+             FROM capture_events
+             WHERE kind = 'request' ${sessionWhere}
+             GROUP BY host, path, method, data_sha256
+             HAVING COUNT(*) > 1
+             ORDER BY duplicateCount DESC, host ASC`,
+          )
+          .all(...args) as CaptureQueryRow[];
+      case "retry-storms":
+        return this.db
+          .prepare(
+            `SELECT host, path, COUNT(*) AS errorCount
+             FROM capture_events
+             WHERE kind = 'response' AND status >= 429 ${sessionWhere}
+             GROUP BY host, path
+             HAVING COUNT(*) > 1
+             ORDER BY errorCount DESC, host ASC`,
+          )
+          .all(...args) as CaptureQueryRow[];
+      case "cache-busting":
+        return this.db
+          .prepare(
+            `SELECT host, path, COUNT(*) AS variantCount
+             FROM capture_events
+             WHERE kind = 'request'
+               AND (path LIKE '%?%' OR headers_json LIKE '%cache-control%' OR headers_json LIKE '%pragma%')
+               ${sessionWhere}
+             GROUP BY host, path
+             ORDER BY variantCount DESC, host ASC`,
+          )
+          .all(...args) as CaptureQueryRow[];
+      case "ws-duplicate-frames":
+        return this.db
+          .prepare(
+            `SELECT host, path, COUNT(*) AS duplicateFrames
+             FROM capture_events
+             WHERE kind = 'ws-frame' AND direction = 'outbound' ${sessionWhere}
+             GROUP BY host, path, data_sha256
+             HAVING COUNT(*) > 1
+             ORDER BY duplicateFrames DESC, host ASC`,
+          )
+          .all(...args) as CaptureQueryRow[];
+      case "missing-ack":
+        return this.db
+          .prepare(
+            `SELECT flow_id AS flowId, host, path, COUNT(*) AS outboundFrames
+             FROM capture_events
+             WHERE kind = 'ws-frame' AND direction = 'outbound' ${sessionWhere}
+               AND flow_id NOT IN (
+                 SELECT flow_id FROM capture_events
+                 WHERE kind = 'ws-frame' AND direction = 'inbound' ${sessionId ? "AND session_id = ?" : ""}
+               )
+             GROUP BY flow_id, host, path
+             ORDER BY outboundFrames DESC`,
+          )
+          .all(...(sessionId ? [sessionId, sessionId] : [])) as CaptureQueryRow[];
+      case "error-bursts":
+        return this.db
+          .prepare(
+            `SELECT host, path, COUNT(*) AS errorCount
+             FROM capture_events
+             WHERE kind = 'error' ${sessionWhere}
+             GROUP BY host, path
+             ORDER BY errorCount DESC, host ASC`,
+          )
+          .all(...args) as CaptureQueryRow[];
+      default:
+        return [];
+    }
+  }
+
+  purgeAll(): { sessions: number; events: number; blobs: number } {
+    const sessionCount =
+      (this.db.prepare(`SELECT COUNT(*) AS count FROM capture_sessions`).get() as { count: number })
+        .count ?? 0;
+    const eventCount =
+      (this.db.prepare(`SELECT COUNT(*) AS count FROM capture_events`).get() as { count: number })
+        .count ?? 0;
+    this.db.exec(`DELETE FROM capture_events; DELETE FROM capture_sessions;`);
+    let blobs = 0;
+    if (fs.existsSync(this.blobDir)) {
+      for (const entry of fs.readdirSync(this.blobDir)) {
+        fs.rmSync(path.join(this.blobDir, entry), { force: true });
+        blobs += 1;
+      }
+    }
+    return { sessions: sessionCount, events: eventCount, blobs };
+  }
+
+  deleteSessions(sessionIds: string[]): { sessions: number; events: number; blobs: number } {
+    const uniqueSessionIds = [...new Set(sessionIds.map((id) => id.trim()).filter(Boolean))];
+    if (uniqueSessionIds.length === 0) {
+      return { sessions: 0, events: 0, blobs: 0 };
+    }
+    const placeholders = uniqueSessionIds.map(() => "?").join(", ");
+    const blobRows = this.db
+      .prepare(
+        `SELECT DISTINCT data_blob_id AS blobId
+         FROM capture_events
+         WHERE session_id IN (${placeholders})
+           AND data_blob_id IS NOT NULL`,
+      )
+      .all(...uniqueSessionIds) as Array<{ blobId?: string | null }>;
+    const eventCount =
+      (
+        this.db
+          .prepare(
+            `SELECT COUNT(*) AS count
+             FROM capture_events
+             WHERE session_id IN (${placeholders})`,
+          )
+          .get(...uniqueSessionIds) as { count: number }
+      ).count ?? 0;
+    const sessionCount =
+      (
+        this.db
+          .prepare(
+            `SELECT COUNT(*) AS count
+             FROM capture_sessions
+             WHERE id IN (${placeholders})`,
+          )
+          .get(...uniqueSessionIds) as { count: number }
+      ).count ?? 0;
+    this.db
+      .prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`)
+      .run(...uniqueSessionIds);
+    this.db
+      .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
+      .run(...uniqueSessionIds);
+    let blobs = 0;
+    for (const row of blobRows) {
+      const blobId = row.blobId?.trim();
+      if (!blobId) {
+        continue;
+      }
+      const blobPath = path.join(this.blobDir, `${blobId}.bin.gz`);
+      if (fs.existsSync(blobPath)) {
+        fs.rmSync(blobPath, { force: true });
+        blobs += 1;
+      }
+    }
+    return { sessions: sessionCount, events: eventCount, blobs };
+  }
+}
+
+let cachedStore: DebugProxyCaptureStore | null = null;
+let cachedKey = "";
+
+export function getDebugProxyCaptureStore(dbPath: string, blobDir: string): DebugProxyCaptureStore {
+  const key = `${dbPath}:${blobDir}`;
+  if (!cachedStore || cachedKey !== key) {
+    cachedStore = new DebugProxyCaptureStore(dbPath, blobDir);
+    cachedKey = key;
+  }
+  return cachedStore;
+}
+
+export function closeDebugProxyCaptureStore(): void {
+  if (!cachedStore) {
+    return;
+  }
+  cachedStore.close();
+  cachedStore = null;
+  cachedKey = "";
+}
+
+export function persistEventPayload(
+  store: DebugProxyCaptureStore,
+  params: { data?: Buffer | string | null; contentType?: string; previewLimit?: number },
+): { dataText?: string; dataBlobId?: string; dataSha256?: string } {
+  if (params.data == null) {
+    return {};
+  }
+  const buffer = Buffer.isBuffer(params.data) ? params.data : Buffer.from(params.data);
+  const previewLimit = params.previewLimit ?? 8192;
+  const blob = store.persistPayload(buffer, params.contentType);
+  return {
+    dataText: buffer.subarray(0, previewLimit).toString("utf8"),
+    dataBlobId: blob.blobId,
+    dataSha256: blob.sha256,
+  };
+}
+
+export function safeJsonString(value: unknown): string | undefined {
+  const raw = serializeJson(value);
+  return raw ?? undefined;
+}

--- a/src/proxy-capture/types.ts
+++ b/src/proxy-capture/types.ts
@@ -1,0 +1,94 @@
+export type CaptureProtocol = "http" | "https" | "sse" | "ws" | "wss" | "connect";
+
+export type CaptureDirection = "outbound" | "inbound" | "local";
+
+export type CaptureEventKind =
+  | "connect"
+  | "tls-handshake"
+  | "request"
+  | "response"
+  | "ws-open"
+  | "ws-frame"
+  | "ws-close"
+  | "error"
+  | "retry-link";
+
+export type CaptureSessionRecord = {
+  id: string;
+  startedAt: number;
+  endedAt?: number;
+  mode: string;
+  sourceScope: "openclaw";
+  sourceProcess: string;
+  proxyUrl?: string;
+  dbPath: string;
+  blobDir: string;
+};
+
+export type CaptureBlobRecord = {
+  blobId: string;
+  path: string;
+  encoding: "gzip";
+  sizeBytes: number;
+  sha256: string;
+  contentType?: string;
+};
+
+export type CaptureEventRecord = {
+  sessionId: string;
+  ts: number;
+  sourceScope: "openclaw";
+  sourceProcess: string;
+  protocol: CaptureProtocol;
+  direction: CaptureDirection;
+  kind: CaptureEventKind;
+  flowId: string;
+  method?: string;
+  host?: string;
+  path?: string;
+  status?: number;
+  closeCode?: number;
+  contentType?: string;
+  headersJson?: string;
+  dataText?: string;
+  dataBlobId?: string;
+  dataSha256?: string;
+  errorText?: string;
+  metaJson?: string;
+};
+
+export type CaptureQueryPreset =
+  | "double-sends"
+  | "retry-storms"
+  | "cache-busting"
+  | "ws-duplicate-frames"
+  | "missing-ack"
+  | "error-bursts";
+
+export type CaptureQueryRow = Record<string, string | number | null>;
+
+export type CaptureSessionSummary = {
+  id: string;
+  startedAt: number;
+  endedAt?: number;
+  mode: string;
+  sourceProcess: string;
+  proxyUrl?: string;
+  eventCount: number;
+};
+
+export type CaptureObservedDimension = {
+  value: string;
+  count: number;
+};
+
+export type CaptureSessionCoverageSummary = {
+  sessionId: string;
+  totalEvents: number;
+  unlabeledEventCount: number;
+  providers: CaptureObservedDimension[];
+  apis: CaptureObservedDimension[];
+  models: CaptureObservedDimension[];
+  hosts: CaptureObservedDimension[];
+  localPeers: CaptureObservedDimension[];
+};


### PR DESCRIPTION
## Summary
- add the proxy capture core, storage, CA, and CLI surfaces
- expand transport capture coverage and route more provider/channel traffic into the shared seam
- add QA Lab capture backend APIs and the Capture UI inspector/timeline workflow

## Commit structure
- `99c33cace0` Add proxy capture core and CLI
- `1bc11e3b7a` Expand transport capture coverage
- `41daa6899a` Add QA Lab capture backend
- `c5e001e18d` Refine QA Lab capture UI

## Validation
- `node scripts/test-projects.mjs src/proxy-capture/store.sqlite.test.ts src/proxy-capture/runtime.test.ts src/proxy-capture/coverage.test.ts src/cli/proxy-cli.test.ts`
- `node scripts/test-projects.mjs src/agents/provider-transport-fetch.test.ts src/agents/openai-ws-connection.test.ts extensions/telegram/src/fetch.test.ts extensions/discord/src/monitor/provider.rest-proxy.test.ts extensions/microsoft/speech-provider.test.ts extensions/openai/tts.test.ts`
- `node scripts/test-projects.mjs extensions/qa-lab/src/lab-server.test.ts`
- `pnpm qa:lab:build`
- `node scripts/test-projects.mjs extensions/qa-lab/src/lab-server.test.ts src/agents/provider-transport-fetch.test.ts src/proxy-capture/runtime.test.ts src/proxy-capture/coverage.test.ts`

## Notes
- the repo commit hook still hits unrelated pre-existing TypeScript failures under `src/auto-reply/*`, so the scoped commits were recorded with direct targeted validation for this stack