### PR TITLE
qa-lab: (GPT 5.4 Parity vs. Opus Agentic) stage mock auth profiles so the parity gate runs without real credentials

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -64,6 +64,11 @@ describe("buildQaRuntimeEnv", () => {
     expect(env.GEMINI_API_KEY).toBe("gemini-live");
   });
 
+  it("defaults gateway-child provider mode to mock-openai when omitted", () => {
+    expect(__testing.resolveQaGatewayChildProviderMode(undefined)).toBe("mock-openai");
+    expect(__testing.resolveQaGatewayChildProviderMode("live-frontier")).toBe("live-frontier");
+  });
+
   it("keeps explicit provider env vars over live aliases", () => {
     const env = buildQaRuntimeEnv({
       ...createParams({

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -280,6 +280,88 @@ describe("buildQaRuntimeEnv", () => {
     });
   });
 
+  it("stages placeholder mock auth profiles per agent dir so mock-openai runs can resolve credentials", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "qa-mock-auth-"));
+    cleanups.push(async () => {
+      await rm(stateDir, { recursive: true, force: true });
+    });
+
+    const cfg = await __testing.stageQaMockAuthProfiles({
+      cfg: {},
+      stateDir,
+    });
+
+    // Config side: both providers should have a profile entry with mode
+    // "api_key" so the runtime picks up the staging without any further
+    // config mutation.
+    expect(cfg.auth?.profiles?.["qa-mock-openai"]).toMatchObject({
+      provider: "openai",
+      mode: "api_key",
+      displayName: "QA mock openai credential",
+    });
+    expect(cfg.auth?.profiles?.["qa-mock-anthropic"]).toMatchObject({
+      provider: "anthropic",
+      mode: "api_key",
+      displayName: "QA mock anthropic credential",
+    });
+
+    // Store side: each agent dir should have its own auth-profiles.json
+    // containing the placeholder credential for each staged provider. This
+    // is what the scenario runner actually reads when it resolves auth
+    // before calling the mock.
+    for (const agentId of ["main", "qa"]) {
+      const storeRaw = await readFile(
+        path.join(stateDir, "agents", agentId, "agent", "auth-profiles.json"),
+        "utf8",
+      );
+      const parsed = JSON.parse(storeRaw) as {
+        profiles: Record<string, { type: string; provider: string; key: string }>;
+      };
+      expect(parsed.profiles["qa-mock-openai"]).toMatchObject({
+        type: "api_key",
+        provider: "openai",
+        key: "sk-qa-mock",
+      });
+      expect(parsed.profiles["qa-mock-anthropic"]).toMatchObject({
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-qa-mock",
+      });
+    }
+  });
+
+  it("stages mock profiles only for the requested agents and providers when callers override the defaults", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "qa-mock-auth-override-"));
+    cleanups.push(async () => {
+      await rm(stateDir, { recursive: true, force: true });
+    });
+
+    const cfg = await __testing.stageQaMockAuthProfiles({
+      cfg: {},
+      stateDir,
+      agentIds: ["qa"],
+      providers: ["openai"],
+    });
+
+    expect(cfg.auth?.profiles?.["qa-mock-openai"]).toMatchObject({
+      provider: "openai",
+      mode: "api_key",
+    });
+    // Anthropic should NOT be staged when the caller restricts providers.
+    expect(cfg.auth?.profiles?.["qa-mock-anthropic"]).toBeUndefined();
+
+    const qaStore = JSON.parse(
+      await readFile(path.join(stateDir, "agents", "qa", "agent", "auth-profiles.json"), "utf8"),
+    ) as { profiles: Record<string, unknown> };
+    expect(qaStore.profiles["qa-mock-openai"]).toBeDefined();
+    expect(qaStore.profiles["qa-mock-anthropic"]).toBeUndefined();
+
+    // main/agent should not exist because it wasn't in the agentIds list.
+    await expect(
+      readFile(path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"), "utf8"),
+    ).rejects.toThrow(/ENOENT/);
+  });
+
   it("allows loopback gateway health probes through the SSRF guard", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -297,6 +297,69 @@ export async function stageQaLiveAnthropicSetupToken(params: {
   });
 }
 
+/** Providers the mock-openai harness stages placeholder credentials for. */
+export const QA_MOCK_AUTH_PROVIDERS = Object.freeze(["openai", "anthropic"] as const);
+
+/** Agent IDs the mock-openai harness stages credentials under. */
+export const QA_MOCK_AUTH_AGENT_IDS = Object.freeze(["main", "qa"] as const);
+
+export function buildQaMockProfileId(provider: string): string {
+  return `qa-mock-${provider}`;
+}
+
+/**
+ * In mock-openai mode the qa suite runs against the embedded mock server
+ * instead of a real provider API. The mock does not validate credentials, but
+ * the agent auth layer still needs a matching `api_key` auth profile in
+ * `auth-profiles.json` before it will route the request through
+ * `providerBaseUrl`. Without this staging step, every scenario fails with
+ * `FailoverError: No API key found for provider "openai"` before the mock
+ * server ever sees a request.
+ *
+ * Stages a placeholder `api_key` profile per provider in each of the agent
+ * dirs the qa suite uses (`main` for the runtime config, `qa` for scenario
+ * runs) and returns a config with matching `auth.profiles` entries so the
+ * runtime accepts the profile on the first lookup.
+ *
+ * The placeholder value `sk-qa-mock` is intentionally not a real API key
+ * shape. It has to be non-empty to pass the credential serializer; anything
+ * beyond that is ignored by the mock.
+ */
+export async function stageQaMockAuthProfiles(params: {
+  cfg: OpenClawConfig;
+  stateDir: string;
+  agentIds?: readonly string[];
+  providers?: readonly string[];
+}): Promise<OpenClawConfig> {
+  const agentIds = params.agentIds ?? QA_MOCK_AUTH_AGENT_IDS;
+  const providers = params.providers ?? QA_MOCK_AUTH_PROVIDERS;
+  let next = params.cfg;
+  for (const agentId of agentIds) {
+    const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    for (const provider of providers) {
+      const profileId = buildQaMockProfileId(provider);
+      upsertAuthProfile({
+        profileId,
+        credential: {
+          type: "api_key",
+          provider,
+          key: "sk-qa-mock",
+          displayName: `QA mock ${provider} credential`,
+        },
+        agentDir,
+      });
+      next = applyAuthProfileConfig(next, {
+        profileId,
+        provider,
+        mode: "api_key",
+        displayName: `QA mock ${provider} credential`,
+      });
+    }
+  }
+  return next;
+}
+
 function isRetryableGatewayCallError(details: string): boolean {
   return (
     details.includes("handshake timeout") ||
@@ -334,6 +397,7 @@ export const __testing = {
   readQaLiveProviderConfigOverrides,
   resolveQaLiveAnthropicSetupToken,
   stageQaLiveAnthropicSetupToken,
+  stageQaMockAuthProfiles,
   resolveQaLiveCliAuthEnv,
   resolveQaOwnerPluginIdsForProviderIds,
   resolveQaBundledPluginsSourceRoot,
@@ -801,6 +865,17 @@ export async function startQaGatewayChild(params: {
     cfg,
     stateDir,
   });
+  // Mock-openai mode never sees a real API key (the env stripper above
+  // removes every provider credential). Stage a placeholder `api_key`
+  // profile per provider in each agent dir so the auth resolver finds a
+  // match before routing the request through `providerBaseUrl` to the
+  // embedded mock server.
+  if (params.providerMode === "mock-openai") {
+    cfg = await stageQaMockAuthProfiles({
+      cfg,
+      stateDir,
+    });
+  }
   cfg = params.mutateConfig ? params.mutateConfig(cfg) : cfg;
   await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, {
     encoding: "utf8",

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -128,6 +128,12 @@ export function normalizeQaProviderModeEnv(
   return env;
 }
 
+export function resolveQaGatewayChildProviderMode(
+  providerMode?: "mock-openai" | "live-frontier",
+): "mock-openai" | "live-frontier" {
+  return providerMode ?? "mock-openai";
+}
+
 function resolveQaLiveCliAuthEnv(
   baseEnv: NodeJS.ProcessEnv,
   opts?: {
@@ -331,8 +337,8 @@ export async function stageQaMockAuthProfiles(params: {
   agentIds?: readonly string[];
   providers?: readonly string[];
 }): Promise<OpenClawConfig> {
-  const agentIds = params.agentIds ?? QA_MOCK_AUTH_AGENT_IDS;
-  const providers = params.providers ?? QA_MOCK_AUTH_PROVIDERS;
+  const agentIds = [...new Set(params.agentIds ?? QA_MOCK_AUTH_AGENT_IDS)];
+  const providers = [...new Set(params.providers ?? QA_MOCK_AUTH_PROVIDERS)];
   let next = params.cfg;
   for (const agentId of agentIds) {
     const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
@@ -349,13 +355,15 @@ export async function stageQaMockAuthProfiles(params: {
         },
         agentDir,
       });
-      next = applyAuthProfileConfig(next, {
-        profileId,
-        provider,
-        mode: "api_key",
-        displayName: `QA mock ${provider} credential`,
-      });
     }
+  }
+  for (const provider of providers) {
+    next = applyAuthProfileConfig(next, {
+      profileId: buildQaMockProfileId(provider),
+      provider,
+      mode: "api_key",
+      displayName: `QA mock ${provider} credential`,
+    });
   }
   return next;
 }
@@ -395,6 +403,7 @@ export const __testing = {
   fetchLocalGatewayHealth,
   isRetryableGatewayCallError,
   readQaLiveProviderConfigOverrides,
+  resolveQaGatewayChildProviderMode,
   resolveQaLiveAnthropicSetupToken,
   stageQaLiveAnthropicSetupToken,
   stageQaMockAuthProfiles,
@@ -839,6 +848,7 @@ export async function startQaGatewayChild(params: {
           providerConfigs: liveProviderConfigs,
         })
       : undefined;
+  const providerMode = resolveQaGatewayChildProviderMode(params.providerMode);
   let cfg = buildQaGatewayConfig({
     bind: "loopback",
     gatewayPort,
@@ -852,7 +862,7 @@ export async function startQaGatewayChild(params: {
       controlUiEnabled: params.controlUiEnabled,
     }),
     controlUiAllowedOrigins: params.controlUiAllowedOrigins,
-    providerMode: params.providerMode,
+    providerMode,
     primaryModel: params.primaryModel,
     alternateModel: params.alternateModel,
     enabledPluginIds,
@@ -870,7 +880,7 @@ export async function startQaGatewayChild(params: {
   // profile per provider in each agent dir so the auth resolver finds a
   // match before routing the request through `providerBaseUrl` to the
   // embedded mock server.
-  if (params.providerMode === "mock-openai") {
+  if (providerMode === "mock-openai") {
     cfg = await stageQaMockAuthProfiles({
       cfg,
       stateDir,
@@ -917,7 +927,7 @@ export async function startQaGatewayChild(params: {
     xdgCacheHome,
     bundledPluginsDir,
     compatibilityHostVersion: runtimeHostVersion,
-    providerMode: params.providerMode,
+    providerMode,
     forwardHostHomeForClaudeCli: liveProviderIds.includes("claude-cli"),
     claudeCliAuthMode: params.claudeCliAuthMode,
   });


### PR DESCRIPTION
## Summary

Makes the mock structural parity gate actually runnable without real provider credentials.

After the current rebase, this PR is intentionally narrow. The legacy runtime seam work that was in earlier drafts has been absorbed elsewhere; what this branch still owns is the auth-staging path that the mock parity gate needs in order to reach the mock providers at all.

Current scope:
- stage placeholder auth profiles per provider / agent dir in mock-openai mode
- apply the staged auth profile config once per provider after the profile files exist
- default the gateway-child provider mode through the shared helper so omitted providerMode still stages mock auth correctly

Part of #64227.

## Why this still matters

Without this branch, the mock parity lane can still fail before the mock server ever sees a request because the auth resolver refuses to route through the mock provider base URL until a matching auth profile exists.

This branch makes the structural gate self-contained:
- `openai` and `anthropic` placeholder API-key profiles are staged for the agents the suite uses
- the child config is patched to reference those profiles
- callers that omit provider mode still get the mock-openai auth staging path through the default-provider-mode helper

The mock server does not validate the key contents. The placeholder is just enough to satisfy the auth resolver so the parity harness can actually hit the local mock server.

## What changed

### `extensions/qa-lab/src/gateway-child.ts`
- stages placeholder mock auth profiles for `openai` and `anthropic`
- applies the auth-profile config once per provider after staging
- resolves the effective provider mode through the shared helper before deciding whether mock auth staging is needed

### `extensions/qa-lab/src/gateway-child.test.ts`
- covers the staged mock-auth profile path
- covers the provider / agent override path
- covers the default-provider-mode path so omitted providerMode still stages mock auth correctly

## Validation

Current head validation after rebase:

```bash
CI=1 pnpm exec vitest run extensions/qa-lab/src/gateway-child.test.ts
```

Result: 26/26 passing.

Program-level verification update:
- this branch is part of what made the offline structural parity rerun possible without real keys
- on the integrated patched stack, with this branch plus the qa-lab mock/provider follow-ups, the full offline 10-scenario parity rerun passed end-to-end

## Non-goals

- no runtime strict-agentic behavior changes
- no scenario YAML changes
- no parity-report scoring changes
- no live-frontier credential path changes
