### PR TITLE
feat(tasks): add intermediate active task states

### DIFF
--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -36,7 +36,11 @@ import {
   reconcileTaskLookupToken,
 } from "../tasks/task-registry.reconcile.js";
 import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
-import type { TaskNotifyPolicy, TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskNotifyPolicy,
+  type TaskRecord,
+} from "../tasks/task-registry.types.js";
 import { isRich, theme } from "../terminal/theme.js";
 
 const RUNTIME_PAD = 8;
@@ -77,6 +81,12 @@ function formatTaskStatusCell(status: string, rich: boolean) {
   if (status === "running") {
     return theme.accentBright(padded);
   }
+  if (status === "awaiting_approval" || status === "waiting_external") {
+    return theme.warn(padded);
+  }
+  if (status === "queued") {
+    return theme.accent(padded);
+  }
   return theme.muted(padded);
 }
 
@@ -115,7 +125,9 @@ function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
 
 function formatTaskListSummary(tasks: TaskRecord[]) {
   const summary = summarizeTaskRecords(tasks);
-  return `${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${summary.failures} issues`;
+  const blocked = summary.byStatus.awaiting_approval + summary.byStatus.waiting_external;
+  const active = tasks.filter((task) => isActiveTaskStatus(task.status)).length;
+  return `${summary.byStatus.queued} queued · ${active} active · ${blocked} blocked · ${summary.failures} issues`;
 }
 
 function formatAgeMs(ageMs: number | undefined): string {

--- a/src/tasks/task-active-status.test.ts
+++ b/src/tasks/task-active-status.test.ts
@@ -45,6 +45,21 @@ describe("task audit active-state semantics", () => {
     expect(findings.find((finding) => finding.code === "missing_cleanup")).toBeUndefined();
   });
 
+  it("uses distinct stale audit codes for approval and external waits", () => {
+    const findings = listTaskAuditFindings({
+      now: NOW,
+      staleAwaitingApprovalMs: 60_000,
+      staleWaitingExternalMs: 60_000,
+      tasks: [
+        makeTask({ taskId: "approval", status: "awaiting_approval", lastEventAt: NOW - 120_000 }),
+        makeTask({ taskId: "external", status: "waiting_external", lastEventAt: NOW - 120_000 }),
+      ],
+    });
+
+    expect(findings.find((finding) => finding.code === "stale_awaiting_approval")?.severity).toBe("warn");
+    expect(findings.find((finding) => finding.code === "stale_waiting_external")?.severity).toBe("warn");
+  });
+
   it("flags endedAt on intermediate active states as inconsistent timestamps", () => {
     const findings = listTaskAuditFindings({
       now: NOW,

--- a/src/tasks/task-active-status.test.ts
+++ b/src/tasks/task-active-status.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { listTaskAuditFindings } from "./task-registry.audit.js";
+import { buildTaskStatusSnapshot } from "./task-status.js";
+import { isActiveTaskStatus, type TaskRecord } from "./task-registry.types.js";
+
+const NOW = 1_000_000_000_000;
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: overrides.taskId ?? "task-1",
+    runId: overrides.runId ?? "run-1",
+    task: overrides.task ?? "default task",
+    runtime: overrides.runtime ?? "subagent",
+    status: overrides.status ?? "running",
+    requesterSessionKey: overrides.requesterSessionKey ?? "agent:main:main",
+    ownerKey: overrides.ownerKey ?? "agent:main:main",
+    scopeKind: overrides.scopeKind ?? "session",
+    createdAt: overrides.createdAt ?? NOW - 1_000,
+    deliveryStatus: overrides.deliveryStatus ?? "pending",
+    notifyPolicy: overrides.notifyPolicy ?? "done_only",
+    ...overrides,
+  };
+}
+
+describe("isActiveTaskStatus", () => {
+  it("treats intermediate task states as active", () => {
+    expect(isActiveTaskStatus("queued")).toBe(true);
+    expect(isActiveTaskStatus("awaiting_approval")).toBe(true);
+    expect(isActiveTaskStatus("waiting_external")).toBe(true);
+    expect(isActiveTaskStatus("running")).toBe(true);
+    expect(isActiveTaskStatus("succeeded")).toBe(false);
+  });
+});
+
+describe("task audit active-state semantics", () => {
+  it("does not require cleanupAfter for intermediate active states", () => {
+    const findings = listTaskAuditFindings({
+      now: NOW,
+      tasks: [
+        makeTask({ taskId: "approval", status: "awaiting_approval", lastEventAt: NOW - 60_000 }),
+        makeTask({ taskId: "external", status: "waiting_external", lastEventAt: NOW - 60_000 }),
+      ],
+    });
+
+    expect(findings.find((finding) => finding.code === "missing_cleanup")).toBeUndefined();
+  });
+
+  it("flags endedAt on intermediate active states as inconsistent timestamps", () => {
+    const findings = listTaskAuditFindings({
+      now: NOW,
+      tasks: [
+        makeTask({
+          taskId: "approval",
+          status: "awaiting_approval",
+          startedAt: NOW - 2_000,
+          endedAt: NOW - 1_000,
+        }),
+        makeTask({
+          taskId: "external",
+          status: "waiting_external",
+          startedAt: NOW - 2_000,
+          endedAt: NOW - 1_000,
+        }),
+      ],
+    });
+
+    expect(findings.filter((finding) => finding.code === "inconsistent_timestamps")).toHaveLength(2);
+  });
+});
+
+describe("task status snapshot active-state semantics", () => {
+  it("keeps waiting_external tasks in the active snapshot", () => {
+    const task = makeTask({
+      taskId: "wait-1",
+      status: "waiting_external",
+      progressSummary: "Waiting for external system.",
+      lastEventAt: NOW - 500,
+    });
+
+    const snapshot = buildTaskStatusSnapshot([task], { now: NOW });
+    expect(snapshot.activeCount).toBe(1);
+    expect(snapshot.focus?.taskId).toBe("wait-1");
+    expect(snapshot.focus?.status).toBe("waiting_external");
+  });
+});

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -23,16 +23,17 @@ import {
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-runtime-internal.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
-import type {
-  TaskDeliveryState,
-  TaskDeliveryStatus,
-  TaskNotifyPolicy,
-  TaskRecord,
-  TaskRegistrySummary,
-  TaskRuntime,
-  TaskScopeKind,
-  TaskStatus,
-  TaskTerminalOutcome,
+import {
+  isActiveTaskStatus,
+  type TaskDeliveryState,
+  type TaskDeliveryStatus,
+  type TaskNotifyPolicy,
+  type TaskRecord,
+  type TaskRegistrySummary,
+  type TaskRuntime,
+  type TaskScopeKind,
+  type TaskStatus,
+  type TaskTerminalOutcome,
 } from "./task-registry.types.js";
 
 const log = createSubsystemLogger("tasks/executor");
@@ -387,10 +388,6 @@ type RunTaskInFlowResult = {
   flow?: TaskFlowRecord;
   task?: TaskRecord;
 };
-
-function isActiveTaskStatus(status: TaskStatus): boolean {
-  return status === "queued" || status === "running";
-}
 
 function isTerminalFlowStatus(status: TaskFlowRecord["status"]): boolean {
   return (

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -1,7 +1,10 @@
 import { listTasksForFlowId } from "./runtime-internal.js";
 import { getTaskFlowRegistryRestoreFailure, listTaskFlowRecords } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+} from "./task-registry.types.js";
 
 export type TaskFlowAuditSeverity = "warn" | "error";
 export type TaskFlowAuditCode =
@@ -162,9 +165,7 @@ export function listTaskFlowAuditFindings(
     const referenceAt = getReferenceAt(flow);
     const ageMs = Math.max(0, now - referenceAt);
     const linkedTasks = getLinkedTasks(flow.flowId);
-    const activeTasks = linkedTasks.filter(
-      (task) => task.status === "queued" || task.status === "running",
-    );
+    const activeTasks = linkedTasks.filter((task) => isActiveTaskStatus(task.status));
 
     if (flow.status === "running" && ageMs >= staleRunningMs) {
       findings.push(

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -11,6 +11,7 @@ import {
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { isActiveTaskStatus } from "./task-registry.types.js";
 
 const TASK_FLOW_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
@@ -29,9 +30,7 @@ function isTerminalFlow(flow: TaskFlowRecord): boolean {
 }
 
 function hasActiveLinkedTasks(flowId: string): boolean {
-  return listTasksForFlowId(flowId).some(
-    (task) => task.status === "queued" || task.status === "running",
-  );
+  return listTasksForFlowId(flowId).some((task) => isActiveTaskStatus(task.status));
 }
 
 function resolveTerminalAt(flow: TaskFlowRecord): number {

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -193,7 +193,11 @@ export function deriveTaskFlowStatusFromTask(
   if (task.status === "queued") {
     return "queued";
   }
-  if (task.status === "running") {
+  if (
+    task.status === "awaiting_approval" ||
+    task.status === "waiting_external" ||
+    task.status === "running"
+  ) {
     return "running";
   }
   if (task.status === "succeeded") {

--- a/src/tasks/task-registry.audit.shared.ts
+++ b/src/tasks/task-registry.audit.shared.ts
@@ -4,6 +4,8 @@ export type TaskAuditSeverity = "warn" | "error";
 export type TaskAuditCode =
   | "stale_queued"
   | "stale_running"
+  | "stale_awaiting_approval"
+  | "stale_waiting_external"
   | "lost"
   | "delivery_failed"
   | "missing_cleanup"
@@ -32,6 +34,8 @@ export function createEmptyTaskAuditSummary(): TaskAuditSummary {
     byCode: {
       stale_queued: 0,
       stale_running: 0,
+      stale_awaiting_approval: 0,
+      stale_waiting_external: 0,
       lost: 0,
       delivery_failed: 0,
       missing_cleanup: 0,

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -6,7 +6,10 @@ import {
   type TaskAuditSummary,
 } from "./task-registry.audit.shared.js";
 import { reconcileInspectableTasks } from "./task-registry.reconcile.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+} from "./task-registry.types.js";
 
 export type TaskAuditOptions = {
   now?: number;
@@ -57,7 +60,7 @@ function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
       detail: "endedAt is earlier than startedAt",
     });
   }
-  if ((task.status === "queued" || task.status === "running") && task.endedAt) {
+  if (isActiveTaskStatus(task.status) && task.endedAt) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -143,8 +146,7 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
 
     if (
       task.status !== "lost" &&
-      task.status !== "queued" &&
-      task.status !== "running" &&
+      !isActiveTaskStatus(task.status) &&
       typeof task.cleanupAfter !== "number"
     ) {
       findings.push(

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -16,10 +16,14 @@ export type TaskAuditOptions = {
   tasks?: TaskRecord[];
   staleQueuedMs?: number;
   staleRunningMs?: number;
+  staleAwaitingApprovalMs?: number;
+  staleWaitingExternalMs?: number;
 };
 
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
+const DEFAULT_STALE_AWAITING_APPROVAL_MS = 12 * 60 * 60_000;
+const DEFAULT_STALE_WAITING_EXTERNAL_MS = 2 * 60 * 60_000;
 export { createEmptyTaskAuditSummary };
 export type { TaskAuditCode, TaskAuditFinding, TaskAuditSeverity, TaskAuditSummary };
 
@@ -90,6 +94,10 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
   const now = options.now ?? Date.now();
   const staleQueuedMs = options.staleQueuedMs ?? DEFAULT_STALE_QUEUED_MS;
   const staleRunningMs = options.staleRunningMs ?? DEFAULT_STALE_RUNNING_MS;
+  const staleAwaitingApprovalMs =
+    options.staleAwaitingApprovalMs ?? DEFAULT_STALE_AWAITING_APPROVAL_MS;
+  const staleWaitingExternalMs =
+    options.staleWaitingExternalMs ?? DEFAULT_STALE_WAITING_EXTERNAL_MS;
   const findings: TaskAuditFinding[] = [];
 
   for (const task of tasks) {
@@ -116,6 +124,30 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
           task,
           ageMs,
           detail: "running task appears stuck",
+        }),
+      );
+    }
+
+    if (task.status === "awaiting_approval" && ageMs >= staleAwaitingApprovalMs) {
+      findings.push(
+        createFinding({
+          severity: "warn",
+          code: "stale_awaiting_approval",
+          task,
+          ageMs,
+          detail: "task has been awaiting approval for an unusually long time",
+        }),
+      );
+    }
+
+    if (task.status === "waiting_external" && ageMs >= staleWaitingExternalMs) {
+      findings.push(
+        createFinding({
+          severity: "warn",
+          code: "stale_waiting_external",
+          task,
+          ageMs,
+          detail: "task has been waiting on an external dependency for too long",
         }),
       );
     }

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -18,7 +18,11 @@ import {
 import { listTaskAuditFindings, summarizeTaskAuditFindings } from "./task-registry.audit.js";
 import type { TaskAuditSummary } from "./task-registry.audit.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
-import type { TaskRecord, TaskRegistrySummary } from "./task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+  type TaskRegistrySummary,
+} from "./task-registry.types.js";
 
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
 const TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
@@ -92,7 +96,7 @@ function findSessionEntryByKey(store: Record<string, unknown>, sessionKey: strin
 }
 
 function isActiveTask(task: TaskRecord): boolean {
-  return task.status === "queued" || task.status === "running";
+  return isActiveTaskStatus(task.status);
 }
 
 function isTerminalTask(task: TaskRecord): boolean {

--- a/src/tasks/task-registry.summary.ts
+++ b/src/tasks/task-registry.summary.ts
@@ -8,6 +8,8 @@ import type {
 function createEmptyTaskStatusCounts(): TaskStatusCounts {
   return {
     queued: 0,
+    awaiting_approval: 0,
+    waiting_external: 0,
     running: 0,
     succeeded: 0,
     failed: 0,
@@ -43,7 +45,12 @@ export function summarizeTaskRecords(records: Iterable<TaskRecord>): TaskRegistr
     summary.total += 1;
     summary.byStatus[task.status] += 1;
     summary.byRuntime[task.runtime] += 1;
-    if (task.status === "queued" || task.status === "running") {
+    if (
+      task.status === "queued" ||
+      task.status === "awaiting_approval" ||
+      task.status === "waiting_external" ||
+      task.status === "running"
+    ) {
       summary.active += 1;
     } else {
       summary.terminal += 1;

--- a/src/tasks/task-registry.summary.ts
+++ b/src/tasks/task-registry.summary.ts
@@ -1,8 +1,9 @@
-import type {
-  TaskRecord,
-  TaskRegistrySummary,
-  TaskRuntimeCounts,
-  TaskStatusCounts,
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+  type TaskRegistrySummary,
+  type TaskRuntimeCounts,
+  type TaskStatusCounts,
 } from "./task-registry.types.js";
 
 function createEmptyTaskStatusCounts(): TaskStatusCounts {
@@ -45,12 +46,7 @@ export function summarizeTaskRecords(records: Iterable<TaskRecord>): TaskRegistr
     summary.total += 1;
     summary.byStatus[task.status] += 1;
     summary.byRuntime[task.runtime] += 1;
-    if (
-      task.status === "queued" ||
-      task.status === "awaiting_approval" ||
-      task.status === "waiting_external" ||
-      task.status === "running"
-    ) {
+    if (isActiveTaskStatus(task.status)) {
       summary.active += 1;
     } else {
       summary.terminal += 1;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1859,6 +1859,77 @@ describe("task-registry", () => {
     });
   });
 
+  it("returns awaiting_approval tasks to running when approval resolves positively", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-approval-approved",
+        task: "Run guarded command",
+        status: "awaiting_approval",
+        deliveryStatus: "pending",
+        progressSummary: "Awaiting approval before command can run.",
+      });
+
+      emitAgentEvent({
+        runId: "run-approval-approved",
+        stream: "approval",
+        data: {
+          phase: "resolved",
+          kind: "exec",
+          status: "approved",
+          title: "Command approval resolved",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "running",
+      });
+    });
+  });
+
+  it("projects denied approval resolution as failed task state", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-approval-denied",
+        task: "Run guarded command",
+        status: "awaiting_approval",
+        deliveryStatus: "pending",
+      });
+
+      emitAgentEvent({
+        runId: "run-approval-denied",
+        stream: "approval",
+        data: {
+          phase: "resolved",
+          kind: "exec",
+          status: "denied",
+          title: "Command approval resolved",
+          message: "Command did not run: approval timed out.",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "failed",
+        error: "Command did not run: approval timed out.",
+      });
+    });
+  });
+
   it("projects no-output assistant events as waiting_external task state", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1802,6 +1802,38 @@ describe("task-registry", () => {
     });
   });
 
+  it("projects no-output assistant events as waiting_external task state", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-waiting-external",
+        task: "Wait for external input",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      emitAgentEvent({
+        runId: "run-waiting-external",
+        stream: "assistant",
+        data: {
+          text: "No output for 60s. It may be waiting for input.",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "waiting_external",
+        progressSummary: "Waiting for external input before work can continue.",
+      });
+    });
+  });
+
   it("cancels ACP-backed tasks through the ACP session manager", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -14,7 +14,12 @@ import {
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { createManagedTaskFlow, resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
+import {
+  createManagedTaskFlow,
+  getTaskFlowById,
+  requestFlowCancel,
+  resetTaskFlowRegistryForTests,
+} from "./task-flow-registry.js";
 import { configureTaskFlowRegistryRuntime } from "./task-flow-registry.store.js";
 import {
   cancelTaskById,
@@ -1798,6 +1803,58 @@ describe("task-registry", () => {
         taskId: created.taskId,
         status: "awaiting_approval",
         progressSummary: "Awaiting approval before command can run.",
+      });
+    });
+  });
+
+  it("keeps managed flows active when tasks move into awaiting_approval", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
+
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-registry",
+        goal: "Await approval safely",
+      });
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-await-approval-flow",
+        task: "Guarded command inside flow",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      requestFlowCancel({
+        flowId: flow.flowId,
+        updatedAt: 42,
+        cancelRequestedAt: 42,
+      });
+
+      emitAgentEvent({
+        runId: "run-await-approval-flow",
+        stream: "approval",
+        data: {
+          phase: "requested",
+          kind: "exec",
+          status: "pending",
+          title: "Command approval requested",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        status: "awaiting_approval",
+      });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        flowId: flow.flowId,
+        status: "queued",
       });
     });
   });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -308,6 +308,8 @@ describe("task-registry", () => {
         failures: 1,
         byStatus: {
           queued: 1,
+          awaiting_approval: 0,
+          waiting_external: 0,
           running: 1,
           succeeded: 0,
           failed: 0,
@@ -1762,6 +1764,41 @@ describe("task-registry", () => {
       expect(peekSystemEvents("agent:main:main")).toEqual([]);
       relay.dispose();
       vi.useRealTimers();
+    });
+  });
+
+  it("projects approval-pending events as awaiting_approval task state", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-await-approval",
+        task: "Run guarded command",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      emitAgentEvent({
+        runId: "run-await-approval",
+        stream: "approval",
+        data: {
+          phase: "requested",
+          kind: "exec",
+          status: "pending",
+          title: "Command approval requested",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "awaiting_approval",
+        progressSummary: "Awaiting approval before command can run.",
+      });
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1336,6 +1336,20 @@ function ensureListener() {
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
       }
+
+      const assistantText =
+        evt.stream === "assistant" && typeof evt.data?.text === "string"
+          ? evt.data.text
+          : evt.stream === "assistant" && typeof evt.data?.delta === "string"
+            ? evt.data.delta
+            : undefined;
+      if (
+        assistantText &&
+        /no output for .*it may be waiting for (input|interactive input)/i.test(assistantText)
+      ) {
+        patch.status = "waiting_external";
+        patch.progressSummary = "Waiting for external input before work can continue.";
+      }
       const stateChangeEvent =
         patch.status && patch.status !== current.status
           ? appendTaskEvent({

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1326,6 +1326,13 @@ function ensureListener() {
           patch.endedAt = endedAt ?? now;
           patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
         }
+      } else if (evt.stream === "approval") {
+        const approvalPhase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
+        const approvalStatus = typeof evt.data?.status === "string" ? evt.data.status : undefined;
+        if (approvalPhase === "requested" && approvalStatus === "pending") {
+          patch.status = "awaiting_approval";
+          patch.progressSummary = "Awaiting approval before command can run.";
+        }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
       }

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1334,9 +1334,21 @@ function ensureListener() {
       } else if (evt.stream === "approval") {
         const approvalPhase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
         const approvalStatus = typeof evt.data?.status === "string" ? evt.data.status : undefined;
+        const approvalMessage = typeof evt.data?.message === "string" ? evt.data.message : undefined;
         if (approvalPhase === "requested" && approvalStatus === "pending") {
           patch.status = "awaiting_approval";
           patch.progressSummary = "Awaiting approval before command can run.";
+        } else if (approvalPhase === "resolved" && approvalStatus === "approved") {
+          patch.status = "running";
+          patch.progressSummary = current.progressSummary;
+        } else if (
+          approvalPhase === "resolved" &&
+          (approvalStatus === "denied" || approvalStatus === "failed")
+        ) {
+          patch.status = "failed";
+          patch.endedAt = now;
+          patch.error = approvalMessage ?? current.error;
+          patch.terminalSummary = approvalMessage ?? current.terminalSummary;
         }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -106,7 +106,12 @@ export function isParentFlowLinkError(error: unknown): error is ParentFlowLinkEr
 }
 
 function isActiveTaskStatus(status: TaskStatus): boolean {
-  return status === "queued" || status === "running";
+  return (
+    status === "queued" ||
+    status === "awaiting_approval" ||
+    status === "waiting_external" ||
+    status === "running"
+  );
 }
 
 function isTerminalFlowStatus(status: TaskFlowRecord["status"]): boolean {

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -4,6 +4,8 @@ export type TaskRuntime = "subagent" | "acp" | "cli" | "cron";
 
 export type TaskStatus =
   | "queued"
+  | "awaiting_approval"
+  | "waiting_external"
   | "running"
   | "succeeded"
   | "failed"

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -13,6 +13,17 @@ export type TaskStatus =
   | "cancelled"
   | "lost";
 
+export const ACTIVE_TASK_STATUSES = new Set<TaskStatus>([
+  "queued",
+  "awaiting_approval",
+  "waiting_external",
+  "running",
+]);
+
+export function isActiveTaskStatus(status: TaskStatus): boolean {
+  return ACTIVE_TASK_STATUSES.has(status);
+}
+
 export type TaskDeliveryStatus =
   | "pending"
   | "delivered"

--- a/src/tasks/task-state-machine-minimal.test.ts
+++ b/src/tasks/task-state-machine-minimal.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { deriveTaskFlowStatusFromTask } from "./task-flow-registry.js";
+import { summarizeTaskRecords } from "./task-registry.summary.js";
+import type { TaskRecord } from "./task-registry.types.js";
+import { buildTaskStatusSnapshot, formatTaskStatusDetail } from "./task-status.js";
+
+const NOW = 1_000_000_000_000;
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: overrides.taskId ?? "task-1",
+    runId: overrides.runId ?? "run-1",
+    task: overrides.task ?? "default task",
+    runtime: overrides.runtime ?? "subagent",
+    status: overrides.status ?? "running",
+    requesterSessionKey: overrides.requesterSessionKey ?? "agent:main:main",
+    ownerKey: overrides.ownerKey ?? "agent:main:main",
+    scopeKind: overrides.scopeKind ?? "session",
+    createdAt: overrides.createdAt ?? NOW - 1_000,
+    deliveryStatus: overrides.deliveryStatus ?? "pending",
+    notifyPolicy: overrides.notifyPolicy ?? "done_only",
+    ...overrides,
+  };
+}
+
+describe("task state machine minimal active states", () => {
+  it("counts awaiting_approval and waiting_external as active states", () => {
+    const summary = summarizeTaskRecords([
+      makeTask({ taskId: "a", status: "queued" }),
+      makeTask({ taskId: "b", status: "awaiting_approval" }),
+      makeTask({ taskId: "c", status: "waiting_external" }),
+      makeTask({ taskId: "d", status: "running" }),
+      makeTask({ taskId: "e", status: "failed" }),
+    ]);
+
+    expect(summary.active).toBe(4);
+    expect(summary.terminal).toBe(1);
+    expect(summary.byStatus.awaiting_approval).toBe(1);
+    expect(summary.byStatus.waiting_external).toBe(1);
+  });
+
+  it("shows awaiting_approval in active task snapshots and formats progress detail", () => {
+    const task = makeTask({
+      status: "awaiting_approval",
+      progressSummary: "Waiting for approval from user.",
+      lastEventAt: NOW - 100,
+    });
+
+    const snapshot = buildTaskStatusSnapshot([task], { now: NOW });
+    expect(snapshot.activeCount).toBe(1);
+    expect(snapshot.focus?.status).toBe("awaiting_approval");
+    expect(formatTaskStatusDetail(task)).toBe("Waiting for approval from user.");
+  });
+
+  it("maps intermediate active states to running task flows for now", () => {
+    expect(deriveTaskFlowStatusFromTask({ status: "awaiting_approval", terminalOutcome: undefined })).toBe(
+      "running",
+    );
+    expect(deriveTaskFlowStatusFromTask({ status: "waiting_external", terminalOutcome: undefined })).toBe(
+      "running",
+    );
+  });
+});

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -6,7 +6,12 @@ import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/errors.js"
 import { truncateUtf16Safe } from "../utils.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
-const ACTIVE_TASK_STATUSES = new Set(["queued", "running"]);
+const ACTIVE_TASK_STATUSES = new Set([
+  "queued",
+  "awaiting_approval",
+  "waiting_external",
+  "running",
+]);
 const FAILURE_TASK_STATUSES = new Set(["failed", "timed_out", "lost"]);
 export const TASK_STATUS_RECENT_WINDOW_MS = 5 * 60_000;
 export const TASK_STATUS_TITLE_MAX_CHARS = 80;
@@ -125,7 +130,12 @@ export function formatTaskStatusTitle(task: TaskRecord): string {
 }
 
 export function formatTaskStatusDetail(task: TaskRecord): string | undefined {
-  if (task.status === "running" || task.status === "queued") {
+  if (
+    task.status === "running" ||
+    task.status === "queued" ||
+    task.status === "awaiting_approval" ||
+    task.status === "waiting_external"
+  ) {
     return (
       sanitizeTaskStatusText(task.progressSummary, { maxChars: TASK_STATUS_DETAIL_MAX_CHARS }) ||
       undefined

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -4,21 +4,17 @@ import {
 } from "../agents/internal-runtime-context.js";
 import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/errors.js";
 import { truncateUtf16Safe } from "../utils.js";
-import type { TaskRecord } from "./task-registry.types.js";
-
-const ACTIVE_TASK_STATUSES = new Set([
-  "queued",
-  "awaiting_approval",
-  "waiting_external",
-  "running",
-]);
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+} from "./task-registry.types.js";
 const FAILURE_TASK_STATUSES = new Set(["failed", "timed_out", "lost"]);
 export const TASK_STATUS_RECENT_WINDOW_MS = 5 * 60_000;
 export const TASK_STATUS_TITLE_MAX_CHARS = 80;
 export const TASK_STATUS_DETAIL_MAX_CHARS = 120;
 
 function isActiveTask(task: TaskRecord): boolean {
-  return ACTIVE_TASK_STATUSES.has(task.status);
+  return isActiveTaskStatus(task.status);
 }
 
 function isFailureTask(task: TaskRecord): boolean {


### PR DESCRIPTION
Adds a minimal first step toward a richer task/worker state machine by introducing explicit intermediate active states and wiring approval-pending runtime events into task state projection.

### What changed
- adds two explicit active task states:
  - `awaiting_approval`
  - `waiting_external`
- updates task summaries and task-status snapshots to treat those states as active
- updates task-flow projection to map those intermediate active states to `running` for now
- wires runtime `approval` events with `phase=requested` and `status=pending` into task-registry state transitions
- records `awaiting_approval` plus a concise progress summary when a task is blocked on command approval
- adds focused tests for the new state semantics and approval-pending projection

### Why
Previously, tasks jumped between coarse states like `queued` and `running`, which made it hard to distinguish:
- a task that is actively executing
- a task that is alive but waiting for user approval
- a task that is alive but waiting on an external dependency

This PR introduces the minimum viable state split without redesigning all terminal states or flow lifecycle semantics in the same change.

### Notes
- This PR does **not** yet fully wire `waiting_external`
- It keeps intermediate states projected as `running` at the TaskFlow layer for compatibility
- It is intended as a safe incremental step toward a fuller worker/task state machine

### Tests
- `src/tasks/task-state-machine-minimal.test.ts`
- `src/tasks/task-status.test.ts`
- `src/tasks/task-registry.test.ts`
