### PR TITLE
fix(amazon-bedrock): stop baking hardcoded contextWindow into discovery results

### DIFF
--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -87,7 +87,6 @@ describe("bedrock discovery", () => {
       name: "Claude 3.7 Sonnet",
       reasoning: false,
       input: ["text", "image"],
-      contextWindow: 32000,
       maxTokens: 4096,
     });
   });
@@ -111,7 +110,7 @@ describe("bedrock discovery", () => {
       config: { defaultContextWindow: 64000, defaultMaxTokens: 8192 },
       clientFactory,
     });
-    expect(models[0]).toMatchObject({ contextWindow: 64000, maxTokens: 8192 });
+    expect(models[0]).toMatchObject({ maxTokens: 8192 });
   });
 
   it("caches results when refreshInterval is enabled", async () => {
@@ -252,7 +251,6 @@ describe("bedrock discovery", () => {
     expect(usProfile).toMatchObject({
       name: "US Anthropic Claude Sonnet 4.6",
       input: ["text", "image"],
-      contextWindow: 32000,
       maxTokens: 4096,
     });
     expect(euProfile).toMatchObject({ input: ["text", "image"] });
@@ -356,7 +354,6 @@ describe("bedrock discovery", () => {
     expect(profile).toMatchObject({
       id: "us.my-prod-profile",
       input: ["text", "image"],
-      contextWindow: 32000,
       maxTokens: 4096,
     });
   });

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -154,7 +154,7 @@ function shouldIncludeSummary(summary: BedrockModelSummary, filter: string[]): b
 
 function toModelDefinition(
   summary: BedrockModelSummary,
-  defaults: { contextWindow: number; maxTokens: number },
+  _defaults: { contextWindow: number; maxTokens: number },
 ): ModelDefinitionConfig {
   const id = summary.modelId?.trim() ?? "";
   return {
@@ -163,8 +163,10 @@ function toModelDefinition(
     reasoning: inferReasoningSupport(summary),
     input: mapInputModalities(summary),
     cost: DEFAULT_COST,
-    contextWindow: defaults.contextWindow,
-    maxTokens: defaults.maxTokens,
+    // NOTE: contextWindow is deliberately omitted — the Bedrock API does not
+    // expose token limits. Leaving it undefined lets the runtime detect
+    // hardcoded-default usage and emit a warning (issue #64919).
+    maxTokens: _defaults.maxTokens,
   };
 }
 
@@ -282,7 +284,7 @@ function resolveInferenceProfiles(
       reasoning: baseModel?.reasoning ?? false,
       input: baseModel?.input ?? ["text"],
       cost: baseModel?.cost ?? DEFAULT_COST,
-      contextWindow: baseModel?.contextWindow ?? defaults.contextWindow,
+      contextWindow: baseModel?.contextWindow,
       maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
     });
   }

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -60,7 +60,12 @@ export type ModelDefinitionConfig = {
     cacheRead: number;
     cacheWrite: number;
   };
-  contextWindow: number;
+  /**
+   * The model's context window from the provider's API. May be undefined if the
+   * provider doesn't expose token limits (e.g. AWS Bedrock), in which case the
+   * runtime resolves it to a hardcoded default and sets source="default".
+   */
+  contextWindow?: number;
   /**
    * Optional effective runtime cap used for compaction/session budgeting.
    * Keeps provider/native contextWindow metadata intact while letting configs


### PR DESCRIPTION
## What

Makes `contextWindow` optional in `ModelDefinitionConfig` and removes the hardcoded default assignment from Bedrock discovery.

## Why

The AWS Bedrock API does not expose token limits. Discovery was setting `contextWindow: 32000` (hardcoded default) on every discovered model, which caused `resolveContextWindowInfo` to mark the source as `"model"` rather than `"default"` — suppressing the `shouldWarnDefault` warning that PR #64901 added.

## How

- `src/config/types.models.ts`: `contextWindow` is now `number | undefined`
- `extensions/amazon-bedrock/discovery.ts`: `toModelDefinition()` no longer sets `contextWindow`; `resolveInferenceProfiles()` inherits only from `baseModel?.contextWindow` (not the fallback default)
- Tests updated to reflect that discovered models have `contextWindow: undefined`

The runtime already handles `undefined` correctly — it falls through to `source: "default"` and fires the warning.

Closes #64919