### PR TITLE
fix(context-engine): restore bundled legacy engine loading

### DIFF
--- a/src/context-engine/legacy.registration.ts
+++ b/src/context-engine/legacy.registration.ts
@@ -1,21 +1,20 @@
 import { registerContextEngineForOwner } from "./registry.js";
 import type { ContextEngine } from "./types.js";
 
-const LEGACY_CONTEXT_ENGINE_CANDIDATES = ["./legacy.js", "./legacy.ts"] as const;
-
 type LegacyContextEngineModule = {
   LegacyContextEngine: new () => ContextEngine;
 };
 
 async function loadLegacyContextEngineModule(): Promise<LegacyContextEngineModule> {
-  for (const candidate of LEGACY_CONTEXT_ENGINE_CANDIDATES) {
+  try {
+    return (await import("./legacy.js")) as LegacyContextEngineModule;
+  } catch {
     try {
-      return (await import(candidate)) as LegacyContextEngineModule;
+      return (await import("./legacy.ts")) as LegacyContextEngineModule;
     } catch {
-      // Try runtime/source candidates in order.
+      throw new Error("Failed to load legacy context engine runtime.");
     }
   }
-  throw new Error("Failed to load legacy context engine runtime.");
 }
 
 export function registerLegacyContextEngine(): void {


### PR DESCRIPTION
## Summary

- Problem: `registerLegacyContextEngine()` switched to a candidate-list dynamic import for `./legacy.js` / `./legacy.ts`.
- Why it matters: the source build stopped bundling the legacy context engine runtime, so gateway runs from `dist/` failed with `Failed to load legacy context engine runtime.`
- What changed: restored bundler-visible lazy imports with explicit `import("./legacy.js")` then `import("./legacy.ts")` fallback.
- What did NOT change (scope boundary): no context-engine behavior changes beyond fixing runtime loading.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the new variable dynamic import path prevented the build from emitting the legacy context engine module into `dist/`, so runtime resolution failed in source-built gateway runs.
- Missing detection / guardrail: no post-build check verified that `resolveContextEngine({})` can still instantiate the default `legacy` engine from emitted `dist/` artifacts.
- Contributing context (if known): the regression came from `747b26ea0f` (`fix(context-engine): lazy-load legacy engine registration`).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: a build-output seam test that imports emitted `dist/runtime-plugins*.js` + registry and resolves the default context engine.
- Scenario the test should lock in: a source build can instantiate the bundled `legacy` context engine from emitted `dist/` files.
- Why this is the smallest reliable guardrail: the bug only reproduces after bundling, not in source-level unit tests.
- Existing test that already covers this (if any): none found.
- If no new test is added, why not: kept this PR scoped to the runtime-loading fix; follow-up coverage can target the build seam directly.

## User-visible / Behavior Changes

- Source-built gateway runs no longer fail during context-engine resolution with `Failed to load legacy context engine runtime.`

## Diagram (if applicable)

```text
Before:
source build -> resolveContextEngine("legacy") -> dynamic import candidates missing from dist -> runtime error

After:
source build -> resolveContextEngine("legacy") -> explicit lazy import kept in bundle -> legacy engine resolves
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: source build from `dist/`
- Model/provider: reproduced before model call during context-engine resolution
- Integration/channel (if any): cron + Discord embedded agent lanes
- Relevant config (redacted): default `legacy` context-engine slot

### Steps

1. Build from source.
2. Import emitted `dist/runtime-plugins*.js` and registry bundle.
3. Call `ensureContextEnginesInitialized()` then `resolveContextEngine({})`.

### Expected

- The default `legacy` context engine resolves successfully.

### Actual

- Before this fix, runtime threw `Error: Failed to load legacy context engine runtime.`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm build` passes; reproduced failure path previously on the mac mini source build; after this patch, local emitted `dist/runtime-plugins*.js` successfully resolves `legacy` via a direct Node import script.
- Edge cases checked: `.js` path remains preferred; `.ts` fallback remains available for source/runtime compatibility.
- What you did **not** verify: full `pnpm check` is currently blocked by an unrelated pre-existing TypeScript failure in `extensions/codex/src/app-server/dynamic-tools.ts` (`prepareArguments` missing on `AnyAgentTool`).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the `.ts` fallback path remains less build-friendly than the `.js` path.
  - Mitigation: `.js` remains the primary explicit import, which restores bundler visibility for the emitted runtime path.
