### PR TITLE
fix(models): respect models.mode=replace in model picker and gateway catalog

### DIFF
--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/model-picker-visibility.js";
 import {
   buildAllowedModelSet,
+  buildConfiguredModelCatalog,
   buildModelAliasIndex,
   type ModelAliasIndex,
   modelKey,
@@ -622,12 +623,16 @@ export async function promptDefaultModel(
     return { model: selection };
   }
 
-  const catalogProgress = params.prompter.progress("Loading available models");
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>>;
-  try {
-    catalog = await loadModelCatalog({ config: cfg });
-  } finally {
-    catalogProgress.stop();
+  if (cfg.models?.mode === "replace") {
+    catalog = buildConfiguredModelCatalog({ cfg });
+  } else {
+    const catalogProgress = params.prompter.progress("Loading available models");
+    try {
+      catalog = await loadModelCatalog({ config: cfg });
+    } finally {
+      catalogProgress.stop();
+    }
   }
   if (catalog.length === 0) {
     return promptManualModel({
@@ -894,12 +899,16 @@ export async function promptModelAllowlist(params: {
     return {};
   }
 
-  const allowlistProgress = params.prompter.progress("Loading available models");
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>>;
-  try {
-    catalog = await loadModelCatalog({ config: cfg });
-  } finally {
-    allowlistProgress.stop();
+  if (cfg.models?.mode === "replace") {
+    catalog = buildConfiguredModelCatalog({ cfg });
+  } else {
+    const allowlistProgress = params.prompter.progress("Loading available models");
+    try {
+      catalog = await loadModelCatalog({ config: cfg });
+    } finally {
+      allowlistProgress.stop();
+    }
   }
   if (catalog.length === 0 && allowedKeys.length === 0) {
     const noCatalogInitialKeys =

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -3,6 +3,7 @@ import {
   type ModelCatalogEntry,
   resetModelCatalogCacheForTest,
 } from "../agents/model-catalog.js";
+import { buildConfiguredModelCatalog } from "../agents/model-selection.js";
 import { getRuntimeConfig } from "../config/config.js";
 
 export type GatewayModelChoice = ModelCatalogEntry;
@@ -17,5 +18,9 @@ export function __resetModelCatalogCacheForTest() {
 export async function loadGatewayModelCatalog(params?: {
   getConfig?: () => ReturnType<typeof getRuntimeConfig>;
 }): Promise<GatewayModelChoice[]> {
-  return await loadModelCatalog({ config: (params?.getConfig ?? getRuntimeConfig)() });
+  const cfg = (params?.getConfig ?? getRuntimeConfig)();
+  if (cfg.models?.mode === "replace") {
+    return buildConfiguredModelCatalog({ cfg });
+  }
+  return await loadModelCatalog({ config: cfg });
 }


### PR DESCRIPTION
## Summary

- When `models.mode` is set to `replace`, the model picker (`promptDefaultModel` and `promptModelAllowlist`) and the gateway catalog (`loadGatewayModelCatalog`) now use `buildConfiguredModelCatalog` instead of fetching the full remote catalog via `loadModelCatalog`.
- Previously, `models.mode=replace` was only honored during inference model resolution but ignored in the picker and gateway catalog, causing the full provider catalog to appear regardless of the user's configuration.
- Both call sites in `src/flows/model-picker.ts` and the single call site in `src/gateway/server-model-catalog.ts` are fixed.

Fixes https://github.com/openclaw/openclaw/issues/64950