### PR TITLE
fix(minimax): add missing api and authHeader to portal OAuth configPatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/WhatsApp: preserve inbound image attachment notes after media understanding so image edits keep the real saved media path instead of hallucinating a missing local path. (#64918) Thanks @ngutman.
 - Telegram/sessions: keep topic-scoped session initialization on the canonical topic transcript path when inbound turns omit `MessageThreadId`, so one topic session no longer alternates between bare and topic-qualified transcript files. (#64869) thanks @jalehman.
 - Agents/failover: scope assistant-side fallback classification and surfaced provider errors to the current attempt instead of stale session history, so cross-provider fallback runs stop inheriting the previous provider's failure. (#62907) Thanks @stainlu.
+- MiniMax/OAuth: write `api: "anthropic-messages"` and `authHeader: true` into the `minimax-portal` config patch during `openclaw configure`, so re-authenticated portal setups keep Bearer auth routing working. (#64964) Thanks @ryanlee666.
 
 ## 2026.4.11-beta.1
 

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -8,6 +8,15 @@ import {
 import { registerMinimaxProviders } from "./provider-registration.js";
 import { createMiniMaxWebSearchProvider } from "./src/minimax-web-search-provider.js";
 
+vi.mock("./oauth.runtime.js", () => ({
+  loginMiniMaxPortalOAuth: vi.fn(async () => ({
+    access: "minimax-oauth-access-token",
+    refresh: "minimax-oauth-refresh-token",
+    expires: Date.now() + 60_000,
+    resourceUrl: "https://api.minimax.io/anthropic",
+  })),
+}));
+
 const minimaxProviderPlugin = {
   register(api: Parameters<typeof registerMinimaxProviders>[0]) {
     registerMinimaxProviders(api);
@@ -185,5 +194,33 @@ describe("minimax provider hooks", () => {
 
     expect(resolveOAuthToken).toHaveBeenCalledWith({ provider: "minimax-portal" });
     expect(resolveApiKeyFromConfigAndStore).not.toHaveBeenCalled();
+  });
+
+  it("writes api and authHeader into the MiniMax portal OAuth config patch", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: minimaxProviderPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+    const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
+    const oauthMethod = portalProvider.auth.find((method) => method.id === "oauth");
+
+    expect(oauthMethod).toBeDefined();
+
+    const result = await oauthMethod?.run({
+      prompter: {
+        progress() {
+          return { stop() {} };
+        },
+        note: vi.fn(async () => undefined),
+      },
+      openUrl: vi.fn(async () => undefined),
+    } as never);
+
+    expect(result?.configPatch?.models?.providers?.["minimax-portal"]).toMatchObject({
+      baseUrl: "https://api.minimax.io/anthropic",
+      api: "anthropic-messages",
+      authHeader: true,
+    });
   });
 });

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -133,6 +133,8 @@ function createOAuthHandler(region: MiniMaxRegion) {
             providers: {
               [PORTAL_PROVIDER_ID]: {
                 baseUrl,
+                api: "anthropic-messages",
+                authHeader: true,
                 models: [],
               },
             },


### PR DESCRIPTION
## Summary

- Fix `minimax-portal` OAuth `configPatch` missing `api` and `authHeader` fields, causing provider auth resolution to fail after `openclaw configure`.

Fixes #64794

## Test plan

- [ ] Run `openclaw configure` with MiniMax OAuth and verify the resulting config includes `api: "anthropic-messages"` and `authHeader: true` under `models.providers.minimax-portal`
- [ ] Verify model inference works after re-authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)