### PR TITLE
fix(model-picker,gateway): respect models.mode=replace

### DIFF
--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -13,6 +13,17 @@ vi.mock("../agents/model-catalog.js", () => ({
   loadModelCatalog,
 }));
 
+const buildConfiguredModelCatalog = vi.hoisted(() => vi.fn());
+vi.mock("../agents/model-selection.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/model-selection.js")>(
+    "../agents/model-selection.js",
+  );
+  return {
+    ...actual,
+    buildConfiguredModelCatalog,
+  };
+});
+
 const ensureAuthProfileStore = vi.hoisted(() =>
   vi.fn(() => ({
     version: 1,
@@ -430,6 +441,53 @@ describe("router model filtering", () => {
     expectRouterModelFiltering(allowlistCall?.options as Array<{ value: string }>);
     expect(allowlistCall?.searchable).toBe(true);
     expect(runProviderPluginAuthMethod).not.toHaveBeenCalled();
+  });
+
+  it("uses the configured catalog when models.mode is replace", async () => {
+    buildConfiguredModelCatalog.mockReturnValue([
+      {
+        provider: "custom",
+        id: "only-model",
+        name: "Only Model",
+      },
+    ]);
+    loadModelCatalog.mockResolvedValue(OPENROUTER_CATALOG);
+
+    const select = vi.fn(async (params) => {
+      const first = params.options[0];
+      return first?.value ?? "";
+    });
+    const multiselect = createSelectAllMultiselect();
+    const defaultPrompter = makePrompter({ select });
+    const allowlistPrompter = makePrompter({ multiselect });
+    const config = {
+      models: { mode: "replace" },
+      agents: { defaults: {} },
+    } as OpenClawConfig;
+
+    await promptDefaultModel({
+      config,
+      prompter: defaultPrompter,
+      allowKeep: false,
+      includeManual: false,
+      ignoreAllowlist: true,
+    });
+    await promptModelAllowlist({ config, prompter: allowlistPrompter });
+
+    const defaultOptions = select.mock.calls[0]?.[0]?.options ?? [];
+    expect(defaultOptions.map((opt: { value: string }) => opt.value)).toContain(
+      "custom/only-model",
+    );
+    expect(defaultOptions.map((opt: { value: string }) => opt.value)).not.toContain(
+      "openrouter/meta-llama/llama-3.3-70b:free",
+    );
+
+    const allowlistOptions = multiselect.mock.calls[0]?.[0]?.options ?? [];
+    expect(allowlistOptions.map((opt: { value: string }) => opt.value)).toEqual([
+      "custom/only-model",
+    ]);
+    expect(buildConfiguredModelCatalog).toHaveBeenCalledTimes(2);
+    expect(loadModelCatalog).not.toHaveBeenCalled();
   });
 });
 

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -4,6 +4,7 @@ import { hasUsableCustomProviderApiKey, resolveEnvApiKey } from "../agents/model
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
   buildAllowedModelSet,
+  buildConfiguredModelCatalog,
   buildModelAliasIndex,
   modelKey,
   normalizeProviderId,
@@ -426,7 +427,9 @@ export async function promptDefaultModel(
   const resolvedKey = modelKey(resolved.provider, resolved.model);
   const configuredKey = configuredRaw ? resolvedKey : "";
 
-  const catalog = await loadModelCatalog({ config: cfg, useCache: false });
+  const catalog = cfg.models?.mode === "replace"
+    ? buildConfiguredModelCatalog({ cfg })
+    : await loadModelCatalog({ config: cfg, useCache: false });
   if (catalog.length === 0) {
     return promptManualModel({
       prompter: params.prompter,
@@ -602,7 +605,9 @@ export async function promptModelAllowlist(params: {
     ? initialSeeds.filter((key) => allowedKeySet.has(key))
     : initialSeeds;
 
-  const catalog = await loadModelCatalog({ config: cfg, useCache: false });
+  const catalog = cfg.models?.mode === "replace"
+    ? buildConfiguredModelCatalog({ cfg })
+    : await loadModelCatalog({ config: cfg, useCache: false });
   if (catalog.length === 0 && allowedKeys.length === 0) {
     const raw = await params.prompter.text({
       message:

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -4,6 +4,7 @@ import {
   resetModelCatalogCacheForTest,
 } from "../agents/model-catalog.js";
 import { getRuntimeConfig } from "../config/config.js";
+import { buildConfiguredModelCatalog } from "../agents/model-selection.js";
 
 export type GatewayModelChoice = ModelCatalogEntry;
 
@@ -17,5 +18,9 @@ export function __resetModelCatalogCacheForTest() {
 export async function loadGatewayModelCatalog(params?: {
   getConfig?: () => ReturnType<typeof getRuntimeConfig>;
 }): Promise<GatewayModelChoice[]> {
-  return await loadModelCatalog({ config: (params?.getConfig ?? getRuntimeConfig)() });
+  const cfg = (params?.getConfig ?? getRuntimeConfig)();
+  if (cfg.models?.mode === "replace") {
+    return buildConfiguredModelCatalog({ cfg });
+  }
+  return await loadModelCatalog({ config: cfg });
 }


### PR DESCRIPTION
Fixes #64950.

When `models.mode: "replace"` is set, the gateway model catalog and CLI picker were still showing the merged built-in catalog. This switches both paths to the configured catalog in replace mode, while leaving the default merge behavior alone.

Testing:
- `pnpm exec vitest run src/commands/model-picker.test.ts`