### PR TITLE
fix: repair provider transport and channel registry CI regressions

### DIFF
--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -58,7 +58,7 @@ function buildManagedResponse(response: Response, release: () => Promise<void>):
 
 function resolveModelRequestPolicy(model: Model<Api>) {
   const debugProxy = resolveDebugProxySettings();
-  const allowExplicitDebugProxy =
+  const explicitDebugProxyUrl =
     debugProxy.enabled &&
     debugProxy.proxyUrl &&
     (() => {
@@ -67,15 +67,16 @@ function resolveModelRequestPolicy(model: Model<Api>) {
       } catch {
         return false;
       }
-    })();
+    })()
+      ? debugProxy.proxyUrl
+      : undefined;
   const request = mergeModelProviderRequestOverrides(getModelProviderRequestTransport(model), {
-    proxy:
-      allowExplicitDebugProxy && debugProxy.proxyUrl
-        ? {
-            mode: "explicit-proxy",
-            url: debugProxy.proxyUrl,
-          }
-        : undefined,
+    proxy: explicitDebugProxyUrl
+      ? {
+          mode: "explicit-proxy",
+          url: explicitDebugProxyUrl,
+        }
+      : undefined,
   });
   return resolveProviderRequestPolicyConfig({
     provider: model.provider,

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -4,16 +4,9 @@ import {
 } from "../../plugins/runtime-channel-state.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { CHAT_CHANNEL_ORDER } from "../registry.js";
+import type { ChannelPlugin } from "./types.plugin.js";
 
-export type LoadedChannelPlugin = {
-  id: string;
-  meta: {
-    order?: number;
-  };
-  capabilities?: {
-    nativeCommands?: boolean;
-  };
-};
+export type LoadedChannelPlugin = ChannelPlugin;
 
 type CachedChannelPlugins = {
   registryVersion: number;
@@ -30,6 +23,20 @@ const EMPTY_CHANNEL_PLUGIN_CACHE: CachedChannelPlugins = {
 };
 
 let cachedChannelPlugins = EMPTY_CHANNEL_PLUGIN_CACHE;
+
+function isLoadedChannelPlugin(
+  plugin: {
+    id?: string | null;
+    meta?: {
+      order?: number;
+    } | null;
+    capabilities?: {
+      nativeCommands?: boolean;
+    } | null;
+  } | null,
+): plugin is LoadedChannelPlugin {
+  return Boolean(normalizeOptionalString(plugin?.id));
+}
 
 function dedupeChannels(channels: LoadedChannelPlugin[]): LoadedChannelPlugin[] {
   const seen = new Set<string>();
@@ -56,8 +63,9 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
   const channelPlugins: LoadedChannelPlugin[] = [];
   if (registry && Array.isArray(registry.channels)) {
     for (const entry of registry.channels) {
-      if (entry?.plugin) {
-        channelPlugins.push(entry.plugin);
+      const plugin = entry?.plugin ?? null;
+      if (isLoadedChannelPlugin(plugin)) {
+        channelPlugins.push(plugin);
       }
     }
   }

--- a/src/channels/plugins/registry.test.ts
+++ b/src/channels/plugins/registry.test.ts
@@ -66,4 +66,32 @@ describe("listChannelPlugins", () => {
     expect(getChannelPlugin("beta")?.meta.label).toBe("beta");
     expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["beta"]);
   });
+
+  it("ignores malformed runtime channel entries and preserves native command metadata", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.channels = [
+      {
+        pluginId: "missing-id",
+        plugin: {
+          id: undefined,
+          meta: { label: "missing-id" },
+          capabilities: { nativeCommands: true },
+        } as never,
+        source: "test",
+      },
+      {
+        pluginId: "dockable",
+        plugin: {
+          id: "dockable",
+          meta: { label: "dockable" },
+          capabilities: { nativeCommands: true },
+        } as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["dockable"]);
+    expect(getChannelPlugin("dockable")?.capabilities.nativeCommands).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: `pnpm build` and the linked CI jobs were failing on three regressions: a non-narrowed debug proxy URL type, a runtime channel registry type mismatch, and a stale test-only `./model-types.js` import
- Why it matters: these failures blocked `build-artifacts`, `check`, and `checks-fast-contracts-protocol` even though the underlying runtime changes were small
- What changed: tightened the debug proxy narrowing, widened the tracked runtime channel shape enough for the cache, preserved loaded channel plugin objects while filtering malformed entries, and fixed the broken test import
- What did NOT change (scope boundary): no behavior changes outside those regressions, and no unrelated repo-wide lint debt cleanup

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the QA-lab proxy capture change added an explicit-proxy override without giving TypeScript a guaranteed `string` URL, `registry-loaded.ts` assumed raw runtime registry entries already satisfied the loaded channel plugin type, and the new provider transport test imported a local type module that does not exist
- Missing detection / guardrail: build/check caught it after merge, but there was no direct unit coverage for malformed runtime channel entries in the cache path
- Contributing context (if known): the runtime registry state is intentionally typed as a light tracked surface, so the cache layer needs an explicit narrowing step before treating entries as loaded plugins

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/channels/plugins/registry.test.ts`, `src/agents/provider-transport-fetch.test.ts`
- Scenario the test should lock in: malformed runtime channel entries are ignored without dropping valid plugin metadata, and provider transport fetch tests compile against the correct `Model` type import
- Why this is the smallest reliable guardrail: both failures are local type/runtime seam issues and do not need broader integration coverage
- Existing test that already covers this (if any): `src/agents/provider-transport-fetch.test.ts` already covered the proxy override path once the broken import was fixed
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: Node 24 / pnpm 10
- Model/provider: N/A
- Integration/channel (if any): runtime channel registry cache, provider transport fetch
- Relevant config (redacted): none

### Steps

1. Run `pnpm build`
2. Run `pnpm test src/agents/provider-transport-fetch.test.ts src/channels/plugins/registry.test.ts`
3. Run `pnpm check`

### Expected

- `pnpm build` succeeds
- the touched tests pass
- `pnpm check` should not report issues in the touched files

### Actual

- `pnpm build` succeeds
- the touched tests pass
- `pnpm check` still fails on 31 unrelated existing lint violations outside this PR's scope

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the original CI/build failures locally, fixed them, reran `pnpm build`, reran the two direct tests, and confirmed `pnpm check` no longer reports issues in the touched files
- Edge cases checked: malformed runtime channel entries with missing ids are dropped while valid plugin metadata remains available
- What you did **not** verify: full repo-wide lint cleanup, because the remaining 31 failures are unrelated existing issues outside this change

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the runtime channel registry cache now relies on an explicit narrowing guard for tracked registry entries
  - Mitigation: added a unit test covering malformed entries plus preservation of valid plugin metadata
