### PR TITLE
fix(telegram): bypass sequentializer for approval callback_queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - Matrix/mentions: keep room mention gating strict while accepting visible `@displayName` Matrix URI labels, so `requireMention` works for non-OpenClaw Matrix clients again. (#64796) Thanks @hclsys.
 - Doctor: warn when on-disk agent directories still exist under `~/.openclaw/agents/<id>/agent` but the matching `agents.list[]` entries are missing from config. (#65113) Thanks @neeravmakwana.
+- Telegram: route approval button callback queries onto a separate sequentializer lane so plugin approval clicks can resolve immediately instead of deadlocking behind the blocked agent turn. (#64979) Thanks @nk3750.
 
 ## 2026.4.11
 

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -94,7 +94,6 @@ describe("getTelegramSequentialKey", () => {
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "halt" }) },
       "telegram:123:control",
     ],
-    // Approval callback_queries get a separate lane to avoid sequentializer deadlock
     [
       {
         update: {
@@ -128,7 +127,6 @@ describe("getTelegramSequentialKey", () => {
       },
       "telegram:789:approval",
     ],
-    // Non-approval callback_queries use normal chat key
     [
       {
         update: {

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -94,6 +94,52 @@ describe("getTelegramSequentialKey", () => {
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "halt" }) },
       "telegram:123:control",
     ],
+    // Approval callback_queries get a separate lane to avoid sequentializer deadlock
+    [
+      {
+        update: {
+          callback_query: {
+            message: mockMessage({ chat: mockChat({ id: 123 }) }),
+            data: "/approve plugin:abc123 allow-once",
+          },
+        },
+      },
+      "telegram:123:approval",
+    ],
+    [
+      {
+        update: {
+          callback_query: {
+            message: mockMessage({ chat: mockChat({ id: 456 }) }),
+            data: "/approve exec:def456 deny",
+          },
+        },
+      },
+      "telegram:456:approval",
+    ],
+    [
+      {
+        update: {
+          callback_query: {
+            message: mockMessage({ chat: mockChat({ id: 789 }) }),
+            data: "/approve plugin:ghi789 always",
+          },
+        },
+      },
+      "telegram:789:approval",
+    ],
+    // Non-approval callback_queries use normal chat key
+    [
+      {
+        update: {
+          callback_query: {
+            message: mockMessage({ chat: mockChat({ id: 123 }) }),
+            data: "some-other-button",
+          },
+        },
+      },
+      "telegram:123",
+    ],
     [{ message: mockMessage({ chat: mockChat({ id: 123 }), text: "/abort" }) }, "telegram:123"],
     [{ message: mockMessage({ chat: mockChat({ id: 123 }), text: "/abort now" }) }, "telegram:123"],
     [

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -53,11 +53,6 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     }
     return "telegram:btw";
   }
-  // Approval callback_queries need their own lane so they bypass a blocked agent
-  // turn that is waiting on plugin.approval.waitDecision. Without this, the
-  // sequentializer deadlocks: the callback can't run because the lane is held,
-  // and the lane can't release because it's waiting for the callback.
-  // Same pattern as abort requests (telegram:<chatId>:control).
   const callbackData = ctx.update?.callback_query?.data;
   if (callbackData && parseExecApprovalCommandText(callbackData) !== null) {
     if (typeof chatId === "number") {

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -1,4 +1,5 @@
 import { type Message, type UserFromGetMe } from "@grammyjs/types";
+import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/infra-runtime";
 import { isAbortRequestText } from "openclaw/plugin-sdk/reply-runtime";
 import { isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveTelegramForumThreadId } from "./bot/helpers.js";
@@ -14,7 +15,7 @@ export type TelegramSequentialKeyContext = {
     edited_message?: Message;
     channel_post?: Message;
     edited_channel_post?: Message;
-    callback_query?: { message?: Message };
+    callback_query?: { message?: Message; data?: string };
     message_reaction?: { chat?: { id?: number } };
   };
 };
@@ -51,6 +52,18 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
       return `telegram:${chatId}:btw`;
     }
     return "telegram:btw";
+  }
+  // Approval callback_queries need their own lane so they bypass a blocked agent
+  // turn that is waiting on plugin.approval.waitDecision. Without this, the
+  // sequentializer deadlocks: the callback can't run because the lane is held,
+  // and the lane can't release because it's waiting for the callback.
+  // Same pattern as abort requests (telegram:<chatId>:control).
+  const callbackData = ctx.update?.callback_query?.data;
+  if (callbackData && parseExecApprovalCommandText(callbackData) !== null) {
+    if (typeof chatId === "number") {
+      return `telegram:${chatId}:approval`;
+    }
+    return "telegram:approval";
   }
   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
   const messageThreadId = msg?.message_thread_id;


### PR DESCRIPTION
## Summary

Fixes #64977 — plugin approval buttons on Telegram deadlock because the Grammy sequentializer queues the approval `callback_query` behind the blocked agent turn.

One file changed, one pattern followed. Same fix as abort requests (`telegram:<chatId>:control`) and btw requests (`telegram:<chatId>:btw`).

## Root Cause

`getTelegramSequentialKey()` returns the same key (`telegram:<chatId>`) for both:
- The user message that starts the agent turn (which blocks on `plugin.approval.waitDecision`)
- The approval `callback_query` from clicking the inline button

The `@grammyjs/runner` sequentializer processes same-key updates sequentially. Deadlock: the callback can't run because the lane is held, and the lane can't release because it's waiting for the callback.

## Fix

Detect approval `callback_query` updates via `parseExecApprovalCommandText(data)` and return a separate sequential key: `telegram:<chatId>:approval`.

This is the same pattern already used for:
- Abort requests → `telegram:<chatId>:control` (line 40-44)
- Btw requests → `telegram:<chatId>:btw` (line 46-54)

## Before / After (gateway logs, same machine, same guardrail)

**Before** — approval times out after 300s, resolve arrives too late:

```
plugin.approval.waitDecision 299961ms  ✓  (timed out)
plugin.approval.resolve 0ms  ✗  errorCode=INVALID_REQUEST errorMessage=unknown or expired approval id
plugin.approval.resolve 1ms  ✗  errorCode=INVALID_REQUEST errorMessage=unknown or expired approval id
```

**After** — approval resolves in 3s:

```
plugin.approval.waitDecision 3147ms  ✓  (resolved by button click)
plugin.approval.resolve 564ms  ✓
```

Audit log confirms: `decision: "approval_required"` at `19:22:32`, `resolution: "allow-once"`, `userResponse: "approved"` at `19:22:35`.

## Changes

| File | Change |
|------|--------|
| `extensions/telegram/src/sequential-key.ts` | Add `data?: string` to `callback_query` context type. Detect approval callbacks via `parseExecApprovalCommandText` and return `telegram:<chatId>:approval` key. |
| `extensions/telegram/src/sequential-key.test.ts` | 4 new tests: plugin approval, exec approval, allow-always variant, non-approval callback (no false positives). All 23 tests pass. |

## Test plan

- [x] `pnpm test -- extensions/telegram/src/sequential-key.test.ts` — 23/23 pass (19 existing + 4 new)
- [x] Plugin approval callback → `telegram:<chatId>:approval` key
- [x] Exec approval callback → `telegram:<chatId>:approval` key
- [x] `always` alias callback → `telegram:<chatId>:approval` key
- [x] Non-approval callback → normal `telegram:<chatId>` key (no false positives)
- [x] Live e2e: ClawLens guardrail `require_approval` → Telegram button click → resolves in 3s (was 300s timeout)

## Environment

- OpenClaw: 2026.4.10 (44e5b62) base, tested on 2026.4.11-beta.1 (faf9fe7)
- Plugin: ClawLens (returns `requireApproval` from `before_tool_call` guardrails)
- Channel: Telegram DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)