### PR TITLE
[codex] fix plugin-sdk DTS build errors

### DIFF
--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import {
   normalizeLowercaseStringOrEmpty,

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -1,3 +1,4 @@
+import type { ActiveChannelPluginRuntimeShape } from "../../plugins/channel-registry-state.types.js";
 import {
   getActivePluginChannelRegistryFromState,
   getActivePluginChannelRegistryVersionFromState,
@@ -31,6 +32,22 @@ const EMPTY_CHANNEL_PLUGIN_CACHE: CachedChannelPlugins = {
 
 let cachedChannelPlugins = EMPTY_CHANNEL_PLUGIN_CACHE;
 
+function toLoadedChannelPlugin(
+  plugin: ActiveChannelPluginRuntimeShape | null | undefined,
+): LoadedChannelPlugin | null {
+  const resolvedPlugin = plugin;
+  const id = normalizeOptionalString(resolvedPlugin?.id) ?? "";
+  if (!resolvedPlugin || !id) {
+    return null;
+  }
+  return {
+    ...resolvedPlugin,
+    id,
+    meta: resolvedPlugin.meta ?? {},
+    capabilities: resolvedPlugin.capabilities ?? undefined,
+  };
+}
+
 function dedupeChannels(channels: LoadedChannelPlugin[]): LoadedChannelPlugin[] {
   const seen = new Set<string>();
   const resolved: LoadedChannelPlugin[] = [];
@@ -56,8 +73,9 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
   const channelPlugins: LoadedChannelPlugin[] = [];
   if (registry && Array.isArray(registry.channels)) {
     for (const entry of registry.channels) {
-      if (entry?.plugin) {
-        channelPlugins.push(entry.plugin);
+      const plugin = toLoadedChannelPlugin(entry?.plugin);
+      if (plugin) {
+        channelPlugins.push(plugin);
       }
     }
   }

--- a/src/plugin-sdk/channel-runtime-context.ts
+++ b/src/plugin-sdk/channel-runtime-context.ts
@@ -2,5 +2,5 @@ export {
   getChannelRuntimeContext,
   registerChannelRuntimeContext,
   watchChannelRuntimeContexts,
-  type ChannelRuntimeContextKey,
 } from "../infra/channel-runtime-context.js";
+export type { ChannelRuntimeContextKey } from "../channels/plugins/channel-runtime-surface.types.js";


### PR DESCRIPTION
## Summary

- Problem: `pnpm build` fails in the `build:plugin-sdk:dts` step because three declarations drifted out of sync during refactors.
- Why it matters: the plugin SDK DTS emit is part of the core build, so this regression blocks upstream builds and publish flows.
- What changed: restored the missing `OpenClawConfig` type import, normalized runtime channel plugin entries before caching them as loaded channel plugins, and re-exported `ChannelRuntimeContextKey` from the module that actually owns that type.
- What did NOT change (scope boundary): no runtime behavior outside the affected type/export seams, no config contract changes, and no unrelated gateway/test fixes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: type-only seams drifted across three files during refactors, leaving one missing config type import, one nullable runtime plugin shape flowing into a stricter cached shape, and one plugin-sdk re-export targeting the wrong source module.
- Missing detection / guardrail: the breakage was caught by the plugin SDK DTS build gate rather than a narrower compile-time seam test.
- Contributing context (if known): `pnpm build` reaches `build:plugin-sdk:dts` late in the build-all flow, so the regression presents as a build blocker instead of an isolated leaf failure.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `pnpm build:plugin-sdk:dts`
- Scenario the test should lock in: plugin SDK declaration emit succeeds when these leaf type/export seams are assembled.
- Why this is the smallest reliable guardrail: the failure is in declaration assembly across module boundaries, so the dedicated DTS build gate exercises the exact contract.
- Existing test that already covers this (if any): `pnpm build` also covers the same failing path through `build-all`.
- If no new test is added, why not: the regression is already directly covered by the existing build gates that failed before this patch and pass after it.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu (local dev shell)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Check out current `main` before this patch.
2. Run `pnpm build`.
3. Observe `build:plugin-sdk:dts` fail with missing `OpenClawConfig`, nullable `LoadedChannelPlugin` id mismatch, and wrong `ChannelRuntimeContextKey` re-export source.

### Expected

- `pnpm build:plugin-sdk:dts` and `pnpm build` complete successfully.

### Actual

- Before the fix, declaration emit failed during `build:plugin-sdk:dts`.
- After the fix, both commands pass locally.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm build:plugin-sdk:dts`; `pnpm build`.
- Edge cases checked: loaded channel registry now drops entries without a normalized id before sorting/caching.
- What you did **not** verify: I did not broaden scope into unrelated existing `tsgo` failures currently present in `src/gateway/server-channels.test.ts` and `src/gateway/server-restart-sentinel.test.ts` outside this diff.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the loaded-channel normalization could hide malformed runtime plugin entries with empty ids instead of surfacing them later.
  - Mitigation: that matches the existing dedupe behavior and keeps the cached `LoadedChannelPlugin` contract honest.
