### PR TITLE
fix(plugins): align channel runtime types after registry narrowing

### DIFF
--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -56,8 +56,13 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
   const channelPlugins: LoadedChannelPlugin[] = [];
   if (registry && Array.isArray(registry.channels)) {
     for (const entry of registry.channels) {
-      if (entry?.plugin) {
-        channelPlugins.push(entry.plugin);
+      const plugin = entry?.plugin;
+      if (plugin?.id) {
+        channelPlugins.push({
+          id: plugin.id,
+          meta: { order: plugin.meta?.order },
+          capabilities: plugin.capabilities ?? undefined,
+        });
       }
     }
   }

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelRuntimeSurface } from "../channels/plugins/channel-runtime-surface.types.js";
 import { type ChannelId, type ChannelPlugin } from "../channels/plugins/types.js";
 import {
   createSubsystemLogger,
@@ -8,7 +9,6 @@ import {
 import { createEmptyPluginRegistry, type PluginRegistry } from "../plugins/registry.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
-import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createChannelManager } from "./server-channels.js";
@@ -110,8 +110,8 @@ function installTestRegistry(...plugins: ChannelPlugin<TestAccount>[]) {
 }
 
 function createManager(options?: {
-  channelRuntime?: PluginRuntime["channel"];
-  resolveChannelRuntime?: () => PluginRuntime["channel"];
+  channelRuntime?: ChannelRuntimeSurface;
+  resolveChannelRuntime?: () => ChannelRuntimeSurface;
   loadConfig?: () => Record<string, unknown>;
   channelIds?: ChannelId[];
 }) {
@@ -224,8 +224,8 @@ describe("server-channels auto restart", () => {
     const channelRuntime = {
       ...createRuntimeChannel(),
       marker: "channel-runtime",
-    } as PluginRuntime["channel"] & { marker: string };
-    const startAccount = vi.fn(async (_ctx: { channelRuntime?: PluginRuntime["channel"] }) => {});
+    } as ChannelRuntimeSurface & { marker: string };
+    const startAccount = vi.fn(async (_ctx: { channelRuntime?: ChannelRuntimeSurface }) => {});
 
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager({ channelRuntime });
@@ -287,9 +287,9 @@ describe("server-channels auto restart", () => {
     const channelRuntime = {
       ...createRuntimeChannel(),
       marker: "lazy-channel-runtime",
-    } as PluginRuntime["channel"] & { marker: string };
+    } as ChannelRuntimeSurface & { marker: string };
     const resolveChannelRuntime = vi.fn(() => channelRuntime);
-    const startAccount = vi.fn(async (_ctx: { channelRuntime?: PluginRuntime["channel"] }) => {});
+    const startAccount = vi.fn(async (_ctx: { channelRuntime?: ChannelRuntimeSurface }) => {});
 
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager({ resolveChannelRuntime });
@@ -311,7 +311,7 @@ describe("server-channels auto restart", () => {
   it("fails fast when channelRuntime is not a full plugin runtime surface", async () => {
     installTestRegistry(createTestPlugin({ startAccount: vi.fn(async () => {}) }));
     const manager = createManager({
-      channelRuntime: { marker: "partial-runtime" } as unknown as PluginRuntime["channel"],
+      channelRuntime: { marker: "partial-runtime" } as unknown as ChannelRuntimeSurface,
     });
 
     await expect(manager.startChannel("discord", DEFAULT_ACCOUNT_ID)).rejects.toThrow(
@@ -324,7 +324,7 @@ describe("server-channels auto restart", () => {
 
   it("keeps auto-restart running when scoped runtime cleanup throws", async () => {
     const baseChannelRuntime = createRuntimeChannel();
-    const channelRuntime: PluginRuntime["channel"] = {
+    const channelRuntime: ChannelRuntimeSurface = {
       ...baseChannelRuntime,
       runtimeContexts: {
         ...baseChannelRuntime.runtimeContexts,
@@ -336,7 +336,7 @@ describe("server-channels auto restart", () => {
       },
     };
     const startAccount = vi.fn(
-      async ({ channelRuntime }: { channelRuntime?: PluginRuntime["channel"] }) => {
+      async ({ channelRuntime }: { channelRuntime?: ChannelRuntimeSurface }) => {
         channelRuntime?.runtimeContexts.register({
           channelId: "discord",
           accountId: DEFAULT_ACCOUNT_ID,

--- a/src/infra/channel-runtime-context.ts
+++ b/src/infra/channel-runtime-context.ts
@@ -3,6 +3,8 @@ import type {
   ChannelRuntimeSurface,
 } from "../channels/plugins/channel-runtime-surface.types.js";
 
+export type { ChannelRuntimeContextKey };
+
 const NOOP_DISPOSE = () => {};
 
 function resolveScopedRuntimeContextRegistry(params: {


### PR DESCRIPTION
## Summary
- Re-export `ChannelRuntimeContextKey` from `src/infra/channel-runtime-context.ts` (was imported but not exported, breaking `plugin-sdk/channel-runtime-context.ts`)
- Narrow `ActiveChannelPluginRuntimeShape` before casting to `LoadedChannelPlugin` in `registry-loaded.ts` (id field is now optional after 0c4a19d060)
- Update test mocks in `server-channels.test.ts` to use `ChannelRuntimeSurface` instead of `PluginRuntime["channel"]` (matches the actual `ChannelGatewayContext` type)

## Context
Commit 0c4a19d060 ("fix(plugins): narrow runtime channel registry state") introduced `ActiveChannelPluginRuntimeShape` with optional `id`, replacing the previous `PluginRegistry` type. This broke type checking in downstream consumers that expected `id: string`.

## Test plan
- [ ] CI passes on this PR (tsgo, lint, build, contracts-protocol, check-additional)
- [ ] Verify the 5 failing checks on main are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)