### PR TITLE
fix(browser): use remote-class timeouts for attachOnly loopback profiles [AI-assisted]

### DIFF
--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -59,9 +59,13 @@ export function createProfileAvailability({
   setProfileRunning,
 }: AvailabilityDeps): AvailabilityOps {
   const capabilities = getBrowserProfileCapabilities(profile);
+  // attachOnly loopback profiles (e.g. WSL2 → Windows host via 127.0.0.1)
+  // share a loopback address but may cross a virtual network boundary.
+  // Use remote-class timeouts so probes survive the extra latency.
+  const effectivelyLoopback = profile.cdpIsLoopback && !profile.attachOnly;
   const resolveTimeouts = (timeoutMs: number | undefined) =>
     resolveCdpReachabilityTimeouts({
-      profileIsLoopback: profile.cdpIsLoopback,
+      profileIsLoopback: effectivelyLoopback,
       timeoutMs,
       remoteHttpTimeoutMs: state().resolved.remoteCdpTimeoutMs,
       remoteHandshakeTimeoutMs: state().resolved.remoteCdpHandshakeTimeoutMs,

--- a/extensions/browser/src/browser/server-context.list-profiles-attach-only.test.ts
+++ b/extensions/browser/src/browser/server-context.list-profiles-attach-only.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "./server-context.chrome-test-harness.js";
+import * as chromeModule from "./chrome.js";
+import { createBrowserRouteContext } from "./server-context.js";
+import { makeBrowserProfile, makeBrowserServerState } from "./server-context.test-harness.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Issue #64900 — attachOnly loopback profiles (e.g. WSL2 → Windows host via
+ * 127.0.0.1) cross a virtual network boundary that adds significant latency.
+ * These tests verify that both listProfiles() and ensureBrowserAvailable() use
+ * remote-class timeouts for such profiles instead of tight loopback defaults.
+ */
+describe("attachOnly loopback profile timeout handling (#64900)", () => {
+  function makeAttachOnlyState() {
+    const profile = makeBrowserProfile({
+      name: "remote",
+      cdpUrl: "http://127.0.0.1:9222",
+      cdpHost: "127.0.0.1",
+      cdpIsLoopback: true,
+      cdpPort: 9222,
+      color: "#00AA00",
+      driver: "openclaw",
+      attachOnly: true,
+    });
+    return makeBrowserServerState({
+      profile,
+      resolvedOverrides: { defaultProfile: "remote" },
+    });
+  }
+
+  describe("listProfiles", () => {
+    it("uses remoteCdpTimeoutMs for attachOnly loopback profiles", async () => {
+      const state = makeAttachOnlyState();
+      const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
+      isChromeReachable.mockResolvedValue(true);
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const profiles = await ctx.listProfiles();
+
+      const remote = profiles.find((p) => p.name === "remote");
+      expect(remote).toBeDefined();
+      expect(remote?.running).toBe(true);
+
+      // Verify the timeout is 1500ms (remoteCdpTimeoutMs) not 200ms
+      const calls = isChromeReachable.mock.calls;
+      const remoteCall = calls.find((c) => c[0] === "http://127.0.0.1:9222");
+      expect(remoteCall).toBeDefined();
+      expect(remoteCall![1]).toBe(state.resolved.remoteCdpTimeoutMs);
+    });
+
+    it("reports running:false when attachOnly profile is unreachable", async () => {
+      const state = makeAttachOnlyState();
+      vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(false);
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const profiles = await ctx.listProfiles();
+
+      const remote = profiles.find((p) => p.name === "remote");
+      expect(remote).toBeDefined();
+      expect(remote?.running).toBe(false);
+    });
+  });
+
+  describe("ensureBrowserAvailable", () => {
+    it("uses remote-class timeouts for HTTP reachability check", async () => {
+      const state = makeAttachOnlyState();
+      const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
+      const isChromeCdpReady = vi.mocked(chromeModule.isChromeCdpReady);
+
+      // HTTP reachable, WebSocket also ready
+      isChromeReachable.mockResolvedValue(true);
+      isChromeCdpReady.mockResolvedValue(true);
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const profile = ctx.forProfile("remote");
+      await expect(profile.ensureBrowserAvailable()).resolves.toBeUndefined();
+
+      // isHttpReachable should use remoteCdpTimeoutMs (1500ms), not
+      // PROFILE_HTTP_REACHABILITY_TIMEOUT_MS (300ms)
+      expect(isChromeReachable).toHaveBeenCalledWith(
+        "http://127.0.0.1:9222",
+        state.resolved.remoteCdpTimeoutMs,
+        state.resolved.ssrfPolicy,
+      );
+    });
+
+    it("uses remote-class timeouts for WebSocket readiness check", async () => {
+      const state = makeAttachOnlyState();
+      const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
+      const isChromeCdpReady = vi.mocked(chromeModule.isChromeCdpReady);
+
+      isChromeReachable.mockResolvedValue(true);
+      isChromeCdpReady.mockResolvedValue(true);
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const profile = ctx.forProfile("remote");
+      await profile.ensureBrowserAvailable();
+
+      // isReachable → isChromeCdpReady should use remote handshake timeout
+      expect(isChromeCdpReady).toHaveBeenCalledWith(
+        "http://127.0.0.1:9222",
+        state.resolved.remoteCdpTimeoutMs,
+        state.resolved.remoteCdpHandshakeTimeoutMs,
+        state.resolved.ssrfPolicy,
+      );
+    });
+
+    it("throws BrowserProfileUnavailableError when HTTP is unreachable", async () => {
+      const state = makeAttachOnlyState();
+      vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(false);
+      vi.mocked(chromeModule.isChromeCdpReady).mockResolvedValue(false);
+
+      const ctx = createBrowserRouteContext({ getState: () => state });
+      const profile = ctx.forProfile("remote");
+      await expect(profile.ensureBrowserAvailable()).rejects.toThrow(
+        /attachOnly.*is not running/,
+      );
+    });
+  });
+});

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -186,9 +186,15 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
       } else {
         // Check if something is listening on the port
         try {
+          // attachOnly profiles may sit across a virtual network boundary
+          // (e.g. WSL2 → Windows host via 127.0.0.1) where the default
+          // 200 ms probe is too tight.  Use the remote CDP timeout instead.
+          const probeTimeoutMs = profile.attachOnly
+            ? current.resolved.remoteCdpTimeoutMs
+            : 200;
           const reachable = await isChromeReachable(
             profile.cdpUrl,
-            200,
+            probeTimeoutMs,
             current.resolved.ssrfPolicy,
           );
           if (reachable) {


### PR DESCRIPTION
## Summary

Fixes #64900.

`attachOnly` profiles pointing at a loopback address (e.g. a WSL2 gateway connecting to a Windows-host browser via `127.0.0.1`) may cross a virtual network boundary where loopback-class timeouts (200–300 ms) are too tight, causing OpenClaw to incorrectly report `running: false`.

## Root Cause

Two timeout paths were affected:

1. **`listProfiles()`** used a hardcoded **200 ms** timeout when probing via `isChromeReachable()`. For WSL2 → Windows host connections through the NAT virtual network stack, the first TCP handshake can take 300–800 ms, causing the probe to time out.

2. **`createProfileAvailability()`** resolved timeouts via `resolveCdpReachabilityTimeouts()` using `profileIsLoopback: true` (because `127.0.0.1` is a loopback address). This gave loopback-class timeouts (300 ms HTTP / 600 ms WS) to all availability probes (`isHttpReachable`, `isReachable`, `ensureBrowserAvailable`), which are also too tight for the WSL2 NAT boundary — causing the `snapshot` command to throw `"Browser attachOnly is enabled and profile "remote" is not running"`.

## Changes

- **`server-context.ts`**: `listProfiles()` now uses `remoteCdpTimeoutMs` (default 1500 ms) instead of the hardcoded 200 ms when probing `attachOnly` profiles. Non-attachOnly profiles keep the existing 200 ms.

- **`server-context.availability.ts`**: When a profile is both `attachOnly` and `cdpIsLoopback`, treat it as effectively non-loopback for timeout resolution. This single change cascades through all reachability probes.

- **New test file**: `server-context.list-profiles-attach-only.test.ts` — 5 tests covering both `listProfiles()` and `ensureBrowserAvailable()` timeout paths for attachOnly loopback profiles.

## Testing

- **Unit tests**: 9/9 pass — 5 new tests verify that both `listProfiles()` and `ensureBrowserAvailable()` correctly propagate `remoteCdpTimeoutMs` for attachOnly loopback profiles; 4 existing `ensureBrowserAvailable` tests confirm zero regression.
- **E2E latency simulation**: On WSL2 Ubuntu 24.04, a 300 ms delay proxy in front of the Windows Edge CDP endpoint (`Edg/146.0.3856.109` on port 9333) confirms the timeout behavior:
  - `timeout 0.2` (original 200 ms) → **exit 124** (timeout → `running: false`)
  - `timeout 1.5` (our 1500 ms fix) → **exit 0** (success → `running: true`)

```bash
npx vitest run "server-context.list-profiles-attach-only" "server-context.ensure-browser-available"
```
