### PR TITLE
fix(cron): normalize malformed persisted job state on load

### DIFF
--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -116,6 +116,58 @@ describe("cron service ops seam coverage", () => {
     stop(state);
   });
 
+  it("start repairs malformed persisted job state before startup cleanup (#64137)", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-04-11T13:30:00.000Z");
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "null-state-job",
+              name: "null state job",
+              enabled: true,
+              createdAtMs: now - 60_000,
+              updatedAtMs: now - 60_000,
+              schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC" },
+              sessionTarget: "main",
+              wakeMode: "next-heartbeat",
+              payload: { kind: "systemEvent", text: "tick" },
+              state: null,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await expect(start(state)).resolves.toBeUndefined();
+    expect(state.store?.jobs[0]?.state).toEqual(expect.any(Object));
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: Array<{ state?: Record<string, unknown> }>;
+    };
+    expect(persisted.jobs[0]?.state).toEqual(expect.any(Object));
+
+    stop(state);
+  });
+
   it("records timed out manual runs as timed_out in the shared task registry", async () => {
     const { storePath } = await makeStorePath();
     const stateRoot = path.dirname(path.dirname(storePath));

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -67,6 +67,12 @@ export async function ensureLoaded(
     if (typeof hydrated.enabled !== "boolean") {
       hydrated.enabled = true;
     }
+    // Persisted jobs can also arrive with a missing or malformed runtime state.
+    // Normalize the in-memory shape before scheduler startup touches state fields.
+    const hydratedState = (hydrated as { state?: unknown }).state;
+    if (!hydratedState || typeof hydratedState !== "object" || Array.isArray(hydratedState)) {
+      hydrated.state = {};
+    }
   }
   state.store = {
     version: 1,


### PR DESCRIPTION
## Summary

- Problem: persisted cron jobs can carry a malformed `state` value such as `null`, and cron startup reads `job.state.runningAtMs` before repairing that shape.
- Why it matters: a gateway restart can abort cron startup with `TypeError: Cannot read properties of null (reading 'runningAtMs')`, leaving scheduled jobs offline until the store is repaired.
- What changed: cron store loading now normalizes missing or malformed runtime `state` values to `{}` before startup cleanup runs, and a regression seam test locks in the null-state restart path.
- What did NOT change (scope boundary): this PR does not change cron scheduling semantics or attempt broader store migrations beyond repairing malformed runtime `state` during load.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64137
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `ensureLoaded()` accepted persisted jobs whose runtime `state` was `null` or otherwise non-object, but `start()` assumes `job.state` is an object and immediately reads `runningAtMs` during stale-run cleanup.
- Missing detection / guardrail: no load-time normalization repaired malformed runtime state, and no seam test covered gateway restart with a persisted `state: null` job.
- Contributing context (if known): the persisted cron store is long-lived across restarts, so a malformed serialized runtime state survives until the next startup path touches it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/service/ops.test.ts`
- Scenario the test should lock in: a persisted cron job with `state: null` does not crash `start()`, and startup repairs the state shape before persisting it again.
- Why this is the smallest reliable guardrail: the failure happens at the load/startup seam, so the seam test exercises the exact persisted-store boundary without needing a full gateway restart harness.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Gateway restarts no longer crash cron startup when a persisted job has malformed runtime state; the in-memory store is repaired and the scheduler continues booting.

## Diagram (if applicable)

```text
Before:
[persisted job state = null] -> start() reads job.state.runningAtMs -> TypeError -> cron startup aborts

After:
[persisted job state = null] -> ensureLoaded() normalizes state to {} -> startup cleanup runs -> cron starts
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout via `pnpm` / Node.js
- Model/provider: N/A
- Integration/channel (if any): cron scheduler startup
- Relevant config (redacted): persisted cron store JSON containing a job with `state: null`

### Steps

1. Persist a cron store snapshot with a valid job whose `state` field is `null`.
2. Start the cron service (equivalent to gateway restart with cron enabled).
3. Observe whether startup completes or throws while clearing stale running markers.

### Expected

- Cron startup repairs malformed runtime state and continues booting.

### Actual

- Before this PR, startup throws `TypeError: Cannot read properties of null (reading 'runningAtMs')`.
- After this PR, startup completes and persists the repaired job state.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the crash on current `main` with a persisted `state: null` job; reran the same startup repro after the fix and confirmed cron starts successfully; added a regression seam test and confirmed it passes.
- Edge cases checked: verified the repaired state is persisted back to disk as an object during startup.
- What you did **not** verify: I did not run a full end-to-end gateway restart outside the cron service seam harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: normalizing malformed runtime `state` to `{}` discards unsupported persisted bookkeeping fields.
  - Mitigation: cron runtime state is derived scheduler bookkeeping, and startup already recomputes/repairs the fields it needs after load.

## AI Assistance

- AI-assisted: Yes (Codex)
- Testing degree: Fully tested for the affected seam
- Prompt/session summary: validated repository health and contribution norms, selected #64137 as the smallest unclaimed null-state bug with clear repro, reproduced the crash on current `main`, implemented a load-time normalization fix, then reran targeted tests plus repository validation before opening this PR.
- Understanding confirmation: I understand this change only repairs malformed persisted cron runtime state during load; it does not change cron scheduling behavior beyond preventing startup from crashing on bad stored state.

## Verification Commands

- `pnpm exec vitest run src/cron/service/ops.test.ts src/cron/service/store.test.ts`
- `pnpm build`
- `pnpm check`
- `git diff --check`
