### PR TITLE
fix(cron): suppress trailing NO_REPLY in announce delivery path [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
+- Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.
 
 ## 2026.4.15-beta.1
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -940,4 +940,50 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       timeoutMs: 10_000,
     });
   });
+
+  it("suppresses trailing NO_REPLY after summary text in direct delivery (#64976)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText: "All 3 items already processed.\n\nNO_REPLY",
+    });
+    (params as Record<string, unknown>).deliveryPayloadHasStructuredContent = true;
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(state.result).toEqual(
+      expect.objectContaining({ status: "ok", delivered: false, deliveryAttempted: true }),
+    );
+  });
+
+  it("suppresses trailing NO_REPLY after summary text in text delivery (#64976)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText: "Nothing actionable found today.\n\nNO_REPLY",
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(state.result).toEqual(
+      expect.objectContaining({ status: "ok", delivered: false, deliveryAttempted: true }),
+    );
+  });
+
+  it("suppresses mixed-case trailing No_Reply after summary text (#64976)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText: "All done, nothing to report.\n\nNo_Reply",
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(state.result).toEqual(
+      expect.objectContaining({ status: "ok", delivered: false, deliveryAttempted: true }),
+    );
+  });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,5 @@
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyText, stripSilentToken, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import {
   resolveAgentMainSessionKey,
@@ -463,9 +463,20 @@ export async function dispatchCronDelivery(
             ? [{ text: synthesizedText }]
             : [];
       // Suppress NO_REPLY sentinel so it never leaks to external channels.
-      const payloadsForDelivery = rawPayloads.filter(
-        (p) => !isSilentReplyText(p.text, SILENT_REPLY_TOKEN),
-      );
+      // Also suppress payloads where the agent appended a trailing NO_REPLY
+      // after other text (e.g. "summary...\n\nNO_REPLY") — the token signals
+      // "do not deliver" regardless of preceding content.
+      const payloadsForDelivery = rawPayloads.filter((p) => {
+        const text = p.text ?? "";
+        if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+          return false;
+        }
+        // Case-insensitive trailing check: uppercase before stripping since
+        // stripSilentToken's regex is case-sensitive.
+        const upper = text.toUpperCase();
+        const stripped = stripSilentToken(upper, SILENT_REPLY_TOKEN);
+        return stripped === upper.trim();
+      });
       if (payloadsForDelivery.length === 0) {
         return await finishSilentReplyDelivery();
       }
@@ -689,7 +700,15 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
+    // Suppress delivery when synthesizedText is (or ends with) NO_REPLY.
+    // isSilentReplyText handles case-insensitive exact matches (e.g. "No_Reply");
+    // stripSilentToken catches trailing tokens after other text.
     if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
+      return await finishSilentReplyDelivery();
+    }
+    const upperSynthesized = synthesizedText.toUpperCase();
+    const strippedSynthesized = stripSilentToken(upperSynthesized, SILENT_REPLY_TOKEN);
+    if (strippedSynthesized !== upperSynthesized.trim()) {
       return await finishSilentReplyDelivery();
     }
     if (params.isAborted()) {


### PR DESCRIPTION
## Problem

Cron announce delivery sends the full agent response to the target channel when it contains NO_REPLY mixed with other text. The NO_REPLY suppression only works when it is the **entire** response.

Agents in cron/isolated sessions often emit analysis or summary text before appending NO_REPLY:

```
All 3 items already processed.

NO_REPLY
```

The delivery path in delivery-dispatch.ts uses isSilentReplyText() which requires an exact match (^\s*NO_REPLY\s*$), so this mixed text passes through and leaks to the user.

## Root Cause

stripSilentToken() from 	okens.ts already handles trailing NO_REPLY removal, but was not called in the cron announce delivery path (delivery-dispatch.ts).

## Fix

Use stripSilentToken() to detect trailing NO_REPLY tokens in both delivery code paths:

1. **deliverViaDirect** (structured/direct path) — filter payloads by comparing text before and after stripping; suppress when different
2. **inalizeTextDelivery** (text-only path) — same comparison on synthesizedText

When the stripped result differs from the original, the payload carried a trailing NO_REPLY and delivery is suppressed via the existing inishSilentReplyDelivery() path.

## Testing

Added 2 regression tests to delivery-dispatch.double-announce.test.ts:

- Trailing NO_REPLY after summary in direct delivery → suppressed ✅
- Trailing NO_REPLY after summary in text delivery → suppressed ✅

All 36 existing tests continue to pass (no regressions).

Fixes #64976