### PR TITLE
fix(memory-wiki): pass app config into CLI metadata registrar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/cron: preserve requested isolated-agent config across runtime reloads so subagent jobs and heartbeat overrides keep the right workspace and heartbeat settings when the hot-loaded snapshot is stale. Thanks @l0cka and @vincentkoc.
 - Gateway/plugins: always send a non-empty `idempotencyKey` for plugin subagent runs, so dreaming narrative jobs stop failing gateway schema validation. (#65354) Thanks @CodeForgeNet and @vincentkoc.
 - Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
+- CLI/memory-wiki: pass the active app config into the metadata registrar so built `openclaw wiki` commands resolve the live wiki plugin config instead of silently falling back to defaults. (#65012) Thanks @leonardsellem and @vincentkoc.
 - Dreaming/cron: wake managed dreaming jobs immediately instead of waiting for the next heartbeat, so scheduled dreaming runs start when the cron fires. (#65053) Thanks @l0cka and @vincentkoc.
 
 ## 2026.4.11

--- a/extensions/memory-wiki/cli-metadata.test.ts
+++ b/extensions/memory-wiki/cli-metadata.test.ts
@@ -1,0 +1,74 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => {
+    throw new Error("loadConfig should not be called during CLI metadata registration");
+  }),
+  registerWikiCli: vi.fn(),
+  resolveMemoryWikiConfig: vi.fn(),
+}));
+
+vi.mock("../../src/config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("./src/cli.js", () => ({
+  registerWikiCli: mocks.registerWikiCli,
+}));
+
+vi.mock("./src/config.js", () => ({
+  resolveMemoryWikiConfig: mocks.resolveMemoryWikiConfig,
+}));
+
+import plugin from "./cli-metadata.js";
+
+describe("memory-wiki cli metadata entry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the registrar context config instead of reloading global config", async () => {
+    const registerCli = vi.fn();
+    const api = createTestPluginApi({
+      id: "memory-wiki",
+      name: "Memory Wiki",
+      registerCli,
+    });
+    const program = new Command();
+    const appConfig = {
+      plugins: {
+        entries: {
+          "memory-wiki": {
+            config: {
+              vaultMode: "bridge",
+            },
+          },
+        },
+      },
+    };
+    const resolvedConfig = { vaultMode: "bridge", vault: { path: "/vault" } };
+    mocks.resolveMemoryWikiConfig.mockReturnValue(resolvedConfig);
+
+    plugin.register(api);
+
+    const register = registerCli.mock.calls[0]?.[0];
+
+    expect(registerCli).toHaveBeenCalledTimes(1);
+    expect(typeof register).toBe("function");
+
+    await register({
+      program,
+      config: appConfig,
+      workspaceDir: "/tmp/openclaw",
+      logger: api.logger,
+    });
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.resolveMemoryWikiConfig).toHaveBeenCalledWith(
+      appConfig.plugins.entries["memory-wiki"].config,
+    );
+    expect(mocks.registerWikiCli).toHaveBeenCalledWith(program, resolvedConfig, appConfig);
+  });
+});

--- a/extensions/memory-wiki/cli-metadata.ts
+++ b/extensions/memory-wiki/cli-metadata.ts
@@ -7,8 +7,15 @@ export default definePluginEntry({
   register(api) {
     api.registerCli(
       async ({ program }) => {
-        const { registerWikiCli } = await import("./src/cli.js");
-        registerWikiCli(program);
+        const [{ loadConfig }, { registerWikiCli }, { resolveMemoryWikiConfig }] =
+          await Promise.all([
+            import("../../src/config/config.js"),
+            import("./src/cli.js"),
+            import("./src/config.js"),
+          ]);
+        const appConfig = loadConfig();
+        const pluginConfig = appConfig.plugins?.entries?.["memory-wiki"]?.config;
+        registerWikiCli(program, resolveMemoryWikiConfig(pluginConfig), appConfig);
       },
       {
         descriptors: [

--- a/extensions/memory-wiki/cli-metadata.ts
+++ b/extensions/memory-wiki/cli-metadata.ts
@@ -6,14 +6,11 @@ export default definePluginEntry({
   description: "Persistent wiki compiler and Obsidian-friendly knowledge vault for OpenClaw.",
   register(api) {
     api.registerCli(
-      async ({ program }) => {
-        const [{ loadConfig }, { registerWikiCli }, { resolveMemoryWikiConfig }] =
-          await Promise.all([
-            import("../../src/config/config.js"),
-            import("./src/cli.js"),
-            import("./src/config.js"),
-          ]);
-        const appConfig = loadConfig();
+      async ({ program, config: appConfig }) => {
+        const [{ registerWikiCli }, { resolveMemoryWikiConfig }] = await Promise.all([
+          import("./src/cli.js"),
+          import("./src/config.js"),
+        ]);
         const pluginConfig = appConfig.plugins?.entries?.["memory-wiki"]?.config;
         registerWikiCli(program, resolveMemoryWikiConfig(pluginConfig), appConfig);
       },


### PR DESCRIPTION
## Summary

- Problem: the metadata-only `memory-wiki` CLI registrar built `openclaw wiki` commands without the active app config, so built CLI status/doctor paths could silently fall back to default wiki config instead of the live plugin config.
- Why it matters: after the loader/cache fix landed, the shipped CLI path could still misreport bridge-mode state because the metadata registrar never resolved the configured `memory-wiki` plugin config.
- What changed: the CLI metadata registrar now passes the active app config through `resolveMemoryWikiConfig(...)` before calling `registerWikiCli(...)`, and a focused regression test locks that in.
- What did NOT change (scope boundary): this PR no longer carries the loader/cache restore work; that landed separately in https://github.com/openclaw/openclaw/pull/65240.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65012
- Related https://github.com/openclaw/openclaw/pull/65240
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/memory-wiki/cli-metadata.ts` registered the CLI surface without the resolved plugin config plus app config, so the built `openclaw wiki` entrypoint could not reflect the live `memory-wiki` configuration.
- Missing detection / guardrail: there was no focused test around metadata-only CLI registration receiving the registrar context config.
- Contributing context (if known): the runtime plugin entrypoint and the metadata-only CLI registrar had drifted apart, so source-path checks could pass while the built CLI surface still used defaults.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-wiki/cli-metadata.test.ts`
- Scenario the test should lock in: metadata CLI registration must use the registrar-provided app config and resolved plugin config instead of reloading global config or defaulting silently.
- Why this is the smallest reliable guardrail: the bug lives in the metadata registrar boundary, not the deeper wiki command implementation.
- Existing test that already covers this (if any): none before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Built `openclaw wiki` commands now see the configured `memory-wiki` plugin settings during metadata registration instead of silently falling back to defaults.

## Diagram (if applicable)

```text
Before:
[built openclaw wiki command] -> [metadata registrar without app config] -> [default wiki config]

After:
[built openclaw wiki command] -> [metadata registrar with app config] -> [resolved memory-wiki config]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): memory-wiki CLI metadata registrar
- Relevant config (redacted): `plugins.entries.memory-wiki.config` with bridge mode enabled

### Steps

1. Register the `memory-wiki` CLI surface through the metadata-only plugin entrypoint.
2. Pass an app config that contains non-default `plugins.entries.memory-wiki.config`.
3. Verify the registrar forwards the resolved plugin config to `registerWikiCli(...)`.

### Expected

- The metadata registrar uses the provided app config and resolved plugin config.

### Actual

- Before this fix, the metadata registrar registered the CLI surface without the live plugin config.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/memory-wiki/cli-metadata.test.ts`
- Edge cases checked: registrar path uses provided config instead of reloading global config
- What you did **not** verify: full end-to-end wiki bridge import flows were not rerun here.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: CLI metadata registration could drift again from runtime registration if future config-sensitive behavior is added in only one path.
  - Mitigation: `extensions/memory-wiki/cli-metadata.test.ts` now locks the registrar path to the provided app config.
