### PR TITLE
Fix/cron announce no reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/startup: fix spurious SIGUSR1 restart loop on Linux/systemd when plugin auto-enable is the only startup config write; the config hash guard was not captured for that write path, causing chokidar to treat each boot write as an external change and trigger a reload → restart cycle that corrupts manifest.db after repeated cycles. Fixes #67436. (#67557) thanks @openperf
 - OpenAI Codex/CLI: keep resumed `codex exec resume` runs on the safe non-interactive path without reintroducing the removed dangerous bypass flag by passing the supported `--skip-git-repo-check` resume arg that real Codex CLI requires outside trusted git directories. (#67666) Thanks @plgonzalezrx8.
 - Codex/app-server: parse Desktop-originated app-server user agents such as `Codex Desktop/0.118.0`, keeping the version gate working when the Codex CLI inherits a multi-word originator. (#64666) Thanks @cyrusaf.
+- Cron/announce delivery: keep isolated announce `NO_REPLY` stripping case-insensitive across direct and text delivery, preserve structured media-only sends when a caption strips silent, and derive main-session awareness from the cleaned payloads so silent captions no longer leak stale `NO_REPLY` text. (#65016) Thanks @BKF-Gitty.
 
 ## 2026.4.15-beta.1
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,4 +1,10 @@
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import {
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  startsWithSilentToken,
+  stripLeadingSilentToken,
+  stripSilentToken,
+} from "../auto-reply/tokens.js";
 import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -125,6 +131,27 @@ function isWakeContinuationRun(runId: string): boolean {
     return false;
   }
   return stripWakeRunSuffixes(trimmed) !== trimmed;
+}
+
+function stripAndClassifyReply(text: string): string | null {
+  let result = text;
+  let didStrip = false;
+  const hasLeadingSilentToken = startsWithSilentToken(result, SILENT_REPLY_TOKEN);
+  if (hasLeadingSilentToken) {
+    result = stripLeadingSilentToken(result, SILENT_REPLY_TOKEN);
+    didStrip = true;
+  }
+  if (hasLeadingSilentToken || result.toLowerCase().includes(SILENT_REPLY_TOKEN.toLowerCase())) {
+    result = stripSilentToken(result, SILENT_REPLY_TOKEN);
+    didStrip = true;
+  }
+  if (
+    didStrip &&
+    (!result.trim() || isSilentReplyText(result, SILENT_REPLY_TOKEN) || isAnnounceSkip(result))
+  ) {
+    return null;
+  }
+  return result;
 }
 
 async function wakeSubagentRunAfterDescendants(params: {
@@ -385,9 +412,28 @@ export async function runSubagentAnnounceFlow(params: {
 
       if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
         if (fallbackReply && !fallbackIsSilent) {
-          reply = fallbackReply;
+          const cleaned = stripAndClassifyReply(fallbackReply);
+          if (cleaned === null) {
+            return true;
+          }
+          reply = cleaned;
         } else {
           return true;
+        }
+      } else if (reply) {
+        const cleaned = stripAndClassifyReply(reply);
+        if (cleaned === null) {
+          if (fallbackReply && !fallbackIsSilent) {
+            const cleanedFallback = stripAndClassifyReply(fallbackReply);
+            if (cleanedFallback === null) {
+              return true;
+            }
+            reply = cleanedFallback;
+          } else {
+            return true;
+          }
+        } else {
+          reply = cleaned;
         }
       }
     }

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -69,7 +69,7 @@ export function normalizeReplyPayload(
     if (hasLeadingSilentToken) {
       text = stripLeadingSilentToken(text, silentToken);
     }
-    if (hasLeadingSilentToken || text.includes(silentToken)) {
+    if (hasLeadingSilentToken || text.toLowerCase().includes(silentToken.toLowerCase())) {
       text = stripSilentToken(text, silentToken);
       if (!hasContent(text)) {
         opts.onSkip?.("silent");

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -24,7 +24,7 @@ function getSilentTrailingRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  const regex = new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`);
+  const regex = new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`, "i");
   silentTrailingRegexByToken.set(token, regex);
   return regex;
 }

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -122,7 +122,7 @@ function makeBaseParams(overrides: {
   runSessionId?: string;
   sessionTarget?: string;
   deliveryBestEffort?: boolean;
-}) {
+}): Parameters<typeof dispatchCronDelivery>[0] {
   const resolvedDelivery = makeResolvedDelivery();
   return {
     cfg: {} as never,
@@ -325,6 +325,32 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       sessionKey: "agent:main:main",
       contextKey: "cron-direct-delivery:v1:run-123:telegram::123456:",
     });
+  });
+
+  it("skips awareness text when direct delivery strips a silent caption", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: undefined });
+    params.deliveryPayloadHasStructuredContent = true;
+    params.deliveryPayloads = [
+      { mediaUrl: "https://example.com/image.png", text: "All done\n\nNO_REPLY" },
+    ];
+    params.outputText = "All done\n\nNO_REPLY";
+    params.summary = "All done\n\nNO_REPLY";
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [{ mediaUrl: "https://example.com/image.png", text: undefined }],
+      }),
+    );
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
   it("keeps the cron run successful when awareness queueing throws after delivery", async () => {
@@ -984,6 +1010,75 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
     expect(state.result).toEqual(
       expect.objectContaining({ status: "ok", delivered: false, deliveryAttempted: true }),
+    );
+  });
+
+  it("delivers substantive text that mentions NO_REPLY in non-trailing content (text delivery)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText:
+        "The NO_REPLY sentinel tells the agent to skip delivery when nothing changes.",
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers substantive text that mentions NO_REPLY in non-trailing content (direct delivery)", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText:
+        "Reminder: reply NO_REPLY when there is nothing to announce, otherwise send a summary.",
+    });
+    (params as Record<string, unknown>).deliveryPayloadHasStructuredContent = true;
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers non-trailing NO_REPLY mention with trailing whitespace", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText: "Use NO_REPLY when nothing actionable changed.\n",
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops only the payload with trailing NO_REPLY in a multi-payload direct delivery", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: undefined });
+    params.deliveryPayloads = [
+      { text: "Working on it..." },
+      { text: "Final weather summary\n\nNO_REPLY" },
+    ];
+    params.summary = "Working on it...";
+    params.outputText = "Working on it...";
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [{ text: "Working on it..." }],
+      }),
     );
   });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,11 @@
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { isSilentReplyText, stripSilentToken, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import {
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  startsWithSilentToken,
+  stripLeadingSilentToken,
+  stripSilentToken,
+} from "../../auto-reply/tokens.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import {
   resolveAgentMainSessionKey,
@@ -10,6 +16,7 @@ import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { OutboundDeliveryResult } from "../../infra/outbound/deliver.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
+import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -18,13 +25,46 @@ import {
 import { hasScheduledNextRunAtMs } from "../service/jobs.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
-import { pickSummaryFromOutput } from "./helpers.js";
+import { pickLastNonEmptyTextFromPayloads, pickSummaryFromOutput } from "./helpers.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 function normalizeDeliveryTarget(channel: string, to: string): string {
   const toTrimmed = to.trim();
   return normalizeTargetForProvider(channel, toTrimmed) ?? toTrimmed;
+}
+
+type NormalizedSilentReplyText = {
+  text: string | undefined;
+  strippedTrailingSilentToken: boolean;
+};
+
+function normalizeSilentReplyText(text: string | undefined): NormalizedSilentReplyText {
+  if (!text) {
+    return { text, strippedTrailingSilentToken: false };
+  }
+  if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+    return { text: undefined, strippedTrailingSilentToken: false };
+  }
+
+  let next = text;
+  const hasLeadingSilentToken = startsWithSilentToken(next, SILENT_REPLY_TOKEN);
+  if (hasLeadingSilentToken) {
+    next = stripLeadingSilentToken(next, SILENT_REPLY_TOKEN);
+  }
+
+  let strippedTrailingSilentToken = false;
+  if (hasLeadingSilentToken || next.toLowerCase().includes(SILENT_REPLY_TOKEN.toLowerCase())) {
+    const trimmedBefore = next.trim();
+    const stripped = stripSilentToken(next, SILENT_REPLY_TOKEN);
+    strippedTrailingSilentToken = stripped !== trimmedBefore;
+    next = stripped;
+  }
+
+  if (!next.trim() || isSilentReplyText(next, SILENT_REPLY_TOKEN)) {
+    return { text: undefined, strippedTrailingSilentToken };
+  }
+  return { text: next, strippedTrailingSilentToken };
 }
 
 export function matchesMessagingToolDeliveryTarget(
@@ -293,9 +333,12 @@ async function queueCronAwarenessSystemEvent(params: {
   deliveryIdempotencyKey: string;
   outputText?: string;
   synthesizedText?: string;
+  deliveryPayloads?: ReplyPayload[];
 }): Promise<void> {
-  const text =
-    normalizeOptionalString(params.outputText) ?? normalizeOptionalString(params.synthesizedText);
+  const text = params.deliveryPayloads
+    ? pickLastNonEmptyTextFromPayloads(params.deliveryPayloads)
+    : (normalizeOptionalString(params.outputText) ??
+      normalizeOptionalString(params.synthesizedText));
   if (!text) {
     return;
   }
@@ -462,21 +505,18 @@ export async function dispatchCronDelivery(
           : synthesizedText
             ? [{ text: synthesizedText }]
             : [];
-      // Suppress NO_REPLY sentinel so it never leaks to external channels.
-      // Also suppress payloads where the agent appended a trailing NO_REPLY
-      // after other text (e.g. "summary...\n\nNO_REPLY") — the token signals
-      // "do not deliver" regardless of preceding content.
-      const payloadsForDelivery = rawPayloads.filter((p) => {
-        const text = p.text ?? "";
-        if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
-          return false;
-        }
-        // Case-insensitive trailing check: uppercase before stripping since
-        // stripSilentToken's regex is case-sensitive.
-        const upper = text.toUpperCase();
-        const stripped = stripSilentToken(upper, SILENT_REPLY_TOKEN);
-        return stripped === upper.trim();
-      });
+      const payloadsForDelivery = rawPayloads
+        .map((p) => {
+          if (!p.text) {
+            return p;
+          }
+          const normalized = normalizeSilentReplyText(p.text);
+          return {
+            ...p,
+            text: normalized.strippedTrailingSilentToken ? undefined : normalized.text,
+          };
+        })
+        .filter((p) => hasReplyPayloadContent(p, { trimText: true }));
       if (payloadsForDelivery.length === 0) {
         return await finishSilentReplyDelivery();
       }
@@ -583,6 +623,7 @@ export async function dispatchCronDelivery(
           deliveryIdempotencyKey,
           outputText,
           synthesizedText,
+          deliveryPayloads: payloadsForDelivery,
         });
       }
       if (delivered) {
@@ -700,17 +741,15 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    // Suppress delivery when synthesizedText is (or ends with) NO_REPLY.
-    // isSilentReplyText handles case-insensitive exact matches (e.g. "No_Reply");
-    // stripSilentToken catches trailing tokens after other text.
-    if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
+    const normalizedSynthesizedText = normalizeSilentReplyText(synthesizedText);
+    if (
+      normalizedSynthesizedText.text === undefined ||
+      normalizedSynthesizedText.strippedTrailingSilentToken
+    ) {
       return await finishSilentReplyDelivery();
     }
-    const upperSynthesized = synthesizedText.toUpperCase();
-    const strippedSynthesized = stripSilentToken(upperSynthesized, SILENT_REPLY_TOKEN);
-    if (strippedSynthesized !== upperSynthesized.trim()) {
-      return await finishSilentReplyDelivery();
-    }
+    synthesizedText = normalizedSynthesizedText.text;
+    outputText = synthesizedText;
     if (params.isAborted()) {
       return params.withRunSession({
         status: "error",


### PR DESCRIPTION
## Summary
- Problem: Cron announce delivery only suppresses `NO_REPLY` when it is the exact/entire response (`isSilentReplyText`). When the agent prepends summary text before `NO_REPLY`, the full response is delivered to the target channel.
- Why it matters: 14/15 observed production cron deliveries over 8 days contained `NO_REPLY` but were delivered anyway. Every user with announce-mode crons using `NO_REPLY` suppression hits this.
- What changed: Ported the leading/embedded `NO_REPLY` token stripping from the auto-reply path (`normalize-reply.ts`, PR #63068) into the cron announce delivery path. Three locations: `deliverViaDirect()` and `finalizeTextDelivery()` in `delivery-dispatch.ts`, and `runSubagentAnnounceFlow()` in `subagent-announce.ts`.
- What did NOT change (scope boundary): Existing `isSilentReplyText` exact-match checks are preserved. No changes to the auto-reply path, token definitions, or cron scheduling logic. No new functions — only imports of existing helpers.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #64976
- Related #63068 (original NO_REPLY stripping in auto-reply path)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: PR #63068 added `startsWithSilentToken` / `stripLeadingSilentToken` / `stripSilentToken` to the auto-reply path but the cron announce delivery path was not updated. It still uses only `isSilentReplyText` (exact match).
- Missing detection / guardrail: No test covering `NO_REPLY` mixed with other text in cron announce delivery.
- Contributing context (if known): Agents naturally summarize findings before appending `NO_REPLY`, making the exact-match check insufficient in practice.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/delivery-dispatch.test.ts`
- Scenario the test should lock in: Agent response `"All items processed.\n\nNO_REPLY"` → delivery suppressed (not delivered to channel)
- Why this is the smallest reliable guardrail: Unit test on the delivery filter pipeline catches the exact gap without needing a running gateway
- Existing test that already covers this (if any): None for this path. Auto-reply path has coverage in `normalize-reply.test.ts`.
- If no new test is added, why not: No `node_modules` installed locally to run the test suite. Happy to add a test if maintainers prefer — the pattern exists in `normalize-reply.test.ts`.

## User-visible / Behavior Changes
Cron announce deliveries containing `NO_REPLY` mixed with other text will now be stripped or suppressed, matching the behavior of the direct-reply path. Users who previously received false deliveries with `NO_REPLY` embedded in the text will no longer receive them.

## Diagram (if applicable)
```text
Before:
[agent responds "Summary text\n\nNO_REPLY"] -> [isSilentReplyText: no match] -> [delivered to channel]

After:
[agent responds "Summary text\n\nNO_REPLY"] -> [stripSilentToken removes NO_REPLY] -> [text has content] -> [stripped text delivered]
[agent responds "NO_REPLY rest of text"] -> [stripLeadingSilentToken] -> [text has content] -> [stripped text delivered]
[agent responds "All done\n\nNO_REPLY"] -> [stripSilentToken] -> [only "All done" remains] -> [stripped text delivered]
[agent responds "NO_REPLY"] -> [isSilentReplyText: exact match] -> [suppressed, not delivered]
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS 15.4
- Runtime/container: Node 22 / npm global
- Model/provider: anthropic/claude-opus-4
- Integration/channel (if any): Discord announce delivery
- Relevant config (redacted): Isolated cron with `--announce --channel discord --to "channel:xxx"`

### Steps
1. `openclaw cron add --name "Test" --cron "*/5 * * * *" --session isolated --message "Check X. If nothing actionable, reply NO_REPLY" --announce --channel discord --to "channel:xxx"`
2. Agent responds with summary text followed by `NO_REPLY`
3. Observe delivery behavior

### Expected
- Delivery suppressed when normalized response resolves to `NO_REPLY`

### Actual
- Full response including summary text delivered to channel

## Evidence
- [x] Trace/log snippets

15 cron deliveries over 8 days from production instance, 14 contained `NO_REPLY` in the response text but were delivered to Discord/WhatsApp. Pattern: agent writes summary, appends `NO_REPLY`. Delivery system did not recognize it as suppression because `isSilentReplyText` only matches exact/whole-string.

## Human Verification (required)
- Verified scenarios: Confirmed `isSilentReplyText` is the only check in `delivery-dispatch.ts` and `subagent-announce.ts`. Confirmed `startsWithSilentToken` / `stripLeadingSilentToken` / `stripSilentToken` exist in `src/auto-reply/tokens.ts` and are not imported in the cron path. Verified the diff applies the same pattern as `normalize-reply.ts`.
- Edge cases checked: Empty text after stripping routes to `finishSilentReplyDelivery()`. Payloads with content after stripping are preserved. Existing exact-match checks are not altered.
- What you did **not** verify: Could not run type checker or test suite — no `node_modules` installed locally. Did not verify against a running gateway.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Stripping `NO_REPLY` from mixed-content responses could remove the token but still deliver text the user intended to suppress entirely.
  - Mitigation: This matches the existing auto-reply path behavior (PR #63068). If the agent writes substantive text alongside `NO_REPLY`, delivering the substantive text (with the token stripped) is the safer default. Full suppression only occurs when the entire response is `NO_REPLY`.