### PR TITLE
fix(memory-core): refresh qmd session exports on transcript updates

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -29,17 +29,22 @@ const MEMORY_EMBEDDING_PROVIDERS_KEY = Symbol.for("openclaw.memoryEmbeddingProvi
 const MCPORTER_STATE_KEY = Symbol.for("openclaw.mcporterState");
 const QMD_EMBED_QUEUE_KEY = Symbol.for("openclaw.qmdEmbedQueueTail");
 
-type MockChild = EventEmitter & {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
+type MockEmitter = {
+  emit: (event: string, ...args: unknown[]) => boolean;
+  on: (event: string, listener: (...args: unknown[]) => void) => MockEmitter;
+};
+
+type MockChild = MockEmitter & {
+  stdout: MockEmitter;
+  stderr: MockEmitter;
   kill: (signal?: NodeJS.Signals) => void;
   closeWith: (code?: number | null) => void;
 };
 
 function createMockChild(params?: { autoClose?: boolean; closeDelayMs?: number }): MockChild {
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
-  const child = new EventEmitter() as MockChild;
+  const stdout = new EventEmitter() as unknown as MockEmitter;
+  const stderr = new EventEmitter() as unknown as MockEmitter;
+  const child = new EventEmitter() as unknown as MockChild;
   child.stdout = stdout;
   child.stderr = stderr;
   child.closeWith = (code = 0) => {
@@ -129,12 +134,13 @@ import {
   requireNodeSqlite,
   resolveMemoryBackendConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { emitSessionTranscriptUpdate } from "../../../../src/sessions/transcript-events.js";
 import { QmdMemoryManager } from "./qmd-manager.js";
 
 const spawnMock = mockedSpawn as unknown as Mock;
 const originalPath = process.env.PATH;
 const originalPathExt = process.env.PATHEXT;
-const originalWindowsPath = (process.env as NodeJS.ProcessEnv & { Path?: string }).Path;
+const originalWindowsPath = process.env.Path;
 
 describe("QmdMemoryManager", () => {
   let fixtureRoot: string;
@@ -269,9 +275,9 @@ describe("QmdMemoryManager", () => {
       process.env.PATHEXT = originalPathExt;
     }
     if (originalWindowsPath === undefined) {
-      delete (process.env as NodeJS.ProcessEnv & { Path?: string }).Path;
+      delete process.env.Path;
     } else {
-      (process.env as NodeJS.ProcessEnv & { Path?: string }).Path = originalWindowsPath;
+      process.env.Path = originalWindowsPath;
     }
     delete (globalThis as Record<PropertyKey, unknown>)[MCPORTER_STATE_KEY];
     delete (globalThis as Record<PropertyKey, unknown>)[QMD_EMBED_QUEUE_KEY];
@@ -423,7 +429,7 @@ describe("QmdMemoryManager", () => {
 
     const { manager } = await createManager({ mode: "full" });
     expect(watchMock).toHaveBeenCalledTimes(1);
-    const watcher = watchMock.mock.results[0]?.value as EventEmitter & { close: Mock };
+    const watcher = watchMock.mock.results[0]?.value;
     const initialUpdateCalls = spawnMock.mock.calls.filter((call) => call[1]?.[0] === "update");
     expect(initialUpdateCalls).toHaveLength(0);
 
@@ -2944,6 +2950,44 @@ describe("QmdMemoryManager", () => {
     expect(results).toHaveLength(4);
     expect(results.some((entry) => entry.source === "memory")).toBe(true);
     expect(results.some((entry) => entry.source === "sessions")).toBe(true);
+    await manager.close();
+  });
+
+  it("debounces transcript updates into a qmd session-delta refresh for the active agent only", async () => {
+    vi.useFakeTimers();
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          sessions: { enabled: true },
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const { manager } = await createManager({ mode: "full" });
+    const inner = manager as unknown as {
+      runUpdate: (reason: string) => Promise<void>;
+      agentStateDir: string;
+    };
+    const runUpdateSpy = vi.spyOn(inner, "runUpdate").mockResolvedValue();
+    const currentSessionFile = path.join(inner.agentStateDir, "sessions", "live.jsonl");
+    const otherSessionFile = path.join(stateDir, "agents", "other", "sessions", "live.jsonl");
+
+    emitSessionTranscriptUpdate({ sessionFile: otherSessionFile });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(runUpdateSpy).not.toHaveBeenCalled();
+
+    emitSessionTranscriptUpdate({ sessionFile: currentSessionFile });
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(runUpdateSpy).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runUpdateSpy).toHaveBeenCalledWith("session-delta");
+
+    runUpdateSpy.mockRestore();
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -129,12 +129,12 @@ vi.mock("openclaw/plugin-sdk/file-lock", async () => {
 });
 
 import { spawn as mockedSpawn } from "node:child_process";
+import { emitSessionTranscriptUpdate } from "openclaw/plugin-sdk/agent-harness";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   requireNodeSqlite,
   resolveMemoryBackendConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { emitSessionTranscriptUpdate } from "../../../../src/sessions/transcript-events.js";
 import { QmdMemoryManager } from "./qmd-manager.js";
 
 const spawnMock = mockedSpawn as unknown as Mock;
@@ -2985,7 +2985,7 @@ describe("QmdMemoryManager", () => {
     await vi.advanceTimersByTimeAsync(4_999);
     expect(runUpdateSpy).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
-    expect(runUpdateSpy).toHaveBeenCalledWith("session-delta");
+    expect(runUpdateSpy).toHaveBeenCalledWith("session-delta", true);
 
     runUpdateSpy.mockRestore();
     await manager.close();

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import chokidar, { type FSWatcher } from "chokidar";
+import { onSessionTranscriptUpdate } from "openclaw/plugin-sdk/agent-harness";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { withFileLock } from "openclaw/plugin-sdk/file-lock";
 import {
@@ -46,7 +47,6 @@ import {
   localeLowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
 } from "openclaw/plugin-sdk/text-runtime";
-import { onSessionTranscriptUpdate } from "../../../../src/sessions/transcript-events.js";
 import { asRecord } from "../dreaming-shared.js";
 import { resolveQmdCollectionPatternFlags, type QmdCollectionPatternFlag } from "./qmd-compat.js";
 
@@ -1342,7 +1342,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     this.sessionWatchTimer = setTimeout(() => {
       this.sessionWatchTimer = null;
-      void this.runUpdate("session-delta").catch((err) => {
+      void this.runUpdate("session-delta", true).catch((err) => {
         log.warn(`qmd session-delta sync failed: ${String(err)}`);
       });
     }, QMD_SESSION_DIRTY_DEBOUNCE_MS);

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -46,6 +46,7 @@ import {
   localeLowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
 } from "openclaw/plugin-sdk/text-runtime";
+import { onSessionTranscriptUpdate } from "../../../../src/sessions/transcript-events.js";
 import { asRecord } from "../dreaming-shared.js";
 import { resolveQmdCollectionPatternFlags, type QmdCollectionPatternFlag } from "./qmd-compat.js";
 
@@ -56,6 +57,7 @@ const log = createSubsystemLogger("memory");
 const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
 const SEARCH_PENDING_UPDATE_WAIT_MS = 500;
 const QMD_WATCH_STABILITY_MS = 200;
+const QMD_SESSION_DIRTY_DEBOUNCE_MS = 5_000;
 const MAX_QMD_OUTPUT_CHARS = 200_000;
 const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
@@ -267,6 +269,8 @@ export class QmdMemoryManager implements MemorySearchManager {
   private embedTimer: NodeJS.Timeout | null = null;
   private watcher: FSWatcher | null = null;
   private watchTimer: NodeJS.Timeout | null = null;
+  private sessionWatchTimer: NodeJS.Timeout | null = null;
+  private sessionUnsubscribe: (() => void) | null = null;
   private pendingUpdate: Promise<void> | null = null;
   private queuedForcedUpdate: Promise<void> | null = null;
   private queuedForcedRuns = 0;
@@ -360,6 +364,7 @@ export class QmdMemoryManager implements MemorySearchManager {
 
     await this.ensureCollections();
     this.ensureWatcher();
+    this.ensureSessionListener();
 
     if (this.qmd.update.onBoot) {
       const bootRun = this.runUpdate("boot", true);
@@ -1191,6 +1196,14 @@ export class QmdMemoryManager implements MemorySearchManager {
       clearTimeout(this.watchTimer);
       this.watchTimer = null;
     }
+    if (this.sessionWatchTimer) {
+      clearTimeout(this.sessionWatchTimer);
+      this.sessionWatchTimer = null;
+    }
+    if (this.sessionUnsubscribe) {
+      this.sessionUnsubscribe();
+      this.sessionUnsubscribe = null;
+    }
     if (this.watcher) {
       await this.watcher.close().catch(() => undefined);
       this.watcher = null;
@@ -1305,6 +1318,40 @@ export class QmdMemoryManager implements MemorySearchManager {
         log.warn(`qmd watch sync failed: ${String(err)}`);
       });
     }, this.syncSettings.watchDebounceMs);
+  }
+
+  private ensureSessionListener(): void {
+    if (!this.sessionExporter || this.sessionUnsubscribe || this.closed) {
+      return;
+    }
+    this.sessionUnsubscribe = onSessionTranscriptUpdate((update) => {
+      if (this.closed) {
+        return;
+      }
+      const sessionFile = update.sessionFile;
+      if (!sessionFile || !this.isSessionFileForAgent(sessionFile)) {
+        return;
+      }
+      this.scheduleSessionSync();
+    });
+  }
+
+  private scheduleSessionSync(): void {
+    if (this.sessionWatchTimer) {
+      clearTimeout(this.sessionWatchTimer);
+    }
+    this.sessionWatchTimer = setTimeout(() => {
+      this.sessionWatchTimer = null;
+      void this.runUpdate("session-delta").catch((err) => {
+        log.warn(`qmd session-delta sync failed: ${String(err)}`);
+      });
+    }, QMD_SESSION_DIRTY_DEBOUNCE_MS);
+  }
+
+  private isSessionFileForAgent(sessionFile: string): boolean {
+    const resolvedFile = path.resolve(sessionFile);
+    const resolvedDir = path.resolve(path.join(this.agentStateDir, "sessions"));
+    return resolvedFile.startsWith(`${resolvedDir}${path.sep}`);
   }
 
   private async maybeWarmSession(sessionKey?: string): Promise<void> {

--- a/src/plugin-sdk/agent-harness.ts
+++ b/src/plugin-sdk/agent-harness.ts
@@ -53,4 +53,7 @@ export { createOpenClawCodingTools } from "../agents/pi-tools.js";
 export { resolveSandboxContext } from "../agents/sandbox.js";
 export { isSubagentSessionKey } from "../routing/session-key.js";
 export { acquireSessionWriteLock } from "../agents/session-write-lock.js";
-export { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+export {
+  emitSessionTranscriptUpdate,
+  onSessionTranscriptUpdate,
+} from "../sessions/transcript-events.js";


### PR DESCRIPTION
## Summary
- subscribe QMD session export to canonical transcript update events when session export is enabled
- debounce active-session refreshes into `runUpdate("session-delta")` so `sessions-main` stays fresh while a conversation is still active
- clean up the transcript listener/timer on manager close and cover the behavior with focused qmd-manager tests

## Validation
- ran targeted test: `pnpm exec node scripts/run-vitest.mjs run extensions/memory-core/src/memory/qmd-manager.test.ts`
- repo hooks passed during commit (`tsgo`, lint, check scripts)

## Why
QMD session export currently refreshes on coarse sync triggers like interval/session-start, so the active conversation can lag behind `sessions-main`. This patch makes current-session recall behave the way users expect while keeping updates bounded by debounce.