### PR TITLE
fix(telegram): enable interrupt/steer message delivery during active runs

### DIFF
--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -6,6 +6,7 @@ import { upsertChannelPairingRequest } from "openclaw/plugin-sdk/conversation-ru
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
 import { buildModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import { isEmbeddedPiRunActiveForSessionKey } from "openclaw/plugin-sdk/reply-runtime";
 import { listSkillCommandsForAgents } from "openclaw/plugin-sdk/skill-commands-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { syncTelegramMenuCommands } from "./bot-native-command-menu.js";
@@ -23,6 +24,8 @@ export type TelegramBotDeps = {
   upsertChannelPairingRequest: typeof upsertChannelPairingRequest;
   enqueueSystemEvent: typeof enqueueSystemEvent;
   dispatchReplyWithBufferedBlockDispatcher: typeof dispatchReplyWithBufferedBlockDispatcher;
+  /** Check whether an embedded Pi run is active for a given sessionKey. */
+  isRunActiveForSessionKey?: (sessionKey: string) => boolean;
   loadWebMedia?: typeof loadWebMedia;
   buildModelsProviderData: typeof buildModelsProviderData;
   listSkillCommandsForAgents: typeof listSkillCommandsForAgents;
@@ -72,6 +75,9 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get wasSentByBot() {
     return wasSentByBot;
+  },
+  get isRunActiveForSessionKey() {
+    return isEmbeddedPiRunActiveForSessionKey;
   },
   get resolveExecApproval() {
     return resolveTelegramExecApproval;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -101,6 +101,7 @@ import {
   type ProviderInfo,
 } from "./model-buttons.js";
 import { buildInlineKeyboard } from "./send.js";
+import { buildChatSessionCacheKey, CHAT_SESSION_CACHE_MAX } from "./sequential-key.js";
 
 export const registerTelegramHandlers = ({
   cfg,
@@ -119,6 +120,7 @@ export const registerTelegramHandlers = ({
   processMessage,
   logger,
   telegramDeps = defaultTelegramBotDeps,
+  chatSessionCache,
 }: RegisterTelegramHandlerParams) => {
   const mediaRuntimeOptions = resolveTelegramMediaRuntimeOptions({
     cfg,
@@ -1091,6 +1093,82 @@ export const registerTelegramHandlers = ({
           debounceLane,
         })
       : null;
+
+    // Populate chat session cache and check for debouncer bypass.
+    // When an agent run is active and the queue mode needs immediate delivery
+    // (steer/interrupt), bypass the debouncer to avoid keyChains serialization.
+    if (chatSessionCache && telegramDeps.isRunActiveForSessionKey) {
+      const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+      const isForum = msg.chat.is_forum === true;
+      try {
+        const sessionState = resolveTelegramSessionState({
+          chatId,
+          isGroup,
+          isForum,
+          resolvedThreadId,
+          messageThreadId: msg.message_thread_id,
+          senderId,
+        });
+        // Resolve the effective queue mode from stored session → channel → global config.
+        // NOTE: Per-message inline queue directives (e.g. /interrupt as a one-off) are resolved
+        // later in the pipeline (resolveQueueSettings). This fast path only covers sessions that
+        // are already in steer/interrupt mode. One-off inline overrides still work correctly via
+        // the normal debouncer path — they just don't get the bypass optimization.
+        //
+        // Use live config (loadConfig) rather than the outer `cfg` snapshot so that
+        // runtime queue-mode changes take effect immediately without a restart.
+        const liveCfg = telegramDeps.loadConfig();
+        const queueCfg = liveCfg.messages?.queue;
+        const channelMode = queueCfg?.byChannel
+          ? (queueCfg.byChannel as Record<string, string | undefined>)["telegram"]
+          : undefined;
+        const effectiveMode =
+          sessionState.sessionEntry?.queueMode ?? channelMode ?? queueCfg?.mode ?? "collect";
+        const needsImmediate =
+          effectiveMode === "steer" ||
+          effectiveMode === "steer-backlog" ||
+          effectiveMode === "steer+backlog" ||
+          effectiveMode === "interrupt";
+        // For groups, key by conversation only (shared session).
+        // For DMs, include senderId (bridge/business-chat can route different senders differently).
+        const cacheSenderId = isGroup ? undefined : senderId;
+        const cacheKey = buildChatSessionCacheKey(chatId, conversationThreadId, cacheSenderId);
+        chatSessionCache.set(cacheKey, {
+          sessionKey: sessionState.sessionKey,
+          needsImmediateDelivery: needsImmediate,
+        });
+        // Evict oldest entries when cache exceeds cap (FIFO via Map insertion order).
+        // NOTE: Under very high fan-out (>500 distinct chats), FIFO eviction could remove an
+        // active session's entry before its next message arrives. In that case the bypass misses
+        // for one message (repopulated on the next). Acceptable for the expected bot scale;
+        // an LRU policy would handle this better if fan-out grows significantly.
+        if (chatSessionCache.size > CHAT_SESSION_CACHE_MAX) {
+          const firstKey = chatSessionCache.keys().next().value;
+          if (firstKey !== undefined) {
+            chatSessionCache.delete(firstKey);
+          }
+        }
+
+        // Fast path: if a run is active and mode needs immediate delivery,
+        // bypass the debouncer and process immediately.
+        if (needsImmediate && telegramDeps.isRunActiveForSessionKey(sessionState.sessionKey)) {
+          const replyMedia = await resolveReplyMediaForMessage(ctx, msg);
+          await processMessage(
+            ctx,
+            allMedia,
+            storeAllowFrom,
+            { receivedAtMs: Date.now() },
+            replyMedia,
+          );
+          return;
+        }
+      } catch (err) {
+        // Session resolution failure is non-fatal — fall through to normal debouncer path.
+        // Log so misconfiguration or route failures are visible.
+        logger.debug(`chat session cache: session resolution failed for chat=${chatId}: ${String(err)}`);
+      }
+    }
+
     await inboundDebouncer.enqueue({
       ctx,
       msg,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -197,6 +197,8 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
+  /** Chat session cache for per-message sequentializer key resolution. */
+  chatSessionCache?: Map<string, { sessionKey: string; needsImmediateDelivery: boolean }>;
 };
 
 export function buildTelegramNativeCommandCallbackData(commandText: string): string {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -36,7 +36,6 @@ const {
 const { resolveTelegramFetch } = await import("./fetch.js");
 const {
   createTelegramBot: createTelegramBotBase,
-  getTelegramSequentialKey,
   setTelegramBotRuntimeForTest,
 } = await import("./bot.js");
 let createTelegramBot: (
@@ -136,7 +135,9 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
     expect(sequentializeSpy).toHaveBeenCalledTimes(1);
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
-    expect(harness.sequentializeKey).toBe(getTelegramSequentialKey);
+    // The key function is now wrapped to pass isRunActiveForChat options,
+    // so we verify it's a function rather than checking reference identity.
+    expect(typeof harness.sequentializeKey).toBe("function");
   });
 
   it("preserves same-chat reply order when a debounced run is still active", async () => {

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -42,12 +42,12 @@ import { resolveTelegramTransport } from "./fetch.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
 import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
-import { getTelegramSequentialKey } from "./sequential-key.js";
+import { buildChatSessionCacheKey, CHAT_SESSION_CACHE_MAX, getTelegramSequentialKey } from "./sequential-key.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
 
 export type { TelegramBotOptions } from "./bot.types.js";
 
-export { getTelegramSequentialKey };
+export { buildChatSessionCacheKey, CHAT_SESSION_CACHE_MAX, getTelegramSequentialKey };
 
 type TelegramBotRuntime = {
   Bot: typeof Bot;
@@ -324,7 +324,48 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
     }
   });
 
-  bot.use(botRuntime.sequentialize(getTelegramSequentialKey));
+  // Cache chatId:threadId[:senderId] → {sessionKey, needsImmediateDelivery} so the sequential
+  // key middleware can check whether an embedded Pi run is active and whether the session
+  // uses a queue mode that needs immediate delivery — without heavy session resolution per update.
+  //
+  // NOTE (cache population order): The sequentializer runs BEFORE the handler that populates
+  // this cache, so the very first message in any chat always gets the default sequential key
+  // (cache miss). This is correct by design — there can't be an active run to bypass for
+  // until after at least one message has been handled.
+  //
+  // Capped at CHAT_SESSION_CACHE_MAX entries to prevent unbounded memory growth.
+  const chatSessionCache = new Map<
+    string,
+    { sessionKey: string; needsImmediateDelivery: boolean }
+  >();
+
+  // Capture once to avoid re-reading the getter per update and remove non-null assertions.
+  const isRunActiveForSessionKey = telegramDeps.isRunActiveForSessionKey;
+
+  bot.use(
+    botRuntime.sequentialize((ctx) =>
+      getTelegramSequentialKey(ctx, {
+        isRunActiveForChat: isRunActiveForSessionKey
+          ? (chatId, threadId, senderId) => {
+              // Try conversation-level key first (groups), then per-sender key (DMs).
+              const convKey = buildChatSessionCacheKey(chatId, threadId);
+              const senderKey = senderId ? buildChatSessionCacheKey(chatId, threadId, senderId) : undefined;
+              const cached = chatSessionCache.get(convKey) ?? (senderKey ? chatSessionCache.get(senderKey) : undefined);
+              if (!cached?.needsImmediateDelivery) {
+                return false;
+              }
+              // When a run is active and mode needs immediate delivery, the sequentializer
+              // returns a per-message key so multiple messages can race into runReplyAgent
+              // in parallel. They will each try to abort and recreate the run; the retry
+              // in agent-runner.ts mitigates the resulting ReplyOperation race, but under
+              // rapid bursts the last arrival can still hit the user-facing "still shutting
+              // down" message. This is better than full serialization behind the debouncer.
+              return isRunActiveForSessionKey(cached.sessionKey);
+            }
+          : undefined,
+      }),
+    ),
+  );
 
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
   const MAX_RAW_UPDATE_CHARS = 8000;
@@ -556,6 +597,7 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
     processMessage,
     logger,
     telegramDeps,
+    chatSessionCache,
   });
 
   const originalStop = bot.stop.bind(bot);

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -1,5 +1,5 @@
 import type { Chat, Message } from "@grammyjs/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 
 const mockChat = (chat: Pick<Chat, "id"> & Partial<Pick<Chat, "type" | "is_forum">>): Chat =>
@@ -102,5 +102,76 @@ describe("getTelegramSequentialKey", () => {
     ],
   ])("resolves key %#", (input, expected) => {
     expect(getTelegramSequentialKey(input)).toBe(expected);
+  });
+});
+
+describe("getTelegramSequentialKey with isRunActiveForChat bypass", () => {
+  it("returns per-message key when run is active for the chat", () => {
+    const key = getTelegramSequentialKey(
+      {
+        message: {
+          message_id: 42,
+          date: 0,
+          chat: { id: 123, type: "private" } as Chat,
+          from: { id: 999, first_name: "Test", is_bot: false },
+        } as Message,
+      },
+      {
+        isRunActiveForChat: () => true,
+      },
+    );
+    expect(key).toBe("telegram:123:msg:42");
+  });
+
+  it("returns default key when run is NOT active", () => {
+    const key = getTelegramSequentialKey(
+      {
+        message: {
+          message_id: 42,
+          date: 0,
+          chat: { id: 123, type: "private" } as Chat,
+          from: { id: 999, first_name: "Test", is_bot: false },
+        } as Message,
+      },
+      {
+        isRunActiveForChat: () => false,
+      },
+    );
+    expect(key).toBe("telegram:123");
+  });
+
+  it("returns per-message key scoped to topic for forum groups", () => {
+    const key = getTelegramSequentialKey(
+      {
+        message: {
+          message_id: 55,
+          date: 0,
+          chat: { id: -100999, type: "supergroup", is_forum: true } as Chat,
+          message_thread_id: 7,
+          from: { id: 888, first_name: "Test", is_bot: false },
+        } as Message,
+      },
+      {
+        isRunActiveForChat: () => true,
+      },
+    );
+    expect(key).toBe("telegram:-100999:topic:7:msg:55");
+  });
+
+  it("passes chatId, threadId, and senderId to the callback", () => {
+    const spy = vi.fn().mockReturnValue(false);
+    getTelegramSequentialKey(
+      {
+        message: {
+          message_id: 10,
+          date: 0,
+          chat: { id: 456, type: "supergroup", is_forum: true } as Chat,
+          message_thread_id: 3,
+          from: { id: 777, first_name: "Test", is_bot: false },
+        } as Message,
+      },
+      { isRunActiveForChat: spy },
+    );
+    expect(spy).toHaveBeenCalledWith(456, 3, "777");
   });
 });

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -19,7 +19,40 @@ export type TelegramSequentialKeyContext = {
   };
 };
 
-export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {
+export type TelegramSequentialKeyOptions = {
+  /**
+   * When provided, the sequentializer checks whether an embedded Pi run is
+   * active for the resolved chat/thread.  If a run is active, the key is
+   * scoped to the individual message so it can be dispatched in parallel
+   * (needed for steer / interrupt queue modes).
+   */
+  isRunActiveForChat?: (chatId: number, threadId: number | undefined, senderId: string) => boolean;
+};
+
+/**
+ * Maximum entries in the chatSessionCache before FIFO eviction kicks in.
+ */
+export const CHAT_SESSION_CACHE_MAX = 500;
+
+/**
+ * Build the cache key used by chatSessionCache.
+ * For groups: keyed by conversation (chatId + threadId) — the session is shared.
+ * For DMs: includes senderId because DM bridge/business-chat deliveries can
+ * route different senders sharing the same chatId to different sessions.
+ */
+export function buildChatSessionCacheKey(
+  chatId: number | string,
+  threadId: number | undefined,
+  senderId?: string,
+): string {
+  const base = threadId != null ? `${chatId}:${threadId}` : String(chatId);
+  return senderId ? `${base}:${senderId}` : base;
+}
+
+export function getTelegramSequentialKey(
+  ctx: TelegramSequentialKeyContext,
+  options?: TelegramSequentialKeyOptions,
+): string {
   const reaction = ctx.update?.message_reaction;
   if (reaction?.chat?.id) {
     return `telegram:${reaction.chat.id}`;
@@ -58,7 +91,22 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const threadId = isGroup
     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
     : messageThreadId;
+
   if (typeof chatId === "number") {
+    // When a run is active and the queue mode needs immediate delivery,
+    // use a per-message key so grammY dispatches this update in parallel
+    // rather than serializing it behind the active handler.
+    if (options?.isRunActiveForChat) {
+      const senderId = msg?.from?.id ? String(msg.from.id) : "";
+      if (options.isRunActiveForChat(chatId, threadId ?? undefined, senderId)) {
+        const messageId = msg?.message_id;
+        if (typeof messageId === "number") {
+          const base =
+            threadId != null ? `telegram:${chatId}:topic:${threadId}` : `telegram:${chatId}`;
+          return `${base}:msg:${messageId}`;
+        }
+      }
+    }
     return threadId != null ? `telegram:${chatId}:topic:${threadId}` : `telegram:${chatId}`;
   }
   return "telegram:unknown";

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -23,8 +23,10 @@ export {
 export {
   abortEmbeddedPiRun,
   abortEmbeddedPiRun as abortEmbeddedAgentRun,
+  forceDetachEmbeddedRun,
   isEmbeddedPiRunActive,
   isEmbeddedPiRunActive as isEmbeddedAgentRunActive,
+  isEmbeddedPiRunActiveForSessionKey,
   isEmbeddedPiRunStreaming,
   isEmbeddedPiRunStreaming as isEmbeddedAgentRunStreaming,
   queueEmbeddedPiMessage,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1496,6 +1496,8 @@ export async function runEmbeddedAttempt(
         getCompactionCount,
       } = subscription;
 
+      let agentLoopStarted = false;
+      let agentLoopStopped = false;
       const queueHandle: EmbeddedPiQueueHandle & {
         kind: "embedded";
         cancel: (reason?: "user_abort" | "restart" | "superseded") => void;
@@ -1506,6 +1508,7 @@ export async function runEmbeddedAttempt(
         },
         isStreaming: () => activeSession.isStreaming,
         isCompacting: () => subscription.isCompacting(),
+        isStopped: () => !agentLoopStarted || agentLoopStopped,
         cancel: () => {
           abortRun();
         },
@@ -1932,6 +1935,9 @@ export async function runEmbeddedAttempt(
               inFlightPrompt: effectivePrompt,
             });
 
+            // Mark the agent loop as started right before prompt submission
+            // so steer messages are only accepted once the agent is actually running.
+            agentLoopStarted = true;
             // Only pass images option if there are actually images to pass
             // This avoids potential issues with models that don't expect the images parameter
             if (imageResult.images.length > 0) {
@@ -1969,6 +1975,9 @@ export async function runEmbeddedAttempt(
             promptErrorSource = "prompt";
           }
         } finally {
+          // Mark the agent loop as stopped so queueEmbeddedPiMessage rejects
+          // new steer messages — the steering queue will no longer be drained.
+          agentLoopStopped = true;
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
           );

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -6,6 +6,7 @@ import {
   clearActiveEmbeddedRun,
   consumeEmbeddedRunModelSwitch,
   getActiveEmbeddedRunSnapshot,
+  queueEmbeddedPiMessage,
   requestEmbeddedRunModelSwitch,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
@@ -15,13 +16,14 @@ import {
 type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
 
 function createRunHandle(
-  overrides: { isCompacting?: boolean; abort?: () => void } = {},
+  overrides: { isCompacting?: boolean; isStopped?: boolean; abort?: () => void } = {},
 ): RunHandle {
   const abort = overrides.abort ?? (() => {});
   return {
     queueMessage: async () => {},
     isStreaming: () => true,
     isCompacting: () => overrides.isCompacting ?? false,
+    isStopped: () => overrides.isStopped ?? false,
     abort,
   };
 }
@@ -171,5 +173,80 @@ describe("pi-embedded runner run registry", () => {
     clearActiveEmbeddedRun("session-clear-switch", handle);
 
     expect(consumeEmbeddedRunModelSwitch("session-clear-switch")).toBeUndefined();
+  });
+});
+
+describe("queueEmbeddedPiMessage", () => {
+  afterEach(() => {
+    __testing.resetActiveEmbeddedRuns();
+  });
+
+  function createQueueableHandle(
+    overrides: { isCompacting?: boolean; isStreaming?: boolean; isStopped?: boolean } = {},
+  ): RunHandle & { queueMessageSpy: ReturnType<typeof vi.fn> } {
+    const queueMessageSpy = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    return {
+      queueMessage: queueMessageSpy,
+      isStreaming: () => overrides.isStreaming ?? true,
+      isCompacting: () => overrides.isCompacting ?? false,
+      isStopped: () => overrides.isStopped ?? false,
+      abort: () => {},
+      queueMessageSpy,
+    };
+  }
+
+  it("returns false when no active run exists for the session", () => {
+    const result = queueEmbeddedPiMessage("no-such-session", "hello");
+    expect(result).toBe(false);
+  });
+
+  it("queues message when session is active but NOT streaming (original bug case)", () => {
+    const handle = createQueueableHandle({ isStreaming: false });
+    setActiveEmbeddedRun("session-not-streaming", handle);
+
+    const result = queueEmbeddedPiMessage("session-not-streaming", "steer message");
+
+    expect(result).toBe(true);
+    expect(handle.queueMessageSpy).toHaveBeenCalledWith("steer message");
+  });
+
+  it("returns false when session is active but compacting", () => {
+    const handle = createQueueableHandle({ isCompacting: true });
+    setActiveEmbeddedRun("session-compacting", handle);
+
+    const result = queueEmbeddedPiMessage("session-compacting", "steer message");
+
+    expect(result).toBe(false);
+    expect(handle.queueMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("queues message when session is active and streaming (not compacting)", () => {
+    const handle = createQueueableHandle();
+    setActiveEmbeddedRun("session-streaming", handle);
+
+    const result = queueEmbeddedPiMessage("session-streaming", "steer message");
+
+    expect(result).toBe(true);
+    expect(handle.queueMessageSpy).toHaveBeenCalledWith("steer message");
+  });
+
+  it("returns false when agent loop is not yet running or already stopped", () => {
+    const handle = createQueueableHandle({ isStopped: true });
+    setActiveEmbeddedRun("session-stopped", handle);
+
+    const result = queueEmbeddedPiMessage("session-stopped", "steer message");
+
+    expect(result).toBe(false);
+    expect(handle.queueMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("queues message when session is active, not streaming, and not stopped (tool execution)", () => {
+    const handle = createQueueableHandle({ isStreaming: false, isStopped: false });
+    setActiveEmbeddedRun("session-tool-exec", handle);
+
+    const result = queueEmbeddedPiMessage("session-tool-exec", "steer message");
+
+    expect(result).toBe(true);
+    expect(handle.queueMessageSpy).toHaveBeenCalledWith("steer message");
   });
 });

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -5,12 +5,16 @@ import {
   abortEmbeddedPiRun,
   clearActiveEmbeddedRun,
   consumeEmbeddedRunModelSwitch,
+  forceDetachEmbeddedRun,
   getActiveEmbeddedRunSnapshot,
+  isEmbeddedPiRunActive,
+  isEmbeddedPiRunActiveForSessionKey,
   queueEmbeddedPiMessage,
   requestEmbeddedRunModelSwitch,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
   waitForActiveEmbeddedRuns,
+  waitForEmbeddedPiRunEnd,
 } from "./runs.js";
 
 type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
@@ -248,5 +252,75 @@ describe("queueEmbeddedPiMessage", () => {
 
     expect(result).toBe(true);
     expect(handle.queueMessageSpy).toHaveBeenCalledWith("steer message");
+  });
+});
+
+describe("isEmbeddedPiRunActiveForSessionKey", () => {
+  afterEach(() => {
+    __testing.resetActiveEmbeddedRuns();
+  });
+
+  it("returns true when a run is active for the resolved session key", () => {
+    const handle = createRunHandle();
+    setActiveEmbeddedRun("session-abc", handle, "key-abc");
+    expect(isEmbeddedPiRunActiveForSessionKey("key-abc")).toBe(true);
+  });
+
+  it("returns false when no run is active for the session key", () => {
+    expect(isEmbeddedPiRunActiveForSessionKey("key-nonexistent")).toBe(false);
+  });
+
+  it("returns false after the run is cleared", () => {
+    const handle = createRunHandle();
+    setActiveEmbeddedRun("session-cleared", handle, "key-cleared");
+    clearActiveEmbeddedRun("session-cleared", handle, "key-cleared");
+    expect(isEmbeddedPiRunActiveForSessionKey("key-cleared")).toBe(false);
+  });
+});
+
+describe("forceDetachEmbeddedRun", () => {
+  afterEach(() => {
+    __testing.resetActiveEmbeddedRuns();
+  });
+
+  it("removes the run from the registry and notifies waiters", async () => {
+    const handle = createRunHandle();
+    setActiveEmbeddedRun("session-detach", handle, "key-detach");
+
+    // Start a waiter
+    const waitPromise = waitForEmbeddedPiRunEnd("session-detach", 5000);
+
+    // Force-detach
+    const detached = forceDetachEmbeddedRun("session-detach");
+    expect(detached).toBe(true);
+
+    // Waiter should resolve
+    const ended = await waitPromise;
+    expect(ended).toBe(true);
+
+    // Run should no longer be active
+    expect(isEmbeddedPiRunActive("session-detach")).toBe(false);
+    expect(isEmbeddedPiRunActiveForSessionKey("key-detach")).toBe(false);
+  });
+
+  it("returns false when no run is registered", () => {
+    expect(forceDetachEmbeddedRun("nonexistent")).toBe(false);
+  });
+
+  it("old run's clearActiveEmbeddedRun becomes no-op after force-detach", () => {
+    const handle = createRunHandle();
+    setActiveEmbeddedRun("session-overlap", handle, "key-overlap");
+
+    forceDetachEmbeddedRun("session-overlap");
+
+    // Register a new run for the same session
+    const newHandle = createRunHandle();
+    setActiveEmbeddedRun("session-overlap", newHandle, "key-overlap");
+
+    // Old run's finally block calls clearActiveEmbeddedRun with old handle
+    clearActiveEmbeddedRun("session-overlap", handle, "key-overlap");
+
+    // New run should still be active (handle mismatch → no-op)
+    expect(isEmbeddedPiRunActive("session-overlap")).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -22,6 +22,13 @@ export type EmbeddedPiQueueHandle = {
   queueMessage: (text: string) => Promise<void>;
   isStreaming: () => boolean;
   isCompacting: () => boolean;
+  /**
+   * Returns true when the agent loop is NOT actively running — either before
+   * the first prompt starts (startup window) or after the prompt finishes
+   * (teardown window).  During these windows the steering queue will NOT be
+   * drained, so accepting messages would silently drop them.
+   */
+  isStopped?: () => boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
   abort: () => void;
 };
@@ -107,12 +114,12 @@ export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean
     diag.debug(`queue message failed: sessionId=${sessionId} reason=no_active_run`);
     return false;
   }
-  if (!handle.isStreaming()) {
-    diag.debug(`queue message failed: sessionId=${sessionId} reason=not_streaming`);
-    return false;
-  }
   if (handle.isCompacting()) {
     diag.debug(`queue message failed: sessionId=${sessionId} reason=compacting`);
+    return false;
+  }
+  if (handle.isStopped?.()) {
+    diag.debug(`queue message failed: sessionId=${sessionId} reason=agent_stopped`);
     return false;
   }
   logMessageQueued({ sessionId, source: "pi-embedded-runner" });

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -122,6 +122,14 @@ export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean
     diag.debug(`queue message failed: sessionId=${sessionId} reason=agent_stopped`);
     return false;
   }
+  // Backends that don't implement isStopped (e.g. Codex app-server)
+  // still need a guard: if the handle isn't stopped AND isn't streaming,
+  // the steering queue won't be drained, so queueing would silently drop
+  // the message.  Fall back to the old isStreaming() check for those.
+  if (!handle.isStopped && !handle.isStreaming()) {
+    diag.debug(`queue message failed: sessionId=${sessionId} reason=not_streaming_no_stop_state`);
+    return false;
+  }
   logMessageQueued({ sessionId, source: "pi-embedded-runner" });
   void handle.queueMessage(text);
   return true;
@@ -223,6 +231,18 @@ export function resolveActiveEmbeddedRunSessionId(sessionKey: string): string | 
   );
 }
 
+/**
+ * Check whether an embedded run is active for a given session key.
+ * Resolves the session key to a session ID, then checks the active run registry.
+ */
+export function isEmbeddedPiRunActiveForSessionKey(sessionKey: string): boolean {
+  const sessionId = resolveActiveEmbeddedRunSessionId(sessionKey);
+  if (!sessionId) {
+    return false;
+  }
+  return isEmbeddedPiRunActive(sessionId);
+}
+
 export function getActiveEmbeddedRunCount(): number {
   let activeCount = ACTIVE_EMBEDDED_RUNS.size;
   for (const sessionId of listActiveReplyRunSessionIds()) {
@@ -307,15 +327,16 @@ export async function waitForActiveEmbeddedRuns(
   }
 }
 
-export function waitForEmbeddedPiRunEnd(sessionId: string, timeoutMs = 15_000): Promise<boolean> {
+export async function waitForEmbeddedPiRunEnd(sessionId: string, timeoutMs = 15_000): Promise<boolean> {
   if (!sessionId) {
-    return Promise.resolve(true);
+    return true;
   }
   if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
     return waitForReplyRunEndBySessionId(sessionId, timeoutMs);
   }
   diag.debug(`waiting for run end: sessionId=${sessionId} timeoutMs=${timeoutMs}`);
-  return new Promise((resolve) => {
+  const startMs = Date.now();
+  const embeddedRunEnded = await new Promise<boolean>((resolve) => {
     const waiters = EMBEDDED_RUN_WAITERS.get(sessionId) ?? new Set();
     const waiter: EmbeddedRunWaiter = {
       resolve,
@@ -342,6 +363,17 @@ export function waitForEmbeddedPiRunEnd(sessionId: string, timeoutMs = 15_000): 
       resolve(true);
     }
   });
+  if (!embeddedRunEnded) {
+    return false;
+  }
+  // After the embedded run handle is removed, the ReplyOperation in the
+  // reply-run-registry may still be active (cleared in the handler's finally
+  // block). Wait for it with the remaining budget so callers see a fully
+  // idle session.
+  // NOTE: The 100ms floor means this function can exceed the stated timeoutMs
+  // by up to 100ms in the worst case (embedded wait consumed the full budget).
+  const remainingMs = Math.max(100, timeoutMs - (Date.now() - startMs));
+  return waitForReplyRunEndBySessionId(sessionId, remainingMs);
 }
 
 function notifyEmbeddedRunEnded(sessionId: string) {
@@ -404,6 +436,48 @@ export function clearActiveEmbeddedRun(
   } else {
     diag.debug(`run clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
   }
+}
+
+/**
+ * Force-detach an embedded run from the scheduling registry without waiting
+ * for the run's finally block to complete.  This is the "two-phase abort"
+ * escape hatch for interrupt mode: the abort signal has already been sent,
+ * but cleanup is taking too long (provider HTTP drain, compaction, etc.).
+ *
+ * The old run's finally block will eventually call `clearActiveEmbeddedRun`,
+ * which does a handle identity check — since the handle was already removed
+ * here, that call becomes a no-op ("handle_mismatch").  This is safe:
+ * the old run can still persist its transcript and clean up resources,
+ * it just no longer blocks the scheduling registry.
+ *
+ * Returns true if a run was detached, false if nothing was registered.
+ */
+export function forceDetachEmbeddedRun(sessionId: string): boolean {
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (!handle) {
+    return false;
+  }
+  // Resolve sessionKey before clearing the reverse map so we can log
+  // the state transition.
+  let sessionKey: string | undefined;
+  for (const [key, activeSessionId] of ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY) {
+    if (activeSessionId === sessionId) {
+      sessionKey = key;
+      break;
+    }
+  }
+  ACTIVE_EMBEDDED_RUNS.delete(sessionId);
+  ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
+  EMBEDDED_RUN_MODEL_SWITCH_REQUESTS.delete(sessionId);
+  clearActiveRunSessionKeys(sessionId);
+  if (sessionKey) {
+    logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "force_detached" });
+  }
+  diag.warn(
+    `force-detached run: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`,
+  );
+  notifyEmbeddedRunEnded(sessionId);
+  return true;
 }
 
 export const __testing = {

--- a/src/agents/pi-embedded.runtime.ts
+++ b/src/agents/pi-embedded.runtime.ts
@@ -1,6 +1,8 @@
 export {
   abortEmbeddedPiRun,
+  forceDetachEmbeddedRun,
   isEmbeddedPiRunActive,
+  isEmbeddedPiRunActiveForSessionKey,
   isEmbeddedPiRunStreaming,
   resolveActiveEmbeddedRunSessionId,
   runEmbeddedPiAgent,

--- a/src/agents/pi-embedded.ts
+++ b/src/agents/pi-embedded.ts
@@ -11,11 +11,13 @@ export type {
 export {
   abortEmbeddedAgentRun,
   abortEmbeddedPiRun,
+  forceDetachEmbeddedRun,
   compactEmbeddedAgentSession,
   compactEmbeddedPiSession,
   isEmbeddedAgentRunActive,
   isEmbeddedAgentRunStreaming,
   isEmbeddedPiRunActive,
+  isEmbeddedPiRunActiveForSessionKey,
   isEmbeddedPiRunStreaming,
   queueEmbeddedAgentMessage,
   queueEmbeddedPiMessage,

--- a/src/auto-reply/reply/agent-runner.steer-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner.steer-guard.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for the steer guard in runReplyAgent — verifies that steer mode
+ * message injection uses `isActive` (not `isStreaming`) to decide whether
+ * to inject a steer message into an already-running agent session.
+ *
+ * Covers the fix for issue #48003 / PR #52351.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+const runCliAgentMock = vi.fn();
+const runWithModelFallbackMock = vi.fn();
+const queueEmbeddedPiMessageMock = vi.fn();
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(),
+  getOAuthProviders: vi.fn().mockReturnValue([]),
+  refreshOAuthApiKey: vi.fn(),
+}));
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => runWithModelFallbackMock(params),
+}));
+
+vi.mock("../../agents/pi-embedded-runner/runs.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/pi-embedded-runner/runs.js")>(
+    "../../agents/pi-embedded-runner/runs.js",
+  );
+  return {
+    ...actual,
+    queueEmbeddedPiMessage: (...args: unknown[]) => queueEmbeddedPiMessageMock(...args),
+  };
+});
+
+vi.mock("../../agents/pi-embedded.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/pi-embedded.js")>(
+    "../../agents/pi-embedded.js",
+  );
+  return {
+    ...actual,
+    runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+  };
+});
+
+vi.mock("../../agents/cli-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/cli-runner.js")>(
+    "../../agents/cli-runner.js",
+  );
+  return {
+    ...actual,
+    runCliAgent: (params: unknown) => runCliAgentMock(params),
+  };
+});
+
+vi.mock("../../runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../../runtime.js")>("../../runtime.js");
+  return {
+    ...actual,
+    defaultRuntime: {
+      ...actual.defaultRuntime,
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    },
+  };
+});
+
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: vi.fn(),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+const loadCronStoreMock = vi.fn();
+vi.mock("../../cron/store.js", async () => {
+  const actual = await vi.importActual<typeof import("../../cron/store.js")>("../../cron/store.js");
+  return {
+    ...actual,
+    loadCronStore: (...args: unknown[]) => loadCronStoreMock(...args),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+type RunWithModelFallbackParams = {
+  provider: string;
+  model: string;
+  run: (provider: string, model: string) => Promise<unknown>;
+};
+
+beforeEach(() => {
+  runEmbeddedPiAgentMock.mockClear();
+  runCliAgentMock.mockClear();
+  runWithModelFallbackMock.mockClear();
+  queueEmbeddedPiMessageMock.mockClear();
+  loadCronStoreMock.mockClear();
+  loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run }: RunWithModelFallbackParams) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("runReplyAgent steer mode message injection", () => {
+  function createSteerRun(params: {
+    shouldSteer: boolean;
+    isActive: boolean;
+    isStreaming?: boolean;
+    shouldFollowup?: boolean;
+    queueEmbeddedResult?: boolean;
+  }) {
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "webchat",
+      OriginatingTo: "session:steer",
+      AccountId: "primary",
+      MessageSid: "msg-steer",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "steer" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "steer this",
+      summaryLine: "steer this",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session-steer",
+        sessionKey: "main",
+        messageProvider: "webchat",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    queueEmbeddedPiMessageMock.mockReturnValue(params.queueEmbeddedResult ?? false);
+
+    return {
+      promise: runReplyAgent({
+        commandBody: "steer this",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: params.shouldSteer,
+        shouldFollowup: params.shouldFollowup ?? false,
+        isActive: params.isActive,
+        isStreaming: params.isStreaming ?? false,
+        typing,
+        sessionCtx,
+        defaultModel: "anthropic/claude",
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      }),
+      typing,
+    };
+  }
+
+  it("injects steer message when shouldSteer=true AND isActive=true", async () => {
+    const { promise, typing } = createSteerRun({
+      shouldSteer: true,
+      isActive: true,
+      queueEmbeddedResult: true,
+    });
+
+    const result = await promise;
+
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith("session-steer", "steer this");
+    // When steered successfully and shouldFollowup=false, returns undefined (early exit).
+    expect(result).toBeUndefined();
+    expect(typing.cleanup).toHaveBeenCalled();
+  });
+
+  it("does NOT inject steer message when shouldSteer=true AND isActive=false", async () => {
+    // When isActive is false, the steer guard is skipped entirely and the
+    // agent proceeds to a full run.
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const { promise } = createSteerRun({
+      shouldSteer: true,
+      isActive: false,
+    });
+
+    const result = await promise;
+
+    expect(queueEmbeddedPiMessageMock).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+
+  it("does NOT inject steer message when shouldSteer=false", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const { promise } = createSteerRun({
+      shouldSteer: false,
+      isActive: true,
+    });
+
+    await promise;
+
+    expect(queueEmbeddedPiMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -61,6 +61,7 @@ import {
   createReplyOperation,
   ReplyRunAlreadyActiveError,
   replyRunRegistry,
+  waitForReplyRunEndBySessionId,
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
@@ -301,6 +302,7 @@ export async function runReplyAgent(params: {
       : null;
 
   const replySessionKey = sessionKey ?? followupRun.run.sessionKey;
+  const isInterruptMode = resolvedQueue.mode === "interrupt";
   let replyOperation: ReplyOperation;
   try {
     replyOperation =
@@ -310,15 +312,41 @@ export async function runReplyAgent(params: {
         sessionKey: replySessionKey ?? "",
         resetTriggered: resetTriggered === true,
         upstreamAbortSignal: opts?.abortSignal,
+        // In interrupt mode after two-phase abort, force-supersede any lingering
+        // ReplyOperation from the old run whose finally block hasn't cleared yet.
+        force: isInterruptMode,
       });
   } catch (error) {
     if (error instanceof ReplyRunAlreadyActiveError) {
-      typing.cleanup();
-      return {
-        text: "⚠️ Previous run is still shutting down. Please try again in a moment.",
-      };
+      // The previous run's ReplyOperation may still be clearing in its
+      // finally block after the embedded run handle was removed. Wait for
+      // the reply-op to clear (returns immediately if already idle) with a
+      // 500ms cap, then retry once.
+      await waitForReplyRunEndBySessionId(followupRun.run.sessionId, 500);
+      try {
+        replyOperation = createReplyOperation({
+          sessionId: followupRun.run.sessionId,
+          sessionKey: replySessionKey ?? "",
+          resetTriggered: resetTriggered === true,
+          upstreamAbortSignal: opts?.abortSignal,
+          // Force-supersede only in interrupt mode.  In collect/followup modes,
+          // force-superseding would abort an in-flight run that the queue policy
+          // says should be preserved — changing user-visible semantics and
+          // risking dropped assistant progress.
+          force: isInterruptMode,
+        });
+      } catch (retryError) {
+        if (retryError instanceof ReplyRunAlreadyActiveError) {
+          typing.cleanup();
+          return {
+            text: "⚠️ Previous run is still shutting down. Please try again in a moment.",
+          };
+        }
+        throw retryError;
+      }
+    } else {
+      throw error;
     }
-    throw error;
   }
   let runFollowupTurn = queuedRunFollowupTurn;
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -146,7 +146,7 @@ export async function runReplyAgent(params: {
     shouldFollowup,
     isActive,
     isRunActive,
-    isStreaming,
+    isStreaming: _isStreaming,
     opts,
     typing,
     sessionEntry,
@@ -207,7 +207,7 @@ export async function runReplyAgent(params: {
     }
   };
 
-  if (shouldSteer && isStreaming) {
+  if (shouldSteer && isActive) {
     const steerSessionId =
       (sessionKey ? replyRunRegistry.resolveSessionId(sessionKey) : undefined) ??
       followupRun.run.sessionId;

--- a/src/auto-reply/reply/get-reply-run-queue.test.ts
+++ b/src/auto-reply/reply/get-reply-run-queue.test.ts
@@ -84,3 +84,87 @@ describe("resolvePreparedReplyQueueState", () => {
     });
   });
 });
+
+it("force-detaches in interrupt mode when still busy after wait", async () => {
+  const forceDetachActiveRun = vi.fn(() => true);
+  const refreshPreparedState = vi.fn(async () => undefined);
+  const resolveBusyState = vi.fn(() => ({
+    activeSessionId: "session-active",
+    isActive: true,
+    isStreaming: false,
+  }));
+
+  const result = await resolvePreparedReplyQueueState({
+    activeRunQueueAction: "run-now",
+    activeSessionId: "session-active",
+    queueMode: "interrupt",
+    sessionKey: "session-key",
+    sessionId: "session-1",
+    abortActiveRun: vi.fn(() => true),
+    waitForActiveRunEnd: vi.fn(async () => undefined),
+    forceDetachActiveRun,
+    refreshPreparedState,
+    resolveBusyState,
+  });
+
+  expect(forceDetachActiveRun).toHaveBeenCalledWith("session-active");
+  expect(refreshPreparedState).toHaveBeenCalledTimes(2);
+  // forceDetach releases the scheduling slot; residual ReplyOperation
+  // is handled downstream by createReplyOperation({ force: true }).
+  // isActive may still be true here — that's expected and correct.
+  expect(result).toEqual({
+    kind: "continue",
+    busyState: { activeSessionId: "session-active", isActive: true, isStreaming: false },
+  });
+});
+
+it("returns shutdown reply when force-detach is not available (non-interrupt mode)", async () => {
+  const result = await resolvePreparedReplyQueueState({
+    activeRunQueueAction: "run-now",
+    activeSessionId: "session-active",
+    queueMode: "collect",
+    sessionKey: "session-key",
+    sessionId: "session-1",
+    abortActiveRun: vi.fn(),
+    waitForActiveRunEnd: vi.fn(async () => undefined),
+    refreshPreparedState: vi.fn(async () => undefined),
+    resolveBusyState: () => ({
+      activeSessionId: "session-active",
+      isActive: true,
+      isStreaming: false,
+    }),
+  });
+
+  expect(result).toEqual({
+    kind: "reply",
+    reply: {
+      text: "⚠️ Previous run is still shutting down. Please try again in a moment.",
+    },
+  });
+});
+
+it("returns shutdown reply when force-detach returns false", async () => {
+  const result = await resolvePreparedReplyQueueState({
+    activeRunQueueAction: "run-now",
+    activeSessionId: "session-active",
+    queueMode: "interrupt",
+    sessionKey: "session-key",
+    sessionId: "session-1",
+    abortActiveRun: vi.fn(() => true),
+    waitForActiveRunEnd: vi.fn(async () => undefined),
+    forceDetachActiveRun: vi.fn(() => false),
+    refreshPreparedState: vi.fn(async () => undefined),
+    resolveBusyState: () => ({
+      activeSessionId: "session-active",
+      isActive: true,
+      isStreaming: false,
+    }),
+  });
+
+  expect(result).toEqual({
+    kind: "reply",
+    reply: {
+      text: "⚠️ Previous run is still shutting down. Please try again in a moment.",
+    },
+  });
+});

--- a/src/auto-reply/reply/get-reply-run-queue.ts
+++ b/src/auto-reply/reply/get-reply-run-queue.ts
@@ -17,6 +17,8 @@ export async function resolvePreparedReplyQueueState(params: {
   sessionId: string;
   abortActiveRun: (sessionId: string) => boolean;
   waitForActiveRunEnd: (sessionId: string) => Promise<unknown>;
+  /** Force-detach the run from the scheduling registry (two-phase abort). */
+  forceDetachActiveRun?: (sessionId: string) => boolean;
   refreshPreparedState: () => Promise<void>;
   resolveBusyState: () => ReplyRunQueueBusyState;
 }): Promise<
@@ -37,6 +39,35 @@ export async function resolvePreparedReplyQueueState(params: {
   await params.refreshPreparedState();
   const refreshedBusyState = params.resolveBusyState();
   if (refreshedBusyState.isActive) {
+    // Abort was signaled but the run's cleanup timed out (provider HTTP drain,
+    // compaction, etc.).  In interrupt mode, force-detach the old run from the
+    // scheduling registry so a new run can start immediately.  The old run's
+    // finally block will still complete asynchronously — it just no longer
+    // blocks the registry (its clearActiveEmbeddedRun call becomes a no-op
+    // due to handle identity mismatch).
+    if (params.queueMode === "interrupt" && params.forceDetachActiveRun) {
+      const detached = params.forceDetachActiveRun(params.activeSessionId);
+      if (detached) {
+        logVerbose(
+          `Force-detached stale run for ${params.sessionKey ?? params.sessionId} after interrupt timeout`,
+        );
+        // forceDetach has released the scheduling slot. A residual ReplyOperation
+        // may still be registered (its clearState runs in the old run's finally
+        // block), but the downstream createReplyOperation({ force: true }) will
+        // abort and clear it synchronously. Re-checking isActive here would
+        // incorrectly reject the new run based on delivery-layer state that
+        // the scheduling layer already decided to supersede.
+        //
+        // Note on rapid-burst: when two interrupt messages arrive concurrently
+        // for the same chat (enabled by per-message sequential keys), only the
+        // first to reach createReplyOperation({ force: true }) wins the slot.
+        // The second sees the first message's new operation as active and
+        // receives the "still shutting down" reply. This is intentional —
+        // only one replacement can be in-flight at a time.
+        await params.refreshPreparedState();
+        return { kind: "continue", busyState: params.resolveBusyState() };
+      }
+    }
     return {
       kind: "reply",
       reply: {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -543,6 +543,8 @@ export async function runPreparedReply(
         piRuntime?.abortEmbeddedPiRun(activeRunSessionId) ?? false,
       waitForActiveRunEnd: (activeRunSessionId) =>
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
+      forceDetachActiveRun: (activeRunSessionId) =>
+        piRuntime?.forceDetachEmbeddedRun(activeRunSessionId) ?? false,
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
         authProfileId = useFastReplyRuntime

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -108,3 +108,129 @@ describe("reply run registry", () => {
     expect(runningOperation.result).toBeNull();
   });
 });
+
+describe("createReplyOperation with force option", () => {
+  afterEach(() => {
+    __testing.resetReplyRunRegistry();
+  });
+
+  it("force-supersedes an existing operation for the same session key", () => {
+    const existing = createReplyOperation({
+      sessionKey: "agent:main:force-test",
+      sessionId: "session-old",
+      resetTriggered: false,
+    });
+    existing.setPhase("running");
+
+    const replacement = createReplyOperation({
+      sessionKey: "agent:main:force-test",
+      sessionId: "session-new",
+      resetTriggered: false,
+      force: true,
+    });
+
+    // Old operation should be aborted
+    expect(existing.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+
+    // New operation should be active
+    expect(replacement.phase).toBe("queued");
+    expect(replyRunRegistry.isActive("agent:main:force-test")).toBe(true);
+    expect(replacement.sessionId).toBe("session-new");
+  });
+
+  it("throws ReplyRunAlreadyActiveError without force", () => {
+    createReplyOperation({
+      sessionKey: "agent:main:no-force",
+      sessionId: "session-existing",
+      resetTriggered: false,
+    });
+
+    expect(() =>
+      createReplyOperation({
+        sessionKey: "agent:main:no-force",
+        sessionId: "session-new",
+        resetTriggered: false,
+      }),
+    ).toThrow("Reply run already active");
+  });
+
+  it("force with no existing operation works normally", () => {
+    const op = createReplyOperation({
+      sessionKey: "agent:main:force-empty",
+      sessionId: "session-1",
+      resetTriggered: false,
+      force: true,
+    });
+
+    expect(op.phase).toBe("queued");
+    expect(op.sessionId).toBe("session-1");
+  });
+
+  it("force: stale operation's clearState does not delete replacement", () => {
+    // Create the original operation and advance it to running
+    const existing = createReplyOperation({
+      sessionKey: "agent:main:force-race",
+      sessionId: "session-old",
+      resetTriggered: false,
+    });
+    existing.setPhase("running");
+
+    // Force-supersede it with a new operation
+    const replacement = createReplyOperation({
+      sessionKey: "agent:main:force-race",
+      sessionId: "session-new",
+      resetTriggered: false,
+      force: true,
+    });
+    replacement.setPhase("running");
+
+    // Now simulate the old operation's finally block running complete()
+    // (which calls clearState). This must NOT delete the replacement's entries.
+    existing.complete();
+
+    // Replacement should still be active
+    expect(replyRunRegistry.isActive("agent:main:force-race")).toBe(true);
+    expect(resolveActiveReplyRunSessionId("agent:main:force-race")).toBe(
+      "session-new",
+    );
+  });
+
+  it("force-supersede preserves rotated wait aliases for the replacement", async () => {
+    vi.useFakeTimers();
+    try {
+      // Old operation with a rotated sessionId
+      const existing = createReplyOperation({
+        sessionKey: "agent:main:force-alias",
+        sessionId: "session-v1",
+        resetTriggered: false,
+      });
+      existing.setPhase("running");
+      existing.updateSessionId("session-v2");
+
+      // A waiter using the OLD sessionId (pre-rotation alias)
+      const aliasWaitPromise = waitForReplyRunEndBySessionId("session-v1", 5_000);
+
+      // Force-supersede
+      const replacement = createReplyOperation({
+        sessionKey: "agent:main:force-alias",
+        sessionId: "session-v3",
+        resetTriggered: false,
+        force: true,
+      });
+      replacement.setPhase("running");
+
+      // The alias waiter should NOT have resolved yet — the replacement is still running
+      let settled = false;
+      void aliasWaitPromise.then(() => { settled = true; });
+      await vi.advanceTimersByTimeAsync(100);
+      expect(settled).toBe(false);
+
+      // When replacement completes, alias waiter resolves
+      replacement.complete();
+      await expect(aliasWaitPromise).resolves.toBe(true);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -55,7 +55,7 @@ export type ReplyOperation = {
   detachBackend(handle: ReplyBackendHandle): void;
   complete(): void;
   fail(code: Exclude<ReplyOperationFailureCode, "aborted_by_user">, cause?: unknown): void;
-  abortByUser(): void;
+  abortByUser(opts?: { skipNotify?: boolean }): void;
   abortForRestart(): void;
 };
 
@@ -114,14 +114,6 @@ function registerWaitSessionId(sessionKey: string, sessionId: string): void {
   replyRunState.waitKeysBySessionId.set(sessionId, sessionKey);
 }
 
-function clearWaitSessionIds(sessionKey: string): void {
-  for (const [sessionId, mappedKey] of replyRunState.waitKeysBySessionId) {
-    if (mappedKey === sessionKey) {
-      replyRunState.waitKeysBySessionId.delete(sessionId);
-    }
-  }
-}
-
 function notifyReplyRunEnded(sessionKey: string): void {
   const waiters = replyRunState.waitersByKey.get(sessionKey);
   if (!waiters || waiters.size === 0) {
@@ -174,18 +166,74 @@ function getAttachedBackend(operation: ReplyOperation): ReplyBackendHandle | und
   return attachedBackendByOperation.get(operation);
 }
 
-function clearReplyRunState(params: { sessionKey: string; sessionId: string }): void {
+function clearReplyRunState(params: {
+  sessionKey: string;
+  sessionId: string;
+  /** If provided, only clear if the currently registered operation is this
+   *  exact object.  This prevents a stale operation's finally block from
+   *  deleting a replacement that was registered via force-supersede — even
+   *  when both operations share the same sessionId. */
+  expectedOperation?: ReplyOperation;
+  /** When true, skip notifying waiters. Used during force-supersede so that
+   *  a replacement operation can register without briefly resolving
+   *  waitForReplyRunEndBySessionId waiters in the gap between clearing the
+   *  old operation and registering the new one. */
+  skipNotify?: boolean;
+}): void {
+  // Identity-check before deletion: if another operation has already replaced
+  // us for this sessionKey (e.g. after a force-supersede via createReplyOperation
+  // with force:true), we must NOT delete the new operation's entries.
+  //
+  // When `expectedOperation` is provided (all internal callers), we use strict
+  // object-identity comparison. When omitted, we fall back to sessionId
+  // comparison — but note this is NOT safe when the replacement shares the same
+  // sessionId (e.g. interrupt-mode retry). External callers that hit this path
+  // should be migrated to pass `expectedOperation`.
+  const currentEntry = replyRunState.activeRunsByKey.get(params.sessionKey);
+  if (currentEntry) {
+    const isReplaced = params.expectedOperation
+      ? currentEntry !== params.expectedOperation
+      : currentEntry.sessionId !== params.sessionId;
+    if (isReplaced) {
+      // Different operation is now registered — skip all map mutations.
+      // Do NOT notify waiters: the replacement is still active, so
+      // resolving waitForReplyRunEnd would incorrectly signal "idle".
+      // Do NOT delete wait-key mappings: the replacement may have
+      // inherited this sessionId via updateSessionId rotation, so
+      // deleting it would break waitForReplyRunEndBySessionId lookups
+      // for the replacement's old session ID.
+      return;
+    }
+  }
   replyRunState.activeRunsByKey.delete(params.sessionKey);
   if (replyRunState.activeSessionIdsByKey.get(params.sessionKey) === params.sessionId) {
-    replyRunState.activeSessionIdsByKey.delete(params.sessionKey);
-  } else {
     replyRunState.activeSessionIdsByKey.delete(params.sessionKey);
   }
   if (replyRunState.activeKeysBySessionId.get(params.sessionId) === params.sessionKey) {
     replyRunState.activeKeysBySessionId.delete(params.sessionId);
   }
-  clearWaitSessionIds(params.sessionKey);
-  notifyReplyRunEnded(params.sessionKey);
+  // Clean up all wait-key aliases for this sessionKey. updateSessionId
+  // registers both old and new sessionIds as wait-key aliases so that
+  // waitForReplyRunEndBySessionId can resolve rotated sessionIds. When a
+  // run finishes normally (no replacement), all those aliases must be
+  // removed to prevent stale aliases from attaching to future runs that
+  // reuse the same sessionKey.
+  //
+  // Skip alias cleanup during force-supersede (skipNotify === true):
+  // the replacement operation inherits the same sessionKey and may need
+  // the existing aliases for waitForReplyRunEndBySessionId to resolve
+  // rotated sessionIds from the old run. The aliases will be cleaned up
+  // when the replacement finishes normally.
+  if (!params.skipNotify) {
+    for (const [aliasId, mappedKey] of replyRunState.waitKeysBySessionId) {
+      if (mappedKey === params.sessionKey) {
+        replyRunState.waitKeysBySessionId.delete(aliasId);
+      }
+    }
+  }
+  if (!params.skipNotify) {
+    notifyReplyRunEnded(params.sessionKey);
+  }
 }
 
 export function createReplyOperation(params: {
@@ -193,6 +241,12 @@ export function createReplyOperation(params: {
   sessionId: string;
   resetTriggered: boolean;
   upstreamAbortSignal?: AbortSignal;
+  /**
+   * When true, forcefully supersede any existing operation for this sessionKey.
+   * The existing operation is aborted and its state is cleared before the new
+   * one is created.  Used by interrupt mode after a two-phase abort detach.
+   */
+  force?: boolean;
 }): ReplyOperation {
   const sessionKey = normalizeOptionalString(params.sessionKey);
   const sessionId = normalizeOptionalString(params.sessionId);
@@ -203,7 +257,19 @@ export function createReplyOperation(params: {
     throw new Error("Reply operations require a sessionId");
   }
   if (replyRunState.activeRunsByKey.has(sessionKey)) {
-    throw new ReplyRunAlreadyActiveError(sessionKey);
+    if (params.force) {
+      const existing = replyRunState.activeRunsByKey.get(sessionKey)!;
+      existing.abortByUser({ skipNotify: true });
+      // For queued operations, abortByUser already cleared the registry
+      // synchronously (with skipNotify). For running operations, the
+      // clearReplyRunState call below handles the registry while the
+      // operation's finally block will later see isReplaced and skip.
+      if (replyRunState.activeRunsByKey.has(sessionKey)) {
+        clearReplyRunState({ sessionKey, sessionId: existing.sessionId, expectedOperation: existing, skipNotify: true });
+      }
+    } else {
+      throw new ReplyRunAlreadyActiveError(sessionKey);
+    }
   }
 
   const controller = new AbortController();
@@ -211,6 +277,11 @@ export function createReplyOperation(params: {
   let phase: ReplyOperationPhase = "queued";
   let result: ReplyOperationResult | null = null;
   let stateCleared = false;
+  // Back-reference: set after the operation object is created so that
+  // clearState() can pass it to clearReplyRunState for object-identity
+  // checking.  This prevents a stale operation from deleting a
+  // replacement that shares the same sessionId.
+  let selfRef: ReplyOperation | undefined;
 
   const clearState = () => {
     if (stateCleared) {
@@ -220,6 +291,7 @@ export function createReplyOperation(params: {
     clearReplyRunState({
       sessionKey,
       sessionId: currentSessionId,
+      expectedOperation: selfRef,
     });
   };
 
@@ -339,13 +411,19 @@ export function createReplyOperation(params: {
       }
       clearState();
     },
-    abortByUser() {
+    abortByUser(opts?: { skipNotify?: boolean }) {
       const phaseBeforeAbort = phase;
       abortWithReason("user_abort", createUserAbortError(), {
         abortedCode: "aborted_by_user",
       });
       if (phaseBeforeAbort === "queued") {
-        clearState();
+        clearReplyRunState({
+          sessionKey,
+          sessionId: currentSessionId,
+          expectedOperation: selfRef,
+          skipNotify: opts?.skipNotify,
+        });
+        stateCleared = true;
       }
     },
     abortForRestart() {
@@ -363,6 +441,9 @@ export function createReplyOperation(params: {
   replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
   replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
   registerWaitSessionId(sessionKey, currentSessionId);
+
+  // Wire up the back-reference so clearState() can pass object identity.
+  selfRef = operation;
 
   return operation;
 }

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -58,3 +58,4 @@ export type { BlockReplyContext } from "../auto-reply/types.js";
 export type { FinalizedMsgContext, MsgContext } from "../auto-reply/templating.js";
 export { generateConversationLabel } from "../auto-reply/reply/conversation-label-generator.js";
 export type { ConversationLabelParams } from "../auto-reply/reply/conversation-label-generator.js";
+export { isEmbeddedPiRunActiveForSessionKey } from "../agents/pi-embedded.js";


### PR DESCRIPTION
## Summary

Enable Telegram interrupt/steer message delivery during active agent runs, and fix ReplyOperation registry races that can lose user messages or cause overlapping runs.

### Problem

When a Telegram user sends a message while an agent run is active and queue mode is `steer`, `steer-backlog`, or `interrupt`, the message gets serialized behind the debouncer — even though steer/interrupt modes are supposed to deliver immediately. Additionally, the ReplyOperation registry has several race conditions around force-supersede:

1. **`notifyReplyRunEnded` fires during the gap** between clearing the old operation and registering the replacement, causing waiters to incorrectly see "idle".
2. **Queued operation abort clears state synchronously** — `abortByUser()` calls `clearState()` inline for queued ops, which triggers `notifyReplyRunEnded` before the replacement is registered.
3. **`clearWaitSessionIds` deletes replacement mappings** — when a stale operation's `finally` block runs after a replacement is registered, it can delete the replacement's wait-key entries.
4. **Stale `waitKeysBySessionId` aliases after `updateSessionId` rotation** — only `currentSessionId` was removed on normal completion, leaving orphaned aliases that could attach `waitForReplyRunEndBySessionId(oldId)` to future unrelated runs.

### Changes

**Telegram sequential key bypass:**
- Add `isRunActiveForChat` callback to `getTelegramSequentialKey`. When an embedded Pi run is active and the queue mode needs immediate delivery, return a per-message sequential key so grammY dispatches in parallel.
- `chatSessionCache` keyed by conversation (chatId:threadId) for groups, and by chatId:threadId:senderId for DMs.
- Cache lookup tries conversation key first, then sender key.
- Cap at 500 entries with FIFO eviction.
- Use live config (`loadConfig()`) for queue-mode resolution so runtime changes take effect without restart.

**Session key lookup for active runs:**
- Add `isEmbeddedPiRunActiveForSessionKey()` that resolves sessionKey → sessionId → active run registry check.
- Export through pi-embedded barrel and plugin-sdk/reply-runtime.

**Interrupt-mode forceDetach: trust scheduling decision:**
- After `forceDetachEmbeddedRun` succeeds in interrupt mode, return `{ kind: "continue" }` immediately without re-checking `isActive`. The residual ReplyOperation is handled downstream by `createReplyOperation({ force: true })`.
- `forceDetachEmbeddedRun` now resolves sessionKey from the reverse map and logs the session state transition to "idle".

**ReplyOperation registry race fixes:**
- `abortByUser` accepts `{ skipNotify }` option; the force-supersede path passes it so that queued operations (which clear state synchronously) also suppress the idle notification.
- `clearReplyRunState` accepts `skipNotify` option; the force path uses it to avoid resolving waiters in the gap between clearing the old operation and registering the new one.
- `clearReplyRunState` accepts `expectedOperation` for strict object-identity comparison in the `isReplaced` guard. The sessionId fallback is documented as unsafe when a replacement shares the same sessionId.
- In the `isReplaced` branch: zero map mutations — the replacement owns all registry entries and may have inherited sessionIds via `updateSessionId` rotation.
- Normal clear path: clean up **all** `waitKeysBySessionId` aliases for the sessionKey (not just `currentSessionId`), preventing stale aliases from attaching to future runs after `updateSessionId` rotation.
- Force-supersede path: skip alias cleanup — aliases are preserved for the replacement operation. They will be cleaned up when the replacement finishes normally.

**`waitForEmbeddedPiRunEnd` enhancement:**
- Now waits for both the embedded run map AND the ReplyOperation registry via `waitForReplyRunEndBySessionId`.
- `waitForEmbeddedPiRunEnd` caps at 15s; `waitForReplyRunEndBySessionId` caps at 500ms within the remaining budget.

**Retry guard scoping:**
- Force-supersede retry in `agent-runner.ts` only fires in interrupt mode (`force: isInterruptMode`). In collect/followup modes, aborting an in-flight run would violate queue semantics, so the retry falls through to the shutdown message.

### Known Limitations

- **Rapid burst:** When two interrupt messages arrive concurrently for the same chat (enabled by per-message sequential keys), only the first to reach `createReplyOperation({ force: true })` wins the slot. The second receives the "still shutting down" reply. This is intentional — only one replacement can be in-flight at a time.
- **`isReplaced` sessionId fallback:** The fallback path (`currentEntry.sessionId !== params.sessionId`) is unsafe when replacement and old operation share the same sessionId. All internal callers pass `expectedOperation` for strict identity comparison.

### Testing

- 37/37 unit tests passing (reply-run-registry + get-reply-run-queue + agent-runner.steer-guard + runs)
- `pnpm lint` clean on changed files

🤖 AI-assisted (Cha via OpenClaw)