### PR TITLE
fix: classify "No conversation found" as session_expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Audio/self-hosted STT: restore `models.providers.*.request.allowPrivateNetwork` for audio transcription so private or LAN speech-to-text endpoints stop tripping SSRF blocks after the v2026.4.14 regression. (#66692) Thanks @jhsmith409.
 - QQBot/cron: guard against undefined `event.content` in `parseFaceTags` and `filterInternalMarkers` so cron-triggered agent turns with no content payload no longer crash with `TypeError: Cannot read properties of undefined (reading 'startsWith')`. (#66302) Thanks @xinmotlanthua.
 - CLI/plugins: stop `--dangerously-force-unsafe-install` plugin installs from falling back to hook-pack installs after security scan failures, while still preserving non-security fallback behavior for real hook packs. (#58909) Thanks @hxy91819.
+- Claude CLI/sessions: classify `No conversation found with session ID` as `session_expired` so expired CLI-backed conversations clear the stale binding and recover on the next turn. (#65028) thanks @Ivan-Fn.
 
 ## 2026.4.14
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -648,6 +648,12 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("410 conversation expired")).toBe("session_expired");
   });
 
+  it("classifies 'No conversation found' from Claude CLI as session_expired", () => {
+    expect(classifyFailoverReason("No conversation found with session ID: abc123")).toBe(
+      "session_expired",
+    );
+  });
+
   it("keeps explicit billing and auth signals on 410 text", () => {
     expect(classifyFailoverReason("HTTP 410: invalid_api_key")).toBe("auth");
     expect(classifyFailoverReason("HTTP 410: authentication failed")).toBe("auth");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -1109,6 +1109,7 @@ function isCliSessionExpiredErrorMessage(raw: string): boolean {
     lower.includes("session expired") ||
     lower.includes("session invalid") ||
     lower.includes("conversation not found") ||
+    lower.includes("no conversation found") ||
     lower.includes("conversation does not exist") ||
     lower.includes("conversation expired") ||
     lower.includes("conversation invalid") ||


### PR DESCRIPTION
## Summary

Added `"no conversation found"` to `isCliSessionExpiredErrorMessage()` in `src/agents/pi-embedded-helpers/errors.ts`.

Claude CLI returns `"No conversation found with session ID: <id>"` when resuming an expired session. The existing classifier checks for `"conversation not found"` but misses the `"no conversation found"` phrasing. This prevents the session-expired recovery path (clear stale binding, retry with fresh session) from firing, causing follow-up messages in CLI-backend conversations to fail permanently.

## Reproduction

1. Configure a CLI backend (claude-cli provider) with sessionMode: "always"
2. Send a message — session is created and binding stored
3. Wait for the Claude CLI session to expire (or clear session files manually)
4. Send a follow-up message in the same conversation
5. **Before fix:** Permanent failure with "No conversation found with session ID"
6. **After fix:** Session binding is cleared, fresh session created transparently

## Test plan

- [x] Verified the error message from Claude CLI is exactly "No conversation found with session ID: ..."
- [x] Confirmed "no conversation found" does not match the existing "conversation not found" pattern
- [x] Tested end-to-end: follow-up messages now recover from expired sessions

Generated with [Claude Code](https://claude.com/claude-code)