### PR TITLE
fix(memory-core): wake managed dreaming jobs immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/memory: restore cached memory capability public artifacts on plugin-registry cache hits so memory-backed artifact surfaces stay visible after warm loads. Thanks @sercada and @vincentkoc.
 - Gateway/cron: preserve requested isolated-agent config across runtime reloads so subagent jobs and heartbeat overrides keep the right workspace and heartbeat settings when the hot-loaded snapshot is stale. Thanks @l0cka and @vincentkoc.
 - Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
+- Dreaming/cron: wake managed dreaming jobs immediately instead of waiting for the next heartbeat, so scheduled dreaming runs start when the cron fires. (#65053) Thanks @l0cka and @vincentkoc.
 
 ## 2026.4.11
 

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -415,7 +415,7 @@ describe("short-term dreaming cron reconciliation", () => {
     expect(harness.addCalls[0]).toMatchObject({
       name: constants.MANAGED_DREAMING_CRON_NAME,
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      wakeMode: "now",
       payload: {
         kind: "systemEvent",
         text: constants.DREAMING_SYSTEM_EVENT_TEXT,
@@ -488,6 +488,7 @@ describe("short-term dreaming cron reconciliation", () => {
       id: "job-primary",
       patch: {
         enabled: true,
+        wakeMode: "now",
         schedule: desired.schedule,
         payload: desired.payload,
       },
@@ -502,7 +503,7 @@ describe("short-term dreaming cron reconciliation", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "0 3 * * *" },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      wakeMode: "now",
       payload: { kind: "systemEvent", text: constants.DREAMING_SYSTEM_EVENT_TEXT },
       createdAtMs: 10,
     };
@@ -548,7 +549,7 @@ describe("short-term dreaming cron reconciliation", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "0 3 * * *" },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      wakeMode: "now",
       payload: { kind: "systemEvent", text: constants.DREAMING_SYSTEM_EVENT_TEXT },
       createdAtMs: 10,
     };
@@ -645,7 +646,7 @@ describe("short-term dreaming cron reconciliation", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "0 3 * * *" },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      wakeMode: "now",
       payload: { kind: "systemEvent", text: constants.DREAMING_SYSTEM_EVENT_TEXT },
       createdAtMs: 10,
     };
@@ -679,7 +680,7 @@ describe("short-term dreaming cron reconciliation", () => {
       enabled: true,
       schedule: { kind: "cron", expr: "0 3 * * *" },
       sessionTarget: "main",
-      wakeMode: "next-heartbeat",
+      wakeMode: "now",
       payload: { kind: "systemEvent", text: constants.DREAMING_SYSTEM_EVENT_TEXT },
       createdAtMs: 10,
     };

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -47,7 +47,7 @@ type ManagedCronJobCreate = {
   enabled: boolean;
   schedule: CronSchedule;
   sessionTarget: "main";
-  wakeMode: "next-heartbeat";
+  wakeMode: "now";
   payload: CronPayload;
 };
 
@@ -57,7 +57,7 @@ type ManagedCronJobPatch = {
   enabled?: boolean;
   schedule?: CronSchedule;
   sessionTarget?: "main";
-  wakeMode?: "next-heartbeat";
+  wakeMode?: "now";
   payload?: CronPayload;
 };
 
@@ -154,7 +154,7 @@ function buildManagedDreamingCronJob(
       ...(config.timezone ? { tz: config.timezone } : {}),
     },
     sessionTarget: "main",
-    wakeMode: "next-heartbeat",
+    wakeMode: "now",
     payload: {
       kind: "systemEvent",
       text: DREAMING_SYSTEM_EVENT_TEXT,
@@ -257,8 +257,8 @@ function buildManagedDreamingPatch(
     patch.sessionTarget = "main";
   }
   const wakeMode = normalizeLowercaseStringOrEmpty(normalizeTrimmedString(job.wakeMode));
-  if (wakeMode !== "next-heartbeat") {
-    patch.wakeMode = "next-heartbeat";
+  if (wakeMode !== "now") {
+    patch.wakeMode = "now";
   }
 
   const payloadKind = normalizeLowercaseStringOrEmpty(normalizeTrimmedString(job.payload?.kind));


### PR DESCRIPTION
## Summary
- change managed short-term dreaming cron jobs to use `wakeMode: "now"`
- update reconciliation so existing managed dreaming jobs are migrated from `next-heartbeat` to `now`
- keep the patch narrow to the memory-core dreaming controller and its focused tests

## Why
Memory-core was still forcing its managed dreaming cron job to `next-heartbeat` even though core OpenClaw already defaults new cron jobs to `now`.

In practice, that made memory dreaming an outlier and contributed to confusing repeated or delayed runs when the job rode the heartbeat lane. The local issue we investigated was a single managed dreaming job appearing duplicated or repeated, not two separate cron jobs.

## Validation
- `pnpm vitest run extensions/memory-core/src/dreaming.test.ts`
- `pnpm lint`
- `pnpm build`
- broader slice: `pnpm vitest run src/cron/*.test.ts extensions/memory-core/src/*.test.ts`

## Notes
The broader cron + memory-core slice had one unrelated failure in `extensions/memory-core/src/cli.test.ts` (`previews rem harness output as json`) that does not touch this patch.