### PR TITLE
fix(minimax): use configured baseUrl for usage polling endpoint

### DIFF
--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -242,8 +242,13 @@ export function registerMinimaxProviders(api: OpenClawPluginApi) {
     ...MINIMAX_FAST_MODE_STREAM_HOOKS,
     resolveReasoningOutputMode: () => resolveMinimaxReasoningOutputMode(),
     isModernModelRef: ({ modelId }) => isMiniMaxModernModelId(modelId),
-    fetchUsageSnapshot: async (ctx) =>
-      await fetchMinimaxUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn),
+    fetchUsageSnapshot: async (ctx) => {
+      const providerConfig = (ctx.config?.models as Record<string, unknown>)?.providers as Record<string, Record<string, unknown>> | undefined;
+      const baseUrl =
+        providerConfig?.["minimax-portal"]?.baseUrl as string | undefined ??
+        providerConfig?.minimax?.baseUrl as string | undefined;
+      return await fetchMinimaxUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn, baseUrl);
+    },
   });
 
   api.registerProvider({

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -366,13 +366,39 @@ function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> 
   });
 }
 
+const DEFAULT_MINIMAX_USAGE_HOST = "https://api.minimaxi.com";
+
+/**
+ * Derive the usage API host from the provider's configured baseUrl.
+ * MiniMax has two endpoints:
+ *   - CN: api.minimaxi.com (default)
+ *   - Global: api.minimax.io
+ * The baseUrl may include a path suffix (e.g. "/anthropic") which we strip.
+ */
+function deriveMinimaxUsageHost(baseUrl?: string): string {
+  if (!baseUrl || typeof baseUrl !== "string") {
+    return DEFAULT_MINIMAX_USAGE_HOST;
+  }
+  try {
+    const url = new URL(baseUrl);
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return DEFAULT_MINIMAX_USAGE_HOST;
+  }
+}
+
 export async function fetchMinimaxUsage(
   apiKey: string,
   timeoutMs: number,
   fetchFn: typeof fetch,
+  baseUrl?: string,
 ): Promise<ProviderUsageSnapshot> {
+  // Derive the usage endpoint from the configured baseUrl so that global
+  // endpoint users (api.minimax.io) hit the correct host instead of the
+  // hardcoded CN endpoint (api.minimaxi.com).  See #65054.
+  const host = deriveMinimaxUsageHost(baseUrl);
   const res = await fetchJson(
-    "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains",
+    `${host}/v1/api/openplatform/coding_plan/remains`,
     {
       method: "GET",
       headers: {


### PR DESCRIPTION
The MiniMax usage fetcher hardcodes the CN endpoint (`api.minimaxi.com`) for `coding_plan/remains`. Global endpoint users (`api.minimax.io`) get wrong/stale usage data or 403 errors.

Add `baseUrl` parameter to `fetchMinimaxUsage` and derive the usage host from the provider config. Falls back to CN endpoint for backward compatibility.

Fixes #65054