### PR TITLE
fix(codex): avoid image tool loops on vision turns and respect image-model providers

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -343,10 +343,14 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
       input.runAbortController.abort("sessions_yield");
     },
   });
+  const visionFilteredTools = filterToolsForVisionInputs(allTools, {
+    modelHasVision,
+    hasInboundImages: (params.images?.length ?? 0) > 0,
+  });
   const filteredTools =
     params.toolsAllow && params.toolsAllow.length > 0
-      ? allTools.filter((tool) => params.toolsAllow?.includes(tool.name))
-      : allTools;
+      ? visionFilteredTools.filter((tool) => params.toolsAllow?.includes(tool.name))
+      : visionFilteredTools;
   return normalizeProviderToolSchemas({
     tools: filteredTools,
     provider: params.provider,
@@ -357,6 +361,19 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelApi: params.model.api,
     model: params.model,
   });
+}
+
+function filterToolsForVisionInputs<T extends { name?: string }>(
+  tools: T[],
+  params: {
+    modelHasVision: boolean;
+    hasInboundImages: boolean;
+  },
+): T[] {
+  if (!params.modelHasVision || !params.hasInboundImages) {
+    return tools;
+  }
+  return tools.filter((tool) => tool.name !== "image");
 }
 
 async function withCodexStartupTimeout<T>(params: {
@@ -473,6 +490,7 @@ function handleApprovalRequest(params: {
 }
 
 export const __testing = {
+  filterToolsForVisionInputs,
   setCodexAppServerClientFactoryForTests(factory: CodexAppServerClientFactory): void {
     clientFactory = factory;
   },

--- a/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./run-attempt.js";
+
+describe("Codex dynamic tool filtering", () => {
+  it("drops the image tool when the model already has inbound vision input", () => {
+    const toolNames = __testing
+      .filterToolsForVisionInputs(
+        [{ name: "image" }, { name: "read" }, { name: "write" }],
+        {
+          modelHasVision: true,
+          hasInboundImages: true,
+        },
+      )
+      .map((tool) => tool.name);
+
+    expect(toolNames).toContain("read");
+    expect(toolNames).toContain("write");
+    expect(toolNames).not.toContain("image");
+  });
+});

--- a/src/agents/model-fallback.image-provider.test.ts
+++ b/src/agents/model-fallback.image-provider.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { runWithImageModelFallback } from "./model-fallback.js";
+import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
+
+describe("runWithImageModelFallback provider resolution", () => {
+  it("inherits the configured image-model provider for bare override ids", async () => {
+    const cfg = makeModelFallbackCfg({
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openai-codex/gpt-5.4",
+            fallbacks: ["openai-codex/gpt-5.4-mini"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("ok");
+
+    const result = await runWithImageModelFallback({
+      cfg,
+      modelOverride: "gpt-5.4-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run.mock.calls).toEqual([["openai-codex", "gpt-5.4-mini"]]);
+  });
+});

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -371,6 +371,25 @@ function resolveImageFallbackCandidates(params: {
   return candidates;
 }
 
+function resolveImageFallbackDefaultProvider(cfg: OpenClawConfig | undefined): string {
+  const configuredPrimary = resolveAgentModelPrimaryValue(cfg?.agents?.defaults?.imageModel);
+  if (configuredPrimary?.trim()) {
+    const aliasIndex = buildModelAliasIndex({
+      cfg: cfg ?? {},
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    const resolved = resolveModelRefFromString({
+      raw: configuredPrimary,
+      defaultProvider: DEFAULT_PROVIDER,
+      aliasIndex,
+    });
+    if (resolved?.ref.provider) {
+      return resolved.ref.provider;
+    }
+  }
+  return DEFAULT_PROVIDER;
+}
+
 function resolveFallbackCandidates(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -909,7 +928,7 @@ export async function runWithImageModelFallback<T>(params: {
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveImageFallbackCandidates({
     cfg: params.cfg,
-    defaultProvider: DEFAULT_PROVIDER,
+    defaultProvider: resolveImageFallbackDefaultProvider(params.cfg),
     modelOverride: params.modelOverride,
   });
   if (candidates.length === 0) {


### PR DESCRIPTION
## Summary

- hide the dynamic `image` tool on Codex-native turns that already include inbound images and use a vision-capable model
- inherit the configured `agents.defaults.imageModel.primary` provider when resolving bare image-model override ids
- add focused regression tests for both paths

## Problem

Codex-native image turns can stall when inbound images are already present in the turn input but the dynamic `image` tool is still exposed. Separately, bare overrides such as `gpt-5.4-mini` can resolve under the wrong provider when the configured image model lives under a non-default provider prefix.

Closes #65050

## Testing

- `pnpm exec node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.vision-tools.test.ts`
- `pnpm exec node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/model-fallback.image-provider.test.ts`
- `pnpm exec node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm exec node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/model-fallback.test.ts`