### PR TITLE
fix(memory-lancedb): register runtime for doctor and status

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -283,6 +283,7 @@ describe("memory plugin e2e", () => {
         }),
       );
       await expect(result.manager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+      expect(embeddingsCreate).not.toHaveBeenCalled();
       await expect(result.manager.probeVectorAvailability()).resolves.toBe(true);
     } finally {
       vi.doUnmock("openclaw/plugin-sdk/runtime-env");

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -187,6 +187,111 @@ describe("memory plugin e2e", () => {
     expect(config?.autoRecall).toBe(true);
   });
 
+  test("registers a memory capability runtime so doctor/status can see the active backend", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const countRows = vi.fn(async () => 2);
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const where = vi.fn(() => ({ limit }));
+    const query = vi.fn(() => ({ where }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          query,
+          vectorSearch,
+          countRows,
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      let memoryCapability: any = null;
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        registerMemoryCapability: (capability: any) => {
+          memoryCapability = capability;
+        },
+        registerTool: vi.fn(),
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      memoryPlugin.register(mockApi as any);
+
+      expect(memoryCapability?.runtime).toBeTruthy();
+      expect(
+        memoryCapability.runtime.resolveMemoryBackendConfig({ cfg: {}, agentId: "main" }),
+      ).toEqual({
+        backend: "builtin",
+      });
+
+      const result = await memoryCapability.runtime.getMemorySearchManager({
+        cfg: {},
+        agentId: "main",
+        purpose: "status",
+      });
+
+      expect(result.manager).toBeTruthy();
+      expect(result.manager.status()).toEqual(
+        expect.objectContaining({
+          backend: "builtin",
+          provider: "openai",
+          model: "text-embedding-3-small",
+          dbPath: getDbPath(),
+        }),
+      );
+      await expect(result.manager.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+      await expect(result.manager.probeVectorAvailability()).resolves.toBe(true);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
   test("passes configured dimensions to OpenAI embeddings API", async () => {
     const embeddingsCreate = vi.fn(async () => ({
       data: [{ embedding: [0.1, 0.2, 0.3] }],
@@ -245,6 +350,7 @@ describe("memory plugin e2e", () => {
           error: vi.fn(),
           debug: vi.fn(),
         },
+        registerMemoryCapability: vi.fn(),
         registerTool: (tool: any, opts: any) => {
           registeredTools.push({ tool, opts });
         },

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -10,6 +10,7 @@ import { randomUUID } from "node:crypto";
 import type * as LanceDB from "@lancedb/lancedb";
 import { Type } from "@sinclair/typebox";
 import OpenAI from "openai";
+import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { definePluginEntry, type OpenClawPluginApi } from "./api.js";
@@ -146,6 +147,27 @@ class MemoryDB {
     await this.ensureInitialized();
     return this.table!.countRows();
   }
+
+  async get(id: string): Promise<MemoryEntry | null> {
+    await this.ensureInitialized();
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(id)) {
+      return null;
+    }
+    const rows = await this.table!.query().where(`id = '${id}'`).limit(1).toArray();
+    const row = rows[0];
+    if (!row) {
+      return null;
+    }
+    return {
+      id: row.id as string,
+      text: row.text as string,
+      vector: row.vector as number[],
+      importance: row.importance as number,
+      category: row.category as MemoryEntry["category"],
+      createdAt: row.createdAt as number,
+    };
+  }
 }
 
 // ============================================================================
@@ -278,6 +300,25 @@ export function detectCategory(text: string): MemoryCategory {
   return "other";
 }
 
+function resolveMemoryProviderLabel(params: { baseUrl?: string; model: string }) {
+  if (params.baseUrl && params.baseUrl.trim().length > 0) {
+    return "openai-compatible";
+  }
+  const lowerModel = normalizeLowercaseStringOrEmpty(params.model);
+  if (lowerModel.startsWith("text-embedding-")) {
+    return "openai";
+  }
+  return "remote";
+}
+
+function extractMemoryIdFromPath(relPath: string): string | null {
+  const normalized = relPath.trim().replace(/\\/g, "/");
+  const match = normalized.match(
+    /(?:^|\/)([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\.md)?$/i,
+  );
+  return match?.[1] ?? null;
+}
+
 // ============================================================================
 // Plugin Definition
 // ============================================================================
@@ -297,8 +338,85 @@ export default definePluginEntry({
     const vectorDim = dimensions ?? vectorDimsForModel(model);
     const db = new MemoryDB(resolvedDbPath, vectorDim);
     const embeddings = new Embeddings(apiKey, model, baseUrl, dimensions);
+    const providerLabel = resolveMemoryProviderLabel({ baseUrl, model });
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
+
+    const memoryRuntime: MemoryPluginRuntime = {
+      async getMemorySearchManager() {
+        return {
+          manager: {
+            async search(query, opts) {
+              const vector = await embeddings.embed(query);
+              const results = await db.search(vector, opts?.maxResults ?? 5, opts?.minScore ?? 0.1);
+              return results.map((result) => ({
+                path: `memories/${result.entry.id}.md`,
+                startLine: 1,
+                endLine: 1,
+                score: result.score,
+                snippet: result.entry.text,
+                source: "memory" as const,
+                citation: result.entry.category,
+              }));
+            },
+            async readFile(params) {
+              const memoryId = extractMemoryIdFromPath(params.relPath);
+              if (!memoryId) {
+                throw new Error(`memory-lancedb: unknown memory path: ${params.relPath}`);
+              }
+              const entry = await db.get(memoryId);
+              if (!entry) {
+                throw new Error(`memory-lancedb: memory not found: ${params.relPath}`);
+              }
+              return {
+                path: `memories/${entry.id}.md`,
+                text: entry.text,
+              };
+            },
+            status() {
+              return {
+                backend: "builtin" as const,
+                provider: providerLabel,
+                model,
+                dbPath: resolvedDbPath,
+                custom: {
+                  pluginId: "memory-lancedb",
+                  vectorDim,
+                },
+              };
+            },
+            async probeEmbeddingAvailability() {
+              return {
+                ok: typeof apiKey === "string" && apiKey.trim().length > 0,
+                error:
+                  typeof apiKey === "string" && apiKey.trim().length > 0
+                    ? undefined
+                    : "memory-lancedb embedding apiKey missing",
+              };
+            },
+            async probeVectorAvailability() {
+              try {
+                await db.count();
+                return true;
+              } catch {
+                return false;
+              }
+            },
+            async close() {},
+          },
+        };
+      },
+      resolveMemoryBackendConfig() {
+        return {
+          backend: "builtin" as const,
+        };
+      },
+      async closeAllMemorySearchManagers() {},
+    };
+
+    api.registerMemoryCapability({
+      runtime: memoryRuntime,
+    });
 
     // ========================================================================
     // Tools

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -386,6 +386,9 @@ export default definePluginEntry({
               };
             },
             async probeEmbeddingAvailability() {
+              // Keep doctor/status probes lightweight: this only confirms that an
+              // embedding credential is configured. Real search/embed operations
+              // still validate the key and endpoint when they execute.
               return {
                 ok: typeof apiKey === "string" && apiKey.trim().length > 0,
                 error:


### PR DESCRIPTION
## Summary
- register a memory capability runtime for `memory-lancedb` so core doctor/status surfaces can discover it as the active memory plugin
- expose the minimal runtime hooks doctor/status need: backend config resolution, search-manager status, embedding probe, and vector probe
- add regression coverage proving the plugin registers a visible runtime instead of only tools/hooks

## Problem
`memory-lancedb` is a `kind: "memory"` plugin, but it did not register a memory runtime/capability. That meant the core memory-runtime path had nothing to resolve, so doctor/status could incorrectly report that no active memory plugin was registered even when the plugin was installed and working.

## Validation
- `pnpm vitest run extensions/memory-lancedb/index.test.ts`
- `pnpm lint extensions/memory-lancedb/index.ts extensions/memory-lancedb/index.test.ts`
- `pnpm build --filter memory-lancedb`

Fixes #60177