### PR TITLE
fix(loop-detection): block generic repeats at critical threshold

### DIFF
--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./pi-tools.before-tool-call.js";
-import { CRITICAL_THRESHOLD, GLOBAL_CIRCUIT_BREAKER_THRESHOLD } from "./tool-loop-detection.js";
+import { CRITICAL_THRESHOLD, WARNING_THRESHOLD } from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
@@ -206,39 +206,38 @@ describe("before_tool_call loop detection behavior", () => {
     }
   });
 
-  it("keeps generic repeated calls warn-only below global breaker", async () => {
+  it("blocks generic repeated calls at critical threshold", async () => {
     const { tool, params } = createGenericReadRepeatFixture();
 
-    for (let i = 0; i < CRITICAL_THRESHOLD + 5; i += 1) {
-      await expect(tool.execute(`read-${i}`, params, undefined, undefined)).resolves.toBeDefined();
-    }
-  });
-
-  it("blocks generic repeated no-progress calls at global breaker threshold", async () => {
-    const { tool, params } = createGenericReadRepeatFixture();
-
-    for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+    for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
       await expect(tool.execute(`read-${i}`, params, undefined, undefined)).resolves.toBeDefined();
     }
 
     await expect(
-      tool.execute(`read-${GLOBAL_CIRCUIT_BREAKER_THRESHOLD}`, params, undefined, undefined),
-    ).rejects.toThrow("global circuit breaker");
+      tool.execute(`read-${CRITICAL_THRESHOLD}`, params, undefined, undefined),
+    ).rejects.toThrow("CRITICAL");
   });
 
-  it("coalesces repeated generic warning events into threshold buckets", async () => {
+  it("emits warning then critical diagnostic events for generic repeats", async () => {
     await withToolLoopEvents(
       async (emitted) => {
         const { tool, params } = createGenericReadRepeatFixture();
 
-        for (let i = 0; i < 21; i += 1) {
+        for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
           await tool.execute(`read-bucket-${i}`, params, undefined, undefined);
         }
 
-        const genericWarns = emitted.filter((evt) => evt.detector === "generic_repeat");
-        expect(genericWarns.map((evt) => evt.count)).toEqual([10, 20]);
+        await expect(
+          tool.execute(`read-bucket-${CRITICAL_THRESHOLD}`, params, undefined, undefined),
+        ).rejects.toThrow("CRITICAL");
+
+        const genericEvents = emitted.filter((evt) => evt.detector === "generic_repeat");
+        expect(genericEvents.map((evt) => [evt.level, evt.count, evt.action])).toEqual([
+          ["warning", WARNING_THRESHOLD, "warn"],
+          ["critical", CRITICAL_THRESHOLD, "block"],
+        ]);
       },
-      (evt) => evt.level === "warning",
+      (evt) => evt.detector === "generic_repeat",
     );
   });
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -299,7 +299,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps generic loops warn-only below global breaker threshold", () => {
+    it("blocks generic loops at critical threshold", () => {
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({
         toolName: fixture.toolName,
@@ -309,7 +309,8 @@ describe("tool-loop-detection", () => {
       });
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -470,10 +470,28 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector: escalate from warning to critical for repeated identical calls.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    recentCount >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(
+      `Critical loop detected: ${toolName} called ${recentCount} times with identical arguments`,
+    );
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: recentCount,
+      message: `CRITICAL: You have called ${toolName} ${recentCount} times with identical arguments. This appears to be a stuck repetitive loop. Session execution blocked to prevent resource waste.`,
+      warningKey: `generic:${toolName}:${currentHash}`,
+    };
+  }
 
   if (
     !knownPollTool &&


### PR DESCRIPTION
## Summary
- escalate `generic_repeat` from warning to critical when repeated identical calls hit `criticalThreshold`
- keep the warning path at `warningThreshold` so diagnostics still surface before the block
- update detector and before-tool-call coverage to assert the warning-then-block behavior

Fixes #60111

## Testing
- `pnpm lint src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts src/agents/pi-tools.before-tool-call.e2e.test.ts`
- `pnpm vitest run src/agents/tool-loop-detection.test.ts`
- `pnpm vitest --config test/vitest/vitest.e2e.config.ts run src/agents/pi-tools.before-tool-call.e2e.test.ts`