### PR TITLE
fix(slack): keep reply suppression thread-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/agents: keep same-channel reply suppression thread-aware so threaded `message` tool sends only suppress replies in the matching Slack thread instead of silencing a different thread in the same channel.
+
 ## 2026.4.11
 
 ### Changes

--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -74,4 +74,15 @@ describe("extractMessagingToolSend", () => {
     expect(result?.to).toBe("channel:C1");
     expect(result?.threadId).toBe("1712345678.123456");
   });
+
+  it("ignores non-integer numeric threadId values", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "thread-reply",
+      provider: "slack",
+      to: "channel:C1",
+      threadId: 1712345678.123456,
+    });
+
+    expect(result?.threadId).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -60,4 +60,18 @@ describe("extractMessagingToolSend", () => {
     expect(result?.provider).toBe("telegram");
     expect(result?.to).toBe("telegram:123");
   });
+
+  it("preserves threadId for generic message sends", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "thread-reply",
+      provider: "slack",
+      to: "channel:C1",
+      threadId: "1712345678.123456",
+    });
+
+    expect(result?.tool).toBe("message");
+    expect(result?.provider).toBe("slack");
+    expect(result?.to).toBe("channel:C1");
+    expect(result?.threadId).toBe("1712345678.123456");
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -405,7 +405,12 @@ export function extractMessagingToolSend(
     const providerId = providerHint ? normalizeChannelId(providerHint) : null;
     const provider = providerId ?? normalizeOptionalLowercaseString(providerHint) ?? "message";
     const to = normalizeTargetForProvider(provider, toRaw);
-    return to ? { tool: toolName, provider, accountId, to } : undefined;
+    const threadIdRaw =
+      typeof args.threadId === "number"
+        ? String(args.threadId)
+        : (normalizeOptionalString(args.threadId) ?? "");
+    const threadId = threadIdRaw.trim() || undefined;
+    return to ? { tool: toolName, provider, accountId, to, threadId } : undefined;
   }
   const providerId = normalizeChannelId(toolName);
   if (!providerId) {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -407,7 +407,9 @@ export function extractMessagingToolSend(
     const to = normalizeTargetForProvider(provider, toRaw);
     const threadIdRaw =
       typeof args.threadId === "number"
-        ? String(args.threadId)
+        ? Number.isInteger(args.threadId)
+          ? String(args.threadId)
+          : ""
         : (normalizeOptionalString(args.threadId) ?? "");
     const threadId = threadIdRaw.trim() || undefined;
     return to ? { tool: toolName, provider, accountId, to, threadId } : undefined;

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -106,6 +106,7 @@ export async function buildReplyPayloads(params: {
   messagingToolSentTargets?: MessagingToolSend[];
   originatingChannel?: OriginatingChannelType;
   originatingTo?: string;
+  originatingThreadId?: string | number;
   accountId?: string;
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
 }): Promise<{ replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean }> {
@@ -183,6 +184,7 @@ export async function buildReplyPayloads(params: {
       originatingTo: resolveOriginMessageTo({
         originatingTo: params.originatingTo,
       }),
+      originatingThreadId: params.originatingThreadId,
       accountId: resolveOriginAccountId({
         originatingAccountId: params.accountId,
       }),

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -908,6 +908,21 @@ describe("runReplyAgent messaging tool suppression", () => {
 
     expect(result).toMatchObject({ text: "hello world!" });
   });
+
+  it("drops replies when Slack auto-threading keeps the send in the current thread", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel:C1" }],
+      meta: {},
+    });
+
+    const result = await createRun("slack", {
+      messageThreadId: "1712345678.123456",
+    });
+
+    expect(result).toBeUndefined();
+  });
 });
 
 describe("runReplyAgent reminder commitment guard", () => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -766,7 +766,7 @@ describe("runReplyAgent claude-cli routing", () => {
 describe("runReplyAgent messaging tool suppression", () => {
   function createRun(
     messageProvider = "slack",
-    opts: { storePath?: string; sessionKey?: string } = {},
+    opts: { storePath?: string; sessionKey?: string; messageThreadId?: string } = {},
   ) {
     const typing = createMockTypingController();
     const sessionKey = opts.sessionKey ?? "main";
@@ -775,6 +775,7 @@ describe("runReplyAgent messaging tool suppression", () => {
       OriginatingTo: "channel:C1",
       AccountId: "primary",
       MessageSid: "msg",
+      MessageThreadId: opts.messageThreadId,
     } as unknown as TemplateContext;
     const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
     const followupRun = {
@@ -882,6 +883,28 @@ describe("runReplyAgent messaging tool suppression", () => {
     });
 
     const result = await createRun("slack");
+
+    expect(result).toMatchObject({ text: "hello world!" });
+  });
+
+  it("delivers replies when Slack channel matches but thread differs", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["different message"],
+      messagingToolSentTargets: [
+        {
+          tool: "message",
+          provider: "slack",
+          to: "channel:C1",
+          threadId: "1712345678.999999",
+        },
+      ],
+      meta: {},
+    });
+
+    const result = await createRun("slack", {
+      messageThreadId: "1712345678.123456",
+    });
 
     expect(result).toMatchObject({ text: "hello world!" });
   });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -592,6 +592,7 @@ export async function runReplyAgent(params: {
         originatingTo: sessionCtx.OriginatingTo,
         to: sessionCtx.To,
       }),
+      originatingThreadId: sessionCtx.MessageThreadId,
       accountId: sessionCtx.AccountId,
       normalizeMediaPaths: normalizeReplyMediaPaths,
     });

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -83,4 +83,44 @@ describe("resolveFollowupDeliveryPayloads", () => {
       }),
     ).toEqual([{ text: "hello world!" }]);
   });
+
+  it("suppresses Slack replies when channel and thread both match", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "hello world!" }],
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "1712345678.123456",
+        sentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "1712345678.123456",
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not suppress Slack replies when channel matches but thread differs", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "hello world!" }],
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "1712345678.123456",
+        sentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "1712345678.999999",
+          },
+        ],
+      }),
+    ).toEqual([{ text: "hello world!" }]);
+  });
 });

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -104,6 +104,19 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toEqual([]);
   });
 
+  it("suppresses Slack replies when the send implicitly uses the current thread", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "hello world!" }],
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "1712345678.123456",
+        sentTargets: [{ tool: "message", provider: "slack", to: "channel:C1" }],
+      }),
+    ).toEqual([]);
+  });
+
   it("does not suppress Slack replies when channel matches but thread differs", () => {
     expect(
       resolveFollowupDeliveryPayloads({

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -31,6 +31,7 @@ export function resolveFollowupDeliveryPayloads(params: {
   originatingChannel?: string;
   originatingChatType?: string | null;
   originatingTo?: string;
+  originatingThreadId?: string | number;
   sentMediaUrls?: string[];
   sentTargets?: MessagingToolSend[];
   sentTexts?: string[];
@@ -76,6 +77,7 @@ export function resolveFollowupDeliveryPayloads(params: {
     originatingTo: resolveOriginMessageTo({
       originatingTo: params.originatingTo,
     }),
+    originatingThreadId: params.originatingThreadId,
     accountId: resolveOriginAccountId({
       originatingAccountId: params.originatingAccountId,
     }),

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -347,6 +347,7 @@ export function createFollowupRunner(params: {
         originatingChannel: queued.originatingChannel,
         originatingChatType: queued.originatingChatType,
         originatingTo: queued.originatingTo,
+        originatingThreadId: queued.originatingThreadId,
         sentMediaUrls: runResult.messagingToolSentMediaUrls,
         sentTargets: runResult.messagingToolSentTargets,
         sentTexts: runResult.messagingToolSentTexts,

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -89,6 +89,16 @@ function normalizeThreadIdForComparison(value?: string): string | undefined {
   return normalizeLowercaseStringOrEmpty(trimmed);
 }
 
+function coerceThreadIdForSuppression(value?: string | number): string | undefined {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      return undefined;
+    }
+    return String(value);
+  }
+  return normalizeOptionalString(value);
+}
+
 function resolveTargetProviderForComparison(params: {
   currentProvider: string;
   targetProvider?: string;
@@ -135,8 +145,7 @@ export function shouldSuppressMessagingToolReplies(params: {
     return false;
   }
   const originRawTarget = normalizeOptionalString(params.originatingTo);
-  const originThreadId =
-    params.originatingThreadId != null ? String(params.originatingThreadId) : undefined;
+  const originThreadId = coerceThreadIdForSuppression(params.originatingThreadId);
   const originAccount = normalizeOptionalAccountId(params.accountId);
   const sentTargets = params.messagingToolSentTargets ?? [];
   if (sentTargets.length === 0) {
@@ -155,7 +164,7 @@ export function shouldSuppressMessagingToolReplies(params: {
       return false;
     }
     const targetRaw = normalizeOptionalString(target.to);
-    if (originRawTarget && targetRaw === originRawTarget && !target.threadId && !originThreadId) {
+    if (originRawTarget && targetRaw === originRawTarget && !target.threadId) {
       return true;
     }
     const originTarget = normalizeTargetForProvider(provider, originRawTarget);
@@ -171,7 +180,7 @@ export function shouldSuppressMessagingToolReplies(params: {
       originTarget,
       originThreadId,
       targetKey,
-      targetThreadId: target.threadId,
+      targetThreadId: coerceThreadIdForSuppression(target.threadId),
     });
   });
 }

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -117,7 +117,8 @@ function targetsMatchForSuppression(params: {
   targetKey: string;
   targetThreadId?: string;
 }): boolean {
-  const pluginMatch = getChannelPlugin(params.provider)?.outbound?.targetsMatchForReplySuppression;
+  const channelPlugin = getChannelPlugin(params.provider);
+  const pluginMatch = channelPlugin?.outbound?.targetsMatchForReplySuppression;
   if (pluginMatch) {
     return pluginMatch({
       originTarget: params.originTarget,
@@ -127,6 +128,10 @@ function targetsMatchForSuppression(params: {
   }
   const originThreadId = normalizeThreadIdForComparison(params.originThreadId);
   const targetThreadId = normalizeThreadIdForComparison(params.targetThreadId);
+  const supportsThreading = Boolean(channelPlugin?.threading);
+  if (!originThreadId && targetThreadId && !supportsThreading) {
+    return params.targetKey === params.originTarget;
+  }
   if (originThreadId || targetThreadId) {
     return params.targetKey === params.originTarget && originThreadId === targetThreadId;
   }

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -103,6 +103,7 @@ function resolveTargetProviderForComparison(params: {
 function targetsMatchForSuppression(params: {
   provider: string;
   originTarget: string;
+  originThreadId?: string;
   targetKey: string;
   targetThreadId?: string;
 }): boolean {
@@ -114,6 +115,11 @@ function targetsMatchForSuppression(params: {
       targetThreadId: normalizeThreadIdForComparison(params.targetThreadId),
     });
   }
+  const originThreadId = normalizeThreadIdForComparison(params.originThreadId);
+  const targetThreadId = normalizeThreadIdForComparison(params.targetThreadId);
+  if (originThreadId || targetThreadId) {
+    return params.targetKey === params.originTarget && originThreadId === targetThreadId;
+  }
   return params.targetKey === params.originTarget;
 }
 
@@ -121,6 +127,7 @@ export function shouldSuppressMessagingToolReplies(params: {
   messageProvider?: string;
   messagingToolSentTargets?: MessagingToolSend[];
   originatingTo?: string;
+  originatingThreadId?: string | number;
   accountId?: string;
 }): boolean {
   const provider = normalizeProviderForComparison(params.messageProvider);
@@ -128,6 +135,8 @@ export function shouldSuppressMessagingToolReplies(params: {
     return false;
   }
   const originRawTarget = normalizeOptionalString(params.originatingTo);
+  const originThreadId =
+    params.originatingThreadId != null ? String(params.originatingThreadId) : undefined;
   const originAccount = normalizeOptionalAccountId(params.accountId);
   const sentTargets = params.messagingToolSentTargets ?? [];
   if (sentTargets.length === 0) {
@@ -146,7 +155,7 @@ export function shouldSuppressMessagingToolReplies(params: {
       return false;
     }
     const targetRaw = normalizeOptionalString(target.to);
-    if (originRawTarget && targetRaw === originRawTarget && !target.threadId) {
+    if (originRawTarget && targetRaw === originRawTarget && !target.threadId && !originThreadId) {
       return true;
     }
     const originTarget = normalizeTargetForProvider(provider, originRawTarget);
@@ -160,6 +169,7 @@ export function shouldSuppressMessagingToolReplies(params: {
     return targetsMatchForSuppression({
       provider,
       originTarget,
+      originThreadId,
       targetKey,
       targetThreadId: target.threadId,
     });

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -277,4 +277,21 @@ describe("shouldSuppressMessagingToolReplies", () => {
       }),
     ).toBe(true);
   });
+
+  it("ignores untrusted target-only thread ids for unthreaded providers", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "custom-channel",
+        originatingTo: "room-1",
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "custom-channel",
+            to: "room-1",
+            threadId: "attacker-controlled",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -219,4 +219,40 @@ describe("shouldSuppressMessagingToolReplies", () => {
       }),
     ).toBe(true);
   });
+
+  it("suppresses Slack replies when channel and thread both match", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "1712345678.123456",
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "1712345678.123456",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress Slack replies when channel matches but thread differs", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "1712345678.123456",
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "1712345678.999999",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -238,6 +238,17 @@ describe("shouldSuppressMessagingToolReplies", () => {
     ).toBe(true);
   });
 
+  it("suppresses Slack replies when the send implicitly uses the current thread", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "1712345678.123456",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel:C1" }],
+      }),
+    ).toBe(true);
+  });
+
   it("does not suppress Slack replies when channel matches but thread differs", () => {
     expect(
       shouldSuppressMessagingToolReplies({
@@ -254,5 +265,16 @@ describe("shouldSuppressMessagingToolReplies", () => {
         ],
       }),
     ).toBe(false);
+  });
+
+  it("ignores non-integer numeric origin thread ids for suppression matching", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel:C1" }],
+        originatingThreadId: 1712345678.123456,
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: generic `message` tool send tracking dropped `threadId`, so same-channel Slack sends were treated as the same destination even when they targeted a different thread.
- Why it matters: a threaded send could suppress the final reply for another Slack thread in the same channel, which is the wrong conversation boundary.
- What changed: preserved `threadId` for generic `message` sends and threaded the originating thread id through both direct and followup reply-suppression checks, with focused Slack regression coverage.
- What did NOT change (scope boundary): this does not alter Slack outbound transport, thread routing, or the existing `NO_REPLY` completion-delivery behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65043
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: generic `message`-tool send extraction recorded provider/account/target but dropped `threadId`, and the fallback suppression path treated same-channel Slack sends as matching even when the originating turn was in a different thread.
- Missing detection / guardrail: we had same-target suppression coverage, but no Slack regression test proving that same channel plus different thread must not suppress.
- Contributing context (if known): the current `#65043` duplicate top-level-post path appears fixed on `main`; this patch hardens the remaining thread-aware suppression edge in the same Slack/threaded completion family.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.tools.extract.test.ts`, `src/auto-reply/reply/reply-payloads.test.ts`, `src/auto-reply/reply/followup-delivery.test.ts`, `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- Scenario the test should lock in: Slack same-channel sends only suppress replies when the thread id also matches; different-thread sends in the same channel must still allow the final reply.
- Why this is the smallest reliable guardrail: the bug spans tool-send extraction plus both direct and queued reply-suppression paths, so these focused tests lock each seam without needing live Slack coverage.
- Existing test that already covers this (if any): existing same-target suppression tests covered provider/account matching but not Slack thread mismatches.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Slack threaded agent runs no longer let a `message` tool send in one thread suppress the final reply for a different thread in the same channel.

## Diagram (if applicable)

```text
Before:
[Slack thread A send via message tool] -> [same channel match] -> [thread B final reply suppressed]

After:
[Slack thread A send via message tool] -> [channel match + thread mismatch] -> [thread B final reply still delivered]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin 25.3.0
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Slack reply suppression path
- Relevant config (redacted): Slack channel replies with threaded agent runs / `message` tool sends

### Steps

1. Start in one Slack thread and trigger a `message` tool send to that thread.
2. Continue a separate Slack thread in the same channel.
3. Let the runner evaluate same-target suppression for the second thread.

### Expected

- Only the matching Slack thread can suppress its own reply.
- A different Slack thread in the same channel still receives its final reply.

### Actual

- Before this fix, same-channel comparison could suppress across Slack threads because the generic `message` tool send metadata did not keep `threadId`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: preserved `threadId` from generic `message` sends; Slack same-channel same-thread suppression; Slack same-channel different-thread non-suppression; direct runner suppression path; followup suppression path.
- Edge cases checked: account mismatch still does not suppress; non-threaded same-target suppression remains unchanged; `NO_REPLY` completion suppression remains covered separately.
- What you did **not** verify: live Slack manual repro.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: provider-specific suppression rules could diverge from the generic fallback for threaded channels.
  - Mitigation: the change only tightens the non-plugin fallback path and adds focused Slack regression coverage around both direct and queued delivery.

## Additional Notes

- AI-assisted: yes.
- Testing depth: focused regression tests passed, `pnpm build` passed, `pnpm format` passed.
- Broader repo gates: `pnpm check` and the support-boundary lane inside `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test` still hit an unrelated existing Codex TypeScript failure in `extensions/codex/src/app-server/dynamic-tools.ts` (`prepareArguments` missing on `AnyAgentTool`).

Made with [Cursor](https://cursor.com)