### PR TITLE
fix: avoid empty provider plugin load fallback

### DIFF
--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -146,6 +146,9 @@ function resolveRuntimeProviderPluginLoadState(
     env: base.env,
     onlyPluginIds: base.requestedPluginIds,
   });
+  if (providerPluginIds.length === 0) {
+    return undefined;
+  }
   const loadOptions = buildPluginRuntimeLoadOptionsFromValues(
     {
       config,
@@ -208,6 +211,9 @@ export function resolvePluginProviders(params: {
     }));
   }
   const loadState = resolveRuntimeProviderPluginLoadState(params, base);
+  if (!loadState) {
+    return [];
+  }
   const registry = resolveRuntimePluginRegistry(loadState.loadOptions);
   if (!registry) {
     return [];

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -685,6 +685,21 @@ describe("resolvePluginProviders", () => {
       }),
     );
   });
+
+  it("short-circuits runtime provider resolution when no provider plugins are enabled", () => {
+    const providers = resolvePluginProviders({
+      config: {
+        plugins: {
+          allow: ["browser"],
+        },
+      },
+      onlyPluginIds: ["browser"],
+    });
+
+    expect(providers).toEqual([]);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  });
+
   it("activates owning plugins for explicit provider refs", () => {
     setOwningProviderManifestPlugins();
 


### PR DESCRIPTION
## Summary
- short-circuit runtime provider loading when `resolveEnabledProviderPluginIds()` returns no provider plugins
- mirror the existing setup-path guard so runtime resolution does not fall back into a full registry load
- add a regression test that keeps runtime provider resolution empty when only non-provider plugins are selected

## Validation
- `pnpm exec vitest run src/plugins/providers.test.ts`
- `pnpm build`
- cloud runtime verification on the affected 2026.4.5 install: `openclaw gateway status`, `openclaw gateway health`, `openclaw status`, `openclaw tasks audit --json`