### PR TITLE
fix(discord): guard zombie gateway reconnects after close

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -1,3 +1,4 @@
+import { ListenerEvent } from "@buape/carbon/dist/src/types/index.js";
 import * as carbonGateway from "@buape/carbon/gateway";
 import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import * as httpsProxyAgent from "https-proxy-agent";
@@ -25,6 +26,22 @@ type DiscordGatewayFetch = (
 
 type DiscordGatewayMetadataError = Error & { transient?: boolean };
 type DiscordGatewayWebSocketCtor = new (url: string, options?: { agent?: unknown }) => ws.WebSocket;
+
+function normalizeGatewayMessageData(data: unknown): string {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString();
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString();
+  }
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString();
+  }
+  return String(data);
+}
 
 export function resolveDiscordGatewayIntents(
   intentsConfig?: import("openclaw/plugin-sdk/config-runtime").DiscordIntentsConfig,
@@ -288,6 +305,204 @@ function createGatewayPlugin(params: {
         }
       }
       return socket;
+    }
+
+    protected override setupWebSocket(): void {
+      if (!this.ws) {
+        return;
+      }
+      let closed = false;
+      const state = this as typeof this & {
+        isConnecting: boolean;
+        reconnectAttempts: number;
+      };
+
+      this.ws.on("open", () => {
+        state.isConnecting = false;
+        state.reconnectAttempts = 0;
+        this.emitter.emit("debug", "WebSocket connection opened");
+      });
+      this.ws.on("message", (data) => {
+        this.monitor.recordMessageReceived();
+        const payload = carbonGateway.validatePayload(normalizeGatewayMessageData(data));
+        if (!payload) {
+          this.monitor.recordError();
+          this.emitter.emit("error", new Error("Invalid gateway payload received"));
+          return;
+        }
+        const { op, d, s, t } = payload;
+        if (s !== null && s !== undefined) {
+          this.sequence = s;
+          this.state.sequence = s;
+        }
+        switch (op) {
+          case carbonGateway.GatewayOpcodes.Hello: {
+            const helloData = d;
+            const interval = helloData.heartbeat_interval;
+            carbonGateway.startHeartbeat(this, {
+              interval,
+              reconnectCallback: () => {
+                if (closed) {
+                  this.emitter.emit(
+                    "debug",
+                    "Ignoring zombie reconnect for an already-closed gateway connection",
+                  );
+                  return;
+                }
+                closed = true;
+                this.handleZombieConnection();
+              },
+            });
+            if (this.canResume()) {
+              this.resume();
+            } else {
+              this.identify();
+            }
+            break;
+          }
+          case carbonGateway.GatewayOpcodes.HeartbeatAck: {
+            this.lastHeartbeatAck = true;
+            this.monitor.recordHeartbeatAck();
+            const latency = this.monitor.getMetrics().latency;
+            if (latency > 0) {
+              this.pings.push(latency);
+              if (this.pings.length > 10) {
+                this.pings.shift();
+              }
+            }
+            break;
+          }
+          case carbonGateway.GatewayOpcodes.Heartbeat: {
+            this.lastHeartbeatAck = false;
+            this.send({
+              op: carbonGateway.GatewayOpcodes.Heartbeat,
+              d: this.sequence,
+            });
+            break;
+          }
+          case carbonGateway.GatewayOpcodes.Dispatch: {
+            const dispatchPayload = payload;
+            const eventType = dispatchPayload.t;
+            try {
+              if (!Object.values(ListenerEvent).includes(eventType)) {
+                break;
+              }
+              if (eventType === "READY") {
+                const readyData = d;
+                this.state.sessionId = readyData.session_id;
+                this.state.resumeGatewayUrl = readyData.resume_gateway_url;
+              }
+              if (t && this.client) {
+                if (!this.options.eventFilter || this.options.eventFilter?.(eventType)) {
+                  if (eventType === "READY" || eventType === "RESUMED") {
+                    this.isConnected = true;
+                  }
+                  if (eventType === "READY") {
+                    const readyData = d;
+                    readyData.guilds.forEach((guild: { id: string }) => {
+                      this.babyCache.setGuild(guild.id, {
+                        available: false,
+                        lastEvent: Date.now(),
+                      });
+                    });
+                  }
+                  if (eventType === "GUILD_CREATE") {
+                    const guildCreateData = d;
+                    const existingGuild = this.babyCache.getGuild(guildCreateData.id);
+                    if (existingGuild && !existingGuild.available) {
+                      this.babyCache.setGuild(guildCreateData.id, {
+                        available: true,
+                        lastEvent: Date.now(),
+                      });
+                      this.client.eventHandler.handleEvent(
+                        {
+                          ...guildCreateData,
+                          clientId: this.client.options.clientId,
+                        },
+                        "GUILD_AVAILABLE",
+                      );
+                      break;
+                    }
+                  }
+                  if (eventType === "GUILD_DELETE") {
+                    const guildDeleteData = d;
+                    const existingGuild = this.babyCache.getGuild(guildDeleteData.id);
+                    if (existingGuild?.available && guildDeleteData.unavailable) {
+                      this.babyCache.setGuild(guildDeleteData.id, {
+                        available: false,
+                        lastEvent: Date.now(),
+                      });
+                      this.client.eventHandler.handleEvent(
+                        {
+                          ...guildDeleteData,
+                          clientId: this.client.options.clientId,
+                        },
+                        "GUILD_UNAVAILABLE",
+                      );
+                      break;
+                    }
+                  }
+                  this.client.eventHandler.handleEvent(
+                    {
+                      ...dispatchPayload.d,
+                      clientId: this.client.options.clientId,
+                    },
+                    eventType,
+                  );
+                }
+              }
+            } catch (err) {
+              console.error(err);
+            }
+            break;
+          }
+          case carbonGateway.GatewayOpcodes.InvalidSession: {
+            const canResume = Boolean(d);
+            setTimeout(() => {
+              closed = true;
+              if (canResume && this.canResume()) {
+                this.connect(true);
+              } else {
+                this.state.sessionId = null;
+                this.state.resumeGatewayUrl = null;
+                this.state.sequence = null;
+                this.sequence = null;
+                this.pings = [];
+                this.connect(false);
+              }
+            }, 5000);
+            break;
+          }
+          case carbonGateway.GatewayOpcodes.Reconnect:
+            if (closed) {
+              this.emitter.emit(
+                "debug",
+                "Ignoring gateway reconnect opcode for an already-closed connection",
+              );
+              break;
+            }
+            closed = true;
+            this.state.sequence = this.sequence;
+            this.ws?.close();
+            this.handleReconnect();
+            break;
+        }
+      });
+      this.ws.on("close", (code) => {
+        state.isConnecting = false;
+        this.emitter.emit("debug", `WebSocket connection closed with code ${code}`);
+        this.monitor.recordReconnect();
+        if (closed) {
+          return;
+        }
+        closed = true;
+        this.handleClose(code);
+      });
+      this.ws.on("error", (error) => {
+        state.isConnecting = false;
+        this.monitor.recordError();
+        this.emitter.emit("error", error);
+      });
     }
   }
 

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -458,8 +458,8 @@ function createGatewayPlugin(params: {
           }
           case carbonGateway.GatewayOpcodes.InvalidSession: {
             const canResume = Boolean(d);
+            closed = true;
             setTimeout(() => {
-              closed = true;
               if (canResume && this.canResume()) {
                 this.connect(true);
               } else {

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -1,7 +1,11 @@
+import { EventEmitter } from "node:events";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   GatewayIntents,
+  GatewayOpcodes,
+  ListenerEvent,
+  startHeartbeatMock,
   baseRegisterClientSpy,
   GatewayPlugin,
   globalFetchMock,
@@ -21,6 +25,7 @@ const {
   const globalFetchMock = vi.fn();
   const baseRegisterClientSpy = vi.fn();
   const webSocketSpy = vi.fn();
+  const startHeartbeatMock = vi.fn();
 
   const GatewayIntents = {
     Guilds: 1 << 0,
@@ -33,9 +38,58 @@ const {
     GuildMembers: 1 << 7,
   } as const;
 
+  const GatewayOpcodes = {
+    Dispatch: 0,
+    Heartbeat: 1,
+    Reconnect: 7,
+    InvalidSession: 9,
+    Hello: 10,
+    HeartbeatAck: 11,
+  } as const;
+
+  const ListenerEvent = {
+    Ready: "READY",
+    Resumed: "RESUMED",
+    GuildCreate: "GUILD_CREATE",
+    GuildDelete: "GUILD_DELETE",
+  } as const;
+
   class GatewayPlugin {
     options: unknown;
     gatewayInfo: unknown;
+    ws: EventEmitter | null = null;
+    emitter = new EventEmitter();
+    monitor = {
+      recordMessageReceived: vi.fn(),
+      recordError: vi.fn(),
+      recordHeartbeatAck: vi.fn(),
+      recordReconnect: vi.fn(),
+      getMetrics: vi.fn(() => ({ latency: 0 })),
+    };
+    state = { sequence: null, sessionId: null, resumeGatewayUrl: null };
+    sequence: number | null = null;
+    lastHeartbeatAck = true;
+    isConnected = false;
+    pings: number[] = [];
+    babyCache = {
+      setGuild: vi.fn(),
+      getGuild: vi.fn(),
+    };
+    client:
+      | {
+          options: { clientId: string };
+          eventHandler: { handleEvent: ReturnType<typeof vi.fn> };
+        }
+      | undefined;
+    connect = vi.fn();
+    disconnect = vi.fn();
+    handleZombieConnection = vi.fn();
+    handleReconnect = vi.fn();
+    handleClose = vi.fn();
+    canResume = vi.fn(() => false);
+    resume = vi.fn();
+    identify = vi.fn();
+    send = vi.fn();
     constructor(options?: unknown, gatewayInfo?: unknown) {
       this.options = options;
       this.gatewayInfo = gatewayInfo;
@@ -61,11 +115,14 @@ const {
   return {
     baseRegisterClientSpy,
     GatewayIntents,
+    GatewayOpcodes,
     GatewayPlugin,
     globalFetchMock,
     HttpsProxyAgent,
+    ListenerEvent,
     getLastAgent: () => HttpsProxyAgent.lastCreated,
     restProxyAgentSpy,
+    startHeartbeatMock,
     undiciFetchMock,
     undiciProxyAgentSpy,
     resetLastAgent: () => {
@@ -79,12 +136,22 @@ const {
 // Unit test: don't import Carbon just to check the prototype chain.
 vi.mock("@buape/carbon/gateway", () => ({
   GatewayIntents,
+  GatewayOpcodes,
   GatewayPlugin,
+  startHeartbeat: startHeartbeatMock,
+  validatePayload: (raw: string) => JSON.parse(raw),
 }));
 
 vi.mock("@buape/carbon/dist/src/plugins/gateway/index.js", () => ({
   GatewayIntents,
+  GatewayOpcodes,
   GatewayPlugin,
+  startHeartbeat: startHeartbeatMock,
+  validatePayload: (raw: string) => JSON.parse(raw),
+}));
+
+vi.mock("@buape/carbon/dist/src/types/index.js", () => ({
+  ListenerEvent,
 }));
 
 vi.mock("https-proxy-agent", () => ({
@@ -219,6 +286,7 @@ describe("createDiscordGatewayPlugin", () => {
     baseRegisterClientSpy.mockClear();
     globalFetchMock.mockClear();
     restProxyAgentSpy.mockClear();
+    startHeartbeatMock.mockClear();
     undiciFetchMock.mockClear();
     undiciProxyAgentSpy.mockClear();
     wsProxyAgentSpy.mockClear();
@@ -437,5 +505,72 @@ describe("createDiscordGatewayPlugin", () => {
       url: "wss://gateway.discord.gg/?v=10",
       shards: 8,
     });
+  });
+
+  it("ignores zombie heartbeat reconnect callbacks after the socket is already closed", () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    }) as unknown as {
+      ws: EventEmitter;
+      setupWebSocket: () => void;
+      emitter: EventEmitter;
+      handleZombieConnection: ReturnType<typeof vi.fn>;
+    };
+    const debugEvents: string[] = [];
+    const socket = new EventEmitter();
+
+    plugin.ws = socket;
+    plugin.emitter.on("debug", (message) => debugEvents.push(String(message)));
+    plugin.setupWebSocket();
+
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ op: GatewayOpcodes.Hello, d: { heartbeat_interval: 1000 } })),
+    );
+    socket.emit("close", 1000, "");
+
+    const reconnectCallback = startHeartbeatMock.mock.calls.at(-1)?.[1]?.reconnectCallback as
+      | (() => void)
+      | undefined;
+
+    expect(reconnectCallback).toBeTypeOf("function");
+    expect(() => reconnectCallback?.()).not.toThrow();
+    expect(plugin.handleZombieConnection).not.toHaveBeenCalled();
+    expect(debugEvents).toContain(
+      "Ignoring zombie reconnect for an already-closed gateway connection",
+    );
+  });
+
+  it("ignores reconnect opcodes after the socket is already closed", () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    }) as unknown as {
+      ws: EventEmitter & { close: ReturnType<typeof vi.fn> };
+      setupWebSocket: () => void;
+      emitter: EventEmitter;
+      handleReconnect: ReturnType<typeof vi.fn>;
+    };
+    const debugEvents: string[] = [];
+    const socket = new EventEmitter() as EventEmitter & { close: ReturnType<typeof vi.fn> };
+    socket.close = vi.fn();
+
+    plugin.ws = socket;
+    plugin.emitter.on("debug", (message) => debugEvents.push(String(message)));
+    plugin.setupWebSocket();
+
+    socket.emit("close", 1000, "");
+
+    expect(() =>
+      socket.emit("message", Buffer.from(JSON.stringify({ op: GatewayOpcodes.Reconnect }))),
+    ).not.toThrow();
+    expect(plugin.handleReconnect).not.toHaveBeenCalled();
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(debugEvents).toContain(
+      "Ignoring gateway reconnect opcode for an already-closed connection",
+    );
   });
 });

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -573,4 +573,40 @@ describe("createDiscordGatewayPlugin", () => {
       "Ignoring gateway reconnect opcode for an already-closed connection",
     );
   });
+
+  it("marks invalid-session reconnects as closed before the delayed reconnect fires", () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = createRuntime();
+      const plugin = createDiscordGatewayPlugin({
+        discordConfig: {},
+        runtime,
+      }) as unknown as {
+        ws: EventEmitter & { close: ReturnType<typeof vi.fn> };
+        setupWebSocket: () => void;
+        connect: ReturnType<typeof vi.fn>;
+        handleClose: ReturnType<typeof vi.fn>;
+      };
+      const socket = new EventEmitter() as EventEmitter & { close: ReturnType<typeof vi.fn> };
+      socket.close = vi.fn();
+
+      plugin.ws = socket;
+      plugin.setupWebSocket();
+
+      socket.emit(
+        "message",
+        Buffer.from(JSON.stringify({ op: GatewayOpcodes.InvalidSession, d: false })),
+      );
+      socket.emit("close", 1000, "");
+
+      expect(plugin.handleClose).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(5_000);
+
+      expect(plugin.connect).toHaveBeenCalledTimes(1);
+      expect(plugin.connect).toHaveBeenCalledWith(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- guard Discord gateway heartbeat reconnect callbacks after the socket has already closed
- ignore late gateway reconnect opcodes on already-closed connections instead of throwing
- add regression coverage for both stale-socket/zombie reconnect paths

## Context
On a local OpenClaw gateway, Discord could crash the whole process during stale-socket recovery with:
`Attempted to reconnect zombie connection after disconnecting first (this shouldn't be possible)`

This change keeps the reconnect path idempotent inside OpenClaw's `SafeGatewayPlugin`, so late heartbeat/reconnect events do not escalate into a process-level crash.

## Validation
- ran targeted regression tests with a minimal Vitest config:
  `pnpm exec vitest run --config /tmp/openclaw-min-vitest.config.ts extensions/discord/src/monitor/provider.proxy.test.ts`
- result: `14 passed`

## Notes
- the repo pre-commit `check` chain was long-running in this environment, so this PR relies on the targeted regression run above rather than a full repo-wide check.