### PR TITLE
test(release): require QA scenario pack in npm tarball

### DIFF
--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -55,7 +55,18 @@ export type NpmDistTagMirrorAuth = {
 };
 const EXPECTED_REPOSITORY_URL = "https://github.com/openclaw/openclaw";
 const MAX_CALVER_DISTANCE_DAYS = 2;
-const REQUIRED_PACKED_PATHS = ["dist/control-ui/index.html"];
+const REQUIRED_PACKED_PATH_RULES = [
+  {
+    path: "dist/control-ui/index.html",
+    describe: (requiredPath: string) =>
+      `npm package is missing required path "${requiredPath}". Ensure UI assets are built and included before publish.`,
+  },
+  {
+    path: "qa/scenarios/index.md",
+    describe: (requiredPath: string) =>
+      `npm package is missing required QA scenario pack path "${requiredPath}". Include qa/scenarios in the published tarball so completion cache and QA CLI registration do not fail.`,
+  },
+] as const;
 const CONTROL_UI_ASSET_PREFIX = "dist/control-ui/assets/";
 const FORBIDDEN_PACKED_PATH_RULES = [
   {
@@ -406,11 +417,9 @@ export function collectControlUiPackErrors(paths: Iterable<string>): string[] {
   const assetPaths = [...packedPaths].filter((path) => path.startsWith(CONTROL_UI_ASSET_PREFIX));
   const errors: string[] = [];
 
-  for (const requiredPath of REQUIRED_PACKED_PATHS) {
-    if (!packedPaths.has(requiredPath)) {
-      errors.push(
-        `npm package is missing required path "${requiredPath}". Ensure UI assets are built and included before publish.`,
-      );
+  for (const rule of REQUIRED_PACKED_PATH_RULES) {
+    if (!packedPaths.has(rule.path)) {
+      errors.push(rule.describe(rule.path));
     }
   }
 

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -278,8 +278,16 @@ describe("parseNpmPackJsonOutput", () => {
 });
 
 describe("collectControlUiPackErrors", () => {
-  it("rejects packs that ship the dashboard HTML without the asset payload", () => {
+  it("rejects packs missing required published paths", () => {
     expect(collectControlUiPackErrors(["dist/control-ui/index.html"])).toEqual([
+      'npm package is missing required QA scenario pack path "qa/scenarios/index.md". Include qa/scenarios in the published tarball so completion cache and QA CLI registration do not fail.',
+      'npm package is missing Control UI asset payload under "dist/control-ui/assets/". Refuse release when the dashboard tarball would be empty.',
+    ]);
+  });
+
+  it("rejects packs missing the dashboard HTML entrypoint", () => {
+    expect(collectControlUiPackErrors(["qa/scenarios/index.md"])).toEqual([
+      'npm package is missing required path "dist/control-ui/index.html". Ensure UI assets are built and included before publish.',
       'npm package is missing Control UI asset payload under "dist/control-ui/assets/". Refuse release when the dashboard tarball would be empty.',
     ]);
   });
@@ -290,6 +298,7 @@ describe("collectControlUiPackErrors", () => {
         "dist/control-ui/index.html",
         "dist/control-ui/assets/index-Bu8rSoJV.js",
         "dist/control-ui/assets/index-BK0yXA_h.css",
+        "qa/scenarios/index.md",
       ]),
     ).toEqual([]);
   });


### PR DESCRIPTION
Fixes #65082

## Summary
- require `qa/scenarios/index.md` in the npm dry-run pack validation
- add focused release-check coverage for missing QA scenario pack paths
- keep the existing Control UI tarball validation while making the required-path errors explicit per path

## Why
The current tree already includes `qa/scenarios/` in `package.json`, so the useful prevention here is release-time validation. This makes npm publish checks fail if a future packaging change drops the QA scenario pack and would re-break completion cache generation after update.

## Validation
- `pnpm vitest run test/openclaw-npm-release-check.test.ts`
- `pnpm lint scripts/openclaw-npm-release-check.ts test/openclaw-npm-release-check.test.ts`
