### PR TITLE
fix: allow built-in chat commands to bypass plugins.allow check (closes #65083)

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -118,8 +118,17 @@ export function resolveMissingPluginCommandMessage(
   }
 
   if (allow.length > 0 && !allow.includes(normalizedPluginId)) {
+    // If there's no plugin entry for this command in the config and no manifest
+    // alias was found, it's likely a built-in chat command (e.g. "commands",
+    // "help") that doesn't require plugin allow-listing.  Return null so the
+    // command can proceed to its normal handler.
+    const hasPluginEntry =
+      config?.plugins?.entries?.[normalizedPluginId] !== undefined;
+    if (!hasPluginEntry && !commandAlias) {
+      return null;
+    }
     return (
-      `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
+      `The \`${normalizedPluginId}\` command is unavailable because ` +
       `\`plugins.allow\` excludes "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +
       `\`plugins.allow\` if you want that bundled plugin CLI surface.`
     );


### PR DESCRIPTION
Closes #65083.

## Summary
The `openclaw commands` command is a built-in chat command registered in the chat commands registry, not a plugin-backed CLI command.

When `plugins.allow` is configured, running `openclaw commands` shows a misleading error suggesting users add "commands" to `plugins.allow`. However, adding "commands" to plugins.allow produces a second error: "plugin not found: commands" because no such plugin exists.

## Fix
Before suggesting to add a command to `plugins.allow`, check if:
1. The command has a corresponding plugin entry in the config
2. The command has a manifest alias registered by a plugin

If neither exists, the command is likely a built-in chat command that should proceed normally instead of showing a misleading plugins.allow error.

## Why This Matters
- Users with `plugins.allow` configured see confusing errors for built-in commands
- The suggested fix (adding to plugins.allow) doesn't work and causes a second error
- Simple defensive check, zero risk for existing plugin commands