### PR TITLE
doctor: warn about orphaned agent dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Matrix/mentions: keep room mention gating strict while accepting visible `@displayName` Matrix URI labels, so `requireMention` works for non-OpenClaw Matrix clients again. (#64796) Thanks @hclsys.
+- Doctor: warn when on-disk agent directories still exist under `~/.openclaw/agents/<id>/agent` but the matching `agents.list[]` entries are missing from config. (#65113) Thanks @neeravmakwana.
 
 ## 2026.4.11
 

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -58,6 +58,17 @@ function stateIntegrityText(): string {
     .join("\n");
 }
 
+function createAgentDir(agentId: string, includeNestedAgentDir = true) {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is not set");
+  }
+  const targetDir = includeNestedAgentDir
+    ? path.join(stateDir, "agents", agentId, "agent")
+    : path.join(stateDir, "agents", agentId);
+  fs.mkdirSync(targetDir, { recursive: true });
+}
+
 const OAUTH_PROMPT_MATCHER = expect.objectContaining({
   message: expect.stringContaining("Create OAuth dir at"),
 });
@@ -142,6 +153,36 @@ describe("doctor state integrity oauth dir checks", () => {
     const confirmRuntimeRepair = await runStateIntegrity(cfg);
     expect(confirmRuntimeRepair).toHaveBeenCalledWith(OAUTH_PROMPT_MATCHER);
     expect(stateIntegrityText()).toContain("CRITICAL: OAuth dir missing");
+  });
+
+  it("warns about orphaned on-disk agent directories missing from agents.list", async () => {
+    createAgentDir("big-brain");
+    createAgentDir("cerebro");
+
+    const text = await runStateIntegrityText({
+      agents: {
+        list: [{ id: "main", default: true }],
+      },
+    });
+
+    expect(text).toContain("without a matching agents.list entry");
+    expect(text).toContain("Examples: big-brain, cerebro");
+    expect(text).toContain("config-driven routing, identity, and model selection will ignore them");
+  });
+
+  it("ignores configured agent dirs and incomplete agent folders", async () => {
+    createAgentDir("main");
+    createAgentDir("ops");
+    createAgentDir("staging", false);
+
+    const text = await runStateIntegrityText({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    });
+
+    expect(text).not.toContain("without a matching agents.list entry");
+    expect(text).not.toContain("Examples:");
   });
 
   it("detects orphan transcripts and offers archival remediation", async () => {

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -170,6 +170,19 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(text).toContain("config-driven routing, identity, and model selection will ignore them");
   });
 
+  it("detects orphaned agent dirs even when the on-disk folder casing differs", async () => {
+    createAgentDir("Research");
+
+    const text = await runStateIntegrityText({
+      agents: {
+        list: [{ id: "main", default: true }],
+      },
+    });
+
+    expect(text).toContain("without a matching agents.list entry");
+    expect(text).toContain("Examples: research");
+  });
+
   it("ignores configured agent dirs and incomplete agent folders", async () => {
     createAgentDir("main");
     createAgentDir("ops");

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -180,7 +180,7 @@ describe("doctor state integrity oauth dir checks", () => {
     });
 
     expect(text).toContain("without a matching agents.list entry");
-    expect(text).toContain("Examples: research");
+    expect(text).toContain("Examples: Research (id research)");
   });
 
   it("ignores configured agent dirs and incomplete agent folders", async () => {
@@ -196,6 +196,67 @@ describe("doctor state integrity oauth dir checks", () => {
 
     expect(text).not.toContain("without a matching agents.list entry");
     expect(text).not.toContain("Examples:");
+  });
+
+  it("warns when a case-mismatched agent dir does not resolve to the configured agent path", async () => {
+    createAgentDir("Research");
+
+    const realpathNative = fs.realpathSync.native.bind(fs.realpathSync);
+    const realpathSpy = vi
+      .spyOn(fs.realpathSync, "native")
+      .mockImplementation((target, options) => {
+        const targetPath = String(target);
+        if (targetPath.endsWith(`${path.sep}agents${path.sep}research${path.sep}agent`)) {
+          const error = new Error("ENOENT");
+          (error as NodeJS.ErrnoException).code = "ENOENT";
+          throw error;
+        }
+        return realpathNative(target, options);
+      });
+
+    try {
+      const text = await runStateIntegrityText({
+        agents: {
+          list: [{ id: "main", default: true }, { id: "research" }],
+        },
+      });
+
+      expect(text).toContain("without a matching agents.list entry");
+      expect(text).toContain("Examples: Research (id research)");
+    } finally {
+      realpathSpy.mockRestore();
+    }
+  });
+
+  it("does not warn when a case-mismatched dir resolves to the configured agent path", async () => {
+    createAgentDir("Research");
+
+    const realpathNative = fs.realpathSync.native.bind(fs.realpathSync);
+    const resolvedResearchAgentDir = realpathNative(
+      path.join(process.env.OPENCLAW_STATE_DIR ?? "", "agents", "Research", "agent"),
+    );
+    const realpathSpy = vi
+      .spyOn(fs.realpathSync, "native")
+      .mockImplementation((target, options) => {
+        const targetPath = String(target);
+        if (targetPath.endsWith(`${path.sep}agents${path.sep}research${path.sep}agent`)) {
+          return resolvedResearchAgentDir;
+        }
+        return realpathNative(target, options);
+      });
+
+    try {
+      const text = await runStateIntegrityText({
+        agents: {
+          list: [{ id: "main", default: true }, { id: "research" }],
+        },
+      });
+
+      expect(text).not.toContain("without a matching agents.list entry");
+      expect(text).not.toContain("Examples:");
+    } finally {
+      realpathSpy.mockRestore();
+    }
   });
 
   it("detects orphan transcripts and offers archival remediation", async () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -60,7 +60,48 @@ function existsFile(filePath: string): boolean {
   }
 }
 
-function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): string[] {
+type OrphanAgentDir = {
+  dirName: string;
+  agentId: string;
+};
+
+function tryResolveNativeRealPath(targetPath: string): string | null {
+  try {
+    return fs.realpathSync.native(targetPath);
+  } catch {
+    return null;
+  }
+}
+
+function isReachableConfiguredAgentDir(params: {
+  agentsRoot: string;
+  dirName: string;
+  agentId: string;
+}): boolean {
+  if (params.dirName === params.agentId) {
+    return true;
+  }
+  const rawDir = path.join(params.agentsRoot, params.dirName, "agent");
+  const normalizedDir = path.join(params.agentsRoot, params.agentId, "agent");
+  const rawRealPath = tryResolveNativeRealPath(rawDir);
+  const normalizedRealPath = tryResolveNativeRealPath(normalizedDir);
+  return rawRealPath !== null && rawRealPath === normalizedRealPath;
+}
+
+function formatOrphanAgentDirLabel(entry: OrphanAgentDir): string {
+  return entry.dirName === entry.agentId ? entry.agentId : `${entry.dirName} (id ${entry.agentId})`;
+}
+
+function formatOrphanAgentDirPreview(entries: OrphanAgentDir[], limit = 3): string {
+  const labels = entries.slice(0, limit).map(formatOrphanAgentDirLabel);
+  const remaining = entries.length - labels.length;
+  if (remaining > 0) {
+    return `${labels.join(", ")}, and ${remaining} more`;
+  }
+  return labels.join(", ");
+}
+
+function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): OrphanAgentDir[] {
   const configuredIds = new Set<string>();
   configuredIds.add(normalizeAgentId(resolveDefaultAgentId(cfg)));
   for (const entry of listAgentEntries(cfg)) {
@@ -77,13 +118,26 @@ function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): string[] {
         agentId: normalizeAgentId(entry.name),
       }))
       .filter(({ dirName, agentId }) => {
-        if (!agentId || configuredIds.has(agentId)) {
+        if (!agentId) {
           return false;
         }
-        return existsDir(path.join(agentsRoot, dirName, "agent"));
+        const hasNestedAgentDir = existsDir(path.join(agentsRoot, dirName, "agent"));
+        if (!hasNestedAgentDir) {
+          return false;
+        }
+        if (!configuredIds.has(agentId)) {
+          return true;
+        }
+        return !isReachableConfiguredAgentDir({
+          agentsRoot,
+          dirName,
+          agentId,
+        });
       })
-      .map(({ agentId }) => agentId)
-      .toSorted((left, right) => left.localeCompare(right));
+      .toSorted(
+        (left, right) =>
+          left.agentId.localeCompare(right.agentId) || left.dirName.localeCompare(right.dirName),
+      );
   } catch {
     return [];
   }
@@ -754,7 +808,7 @@ export async function noteStateIntegrity(
       [
         `- Found ${countLabel(orphanAgentDirs.length, "agent directory")} on disk without a matching agents.list entry.`,
         "  These agents can still have sessions/auth state on disk, but config-driven routing, identity, and model selection will ignore them.",
-        `  Examples: ${orphanAgentDirs.slice(0, 3).join(", ")}${orphanAgentDirs.length > 3 ? `, and ${orphanAgentDirs.length - 3} more` : ""}`,
+        `  Examples: ${formatOrphanAgentDirPreview(orphanAgentDirs)}`,
         `  Restore the missing agents.list entries or remove stale dirs after confirming they are no longer needed: ${shortenHomePath(path.join(stateDir, "agents"))}`,
       ].join("\n"),
     );

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -118,9 +118,6 @@ function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): OrphanAgent
         agentId: normalizeAgentId(entry.name),
       }))
       .filter(({ dirName, agentId }) => {
-        if (!agentId) {
-          return false;
-        }
         const hasNestedAgentDir = existsDir(path.join(agentsRoot, dirName, "agent"));
         if (!hasNestedAgentDir) {
           return false;
@@ -806,7 +803,7 @@ export async function noteStateIntegrity(
   if (orphanAgentDirs.length > 0) {
     warnings.push(
       [
-        `- Found ${countLabel(orphanAgentDirs.length, "agent directory")} on disk without a matching agents.list entry.`,
+        `- Found ${countLabel(orphanAgentDirs.length, "agent directory", "agent directories")} on disk without a matching agents.list entry.`,
         "  These agents can still have sessions/auth state on disk, but config-driven routing, identity, and model selection will ignore them.",
         `  Examples: ${formatOrphanAgentDirPreview(orphanAgentDirs)}`,
         `  Restore the missing agents.list entries or remove stale dirs after confirming they are no longer needed: ${shortenHomePath(path.join(stateDir, "agents"))}`,

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listAgentEntries, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { listBundledChannelPluginIds } from "../channels/plugins/bundled-ids.js";
 import { hasBundledChannelPersistedAuthState } from "../channels/plugins/persisted-auth-state.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -19,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { resolveMemoryBackendConfig } from "../memory-host-sdk/engine-storage.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { asNullableObjectRecord } from "../shared/record-coerce.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
@@ -56,6 +57,31 @@ function existsFile(filePath: string): boolean {
     return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
   } catch {
     return false;
+  }
+}
+
+function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): string[] {
+  const configuredIds = new Set<string>();
+  configuredIds.add(normalizeAgentId(resolveDefaultAgentId(cfg)));
+  for (const entry of listAgentEntries(cfg)) {
+    configuredIds.add(normalizeAgentId(entry.id));
+  }
+
+  const agentsRoot = path.join(stateDir, "agents");
+  try {
+    const entries = fs.readdirSync(agentsRoot, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => normalizeAgentId(entry.name))
+      .filter((agentId) => {
+        if (!agentId || configuredIds.has(agentId)) {
+          return false;
+        }
+        return existsDir(path.join(agentsRoot, agentId, "agent"));
+      })
+      .toSorted((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
   }
 }
 
@@ -714,6 +740,18 @@ export async function noteStateIntegrity(
         "- Multiple state directories detected. This can split session history.",
         ...Array.from(extraStateDirs).map((dir) => `  - ${shortenHomePath(dir)}`),
         `  Active state dir: ${displayStateDir}`,
+      ].join("\n"),
+    );
+  }
+
+  const orphanAgentDirs = listOrphanAgentDirs(cfg, stateDir);
+  if (orphanAgentDirs.length > 0) {
+    warnings.push(
+      [
+        `- Found ${countLabel(orphanAgentDirs.length, "agent directory")} on disk without a matching agents.list entry.`,
+        "  These agents can still have sessions/auth state on disk, but config-driven routing, identity, and model selection will ignore them.",
+        `  Examples: ${orphanAgentDirs.slice(0, 3).join(", ")}${orphanAgentDirs.length > 3 ? `, and ${orphanAgentDirs.length - 3} more` : ""}`,
+        `  Restore the missing agents.list entries or remove stale dirs after confirming they are no longer needed: ${shortenHomePath(path.join(stateDir, "agents"))}`,
       ].join("\n"),
     );
   }

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -72,13 +72,17 @@ function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): string[] {
     const entries = fs.readdirSync(agentsRoot, { withFileTypes: true });
     return entries
       .filter((entry) => entry.isDirectory())
-      .map((entry) => normalizeAgentId(entry.name))
-      .filter((agentId) => {
+      .map((entry) => ({
+        dirName: entry.name,
+        agentId: normalizeAgentId(entry.name),
+      }))
+      .filter(({ dirName, agentId }) => {
         if (!agentId || configuredIds.has(agentId)) {
           return false;
         }
-        return existsDir(path.join(agentsRoot, agentId, "agent"));
+        return existsDir(path.join(agentsRoot, dirName, "agent"));
       })
+      .map(({ agentId }) => agentId)
       .toSorted((left, right) => left.localeCompare(right));
   } catch {
     return [];


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` did not warn when `~/.openclaw/agents/<id>/agent` directories still existed on disk but the matching `agents.list[]` entries were missing from config.
- Why it matters: a partially lost config can leave agent state on disk while routing, identity, and model selection ignore those agents, which makes recovery confusing.
- What changed: the state-integrity doctor pass now scans on-disk agent directories and warns when they no longer have matching `agents.list[]` entries.
- What did NOT change (scope boundary): this PR does not reconstruct missing agent config automatically or change the already-fixed backup/update recovery paths from #65105.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65105
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: doctor only checked general state/session integrity and never compared on-disk agent directories against configured `agents.list[]` entries.
- Missing detection / guardrail: no doctor warning existed for orphaned agent directories, even though some runtime surfaces can still discover agents from disk.
- Contributing context (if known): the original report in #65105 described agent directories remaining on disk after config loss, but doctor did not flag that mismatch.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor-state-integrity.test.ts`
- Scenario the test should lock in: doctor warns for real orphaned `~/.openclaw/agents/<id>/agent` directories, but ignores configured agents and incomplete folders.
- Why this is the smallest reliable guardrail: the new behavior is isolated to the doctor state-integrity scan and can be exercised deterministically with a temp state dir.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw doctor` now warns when agent state directories exist on disk without matching `agents.list[]` entries in config.

## Diagram (if applicable)

```text
Before:
[config loses agents.list entries] -> [agent dirs still exist on disk] -> [doctor stays silent]

After:
[config loses agents.list entries] -> [agent dirs still exist on disk] -> [doctor warns about orphaned agent dirs]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.0
- Runtime/container: Node 25 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): doctor CLI
- Relevant config (redacted): config with only `agents.list: [{ id: "main", default: true }]` plus extra on-disk agent dirs under `~/.openclaw/agents/`

### Steps

1. Create `~/.openclaw/agents/big-brain/agent` and `~/.openclaw/agents/cerebro/agent` in a temp state dir.
2. Run `noteStateIntegrity()` with config that only defines `main` in `agents.list`.
3. Inspect the emitted doctor state-integrity text.

### Expected

- Doctor warns that on-disk agent directories exist without matching `agents.list[]` entries.

### Actual

- Doctor now emits that warning and includes example agent ids.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted regression test for orphaned agent detection; targeted regression test for configured-agent and incomplete-folder false positives; repo-wide `pnpm check`.
- Edge cases checked: default agent remains ignored; incomplete `~/.openclaw/agents/<id>` folders without nested `agent/` do not warn.
- What you did **not** verify: full end-to-end recovery from a historical config wipe; `pnpm build` is currently failing in the existing tree due to an unrelated `extensions/acpx/src/runtime.ts` export-resolution error.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: stale non-agent directories under `~/.openclaw/agents/` could be mistaken for orphaned agents.
  - Mitigation: the warning only considers directories that contain the nested `agent/` runtime dir, and tests cover the incomplete-folder false-positive case.

AI assistance: prepared with an agent, with the code path, tests, and verification reviewed before submission.

Made with [Cursor](https://cursor.com)