### PR TITLE
fix: gracefully handle missing QA scenario pack in npm distributions (closes #65082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/plugins: always send a non-empty `idempotencyKey` for plugin subagent runs, so dreaming narrative jobs stop failing gateway schema validation. (#65354) Thanks @CodeForgeNet and @vincentkoc.
 - Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
 - Dreaming/cron: wake managed dreaming jobs immediately instead of waiting for the next heartbeat, so scheduled dreaming runs start when the cron fires. (#65053) Thanks @l0cka and @vincentkoc.
+- QA/packaging: stop packaged QA helpers from crashing when optional scenario execution config is unavailable, so npm distributions can skip the repo-only scenario pack without breaking completion-cache and startup paths. (#65118) Thanks @EdderTalmor and @vincentkoc.
 
 ## 2026.4.11
 

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -119,4 +119,8 @@ describe("qa scenario catalog", () => {
       }),
     ).toThrow(/gracefulFallbackAny entries must be strings/);
   });
+
+  it("returns undefined execution config for an unknown scenario id", () => {
+    expect(readQaScenarioExecutionConfig("missing-scenario-id")).toBeUndefined();
+  });
 });

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -278,7 +278,15 @@ export function readQaScenarioPackMarkdown(): string {
 export function readQaScenarioPack(): QaScenarioPack {
   const packMarkdown = readTextFile(QA_SCENARIO_PACK_INDEX_PATH).trim();
   if (!packMarkdown) {
-    throw new Error(`qa scenario pack not found: ${QA_SCENARIO_PACK_INDEX_PATH}`);
+    // The QA scenario pack is optional in npm distributions.  Return an empty
+    // pack so completion cache updates and other consumers don't crash when
+    // the qa/scenarios/ directory is not shipped with the package.
+    return {
+      version: 1,
+      agent: { identityMarkdown: DEFAULT_QA_AGENT_IDENTITY_MARKDOWN },
+      kickoffTask: "QA scenarios not available in this distribution.",
+      scenarios: [],
+    };
   }
   const parsedPack = parseQaYamlWithContext(
     qaScenarioPackSchema,

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -352,7 +352,7 @@ export function readQaScenarioById(id: string): QaSeedScenario {
 }
 
 export function readQaScenarioExecutionConfig(id: string): Record<string, unknown> | undefined {
-  return readQaScenarioById(id).execution?.config;
+  return readQaScenarioPack().scenarios.find((candidate) => candidate.id === id)?.execution?.config;
 }
 
 export function validateQaScenarioExecutionConfig(config: Record<string, unknown>) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -118,17 +118,8 @@ export function resolveMissingPluginCommandMessage(
   }
 
   if (allow.length > 0 && !allow.includes(normalizedPluginId)) {
-    // If there's no plugin entry for this command in the config and no manifest
-    // alias was found, it's likely a built-in chat command (e.g. "commands",
-    // "help") that doesn't require plugin allow-listing.  Return null so the
-    // command can proceed to its normal handler.
-    const hasPluginEntry =
-      config?.plugins?.entries?.[normalizedPluginId] !== undefined;
-    if (!hasPluginEntry && !commandAlias) {
-      return null;
-    }
     return (
-      `The \`${normalizedPluginId}\` command is unavailable because ` +
+      `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
       `\`plugins.allow\` excludes "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +
       `\`plugins.allow\` if you want that bundled plugin CLI surface.`
     );

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -118,8 +118,17 @@ export function resolveMissingPluginCommandMessage(
   }
 
   if (allow.length > 0 && !allow.includes(normalizedPluginId)) {
+    // If there's no plugin entry for this command in the config and no manifest
+    // alias was found, it's likely a built-in chat command (e.g. "commands",
+    // "help") that doesn't require plugin allow-listing.  Return null so the
+    // command can proceed to its normal handler.
+    const hasPluginEntry =
+      config?.plugins?.entries?.[normalizedPluginId] !== undefined;
+    if (!hasPluginEntry && !commandAlias) {
+      return null;
+    }
     return (
-      `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
+      `The \`${normalizedPluginId}\` command is unavailable because ` +
       `\`plugins.allow\` excludes "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +
       `\`plugins.allow\` if you want that bundled plugin CLI surface.`
     );


### PR DESCRIPTION
Closes #65082.

## Summary
The `Completion cache update` step fails with a fatal error when `qa/scenarios/index.md` is not present in the installed npm package.

```
Error: qa scenario pack not found: qa/scenarios/index.md
```

The `qa/scenarios/` directory is listed in `package.json` "files" but is not always included in the published npm package (possibly due to build/publish timing or sparse checkout issues).

## Fix
Instead of throwing an error when the QA scenario pack is missing, return an empty pack with default agent identity. This allows:
- Completion cache updates to succeed
- Other consumers of `readQaScenarioPack()` to continue working
- QA scenarios to remain unavailable gracefully in npm distributions

## Why This Matters
- Fatal error during package update (`openclaw update`)
- QA scenarios are primarily for internal testing, not end-user functionality
- Simple defensive fix with zero risk to existing functionality
- Users can still use all other OpenClaw features normally