### PR TITLE
fix: validate channel requirement at cron job creation time (#53379)

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -17,6 +17,7 @@ import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool, readGatewayCallOptions, type GatewayCallOptions } from "./gateway.js";
 import { isOpenClawOwnerOnlyCoreToolName } from "./owner-only-tools.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
+import { listConfiguredMessageChannels } from "../../infra/outbound/channel-selection.js";
 
 // We spell out job/patch properties so that LLMs know what fields to send.
 // Nested unions are avoided; runtime validation happens in normalizeCronJob*.
@@ -577,6 +578,37 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                   ...delivery,
                   ...inferred,
                 } satisfies CronDelivery;
+              }
+            }
+
+            // Validate: if delivery.mode is announce/empty and no explicit
+            // channel/to, require explicit targeting when multiple channels configured
+            const finalDelivery = (job as { delivery?: unknown }).delivery;
+            const finalMode =
+              typeof finalDelivery === "object" &&
+              finalDelivery !== null &&
+              "mode" in finalDelivery &&
+              typeof finalDelivery.mode === "string"
+                ? normalizeLowercaseStringOrEmpty(finalDelivery.mode)
+                : "";
+            const hasExplicitTarget =
+              typeof finalDelivery === "object" &&
+              finalDelivery !== null &&
+              (("channel" in finalDelivery &&
+                typeof finalDelivery.channel === "string" &&
+                finalDelivery.channel.trim()) ||
+                ("to" in finalDelivery &&
+                  typeof finalDelivery.to === "string" &&
+                  finalDelivery.to.trim()));
+            if (
+              (finalMode === "" || finalMode === "announce") &&
+              !hasExplicitTarget
+            ) {
+              const configuredChannels = await listConfiguredMessageChannels(cfg);
+              if (configuredChannels.length > 1) {
+                throw new Error(
+                  `Channel is required when multiple channels are configured: ${configuredChannels.join(", ")}. Set delivery.channel or delivery.to explicitly.`,
+                );
               }
             }
           }


### PR DESCRIPTION
## Summary

Fixes #53379

When multiple messaging channels are configured (e.g. Discord + Telegram + WhatsApp), cron jobs with `delivery.mode: "announce"` or empty delivery silently fail at delivery time because no channel is specified.

## Problem

Currently, if you create a cron job without specifying `delivery.channel` or `delivery.to`, and multiple channels are configured, the job is created successfully but silently fails when it tries to deliver. The user gets no feedback until the job runs and nothing shows up.

## Solution

Validate at **creation time** instead of delivery time:

1. After delivery inference resolves the mode to `"announce"` (or empty)
2. Check if `delivery.channel` or `delivery.to` is explicitly set
3. If not, call `listConfiguredMessageChannels()` to check how many channels exist
4. If more than 1 channel is configured, throw a clear error: `"Channel is required when multiple channels are configured: discord, telegram. Set delivery.channel or delivery.to explicitly."`

## Why at creation time?

- **Fail fast** — the user learns about the problem immediately, not when the job silently fails
- **Clear error message** — lists available channels so the user knows what to set
- **Zero runtime impact** — validation only runs once at creation, not on every execution
- **Single channel = no change** — when only one channel is configured, behavior is unchanged (auto-selects the only channel)

## Changes

- `src/agents/tools/cron-tool.ts`: Added import for `listConfiguredMessageChannels` and validation logic after delivery inference in the `add` action handler (31 lines added)

## Testing

Manually tested by creating cron jobs with 0, 1, and 2+ configured channels. Single-channel setups work unchanged; multi-channel setups correctly reject jobs without explicit targeting.

---

*This contribution was developed with AI assistance. The code was written by Raccoon (AI agent), the PR description was written by the contributor.*