### PR TITLE
fix(discord): preserve explicit target kind when parsing recipients

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -358,6 +358,38 @@ describe("discordPlugin outbound", () => {
   });
 });
 
+describe("discordPlugin explicit target parsing", () => {
+  it("preserves user-prefixed explicit DM targets", () => {
+    const parsed = discordPlugin.messaging?.parseExplicitTarget?.({
+      raw: "user:123456789012345678",
+    });
+
+    expect(parsed).toEqual({
+      to: "user:123456789012345678",
+      chatType: "direct",
+    });
+  });
+
+  it("preserves channel-prefixed explicit channel targets", () => {
+    const parsed = discordPlugin.messaging?.parseExplicitTarget?.({
+      raw: "channel:987654321098765432",
+    });
+
+    expect(parsed).toEqual({
+      to: "channel:987654321098765432",
+      chatType: "channel",
+    });
+  });
+
+  it("infers direct chat type from normalized explicit DM targets", () => {
+    const chatType = discordPlugin.messaging?.inferTargetChatType?.({
+      to: "user:123456789012345678",
+    });
+
+    expect(chatType).toBe("direct");
+  });
+});
+
 describe("discordPlugin bindings", () => {
   it("derives DM current conversation ids from direct sender context", () => {
     const result = discordPlugin.bindings?.resolveCommandConversation?.({

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -429,7 +429,7 @@ function parseDiscordExplicitTarget(raw: string) {
       return null;
     }
     return {
-      to: target.id,
+      to: target.normalized,
       chatType: target.kind === "user" ? ("direct" as const) : ("channel" as const),
     };
   } catch {


### PR DESCRIPTION
## Summary
Fix Discord explicit-target parsing so an explicit DM target like `user:<id>` keeps its kind through downstream delivery resolution.

## What was broken
When OpenClaw was asked to deliver to an explicit Discord DM target such as:
- `user:123456789012345678`

it could later attempt delivery to:
- `channel:123456789012345678`

That is not a valid Discord channel id. In practice, this sent DM delivery down the wrong route and produced failures like `Unknown Channel`.

## Why it happened
The bug is in `extensions/discord/src/channel.ts`, inside `parseDiscordExplicitTarget(raw)`.

That function parses the raw recipient string with `parseDiscordTarget(...)`. For an input like:
- `user:123456789012345678`

`parseDiscordTarget(...)` correctly returns a user target object whose normalized form is:
- `user:123456789012345678`

But `parseDiscordExplicitTarget(raw)` returned:
- `to: target.id`

instead of:
- `to: target.normalized`

So the explicit target kind was lost at parse time.

Concretely, this transformed:
- `user:123456789012345678`

into:
- `123456789012345678`

Once the value became a bare numeric Discord id, later target resolution treated it as a channel target and normalized it to:
- `channel:123456789012345678`

That is what caused the wrong final destination.

## The fix
Return `target.normalized` instead of `target.id` from `parseDiscordExplicitTarget(raw)`.

That preserves the explicit target kind chosen by the caller:
- `user:<id>` stays `user:<id>`
- `channel:<id>` stays `channel:<id>`

## How this was tested
This was reproduced and validated locally against an installed OpenClaw runtime with targeted logging around Discord target parsing and delivery resolution.

### Reproduction path
A controlled `/hooks/agent` request was sent with:
- `agentId: "assistant"`
- `channel: "discord"`
- `to: "user:123456789012345678"` (representative example; validated locally with a real DM target)
- `deliver: true`

Before the fix, logs showed this exact failure chain:
1. the incoming hook payload carried `to: "user:123456789012345678"`
2. Discord explicit-target parsing reduced that to bare `"123456789012345678"`
3. `resolveCronDeliveryContext(...)` then carried the wrong target forward
4. final delivery attempted to send to `channel:123456789012345678`

### Concrete before/after behavior
Before the fix:
- explicit target observed entering delivery: `user:123456789012345678`
- parser/output inside delivery prep: `123456789012345678`
- final direct delivery target: `channel:123456789012345678`

After the fix:
- `resolveCronDeliveryContext`: `to: "user:123456789012345678"`
- text delivery path: `to=user:123456789012345678`
- final direct delivery: `deliverViaDirect results=1 hadPartialFailure=false`

A focused Discord unit test was also added for explicit target normalization.

## Scope
This PR is intentionally narrow. It only fixes the confirmed Discord explicit-target parsing bug and does not change broader delivery behavior.
