### PR TITLE
fix: preserve anthropic replay safety for signed thinking sessions

### DIFF
--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -555,6 +555,34 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     ]);
   });
 
+  it("preserves signed-thinking turns when the matching tool result is embedded in user content", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolUse", id: "tool-1", name: "gateway", arguments: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "ok" }] },
+          { type: "text", text: "Continue" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    expect((result[1] as { content?: unknown[] }).content).toEqual([
+      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+      { type: "toolUse", id: "tool-1", name: "gateway", arguments: {} },
+    ]);
+  });
+
   it("drops signed-thinking turns whose sibling tool calls are dangling", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -525,7 +525,37 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     ]);
   });
 
-  it("preserves assistant turns that include signed thinking blocks", () => {
+  it("preserves signed-thinking turns whose sibling tool calls still resolve", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "tool-1", name: "gateway", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "gateway",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+      { role: "user", content: [{ type: "text", text: "Continue" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(4);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([
+      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+      { type: "toolCall", id: "tool-1", name: "gateway", arguments: {} },
+    ]);
+  });
+
+  it("drops signed-thinking turns whose sibling tool calls are dangling", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },
       {
@@ -541,14 +571,13 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     const result = validateAnthropicTurns(msgs);
 
     expect(result).toHaveLength(3);
-    const assistantContent = (result[1] as { content?: unknown[] }).content;
-    expect(assistantContent).toEqual([
-      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
-      { type: "toolCall", id: "tool-1", name: "gateway", arguments: {} },
+    expect((result[1] as { role?: unknown }).role).toBe("assistant");
+    expect((result[1] as { content?: unknown[] }).content).toEqual([
+      { type: "text", text: "[tool calls omitted]" },
     ]);
   });
 
-  it("preserves assistant turns that include redacted thinking blocks", () => {
+  it("drops redacted-thinking turns whose sibling tool calls are dangling", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },
       {
@@ -566,8 +595,7 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     expect(result).toHaveLength(3);
     const assistantContent = (result[1] as { content?: unknown[] }).content;
     expect(assistantContent).toEqual([
-      { type: "redacted_thinking", data: "blob", thinkingSignature: "sig_1" },
-      { type: "toolUse", id: "tool-1", name: "gateway", arguments: {} },
+      { type: "text", text: "[tool calls omitted]" },
     ]);
   });
 

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -583,6 +583,39 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     ]);
   });
 
+  it("preserves signed-thinking turns when a tool result carries both stale and current id aliases", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "tool-current", name: "gateway", arguments: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "toolResult",
+            toolUseId: "tool-stale",
+            toolCallId: "tool-current",
+            content: [{ type: "text", text: "ok" }],
+          },
+          { type: "text", text: "Continue" },
+        ],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    expect((result[1] as { content?: unknown[] }).content).toEqual([
+      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+      { type: "toolCall", id: "tool-current", name: "gateway", arguments: {} },
+    ]);
+  });
+
   it("drops signed-thinking turns whose sibling tool calls are dangling", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -577,6 +577,34 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     ]);
   });
 
+  it("does not trust future tool results with the right id but the wrong tool name", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "tool-1", name: "gateway", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "wrong tool" }],
+        isError: false,
+      },
+      { role: "user", content: [{ type: "text", text: "Continue" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(4);
+    expect((result[1] as { content?: unknown[] }).content).toEqual([
+      { type: "text", text: "[tool calls omitted]" },
+    ]);
+  });
+
   it("drops redacted-thinking turns whose sibling tool calls are dangling", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -555,7 +555,7 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     ]);
   });
 
-  it("preserves signed-thinking turns when the matching tool result is embedded in user content", () => {
+  it("drops signed-thinking turns when the only matching tool result is embedded in user content", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },
       {
@@ -577,13 +577,13 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     const result = validateAnthropicTurns(msgs);
 
     expect(result).toHaveLength(3);
+    expect((result[1] as { role?: unknown }).role).toBe("assistant");
     expect((result[1] as { content?: unknown[] }).content).toEqual([
-      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
-      { type: "toolUse", id: "tool-1", name: "gateway", arguments: {} },
+      { type: "text", text: "[tool calls omitted]" },
     ]);
   });
 
-  it("preserves signed-thinking turns when a tool result carries both stale and current id aliases", () => {
+  it("preserves signed-thinking turns when a trusted tool result carries both stale and current id aliases", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Use tool" }] },
       {
@@ -594,22 +594,19 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
         ],
       },
       {
-        role: "user",
-        content: [
-          {
-            type: "toolResult",
-            toolUseId: "tool-stale",
-            toolCallId: "tool-current",
-            content: [{ type: "text", text: "ok" }],
-          },
-          { type: "text", text: "Continue" },
-        ],
+        role: "toolResult",
+        toolUseId: "tool-stale",
+        toolCallId: "tool-current",
+        toolName: "gateway",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
       },
+      { role: "user", content: [{ type: "text", text: "Continue" }] },
     ]);
 
     const result = validateAnthropicTurns(msgs);
 
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
     expect((result[1] as { content?: unknown[] }).content).toEqual([
       { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
       { type: "toolCall", id: "tool-current", name: "gateway", arguments: {} },
@@ -683,9 +680,7 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
 
     expect(result).toHaveLength(3);
     const assistantContent = (result[1] as { content?: unknown[] }).content;
-    expect(assistantContent).toEqual([
-      { type: "text", text: "[tool calls omitted]" },
-    ]);
+    expect(assistantContent).toEqual([{ type: "text", text: "[tool calls omitted]" }]);
   });
 
   it("is replay-safe across repeated validation passes", () => {

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -525,6 +525,52 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     ]);
   });
 
+  it("preserves assistant turns that include signed thinking blocks", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "tool-1", name: "gateway", arguments: {} },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "Continue" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([
+      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+      { type: "toolCall", id: "tool-1", name: "gateway", arguments: {} },
+    ]);
+  });
+
+  it("preserves assistant turns that include redacted thinking blocks", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "blob", thinkingSignature: "sig_1" },
+          { type: "toolUse", id: "tool-1", name: "gateway", arguments: {} },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "Continue" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([
+      { type: "redacted_thinking", data: "blob", thinkingSignature: "sig_1" },
+      { type: "toolUse", id: "tool-1", name: "gateway", arguments: {} },
+    ]);
+  });
+
   it("is replay-safe across repeated validation passes", () => {
     const msgs = makeDualToolAnthropicTurns([
       {

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -125,10 +125,6 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       result.push(msg);
       continue;
     }
-    if (originalContent.some((block) => isThinkingLikeBlock(block))) {
-      result.push(msg);
-      continue;
-    }
     if (
       extractToolCallsFromAssistant(msg as Extract<AgentMessage, { role: "assistant" }>).length ===
       0
@@ -136,7 +132,29 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       result.push(msg);
       continue;
     }
+    const hasThinking = originalContent.some((block) => isThinkingLikeBlock(block));
     const validToolUseIds = collectFutureToolResultIds(messages, i);
+
+    if (hasThinking) {
+      const allToolCallsResolvable = originalContent.every((block) => {
+        if (!block || !isToolCallBlock(block)) {
+          return true;
+        }
+        const blockId = normalizeOptionalString(block.id);
+        return blockId ? validToolUseIds.has(blockId) : false;
+      });
+      if (allToolCallsResolvable) {
+        result.push(msg);
+      } else {
+        result.push({
+          ...assistantMsg,
+          content: isAbortedAssistantTurn(msg)
+            ? []
+            : ([{ type: "text", text: "[tool calls omitted]" }] as AnthropicContentBlock[]),
+        } as AgentMessage);
+      }
+      continue;
+    }
 
     const filteredContent = originalContent.filter((block) => {
       if (!block) {

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -88,11 +88,13 @@ function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set
   const matches = new Map<string, Set<string>>();
   const role = (message as { role?: unknown }).role;
   const addMatch = (id: string | null, toolName: string | null) => {
-    if (!id || !toolName) {
+    if (!id) {
       return;
     }
     const bucket = matches.get(id) ?? new Set<string>();
-    bucket.add(toolName);
+    if (toolName) {
+      bucket.add(toolName);
+    }
     matches.set(id, bucket);
   };
 
@@ -104,6 +106,22 @@ function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set
     );
   } else if (role === "tool") {
     const record = message as unknown as Record<string, unknown>;
+    addMatch(extractToolResultMatchId(record), extractToolResultMatchName(record));
+  }
+
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return matches;
+  }
+
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as Record<string, unknown>;
+    if (record.type !== "toolResult" && record.type !== "tool") {
+      continue;
+    }
     addMatch(extractToolResultMatchId(record), extractToolResultMatchName(record));
   }
 
@@ -198,9 +216,14 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
         }
         const blockId = normalizeOptionalString(block.id);
         const blockName = normalizeOptionalString(block.name);
-        return blockId && blockName
-          ? validToolResultMatches.get(blockId)?.has(blockName) === true
-          : false;
+        if (!blockId || !blockName) {
+          return false;
+        }
+        const matchingToolNames = validToolResultMatches.get(blockId);
+        if (!matchingToolNames) {
+          return false;
+        }
+        return matchingToolNames.size === 0 || matchingToolNames.has(blockName);
       });
       if (allToolCallsResolvable) {
         result.push(msg);

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -120,22 +120,6 @@ function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set
     addMatch(extractToolResultMatchIds(record), extractToolResultMatchName(record));
   }
 
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return matches;
-  }
-
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const record = block as Record<string, unknown>;
-    if (record.type !== "toolResult" && record.type !== "tool") {
-      continue;
-    }
-    addMatch(extractToolResultMatchIds(record), extractToolResultMatchName(record));
-  }
-
   return matches;
 }
 

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -28,19 +28,23 @@ function isAbortedAssistantTurn(message: AgentMessage): boolean {
   return stopReason === "aborted" || stopReason === "error";
 }
 
-function extractToolResultIdsFromRecord(record: Record<string, unknown>): string[] {
-  const ids = [
-    normalizeOptionalString(record.toolUseId),
-    normalizeOptionalString(record.toolCallId),
-    normalizeOptionalString(record.tool_use_id),
-    normalizeOptionalString(record.tool_call_id),
-    normalizeOptionalString(record.callId),
-    normalizeOptionalString(record.call_id),
-  ].filter((value): value is string => typeof value === "string");
-  return [...new Set(ids)];
+function extractToolResultMatchId(record: Record<string, unknown>): string | null {
+  return (
+    normalizeOptionalString(record.toolUseId) ??
+    normalizeOptionalString(record.toolCallId) ??
+    normalizeOptionalString(record.tool_use_id) ??
+    normalizeOptionalString(record.tool_call_id) ??
+    normalizeOptionalString(record.callId) ??
+    normalizeOptionalString(record.call_id) ??
+    null
+  );
 }
 
-function collectMatchingToolResultIds(message: AgentMessage): Set<string> {
+function extractToolResultMatchName(record: Record<string, unknown>): string | null {
+  return normalizeOptionalString(record.toolName) ?? normalizeOptionalString(record.name) ?? null;
+}
+
+function collectAnyToolResultIds(message: AgentMessage): Set<string> {
   const ids = new Set<string>();
   const role = (message as { role?: unknown }).role;
   if (role === "toolResult") {
@@ -51,9 +55,9 @@ function collectMatchingToolResultIds(message: AgentMessage): Set<string> {
       ids.add(toolResultId);
     }
   } else if (role === "tool") {
-    for (const id of extractToolResultIdsFromRecord(
-      message as unknown as Record<string, unknown>,
-    )) {
+    const record = message as unknown as Record<string, unknown>;
+    const id = extractToolResultMatchId(record);
+    if (id) {
       ids.add(id);
     }
   }
@@ -71,12 +75,63 @@ function collectMatchingToolResultIds(message: AgentMessage): Set<string> {
     if (record.type !== "toolResult" && record.type !== "tool") {
       continue;
     }
-    for (const id of extractToolResultIdsFromRecord(record)) {
+    const id = extractToolResultMatchId(record);
+    if (id) {
       ids.add(id);
     }
   }
 
   return ids;
+}
+
+function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set<string>> {
+  const matches = new Map<string, Set<string>>();
+  const role = (message as { role?: unknown }).role;
+  const addMatch = (id: string | null, toolName: string | null) => {
+    if (!id || !toolName) {
+      return;
+    }
+    const bucket = matches.get(id) ?? new Set<string>();
+    bucket.add(toolName);
+    matches.set(id, bucket);
+  };
+
+  if (role === "toolResult") {
+    const record = message as unknown as Record<string, unknown>;
+    addMatch(
+      extractToolResultId(message as Extract<AgentMessage, { role: "toolResult" }>),
+      extractToolResultMatchName(record),
+    );
+  } else if (role === "tool") {
+    const record = message as unknown as Record<string, unknown>;
+    addMatch(extractToolResultMatchId(record), extractToolResultMatchName(record));
+  }
+
+  return matches;
+}
+
+function collectFutureToolResultMatches(
+  messages: AgentMessage[],
+  startIndex: number,
+): Map<string, Set<string>> {
+  const matches = new Map<string, Set<string>>();
+  for (let index = startIndex + 1; index < messages.length; index += 1) {
+    const candidate = messages[index];
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    if ((candidate as { role?: unknown }).role === "assistant") {
+      break;
+    }
+    for (const [id, toolNames] of collectTrustedToolResultMatches(candidate)) {
+      const bucket = matches.get(id) ?? new Set<string>();
+      for (const toolName of toolNames) {
+        bucket.add(toolName);
+      }
+      matches.set(id, bucket);
+    }
+  }
+  return matches;
 }
 
 function collectFutureToolResultIds(messages: AgentMessage[], startIndex: number): Set<string> {
@@ -89,7 +144,7 @@ function collectFutureToolResultIds(messages: AgentMessage[], startIndex: number
     if ((candidate as { role?: unknown }).role === "assistant") {
       break;
     }
-    for (const id of collectMatchingToolResultIds(candidate)) {
+    for (const id of collectAnyToolResultIds(candidate)) {
       ids.add(id);
     }
   }
@@ -133,6 +188,7 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
       continue;
     }
     const hasThinking = originalContent.some((block) => isThinkingLikeBlock(block));
+    const validToolResultMatches = collectFutureToolResultMatches(messages, i);
     const validToolUseIds = collectFutureToolResultIds(messages, i);
 
     if (hasThinking) {
@@ -141,7 +197,10 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
           return true;
         }
         const blockId = normalizeOptionalString(block.id);
-        return blockId ? validToolUseIds.has(blockId) : false;
+        const blockName = normalizeOptionalString(block.name);
+        return blockId && blockName
+          ? validToolResultMatches.get(blockId)?.has(blockName) === true
+          : false;
       });
       if (allToolCallsResolvable) {
         result.push(msg);

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -28,16 +28,22 @@ function isAbortedAssistantTurn(message: AgentMessage): boolean {
   return stopReason === "aborted" || stopReason === "error";
 }
 
-function extractToolResultMatchId(record: Record<string, unknown>): string | null {
-  return (
-    normalizeOptionalString(record.toolUseId) ??
-    normalizeOptionalString(record.toolCallId) ??
-    normalizeOptionalString(record.tool_use_id) ??
-    normalizeOptionalString(record.tool_call_id) ??
-    normalizeOptionalString(record.callId) ??
-    normalizeOptionalString(record.call_id) ??
-    null
-  );
+function extractToolResultMatchIds(record: Record<string, unknown>): Set<string> {
+  const ids = new Set<string>();
+  for (const value of [
+    record.toolUseId,
+    record.toolCallId,
+    record.tool_use_id,
+    record.tool_call_id,
+    record.callId,
+    record.call_id,
+  ]) {
+    const id = normalizeOptionalString(value);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return ids;
 }
 
 function extractToolResultMatchName(record: Record<string, unknown>): string | null {
@@ -56,8 +62,7 @@ function collectAnyToolResultIds(message: AgentMessage): Set<string> {
     }
   } else if (role === "tool") {
     const record = message as unknown as Record<string, unknown>;
-    const id = extractToolResultMatchId(record);
-    if (id) {
+    for (const id of extractToolResultMatchIds(record)) {
       ids.add(id);
     }
   }
@@ -75,8 +80,7 @@ function collectAnyToolResultIds(message: AgentMessage): Set<string> {
     if (record.type !== "toolResult" && record.type !== "tool") {
       continue;
     }
-    const id = extractToolResultMatchId(record);
-    if (id) {
+    for (const id of extractToolResultMatchIds(record)) {
       ids.add(id);
     }
   }
@@ -87,26 +91,33 @@ function collectAnyToolResultIds(message: AgentMessage): Set<string> {
 function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set<string>> {
   const matches = new Map<string, Set<string>>();
   const role = (message as { role?: unknown }).role;
-  const addMatch = (id: string | null, toolName: string | null) => {
-    if (!id) {
-      return;
+  const addMatch = (ids: Iterable<string>, toolName: string | null) => {
+    for (const id of ids) {
+      const bucket = matches.get(id) ?? new Set<string>();
+      if (toolName) {
+        bucket.add(toolName);
+      }
+      matches.set(id, bucket);
     }
-    const bucket = matches.get(id) ?? new Set<string>();
-    if (toolName) {
-      bucket.add(toolName);
-    }
-    matches.set(id, bucket);
   };
 
   if (role === "toolResult") {
     const record = message as unknown as Record<string, unknown>;
     addMatch(
-      extractToolResultId(message as Extract<AgentMessage, { role: "toolResult" }>),
+      [
+        ...extractToolResultMatchIds(record),
+        ...(() => {
+          const canonicalId = extractToolResultId(
+            message as Extract<AgentMessage, { role: "toolResult" }>,
+          );
+          return canonicalId ? [canonicalId] : [];
+        })(),
+      ],
       extractToolResultMatchName(record),
     );
   } else if (role === "tool") {
     const record = message as unknown as Record<string, unknown>;
-    addMatch(extractToolResultMatchId(record), extractToolResultMatchName(record));
+    addMatch(extractToolResultMatchIds(record), extractToolResultMatchName(record));
   }
 
   const content = (message as { content?: unknown }).content;
@@ -122,7 +133,7 @@ function collectTrustedToolResultMatches(message: AgentMessage): Map<string, Set
     if (record.type !== "toolResult" && record.type !== "tool") {
       continue;
     }
-    addMatch(extractToolResultMatchId(record), extractToolResultMatchName(record));
+    addMatch(extractToolResultMatchIds(record), extractToolResultMatchName(record));
   }
 
   return matches;

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -15,6 +15,14 @@ function isToolCallBlock(block: AnthropicContentBlock): boolean {
   return block.type === "toolUse" || block.type === "toolCall" || block.type === "functionCall";
 }
 
+function isThinkingLikeBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
 function isAbortedAssistantTurn(message: AgentMessage): boolean {
   const stopReason = (message as { stopReason?: unknown }).stopReason;
   return stopReason === "aborted" || stopReason === "error";
@@ -114,6 +122,10 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
     };
     const originalContent = Array.isArray(assistantMsg.content) ? assistantMsg.content : [];
     if (originalContent.length === 0) {
+      result.push(msg);
+      continue;
+    }
+    if (originalContent.some((block) => isThinkingLikeBlock(block))) {
       result.push(msg);
       continue;
     }

--- a/src/agents/pi-embedded-runner.anthropic-tool-replay.live.test.ts
+++ b/src/agents/pi-embedded-runner.anthropic-tool-replay.live.test.ts
@@ -76,6 +76,8 @@ describeLive("pi embedded anthropic replay sanitization (live)", () => {
       const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["noop"]), {
         validateGeminiTurns: false,
         validateAnthropicTurns: true,
+        preserveSignatures: false,
+        dropThinkingBlocks: false,
       });
 
       await Promise.resolve(wrapped(model as never, { messages } as never, {} as never));

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1088,6 +1088,73 @@ describe("sanitizeSessionHistory", () => {
     expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call_1");
   });
 
+  it("keeps earlier mutable ids from colliding with later preserved signed ids", async () => {
+    setNonGoogleModelApi();
+
+    const sessionManager = makeMockSessionManager();
+    const messages = castAgentMessages([
+      makeUserMessage("first"),
+      makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }]),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "first result" }],
+        isError: false,
+      }),
+      makeUserMessage("second"),
+      makeAssistantMessage(
+        [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ] as unknown as AssistantMessage["content"],
+        { stopReason: "toolUse" },
+      ),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call1",
+        toolName: "read",
+        content: [{ type: "text", text: "second result" }],
+        isError: false,
+      }),
+      makeUserMessage("retry"),
+    ]);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+    const validated = await validateReplayTurns({
+      messages: sanitized,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const firstAssistant = sanitized[1] as Extract<AgentMessage, { role: "assistant" }>;
+    const secondAssistant = sanitized[4] as Extract<AgentMessage, { role: "assistant" }>;
+    const firstToolCall = firstAssistant.content[0] as { id?: string };
+    const secondToolCall = secondAssistant.content[1] as { id?: string };
+    expect(firstToolCall.id).not.toBe("call1");
+    expect(secondToolCall.id).toBe("call1");
+    expect(firstToolCall.id).not.toBe(secondToolCall.id);
+    expect((sanitized[2] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+      firstToolCall.id,
+    );
+    expect((sanitized[5] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+      "call1",
+    );
+    expect((validated[4] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+      { type: "toolCall", id: "call1", name: "read", arguments: {} },
+    ]);
+  });
+
   it("keeps mutable thinking turns outside exact anthropic replay", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -816,7 +816,7 @@ describe("sanitizeSessionHistory", () => {
       messages,
       modelApi: "anthropic-messages",
       provider: "anthropic",
-      modelId: "claude-opus-4-6",
+      modelId: "claude-sonnet-4-6",
       sessionManager,
       sessionId: TEST_SESSION_ID,
     });
@@ -856,7 +856,7 @@ describe("sanitizeSessionHistory", () => {
       messages,
       modelApi: "anthropic-messages",
       provider: "anthropic",
-      modelId: "claude-opus-4-6",
+      modelId: "claude-sonnet-4-6",
       sessionManager,
       sessionId: TEST_SESSION_ID,
     });

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1243,8 +1243,7 @@ describe("sanitizeSessionHistory", () => {
           message &&
           typeof message === "object" &&
           message.role === "assistant" &&
-          extractToolCallsFromAssistant(message as Extract<AgentMessage, { role: "assistant" }>)
-            .length > 0,
+          extractToolCallsFromAssistant(message).length > 0,
       ),
     ).toHaveLength(1);
     expect(
@@ -1258,8 +1257,7 @@ describe("sanitizeSessionHistory", () => {
           message &&
           typeof message === "object" &&
           message.role === "assistant" &&
-          extractToolCallsFromAssistant(message as Extract<AgentMessage, { role: "assistant" }>)
-            .length > 0,
+          extractToolCallsFromAssistant(message).length > 0,
       ),
     ).toHaveLength(1);
     expect(

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -968,6 +968,33 @@ describe("sanitizeSessionHistory", () => {
     ]);
   });
 
+  it("keeps mutable thinking turns outside exact anthropic replay", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("read a file"),
+      makeAssistantMessage([
+        {
+          type: "thinking",
+          thinking: "I should use the read tool",
+          thinkingSignature: "reasoning_text",
+        },
+        { type: "toolCall", id: "tool_123", name: " read ", arguments: { path: "/tmp/test" } },
+      ]),
+    ]);
+
+    const result = await sanitizeGithubCopilotHistory({ messages });
+    const assistant = getAssistantMessage(result);
+    expect(assistant.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "I should use the read tool",
+        thinkingSignature: "reasoning_text",
+      },
+      { type: "toolCall", id: "tool_123", name: "read", arguments: { path: "/tmp/test" } },
+    ]);
+  });
+
   it("keeps the earlier anthropic replay prefix stable after a later subagent turn", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1010,6 +1010,34 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
+  it("uses immutable thinking replay for amazon-bedrock claude providers when policy preserves signatures", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("retry"),
+      makeAssistantMessage([
+        {
+          type: "thinking",
+          thinking: "internal",
+          thinkingSignature: "sig_1",
+        },
+        { type: "toolCall", id: "call_1", name: " read ", arguments: {} },
+      ] as unknown as AssistantMessage["content"]),
+    ]);
+
+    const result = await sanitizeAnthropicHistory({
+      provider: "amazon-bedrock",
+      modelApi: "bedrock-converse-stream",
+      messages,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: "retry",
+    });
+  });
+
   it("keeps mutable thinking turns outside exact anthropic replay", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -15,6 +15,7 @@ import {
   sanitizeWithOpenAIResponses,
   TEST_SESSION_ID,
 } from "./pi-embedded-runner.sanitize-session-history.test-harness.js";
+import { validateReplayTurns } from "./pi-embedded-runner/replay-history.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 import type { TranscriptPolicy } from "./transcript-policy.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
@@ -828,6 +829,57 @@ describe("sanitizeSessionHistory", () => {
           (msg as { toolCallId?: string }).toolCallId === "tool_01VihkDRptyLpX1ApUPe7ooU",
       ),
     ).toBe(false);
+  });
+
+  it("preserves signed thinking turns while repairing legacy tool-result pairing for anthropic", async () => {
+    const sessionManager = makeMockSessionManager();
+    const messages: AgentMessage[] = [
+      makeUserMessage("Use the gateway"),
+      makeAssistantMessage(
+        [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "toolu_legacy", name: "gateway", arguments: {} },
+        ],
+        { stopReason: "toolUse" },
+      ),
+      {
+        role: "toolResult",
+        toolName: "gateway",
+        content: [{ type: "text", text: "legacy tool output without a linked id" }],
+        isError: false,
+        timestamp: nextTimestamp(),
+      } as AgentMessage,
+      makeUserMessage("continue"),
+    ];
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+    const validated = await validateReplayTurns({
+      messages: sanitized,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(sanitized.map((msg) => msg.role)).toEqual(["user", "assistant", "toolResult", "user"]);
+    expect(validated.map((msg) => msg.role)).toEqual(["user", "assistant", "toolResult", "user"]);
+
+    const assistant = validated[1] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([
+      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+      { type: "toolCall", id: "toolu_legacy", name: "gateway", arguments: {} },
+    ]);
+
+    const toolResult = validated[2] as Extract<AgentMessage, { role: "toolResult" }>;
+    expect(toolResult.toolCallId).toBe("toolu_legacy");
+    expect(toolResult.isError).toBe(true);
   });
 
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1038,6 +1038,56 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
+  it.each([
+    {
+      provider: "anthropic",
+      modelApi: "anthropic-messages",
+      label: "anthropic",
+    },
+    {
+      provider: "amazon-bedrock",
+      modelApi: "bedrock-converse-stream",
+      label: "bedrock",
+    },
+  ])("preserves replay-safe signed tool ids for $label history", async ({ provider, modelApi }) => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("retry"),
+      makeAssistantMessage([
+        {
+          type: "thinking",
+          thinking: "internal",
+          thinkingSignature: "sig_1",
+        },
+        { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+      ] as unknown as AssistantMessage["content"]),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      }),
+    ]);
+
+    const result = await sanitizeAnthropicHistory({
+      provider,
+      modelApi,
+      messages,
+    });
+
+    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+      {
+        type: "thinking",
+        thinking: "internal",
+        thinkingSignature: "sig_1",
+      },
+      { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+    ]);
+    expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call_1");
+  });
+
   it("keeps mutable thinking turns outside exact anthropic replay", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -968,6 +968,48 @@ describe("sanitizeSessionHistory", () => {
     ]);
   });
 
+  it("uses immutable thinking replay for anthropic-compatible providers when policy preserves signatures", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("retry"),
+      makeAssistantMessage([
+        {
+          type: "thinking",
+          thinking: "internal",
+          thinkingSignature: "sig_1",
+        },
+        { type: "toolCall", id: "call_1", name: " read ", arguments: {} },
+      ] as unknown as AssistantMessage["content"]),
+    ]);
+
+    const result = await sanitizeAnthropicHistory({
+      provider: "anthropic-vertex",
+      messages,
+      policy: {
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        preserveNativeAnthropicToolUseIds: true,
+        repairToolUseResultPairing: true,
+        preserveSignatures: true,
+        sanitizeThoughtSignatures: undefined,
+        sanitizeThinkingSignatures: false,
+        dropThinkingBlocks: false,
+        applyGoogleTurnOrdering: false,
+        validateGeminiTurns: false,
+        validateAnthropicTurns: true,
+        allowSyntheticToolResults: true,
+      },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: "retry",
+    });
+  });
+
   it("keeps mutable thinking turns outside exact anthropic replay", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./pi-embedded-runner.sanitize-session-history.test-harness.js";
 import { validateReplayTurns } from "./pi-embedded-runner/replay-history.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
+import { extractToolCallsFromAssistant } from "./tool-call-id.js";
 import type { TranscriptPolicy } from "./transcript-policy.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
@@ -1180,6 +1181,93 @@ describe("sanitizeSessionHistory", () => {
       },
       { type: "toolCall", id: "tool_123", name: "read", arguments: { path: "/tmp/test" } },
     ]);
+  });
+
+  it("drops later preserved signed turns that reuse an earlier raw tool id across the transcript", async () => {
+    setNonGoogleModelApi();
+
+    const sessionManager = makeMockSessionManager();
+    const messages = castAgentMessages([
+      makeUserMessage("first"),
+      makeAssistantMessage(
+        [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ] as unknown as AssistantMessage["content"],
+        { stopReason: "toolUse" },
+      ),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call1",
+        toolName: "read",
+        content: [{ type: "text", text: "first result" }],
+        isError: false,
+      }),
+      makeUserMessage("second"),
+      makeAssistantMessage(
+        [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_2" },
+          { type: "toolCall", id: "call1", name: "read", arguments: {} },
+        ] as unknown as AssistantMessage["content"],
+        { stopReason: "toolUse" },
+      ),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call1",
+        toolName: "read",
+        content: [{ type: "text", text: "second result" }],
+        isError: false,
+      }),
+      makeUserMessage("retry"),
+    ]);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+    const validated = await validateReplayTurns({
+      messages: sanitized,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(
+      sanitized.filter(
+        (message) =>
+          message &&
+          typeof message === "object" &&
+          message.role === "assistant" &&
+          extractToolCallsFromAssistant(message as Extract<AgentMessage, { role: "assistant" }>)
+            .length > 0,
+      ),
+    ).toHaveLength(1);
+    expect(
+      sanitized.filter(
+        (message) => message && typeof message === "object" && message.role === "toolResult",
+      ),
+    ).toHaveLength(1);
+    expect(
+      validated.filter(
+        (message) =>
+          message &&
+          typeof message === "object" &&
+          message.role === "assistant" &&
+          extractToolCallsFromAssistant(message as Extract<AgentMessage, { role: "assistant" }>)
+            .length > 0,
+      ),
+    ).toHaveLength(1);
+    expect(
+      validated.filter(
+        (message) => message && typeof message === "object" && message.role === "toolResult",
+      ),
+    ).toHaveLength(1);
+    expect(JSON.stringify(validated)).not.toContain("[tool calls omitted]");
   });
 
   it("keeps the earlier anthropic replay prefix stable after a later subagent turn", async () => {

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -418,6 +418,7 @@ export async function sanitizeSessionHistory(params: {
     : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
+    preserveImmutableThinkingTurns: policy.validateAnthropicTurns,
   });
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedToolCalls, {

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -418,7 +418,10 @@ export async function sanitizeSessionHistory(params: {
     : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
-    preserveImmutableThinkingTurns: policy.validateAnthropicTurns,
+    allowProviderOwnedThinkingReplay:
+      policy.validateAnthropicTurns &&
+      params.provider === "anthropic" &&
+      params.modelApi === "anthropic-messages",
   });
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedToolCalls, {

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -33,6 +33,7 @@ import {
   resolveTranscriptPolicy,
   shouldAllowProviderOwnedThinkingReplay,
 } from "../transcript-policy.js";
+import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
 import {
   makeZeroUsageSnapshot,
   normalizeUsage,
@@ -403,12 +404,16 @@ export async function sanitizeSessionHistory(params: {
       model: params.model,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
+  const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
+    modelApi: params.modelApi,
+    policy,
+  });
   const sanitizedImages = await sanitizeSessionMessagesImages(
     withInterSessionMarkers,
     "session:history",
     {
       sanitizeMode: policy.sanitizeMode,
-      sanitizeToolCallIds: policy.sanitizeToolCallIds,
+      sanitizeToolCallIds: policy.sanitizeToolCallIds && !allowProviderOwnedThinkingReplay,
       toolCallIdMode: policy.toolCallIdMode,
       preserveNativeAnthropicToolUseIds: policy.preserveNativeAnthropicToolUseIds,
       preserveSignatures: policy.preserveSignatures,
@@ -421,16 +426,21 @@ export async function sanitizeSessionHistory(params: {
     : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
-    allowProviderOwnedThinkingReplay: shouldAllowProviderOwnedThinkingReplay({
-      modelApi: params.modelApi,
-      policy,
-    }),
+    allowProviderOwnedThinkingReplay,
   });
+  const sanitizedToolIds =
+    policy.sanitizeToolCallIds && policy.toolCallIdMode
+      ? sanitizeToolCallIdsForCloudCodeAssist(sanitizedToolCalls, policy.toolCallIdMode, {
+          preserveNativeAnthropicToolUseIds: policy.preserveNativeAnthropicToolUseIds,
+          preserveReplaySafeThinkingToolCallIds: allowProviderOwnedThinkingReplay,
+          allowedToolNames: params.allowedToolNames,
+        })
+      : sanitizedToolCalls;
   const repairedTools = policy.repairToolUseResultPairing
-    ? sanitizeToolUseResultPairing(sanitizedToolCalls, {
+    ? sanitizeToolUseResultPairing(sanitizedToolIds, {
         erroredAssistantResultPolicy: "drop",
       })
-    : sanitizedToolCalls;
+    : sanitizedToolIds;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
   const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(
     stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults),

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -29,7 +29,10 @@ import {
   stripToolResultDetails,
 } from "../session-transcript-repair.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
-import { resolveTranscriptPolicy } from "../transcript-policy.js";
+import {
+  resolveTranscriptPolicy,
+  shouldAllowProviderOwnedThinkingReplay,
+} from "../transcript-policy.js";
 import {
   makeZeroUsageSnapshot,
   normalizeUsage,
@@ -418,10 +421,10 @@ export async function sanitizeSessionHistory(params: {
     : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
-    allowProviderOwnedThinkingReplay:
-      policy.validateAnthropicTurns &&
-      params.provider === "anthropic" &&
-      params.modelApi === "anthropic-messages",
+    allowProviderOwnedThinkingReplay: shouldAllowProviderOwnedThinkingReplay({
+      modelApi: params.modelApi,
+      policy,
+    }),
   });
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedToolCalls, {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -907,15 +907,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
-      baseFn as never,
-      new Set(["read"]),
-      {
-        validateAnthropicTurns: true,
-        preserveSignatures: true,
-        dropThinkingBlocks: false,
-      } as never,
-    );
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
+      validateAnthropicTurns: true,
+      preserveSignatures: true,
+      dropThinkingBlocks: false,
+    } as never);
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
       | Promise<FakeWrappedStream>;
@@ -943,15 +939,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
-      baseFn as never,
-      new Set(["read"]),
-      {
-        validateAnthropicTurns: true,
-        preserveSignatures: true,
-        dropThinkingBlocks: false,
-      } as never,
-    );
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
+      validateAnthropicTurns: true,
+      preserveSignatures: true,
+      dropThinkingBlocks: false,
+    } as never);
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
       | Promise<FakeWrappedStream>;
@@ -980,15 +972,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
-      baseFn as never,
-      new Set(["read"]),
-      {
-        validateAnthropicTurns: true,
-        preserveSignatures: true,
-        dropThinkingBlocks: false,
-      } as never,
-    );
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
+      validateAnthropicTurns: true,
+      preserveSignatures: true,
+      dropThinkingBlocks: false,
+    } as never);
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
       { messages } as never,
@@ -1024,15 +1012,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
-      baseFn as never,
-      new Set(["read"]),
-      {
-        validateAnthropicTurns: true,
-        preserveSignatures: true,
-        dropThinkingBlocks: false,
-      } as never,
-    );
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
+      validateAnthropicTurns: true,
+      preserveSignatures: true,
+      dropThinkingBlocks: false,
+    } as never);
     const stream = wrapped(
       { api: "bedrock-converse-stream" } as never,
       { messages } as never,
@@ -1180,11 +1164,9 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
-      baseFn as never,
-      new Set(["read"]),
-      { validateAnthropicTurns: true } as never,
-    );
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
+      validateAnthropicTurns: true,
+    } as never);
     const stream = wrapped(
       { api: "openai-completions" } as never,
       { messages } as never,
@@ -1695,6 +1677,60 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       {
         role: "assistant",
         content: [{ type: "text", text: "partial response" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ]);
+  });
+
+  it("drops embedded Anthropic user tool_result blocks when signed-thinking replay must stay provider-owned", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolUse", id: "call_1", name: "read", input: { path: "." } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "toolResult",
+            toolUseId: "call_1",
+            content: [{ type: "text", text: "embedded result" }],
+          },
+          { type: "text", text: "retry" },
+        ],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
+      validateGeminiTurns: false,
+      validateAnthropicTurns: true,
+      preserveSignatures: true,
+      dropThinkingBlocks: false,
+    });
+    const stream = wrapped(
+      { api: "anthropic-messages" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as {
+      messages: Array<{ role?: string; content?: unknown[] }>;
+    };
+    expect(seenContext.messages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[tool calls omitted]" }],
       },
       {
         role: "user",

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1006,6 +1006,50 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     ]);
   });
 
+  it("drops signed thinking turns for bedrock claude replay when sibling tool calls are not replay-safe", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "toolu_legacy", name: "gateway", arguments: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["read"]),
+      {
+        validateAnthropicTurns: true,
+        preserveSignatures: true,
+        dropThinkingBlocks: false,
+      } as never,
+    );
+    const stream = wrapped(
+      { api: "bedrock-converse-stream" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as { messages: unknown[] };
+    expect(seenContext.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ]);
+  });
+
   it("drops signed thinking turns when replay would expose inline sessions_spawn attachments", async () => {
     const attachmentContent = "SIGNED_THINKING_INLINE_ATTACHMENT";
     const messages = [
@@ -1588,6 +1632,8 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
       validateGeminiTurns: false,
       validateAnthropicTurns: true,
+      preserveSignatures: false,
+      dropThinkingBlocks: false,
     });
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -1633,6 +1679,8 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
       validateGeminiTurns: false,
       validateAnthropicTurns: true,
+      preserveSignatures: false,
+      dropThinkingBlocks: false,
     });
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -1682,6 +1730,8 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
         validateGeminiTurns: false,
         validateAnthropicTurns: true,
+        preserveSignatures: false,
+        dropThinkingBlocks: false,
       });
       const stream = wrapped({} as never, { messages } as never, {} as never) as
         | FakeWrappedStream
@@ -1722,6 +1772,8 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
       validateGeminiTurns: false,
       validateAnthropicTurns: true,
+      preserveSignatures: false,
+      dropThinkingBlocks: false,
     });
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1043,6 +1043,121 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     ]);
   });
 
+  it("drops signed thinking turns when replay would expose non-content attachment payload fields", async () => {
+    const attachmentContent = "SIGNED_THINKING_NESTED_ATTACHMENT";
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          {
+            type: "toolUse",
+            id: "call_1",
+            name: "sessions_spawn",
+            input: {
+              task: "inspect attachment",
+              attachments: [
+                {
+                  name: "snapshot.txt",
+                  mimeType: "text/plain",
+                  data: attachmentContent,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["sessions_spawn"]),
+      { validateAnthropicTurns: true } as never,
+    );
+    const stream = wrapped(
+      { api: "anthropic-messages" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as { messages: unknown[] };
+    expect(seenContext.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ]);
+  });
+
+  it("keeps mutable thinking turns outside anthropic replay-only preservation", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "call_1", name: " read ", arguments: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["read"]),
+      { validateAnthropicTurns: true } as never,
+    );
+    const stream = wrapped(
+      { api: "openai-completions" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as { messages: unknown[] };
+    expect(seenContext.messages).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [
+          {
+            type: "text",
+            text: "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.",
+          },
+        ],
+        isError: true,
+        timestamp: expect.any(Number),
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ]);
+  });
+
   it("preserves sessions_spawn attachment payloads on replay", async () => {
     const attachmentContent = "INLINE_ATTACHMENT_PAYLOAD";
     const messages = [

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1034,6 +1034,51 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     ]);
   });
 
+  it("drops signed thinking turns when sibling replay tool calls reuse an id", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+          { type: "functionCall", id: "call_1", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["read"]),
+      {
+        validateAnthropicTurns: true,
+        preserveSignatures: true,
+        dropThinkingBlocks: false,
+      } as never,
+    );
+    const stream = wrapped(
+      { api: "anthropic-messages" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as { messages: unknown[] };
+    expect(seenContext.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ]);
+  });
+
   it("drops signed thinking turns when replay would expose inline sessions_spawn attachments", async () => {
     const attachmentContent = "SIGNED_THINKING_INLINE_ATTACHMENT";
     const messages = [

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -907,7 +907,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["read"]),
+      { validateAnthropicTurns: true } as never,
+    );
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
       | Promise<FakeWrappedStream>;
@@ -935,7 +939,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["read"]),
+      { validateAnthropicTurns: true } as never,
+    );
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
       | Promise<FakeWrappedStream>;
@@ -964,7 +972,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
     );
 
-    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["read"]),
+      { validateAnthropicTurns: true } as never,
+    );
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
       { messages } as never,
@@ -1012,6 +1024,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       new Set(["sessions_spawn"]),
+      { validateAnthropicTurns: true } as never,
     );
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -1055,6 +1068,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       new Set(["sessions_spawn"]),
+      { validateAnthropicTurns: true } as never,
     );
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -1071,6 +1085,40 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     };
     expect(toolCall.name).toBe("sessions_spawn");
     expect(toolCall.input?.attachments?.[0]?.content).toBe(attachmentContent);
+  });
+
+  it("keeps non-Anthropic thinking turns mutable when Anthropic replay validation is off", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "call_read", name: " read ", arguments: { path: "README.md" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
+    const stream = wrapped({ api: "google-gemini" } as never, { messages } as never, {} as never) as
+      | FakeWrappedStream
+      | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as {
+      messages: Array<{ content?: unknown[] }>;
+    };
+    expect(seenContext.messages[0]?.content).toEqual([
+      { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+      { type: "toolCall", id: "call_read", name: "read", arguments: { path: "README.md" } },
+    ]);
   });
 
   it("preserves allowlisted tool names that contain punctuation", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -910,7 +910,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       new Set(["read"]),
-      { validateAnthropicTurns: true } as never,
+      {
+        validateAnthropicTurns: true,
+        preserveSignatures: true,
+        dropThinkingBlocks: false,
+      } as never,
     );
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -942,7 +946,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       new Set(["read"]),
-      { validateAnthropicTurns: true } as never,
+      {
+        validateAnthropicTurns: true,
+        preserveSignatures: true,
+        dropThinkingBlocks: false,
+      } as never,
     );
     const stream = wrapped({} as never, { messages } as never, {} as never) as
       | FakeWrappedStream
@@ -975,7 +983,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       new Set(["read"]),
-      { validateAnthropicTurns: true } as never,
+      {
+        validateAnthropicTurns: true,
+        preserveSignatures: true,
+        dropThinkingBlocks: false,
+      } as never,
     );
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -1024,7 +1036,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       new Set(["sessions_spawn"]),
-      { validateAnthropicTurns: true } as never,
+      {
+        validateAnthropicTurns: true,
+        preserveSignatures: true,
+        dropThinkingBlocks: false,
+      } as never,
     );
     const stream = wrapped(
       { api: "anthropic-messages" } as never,
@@ -1079,7 +1095,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       new Set(["sessions_spawn"]),
-      { validateAnthropicTurns: true } as never,
+      {
+        validateAnthropicTurns: true,
+        preserveSignatures: true,
+        dropThinkingBlocks: false,
+      } as never,
     );
     const stream = wrapped(
       { api: "anthropic-messages" } as never,

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -946,6 +946,37 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     expect(seenContext.messages).toBe(messages);
   });
 
+  it("preserves signed thinking turns when replayed tool calls would otherwise be sanitized", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          { type: "toolCall", id: "toolu_legacy", name: "gateway", arguments: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
+    const stream = wrapped(
+      { api: "anthropic-messages" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as { messages: unknown[] };
+    expect(seenContext.messages).toBe(messages);
+  });
+
   it("preserves sessions_spawn attachment payloads on replay", async () => {
     const attachmentContent = "INLINE_ATTACHMENT_PAYLOAD";
     const messages = [

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1784,6 +1784,48 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     ]);
   });
 
+  it("preserves embedded Anthropic user tool_result blocks for non-thinking turns even when immutable replay is enabled", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "call_1", name: "read", input: { path: "." } }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "toolResult",
+            toolUseId: "call_1",
+            content: [{ type: "text", text: "kept result" }],
+          },
+          { type: "text", text: "retry" },
+        ],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]), {
+      validateGeminiTurns: false,
+      validateAnthropicTurns: true,
+      preserveSignatures: true,
+      dropThinkingBlocks: false,
+    });
+    const stream = wrapped(
+      { api: "anthropic-messages" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as {
+      messages: Array<{ role?: string; content?: unknown[] }>;
+    };
+    expect(seenContext.messages).toEqual(messages);
+  });
+
   it.each(["toolCall", "functionCall"] as const)(
     "preserves matching Anthropic user tool_result blocks after %s replay turns",
     async (toolCallType) => {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -946,7 +946,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     expect(seenContext.messages).toBe(messages);
   });
 
-  it("preserves signed thinking turns when replayed tool calls would otherwise be sanitized", async () => {
+  it("drops signed thinking turns when sibling replay tool calls are not allowlisted", async () => {
     const messages = [
       {
         role: "assistant",
@@ -974,7 +974,60 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 
     expect(baseFn).toHaveBeenCalledTimes(1);
     const seenContext = baseFn.mock.calls[0]?.[1] as { messages: unknown[] };
-    expect(seenContext.messages).toBe(messages);
+    expect(seenContext.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ]);
+  });
+
+  it("drops signed thinking turns when replay would expose inline sessions_spawn attachments", async () => {
+    const attachmentContent = "SIGNED_THINKING_INLINE_ATTACHMENT";
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+          {
+            type: "toolUse",
+            id: "call_1",
+            name: "sessions_spawn",
+            input: {
+              task: "inspect attachment",
+              attachments: [{ name: "snapshot.txt", content: attachmentContent }],
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ];
+    const baseFn = vi.fn((_model, _context) =>
+      createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
+    );
+
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      new Set(["sessions_spawn"]),
+    );
+    const stream = wrapped(
+      { api: "anthropic-messages" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
+    await Promise.resolve(stream);
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    const seenContext = baseFn.mock.calls[0]?.[1] as { messages: unknown[] };
+    expect(seenContext.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "retry" }],
+      },
+    ]);
   });
 
   it("preserves sessions_spawn attachment payloads on replay", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -6,6 +6,7 @@ import {
   isRedactedSessionsSpawnAttachment,
   sanitizeToolUseResultPairing,
 } from "../../session-transcript-repair.js";
+import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
 import type { TranscriptPolicy } from "../../transcript-policy.js";
 
@@ -626,7 +627,10 @@ export function wrapStreamFnTrimToolCallNames(
 export function wrapStreamFnSanitizeMalformedToolCalls(
   baseFn: StreamFn,
   allowedToolNames?: Set<string>,
-  transcriptPolicy?: Pick<TranscriptPolicy, "validateGeminiTurns" | "validateAnthropicTurns">,
+  transcriptPolicy?: Pick<
+    TranscriptPolicy,
+    "validateGeminiTurns" | "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks"
+  >,
 ): StreamFn {
   return (model, context, options) => {
     const ctx = context as unknown as { messages?: unknown };
@@ -637,8 +641,14 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
     const sanitized = sanitizeReplayToolCallInputs(
       messages as AgentMessage[],
       allowedToolNames,
-      transcriptPolicy?.validateAnthropicTurns === true &&
-        (model as { api?: unknown })?.api === "anthropic-messages",
+      shouldAllowProviderOwnedThinkingReplay({
+        modelApi: (model as { api?: unknown })?.api as string | null | undefined,
+        policy: {
+          validateAnthropicTurns: transcriptPolicy?.validateAnthropicTurns === true,
+          preserveSignatures: transcriptPolicy?.preserveSignatures === true,
+          dropThinkingBlocks: transcriptPolicy?.dropThinkingBlocks === true,
+        },
+      }),
     );
     if (sanitized.messages === messages) {
       return baseFn(model, context, options);

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -6,6 +6,7 @@ import {
   isRedactedSessionsSpawnAttachment,
   sanitizeToolUseResultPairing,
 } from "../../session-transcript-repair.js";
+import { extractToolCallsFromAssistant } from "../../tool-call-id.js";
 import { normalizeToolName } from "../../tool-policy.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import type { TranscriptPolicy } from "../../transcript-policy.js";
@@ -284,7 +285,7 @@ function isReplaySafeThinkingTurn(content: unknown[], allowedToolNames?: Set<str
     }
     seenToolCallIds.add(toolCallId);
     const rawName = typeof replayBlock.name === "string" ? replayBlock.name : "";
-    const resolvedName = resolveReplayToolCallName(rawName, replayBlock.id, allowedToolNames);
+    const resolvedName = resolveReplayToolCallName(rawName, toolCallId, allowedToolNames);
     if (!resolvedName || replayBlock.name !== resolvedName) {
       return false;
     }
@@ -337,6 +338,7 @@ function sanitizeReplayToolCallInputs(
   let changed = false;
   let droppedAssistantMessages = 0;
   const out: AgentMessage[] = [];
+  const claimedReplaySafeToolCallIds = new Set<string>();
 
   for (const message of messages) {
     if (!message || typeof message !== "object" || message.role !== "assistant") {
@@ -352,7 +354,16 @@ function sanitizeReplayToolCallInputs(
       message.content.some((block) => isThinkingLikeReplayBlock(block)) &&
       message.content.some((block) => isReplayToolCallBlock(block))
     ) {
-      if (isReplaySafeThinkingTurn(message.content, allowedToolNames)) {
+      const replaySafeToolCalls = extractToolCallsFromAssistant(
+        message as Extract<AgentMessage, { role: "assistant" }>,
+      );
+      if (
+        isReplaySafeThinkingTurn(message.content, allowedToolNames) &&
+        replaySafeToolCalls.every((toolCall) => !claimedReplaySafeToolCallIds.has(toolCall.id))
+      ) {
+        for (const toolCall of replaySafeToolCalls) {
+          claimedReplaySafeToolCallIds.add(toolCall.id);
+        }
         out.push(message);
       } else {
         changed = true;

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -354,9 +354,7 @@ function sanitizeReplayToolCallInputs(
       message.content.some((block) => isThinkingLikeReplayBlock(block)) &&
       message.content.some((block) => isReplayToolCallBlock(block))
     ) {
-      const replaySafeToolCalls = extractToolCallsFromAssistant(
-        message as Extract<AgentMessage, { role: "assistant" }>,
-      );
+      const replaySafeToolCalls = extractToolCallsFromAssistant(message);
       if (
         isReplaySafeThinkingTurn(message.content, allowedToolNames) &&
         replaySafeToolCalls.every((toolCall) => !claimedReplaySafeToolCallIds.has(toolCall.id))
@@ -720,8 +718,7 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
       : sanitized.messages;
     if (transcriptPolicy?.validateAnthropicTurns) {
       nextMessages = sanitizeAnthropicReplayToolResults(nextMessages, {
-        disallowEmbeddedUserToolResultsForSignedThinkingReplay:
-          allowProviderOwnedThinkingReplay,
+        disallowEmbeddedUserToolResultsForSignedThinkingReplay: allowProviderOwnedThinkingReplay,
       });
     }
     if (nextMessages === messages) {

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -439,15 +439,30 @@ function extractAnthropicReplayToolResultIds(block: AnthropicToolResultContentBl
   return ids;
 }
 
+function isSignedThinkingReplayAssistantSpan(message: AgentMessage | undefined): boolean {
+  if (!message || typeof message !== "object" || message.role !== "assistant") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return (
+    content.some((block) => isThinkingLikeReplayBlock(block)) &&
+    content.some((block) => isReplayToolCallBlock(block))
+  );
+}
+
 function sanitizeAnthropicReplayToolResults(
   messages: AgentMessage[],
   options?: {
-    allowEmbeddedUserToolResults?: boolean;
+    disallowEmbeddedUserToolResultsForSignedThinkingReplay?: boolean;
   },
 ): AgentMessage[] {
   let changed = false;
   const out: AgentMessage[] = [];
-  const allowEmbeddedUserToolResults = options?.allowEmbeddedUserToolResults !== false;
+  const disallowEmbeddedUserToolResultsForSignedThinkingReplay =
+    options?.disallowEmbeddedUserToolResultsForSignedThinkingReplay === true;
 
   for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index];
@@ -461,6 +476,9 @@ function sanitizeAnthropicReplayToolResults(
     }
 
     const previous = messages[index - 1];
+    const shouldStripEmbeddedToolResults =
+      disallowEmbeddedUserToolResultsForSignedThinkingReplay &&
+      isSignedThinkingReplayAssistantSpan(previous);
     const validToolUseIds = new Set<string>();
     if (previous && typeof previous === "object" && previous.role === "assistant") {
       const previousContent = (previous as { content?: unknown }).content;
@@ -489,7 +507,7 @@ function sanitizeAnthropicReplayToolResults(
       if (typedBlock.type !== "toolResult" && typedBlock.type !== "tool") {
         return true;
       }
-      if (!allowEmbeddedUserToolResults) {
+      if (shouldStripEmbeddedToolResults) {
         changed = true;
         return false;
       }
@@ -702,7 +720,8 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
       : sanitized.messages;
     if (transcriptPolicy?.validateAnthropicTurns) {
       nextMessages = sanitizeAnthropicReplayToolResults(nextMessages, {
-        allowEmbeddedUserToolResults: !allowProviderOwnedThinkingReplay,
+        disallowEmbeddedUserToolResultsForSignedThinkingReplay:
+          allowProviderOwnedThinkingReplay,
       });
     }
     if (nextMessages === messages) {

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -2,7 +2,10 @@ import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
 import { validateAnthropicTurns, validateGeminiTurns } from "../../pi-embedded-helpers.js";
-import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
+import {
+  isRedactedSessionsSpawnAttachment,
+  sanitizeToolUseResultPairing,
+} from "../../session-transcript-repair.js";
 import { normalizeToolName } from "../../tool-policy.js";
 import type { TranscriptPolicy } from "../../transcript-policy.js";
 
@@ -251,14 +254,7 @@ function hasUnredactedSessionsSpawnAttachments(block: ReplayToolCallBlock): bool
       continue;
     }
     for (const attachment of attachments) {
-      if (!attachment || typeof attachment !== "object") {
-        continue;
-      }
-      if (!Object.hasOwn(attachment, "content")) {
-        continue;
-      }
-      const content = (attachment as { content?: unknown }).content;
-      if (content !== "__OPENCLAW_REDACTED__") {
+      if (!isRedactedSessionsSpawnAttachment(attachment)) {
         return true;
       }
     }
@@ -331,7 +327,7 @@ function resolveReplayToolCallName(
 function sanitizeReplayToolCallInputs(
   messages: AgentMessage[],
   allowedToolNames?: Set<string>,
-  preserveImmutableThinkingTurns?: boolean,
+  allowProviderOwnedThinkingReplay?: boolean,
 ): ReplayToolCallSanitizeReport {
   let changed = false;
   let droppedAssistantMessages = 0;
@@ -347,7 +343,7 @@ function sanitizeReplayToolCallInputs(
       continue;
     }
     if (
-      preserveImmutableThinkingTurns &&
+      allowProviderOwnedThinkingReplay &&
       message.content.some((block) => isThinkingLikeReplayBlock(block)) &&
       message.content.some((block) => isReplayToolCallBlock(block))
     ) {
@@ -641,7 +637,8 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
     const sanitized = sanitizeReplayToolCallInputs(
       messages as AgentMessage[],
       allowedToolNames,
-      transcriptPolicy?.validateAnthropicTurns === true,
+      transcriptPolicy?.validateAnthropicTurns === true &&
+        (model as { api?: unknown })?.api === "anthropic-messages",
     );
     if (sanitized.messages === messages) {
       return baseFn(model, context, options);

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -6,8 +6,8 @@ import {
   isRedactedSessionsSpawnAttachment,
   sanitizeToolUseResultPairing,
 } from "../../session-transcript-repair.js";
-import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
+import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import type { TranscriptPolicy } from "../../transcript-policy.js";
 
 function resolveCaseInsensitiveAllowedToolName(
@@ -231,6 +231,9 @@ type ReplayToolCallSanitizeReport = {
 type AnthropicToolResultContentBlock = {
   type?: unknown;
   toolUseId?: unknown;
+  toolCallId?: unknown;
+  tool_use_id?: unknown;
+  tool_call_id?: unknown;
 };
 
 function isThinkingLikeReplayBlock(block: unknown): boolean {
@@ -263,15 +266,12 @@ function hasUnredactedSessionsSpawnAttachments(block: ReplayToolCallBlock): bool
   return false;
 }
 
-function isReplaySafeThinkingTurn(
-  content: unknown[],
-  allowedToolNames?: Set<string>,
-): boolean {
+function isReplaySafeThinkingTurn(content: unknown[], allowedToolNames?: Set<string>): boolean {
   for (const block of content) {
     if (!isReplayToolCallBlock(block)) {
       continue;
     }
-    const replayBlock = block as ReplayToolCallBlock;
+    const replayBlock = block;
     if (
       !replayToolCallHasInput(replayBlock) ||
       !replayToolCallNonEmptyString(replayBlock.id) ||
@@ -409,9 +409,30 @@ function sanitizeReplayToolCallInputs(
   };
 }
 
-function sanitizeAnthropicReplayToolResults(messages: AgentMessage[]): AgentMessage[] {
+function extractAnthropicReplayToolResultIds(block: AnthropicToolResultContentBlock): string[] {
+  const ids: string[] = [];
+  for (const value of [block.toolUseId, block.toolCallId, block.tool_use_id, block.tool_call_id]) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (!trimmed || ids.includes(trimmed)) {
+      continue;
+    }
+    ids.push(trimmed);
+  }
+  return ids;
+}
+
+function sanitizeAnthropicReplayToolResults(
+  messages: AgentMessage[],
+  options?: {
+    allowEmbeddedUserToolResults?: boolean;
+  },
+): AgentMessage[] {
   let changed = false;
   const out: AgentMessage[] = [];
+  const allowEmbeddedUserToolResults = options?.allowEmbeddedUserToolResults !== false;
 
   for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index];
@@ -450,10 +471,19 @@ function sanitizeAnthropicReplayToolResults(messages: AgentMessage[]): AgentMess
         return true;
       }
       const typedBlock = block as AnthropicToolResultContentBlock;
-      if (typedBlock.type !== "toolResult" || typeof typedBlock.toolUseId !== "string") {
+      if (typedBlock.type !== "toolResult" && typedBlock.type !== "tool") {
         return true;
       }
-      return validToolUseIds.size > 0 && validToolUseIds.has(typedBlock.toolUseId);
+      if (!allowEmbeddedUserToolResults) {
+        changed = true;
+        return false;
+      }
+      const resultIds = extractAnthropicReplayToolResultIds(typedBlock);
+      if (resultIds.length === 0) {
+        changed = true;
+        return false;
+      }
+      return validToolUseIds.size > 0 && resultIds.some((id) => validToolUseIds.has(id));
     });
 
     if (nextContent.length === message.content.length) {
@@ -638,24 +668,30 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
     if (!Array.isArray(messages)) {
       return baseFn(model, context, options);
     }
+    const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
+      modelApi: (model as { api?: unknown })?.api as string | null | undefined,
+      policy: {
+        validateAnthropicTurns: transcriptPolicy?.validateAnthropicTurns === true,
+        preserveSignatures: transcriptPolicy?.preserveSignatures === true,
+        dropThinkingBlocks: transcriptPolicy?.dropThinkingBlocks === true,
+      },
+    });
     const sanitized = sanitizeReplayToolCallInputs(
       messages as AgentMessage[],
       allowedToolNames,
-      shouldAllowProviderOwnedThinkingReplay({
-        modelApi: (model as { api?: unknown })?.api as string | null | undefined,
-        policy: {
-          validateAnthropicTurns: transcriptPolicy?.validateAnthropicTurns === true,
-          preserveSignatures: transcriptPolicy?.preserveSignatures === true,
-          dropThinkingBlocks: transcriptPolicy?.dropThinkingBlocks === true,
-        },
-      }),
+      allowProviderOwnedThinkingReplay,
     );
-    if (sanitized.messages === messages) {
-      return baseFn(model, context, options);
-    }
-    let nextMessages = sanitizeToolUseResultPairing(sanitized.messages);
+    const replayInputsChanged = sanitized.messages !== messages;
+    let nextMessages = replayInputsChanged
+      ? sanitizeToolUseResultPairing(sanitized.messages)
+      : sanitized.messages;
     if (transcriptPolicy?.validateAnthropicTurns) {
-      nextMessages = sanitizeAnthropicReplayToolResults(nextMessages);
+      nextMessages = sanitizeAnthropicReplayToolResults(nextMessages, {
+        allowEmbeddedUserToolResults: !allowProviderOwnedThinkingReplay,
+      });
+    }
+    if (nextMessages === messages) {
+      return baseFn(model, context, options);
     }
     if (sanitized.droppedAssistantMessages > 0 || transcriptPolicy?.validateAnthropicTurns) {
       if (transcriptPolicy?.validateGeminiTurns) {

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -267,18 +267,22 @@ function hasUnredactedSessionsSpawnAttachments(block: ReplayToolCallBlock): bool
 }
 
 function isReplaySafeThinkingTurn(content: unknown[], allowedToolNames?: Set<string>): boolean {
+  const seenToolCallIds = new Set<string>();
   for (const block of content) {
     if (!isReplayToolCallBlock(block)) {
       continue;
     }
     const replayBlock = block;
+    const toolCallId = typeof replayBlock.id === "string" ? replayBlock.id.trim() : "";
     if (
       !replayToolCallHasInput(replayBlock) ||
-      !replayToolCallNonEmptyString(replayBlock.id) ||
+      !toolCallId ||
+      seenToolCallIds.has(toolCallId) ||
       hasUnredactedSessionsSpawnAttachments(replayBlock)
     ) {
       return false;
     }
+    seenToolCallIds.add(toolCallId);
     const rawName = typeof replayBlock.name === "string" ? replayBlock.name : "";
     const resolvedName = resolveReplayToolCallName(rawName, replayBlock.id, allowedToolNames);
     if (!resolvedName || replayBlock.name !== resolvedName) {

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -237,6 +237,60 @@ function isThinkingLikeReplayBlock(block: unknown): boolean {
   return type === "thinking" || type === "redacted_thinking";
 }
 
+function hasUnredactedSessionsSpawnAttachments(block: ReplayToolCallBlock): boolean {
+  const rawName = typeof block.name === "string" ? block.name.trim() : "";
+  if (normalizeLowercaseStringOrEmpty(rawName) !== "sessions_spawn") {
+    return false;
+  }
+  for (const payload of [block.arguments, block.input]) {
+    if (!payload || typeof payload !== "object") {
+      continue;
+    }
+    const attachments = (payload as { attachments?: unknown }).attachments;
+    if (!Array.isArray(attachments)) {
+      continue;
+    }
+    for (const attachment of attachments) {
+      if (!attachment || typeof attachment !== "object") {
+        continue;
+      }
+      if (!Object.hasOwn(attachment, "content")) {
+        continue;
+      }
+      const content = (attachment as { content?: unknown }).content;
+      if (content !== "__OPENCLAW_REDACTED__") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isReplaySafeThinkingTurn(
+  content: unknown[],
+  allowedToolNames?: Set<string>,
+): boolean {
+  for (const block of content) {
+    if (!isReplayToolCallBlock(block)) {
+      continue;
+    }
+    const replayBlock = block as ReplayToolCallBlock;
+    if (
+      !replayToolCallHasInput(replayBlock) ||
+      !replayToolCallNonEmptyString(replayBlock.id) ||
+      hasUnredactedSessionsSpawnAttachments(replayBlock)
+    ) {
+      return false;
+    }
+    const rawName = typeof replayBlock.name === "string" ? replayBlock.name : "";
+    const resolvedName = resolveReplayToolCallName(rawName, replayBlock.id, allowedToolNames);
+    if (!resolvedName || replayBlock.name !== resolvedName) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isReplayToolCallBlock(block: unknown): block is ReplayToolCallBlock {
   if (!block || typeof block !== "object") {
     return false;
@@ -292,7 +346,12 @@ function sanitizeReplayToolCallInputs(
       continue;
     }
     if (message.content.some((block) => isThinkingLikeReplayBlock(block))) {
-      out.push(message);
+      if (isReplaySafeThinkingTurn(message.content, allowedToolNames)) {
+        out.push(message);
+      } else {
+        changed = true;
+        droppedAssistantMessages += 1;
+      }
       continue;
     }
 

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -331,6 +331,7 @@ function resolveReplayToolCallName(
 function sanitizeReplayToolCallInputs(
   messages: AgentMessage[],
   allowedToolNames?: Set<string>,
+  preserveImmutableThinkingTurns?: boolean,
 ): ReplayToolCallSanitizeReport {
   let changed = false;
   let droppedAssistantMessages = 0;
@@ -345,7 +346,11 @@ function sanitizeReplayToolCallInputs(
       out.push(message);
       continue;
     }
-    if (message.content.some((block) => isThinkingLikeReplayBlock(block))) {
+    if (
+      preserveImmutableThinkingTurns &&
+      message.content.some((block) => isThinkingLikeReplayBlock(block)) &&
+      message.content.some((block) => isReplayToolCallBlock(block))
+    ) {
       if (isReplaySafeThinkingTurn(message.content, allowedToolNames)) {
         out.push(message);
       } else {
@@ -633,7 +638,11 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
     if (!Array.isArray(messages)) {
       return baseFn(model, context, options);
     }
-    const sanitized = sanitizeReplayToolCallInputs(messages as AgentMessage[], allowedToolNames);
+    const sanitized = sanitizeReplayToolCallInputs(
+      messages as AgentMessage[],
+      allowedToolNames,
+      transcriptPolicy?.validateAnthropicTurns === true,
+    );
     if (sanitized.messages === messages) {
       return baseFn(model, context, options);
     }

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -229,6 +229,14 @@ type AnthropicToolResultContentBlock = {
   toolUseId?: unknown;
 };
 
+function isThinkingLikeReplayBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
 function isReplayToolCallBlock(block: unknown): block is ReplayToolCallBlock {
   if (!block || typeof block !== "object") {
     return false;
@@ -280,6 +288,10 @@ function sanitizeReplayToolCallInputs(
       continue;
     }
     if (!Array.isArray(message.content)) {
+      out.push(message);
+      continue;
+    }
+    if (message.content.some((block) => isThinkingLikeReplayBlock(block))) {
       out.push(message);
       continue;
     }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -111,7 +111,10 @@ import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
-import { resolveTranscriptPolicy } from "../../transcript-policy.js";
+import {
+  resolveTranscriptPolicy,
+  shouldAllowProviderOwnedThinkingReplay,
+} from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -1156,11 +1159,17 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
+          const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
+            modelApi: (model as { api?: unknown })?.api as string | null | undefined,
+            policy: transcriptPolicy,
+          });
           const sanitized = sanitizeToolCallIdsForCloudCodeAssist(
             messages as AgentMessage[],
             mode,
             {
               preserveNativeAnthropicToolUseIds: transcriptPolicy.preserveNativeAnthropicToolUseIds,
+              preserveReplaySafeThinkingToolCallIds: allowProviderOwnedThinkingReplay,
+              allowedToolNames,
             },
           );
           if (sanitized === messages) {

--- a/src/agents/session-transcript-repair.attachments.test.ts
+++ b/src/agents/session-transcript-repair.attachments.test.ts
@@ -74,4 +74,50 @@ describe("sanitizeToolCallInputs redacts sessions_spawn attachments", () => {
     ).toBe("__OPENCLAW_REDACTED__");
     expect(JSON.stringify(out)).not.toContain(secret);
   });
+
+  it("replaces non-content attachment payload fields with a minimal redacted stub", () => {
+    const secret = "NESTED_ATTACHMENT_SECRET"; // pragma: allowlist secret
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolUse",
+            id: "call_3",
+            name: "sessions_spawn",
+            input: {
+              task: "do thing",
+              attachments: [
+                {
+                  name: "payload.json",
+                  mimeType: "application/json",
+                  encoding: "utf8",
+                  data: secret,
+                  nested: { secret },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const msg = out[0] as { content?: unknown[] };
+    const tool = (msg.content?.[0] ?? null) as {
+      input?: { attachments?: unknown[] };
+      arguments?: { attachments?: unknown[] };
+    } | null;
+    const attachment =
+      (tool?.input?.attachments?.[0] ?? tool?.arguments?.attachments?.[0] ?? null) as
+        | Record<string, unknown>
+        | null;
+    expect(attachment).toEqual({
+      name: "payload.json",
+      mimeType: "application/json",
+      encoding: "utf8",
+      content: "__OPENCLAW_REDACTED__",
+    });
+    expect(JSON.stringify(out)).not.toContain(secret);
+  });
 });

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -405,7 +405,7 @@ describe("sanitizeToolCallInputs", () => {
 
     const out = sanitizeToolCallInputs(input, {
       allowedToolNames: ["read"],
-      preserveImmutableThinkingTurns: true,
+      allowProviderOwnedThinkingReplay: true,
     });
 
     expect(out).toEqual([]);
@@ -437,11 +437,48 @@ describe("sanitizeToolCallInputs", () => {
 
     const out = sanitizeToolCallInputs(input, {
       allowedToolNames: ["sessions_spawn"],
-      preserveImmutableThinkingTurns: true,
+      allowProviderOwnedThinkingReplay: true,
     });
 
     expect(out).toEqual([]);
     expect(JSON.stringify(out)).not.toContain(secret);
+  });
+
+  it("keeps signed-thinking assistant turns when sessions_spawn attachments are already redacted", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me replay the helper turn.",
+            thinkingSignature: "sig_spawn_safe",
+          },
+          {
+            type: "toolUse",
+            id: "call_spawn",
+            name: "sessions_spawn",
+            input: {
+              task: "inspect attachment",
+              attachments: [
+                {
+                  name: "snapshot.txt",
+                  mimeType: "text/plain",
+                  content: "__OPENCLAW_REDACTED__",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, {
+      allowedToolNames: ["sessions_spawn"],
+      allowProviderOwnedThinkingReplay: true,
+    });
+
+    expect(out).toEqual(input);
   });
 
   it("keeps generic thinking turns mutable when immutable preservation is disabled", () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -435,6 +435,40 @@ describe("sanitizeToolCallInputs", () => {
     expect(out).toEqual([]);
   });
 
+  it("drops later signed-thinking assistant turns that reuse an earlier signed tool id", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "First signed replay turn.",
+            thinkingSignature: "sig_first",
+          },
+          { type: "toolCall", id: "call_shared", name: "read", arguments: { path: "a" } },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Second signed replay turn.",
+            thinkingSignature: "sig_second",
+          },
+          { type: "toolUse", id: "call_shared", name: "read", input: { path: "b" } },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, {
+      allowedToolNames: ["read"],
+      allowProviderOwnedThinkingReplay: true,
+    });
+
+    expect(out).toEqual([input[0]]);
+  });
+
   it("drops signed-thinking assistant turns that would require attachment redaction", () => {
     const secret = "SIGNED_THINKING_ATTACHMENT_SECRET"; // pragma: allowlist secret
     const input = castAgentMessages([

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -380,6 +380,40 @@ describe("sanitizeToolCallInputs", () => {
     expect(types).toEqual(["text", "toolUse"]);
   });
 
+  it("preserves assistant turns that include thinking blocks", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me check the gateway config.",
+            thinkingSignature: "sig_gateway",
+          },
+          {
+            type: "toolCall",
+            id: "call_gateway",
+            name: "gateway",
+            arguments: {
+              action: "config.get",
+              path: "channels.telegram",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["read"] });
+
+    expect(out).toBe(input);
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const types = Array.isArray(assistant.content)
+      ? assistant.content.map((block) => (block as { type?: unknown }).type)
+      : [];
+    expect(types).toEqual(["thinking", "toolCall"]);
+    expect((assistant.content?.[1] as { name?: unknown })?.name).toBe("gateway");
+  });
+
   it.each([
     {
       name: "trims leading whitespace from tool names",

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -411,6 +411,30 @@ describe("sanitizeToolCallInputs", () => {
     expect(out).toEqual([]);
   });
 
+  it("drops signed-thinking assistant turns when sibling tool calls reuse an id", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me reuse the tool id.",
+            thinkingSignature: "sig_duplicate",
+          },
+          { type: "toolCall", id: "call_shared", name: "read", arguments: { path: "a" } },
+          { type: "toolUse", id: "call_shared", name: "read", input: { path: "b" } },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, {
+      allowedToolNames: ["read"],
+      allowProviderOwnedThinkingReplay: true,
+    });
+
+    expect(out).toEqual([]);
+  });
+
   it("drops signed-thinking assistant turns that would require attachment redaction", () => {
     const secret = "SIGNED_THINKING_ATTACHMENT_SECRET"; // pragma: allowlist secret
     const input = castAgentMessages([

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -403,7 +403,10 @@ describe("sanitizeToolCallInputs", () => {
       },
     ]);
 
-    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["read"] });
+    const out = sanitizeToolCallInputs(input, {
+      allowedToolNames: ["read"],
+      preserveImmutableThinkingTurns: true,
+    });
 
     expect(out).toEqual([]);
   });
@@ -432,10 +435,50 @@ describe("sanitizeToolCallInputs", () => {
       },
     ]);
 
-    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["sessions_spawn"] });
+    const out = sanitizeToolCallInputs(input, {
+      allowedToolNames: ["sessions_spawn"],
+      preserveImmutableThinkingTurns: true,
+    });
 
     expect(out).toEqual([]);
     expect(JSON.stringify(out)).not.toContain(secret);
+  });
+
+  it("keeps generic thinking turns mutable when immutable preservation is disabled", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me normalize this tool name.",
+            thinkingSignature: "sig_generic",
+          },
+          {
+            type: "toolCall",
+            id: "call_read",
+            name: " read ",
+            arguments: { path: "README.md" },
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["read"] });
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "Let me normalize this tool name.",
+        thinkingSignature: "sig_generic",
+      },
+      {
+        type: "toolCall",
+        id: "call_read",
+        name: "read",
+        arguments: { path: "README.md" },
+      },
+    ]);
   });
 
   it.each([

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -380,7 +380,7 @@ describe("sanitizeToolCallInputs", () => {
     expect(types).toEqual(["text", "toolUse"]);
   });
 
-  it("preserves assistant turns that include thinking blocks", () => {
+  it("drops signed-thinking assistant turns when sibling tool calls are not replay-safe", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -405,13 +405,37 @@ describe("sanitizeToolCallInputs", () => {
 
     const out = sanitizeToolCallInputs(input, { allowedToolNames: ["read"] });
 
-    expect(out).toBe(input);
-    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
-    const types = Array.isArray(assistant.content)
-      ? assistant.content.map((block) => (block as { type?: unknown }).type)
-      : [];
-    expect(types).toEqual(["thinking", "toolCall"]);
-    expect((assistant.content?.[1] as { name?: unknown })?.name).toBe("gateway");
+    expect(out).toEqual([]);
+  });
+
+  it("drops signed-thinking assistant turns that would require attachment redaction", () => {
+    const secret = "SIGNED_THINKING_ATTACHMENT_SECRET"; // pragma: allowlist secret
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me spawn a helper.",
+            thinkingSignature: "sig_spawn",
+          },
+          {
+            type: "toolUse",
+            id: "call_spawn",
+            name: "sessions_spawn",
+            input: {
+              task: "inspect attachment",
+              attachments: [{ name: "snapshot.txt", content: secret }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["sessions_spawn"] });
+
+    expect(out).toEqual([]);
+    expect(JSON.stringify(out)).not.toContain(secret);
   });
 
   it.each([

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -142,7 +142,7 @@ export function isRedactedSessionsSpawnAttachment(item: unknown): boolean {
     if (!(SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS as readonly string[]).includes(key)) {
       return false;
     }
-    if (typeof attachment[key] !== "string" || (attachment[key] as string).trim().length === 0) {
+    if (typeof attachment[key] !== "string" || attachment[key].trim().length === 0) {
       return false;
     }
   }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -201,18 +201,22 @@ function isReplaySafeThinkingAssistantTurn(
   allowedToolNames: Set<string> | null,
 ): boolean {
   let sawToolCall = false;
+  const seenToolCallIds = new Set<string>();
   for (const block of content) {
     if (!isRawToolCallBlock(block)) {
       continue;
     }
     sawToolCall = true;
+    const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
     if (
       !hasToolCallInput(block) ||
-      !hasToolCallId(block) ||
+      !toolCallId ||
+      seenToolCallIds.has(toolCallId) ||
       !hasToolCallName(block, allowedToolNames)
     ) {
       return false;
     }
+    seenToolCallIds.add(toolCallId);
     if (sanitizeToolCallBlock(block) !== block) {
       return false;
     }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -145,6 +145,40 @@ function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
   return next as RawToolCallBlock;
 }
 
+function countRawToolCallBlocks(content: unknown[]): number {
+  let count = 0;
+  for (const block of content) {
+    if (isRawToolCallBlock(block)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function isReplaySafeThinkingAssistantTurn(
+  content: unknown[],
+  allowedToolNames: Set<string> | null,
+): boolean {
+  let sawToolCall = false;
+  for (const block of content) {
+    if (!isRawToolCallBlock(block)) {
+      continue;
+    }
+    sawToolCall = true;
+    if (
+      !hasToolCallInput(block) ||
+      !hasToolCallId(block) ||
+      !hasToolCallName(block, allowedToolNames)
+    ) {
+      return false;
+    }
+    if (sanitizeToolCallBlock(block) !== block) {
+      return false;
+    }
+  }
+  return sawToolCall || content.some((block) => isThinkingLikeBlock(block));
+}
+
 function makeMissingToolResult(params: {
   toolCallId: string;
   toolName?: string;
@@ -247,11 +281,18 @@ export function repairToolCallInputs(
       continue;
     }
 
-    // Preserve provider-owned thinking turns verbatim. Anthropic replays can
-    // reject any historical assistant turn whose signed thinking block no
-    // longer matches the original response, including sibling tool calls.
     if (msg.content.some((block) => isThinkingLikeBlock(block))) {
-      out.push(msg);
+      // Signed Anthropic thinking blocks must remain byte-for-byte stable on
+      // replay. Preserve the turn only if every sibling tool call is already
+      // valid and requires no redaction or normalization. Otherwise drop the
+      // whole assistant turn rather than mutating provider-owned content.
+      if (isReplaySafeThinkingAssistantTurn(msg.content, allowedToolNames)) {
+        out.push(msg);
+      } else {
+        droppedToolCalls += countRawToolCallBlocks(msg.content);
+        droppedAssistantMessages += 1;
+        changed = true;
+      }
       continue;
     }
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -316,6 +316,7 @@ export function repairToolCallInputs(
   const out: AgentMessage[] = [];
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
   const allowProviderOwnedThinkingReplay = options?.allowProviderOwnedThinkingReplay === true;
+  const claimedReplaySafeToolCallIds = new Set<string>();
 
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") {
@@ -337,7 +338,14 @@ export function repairToolCallInputs(
       // replay. Preserve the turn only if every sibling tool call is already
       // valid and requires no redaction or normalization. Otherwise drop the
       // whole assistant turn rather than mutating provider-owned content.
-      if (isReplaySafeThinkingAssistantTurn(msg.content, allowedToolNames)) {
+      const replaySafeToolCalls = extractToolCallsFromAssistant(msg);
+      if (
+        isReplaySafeThinkingAssistantTurn(msg.content, allowedToolNames) &&
+        replaySafeToolCalls.every((toolCall) => !claimedReplaySafeToolCallIds.has(toolCall.id))
+      ) {
+        for (const toolCall of replaySafeToolCalls) {
+          claimedReplaySafeToolCallIds.add(toolCall.id);
+        }
         out.push(msg);
       } else {
         droppedToolCalls += countRawToolCallBlocks(msg.content);

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -8,6 +8,8 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_:.-]+$/;
+const REDACTED_SESSIONS_SPAWN_ATTACHMENT_CONTENT = "__OPENCLAW_REDACTED__";
+const SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS = ["name", "encoding", "mimeType"] as const;
 
 type RawToolCallBlock = {
   type?: unknown;
@@ -94,18 +96,57 @@ function redactSessionsSpawnAttachmentsArgs(value: unknown): unknown {
   if (!Array.isArray(raw)) {
     return value;
   }
+  let changed = false;
   const next = raw.map((item) => {
-    if (!item || typeof item !== "object") {
+    if (isRedactedSessionsSpawnAttachment(item)) {
       return item;
     }
-    const a = item as Record<string, unknown>;
-    if (!Object.hasOwn(a, "content")) {
-      return item;
-    }
-    const { content: _content, ...rest } = a;
-    return { ...rest, content: "__OPENCLAW_REDACTED__" };
+    changed = true;
+    return redactSessionsSpawnAttachment(item);
   });
+  if (!changed) {
+    return value;
+  }
   return { ...rec, attachments: next };
+}
+
+function redactSessionsSpawnAttachment(item: unknown): Record<string, unknown> {
+  const next: Record<string, unknown> = {
+    content: REDACTED_SESSIONS_SPAWN_ATTACHMENT_CONTENT,
+  };
+  if (!item || typeof item !== "object") {
+    return next;
+  }
+  const attachment = item as Record<string, unknown>;
+  for (const key of SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS) {
+    const value = attachment[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+export function isRedactedSessionsSpawnAttachment(item: unknown): boolean {
+  if (!item || typeof item !== "object") {
+    return false;
+  }
+  const attachment = item as Record<string, unknown>;
+  if (attachment.content !== REDACTED_SESSIONS_SPAWN_ATTACHMENT_CONTENT) {
+    return false;
+  }
+  for (const key of Object.keys(attachment)) {
+    if (key === "content") {
+      continue;
+    }
+    if (!(SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS as readonly string[]).includes(key)) {
+      return false;
+    }
+    if (typeof attachment[key] !== "string" || (attachment[key] as string).trim().length === 0) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
@@ -232,7 +273,7 @@ export type ToolCallInputRepairReport = {
 
 export type ToolCallInputRepairOptions = {
   allowedToolNames?: Iterable<string>;
-  preserveImmutableThinkingTurns?: boolean;
+  allowProviderOwnedThinkingReplay?: boolean;
 };
 
 export type ErroredAssistantResultPolicy = "preserve" | "drop";
@@ -270,7 +311,7 @@ export function repairToolCallInputs(
   let changed = false;
   const out: AgentMessage[] = [];
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
-  const preserveImmutableThinkingTurns = options?.preserveImmutableThinkingTurns === true;
+  const allowProviderOwnedThinkingReplay = options?.allowProviderOwnedThinkingReplay === true;
 
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") {
@@ -284,7 +325,7 @@ export function repairToolCallInputs(
     }
 
     if (
-      preserveImmutableThinkingTurns &&
+      allowProviderOwnedThinkingReplay &&
       msg.content.some((block) => isThinkingLikeBlock(block)) &&
       countRawToolCallBlocks(msg.content) > 0
     ) {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -17,6 +17,14 @@ type RawToolCallBlock = {
   arguments?: unknown;
 };
 
+function isThinkingLikeBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
 function isRawToolCallBlock(block: unknown): block is RawToolCallBlock {
   if (!block || typeof block !== "object") {
     return false;
@@ -235,6 +243,14 @@ export function repairToolCallInputs(
     }
 
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+      out.push(msg);
+      continue;
+    }
+
+    // Preserve provider-owned thinking turns verbatim. Anthropic replays can
+    // reject any historical assistant turn whose signed thinking block no
+    // longer matches the original response, including sibling tool calls.
+    if (msg.content.some((block) => isThinkingLikeBlock(block))) {
       out.push(msg);
       continue;
     }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -176,7 +176,7 @@ function isReplaySafeThinkingAssistantTurn(
       return false;
     }
   }
-  return sawToolCall || content.some((block) => isThinkingLikeBlock(block));
+  return sawToolCall;
 }
 
 function makeMissingToolResult(params: {
@@ -232,6 +232,7 @@ export type ToolCallInputRepairReport = {
 
 export type ToolCallInputRepairOptions = {
   allowedToolNames?: Iterable<string>;
+  preserveImmutableThinkingTurns?: boolean;
 };
 
 export type ErroredAssistantResultPolicy = "preserve" | "drop";
@@ -269,6 +270,7 @@ export function repairToolCallInputs(
   let changed = false;
   const out: AgentMessage[] = [];
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
+  const preserveImmutableThinkingTurns = options?.preserveImmutableThinkingTurns === true;
 
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") {
@@ -281,7 +283,11 @@ export function repairToolCallInputs(
       continue;
     }
 
-    if (msg.content.some((block) => isThinkingLikeBlock(block))) {
+    if (
+      preserveImmutableThinkingTurns &&
+      msg.content.some((block) => isThinkingLikeBlock(block)) &&
+      countRawToolCallBlocks(msg.content) > 0
+    ) {
       // Signed Anthropic thinking blocks must remain byte-for-byte stable on
       // replay. Preserve the turn only if every sibling tool call is already
       // valid and requires no redaction or normalization. Otherwise drop the

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -322,6 +322,52 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call_1");
     });
 
+    it("rewrites earlier mutable ids away from later preserved signed ids", () => {
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read",
+          content: [{ type: "text", text: "first" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+            { type: "toolCall", id: "call1", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call1",
+          toolName: "read",
+          content: [{ type: "text", text: "second" }],
+        },
+      ]);
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "strict", {
+        preserveReplaySafeThinkingToolCallIds: true,
+        allowedToolNames: ["read"],
+      });
+
+      expect(out).not.toBe(input);
+      const firstAssistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+      const secondAssistant = out[2] as Extract<AgentMessage, { role: "assistant" }>;
+      const firstToolCall = firstAssistant.content?.[0] as { id?: string };
+      const secondToolCall = secondAssistant.content?.[1] as { id?: string };
+      expect(firstToolCall.id).not.toBe("call1");
+      expect(secondToolCall.id).toBe("call1");
+      expect(firstToolCall.id).not.toBe(secondToolCall.id);
+      expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+        firstToolCall.id,
+      );
+      expect((out[3] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call1");
+    });
+
     it("avoids collisions with alphanumeric-only suffixes", () => {
       const input = buildDuplicateIdCollisionInput();
 

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -316,9 +316,10 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       });
 
       expect(out).toBe(input);
-      expect(((out[0] as Extract<AgentMessage, { role: "assistant" }>).content?.[1] as { id?: string }).id).toBe(
-        "call_1",
-      );
+      expect(
+        ((out[0] as Extract<AgentMessage, { role: "assistant" }>).content?.[1] as { id?: string })
+          .id,
+      ).toBe("call_1");
       expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call_1");
     });
 
@@ -366,6 +367,55 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
         firstToolCall.id,
       );
       expect((out[3] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call1");
+    });
+
+    it("rewrites later signed turns when an earlier signed turn already owns the raw id", () => {
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+            { type: "toolCall", id: "call1", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call1",
+          toolName: "read",
+          content: [{ type: "text", text: "first" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thinkingSignature: "sig_2" },
+            { type: "toolCall", id: "call1", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call1",
+          toolName: "read",
+          content: [{ type: "text", text: "second" }],
+        },
+      ]);
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "strict", {
+        preserveReplaySafeThinkingToolCallIds: true,
+        allowedToolNames: ["read"],
+      });
+
+      expect(out).not.toBe(input);
+      const firstAssistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+      const secondAssistant = out[2] as Extract<AgentMessage, { role: "assistant" }>;
+      const firstToolCall = firstAssistant.content?.[1] as { id?: string };
+      const secondToolCall = secondAssistant.content?.[1] as { id?: string };
+      expect(firstToolCall.id).toBe("call1");
+      expect(secondToolCall.id).not.toBe("call1");
+      expect(secondToolCall.id).not.toBe(firstToolCall.id);
+      expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call1");
+      expect((out[3] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+        secondToolCall.id,
+      );
     });
 
     it("avoids collisions with alphanumeric-only suffixes", () => {

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -293,6 +293,35 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       ).toBe("call123fc123");
     });
 
+    it("preserves replay-safe signed-thinking tool ids when requested", () => {
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+            { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+        },
+      ]);
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "strict", {
+        preserveReplaySafeThinkingToolCallIds: true,
+        allowedToolNames: ["read"],
+      });
+
+      expect(out).toBe(input);
+      expect(((out[0] as Extract<AgentMessage, { role: "assistant" }>).content?.[1] as { id?: string }).id).toBe(
+        "call_1",
+      );
+      expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call_1");
+    });
+
     it("avoids collisions with alphanumeric-only suffixes", () => {
       const input = buildDuplicateIdCollisionInput();
 

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -111,10 +111,6 @@ function hasToolCallInput(block: ReplaySafeToolCallBlock): boolean {
   return hasInput || hasArguments;
 }
 
-function hasNonEmptyStringField(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
 function normalizeAllowedToolNames(allowedToolNames?: Iterable<string>): Set<string> | null {
   if (!allowedToolNames) {
     return null;
@@ -212,6 +208,7 @@ function isReplaySafeThinkingAssistantMessage(
 
   let sawThinking = false;
   let sawToolCall = false;
+  const seenToolCallIds = new Set<string>();
   for (const block of content) {
     if (isThinkingLikeBlock(block)) {
       sawThinking = true;
@@ -228,16 +225,39 @@ function isReplaySafeThinkingAssistantMessage(
       continue;
     }
     sawToolCall = true;
+    const toolCallId = typeof typedBlock.id === "string" ? typedBlock.id.trim() : "";
     if (
       !hasToolCallInput(typedBlock) ||
-      !hasNonEmptyStringField(typedBlock.id) ||
+      !toolCallId ||
+      seenToolCallIds.has(toolCallId) ||
       !hasReplaySafeToolCallName(typedBlock, allowedToolNames) ||
       toolCallNeedsReplayMutation(typedBlock)
     ) {
       return false;
     }
+    seenToolCallIds.add(toolCallId);
   }
   return sawThinking && sawToolCall;
+}
+
+function collectReplaySafeThinkingToolIds(
+  messages: AgentMessage[],
+  allowedToolNames: Set<string> | null,
+): Set<string> {
+  const reserved = new Set<string>();
+  for (const message of messages) {
+    if (!message || typeof message !== "object" || message.role !== "assistant") {
+      continue;
+    }
+    const assistant = message as Extract<AgentMessage, { role: "assistant" }>;
+    if (!isReplaySafeThinkingAssistantMessage(assistant, allowedToolNames)) {
+      continue;
+    }
+    for (const toolCall of extractToolCallsFromAssistant(assistant)) {
+      reserved.add(toolCall.id);
+    }
+  }
+  return reserved;
 }
 
 export function isValidCloudCodeAssistToolId(id: string, mode: ToolCallIdMode = "strict"): boolean {
@@ -308,13 +328,16 @@ function makeUniqueToolId(params: { id: string; used: Set<string>; mode: ToolCal
 
 function createOccurrenceAwareResolver(
   mode: ToolCallIdMode,
-  options?: { preserveNativeAnthropicToolUseIds?: boolean },
+  options?: {
+    preserveNativeAnthropicToolUseIds?: boolean;
+    reservedIds?: Iterable<string>;
+  },
 ): {
   resolveAssistantId: (id: string) => string;
   resolveToolResultId: (id: string) => string;
   preserveAssistantId: (id: string) => string;
 } {
-  const used = new Set<string>();
+  const used = new Set<string>(options?.reservedIds ?? []);
   const assistantOccurrences = new Map<string, number>();
   const orphanToolResultOccurrences = new Map<string, number>();
   const pendingByRawId = new Map<string, string[]>();
@@ -479,11 +502,17 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
   // duplicate tool-call IDs. Track assistant occurrences in-order so repeated
   // raw IDs receive distinct rewritten IDs, while matching tool results consume
   // the same rewritten IDs in encounter order.
-  const { resolveAssistantId, resolveToolResultId, preserveAssistantId } =
-    createOccurrenceAwareResolver(mode, options);
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
   const preserveReplaySafeThinkingToolCallIds =
     options?.preserveReplaySafeThinkingToolCallIds === true;
+  const reservedIds = preserveReplaySafeThinkingToolCallIds
+    ? collectReplaySafeThinkingToolIds(messages, allowedToolNames)
+    : undefined;
+  const { resolveAssistantId, resolveToolResultId, preserveAssistantId } =
+    createOccurrenceAwareResolver(mode, {
+      ...options,
+      reservedIds,
+    });
 
   let changed = false;
   const out = messages.map((msg) => {

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -1,8 +1,13 @@
 import { createHash } from "node:crypto";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 export type ToolCallIdMode = "strict" | "strict9";
 const NATIVE_ANTHROPIC_TOOL_USE_ID_RE = /^toolu_[A-Za-z0-9_]+$/;
+const REDACTED_SESSIONS_SPAWN_ATTACHMENT_CONTENT = "__OPENCLAW_REDACTED__";
+const SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS = ["name", "encoding", "mimeType"] as const;
+const TOOL_CALL_NAME_MAX_CHARS = 64;
+const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_:.-]+$/;
 
 const STRICT9_LEN = 9;
 const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
@@ -10,6 +15,14 @@ const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
 export type ToolCallLike = {
   id: string;
   name?: string;
+};
+
+type ReplaySafeToolCallBlock = {
+  type?: unknown;
+  id?: unknown;
+  name?: unknown;
+  input?: unknown;
+  arguments?: unknown;
 };
 
 /**
@@ -81,6 +94,150 @@ export function extractToolResultId(
     return toolUseId;
   }
   return null;
+}
+
+function isThinkingLikeBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
+function hasToolCallInput(block: ReplaySafeToolCallBlock): boolean {
+  const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;
+  const hasArguments =
+    "arguments" in block ? block.arguments !== undefined && block.arguments !== null : false;
+  return hasInput || hasArguments;
+}
+
+function hasNonEmptyStringField(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeAllowedToolNames(allowedToolNames?: Iterable<string>): Set<string> | null {
+  if (!allowedToolNames) {
+    return null;
+  }
+  const normalized = new Set<string>();
+  for (const name of allowedToolNames) {
+    if (typeof name !== "string") {
+      continue;
+    }
+    const trimmed = name.trim();
+    if (!trimmed) {
+      continue;
+    }
+    normalized.add(normalizeLowercaseStringOrEmpty(trimmed));
+  }
+  return normalized.size > 0 ? normalized : null;
+}
+
+function isRedactedSessionsSpawnAttachment(item: unknown): boolean {
+  if (!item || typeof item !== "object") {
+    return false;
+  }
+  const attachment = item as Record<string, unknown>;
+  if (attachment.content !== REDACTED_SESSIONS_SPAWN_ATTACHMENT_CONTENT) {
+    return false;
+  }
+  for (const key of Object.keys(attachment)) {
+    if (key === "content") {
+      continue;
+    }
+    if (!(SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS as readonly string[]).includes(key)) {
+      return false;
+    }
+    if (typeof attachment[key] !== "string" || (attachment[key] as string).trim().length === 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function toolCallNeedsReplayMutation(block: ReplaySafeToolCallBlock): boolean {
+  const rawName = typeof block.name === "string" ? block.name : undefined;
+  const trimmedName = rawName?.trim();
+  if (rawName && rawName !== trimmedName) {
+    return true;
+  }
+  if (normalizeLowercaseStringOrEmpty(trimmedName) !== "sessions_spawn") {
+    return false;
+  }
+  for (const payload of [block.arguments, block.input]) {
+    if (!payload || typeof payload !== "object") {
+      continue;
+    }
+    const attachments = (payload as { attachments?: unknown }).attachments;
+    if (!Array.isArray(attachments)) {
+      continue;
+    }
+    for (const attachment of attachments) {
+      if (!isRedactedSessionsSpawnAttachment(attachment)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function hasReplaySafeToolCallName(
+  block: ReplaySafeToolCallBlock,
+  allowedToolNames: Set<string> | null,
+): boolean {
+  if (typeof block.name !== "string") {
+    return false;
+  }
+  const trimmed = block.name.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.length > TOOL_CALL_NAME_MAX_CHARS || !TOOL_CALL_NAME_RE.test(trimmed)) {
+    return false;
+  }
+  if (!allowedToolNames) {
+    return true;
+  }
+  return allowedToolNames.has(normalizeLowercaseStringOrEmpty(trimmed));
+}
+
+function isReplaySafeThinkingAssistantMessage(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+  allowedToolNames: Set<string> | null,
+): boolean {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  let sawThinking = false;
+  let sawToolCall = false;
+  for (const block of content) {
+    if (isThinkingLikeBlock(block)) {
+      sawThinking = true;
+      continue;
+    }
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as ReplaySafeToolCallBlock;
+    if (
+      typeof typedBlock.type !== "string" ||
+      !TOOL_CALL_TYPES.has(typedBlock.type)
+    ) {
+      continue;
+    }
+    sawToolCall = true;
+    if (
+      !hasToolCallInput(typedBlock) ||
+      !hasNonEmptyStringField(typedBlock.id) ||
+      !hasReplaySafeToolCallName(typedBlock, allowedToolNames) ||
+      toolCallNeedsReplayMutation(typedBlock)
+    ) {
+      return false;
+    }
+  }
+  return sawThinking && sawToolCall;
 }
 
 export function isValidCloudCodeAssistToolId(id: string, mode: ToolCallIdMode = "strict"): boolean {
@@ -155,6 +312,7 @@ function createOccurrenceAwareResolver(
 ): {
   resolveAssistantId: (id: string) => string;
   resolveToolResultId: (id: string) => string;
+  preserveAssistantId: (id: string) => string;
 } {
   const used = new Set<string>();
   const assistantOccurrences = new Map<string, number>();
@@ -218,7 +376,18 @@ function createOccurrenceAwareResolver(
     return allocate(`${id}:tool_result:${occurrence}`);
   };
 
-  return { resolveAssistantId, resolveToolResultId };
+  const preserveAssistantId = (id: string): string => {
+    used.add(id);
+    const pending = pendingByRawId.get(id);
+    if (pending) {
+      pending.push(id);
+    } else {
+      pendingByRawId.set(id, [id]);
+    }
+    return id;
+  };
+
+  return { resolveAssistantId, resolveToolResultId, preserveAssistantId };
 }
 
 function rewriteAssistantToolCallIds(params: {
@@ -298,7 +467,11 @@ function rewriteToolResultIds(params: {
 export function sanitizeToolCallIdsForCloudCodeAssist(
   messages: AgentMessage[],
   mode: ToolCallIdMode = "strict",
-  options?: { preserveNativeAnthropicToolUseIds?: boolean },
+  options?: {
+    preserveNativeAnthropicToolUseIds?: boolean;
+    preserveReplaySafeThinkingToolCallIds?: boolean;
+    allowedToolNames?: Iterable<string>;
+  },
 ): AgentMessage[] {
   // Strict mode: only [a-zA-Z0-9]
   // Strict9 mode: only [a-zA-Z0-9], length 9 (Mistral tool call requirement)
@@ -306,7 +479,11 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
   // duplicate tool-call IDs. Track assistant occurrences in-order so repeated
   // raw IDs receive distinct rewritten IDs, while matching tool results consume
   // the same rewritten IDs in encounter order.
-  const { resolveAssistantId, resolveToolResultId } = createOccurrenceAwareResolver(mode, options);
+  const { resolveAssistantId, resolveToolResultId, preserveAssistantId } =
+    createOccurrenceAwareResolver(mode, options);
+  const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
+  const preserveReplaySafeThinkingToolCallIds =
+    options?.preserveReplaySafeThinkingToolCallIds === true;
 
   let changed = false;
   const out = messages.map((msg) => {
@@ -315,8 +492,18 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
     }
     const role = (msg as { role?: unknown }).role;
     if (role === "assistant") {
+      const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
+      if (
+        preserveReplaySafeThinkingToolCallIds &&
+        isReplaySafeThinkingAssistantMessage(assistant, allowedToolNames)
+      ) {
+        for (const toolCall of extractToolCallsFromAssistant(assistant)) {
+          preserveAssistantId(toolCall.id);
+        }
+        return msg;
+      }
       const next = rewriteAssistantToolCallIds({
-        message: msg as Extract<AgentMessage, { role: "assistant" }>,
+        message: assistant,
         resolveId: resolveAssistantId,
       });
       if (next !== msg) {

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -144,7 +144,7 @@ function isRedactedSessionsSpawnAttachment(item: unknown): boolean {
     if (!(SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS as readonly string[]).includes(key)) {
       return false;
     }
-    if (typeof attachment[key] !== "string" || (attachment[key] as string).trim().length === 0) {
+    if (typeof attachment[key] !== "string" || attachment[key].trim().length === 0) {
       return false;
     }
   }
@@ -218,10 +218,7 @@ function isReplaySafeThinkingAssistantMessage(
       continue;
     }
     const typedBlock = block as ReplaySafeToolCallBlock;
-    if (
-      typeof typedBlock.type !== "string" ||
-      !TOOL_CALL_TYPES.has(typedBlock.type)
-    ) {
+    if (typeof typedBlock.type !== "string" || !TOOL_CALL_TYPES.has(typedBlock.type)) {
       continue;
     }
     sawToolCall = true;
@@ -243,21 +240,28 @@ function isReplaySafeThinkingAssistantMessage(
 function collectReplaySafeThinkingToolIds(
   messages: AgentMessage[],
   allowedToolNames: Set<string> | null,
-): Set<string> {
+): { reservedIds: Set<string>; preservedIndexes: Set<number> } {
   const reserved = new Set<string>();
-  for (const message of messages) {
+  const preservedIndexes = new Set<number>();
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
     if (!message || typeof message !== "object" || message.role !== "assistant") {
       continue;
     }
-    const assistant = message as Extract<AgentMessage, { role: "assistant" }>;
+    const assistant = message;
     if (!isReplaySafeThinkingAssistantMessage(assistant, allowedToolNames)) {
       continue;
     }
-    for (const toolCall of extractToolCallsFromAssistant(assistant)) {
+    const toolCalls = extractToolCallsFromAssistant(assistant);
+    if (toolCalls.some((toolCall) => reserved.has(toolCall.id))) {
+      continue;
+    }
+    preservedIndexes.add(index);
+    for (const toolCall of toolCalls) {
       reserved.add(toolCall.id);
     }
   }
-  return reserved;
+  return { reservedIds: reserved, preservedIndexes };
 }
 
 export function isValidCloudCodeAssistToolId(id: string, mode: ToolCallIdMode = "strict"): boolean {
@@ -505,27 +509,24 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
   const preserveReplaySafeThinkingToolCallIds =
     options?.preserveReplaySafeThinkingToolCallIds === true;
-  const reservedIds = preserveReplaySafeThinkingToolCallIds
+  const replaySafeThinking = preserveReplaySafeThinkingToolCallIds
     ? collectReplaySafeThinkingToolIds(messages, allowedToolNames)
     : undefined;
   const { resolveAssistantId, resolveToolResultId, preserveAssistantId } =
     createOccurrenceAwareResolver(mode, {
       ...options,
-      reservedIds,
+      reservedIds: replaySafeThinking?.reservedIds,
     });
 
   let changed = false;
-  const out = messages.map((msg) => {
+  const out = messages.map((msg, index) => {
     if (!msg || typeof msg !== "object") {
       return msg;
     }
     const role = (msg as { role?: unknown }).role;
     if (role === "assistant") {
       const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
-      if (
-        preserveReplaySafeThinkingToolCallIds &&
-        isReplaySafeThinkingAssistantMessage(assistant, allowedToolNames)
-      ) {
+      if (replaySafeThinking?.preservedIndexes.has(index)) {
         for (const toolCall of extractToolCallsFromAssistant(assistant)) {
           preserveAssistantId(toolCall.id);
         }

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -4,6 +4,9 @@ vi.mock("../plugins/provider-runtime.js", async () => {
   const actual = await vi.importActual<typeof import("../plugins/provider-runtime.js")>(
     "../plugins/provider-runtime.js",
   );
+  const replayHelpers = await vi.importActual<
+    typeof import("../plugins/provider-replay-helpers.js")
+  >("../plugins/provider-replay-helpers.js");
   return {
     ...actual,
     resolveProviderRuntimePlugin: vi.fn(({ provider }: { provider?: string }) => {
@@ -51,7 +54,10 @@ vi.mock("../plugins/provider-runtime.js", async () => {
                 repairToolUseResultPairing: true,
                 validateAnthropicTurns: true,
                 allowSyntheticToolResults: true,
-                ...(modelId.includes("claude") ? { dropThinkingBlocks: true } : {}),
+                ...(modelId.includes("claude") &&
+                !replayHelpers.shouldPreserveThinkingBlocks(modelId)
+                  ? { dropThinkingBlocks: true }
+                  : {}),
               };
             case "minimax":
             case "minimax-portal":
@@ -71,7 +77,10 @@ vi.mock("../plugins/provider-runtime.js", async () => {
                     repairToolUseResultPairing: true,
                     validateAnthropicTurns: true,
                     allowSyntheticToolResults: true,
-                    ...(modelId.includes("claude") ? { dropThinkingBlocks: true } : {}),
+                    ...(modelId.includes("claude") &&
+                    !replayHelpers.shouldPreserveThinkingBlocks(modelId)
+                      ? { dropThinkingBlocks: true }
+                      : {}),
                   };
             case "moonshot":
             case "ollama":
@@ -182,9 +191,8 @@ let shouldAllowProviderOwnedThinkingReplay: typeof import("./transcript-policy.j
 
 describe("resolveTranscriptPolicy", () => {
   beforeAll(async () => {
-    ({ resolveTranscriptPolicy, shouldAllowProviderOwnedThinkingReplay } = await import(
-      "./transcript-policy.js"
-    ));
+    ({ resolveTranscriptPolicy, shouldAllowProviderOwnedThinkingReplay } =
+      await import("./transcript-policy.js"));
   });
 
   beforeEach(() => {
@@ -416,6 +424,20 @@ describe("resolveTranscriptPolicy", () => {
     expect(
       shouldAllowProviderOwnedThinkingReplay({
         modelApi: "anthropic-messages",
+        policy,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows immutable provider-owned thinking replay for bedrock claude replay policies", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "amazon-bedrock",
+      modelId: "us.anthropic.claude-opus-4-6-v1",
+      modelApi: "bedrock-converse-stream",
+    });
+    expect(
+      shouldAllowProviderOwnedThinkingReplay({
+        modelApi: "bedrock-converse-stream",
         policy,
       }),
     ).toBe(true);

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -178,10 +178,13 @@ vi.mock("../plugins/provider-runtime.js", async () => {
 });
 
 let resolveTranscriptPolicy: typeof import("./transcript-policy.js").resolveTranscriptPolicy;
+let shouldAllowProviderOwnedThinkingReplay: typeof import("./transcript-policy.js").shouldAllowProviderOwnedThinkingReplay;
 
 describe("resolveTranscriptPolicy", () => {
   beforeAll(async () => {
-    ({ resolveTranscriptPolicy } = await import("./transcript-policy.js"));
+    ({ resolveTranscriptPolicy, shouldAllowProviderOwnedThinkingReplay } = await import(
+      "./transcript-policy.js"
+    ));
   });
 
   beforeEach(() => {
@@ -402,6 +405,34 @@ describe("resolveTranscriptPolicy", () => {
   ])("sets preserveSignatures for $title (#32526, #39798)", ({ preserveSignatures, ...input }) => {
     const policy = resolveTranscriptPolicy(input);
     expect(policy.preserveSignatures).toBe(preserveSignatures);
+  });
+
+  it("allows immutable provider-owned thinking replay for anthropic-compatible native replay policies", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "minimax",
+      modelId: "MiniMax-M2.7",
+      modelApi: "anthropic-messages",
+    });
+    expect(
+      shouldAllowProviderOwnedThinkingReplay({
+        modelApi: "anthropic-messages",
+        policy,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not allow immutable provider-owned thinking replay for strict openai-compatible replay", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "vllm",
+      modelId: "gemma-3-27b",
+      modelApi: "openai-completions",
+    });
+    expect(
+      shouldAllowProviderOwnedThinkingReplay({
+        modelApi: "openai-completions",
+        policy,
+      }),
+    ).toBe(false);
   });
 
   it("enables turn-ordering and assistant-merge for strict OpenAI-compatible providers (#38962)", () => {

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -16,6 +16,7 @@ vi.mock("../plugins/provider-runtime.js", async () => {
           "amazon-bedrock",
           "anthropic",
           "google",
+          "github-copilot",
           "kilocode",
           "kimi",
           "kimi-code",
@@ -109,6 +110,12 @@ vi.mock("../plugins/provider-runtime.js", async () => {
                 validateAnthropicTurns: false,
                 allowSyntheticToolResults: true,
               };
+            case "github-copilot":
+              return modelId.includes("claude")
+                ? {
+                    dropThinkingBlocks: true,
+                  }
+                : {};
             case "mistral":
               return {
                 sanitizeToolCallIds: true,
@@ -441,6 +448,34 @@ describe("resolveTranscriptPolicy", () => {
         policy,
       }),
     ).toBe(true);
+  });
+
+  it("does not allow immutable provider-owned thinking replay for github-copilot claude models", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "github-copilot",
+      modelId: "claude-sonnet-4",
+      modelApi: "anthropic-messages",
+    });
+    expect(
+      shouldAllowProviderOwnedThinkingReplay({
+        modelApi: "anthropic-messages",
+        policy,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not allow immutable provider-owned thinking replay for openrouter models on openai replay", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openrouter",
+      modelId: "anthropic/claude-sonnet-4-6",
+      modelApi: "openai-completions",
+    });
+    expect(
+      shouldAllowProviderOwnedThinkingReplay({
+        modelApi: "openai-completions",
+        policy,
+      }),
+    ).toBe(false);
   });
 
   it("does not allow immutable provider-owned thinking replay for strict openai-compatible replay", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -29,6 +29,18 @@ export type TranscriptPolicy = {
   allowSyntheticToolResults: boolean;
 };
 
+export function shouldAllowProviderOwnedThinkingReplay(params: {
+  modelApi?: string | null;
+  policy: Pick<TranscriptPolicy, "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks">;
+}): boolean {
+  return (
+    params.modelApi === "anthropic-messages" &&
+    params.policy.validateAnthropicTurns === true &&
+    params.policy.preserveSignatures === true &&
+    params.policy.dropThinkingBlocks !== true
+  );
+}
+
 const DEFAULT_TRANSCRIPT_POLICY: TranscriptPolicy = {
   sanitizeMode: "images-only",
   sanitizeToolCallIds: false,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -31,13 +31,16 @@ export type TranscriptPolicy = {
 
 export function shouldAllowProviderOwnedThinkingReplay(params: {
   modelApi?: string | null;
-  policy: Pick<TranscriptPolicy, "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks">;
+  policy: Pick<
+    TranscriptPolicy,
+    "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks"
+  >;
 }): boolean {
   return (
-    params.modelApi === "anthropic-messages" &&
-    params.policy.validateAnthropicTurns === true &&
-    params.policy.preserveSignatures === true &&
-    params.policy.dropThinkingBlocks !== true
+    isAnthropicApi(params.modelApi) &&
+    params.policy.validateAnthropicTurns &&
+    params.policy.preserveSignatures &&
+    !params.policy.dropThinkingBlocks
   );
 }
 


### PR DESCRIPTION
## Summary
- preserve Anthropic signed-thinking turns only when sibling tool calls are already replay-safe
- drop signed-thinking assistant turns that would require tool-call mutation, stale allowlist rewrites, or attachment redaction
- cover the poisoned-session replay path and the new unsafe-turn fallback behavior with targeted regression tests

## Why
Historical Anthropic assistant turns that contain signed `thinking` / `redacted_thinking` blocks cannot be mutated during replay. The initial fix preserved too much and skipped other hygiene work. This version keeps replay-safe signed turns intact but drops unsafe ones before they can leak inline `sessions_spawn` attachment payloads or forward malformed / stale tool calls.

## Testing
- pnpm vitest run src/agents/session-transcript-repair.test.ts src/agents/pi-embedded-helpers.validate-turns.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts
- 4 files passed
- 173 tests passed