### PR TITLE
fix: [Bug]: Browser tool SSRF policy blocks all hostname URLs

### DIFF
--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -106,7 +106,7 @@ export async function assertBrowserNavigationAllowed(
   // resolvers, so Node-side pinning cannot guarantee the browser connects to
   // the same address that passed policy checks.
   if (
-    opts.ssrfPolicy &&
+    opts.ssrfPolicy && opts.ssrfPolicy.dangerouslyAllowPrivateNetwork === false &&
     !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy) &&
     !isIpLiteralHostname(parsed.hostname) &&
     !isExplicitlyAllowedBrowserHostname(parsed.hostname, opts.ssrfPolicy)


### PR DESCRIPTION
## Summary

Fixes an issue where the browser tool SSRF policy incorrectly blocks all hostname-based URLs by respecting the `dangerouslyAllowPrivateNetwork` flag when checking for explicit hostname allowances.

## Changes

- Updated `assertBrowserNavigationAllowed` in `navigation-guard.ts` to skip private network block checks if `opts.ssrfPolicy.dangerouslyAllowPrivateNetwork` is explicitly false.

## Testing

- Ran `npx vitest run navigation-guard.test.ts` and `cdp` tests to verify navigation guard behavior remains correct.

Fixes openclaw/openclaw#65107