### PR TITLE
fix(agents): suppress commentary text in visible replies

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -932,6 +932,130 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(doneEvent?.message.stopReason).toBe("toolUse");
   });
 
+  it("buffers partial text until final_answer phase is known", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-buffer");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: unknown[] = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_final",
+      output_index: 0,
+      content_index: 0,
+      delta: "Hello",
+    });
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "item_final",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Hello" }],
+        phase: "final_answer",
+      },
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        ...makeResponseObject("resp_phase_buffer", "Hello", undefined, "final_answer"),
+        output: [
+          {
+            type: "message",
+            id: "item_final",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hello" }],
+            phase: "final_answer",
+          },
+        ],
+      },
+    });
+
+    await done;
+
+    const textDeltaEvents = events.filter((e) => (e as { type?: string }).type === "text_delta") as Array<{
+      delta: string;
+      partial?: { phase?: string };
+    }>;
+    expect(textDeltaEvents).toHaveLength(1);
+    expect(textDeltaEvents[0]?.delta).toBe("Hello");
+    expect(textDeltaEvents[0]?.partial?.phase).toBe("final_answer");
+  });
+
+  it("suppresses buffered commentary partial text once commentary phase is known", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-commentary-buffer");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: unknown[] = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_commentary",
+      output_index: 0,
+      content_index: 0,
+      delta: "Need act verify",
+    });
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "item_commentary",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Need act verify" }],
+        phase: "commentary",
+      },
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        ...makeResponseObject("resp_phase_commentary", "Need act verify", "exec", "commentary"),
+        output: [
+          {
+            type: "message",
+            id: "item_commentary",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Need act verify" }],
+            phase: "commentary",
+          },
+          {
+            type: "function_call",
+            id: "item_tool",
+            call_id: "call_abc",
+            name: "exec",
+            arguments: '{"arg":"value"}',
+          },
+        ],
+      },
+    });
+
+    await done;
+
+    const textDeltaEvents = events.filter((e) => (e as { type?: string }).type === "text_delta");
+    expect(textDeltaEvents).toHaveLength(0);
+  });
+
   it("falls back to HTTP when WebSocket connect fails (session pre-broken via flag)", async () => {
     // Set the class-level flag BEFORE calling streamFn so the new instance
     // fails on connect().  We patch the static default via MockManager directly.

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -855,10 +855,60 @@ export function createOpenAIWebSocketStreamFn(
         };
         session.manager.on("close", closeHandler);
 
+        const itemPhaseById = new Map<string, OpenAIResponsesAssistantPhase | "unknown">();
+        const bufferedDeltaByItemId = new Map<string, string[]>();
+
+        const emitVisibleDelta = (
+          delta: string,
+          phase?: OpenAIResponsesAssistantPhase,
+        ) => {
+          const partialMsg = buildAssistantMessageWithZeroUsage({
+            model,
+            content: [{ type: "text", text: delta }],
+            stopReason: "stop",
+          }) as AssistantMessageWithPhase;
+          if (phase) {
+            partialMsg.phase = phase;
+          }
+          eventStream.push({
+            type: "text_delta",
+            contentIndex: 0,
+            delta,
+            partial: partialMsg,
+          });
+        };
+
+        const flushBufferedItemDelta = (itemId: string, phase?: OpenAIResponsesAssistantPhase) => {
+          const chunks = bufferedDeltaByItemId.get(itemId);
+          if (!chunks || chunks.length === 0) {
+            return;
+          }
+          bufferedDeltaByItemId.delete(itemId);
+          if (phase === "commentary") {
+            return;
+          }
+          for (const chunk of chunks) {
+            emitVisibleDelta(chunk, phase);
+          }
+        };
+
+        const noteItemPhase = (item: { id?: unknown; type?: unknown; phase?: unknown }) => {
+          if (item.type !== "message" || typeof item.id !== "string") {
+            return;
+          }
+          const phase = normalizeAssistantPhase(item.phase);
+          itemPhaseById.set(item.id, phase ?? "unknown");
+          if (phase) {
+            flushBufferedItemDelta(item.id, phase);
+          }
+        };
+
         const cleanup = () => {
           signal?.removeEventListener("abort", abortHandler);
           session.manager.off("close", closeHandler);
           unsubscribe();
+          itemPhaseById.clear();
+          bufferedDeltaByItemId.clear();
         };
 
         const unsubscribe = session.manager.onMessage((event) => {
@@ -883,19 +933,23 @@ export function createOpenAIWebSocketStreamFn(
           } else if (event.type === "error") {
             cleanup();
             reject(new Error(`OpenAI WebSocket error: ${event.message} (code=${event.code})`));
+          } else if (
+            event.type === "response.output_item.added" ||
+            event.type === "response.output_item.done"
+          ) {
+            noteItemPhase(event.item);
           } else if (event.type === "response.output_text.delta") {
-            // Stream partial text updates for responsive UI
-            const partialMsg: AssistantMessage = buildAssistantMessageWithZeroUsage({
-              model,
-              content: [{ type: "text", text: event.delta }],
-              stopReason: "stop",
-            });
-            eventStream.push({
-              type: "text_delta",
-              contentIndex: 0,
-              delta: event.delta,
-              partial: partialMsg,
-            });
+            const phase = itemPhaseById.get(event.item_id);
+            if (phase === "commentary") {
+              return;
+            }
+            if (phase === "final_answer") {
+              emitVisibleDelta(event.delta, phase);
+              return;
+            }
+            const chunks = bufferedDeltaByItemId.get(event.item_id) ?? [];
+            chunks.push(event.delta);
+            bufferedDeltaByItemId.set(event.item_id, chunks);
           }
         });
       });

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -605,3 +605,53 @@ describe("empty input handling", () => {
     }
   });
 });
+
+describe("extractAssistantText phase filtering", () => {
+  it("returns empty text for commentary-phase assistant messages", () => {
+    expect(
+      extractAssistantText({
+        role: "assistant",
+        phase: "commentary",
+        content: [{ type: "text", text: "Need act verify each sample exists in library." }],
+        stopReason: "toolUse",
+      } as any),
+    ).toBe("");
+  });
+
+  it("ignores commentary text blocks when final_answer blocks are present", () => {
+    expect(
+      extractAssistantText({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Need act verify each sample exists in library.",
+            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+          },
+          {
+            type: "text",
+            text: "Done. I set the setting to true.",
+            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+          },
+        ],
+        stopReason: "stop",
+      } as any),
+    ).toBe("Done. I set the setting to true.");
+  });
+
+  it("suppresses commentary-only text blocks even without a top-level phase", () => {
+    expect(
+      extractAssistantText({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Need act verify each sample exists in library.",
+            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+          },
+        ],
+        stopReason: "toolUse",
+      } as any),
+    ).toBe("");
+  });
+});

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -233,9 +233,62 @@ export function stripThinkingTagsFromText(text: string): string {
   return stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
 }
 
+type AssistantTextPhase = "commentary" | "final_answer";
+
+function normalizeAssistantTextPhase(value: unknown): AssistantTextPhase | undefined {
+  return value === "commentary" || value === "final_answer" ? value : undefined;
+}
+
+function parseAssistantTextSignaturePhase(value: unknown): AssistantTextPhase | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+  if (!value.trimStart().startsWith("{")) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as { phase?: unknown };
+    return normalizeAssistantTextPhase(parsed.phase);
+  } catch {
+    return undefined;
+  }
+}
+
+function filterUserVisibleAssistantContent(content: unknown): unknown {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  const textEntries = content.filter(
+    (block) => block && typeof block === "object" && (block as { type?: unknown }).type === "text",
+  ) as Array<{ text?: unknown; textSignature?: unknown }>;
+  const hasFinalAnswerText = textEntries.some(
+    (block) => parseAssistantTextSignaturePhase(block.textSignature) === "final_answer",
+  );
+
+  return content.filter((block) => {
+    if (!block || typeof block !== "object") {
+      return true;
+    }
+    if ((block as { type?: unknown }).type !== "text") {
+      return true;
+    }
+    const phase = parseAssistantTextSignaturePhase((block as { textSignature?: unknown }).textSignature);
+    if (phase === "commentary") {
+      return false;
+    }
+    if (hasFinalAnswerText) {
+      return phase === "final_answer";
+    }
+    return true;
+  });
+}
+
 export function extractAssistantText(msg: AssistantMessage): string {
+  if (normalizeAssistantTextPhase((msg as { phase?: unknown }).phase) === "commentary") {
+    return "";
+  }
   const extracted =
-    extractTextFromChatContent(msg.content, {
+    extractTextFromChatContent(filterUserVisibleAssistantContent(msg.content), {
       sanitizeText: (text) =>
         stripThinkingTagsFromText(
           stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),


### PR DESCRIPTION
## Summary
Fixes a remaining commentary leak path related to #65132.

This change does two things:
- suppresses buffered OpenAI WS partial text until the item phase is known, and drops it entirely when that phase resolves to `commentary`
- makes visible assistant text extraction ignore `commentary` blocks and prefer `final_answer` blocks when both exist in the same assistant message

## Why
On 2026.4.11 I was able to reproduce a Discord-visible leak where internal planning text tagged `phase: "commentary"` reached the user with `openai-codex/gpt-5.4`.

The two main gaps addressed here were:
1. `response.output_text.delta` partials were emitted before phase was known
2. mixed-phase assistant messages could still contribute commentary text to visible reply extraction

## Changes
- `src/agents/openai-ws-stream.ts`
  - buffer `response.output_text.delta` per `item_id`
  - wait for `response.output_item.added/done` to determine item phase
  - flush only for `final_answer`
  - discard buffered commentary partials
- `src/agents/pi-embedded-utils.ts`
  - return empty visible text for top-level `commentary` assistant messages
  - ignore commentary text blocks via `textSignature.phase`
  - when `final_answer` blocks exist, use only those for visible extraction

## Tests
Added/updated tests covering:
- buffered final text flushes once `final_answer` phase is known
- buffered commentary partials are suppressed
- commentary-only assistant messages produce no visible text
- mixed commentary + `final_answer` assistant messages only expose `final_answer`

## Validation
Ran:
- `pnpm exec vitest run src/agents/openai-ws-stream.test.ts src/agents/pi-embedded-utils.test.ts`
