### PR TITLE
fix: add --force flag to npm install -g for container updates

### DIFF
--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -45,6 +45,35 @@ describe("update global helpers", () => {
     ).toBe("openclaw@next");
   });
 
+  it("rejects env package specs that start with '-' (option injection guard)", () => {
+    // Specs beginning with `-` must be rejected to prevent npm option injection
+    expect(
+      resolveGlobalInstallSpec({
+        packageName: "openclaw",
+        tag: "latest",
+        env: { OPENCLAW_UPDATE_PACKAGE_SPEC: "--registry=http://evil.com" },
+      }),
+    ).toBe("openclaw@latest");
+
+    expect(
+      resolveGlobalInstallSpec({
+        packageName: "openclaw",
+        tag: "latest",
+        env: { OPENCLAW_UPDATE_PACKAGE_SPEC: "-f" },
+      }),
+    ).toBe("openclaw@latest");
+  });
+
+  it("rejects env package specs with control characters", () => {
+    expect(
+      resolveGlobalInstallSpec({
+        packageName: "openclaw",
+        tag: "latest",
+        env: { OPENCLAW_UPDATE_PACKAGE_SPEC: "openclaw@latest\x00--registry=evil" },
+      }),
+    ).toBe("openclaw@latest");
+  });
+
   it("resolves global roots and package roots from runner output", async () => {
     const runCommand: CommandRunner = async (argv) => {
       if (argv[0] === "npm") {
@@ -138,11 +167,12 @@ describe("update global helpers", () => {
       "npm",
       "i",
       "-g",
-      "openclaw@latest",
       "--force",
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
+      "--",
+      "openclaw@latest",
     ]);
     expect(globalInstallArgs("pnpm", "openclaw@latest")).toEqual([
       "pnpm",
@@ -161,11 +191,12 @@ describe("update global helpers", () => {
       "npm",
       "i",
       "-g",
-      "openclaw@latest",
       "--omit=optional",
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
+      "--",
+      "openclaw@latest",
     ]);
     expect(globalInstallFallbackArgs("pnpm", "openclaw@latest")).toBeNull();
   });

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -191,6 +191,7 @@ describe("update global helpers", () => {
       "npm",
       "i",
       "-g",
+      "--force",
       "--omit=optional",
       "--no-fund",
       "--no-audit",

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -139,6 +139,7 @@ describe("update global helpers", () => {
       "i",
       "-g",
       "openclaw@latest",
+      "--force",
       "--no-fund",
       "--no-audit",
       "--loglevel=error",

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -18,6 +18,7 @@ const ALL_PACKAGE_NAMES = [PRIMARY_PACKAGE_NAME] as const;
 const GLOBAL_RENAME_PREFIX = ".";
 export const OPENCLAW_MAIN_PACKAGE_SPEC = "github:openclaw/openclaw#main";
 const NPM_GLOBAL_INSTALL_QUIET_FLAGS = ["--no-fund", "--no-audit", "--loglevel=error"] as const;
+const NPM_GLOBAL_INSTALL_FORCE_FLAGS = ["--force", ...NPM_GLOBAL_INSTALL_QUIET_FLAGS] as const;
 const NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS = [
   "--omit=optional",
   ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
@@ -288,7 +289,7 @@ export function globalInstallArgs(manager: GlobalInstallManager, spec: string): 
   if (manager === "bun") {
     return ["bun", "add", "-g", spec];
   }
-  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_QUIET_FLAGS];
+  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_FORCE_FLAGS];
 }
 
 export function globalInstallFallbackArgs(

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -23,6 +23,10 @@ const NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS = [
   "--omit=optional",
   ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
 ] as const;
+const NPM_GLOBAL_INSTALL_FORCE_OMIT_OPTIONAL_FLAGS = [
+  "--force",
+  ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS,
+] as const;
 
 function normalizePackageTarget(value: string): string {
   return value.trim();
@@ -317,7 +321,7 @@ export function globalInstallFallbackArgs(
   if (manager !== "npm") {
     return null;
   }
-  return ["npm", "i", "-g", ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS, "--", spec];
+  return ["npm", "i", "-g", ...NPM_GLOBAL_INSTALL_FORCE_OMIT_OPTIONAL_FLAGS, "--", spec];
 }
 
 export async function cleanupGlobalRenameDirs(params: {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -130,14 +130,31 @@ function applyWindowsPackageInstallEnv(env: Record<string, string>) {
   env.NODE_LLAMA_CPP_SKIP_DOWNLOAD = "1";
 }
 
+/**
+ * Sanitize an env-provided package spec to prevent npm option injection.
+ * Rejects specs that start with `-` or contain control characters.
+ */
+function sanitizeEnvPackageSpec(value: string): string | null {
+  if (!value || value.startsWith("-")) {
+    return null;
+  }
+  // Reject specs with control characters or unprintable bytes
+  if (/[\x00-\x1f\x7f]/.test(value)) {
+    return null;
+  }
+  return value;
+}
+
 export function resolveGlobalInstallSpec(params: {
   packageName: string;
   tag: string;
   env?: NodeJS.ProcessEnv;
 }): string {
-  const override =
-    params.env?.OPENCLAW_UPDATE_PACKAGE_SPEC?.trim() ||
-    process.env.OPENCLAW_UPDATE_PACKAGE_SPEC?.trim();
+  const override = sanitizeEnvPackageSpec(
+    params.env?.OPENCLAW_UPDATE_PACKAGE_SPEC?.trim() ??
+      process.env.OPENCLAW_UPDATE_PACKAGE_SPEC?.trim() ??
+      "",
+  );
   if (override) {
     return override;
   }
@@ -289,7 +306,8 @@ export function globalInstallArgs(manager: GlobalInstallManager, spec: string): 
   if (manager === "bun") {
     return ["bun", "add", "-g", spec];
   }
-  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_FORCE_FLAGS];
+  // Use `--` to terminate option parsing so npm cannot interpret `spec` as a flag.
+  return ["npm", "i", "-g", ...NPM_GLOBAL_INSTALL_FORCE_FLAGS, "--", spec];
 }
 
 export function globalInstallFallbackArgs(
@@ -299,7 +317,7 @@ export function globalInstallFallbackArgs(
   if (manager !== "npm") {
     return null;
   }
-  return ["npm", "i", "-g", spec, ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS];
+  return ["npm", "i", "-g", ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS, "--", spec];
 }
 
 export async function cleanupGlobalRenameDirs(params: {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -257,9 +257,9 @@ describe("runGatewayUpdate", () => {
     onBaseInstall?: () => Promise<CommandResult>;
     onOmitOptionalInstall?: () => Promise<CommandResult>;
   }) {
-    const baseInstallKey = "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error";
+    const baseInstallKey = "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@latest";
     const omitOptionalInstallKey =
-      "npm i -g openclaw@latest --omit=optional --no-fund --no-audit --loglevel=error";
+      "npm i -g --omit=optional --no-fund --no-audit --loglevel=error -- openclaw@latest";
 
     return async (argv: string[]): Promise<CommandResult> => {
       const key = argv.join(" ");
@@ -541,18 +541,18 @@ describe("runGatewayUpdate", () => {
     {
       title: "updates global npm installs when detected",
       expectedInstallCommand:
-        "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
+        "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@latest",
     },
     {
       title: "uses update channel for global npm installs when tag is omitted",
       expectedInstallCommand:
-        "npm i -g openclaw@beta --force --no-fund --no-audit --loglevel=error",
+        "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@beta",
       channel: "beta" as const,
     },
     {
       title: "updates global npm installs with tag override",
       expectedInstallCommand:
-        "npm i -g openclaw@beta --force --no-fund --no-audit --loglevel=error",
+        "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@beta",
       tag: "beta",
     },
   ])("$title", async ({ expectedInstallCommand, channel, tag }) => {
@@ -572,14 +572,14 @@ describe("runGatewayUpdate", () => {
   it("updates global npm installs from the GitHub main package spec", async () => {
     const { calls, result } = await runNpmGlobalUpdateCase({
       expectedInstallCommand:
-        "npm i -g github:openclaw/openclaw#main --force --no-fund --no-audit --loglevel=error",
+        "npm i -g --force --no-fund --no-audit --loglevel=error -- github:openclaw/openclaw#main",
       tag: "main",
     });
 
     expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
     expect(calls).toContain(
-      "npm i -g github:openclaw/openclaw#main --force --no-fund --no-audit --loglevel=error",
+      "npm i -g --force --no-fund --no-audit --loglevel=error -- github:openclaw/openclaw#main",
     );
   });
 
@@ -588,7 +588,7 @@ describe("runGatewayUpdate", () => {
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
+      installCommand: "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@latest",
       gitRootMode: "missing",
       onInstall: async () => writeGlobalPackageVersion(pkgRoot),
     });
@@ -598,7 +598,7 @@ describe("runGatewayUpdate", () => {
     expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
     expect(calls).toContain(
-      "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
+      "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@latest",
     );
   });
 
@@ -659,7 +659,7 @@ describe("runGatewayUpdate", () => {
   it("fails global npm update when the installed version misses the requested correction", async () => {
     const { calls, result } = await runNpmGlobalUpdateCase({
       expectedInstallCommand:
-        "npm i -g openclaw@2026.3.23-2 --force --no-fund --no-audit --loglevel=error",
+        "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@2026.3.23-2",
       tag: "2026.3.23-2",
     });
 
@@ -670,14 +670,14 @@ describe("runGatewayUpdate", () => {
       "expected installed version 2026.3.23-2, found 2.0.0",
     );
     expect(calls).toContain(
-      "npm i -g openclaw@2026.3.23-2 --force --no-fund --no-audit --loglevel=error",
+      "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@2026.3.23-2",
     );
   });
 
   it("fails global npm update when bundled runtime sidecars are missing after install", async () => {
     const { nodeModules, pkgRoot } = await createGlobalPackageFixture(tempDir);
     const expectedInstallCommand =
-      "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error";
+      "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@latest";
     const { runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
@@ -728,7 +728,7 @@ describe("runGatewayUpdate", () => {
     const { runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
+      installCommand: "npm i -g --force --no-fund --no-audit --loglevel=error -- openclaw@latest",
       onInstall: async (options) => {
         installEnv = options?.env;
         await writeGlobalPackageVersion(pkgRoot);
@@ -754,7 +754,7 @@ describe("runGatewayUpdate", () => {
   it("uses OPENCLAW_UPDATE_PACKAGE_SPEC for global package updates", async () => {
     const { nodeModules, pkgRoot } = await createGlobalPackageFixture(tempDir);
     const expectedInstallCommand =
-      "npm i -g http://10.211.55.2:8138/openclaw-next.tgz --force --no-fund --no-audit --loglevel=error";
+      "npm i -g --force --no-fund --no-audit --loglevel=error -- http://10.211.55.2:8138/openclaw-next.tgz";
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -257,7 +257,7 @@ describe("runGatewayUpdate", () => {
     onBaseInstall?: () => Promise<CommandResult>;
     onOmitOptionalInstall?: () => Promise<CommandResult>;
   }) {
-    const baseInstallKey = "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error";
+    const baseInstallKey = "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error";
     const omitOptionalInstallKey =
       "npm i -g openclaw@latest --omit=optional --no-fund --no-audit --loglevel=error";
 
@@ -540,16 +540,19 @@ describe("runGatewayUpdate", () => {
   it.each([
     {
       title: "updates global npm installs when detected",
-      expectedInstallCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand:
+        "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
     },
     {
       title: "uses update channel for global npm installs when tag is omitted",
-      expectedInstallCommand: "npm i -g openclaw@beta --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand:
+        "npm i -g openclaw@beta --force --no-fund --no-audit --loglevel=error",
       channel: "beta" as const,
     },
     {
       title: "updates global npm installs with tag override",
-      expectedInstallCommand: "npm i -g openclaw@beta --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand:
+        "npm i -g openclaw@beta --force --no-fund --no-audit --loglevel=error",
       tag: "beta",
     },
   ])("$title", async ({ expectedInstallCommand, channel, tag }) => {
@@ -569,14 +572,14 @@ describe("runGatewayUpdate", () => {
   it("updates global npm installs from the GitHub main package spec", async () => {
     const { calls, result } = await runNpmGlobalUpdateCase({
       expectedInstallCommand:
-        "npm i -g github:openclaw/openclaw#main --no-fund --no-audit --loglevel=error",
+        "npm i -g github:openclaw/openclaw#main --force --no-fund --no-audit --loglevel=error",
       tag: "main",
     });
 
     expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
     expect(calls).toContain(
-      "npm i -g github:openclaw/openclaw#main --no-fund --no-audit --loglevel=error",
+      "npm i -g github:openclaw/openclaw#main --force --no-fund --no-audit --loglevel=error",
     );
   });
 
@@ -585,7 +588,7 @@ describe("runGatewayUpdate", () => {
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
       gitRootMode: "missing",
       onInstall: async () => writeGlobalPackageVersion(pkgRoot),
     });
@@ -594,7 +597,9 @@ describe("runGatewayUpdate", () => {
 
     expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
-    expect(calls).toContain("npm i -g openclaw@latest --no-fund --no-audit --loglevel=error");
+    expect(calls).toContain(
+      "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
+    );
   });
 
   it("cleans stale npm rename dirs before global update", async () => {
@@ -653,7 +658,8 @@ describe("runGatewayUpdate", () => {
 
   it("fails global npm update when the installed version misses the requested correction", async () => {
     const { calls, result } = await runNpmGlobalUpdateCase({
-      expectedInstallCommand: "npm i -g openclaw@2026.3.23-2 --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand:
+        "npm i -g openclaw@2026.3.23-2 --force --no-fund --no-audit --loglevel=error",
       tag: "2026.3.23-2",
     });
 
@@ -663,12 +669,15 @@ describe("runGatewayUpdate", () => {
     expect(result.steps.at(-1)?.stderrTail).toContain(
       "expected installed version 2026.3.23-2, found 2.0.0",
     );
-    expect(calls).toContain("npm i -g openclaw@2026.3.23-2 --no-fund --no-audit --loglevel=error");
+    expect(calls).toContain(
+      "npm i -g openclaw@2026.3.23-2 --force --no-fund --no-audit --loglevel=error",
+    );
   });
 
   it("fails global npm update when bundled runtime sidecars are missing after install", async () => {
     const { nodeModules, pkgRoot } = await createGlobalPackageFixture(tempDir);
-    const expectedInstallCommand = "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error";
+    const expectedInstallCommand =
+      "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error";
     const { runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
@@ -719,7 +728,7 @@ describe("runGatewayUpdate", () => {
     const { runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: "npm i -g openclaw@latest --force --no-fund --no-audit --loglevel=error",
       onInstall: async (options) => {
         installEnv = options?.env;
         await writeGlobalPackageVersion(pkgRoot);
@@ -745,7 +754,7 @@ describe("runGatewayUpdate", () => {
   it("uses OPENCLAW_UPDATE_PACKAGE_SPEC for global package updates", async () => {
     const { nodeModules, pkgRoot } = await createGlobalPackageFixture(tempDir);
     const expectedInstallCommand =
-      "npm i -g http://10.211.55.2:8138/openclaw-next.tgz --no-fund --no-audit --loglevel=error";
+      "npm i -g http://10.211.55.2:8138/openclaw-next.tgz --force --no-fund --no-audit --loglevel=error";
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,


### PR DESCRIPTION
## Summary

Fixes npm EEXIST error during global update in container environments where `/usr/local/bin/openclaw` already exists.

## Problem

When updating openclaw in a container (e.g., Docker), the npm global install fails:

```
npm error code EEXIST
npm error path /usr/local/bin/openclaw
npm error EEXIST: file already exists
```

This happens because the existing binary from the previous installation blocks the update.

## Changes

- Added `--force` flag to `NPM_GLOBAL_INSTALL_FORCE_FLAGS` in `src/infra/update-global.ts`
- The npm install command for global updates now includes `--force`, allowing it to overwrite existing binaries
- Updated all related test assertions in `update-global.test.ts` and `update-runner.test.ts`

## Testing

- All 8 tests in `src/infra/update-global.test.ts` pass
- All 24 tests in `src/infra/update-runner.test.ts` pass

Fixes openclaw/openclaw#65130