### PR TITLE
feat(gateway): expose channelConnectGraceMs as configurable option

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -451,4 +451,16 @@ export type GatewayConfig = {
    * the rolling window expires. Default: 10.
    */
   channelMaxRestartsPerHour?: number;
+  /**
+   * Grace period in milliseconds after a channel starts connecting before the
+   * health monitor begins evaluating its health. This prevents premature
+   * restart attempts during normal channel startup. Default: 120000 (120s).
+   */
+  channelConnectGraceMs?: number;
+  /**
+   * Grace period in milliseconds after the gateway starts before the health
+   * monitor begins evaluating any channels. This allows channels time to
+   * establish connections during gateway startup. Default: 60000 (60s).
+   */
+  monitorStartupGraceMs?: number;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -742,6 +742,8 @@ export const OpenClawSchema = z
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),
+        channelConnectGraceMs: z.number().int().min(0).optional(),
+        monitorStartupGraceMs: z.number().int().min(0).optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -37,6 +37,10 @@ export function startGatewayChannelHealthMonitor(params: {
   return startChannelHealthMonitor({
     channelManager: params.channelManager,
     checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
+    timing: {
+      channelConnectGraceMs: params.cfg.gateway?.channelConnectGraceMs,
+      monitorStartupGraceMs: params.cfg.gateway?.monitorStartupGraceMs,
+    },
     ...(staleEventThresholdMinutes != null && {
       staleEventThresholdMs: staleEventThresholdMinutes * 60_000,
     }),


### PR DESCRIPTION
## Summary

This PR exposes two previously hardcoded timing values in the channel health monitor as configurable gateway options.

### Problem

- `channelConnectGraceMs` (default: 120,000ms / 120s) — grace period after a channel starts connecting before the health monitor begins evaluating it
- `monitorStartupGraceMs` (default: 60,000ms / 60s) — grace period after gateway starts before any channel health evaluation begins

Both were hardcoded constants. Users who needed faster channel startup had no way to adjust these values.

### Solution

Both values are now configurable via `openclaw.json` under `gateway`:

```json
{
  "gateway": {
    "channelConnectGraceMs": 5000,
    "monitorStartupGraceMs": 10000
  }
}
```

### Changes

| File | Change |
|------|--------|
| `src/config/types.gateway.ts` | Add `channelConnectGraceMs?` and `monitorStartupGraceMs?` to `GatewayConfig` type |
| `src/config/zod-schema.ts` | Add Zod validation for both fields (int, min: 0) |
| `src/gateway/server-runtime-services.ts` | Read values from config and pass to `startChannelHealthMonitor` via `timing` object |

### Verification

The health monitor logs will confirm the new value:
```
started (interval: 300s, startup-grace: 10s, channel-connect-grace: 5s)
```
