### PR TITLE
fix: reconcile stale subagent tasks after reset

### DIFF
--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -102,7 +102,7 @@ async function loadMaintenanceModule(params: {
   return { mod, currentTasks };
 }
 
-describe("task-registry maintenance issue #60299", () => {
+describe("task-registry maintenance stale run reconciliation", () => {
   it("marks stale cron tasks lost once the runtime no longer tracks the job as active", async () => {
     const childSessionKey = "agent:main:slack:channel:test-channel";
     const task = makeStaleTask({
@@ -171,6 +171,59 @@ describe("task-registry maintenance issue #60299", () => {
       tasks: [task],
       sessionStore: { [channelKey]: { updatedAt: Date.now() } },
       activeRunIds: ["run-chat-cli-live"],
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
+  });
+
+  it("marks stale subagent tasks lost after reset leaves only the persisted session row", async () => {
+    const childSessionKey = "agent:main:subagent:worker";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      sourceId: "run-subagent-reset",
+      runId: "run-subagent-reset",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: {
+        [childSessionKey]: {
+          sessionId: "sess-reset-replaced",
+          updatedAt: Date.now(),
+          status: "running",
+        },
+      },
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("keeps stale subagent tasks live while their run context is still active", async () => {
+    const childSessionKey = "agent:main:subagent:worker";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      sourceId: "run-subagent-live",
+      runId: "run-subagent-live",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: {
+        [childSessionKey]: {
+          sessionId: "sess-subagent-live",
+          updatedAt: Date.now(),
+          status: "running",
+        },
+      },
+      activeRunIds: ["run-subagent-live"],
     });
 
     expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -108,7 +108,7 @@ function hasLostGraceExpired(task: TaskRecord, now: number): boolean {
   return now - referenceAt >= TASK_RECONCILE_GRACE_MS;
 }
 
-function hasActiveCliRun(task: TaskRecord): boolean {
+function hasActiveRunContext(task: TaskRecord): boolean {
   const candidateRunIds = [task.sourceId, task.runId];
   for (const candidate of candidateRunIds) {
     const runId = candidate?.trim();
@@ -119,14 +119,18 @@ function hasActiveCliRun(task: TaskRecord): boolean {
   return false;
 }
 
+function requiresLiveRunContext(task: TaskRecord): boolean {
+  return task.runtime === "cli" || task.runtime === "subagent" || task.runtime === "acp";
+}
+
 function hasBackingSession(task: TaskRecord): boolean {
   if (task.runtime === "cron") {
     const jobId = task.sourceId?.trim();
     return jobId ? taskRegistryMaintenanceRuntime.isCronJobActive(jobId) : false;
   }
 
-  if (task.runtime === "cli" && hasActiveCliRun(task)) {
-    return true;
+  if (requiresLiveRunContext(task)) {
+    return hasActiveRunContext(task);
   }
 
   const childSessionKey = task.childSessionKey?.trim();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1563,6 +1563,7 @@ describe("task-registry", () => {
           saveSnapshot: () => {},
         },
       });
+      registerAgentRunContext("run-audit-summary", { sessionKey: "agent:main:acp:child" });
 
       expect(getInspectableTaskAuditSummary()).toEqual({
         total: 1,


### PR DESCRIPTION
## Summary
- treat subagent, ACP, and CLI task records as live only while their run context is still registered
- stop relying on persisted session rows alone, which survive /reset and gateway restart
- add regressions covering reset-stale subagent tasks and keep existing stale-running audit coverage explicit

## Testing
- pnpm test src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.test.ts

## Issue
- closes #65136