### PR TITLE
fix: node.invoke stays reachable before node pairing approval exists

### DIFF
--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -81,7 +81,7 @@ export async function reconcileNodePairingOnConnect(params: {
     );
     return {
       nodeId,
-      effectiveCommands: declared,
+      effectiveCommands: [],
       pendingPairing,
     };
   }

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -7,6 +7,7 @@ import {
   publicKeyRawBase64UrlFromPem,
   signDevicePayload,
 } from "../infra/device-identity.js";
+import { approveNodePairing, requestNodePairing } from "../infra/node-pairing.js";
 import { sleep } from "../utils.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
@@ -211,6 +212,15 @@ describe("node.invoke approval bypass", () => {
     });
 
     const resolvedDeviceIdentity = deviceIdentity ?? createDeviceIdentity();
+    const initialApproval = await requestNodePairing({
+      nodeId: resolvedDeviceIdentity.deviceId,
+      platform: "linux",
+      commands,
+    });
+    await approveNodePairing(initialApproval.request.requestId, {
+      callerScopes: ["operator.pairing", "operator.admin"],
+    });
+
     const client = new GatewayClient({
       url: `ws://127.0.0.1:${port}`,
       // Keep challenge timeout realistic in tests; 0 maps to a 250ms timeout and can

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -381,7 +381,7 @@ describe("gateway node command allowlist", () => {
     }
   });
 
-  test("keeps allowlisted declared commands available before node pairing exists", async () => {
+  test("hides declared commands until node pairing exists", async () => {
     const findConnectedNode = async (displayName: string) => {
       const listRes = await rpcReq<{
         nodes?: Array<{
@@ -413,11 +413,20 @@ describe("gateway node command allowlist", () => {
           const node = await findConnectedNode(displayName);
           return node?.commands?.toSorted() ?? [];
         }, FAST_WAIT_OPTS)
-        .toEqual(["canvas.snapshot", "system.run"]);
+        .toEqual([]);
 
       const node = await findConnectedNode(displayName);
       const nodeId = node?.nodeId ?? "";
       expect(nodeId).toBeTruthy();
+
+      const invokeRes = await rpcReq(ws, "node.invoke", {
+        nodeId,
+        command: "system.run",
+        params: { command: "echo blocked" },
+        idempotencyKey: "allowlist-before-pairing-blocked",
+      });
+      expect(invokeRes.ok).toBe(false);
+      expect(invokeRes.error?.message ?? "").toContain("node command not allowed");
 
       const pairingList = await rpcReq<{
         pending?: Array<{ nodeId?: string; commands?: string[] }>;


### PR DESCRIPTION
## Fix Summary
An authenticated `operator.write` session can invoke commands on a reconnecting node before `node.pair.approve` has established that node as trusted. On macOS and Linux, this exposes pre-approval `system.run`, which can become remote code execution on the node host when the node's local exec-approval policy is permissive.

## Issue Linkage
Fixes #65168

## Security Snapshot
- CVSS v3.1: 9.9 (Critical)
- CVSS v4.0: 9.4 (Critical)

## Implementation Details
### Files Changed
- `src/gateway/node-connect-reconcile.ts` (+1/-1)
- `src/gateway/server.node-invoke-approval-bypass.test.ts` (+10/-0)
- `src/gateway/server.roles-allowlist-update.test.ts` (+11/-2)

### Technical Analysis
1. Approve device pairing for a node identity, but do not approve the pending `node.pair` request for that node.
2. Reconnect the node while it declares allowlisted commands such as `canvas.snapshot` and `system.run`.
3. During the reconnect handshake, `reconcileNodePairingOnConnect()` sees `pairedNode === null`, creates a pending node-pair request, and still returns `effectiveCommands: declared` from `src/gateway/node-connect-reconcile.ts:73-86`.
4. `src/gateway/server/ws-connection/message-handler.ts:1143-1157` writes those commands into `connectParams.commands`, and `src/gateway/node-registry.ts:45-82` stores them on the connected `NodeSession`.
5. From a separate gateway session that has `operator.write` but not `operator.pairing`, call `node.invoke` for `system.run` or another declared command.
6. `src/gateway/server-methods/nodes.ts:993-1034` checks only the node session's declared commands plus the platform allowlist, then forwards the request to the node. `src/gateway/server.node-pairing-authz.test.ts:86-127` confirms that the same caller lacks permission to approve the node pairing, so invocation succeeds before the approval gate it is supposed to depend on.

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed (with pre-existing baseline failures)

## Risk and Compatibility
- non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: github-copilot/gpt-5.4
