### PR TITLE
Improve subagent start notices with resolved model info

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -655,7 +655,7 @@
     },
     "sessions_spawn": {
       "emoji": "🧑‍🔧",
-      "title": "Sub-agent",
+      "title": "Delegated task started",
       "detailKeys": [
         "label",
         "task",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -1,9 +1,22 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({
+    agents: {
+      defaults: {
+        model: { primary: "openai/gpt-5.4" },
+        subagents: { model: "openai/gpt-5.4-mini" },
+      },
+    },
+  }),
+}));
+
 import {
   extractAssistantText,
   extractAssistantVisibleText,
   formatReasoningMessage,
+  inferToolMetaFromArgs,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
@@ -30,6 +43,17 @@ function makeAssistantMessage(
     ...message,
   };
 }
+
+describe("inferToolMetaFromArgs", () => {
+  it("includes the resolved subagent model in sessions_spawn summaries", () => {
+    expect(
+      inferToolMetaFromArgs("sessions_spawn", {
+        task: "review this patch",
+        agentId: "main",
+      }),
+    ).toBe("prompt review this patch · agent main · model openai/gpt-5.4-mini");
+  });
+});
 
 describe("extractAssistantText", () => {
   it("strips tool-only Minimax invocation XML from text", () => {

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { loadConfig } from "../config/config.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
   normalizeAssistantPhase,
@@ -8,6 +9,7 @@ import {
 } from "../shared/chat-message-content.js";
 import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
+import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { sanitizeUserFacingText } from "./pi-embedded-helpers/sanitize-user-facing-text.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
 
@@ -334,7 +336,56 @@ export function extractThinkingFromTaggedStream(text: string): string {
   return text.slice(start).trim();
 }
 
+function inferSessionsSpawnMeta(args: unknown): string | undefined {
+  const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+  const task = typeof record.task === "string" ? record.task.trim() : "";
+  const agentId = typeof record.agentId === "string" ? record.agentId.trim() : "";
+  const thinking = typeof record.thinking === "string" ? record.thinking.trim() : "";
+  const timeout =
+    typeof record.runTimeoutSeconds === "number" && Number.isFinite(record.runTimeoutSeconds)
+      ? Math.max(0, Math.floor(record.runTimeoutSeconds))
+      : undefined;
+  const cleanup = typeof record.cleanup === "string" ? record.cleanup.trim() : "";
+
+  const parts: string[] = [];
+  if (task) {
+    parts.push(`prompt ${task}`);
+  }
+  if (agentId) {
+    parts.push(`agent ${agentId}`);
+    try {
+      const resolvedModel = resolveSubagentSpawnModelSelection({
+        cfg: loadConfig(),
+        agentId,
+        modelOverride: record.model,
+      });
+      if (resolvedModel) {
+        parts.push(`model ${resolvedModel}`);
+      }
+    } catch {
+      if (typeof record.model === "string" && record.model.trim()) {
+        parts.push(`model ${record.model.trim()}`);
+      }
+    }
+  } else if (typeof record.model === "string" && record.model.trim()) {
+    parts.push(`model ${record.model.trim()}`);
+  }
+  if (thinking) {
+    parts.push(`thinking ${thinking}`);
+  }
+  if (timeout && timeout > 0) {
+    parts.push(`timeout ${timeout}`);
+  }
+  if (cleanup) {
+    parts.push(`cleanup ${cleanup}`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+
 export function inferToolMetaFromArgs(toolName: string, args: unknown): string | undefined {
+  if (toolName === "sessions_spawn") {
+    return inferSessionsSpawnMeta(args);
+  }
   const display = resolveToolDisplay({ name: toolName, args });
   return formatToolDetail(display);
 }

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -123,6 +123,7 @@ export type SpawnSubagentResult = {
   mode?: SpawnSubagentMode;
   note?: string;
   modelApplied?: boolean;
+  resolvedModel?: string;
   error?: string;
   attachments?: {
     count: number;
@@ -891,6 +892,7 @@ export async function spawnSubagentDirect(
       agentSessionKey: ctx.agentSessionKey,
     }),
     modelApplied: resolvedModel ? modelApplied : undefined,
+    resolvedModel: resolvedModel || undefined,
     attachments: attachmentsReceipt,
   };
 }

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -435,7 +435,7 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
     },
     sessions_spawn: {
       emoji: "🧑‍🔧",
-      title: "Sub-agent",
+      title: "Delegated task started",
       detailKeys: ["label", "task", "agentId", "model", "thinking", "runTimeoutSeconds", "cleanup"],
     },
     subagents: {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -259,6 +259,19 @@ describe("tool display details", () => {
     expect(detail).toMatch(/^print text/);
   });
 
+  it("uses delegated-task title for sessions_spawn", () => {
+    const display = resolveToolDisplay({
+      name: "sessions_spawn",
+      args: {
+        task: "review this patch",
+        agentId: "main",
+      },
+    });
+
+    expect(display.title).toBe("Delegated task started");
+    expect(display.label).toBe("Delegated task started");
+  });
+
   it("recognizes heredoc/inline script exec details", () => {
     const pyDetail = formatToolDetail(
       resolveToolDisplay({

--- a/src/auto-reply/reply/commands-subagents-spawn-action.test.ts
+++ b/src/auto-reply/reply/commands-subagents-spawn-action.test.ts
@@ -10,6 +10,20 @@ const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/subagent-spawn.js", () => ({
   spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+  splitModelRef: (value?: string) => {
+    const raw = typeof value === "string" ? value.trim() : "";
+    if (!raw) {
+      return { provider: undefined, model: undefined };
+    }
+    const slash = raw.indexOf("/");
+    if (slash <= 0 || slash === raw.length - 1) {
+      return { provider: undefined, model: raw };
+    }
+    return {
+      provider: raw.slice(0, slash),
+      model: raw.slice(slash + 1),
+    };
+  },
   SUBAGENT_SPAWN_MODES: ["run", "session"],
 }));
 
@@ -47,7 +61,6 @@ function buildContext(params?: {
     hasVerboseDirective: false,
     hasFastDirective: false,
     hasReasoningDirective: false,
-    hasTraceDirective: false,
     hasElevatedDirective: false,
     hasExecDirective: false,
     hasExecOptions: false,
@@ -57,6 +70,7 @@ function buildContext(params?: {
     invalidExecNode: false,
     hasStatusDirective: false,
     hasModelDirective: false,
+    hasTraceDirective: false,
     hasQueueDirective: false,
     queueReset: false,
     hasQueueOptions: false,
@@ -131,12 +145,14 @@ describe("subagents spawn action", () => {
   });
 
   it("spawns a subagent and formats the success reply", async () => {
-    spawnSubagentDirectMock.mockResolvedValue(acceptedResult());
+    spawnSubagentDirectMock.mockResolvedValue(
+      acceptedResult({ resolvedModel: "openai-codex/gpt-5.4" }),
+    );
     const result = await handleSubagentsSpawnAction(buildContext());
     expect(result).toEqual({
       shouldContinue: false,
       reply: {
-        text: "Spawned subagent beta (session agent:beta:subagent:test-uuid, run run-spaw).",
+        text: "Delegated task started for beta using openai-codex/gpt-5.4.\nDelegated Task Prompt: do the thing\nSession agent:beta:subagent:test-uuid, run run-spaw.",
       },
     });
     expect(spawnSubagentDirectMock).toHaveBeenCalledWith(

--- a/src/auto-reply/reply/commands-subagents/action-spawn.ts
+++ b/src/auto-reply/reply/commands-subagents/action-spawn.ts
@@ -1,4 +1,4 @@
-import { spawnSubagentDirect } from "../../../agents/subagent-spawn.js";
+import { spawnSubagentDirect, splitModelRef } from "../../../agents/subagent-spawn.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import type { CommandHandlerResult } from "../commands-types.js";
 import { type SubagentsCommandContext, stopWithText } from "./shared.js";
@@ -58,8 +58,15 @@ export async function handleSubagentsSpawnAction(
     },
   );
   if (result.status === "accepted") {
+    const prompt = task;
+    const { provider, model: resolvedModelName } = splitModelRef(result.resolvedModel);
+    const modelDetail = resolvedModelName
+      ? provider
+        ? ` using ${provider}/${resolvedModelName}`
+        : ` using ${resolvedModelName}`
+      : "";
     return stopWithText(
-      `Spawned subagent ${agentId} (session ${result.childSessionKey}, run ${result.runId?.slice(0, 8)}).`,
+      `Delegated task started for ${agentId}${modelDetail}.\nDelegated Task Prompt: ${prompt}\nSession ${result.childSessionKey}, run ${result.runId?.slice(0, 8)}.`,
     );
   }
   return stopWithText(`Spawn failed: ${result.error ?? result.status}`);


### PR DESCRIPTION
## Summary
- rename the user-facing sessions_spawn start notice to "Delegated task started"
- include the delegated task prompt and the resolved provider/model when the spawn summary is shown
- return resolvedModel from subagent spawn so /subagents spawn can report the actual runtime target

## Testing
- Added/updated unit tests for tool display, tool meta, and /subagents spawn reply formatting
- Additional local/live validation: Telegram subagent start notice smoke-tested and confirmed as a single user-visible notice in chat
