### PR TITLE
fix(cron): persist sessionFile for isolated cron runs to prevent orphans

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -71,6 +71,10 @@ export function createCronPromptExecutor(params: {
     params.cronSession.sessionEntry.sessionId,
     params.agentId,
   );
+  // Persist the transcript path back to the session entry so that
+  // finalizeCronRun → persistSessionEntry writes it to sessions.json.
+  // Without this, the .jsonl file is orphaned on disk.  See #65151.
+  params.cronSession.sessionEntry.sessionFile = sessionFile;
   const cronFallbacksOverride = resolveCronFallbacksOverride({
     cfg: params.cfg,
     job: params.job,


### PR DESCRIPTION
Isolated cron runs compute `sessionFile` via `resolveSessionTranscriptPath` but never assign it back to the session entry. When `finalizeCronRun` persists the entry to `sessions.json`, the `sessionFile` field is missing, leaving the `.jsonl` transcript as an orphan that `openclaw doctor` reports as unreferenced.

One-line fix: assign `sessionFile` back to the session entry immediately after computing it.

Fixes #65151