### PR TITLE
fix: case-insensitive model lookup for image support resolution

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1023,4 +1023,23 @@ describe("resolveGatewayModelSupportsImages", () => {
       }),
     ).resolves.toBe(false);
   });
+
+  test("fails closed when explicit provider is given but model not found in that provider", async () => {
+    // Even if a matching model-id exists under a different provider,
+    // the explicit-provider lookup must not fall back to model-only search.
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "gpt-4",
+        provider: "openai",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "other/gpt-4",
+            name: "GPT-4",
+            provider: "other",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(false);
+  });
 });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -974,4 +974,53 @@ describe("resolveGatewayModelSupportsImages", () => {
       }),
     ).resolves.toBe(true);
   });
+
+  test("matches models case-insensitively when provider is given", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "Qwen/Qwen3.5-35B-A3B",
+        provider: "qwen",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "qwen/qwen3.5-35b-a3b",
+            name: "Qwen3.5-35B-A3B",
+            provider: "qwen",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("falls back to model-only case-insensitive search when provider is missing", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "Qwen/Qwen3.5-35B-A3B",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "qwen/qwen3.5-35b-a3b",
+            name: "Qwen3.5-35B-A3B",
+            provider: "qwen",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("returns false when model-only fallback also finds no match", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "unknown/model",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "qwen/qwen3.5-35b-a3b",
+            name: "Qwen3.5-35B-A3B",
+            provider: "qwen",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(false);
+  });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1058,19 +1058,26 @@ export async function resolveGatewayModelSupportsImages(params: {
   try {
     const catalog = await params.loadGatewayModelCatalog();
     // Use case-insensitive, provider-normalized lookup when a provider is
-    // available.  Fall back to a model-only case-insensitive search when no
-    // provider is specified (e.g. user-configured models from
+    // available.  Fall back to a model-only case-insensitive search only when
+    // no provider is specified (e.g. user-configured models from
     // `providers.*.models`), because the catalog may contain models whose
     // provider field is missing or differs in casing.
+    // When an explicit provider is given but finds no match, fail closed.
     let modelEntry: ModelCatalogEntry | undefined;
-    if (params.provider) {
+    const hasExplicitProvider = typeof params.provider === "string" && params.provider.trim() !== "";
+    if (hasExplicitProvider) {
       modelEntry = findModelInCatalog(catalog, params.provider, params.model);
+      // Explicit provider: fail closed if not found — do not fall back to
+      // model-only search which could match a same-id model from another provider.
     }
-    if (!modelEntry) {
+    if (!modelEntry && !hasExplicitProvider) {
       const normalizedModelId = params.model.toLowerCase().trim();
       modelEntry = catalog.find((entry) => entry.id.toLowerCase().trim() === normalizedModelId);
     }
-    const normalizedProvider = params.provider?.trim().toLowerCase();
+    // Derive effective provider for legacy shims: prefer explicit params.provider,
+    // then fall back to the discovered model entry's provider.
+    const normalizedProvider =
+      params.provider?.trim().toLowerCase() ?? modelEntry?.provider?.trim().toLowerCase();
     const normalizedCandidates = [
       params.model.trim().toLowerCase(),
       typeof modelEntry?.name === "string" ? modelEntry.name.trim().toLowerCase() : "",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -8,7 +8,7 @@ import {
 } from "../agents/agent-scope.js";
 import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { findModelInCatalog, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
   parseModelRef,
@@ -1057,10 +1057,19 @@ export async function resolveGatewayModelSupportsImages(params: {
 
   try {
     const catalog = await params.loadGatewayModelCatalog();
-    const modelEntry = catalog.find(
-      (entry) =>
-        entry.id === params.model && (!params.provider || entry.provider === params.provider),
-    );
+    // Use case-insensitive, provider-normalized lookup when a provider is
+    // available.  Fall back to a model-only case-insensitive search when no
+    // provider is specified (e.g. user-configured models from
+    // `providers.*.models`), because the catalog may contain models whose
+    // provider field is missing or differs in casing.
+    let modelEntry: ModelCatalogEntry | undefined;
+    if (params.provider) {
+      modelEntry = findModelInCatalog(catalog, params.provider, params.model);
+    }
+    if (!modelEntry) {
+      const normalizedModelId = params.model.toLowerCase().trim();
+      modelEntry = catalog.find((entry) => entry.id.toLowerCase().trim() === normalizedModelId);
+    }
     const normalizedProvider = params.provider?.trim().toLowerCase();
     const normalizedCandidates = [
       params.model.trim().toLowerCase(),


### PR DESCRIPTION
## Summary

Fixes image attachment dropping when models are configured via the `providers.*.models` format with `"input": ["text", "image"]`.

## Root cause

The `resolveGatewayModelSupportsImages` function used case-sensitive model ID matching and required exact provider match, causing configured models (e.g., `Qwen/Qwen3.5-35B-A3B`) to not be found in the catalog. User-configured models from `providers.*.models` were also being skipped during catalog lookup.

## Fix

- Made model ID comparison case-insensitive in the lookup by reusing the existing `findModelInCatalog` helper (which normalizes both provider and model ID)
- Added a fallback model-only case-insensitive search when no provider is specified, so user-configured models without a matching provider field can still be resolved
- Made provider matching flexible via the existing `normalizeProviderId` utility

## Files changed

- `src/gateway/session-utils.ts` — updated `resolveGatewayModelSupportsImages` to use case-insensitive lookup
- `src/gateway/session-utils.test.ts` — added 3 new test cases for case-insensitive matching and fallback behavior

## Testing

All 55 tests in `session-utils.test.ts` pass, including 3 new tests:
- matches models case-insensitively when provider is given
- falls back to model-only case-insensitive search when provider is missing
- returns false when model-only fallback also finds no match

Fixes openclaw/openclaw#65165