### PR TITLE
fix(ios): allow plaintext ws:// for LAN/Tailscale hosts; prefer password over bootstrap token (#47887)

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -688,7 +688,12 @@ final class GatewayConnectionController {
     }
 
     private func shouldRequireTLS(host: String) -> Bool {
-        !Self.isLoopbackHost(host)
+        // Allow plaintext for loopback and local-network hosts (RFC-1918, .local,
+        // Tailscale .ts.net). Only force TLS for internet-routable hosts.
+        // Previously this returned `!isLoopbackHost`, which silently upgraded
+        // ws:// to wss:// for all LAN/Tailscale addresses and broke onboarding
+        // when the gateway runs without TLS (the common LAN default). (#47887)
+        !Self.isLoopbackHost(host) && !Self.isLocalNetworkHost(host)
     }
 
     private func shouldForceTLS(host: String) -> Bool {
@@ -740,6 +745,47 @@ final class GatewayConnectionController {
             let isMappedV4 = bytes[0..<10].allSatisfy { $0 == 0 } && bytes[10] == 0xFF && bytes[11] == 0xFF
             return isMappedV4 && bytes[12] == 127
         }
+    }
+
+    /// Returns true for hosts that are on a local network and should not require TLS
+    /// by default: RFC-1918 private ranges, link-local, .local mDNS names, and
+    /// Tailscale MagicDNS addresses (.ts.net). These are trusted-network endpoints
+    /// where the gateway commonly runs without a certificate. (#47887)
+    private static func isLocalNetworkHost(_ rawHost: String) -> Bool {
+        var host = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !host.isEmpty else { return false }
+        if host.hasPrefix("[") && host.hasSuffix("]") { host.removeFirst(); host.removeLast() }
+        if host.hasSuffix(".") { host.removeLast() }
+
+        // .local mDNS names (Bonjour)
+        if host.hasSuffix(".local") { return true }
+
+        // Tailscale MagicDNS hostnames
+        if host.hasSuffix(".ts.net") { return true }
+
+        // RFC-1918 and link-local IPv4 ranges
+        var addr = in_addr()
+        if host.withCString({ inet_pton(AF_INET, $0, &addr) == 1 }) {
+            let value = UInt32(bigEndian: addr.s_addr)
+            let a = UInt8((value >> 24) & 0xFF)
+            let b = UInt8((value >> 16) & 0xFF)
+            if a == 10 { return true }                        // 10.0.0.0/8
+            if a == 172 && (b >= 16 && b <= 31) { return true }  // 172.16-31.0.0/12
+            if a == 192 && b == 168 { return true }           // 192.168.0.0/16
+            if a == 169 && b == 254 { return true }           // 169.254.0.0/16 link-local
+            if a == 100 && (b >= 64 && b <= 127) { return true }  // 100.64-127 CG-NAT / Tailscale
+        }
+
+        // RFC-4193 ULA IPv6 (fc00::/7) — local
+        var addr6 = in6_addr()
+        if host.withCString({ inet_pton(AF_INET6, $0, &addr6) == 1 }) {
+            return withUnsafeBytes(of: &addr6) {
+                let first = $0.bindMemory(to: UInt8.self)[0]
+                return (first & 0xFE) == 0xFC   // fc00::/7
+            }
+        }
+
+        return false
     }
 
     private func manualStableID(host: String, port: Int) -> String {
@@ -995,6 +1041,10 @@ extension GatewayConnectionController {
         allowTOFU: Bool) -> GatewayTLSParams?
     {
         self.resolveDiscoveredTLSParams(gateway: gateway, allowTOFU: allowTOFU)
+    }
+
+    func _test_isLocalNetworkHost(_ host: String) -> Bool {
+        Self.isLocalNetworkHost(host)
     }
 
     func _test_resolveManualUseTLS(host: String, useTLS: Bool) -> Bool {

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -144,3 +144,66 @@ import Testing
         #expect(GatewayTLSStore.loadFingerprint(stableID: stableID2) == nil)
     }
 }
+
+    // MARK: - LAN host TLS override tests (#47887)
+
+    @Test @MainActor func localNetworkHost_rfc1918_10x() async {
+        let c = makeController()
+        #expect(c._test_isLocalNetworkHost("10.0.0.1"))
+        #expect(c._test_isLocalNetworkHost("10.255.255.255"))
+    }
+
+    @Test @MainActor func localNetworkHost_rfc1918_172() async {
+        let c = makeController()
+        #expect(c._test_isLocalNetworkHost("172.16.0.1"))
+        #expect(c._test_isLocalNetworkHost("172.31.255.255"))
+        #expect(!c._test_isLocalNetworkHost("172.15.0.1"))   // outside range
+        #expect(!c._test_isLocalNetworkHost("172.32.0.1"))   // outside range
+    }
+
+    @Test @MainActor func localNetworkHost_rfc1918_192168() async {
+        let c = makeController()
+        #expect(c._test_isLocalNetworkHost("192.168.1.1"))
+        #expect(c._test_isLocalNetworkHost("192.168.0.1"))
+    }
+
+    @Test @MainActor func localNetworkHost_mDNS() async {
+        let c = makeController()
+        #expect(c._test_isLocalNetworkHost("openclaw.local"))
+        #expect(c._test_isLocalNetworkHost("mymac.local"))
+    }
+
+    @Test @MainActor func localNetworkHost_tailscale() async {
+        let c = makeController()
+        #expect(c._test_isLocalNetworkHost("mymachine.tail1234.ts.net"))
+        #expect(c._test_isLocalNetworkHost("gateway.ts.net"))
+    }
+
+    @Test @MainActor func localNetworkHost_publicHostnames_notLocal() async {
+        let c = makeController()
+        #expect(!c._test_isLocalNetworkHost("example.com"))
+        #expect(!c._test_isLocalNetworkHost("8.8.8.8"))
+        #expect(!c._test_isLocalNetworkHost("1.1.1.1"))
+    }
+
+    @Test @MainActor func manualUseTLS_lanHostDoesNotForceTLS() async {
+        let c = makeController()
+        // LAN hosts with useTLS=false should stay plaintext (#47887)
+        #expect(!c._test_resolveManualUseTLS(host: "192.168.1.100", useTLS: false))
+        #expect(!c._test_resolveManualUseTLS(host: "10.0.0.1", useTLS: false))
+        #expect(!c._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false))
+        #expect(!c._test_resolveManualUseTLS(host: "gateway.ts.net", useTLS: false))
+    }
+
+    @Test @MainActor func manualUseTLS_publicHostForcedTLS() async {
+        let c = makeController()
+        // Public hosts without explicit useTLS should still require TLS
+        #expect(c._test_resolveManualUseTLS(host: "my-server.example.com", useTLS: false))
+    }
+
+    @Test @MainActor func manualUseTLS_explicitTLSTrueAlwaysUseTLS() async {
+        let c = makeController()
+        // Explicit useTLS=true always wins regardless of host type
+        #expect(c._test_resolveManualUseTLS(host: "192.168.1.1", useTLS: true))
+        #expect(c._test_resolveManualUseTLS(host: "localhost", useTLS: true))
+    }

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -143,7 +143,7 @@ import Testing
         #expect(GatewayTLSStore.loadFingerprint(stableID: stableID1) == nil)
         #expect(GatewayTLSStore.loadFingerprint(stableID: stableID2) == nil)
     }
-}
+    }
 
     // MARK: - LAN host TLS override tests (#47887)
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -518,7 +518,9 @@ public actor GatewayChannelActor {
                 (includeDeviceIdentity && explicitPassword == nil && explicitBootstrapToken == nil
                     ? storedToken
                     : nil)
-        let authBootstrapToken = authToken == nil ? explicitBootstrapToken : nil
+        // Suppress bootstrap auth when an explicit password is present:
+        // mixed payloads and stale bootstrap state should defer to password. (#47887)
+        let authBootstrapToken = (authToken == nil && explicitPassword == nil) ? explicitBootstrapToken : nil
         let authDeviceToken = shouldUseDeviceRetryToken ? storedToken : nil
         let authSource: GatewayAuthSource
         if authDeviceToken != nil || (explicitToken == nil && authToken != nil) {


### PR DESCRIPTION
## Summary

Four related bugs caused iOS LAN gateway onboarding to fail. This PR addresses two of them in the iOS/shared Swift layer (bugs 1 and 4 from the issue report); bugs 2 and 3 affect the TypeScript gateway side and are tracked separately.

## Bug 1: `ws://` silently upgraded to `wss://` for LAN hosts

`GatewayConnectionController.shouldRequireTLS` returned `true` for **any** host that wasn't loopback, including:
- RFC-1918 addresses: `192.168.x.x`, `10.x.x.x`, `172.16-31.x.x`
- Link-local: `169.254.x.x`
- mDNS names: `*.local`
- Tailscale: `*.ts.net`, CG-NAT `100.64.x.x`

Gateways on these networks commonly run without TLS (the documented default for LAN), so the forced upgrade caused connection hangs before auth even started.

**Fix:** Add `isLocalNetworkHost()` that correctly identifies these address families. `shouldRequireTLS` now returns `false` for local-network hosts when `useTLS` is explicitly `false`.

## Bug 4: `bootstrapToken` used even when explicit `password` is present

Mixed auth payloads (both `bootstrapToken` and `password`) always chose the bootstrap path. When the bootstrap token was already consumed (single-use), subsequent connection attempts got `AUTH_BOOTSTRAP_TOKEN_INVALID` while a valid `password` was available.

**Fix:** Suppress `authBootstrapToken` whenever `explicitPassword != nil`, making password take precedence.

## Files changed

- `apps/ios/Sources/Gateway/GatewayConnectionController.swift`
  - `shouldRequireTLS`: exclude local-network hosts
  - `isLocalNetworkHost()`: new static helper
  - `_test_isLocalNetworkHost()`: test hook

- `apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift`
  - Suppress `authBootstrapToken` when `explicitPassword != nil`

## Tests

9 new tests in `GatewayConnectionSecurityTests`:
- RFC-1918 range detection (10.x, 172.16-31.x, 192.168.x)
- `.local` mDNS names
- Tailscale `.ts.net` names
- Public hostnames correctly excluded
- `resolveManualUseTLS` behaviour for LAN hosts, public hosts, and explicit `useTLS=true`

Build verified: `xcodebuild BUILD SUCCEEDED` for `generic/platform=iOS`.

Fixes #47887
