### PR TITLE
fix: preserve cron persisted runtime state on load

### DIFF
--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -288,6 +288,71 @@ function coerceDelivery(delivery: UnknownRecord) {
   return next;
 }
 
+function coerceState(rawState: UnknownRecord) {
+  const next: UnknownRecord = {};
+
+  const copyFiniteNumber = (
+    field:
+      | "nextRunAtMs"
+      | "runningAtMs"
+      | "lastRunAtMs"
+      | "lastDurationMs"
+      | "consecutiveErrors"
+      | "lastFailureAlertAtMs"
+      | "scheduleErrorCount",
+  ) => {
+    const value = rawState[field];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      next[field] = value;
+    }
+  };
+
+  copyFiniteNumber("nextRunAtMs");
+  copyFiniteNumber("runningAtMs");
+  copyFiniteNumber("lastRunAtMs");
+  copyFiniteNumber("lastDurationMs");
+  copyFiniteNumber("consecutiveErrors");
+  copyFiniteNumber("lastFailureAlertAtMs");
+  copyFiniteNumber("scheduleErrorCount");
+
+  const lastRunStatus = normalizeOptionalLowercaseString(rawState.lastRunStatus);
+  if (lastRunStatus === "ok" || lastRunStatus === "error" || lastRunStatus === "skipped") {
+    next.lastRunStatus = lastRunStatus;
+  }
+
+  const lastStatus = normalizeOptionalLowercaseString(rawState.lastStatus);
+  if (lastStatus === "ok" || lastStatus === "error" || lastStatus === "skipped") {
+    next.lastStatus = lastStatus;
+  }
+
+  const lastDeliveryStatus = normalizeOptionalLowercaseString(rawState.lastDeliveryStatus);
+  if (
+    lastDeliveryStatus === "delivered" ||
+    lastDeliveryStatus === "not-delivered" ||
+    lastDeliveryStatus === "unknown" ||
+    lastDeliveryStatus === "not-requested"
+  ) {
+    next.lastDeliveryStatus = lastDeliveryStatus;
+  }
+
+  const copyOptionalString = (field: "lastError" | "lastErrorReason" | "lastDeliveryError") => {
+    const value = normalizeOptionalString(rawState[field]);
+    if (value) {
+      next[field] = value;
+    }
+  };
+
+  copyOptionalString("lastError");
+  copyOptionalString("lastErrorReason");
+  copyOptionalString("lastDeliveryError");
+
+  if (typeof rawState.lastDelivered === "boolean") {
+    next.lastDelivered = rawState.lastDelivered;
+  }
+
+  return next;
+}
+
 function inferTopLevelPayload(next: UnknownRecord) {
   const message = normalizeOptionalString(next.message) ?? "";
   if (message) {
@@ -490,6 +555,10 @@ export function normalizeCronJobInput(
 
   if (isRecord(base.delivery)) {
     next.delivery = coerceDelivery(base.delivery);
+  }
+
+  if (isRecord(base.state)) {
+    next.state = coerceState(base.state);
   }
 
   if ("isolation" in next) {

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -162,6 +162,44 @@ describe("cron service store seam coverage", () => {
     expect(after).toBe(before);
   });
 
+  it("preserves persisted runtime state when normalizing loaded jobs", async () => {
+    const { storePath } = await makeStorePath();
+    const nextRunAtMs = STORE_TEST_NOW - 5_000;
+    const runningAtMs = STORE_TEST_NOW - 1_000;
+
+    await writeSingleJobStore(storePath, {
+      id: "stateful-job",
+      name: "stateful job",
+      enabled: true,
+      createdAtMs: STORE_TEST_NOW - 60_000,
+      updatedAtMs: STORE_TEST_NOW - 60_000,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {
+        nextRunAtMs,
+        runningAtMs,
+        lastRunAtMs: STORE_TEST_NOW - 60_000,
+        lastStatus: "error",
+        lastError: "boom",
+      },
+    });
+
+    const state = createStoreTestState(storePath);
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    const job = findJobOrThrow(state, "stateful-job");
+    expect(job.state).toMatchObject({
+      nextRunAtMs,
+      runningAtMs,
+      lastRunAtMs: STORE_TEST_NOW - 60_000,
+      lastStatus: "error",
+      lastError: "boom",
+    });
+  });
+
   it("loads persisted jobs with unsafe custom session ids so run paths can fail closed", async () => {
     const { storePath } = await makeStorePath();
 


### PR DESCRIPTION
## Summary
- preserve persisted `job.state` when cron jobs are normalized during store load
- keep legacy runtime fields like `runningAtMs` and `nextRunAtMs` available for startup catch-up
- add a regression test covering persisted runtime state round-tripping through `ensureLoaded()`

## Testing
- `./node_modules/.bin/vitest run src/cron/service/store.test.ts src/cron/service.restart-catchup.test.ts`

Fixes #65193