### PR TITLE
fix: include user-configured provider models in gateway catalog for capability checks

### DIFF
--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -56,7 +56,7 @@ export async function loadGatewayModelCatalog(params?: {
       if (findModelInCatalog(catalog, providerId, id)) {
         continue;
       }
-      const rawInput = Array.isArray(m.input) ? m.input : [];
+      const rawInput: unknown[] = Array.isArray(m.input) ? m.input : [];
       const input = rawInput.filter(
         (v): v is ModelInputType => v === "text" || v === "image" || v === "document",
       );

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -1,9 +1,12 @@
 import {
   loadModelCatalog,
+  findModelInCatalog,
   type ModelCatalogEntry,
+  type ModelInputType,
   resetModelCatalogCacheForTest,
 } from "../agents/model-catalog.js";
 import { getRuntimeConfig } from "../config/config.js";
+import type { ModelProviderConfig } from "../config/types.models.js";
 
 export type GatewayModelChoice = ModelCatalogEntry;
 
@@ -14,8 +17,62 @@ export function __resetModelCatalogCacheForTest() {
   resetModelCatalogCacheForTest();
 }
 
+/**
+ * Load the gateway model catalog, augmented with custom models declared in
+ * `models.providers.*.models[]` from the user config.  The built-in catalog
+ * only contains first-party / plugin-contributed entries; user-configured
+ * provider models (e.g. custom OpenAI-compatible endpoints) carry capability
+ * declarations such as `input: ["text", "image"]` that must be visible to
+ * capability-check helpers like `resolveGatewayModelSupportsImages`.
+ */
 export async function loadGatewayModelCatalog(params?: {
   getConfig?: () => ReturnType<typeof getRuntimeConfig>;
 }): Promise<GatewayModelChoice[]> {
-  return await loadModelCatalog({ config: (params?.getConfig ?? getRuntimeConfig)() });
+  const cfg = (params?.getConfig ?? getRuntimeConfig)();
+  const catalog = await loadModelCatalog({ config: cfg });
+
+  // Augment with custom-configured provider models from models.providers.*.models[].
+  // These are absent from the built-in Pi SDK registry but their capability
+  // declarations (e.g. input: ["text", "image"]) should be honoured for routing.
+  const providerConfigs = (cfg as { models?: { providers?: Record<string, ModelProviderConfig | undefined> } } | undefined)
+    ?.models?.providers;
+
+  if (!providerConfigs) {
+    return catalog;
+  }
+
+  const extra: ModelCatalogEntry[] = [];
+  for (const [providerId, providerConfig] of Object.entries(providerConfigs)) {
+    const customModels = providerConfig?.models;
+    if (!Array.isArray(customModels) || customModels.length === 0) {
+      continue;
+    }
+    for (const m of customModels) {
+      const id = typeof m?.id === "string" ? m.id.trim() : "";
+      if (!id) {
+        continue;
+      }
+      // Skip if already present (case-insensitive) to avoid duplicates.
+      if (findModelInCatalog(catalog, providerId, id)) {
+        continue;
+      }
+      const rawInput = Array.isArray(m.input) ? m.input : [];
+      const input = rawInput.filter(
+        (v): v is ModelInputType => v === "text" || v === "image" || v === "document",
+      );
+      extra.push({
+        id,
+        name: typeof m.name === "string" && m.name.trim() ? m.name.trim() : id,
+        provider: providerId,
+        contextWindow:
+          typeof m.contextWindow === "number" && m.contextWindow > 0
+            ? m.contextWindow
+            : undefined,
+        reasoning: typeof m.reasoning === "boolean" ? m.reasoning : undefined,
+        input: input.length > 0 ? input : undefined,
+      });
+    }
+  }
+
+  return extra.length > 0 ? [...catalog, ...extra] : catalog;
 }

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -6,7 +6,7 @@ import {
   resetModelCatalogCacheForTest,
 } from "../agents/model-catalog.js";
 import { getRuntimeConfig } from "../config/config.js";
-import type { ModelProviderConfig } from "../config/types.models.js";
+
 
 export type GatewayModelChoice = ModelCatalogEntry;
 
@@ -34,8 +34,7 @@ export async function loadGatewayModelCatalog(params?: {
   // Augment with custom-configured provider models from models.providers.*.models[].
   // These are absent from the built-in Pi SDK registry but their capability
   // declarations (e.g. input: ["text", "image"]) should be honoured for routing.
-  const providerConfigs = (cfg as { models?: { providers?: Record<string, ModelProviderConfig | undefined> } } | undefined)
-    ?.models?.providers;
+  const providerConfigs = cfg.models?.providers;
 
   if (!providerConfigs) {
     return catalog;
@@ -52,8 +51,10 @@ export async function loadGatewayModelCatalog(params?: {
       if (!id) {
         continue;
       }
-      // Skip if already present (case-insensitive) to avoid duplicates.
-      if (findModelInCatalog(catalog, providerId, id)) {
+      // Skip if already present in the base catalog or in the extra slice being
+      // built (case-insensitive) to avoid duplicates when the same model ID
+      // appears more than once in providerConfig.models[].
+      if (findModelInCatalog(catalog, providerId, id) || findModelInCatalog(extra, providerId, id)) {
         continue;
       }
       const rawInput: unknown[] = Array.isArray(m.input) ? m.input : [];

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -9,6 +9,7 @@ import {
 import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { findModelInCatalog } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
   normalizeStoredOverrideModel,
@@ -1000,10 +1001,17 @@ export async function resolveGatewayModelSupportsImages(params: {
 
   try {
     const catalog = await params.loadGatewayModelCatalog();
-    const modelEntry = catalog.find(
-      (entry) =>
-        entry.id === params.model && (!params.provider || entry.provider === params.provider),
-    );
+    // Use case-insensitive lookup so user-configured model IDs that differ
+    // only in casing (e.g. from persisted session rows vs. config) still
+    // resolve to the correct catalog entry and its capability declarations.
+    let modelEntry: ModelCatalogEntry | undefined;
+    if (params.provider) {
+      modelEntry = findModelInCatalog(catalog, params.provider, params.model);
+    }
+    if (!modelEntry) {
+      const normalizedModelId = params.model.toLowerCase().trim();
+      modelEntry = catalog.find((entry) => entry.id.toLowerCase().trim() === normalizedModelId);
+    }
     const normalizedProvider = normalizeOptionalLowercaseString(params.provider);
     const normalizedCandidates = [
       normalizeLowercaseStringOrEmpty(params.model),

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1006,9 +1006,12 @@ export async function resolveGatewayModelSupportsImages(params: {
     // resolve to the correct catalog entry and its capability declarations.
     let modelEntry: ModelCatalogEntry | undefined;
     if (params.provider) {
+      // Provider is known — scope the lookup to that provider only so a
+      // model that exists under a different provider does not satisfy the
+      // check (fail-closed intent preserved).
       modelEntry = findModelInCatalog(catalog, params.provider, params.model);
-    }
-    if (!modelEntry) {
+    } else {
+      // No provider context — fall back to a model-ID-only lookup.
       const normalizedModelId = params.model.toLowerCase().trim();
       modelEntry = catalog.find((entry) => entry.id.toLowerCase().trim() === normalizedModelId);
     }


### PR DESCRIPTION
## Problem

Custom models declared in `models.providers.*.models[]` (e.g. a local copilot proxy with `input: ["text", "image"]`) were **absent from the built-in Pi SDK model registry**. This meant `resolveGatewayModelSupportsImages` could never find them in the catalog and always returned `false`, causing image attachments to be silently dropped with:

```
parseMessageWithAttachments: 1 attachment(s) dropped — model does not support images
```

...even when the config **explicitly declared** image support via `input: ["text", "image"]`.

This is a deeper root cause than the case-sensitivity issue addressed in #65178 — even with case-insensitive lookup, the entry simply isn't there to find.

## Fix

**`server-model-catalog.ts`** — `loadGatewayModelCatalog` now augments the standard catalog with entries from `models.providers.*.models[]`, preserving their `input`, `contextWindow`, and `reasoning` capability declarations. Deduplication uses `findModelInCatalog` (case-insensitive) to avoid duplicate entries.

**`session-utils.ts`** — `resolveGatewayModelSupportsImages` now uses `findModelInCatalog` for a case-insensitive provider+model lookup (matching the pattern in the rest of the codebase), with a model-only ID fallback for sessions without a stored provider.

## Testing

Verified locally against a `copilot` provider entry with `input: ["text", "image"]` pointing to a local OpenAI-compatible proxy — images are no longer dropped after this patch.

## Related

Closes (supersedes) #65178 — this PR addresses the same symptom but fixes the underlying catalog gap rather than only the lookup heuristic.