### PR TITLE
GPT-5.4 parity proof rollup

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -1,0 +1,85 @@
+name: Parity gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "extensions/qa-lab/**"
+      - "qa/scenarios/**"
+      - "src/agents/**"
+      - "src/context-engine/**"
+      - ".github/workflows/parity-gate.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: parity-gate-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  parity-gate:
+    name: Run the GPT-5.4 / Opus 4.6 parity gate against the qa-lab mock
+    if: ${{ github.event.pull_request.draft != true }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    env:
+      # Fence the gate off from any real provider credentials. The qa-lab
+      # mock server + auth staging (PR N) should be enough to produce a
+      # meaningful verdict without touching a real API. If any of these
+      # leak into the job env, fail hard instead of silently running
+      # against a live provider and burning real budget.
+      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
+      OPENCLAW_LIVE_OPENAI_KEY: ""
+      OPENCLAW_LIVE_ANTHROPIC_KEY: ""
+      OPENCLAW_LIVE_GEMINI_KEY: ""
+      OPENCLAW_LIVE_SETUP_TOKEN_VALUE: ""
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run GPT-5.4 lane
+        run: |
+          pnpm openclaw qa suite \
+            --parity-pack agentic \
+            --model openai/gpt-5.4 \
+            --output-dir .artifacts/qa-e2e/gpt54
+
+      - name: Run Opus 4.6 lane
+        run: |
+          pnpm openclaw qa suite \
+            --parity-pack agentic \
+            --model anthropic/claude-opus-4-6 \
+            --output-dir .artifacts/qa-e2e/opus46
+
+      - name: Generate parity report
+        run: |
+          pnpm openclaw qa parity-report \
+            --repo-root . \
+            --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
+            --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+            --candidate-label openai/gpt-5.4 \
+            --baseline-label anthropic/claude-opus-4-6 \
+            --output-dir .artifacts/qa-e2e/parity
+
+      - name: Upload parity artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-gate-${{ github.event.pull_request.number || github.sha }}
+          path: .artifacts/qa-e2e/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -21,7 +21,7 @@ jobs:
   parity-gate:
     name: Run the mock structural GPT-5.4 / Opus 4.6 parity gate
     if: ${{ github.event.pull_request.draft != true }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 20
     env:
       # Fence the gate off from any real provider credentials. The qa-lab

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - "extensions/qa-lab/**"
+      - "extensions/qa-channel/**"
       - "qa/scenarios/**"
       - "src/agents/**"
       - "src/context-engine/**"

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -8,6 +8,7 @@ on:
       - "qa/scenarios/**"
       - "src/agents/**"
       - "src/context-engine/**"
+      - "src/gateway/**"
       - ".github/workflows/parity-gate.yml"
 
 permissions:

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   parity-gate:
-    name: Run the GPT-5.4 / Opus 4.6 parity gate against the qa-lab mock
+    name: Run the mock structural GPT-5.4 / Opus 4.6 parity gate
     if: ${{ github.event.pull_request.draft != true }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
@@ -51,16 +51,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run GPT-5.4 lane
+      - name: Run GPT-5.4 mock lane
         run: |
           pnpm openclaw qa suite \
+            --provider-mode mock-openai \
             --parity-pack agentic \
             --model openai/gpt-5.4 \
             --output-dir .artifacts/qa-e2e/gpt54
 
-      - name: Run Opus 4.6 lane
+      - name: Run Opus 4.6 mock lane
         run: |
           pnpm openclaw qa suite \
+            --provider-mode mock-openai \
             --parity-pack agentic \
             --model anthropic/claude-opus-4-6 \
             --output-dir .artifacts/qa-e2e/opus46

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -58,6 +58,7 @@ jobs:
             --provider-mode mock-openai \
             --parity-pack agentic \
             --model openai/gpt-5.4 \
+            --alt-model openai/gpt-5.4-alt \
             --output-dir .artifacts/qa-e2e/gpt54
 
       - name: Run Opus 4.6 mock lane
@@ -66,6 +67,7 @@ jobs:
             --provider-mode mock-openai \
             --parity-pack agentic \
             --model anthropic/claude-opus-4-6 \
+            --alt-model anthropic/claude-sonnet-4-6 \
             --output-dir .artifacts/qa-e2e/opus46
 
       - name: Generate parity report

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,14 +1,14 @@
-# GPT-5.4 / Codex Parity Maintainer Notes
+# GPT-5.4 / Codex parity maintainer notes
 
-This note explains how to review the GPT-5.4 / Codex parity program without losing the original six-contract architecture. The program ships as ten runtime/test merge units (PRs A, B, C, D, E, F, H, J, K, L) plus a separate documentation catch-up (PR M #64837 — this page). Wave 1 — the four initial PRs A, B, C, D — established the runtime contract, parity harness, and first-wave scenario pack and is now merged. Wave 2 — the six follow-up PRs E, F, H, J, K, L — doubles the parity pack, auto-activates strict-agentic on GPT-5, tightens tool-call enforcement, covers the baseline provider for offline runs, and self-describes each run in its summary artifact. PR F was closed as superseded after its three fixes were resolved upstream independently, so wave 2 lands as five code PRs plus PR M.
+This is the review-oriented companion to [`gpt54-codex-agentic-parity.md`](/help/gpt54-codex-agentic-parity). The goal here is to make the program legible as merge units without losing the underlying six-contract architecture, so someone picking up a PR knows what it's supposed to own and what it deliberately doesn't.
 
-## Program status
+The program ends up as ten runtime/test merge units plus a separate documentation pass (PR M, this note). Wave 1 — PRs A, B, C, D — is merged and landed the runtime contract, the parity harness, and the first-wave scenario pack. Wave 2 — PRs E, F, H, J, K, L — is the refinement round: it doubles the parity pack, makes strict-agentic the real default for GPT-5, adds tool-call enforcement, brings the mock server up to dual-provider coverage, and teaches each summary artifact to describe itself. PR F was closed after each of its three fixes landed on `main` through unrelated commits during the review window, so wave 2 effectively merges as five code PRs plus this docs pass.
 
-Sections below describe each PR's scope, including wave-2 PRs that have not yet merged. This doc is merged as PR M after the wave-2 code PRs. Until then, "Owns" blocks for wave-2 PRs describe the intended end state of each slice.
+Sections below describe each PR's scope including the wave-2 ones that haven't merged yet. "Owns" blocks for wave-2 PRs describe their intended end state, not what's on `main` today.
 
 ## Merge units
 
-### PR A: strict-agentic execution
+### PR A — strict-agentic execution
 
 Owns:
 
@@ -17,14 +17,9 @@ Owns:
 - `update_plan` as non-terminal progress tracking
 - explicit blocked states instead of plan-only silent stops
 
-Does not own:
+Does not own: auth/runtime failure classification, permission truthfulness, replay/continuation redesign, parity benchmarking.
 
-- auth/runtime failure classification
-- permission truthfulness
-- replay/continuation redesign
-- parity benchmarking
-
-### PR B: runtime truthfulness
+### PR B — runtime truthfulness
 
 Owns:
 
@@ -32,13 +27,9 @@ Owns:
 - typed provider/runtime failure classification
 - truthful `/elevated full` availability and blocked reasons
 
-Does not own:
+Does not own: tool schema normalization, replay/liveness state, benchmark gating.
 
-- tool schema normalization
-- replay/liveness state
-- benchmark gating
-
-### PR C: execution correctness
+### PR C — execution correctness
 
 Owns:
 
@@ -47,13 +38,9 @@ Owns:
 - replay-invalid surfacing
 - paused, blocked, and abandoned long-task state visibility
 
-Does not own:
+Does not own: self-elected continuation, generic Codex dialect behavior outside provider hooks, benchmark gating.
 
-- self-elected continuation
-- generic Codex dialect behavior outside provider hooks
-- benchmark gating
-
-### PR D: first-wave parity harness
+### PR D — first-wave parity harness
 
 Owns:
 
@@ -61,31 +48,23 @@ Owns:
 - parity documentation baseline
 - parity report and release-gate mechanics
 
-Does not own:
+Does not own: second-wave scenarios, dual-provider mock routing, runtime behavior changes outside QA-lab.
 
-- second-wave scenarios
-- dual-provider mock routing
-- runtime behavior changes outside QA-lab
-
-### PR E: second-wave parity pack
+### PR E — second-wave parity pack
 
 Owns:
 
 - five additional parity scenarios (`subagent-handoff`, `subagent-fanout-synthesis`, `memory-recall`, `thread-memory-isolation`, `config-restart-capability-flip`)
 - parity report header parametrization so non-default model pairs render accurate labels
-- parity gate failure when any required scenario fails on either candidate or baseline, so “both models fail” no longer leaks through the relative metric comparison
+- parity gate failure when a required scenario fails on either candidate or baseline, so "both models fail" no longer slips through the relative metric comparison
 
-Does not own:
+Does not own: dual-provider mock routing (PR K), self-describing run metadata (PR L), tool-call assertions (PR J).
 
-- dual-provider mock routing (PR K)
-- self-describing run metadata (PR L)
-- tool-call assertions (PR J)
+### PR F — post-parity main stabilization (closed as superseded)
 
-### PR F: post-parity main stabilization (closed as superseded)
+Had three inherited red-CI fixes against `target-resolver.test.ts`, `memory-wiki/index.test.ts`, and `config.pruning-defaults.test.ts`. All three got resolved upstream through unrelated commits during the review window, so the PR was closed after verification and no review action is needed.
 
-Owned three inherited red-CI fixes against `target-resolver.test.ts`, `memory-wiki/index.test.ts`, and `config.pruning-defaults.test.ts`. All three failures were resolved upstream through independent commits while the parity loop was in progress, and the PR was closed as superseded after verification. No review action needed.
-
-### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
+### PR H — strict-agentic auto-activation + blocked-exit liveness
 
 Owns:
 
@@ -93,50 +72,38 @@ Owns:
 - explicit `"blocked"` liveness state at the strict-agentic blocked exit
 - regression coverage pinning both behaviors
 
-Does not own:
+Does not own: the `executionContract` mechanism itself (PR A), non-GPT-5 provider defaults.
 
-- the `executionContract` mechanism itself (that's PR A)
-- non-GPT-5 provider defaults
-
-### PR J: parity scenario tool-call enforcement
+### PR J — parity scenario tool-call enforcement
 
 Owns:
 
-- tool-call assertions on the `source-docs-discovery-report` and `subagent-handoff` parity scenarios
+- tool-call assertions on `source-docs-discovery-report` and `subagent-handoff`
 - `/debug/requests` seam consumption from scenario YAML flows
-- matching on scenario-unique prompt substrings to keep assertions scoped to their own scenario
+- matching on scenario-unique prompt substrings so neighboring scenarios can't accidentally satisfy each other's assertions
 
-Does not own:
+Does not own: the `/debug/requests` store itself (part of the mock server), tool schemas or tool execution.
 
-- the `/debug/requests` store itself (part of the mock server)
-- tool schemas or tool execution
-
-### PR K: Anthropic `/v1/messages` mock route
+### PR K — Anthropic `/v1/messages` mock route
 
 Owns:
 
 - the `/v1/messages` route on the qa-lab mock server
 - Anthropic messages → shared `ResponsesInputItem[]` conversion
-- empty-model and streaming-request edge cases (empty string defaults to `claude-opus-4-6`; `stream: true` returns a 400 so the failure mode is visible)
+- the empty-model and streaming-request edge cases (empty-string defaults to `claude-opus-4-6`; `stream: true` returns a 400 so the failure mode is visible)
 
-Does not own:
+Does not own: real Anthropic API compatibility beyond what the scenario dispatcher reads, live Anthropic credential wiring.
 
-- real Anthropic API compatibility beyond what the scenario dispatcher reads
-- live Anthropic credential wiring
-
-### PR L: qa-suite-summary.json run metadata
+### PR L — `qa-suite-summary.json` run metadata
 
 Owns:
 
 - the `run` block in `qa-suite-summary.json` (`primaryProvider`, `primaryModel`, `providerMode`, `scenarioIds`)
 - reuse of the canonical `QaProviderMode` union in `writeQaSuiteArtifacts` instead of a re-declared string-literal union
 
-Does not own:
+Does not own: parity report consumption of the run block (PR D's report helper), scenario catalog filtering.
 
-- parity report consumption of the run block (that's PR D's report helper)
-- scenario catalog filtering
-
-### PR M: documentation catch-up
+### PR M — parity documentation catch-up
 
 Owns:
 
@@ -146,12 +113,7 @@ Owns:
 - the goal-to-evidence matrix update covering all 10 PRs
 - the program-status disclaimer that marks wave-2 sections as forward-looking until each wave-2 PR merges
 
-Does not own:
-
-- any runtime, test, or scenario registry change (documentation-only PR)
-- the `QA_AGENTIC_PARITY_SCENARIOS` registry expansion (PR E owns that)
-- the CLI flag reference (PR M describes `--model` / `--alt-model` as they exist on `main`; PR M does not change the CLI surface)
-- any architecture change to the mock server, parity report, or strict-agentic contract
+Does not own: any runtime, test, or scenario registry change (docs-only), the `QA_AGENTIC_PARITY_SCENARIOS` registry expansion (PR E owns that), the CLI flag reference itself (PR M describes `--model` / `--alt-model` as they exist on `main` but doesn't change the CLI surface), the mock server, the parity report, or the strict-agentic contract.
 
 ## Mapping back to the original six contracts
 
@@ -166,18 +128,16 @@ Does not own:
 
 ## Review order
 
-1. PR A
-2. PR B
-3. PR C
-4. PR D
-5. PR H (runtime follow-up, parallelizable with D)
-6. PR E (parity pack expansion, depends on D)
-7. PR K (Anthropic mock route, parallelizable with E/J)
-8. PR J (tool-call enforcement, depends on E)
-9. PR L (run metadata, parallelizable with J)
-10. PR M (documentation catch-up, depends on E/H/J/K/L)
+Wave 1 landed in A → B → C → D order. For wave 2, the dependencies are:
 
-PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed. PRs E/H/J/K/L are independent refinements that can land in any order as long as their individual dependency callouts are respected. PR M is documentation-only and can land in parallel with the last code PR.
+1. PR H is a runtime follow-up, independent of the parity harness work — review it any time.
+2. PR E depends on PR D being merged (it extends the parity pack registry).
+3. PR K is independent of E/H/J/L.
+4. PR J depends on PR E because it asserts against scenarios the second-wave pack registers.
+5. PR L is independent of J.
+6. PR M is docs-only and should land last so its references point to merged content.
+
+PRs H, K, and L can be reviewed in parallel. PR E should land before PR J. PR M should be the tail.
 
 ## What to look for
 
@@ -189,15 +149,15 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 
 ### PR B
 
-- auth/proxy/runtime failures stop collapsing into generic “model failed” handling
-- `/elevated full` is only described as available when it is actually available
+- auth/proxy/runtime failures don't collapse into a generic "model failed" handler
+- `/elevated full` is only described as available when it actually is
 - blocked reasons are visible to both the model and the user-facing runtime
 
 ### PR C
 
 - strict OpenAI/Codex tool registration behaves predictably
-- parameter-free tools do not fail strict schema checks
-- replay and compaction outcomes preserve truthful liveness state
+- parameter-free tools don't fail strict schema checks
+- replay and compaction outcomes keep truthful liveness state
 
 ### PR D
 
@@ -206,17 +166,13 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
 
-Expected artifacts from PR D:
-
-- `qa-suite-report.md` / `qa-suite-summary.json` for each model run
-- `qa-agentic-parity-report.md` with aggregate and scenario-level comparison
-- `qa-agentic-parity-summary.json` with a machine-readable verdict
+Expected artifacts: `qa-suite-report.md` / `qa-suite-summary.json` for each model run, `qa-agentic-parity-report.md` with aggregate and scenario-level comparison, `qa-agentic-parity-summary.json` with a machine-readable verdict.
 
 ### PR E
 
-- the parity pack is now ten scenarios, not five
-- the parity report Markdown header reflects the candidate and baseline labels instead of a hardcoded legacy string
-- a required scenario that fails on either side fails the gate, even if both sides fail the same scenario (this closes the relative-metric loophole)
+- the parity pack is ten scenarios, not five
+- the parity report Markdown header reflects the candidate and baseline labels, not a hardcoded legacy string
+- a required scenario that fails on either side fails the gate, even when both sides fail the same scenario — this closes the relative-metric loophole
 - the five new scenarios exercise delegation, fanout synthesis, memory recall, thread-memory isolation, and a capability flip across config restart
 
 ### PR H
@@ -228,16 +184,16 @@ Expected artifacts from PR D:
 
 ### PR J
 
-- the `source-docs-discovery-report` scenario gates on a real `read` tool call via `/debug/requests`, not just the prose shape of the reply
-- the `subagent-handoff` scenario gates on a real `sessions_spawn` call before accepting the three labeled sections
-- both assertions use a scenario-unique prompt substring so neighboring scenarios (for example `subagent-fanout-synthesis`) cannot accidentally satisfy them
+- `source-docs-discovery-report` gates on a real `read` tool call via `/debug/requests`, not just the prose shape of the reply
+- `subagent-handoff` gates on a real `sessions_spawn` call before accepting the three labeled sections
+- both assertions match on a scenario-unique prompt substring so neighboring scenarios (for example `subagent-fanout-synthesis`, which also contains "delegate" and produces its own `sessions_spawn` request) can't accidentally satisfy them
 
 ### PR K
 
-- the `/v1/messages` mock route routes through the same scenario dispatcher as `/v1/responses` so one scenario plan drives both providers
+- `/v1/messages` routes through the same scenario dispatcher as `/v1/responses` so one scenario plan drives both providers
 - streaming requests return a 400 with an Anthropic-shaped error body, not a silent non-streaming fallback
 - empty-string `model` is treated the same as absent and defaults to `claude-opus-4-6`
-- `/debug/requests` snapshots record the same `plannedToolName` / `allInputText` / `toolOutput` fields that the OpenAI route exposes, so a single parity run can diff assertions across both lanes
+- `/debug/requests` snapshots record the same `plannedToolName` / `allInputText` / `toolOutput` fields on the Anthropic route that the OpenAI route already exposes, so a single parity run can diff assertions across both lanes
 
 ### PR L
 
@@ -249,24 +205,24 @@ Expected artifacts from PR D:
 
 - the parity docs cover all ten PRs, not just the first four
 - the three new mermaid diagrams are present (dual-provider mock, parity run orchestration, tool-call assertion seam)
-- the end-to-end parity runbook is reproducible offline
+- the end-to-end parity runbook uses the real CLI flags and calls out which steps depend on unmerged wave-2 PRs
 - the goal-to-evidence matrix matches the ten-PR program
 
 ## Release gate
 
-Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
+Don't claim GPT-5.4 parity or superiority over Opus 4.6 until:
 
-- PR A, PR B, PR C, and PR H are merged (runtime contract enforced by default for GPT-5)
-- PR D and PR E run the ten-scenario parity pack cleanly on both providers
-- PR J tool-call assertions pass on the tool-mediated scenarios
-- PR K offline dual-provider mock is exercised in CI
-- PR L run metadata is present in both summary artifacts
-- runtime-truthfulness regression suites remain green
+- PRs A, B, C, and H are merged (runtime contract enforced by default for GPT-5)
+- PRs D and E run the ten-scenario parity pack cleanly on both providers
+- PR J's tool-call assertions pass on the tool-mediated scenarios
+- PR K's offline dual-provider mock is exercised in CI
+- PR L's run metadata is present in both summary artifacts
+- runtime-truthfulness regression suites stay green
 - the parity report shows no fake-success cases and no regression in stop behavior
 
 ```mermaid
 flowchart LR
-    A["PR A-C merged"] --> B["Run GPT-5.4 parity pack"]
+    A["Runtime PRs merged"] --> B["Run GPT-5.4 parity pack"]
     A --> C["Run Opus 4.6 parity pack"]
     B --> D["qa-suite-summary.json"]
     C --> E["qa-suite-summary.json"]
@@ -275,25 +231,22 @@ flowchart LR
     F --> G["Markdown report + JSON verdict"]
     G --> H{"Pass?"}
     H -- "yes" --> I["Parity claim allowed"]
-    H -- "no" --> J["Keep runtime fixes / review loop open"]
+    H -- "no" --> J["Keep runtime fixes in play"]
 ```
 
-The parity harness is not the only evidence source. Keep this split explicit in review:
-
-- PR D owns the scenario-based GPT-5.4 vs Opus 4.6 comparison
-- PR B deterministic suites still own auth/proxy/DNS and full-access truthfulness evidence
+The parity harness isn't the only evidence source. Keep the split explicit in review: PRs D and E own the scenario-based GPT-5.4 vs Opus 4.6 comparison, and PR B's deterministic suites still own auth, proxy, DNS, and `/elevated full` truthfulness.
 
 ## Goal-to-evidence map
 
-| Completion gate item                     | Primary owners            | Review artifact                                                                                                       |
-| ---------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| No plan-only stalls                      | PR A + PR H               | strict-agentic runtime tests, `approval-turn-tool-followthrough`, PR H auto-activation regression                     |
-| No fake progress or fake tool completion | PR A + PR D + PR J        | parity fake-success count, scenario-level report details, `/debug/requests` tool-call assertions                      |
-| No false `/elevated full` guidance       | PR B                      | deterministic runtime-truthfulness suites                                                                             |
-| Replay/liveness failures remain explicit | PR C + PR H               | lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                                     |
-| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, full ten-scenario coverage on both providers offline |
+| Completion gate criterion                | Primary owners            | Review artifact                                                                                                   |
+| ---------------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| No plan-only stalls                      | PR A + PR H               | strict-agentic runtime tests, `approval-turn-tool-followthrough`, PR H auto-activation regression                 |
+| No fake progress or fake tool completion | PR A + PR D + PR J        | parity fake-success count, scenario-level report details, `/debug/requests` tool-call assertions                  |
+| No false `/elevated full` guidance       | PR B                      | deterministic runtime-truthfulness suites                                                                         |
+| Replay/liveness failures remain explicit | PR C + PR H               | lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                                 |
+| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, ten-scenario coverage on both providers, offline |
 
-## Reviewer shorthand: before vs after
+## Reviewer shorthand
 
 | User-visible problem before                                 | Review signal after                                                                               |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -205,7 +205,7 @@ Expected artifacts: `qa-suite-report.md` / `qa-suite-summary.json` for each mode
 
 - the parity docs cover all ten PRs, not just the first four
 - the three new mermaid diagrams are present (dual-provider mock, parity run orchestration, tool-call assertion seam)
-- the end-to-end parity runbook uses the real CLI flags and calls out which steps depend on unmerged wave-2 PRs
+- the end-to-end parity runbook clearly separates the mock structural gate from the live-frontier proof run
 - the goal-to-evidence matrix matches the ten-PR program
 
 ## Release gate
@@ -235,6 +235,12 @@ flowchart LR
 ```
 
 The parity harness isn't the only evidence source. Keep the split explicit in review: PRs D and E own the scenario-based GPT-5.4 vs Opus 4.6 comparison, and PR B's deterministic suites still own auth, proxy, DNS, and `/elevated full` truthfulness.
+
+## Mock gate vs live proof
+
+- The workflow in `.github/workflows/parity-gate.yml` is the **mock structural gate**. It should run `openclaw qa suite --provider-mode mock-openai ...` for both lanes and verify harness structure, scenario registration, artifact generation, and fail-fast semantics without touching real credentials.
+- The final product claim still requires a **live-frontier proof run**. That run should use `--provider-mode live-frontier` for both GPT-5.4 and Opus 4.6, then feed the resulting summaries into `openclaw qa parity-report`.
+- Reviewers should reject any wording that treats the mock structural gate as the final parity proof by itself.
 
 ## Goal-to-evidence map
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,6 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as four merge units without losing the original six-contract architecture.
+This note explains how to review the GPT-5.4 / Codex parity program as five merge units without losing the original six-contract architecture.
 
 ## Merge units
 
@@ -62,6 +62,19 @@ Does not own:
 - runtime behavior changes outside QA-lab
 - auth/proxy/DNS simulation inside the harness
 
+### PR E: second-wave parity expansion
+
+Owns:
+
+- second-wave parity scenario expansion
+- merged-main proof packaging
+- goal-to-evidence parity documentation
+
+Does not own:
+
+- runtime behavior changes outside QA-lab
+- auth/proxy/DNS truthfulness logic
+
 ## Mapping back to the original six contracts
 
 | Original contract                        | Merge unit |
@@ -79,8 +92,9 @@ Does not own:
 2. PR B
 3. PR C
 4. PR D
+5. PR E
 
-PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed.
+PR D establishes the proof base. PR E expands scenario breadth and merged-main proof depth. Neither should be the reason runtime-correctness PRs are delayed.
 
 ## What to look for
 
@@ -109,6 +123,12 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
 
+### PR E
+
+- the parity pack widens beyond the first wave without adding runtime-scope behavior
+- subagent, memory, thread-isolation, and restart-capability lanes are covered
+- merged-main parity proof is explicitly documented and traceable
+
 Expected artifacts from PR D:
 
 - `qa-suite-report.md` / `qa-suite-summary.json` for each model run
@@ -120,7 +140,7 @@ Expected artifacts from PR D:
 Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
 
 - PR A, PR B, and PR C are merged
-- PR D runs the first-wave parity pack cleanly
+- PR D and PR E run the full parity pack cleanly
 - runtime-truthfulness regression suites remain green
 - the parity report shows no fake-success cases and no regression in stop behavior
 
@@ -140,18 +160,18 @@ flowchart LR
 
 The parity harness is not the only evidence source. Keep this split explicit in review:
 
-- PR D owns the scenario-based GPT-5.4 vs Opus 4.6 comparison
+- PR D and PR E own the scenario-based GPT-5.4 vs Opus 4.6 comparison
 - PR B deterministic suites still own auth/proxy/DNS and full-access truthfulness evidence
 
 ## Goal-to-evidence map
 
-| Completion gate item                     | Primary owner | Review artifact                                                     |
-| ---------------------------------------- | ------------- | ------------------------------------------------------------------- |
-| No plan-only stalls                      | PR A          | strict-agentic runtime tests and `approval-turn-tool-followthrough` |
-| No fake progress or fake tool completion | PR A + PR D   | parity fake-success count plus scenario-level report details        |
-| No false `/elevated full` guidance       | PR B          | deterministic runtime-truthfulness suites                           |
-| Replay/liveness failures remain explicit | PR C + PR D   | lifecycle/replay suites plus `compaction-retry-mutating-tool`       |
-| GPT-5.4 matches or beats Opus 4.6        | PR D          | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`  |
+| Completion gate item                     | Primary owner      | Review artifact                                                                    |
+| ---------------------------------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| No plan-only stalls                      | PR A               | strict-agentic runtime tests and `approval-turn-tool-followthrough`                |
+| No fake progress or fake tool completion | PR A + PR D + PR E | parity fake-success count plus scenario-level report details                       |
+| No false `/elevated full` guidance       | PR B               | deterministic runtime-truthfulness suites                                          |
+| Replay/liveness failures remain explicit | PR C + PR D + PR E | lifecycle/replay suites plus `compaction-retry-mutating-tool` and continuity lanes |
+| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`                 |
 
 ## Reviewer shorthand: before vs after
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,10 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as ten merge units without losing the original six-contract architecture. The program shipped as four initial PRs (A through D) that established the runtime contract, parity harness, and first-wave scenario pack, plus six follow-up PRs (E, F, H, J, K, L) that doubled the parity pack, auto-activated strict-agentic on GPT-5, tightened tool-call enforcement, covered the baseline provider for offline runs, and self-described each run in its summary artifact.
+This note explains how to review the GPT-5.4 / Codex parity program without losing the original six-contract architecture. The program ships as ten runtime/test merge units (PRs A, B, C, D, E, F, H, J, K, L) plus a separate documentation catch-up (PR M #64837 — this page). Wave 1 — the four initial PRs A, B, C, D — established the runtime contract, parity harness, and first-wave scenario pack and is now merged. Wave 2 — the six follow-up PRs E, F, H, J, K, L — doubles the parity pack, auto-activates strict-agentic on GPT-5, tightens tool-call enforcement, covers the baseline provider for offline runs, and self-describes each run in its summary artifact. PR F was closed as superseded after its three fixes were resolved upstream independently, so wave 2 lands as five code PRs plus PR M.
+
+## Program status
+
+Sections below describe each PR's scope, including wave-2 PRs that have not yet merged. This doc is merged as PR M after the wave-2 code PRs. Until then, "Owns" blocks for wave-2 PRs describe the intended end state of each slice.
 
 ## Merge units
 
@@ -140,6 +144,14 @@ Owns:
 - three new mermaid diagrams (dual-provider mock, parity run orchestration, tool-call assertion seam)
 - the end-to-end parity runbook section
 - the goal-to-evidence matrix update covering all 10 PRs
+- the program-status disclaimer that marks wave-2 sections as forward-looking until each wave-2 PR merges
+
+Does not own:
+
+- any runtime, test, or scenario registry change (documentation-only PR)
+- the `QA_AGENTIC_PARITY_SCENARIOS` registry expansion (PR E owns that)
+- the CLI flag reference (PR M describes `--model` / `--alt-model` as they exist on `main`; PR M does not change the CLI surface)
+- any architecture change to the mock server, parity report, or strict-agentic contract
 
 ## Mapping back to the original six contracts
 

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,6 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as four merge units without losing the original six-contract architecture.
+This note explains how to review the GPT-5.4 / Codex parity program as ten merge units without losing the original six-contract architecture. The program shipped as four initial PRs (A through D) that established the runtime contract, parity harness, and first-wave scenario pack, plus six follow-up PRs (E, F, H, J, K, L) that doubled the parity pack, auto-activated strict-agentic on GPT-5, tightened tool-call enforcement, covered the baseline provider for offline runs, and self-described each run in its summary artifact.
 
 ## Merge units
 
@@ -49,29 +49,108 @@ Does not own:
 - generic Codex dialect behavior outside provider hooks
 - benchmark gating
 
-### PR D: parity harness
+### PR D: first-wave parity harness
 
 Owns:
 
-- first-wave GPT-5.4 vs Opus 4.6 scenario pack
-- parity documentation
+- first-wave GPT-5.4 vs Opus 4.6 scenario pack (five scenarios)
+- parity documentation baseline
 - parity report and release-gate mechanics
 
 Does not own:
 
+- second-wave scenarios
+- dual-provider mock routing
 - runtime behavior changes outside QA-lab
-- auth/proxy/DNS simulation inside the harness
+
+### PR E: second-wave parity pack
+
+Owns:
+
+- five additional parity scenarios (`subagent-handoff`, `subagent-fanout-synthesis`, `memory-recall`, `thread-memory-isolation`, `config-restart-capability-flip`)
+- parity report header parametrization so non-default model pairs render accurate labels
+- parity gate failure when any required scenario fails on either candidate or baseline, so “both models fail” no longer leaks through the relative metric comparison
+
+Does not own:
+
+- dual-provider mock routing (PR K)
+- self-describing run metadata (PR L)
+- tool-call assertions (PR J)
+
+### PR F: post-parity main stabilization (closed as superseded)
+
+Owned three inherited red-CI fixes against `target-resolver.test.ts`, `memory-wiki/index.test.ts`, and `config.pruning-defaults.test.ts`. All three failures were resolved upstream through independent commits while the parity loop was in progress, and the PR was closed as superseded after verification. No review action needed.
+
+### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
+
+Owns:
+
+- auto-activation of the strict-agentic contract for unconfigured GPT-5-family `openai` and `openai-codex` runs
+- explicit `"blocked"` liveness state at the strict-agentic blocked exit
+- regression coverage pinning both behaviors
+
+Does not own:
+
+- the `executionContract` mechanism itself (that's PR A)
+- non-GPT-5 provider defaults
+
+### PR J: parity scenario tool-call enforcement
+
+Owns:
+
+- tool-call assertions on the `source-docs-discovery-report` and `subagent-handoff` parity scenarios
+- `/debug/requests` seam consumption from scenario YAML flows
+- matching on scenario-unique prompt substrings to keep assertions scoped to their own scenario
+
+Does not own:
+
+- the `/debug/requests` store itself (part of the mock server)
+- tool schemas or tool execution
+
+### PR K: Anthropic `/v1/messages` mock route
+
+Owns:
+
+- the `/v1/messages` route on the qa-lab mock server
+- Anthropic messages → shared `ResponsesInputItem[]` conversion
+- empty-model and streaming-request edge cases (empty string defaults to `claude-opus-4-6`; `stream: true` returns a 400 so the failure mode is visible)
+
+Does not own:
+
+- real Anthropic API compatibility beyond what the scenario dispatcher reads
+- live Anthropic credential wiring
+
+### PR L: qa-suite-summary.json run metadata
+
+Owns:
+
+- the `run` block in `qa-suite-summary.json` (`primaryProvider`, `primaryModel`, `providerMode`, `scenarioIds`)
+- reuse of the canonical `QaProviderMode` union in `writeQaSuiteArtifacts` instead of a re-declared string-literal union
+
+Does not own:
+
+- parity report consumption of the run block (that's PR D's report helper)
+- scenario catalog filtering
+
+### PR M: documentation catch-up
+
+Owns:
+
+- the 10-PR rewrite of `docs/help/gpt54-codex-agentic-parity.md` and `docs/help/gpt54-codex-agentic-parity-maintainers.md`
+- three new mermaid diagrams (dual-provider mock, parity run orchestration, tool-call assertion seam)
+- the end-to-end parity runbook section
+- the goal-to-evidence matrix update covering all 10 PRs
 
 ## Mapping back to the original six contracts
 
-| Original contract                        | Merge unit |
-| ---------------------------------------- | ---------- |
-| Provider transport/auth correctness      | PR B       |
-| Tool contract/schema compatibility       | PR C       |
-| Same-turn execution                      | PR A       |
-| Permission truthfulness                  | PR B       |
-| Replay/continuation/liveness correctness | PR C       |
-| Benchmark/release gate                   | PR D       |
+| Original contract                        | Merge units                             |
+| ---------------------------------------- | --------------------------------------- |
+| Provider transport/auth correctness      | PR B                                    |
+| Tool contract/schema compatibility       | PR C                                    |
+| Same-turn execution                      | PR A + PR H                             |
+| Permission truthfulness                  | PR B                                    |
+| Replay/continuation/liveness correctness | PR C + PR H                             |
+| Benchmark/release gate                   | PR D + PR E + PR J + PR K + PR L + PR M |
 
 ## Review order
 
@@ -79,8 +158,14 @@ Does not own:
 2. PR B
 3. PR C
 4. PR D
+5. PR H (runtime follow-up, parallelizable with D)
+6. PR E (parity pack expansion, depends on D)
+7. PR K (Anthropic mock route, parallelizable with E/J)
+8. PR J (tool-call enforcement, depends on E)
+9. PR L (run metadata, parallelizable with J)
+10. PR M (documentation catch-up, depends on E/H/J/K/L)
 
-PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed.
+PR D is the proof layer. It should not be the reason runtime-correctness PRs are delayed. PRs E/H/J/K/L are independent refinements that can land in any order as long as their individual dependency callouts are respected. PR M is documentation-only and can land in parallel with the last code PR.
 
 ## What to look for
 
@@ -104,7 +189,7 @@ PR D is the proof layer. It should not be the reason runtime-correctness PRs are
 
 ### PR D
 
-- the scenario pack is understandable and reproducible
+- the first-wave scenario pack is understandable and reproducible
 - the pack includes a mutating replay-safety lane, not only read-only flows
 - reports are readable by humans and automation
 - parity claims are evidence-backed, not anecdotal
@@ -115,12 +200,55 @@ Expected artifacts from PR D:
 - `qa-agentic-parity-report.md` with aggregate and scenario-level comparison
 - `qa-agentic-parity-summary.json` with a machine-readable verdict
 
+### PR E
+
+- the parity pack is now ten scenarios, not five
+- the parity report Markdown header reflects the candidate and baseline labels instead of a hardcoded legacy string
+- a required scenario that fails on either side fails the gate, even if both sides fail the same scenario (this closes the relative-metric loophole)
+- the five new scenarios exercise delegation, fanout synthesis, memory recall, thread-memory isolation, and a capability flip across config restart
+
+### PR H
+
+- unconfigured GPT-5-family `openai` / `openai-codex` runs auto-activate strict-agentic without per-agent configuration
+- the strict-agentic blocked exit emits an explicit `"blocked"` liveness state on the final turn
+- `executionContract: "default"` still opts out, and explicit `executionContract: "strict-agentic"` is always honored
+- the regression test title matches the asserted liveness state
+
+### PR J
+
+- the `source-docs-discovery-report` scenario gates on a real `read` tool call via `/debug/requests`, not just the prose shape of the reply
+- the `subagent-handoff` scenario gates on a real `sessions_spawn` call before accepting the three labeled sections
+- both assertions use a scenario-unique prompt substring so neighboring scenarios (for example `subagent-fanout-synthesis`) cannot accidentally satisfy them
+
+### PR K
+
+- the `/v1/messages` mock route routes through the same scenario dispatcher as `/v1/responses` so one scenario plan drives both providers
+- streaming requests return a 400 with an Anthropic-shaped error body, not a silent non-streaming fallback
+- empty-string `model` is treated the same as absent and defaults to `claude-opus-4-6`
+- `/debug/requests` snapshots record the same `plannedToolName` / `allInputText` / `toolOutput` fields that the OpenAI route exposes, so a single parity run can diff assertions across both lanes
+
+### PR L
+
+- each `qa-suite-summary.json` carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`
+- `writeQaSuiteArtifacts` reuses the canonical `QaProviderMode` union instead of a re-declared string-literal union
+- parity consumers can verify the provider, model, and mode of each input summary without relying on filenames
+
+### PR M
+
+- the parity docs cover all ten PRs, not just the first four
+- the three new mermaid diagrams are present (dual-provider mock, parity run orchestration, tool-call assertion seam)
+- the end-to-end parity runbook is reproducible offline
+- the goal-to-evidence matrix matches the ten-PR program
+
 ## Release gate
 
 Do not claim GPT-5.4 parity or superiority over Opus 4.6 until:
 
-- PR A, PR B, and PR C are merged
-- PR D runs the first-wave parity pack cleanly
+- PR A, PR B, PR C, and PR H are merged (runtime contract enforced by default for GPT-5)
+- PR D and PR E run the ten-scenario parity pack cleanly on both providers
+- PR J tool-call assertions pass on the tool-mediated scenarios
+- PR K offline dual-provider mock is exercised in CI
+- PR L run metadata is present in both summary artifacts
 - runtime-truthfulness regression suites remain green
 - the parity report shows no fake-success cases and no regression in stop behavior
 
@@ -145,20 +273,23 @@ The parity harness is not the only evidence source. Keep this split explicit in 
 
 ## Goal-to-evidence map
 
-| Completion gate item                     | Primary owner | Review artifact                                                     |
-| ---------------------------------------- | ------------- | ------------------------------------------------------------------- |
-| No plan-only stalls                      | PR A          | strict-agentic runtime tests and `approval-turn-tool-followthrough` |
-| No fake progress or fake tool completion | PR A + PR D   | parity fake-success count plus scenario-level report details        |
-| No false `/elevated full` guidance       | PR B          | deterministic runtime-truthfulness suites                           |
-| Replay/liveness failures remain explicit | PR C + PR D   | lifecycle/replay suites plus `compaction-retry-mutating-tool`       |
-| GPT-5.4 matches or beats Opus 4.6        | PR D          | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`  |
+| Completion gate item                     | Primary owners            | Review artifact                                                                                                       |
+| ---------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| No plan-only stalls                      | PR A + PR H               | strict-agentic runtime tests, `approval-turn-tool-followthrough`, PR H auto-activation regression                     |
+| No fake progress or fake tool completion | PR A + PR D + PR J        | parity fake-success count, scenario-level report details, `/debug/requests` tool-call assertions                      |
+| No false `/elevated full` guidance       | PR B                      | deterministic runtime-truthfulness suites                                                                             |
+| Replay/liveness failures remain explicit | PR C + PR H               | lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                                     |
+| GPT-5.4 matches or beats Opus 4.6        | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, full ten-scenario coverage on both providers offline |
 
 ## Reviewer shorthand: before vs after
 
-| User-visible problem before                                 | Review signal after                                                                     |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| GPT-5.4 stopped after planning                              | PR A shows act-or-block behavior instead of commentary-only completion                  |
-| Tool use felt brittle with strict OpenAI/Codex schemas      | PR C keeps tool registration and parameter-free invocation predictable                  |
-| `/elevated full` hints were sometimes misleading            | PR B ties guidance to actual runtime capability and blocked reasons                     |
-| Long tasks could disappear into replay/compaction ambiguity | PR C emits explicit paused, blocked, abandoned, and replay-invalid state                |
-| Parity claims were anecdotal                                | PR D produces a report plus JSON verdict with the same scenario coverage on both models |
+| User-visible problem before                                 | Review signal after                                                                               |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| GPT-5.4 stopped after planning                              | PR A + PR H: GPT-5 runs auto-activate act-or-block instead of commentary-only completion          |
+| Tool use felt brittle with strict OpenAI/Codex schemas      | PR C keeps tool registration and parameter-free invocation predictable                            |
+| `/elevated full` hints were sometimes misleading            | PR B ties guidance to actual runtime capability and blocked reasons                               |
+| Long tasks could disappear into replay/compaction ambiguity | PR C + PR H emit explicit paused, blocked, abandoned, and replay-invalid state                    |
+| Parity claims were anecdotal                                | PR D + PR E produce a ten-scenario report plus JSON verdict with the same coverage on both models |
+| Parity scenarios could pass with prose alone                | PR J adds `/debug/requests` tool-call assertions on the tool-mediated scenarios                   |
+| Baseline parity needed live Anthropic credentials           | PR K adds an Anthropic `/v1/messages` route on the qa-lab mock so the gate runs offline           |
+| Parity consumers had to trust file paths for provenance     | PR L records `run.primaryProvider` / `run.primaryModel` / `run.providerMode` in each summary      |

--- a/docs/help/gpt54-codex-agentic-parity-maintainers.md
+++ b/docs/help/gpt54-codex-agentic-parity-maintainers.md
@@ -1,6 +1,6 @@
 # GPT-5.4 / Codex Parity Maintainer Notes
 
-This note explains how to review the GPT-5.4 / Codex parity program as five merge units without losing the original six-contract architecture.
+This note explains how to review the GPT-5.4 / Codex parity program as a two-wave closeout without losing the original six-contract architecture.
 
 ## Merge units
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -204,12 +204,14 @@ Use this lane in CI and in reproducible local smoke runs:
 pnpm openclaw qa suite \
   --provider-mode mock-openai \
   --model openai/gpt-5.4 \
+  --alt-model openai/gpt-5.4-alt \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/gpt54
 
 pnpm openclaw qa suite \
   --provider-mode mock-openai \
   --model anthropic/claude-opus-4-6 \
+  --alt-model anthropic/claude-sonnet-4-6 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/opus46
 
@@ -221,6 +223,9 @@ pnpm openclaw qa parity-report \
 ```
 
 This is what the parity-gate workflow should run. It keeps the job fenced away from real provider credentials and proves the harness structure is sound.
+The explicit `--alt-model` values matter: they keep `model-switch-tool-continuity`
+inside the intended provider lane instead of silently falling back to the CLI
+default alternate model.
 
 ### Live-frontier proof run
 
@@ -230,12 +235,14 @@ Use this lane only when you want the release-evidence comparison against real fr
 pnpm openclaw qa suite \
   --provider-mode live-frontier \
   --model openai/gpt-5.4 \
+  --alt-model openai/gpt-5.4-mini \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/gpt54-live
 
 pnpm openclaw qa suite \
   --provider-mode live-frontier \
   --model anthropic/claude-opus-4-6 \
+  --alt-model anthropic/claude-sonnet-4-6 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/opus46-live
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,13 +8,13 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in four reviewable slices.
+This parity program fixes those gaps in ten reviewable slices. PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that doubled the parity pack, tightened the runtime contract, added tool-call enforcement to the gate, expanded the mock server to cover both providers for offline parity runs, and self-described each run in its summary artifact.
 
 ## What changed
 
 ### PR A: strict-agentic execution
 
-This slice adds an opt-in `strict-agentic` execution contract for embedded Pi GPT-5 runs.
+This slice adds the `strict-agentic` execution contract for embedded Pi GPT-5 runs.
 
 When enabled, OpenClaw stops accepting plan-only turns as “good enough” completion. If the model only says what it intends to do and does not actually use tools or make progress, OpenClaw retries with an act-now steer and then fails closed with an explicit blocked state instead of silently ending the task.
 
@@ -42,7 +42,7 @@ This slice improves two kinds of correctness:
 
 The tool-compat work reduces schema friction for strict OpenAI/Codex tool registration, especially around parameter-free tools and strict object-root expectations. The replay/liveness work makes long-running tasks more observable, so paused, blocked, and abandoned states are visible instead of disappearing into generic failure text.
 
-### PR D: parity harness
+### PR D: first-wave parity harness
 
 This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be exercised through the same scenarios and compared using shared evidence.
 
@@ -63,6 +63,46 @@ That command writes:
 - a human-readable Markdown report
 - a machine-readable JSON verdict
 - an explicit `pass` / `fail` gate result
+
+### PR E: second-wave parity scenarios
+
+This slice doubles the parity pack from the first-wave five scenarios to ten. The new scenarios exercise delegation, fanout synthesis, memory recall after a context switch, thread-memory isolation, and a live capability flip across a config restart. They run through the same `openclaw qa parity-report` gate and the same `QA_AGENTIC_PARITY_SCENARIOS` registration so the verdict covers the full pack without a CLI flag change.
+
+PR E also rewrites the parity report Markdown header to use the candidate and baseline labels passed to `buildQaAgenticParityComparison`, so reports generated for non-default model pairs no longer carry a hard-coded “GPT-5.4 / Opus 4.6” title.
+
+Criterion 5 of the release gate (GPT-5.4 matches or beats Opus 4.6 on the agreed metrics) now requires green outcomes across all ten scenarios on both sides.
+
+### PR F: post-parity main stabilization (subsumed by upstream main)
+
+This slice was a stabilization PR that addressed three inherited red-CI failures on main during the parity program. All three failures were resolved upstream through independent commits while the parity loop was in progress, so the PR was closed as superseded after verification. No follow-up work is needed from this slice.
+
+### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
+
+This slice takes the PR A `strict-agentic` contract from an opt-in default to an automatic default for GPT-5-family OpenAI and OpenAI-Codex runs. Unconfigured runs on those providers now auto-activate strict-agentic and emit an explicit `"blocked"` liveness state at the strict-agentic blocked exit, instead of silently reporting a generic completion. Runs that set `executionContract: "default"` still opt out, and explicit `executionContract: "strict-agentic"` is always honored.
+
+This closes the remaining hole in criterion 1 (“GPT-5.4 no longer stalls after planning”): users no longer need to know about the contract for the runtime to enforce it.
+
+### PR J: parity scenario tool-call enforcement
+
+This slice adds tool-call assertions to the `source-docs-discovery-report` and `subagent-handoff` parity scenarios. Both scenarios previously asserted the textual shape of the agent's prose reply; the assertions now also read the mock server's `/debug/requests` log and require that the scenario actually invoked the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply.
+
+This closes the remaining hole in criterion 2 (“no fake progress or fake tool completion”): a model that hallucinates a report without reading files or delegates without actually spawning a subagent can no longer satisfy the scenario with prose alone.
+
+### PR K: Anthropic `/v1/messages` mock route
+
+This slice adds an Anthropic Messages API route to the qa-lab mock server so the parity baseline lane (`anthropic/claude-opus-4-6`) can run through the same scenario dispatcher without requiring real Anthropic API credentials. The route converts the Anthropic request shape into the shared `ResponsesInputItem[]` representation, dispatches through the same scenario logic the OpenAI `/v1/responses` route uses, and shapes the response back into an Anthropic Messages body.
+
+The route rejects streaming requests with an explicit Anthropic-shaped 400 (the runner always uses non-streaming in mock mode) and treats an empty-string `model` as absent, defaulting to `claude-opus-4-6` so the echoed model label matches what parity consumers expect.
+
+This closes the remaining hole in infrastructure for criterion 5: operators can now run the parity gate end-to-end offline against both providers.
+
+### PR L: qa-suite-summary.json run metadata
+
+This slice records `run.primaryProvider`, `run.primaryModel`, `run.providerMode`, and `run.scenarioIds` in each `qa-suite-summary.json` artifact. Parity consumers can now verify the provider, model, and mode of each input summary when reading the report, which means the parity report can distinguish two “qa-suite-summary.json” files by provenance instead of relying on filenames.
+
+The writer-side parameter type now reuses the canonical `QaProviderMode` union instead of re-declaring the string-literal union inline, so a future addition to the mode list propagates automatically.
+
+This closes the remaining self-description hole for criterion 5: the report no longer has to trust file paths to know which provider produced which summary.
 
 ## Why this improves GPT-5.4 in practice
 
@@ -127,9 +167,55 @@ flowchart LR
     I -- "no" --> K["Keep runtime/review loop open"]
 ```
 
+## Dual-provider mock architecture
+
+The qa-lab mock server now exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans.
+
+```mermaid
+flowchart LR
+    A[QA suite runner] -- "candidate: gpt-5.4" --> B["POST /v1/responses"]
+    A -- "baseline: claude-opus-4-6" --> C["POST /v1/messages"]
+    B --> D[buildResponsesPayload]
+    C --> E[convertAnthropicMessagesToResponsesInput]
+    E --> D
+    D --> F[Scenario dispatcher]
+    F --> G["/debug/requests log"]
+    F --> H[Scenario-specific response]
+    H --> B
+    H --> C
+```
+
+## Parity run orchestration
+
+The release gate consumes two `qa-suite-summary.json` artifacts (one per provider) and produces the Markdown report plus the machine-readable verdict. Each summary file now carries a self-describing `run` block, so the parity consumer can label the inputs without relying on filenames.
+
+```mermaid
+flowchart TD
+    A[runQaSuite candidate=openai/gpt-5.4] --> B[qa-suite-summary.json<br/>run.primaryProvider=openai]
+    C[runQaSuite baseline=anthropic/claude-opus-4-6] --> D[qa-suite-summary.json<br/>run.primaryProvider=anthropic]
+    B --> E[runQaParityReportCommand]
+    D --> E
+    E --> F[qa-agentic-parity-report.md]
+    E --> G[qa-agentic-parity-summary.json<br/>pass/fail verdict]
+    E --> H[process.exitCode 1 on fail]
+```
+
+## Tool-call assertion seam
+
+Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. The tool-call assertion seam closes that gap by requiring the scenario to actually invoke the expected tool before the prose is accepted.
+
+```mermaid
+flowchart LR
+    A[Scenario YAML qa-flow] -- "runAgentPrompt" --> B[Embedded Pi runner]
+    B -- "Responses API call" --> C[mock-openai-server]
+    C -- "record plannedToolName" --> D["/debug/requests store"]
+    A -- "fetchJson /debug/requests" --> D
+    A -- "assert plannedToolName matches" --> E[Pass or Fail]
+```
+
 ## Scenario pack
 
-The first-wave parity pack currently covers five scenarios:
+The parity pack covers ten scenarios after the second-wave expansion:
 
 ### `approval-turn-tool-followthrough`
 
@@ -141,7 +227,7 @@ Checks that tool-using work remains coherent across model/runtime switching boun
 
 ### `source-docs-discovery-report`
 
-Checks that the model can read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping early.
+Checks that the model can read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping early. The scenario also requires a real `read` tool call to land before the prose reply is accepted.
 
 ### `image-understanding-attachment`
 
@@ -151,19 +237,78 @@ Checks that mixed-mode tasks involving attachments remain actionable and do not 
 
 Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
 
+### `subagent-handoff`
+
+Checks that a bounded delegation actually spawns a subagent via the `sessions_spawn` tool and folds the subagent's result back into the main flow, instead of producing a prose report that claims delegation occurred without a real subagent call.
+
+### `subagent-fanout-synthesis`
+
+Checks that a fanout across multiple subagents synthesizes results honestly and labels which sub-result contributed to which part of the final answer.
+
+### `memory-recall`
+
+Checks that a task can pull a prior detail back after an intervening context switch, instead of implicitly asking the user to restate it.
+
+### `thread-memory-isolation`
+
+Checks that memory recorded against one thread does not leak into an unrelated thread, so the runtime's isolation contract matches what the model behaves as if.
+
+### `config-restart-capability-flip`
+
+Checks that a live capability change survives a config restart on the agent and is visible to the next run without a stale feature flag cached in the agent's state.
+
 ## Scenario matrix
 
 | Scenario                           | What it tests                           | Good GPT-5.4 behavior                                                          | Failure signal                                                                 |
 | ---------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | `approval-turn-tool-followthrough` | Short approval turns after a plan       | Starts the first concrete tool action immediately instead of restating intent  | plan-only follow-up, no tool activity, or blocked turn without a real blocker  |
 | `model-switch-tool-continuity`     | Runtime/model switching under tool use  | Preserves task context and continues acting coherently                         | resets into commentary, loses tool context, or stops after switch              |
-| `source-docs-discovery-report`     | Source reading + synthesis + action     | Finds sources, uses tools, and produces a useful report without stalling       | thin summary, missing tool work, or incomplete-turn stop                       |
+| `source-docs-discovery-report`     | Source reading + synthesis + tool call  | Reads source via a real `read` tool call and produces a useful report          | thin summary, no `read` tool call recorded, or incomplete-turn stop            |
 | `image-understanding-attachment`   | Attachment-driven agentic work          | Interprets the attachment, connects it to tools, and continues the task        | vague narration, attachment ignored, or no concrete next action                |
 | `compaction-retry-mutating-tool`   | Mutating work under compaction pressure | Performs a real write and keeps replay-unsafety explicit after the side effect | mutating write happens but replay safety is implied, missing, or contradictory |
+| `subagent-handoff`                 | Bounded delegation to a subagent        | Spawns a real subagent via `sessions_spawn` and folds the result back          | prose report claims delegation but no `sessions_spawn` call recorded           |
+| `subagent-fanout-synthesis`        | Multi-subagent fanout synthesis         | Spawns multiple subagents and attributes each sub-result honestly              | merges results without attribution or fabricates fanout evidence               |
+| `memory-recall`                    | Recall after a context switch           | Pulls the prior detail back without asking the user to restate it              | implicitly restates the context by asking the user for the same detail         |
+| `thread-memory-isolation`          | Cross-thread memory isolation           | Keeps memory scoped to the right thread and does not leak                      | a detail from thread A surfaces in thread B                                    |
+| `config-restart-capability-flip`   | Live capability change across restart   | Next run sees the new capability instead of the cached feature flag            | stale capability survives the restart and leaks into the next run              |
+
+## Running the parity gate end-to-end
+
+The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers.
+
+1. Run the suite against the candidate provider/model:
+
+   ```bash
+   pnpm openclaw qa suite \
+     --primary-model openai/gpt-5.4 \
+     --parity-pack agentic \
+     --output-dir .artifacts/qa-e2e/gpt54
+   ```
+
+2. Run the suite against the baseline provider/model:
+
+   ```bash
+   pnpm openclaw qa suite \
+     --primary-model anthropic/claude-opus-4-6 \
+     --parity-pack agentic \
+     --output-dir .artifacts/qa-e2e/opus46
+   ```
+
+3. Generate the parity report and read the verdict:
+
+   ```bash
+   pnpm openclaw qa parity-report \
+     --repo-root . \
+     --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
+     --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+     --output-dir .artifacts/qa-e2e/parity
+   ```
+
+Each `qa-suite-summary.json` now carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
 
 ## Release gate
 
-GPT-5.4 can only be considered at parity or better when the merged runtime passes the parity pack and the runtime-truthfulness regressions at the same time.
+GPT-5.4 can only be considered at parity or better when the merged runtime passes the full ten-scenario parity pack and the runtime-truthfulness regressions at the same time.
 
 Required outcomes:
 
@@ -171,29 +316,31 @@ Required outcomes:
 - no fake completion without real execution
 - no incorrect `/elevated full` guidance
 - no silent replay or compaction abandonment
-- parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline
+- parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline across all ten scenarios
 
-For the first-wave harness, the gate compares:
+The gate compares:
 
 - completion rate
 - unintended-stop rate
 - valid-tool-call rate
 - fake-success count
+- required-scenario outcomes (any required scenario that fails on either side fails the gate, even if the baseline also failed)
+- tool-call assertions on the scenarios that require a real tool invocation (`read` for `source-docs-discovery-report`, `sessions_spawn` for `subagent-handoff`)
 
 Parity evidence is intentionally split across two layers:
 
-- PR D proves same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
+- PRs D and E prove same-scenario GPT-5.4 vs Opus 4.6 behavior through the ten-scenario QA-lab pack
 - PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
 
 ## Goal-to-evidence matrix
 
-| Completion gate item                                     | Owning PR   | Evidence source                                                    | Pass signal                                                                              |
-| -------------------------------------------------------- | ----------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 no longer stalls after planning                  | PR A        | `approval-turn-tool-followthrough` plus PR A runtime suites        | approval turns trigger real work or an explicit blocked state                            |
-| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D | parity report scenario outcomes and fake-success count             | no suspicious pass results and no commentary-only completion                             |
-| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B        | deterministic truthfulness suites                                  | blocked reasons and full-access hints stay runtime-accurate                              |
-| Replay/liveness failures stay explicit                   | PR C + PR D | PR C lifecycle/replay suites plus `compaction-retry-mutating-tool` | mutating work keeps replay-unsafety explicit instead of silently disappearing            |
-| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json` | same scenario coverage and no regression on completion, stop behavior, or valid tool use |
+| Completion gate item                                     | Owning PRs                | Evidence source                                                                                                  | Pass signal                                                                                                            |
+| -------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| GPT-5.4 no longer stalls after planning                  | PR A + PR H               | PR A runtime suites, `approval-turn-tool-followthrough`, PR H auto-activation regression                         | unconfigured GPT-5 runs auto-activate strict-agentic and approval turns trigger real work or an explicit blocked state |
+| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR J        | parity report scenario outcomes, fake-success count, `/debug/requests` tool-call assertions                      | no suspicious pass results and a real `read` / `sessions_spawn` call is recorded before prose is accepted              |
+| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B                      | deterministic truthfulness suites                                                                                | blocked reasons and full-access hints stay runtime-accurate                                                            |
+| Replay/liveness failures stay explicit                   | PR C + PR H               | PR C lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                           | mutating work keeps replay-unsafety explicit and the strict-agentic blocked exit emits `"blocked"`                     |
+| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, self-describing `run` block, dual-provider mock | full ten-scenario coverage on both providers with no regression on the agreed metrics, verifiable offline              |
 
 ## How to read the parity verdict
 
@@ -204,16 +351,24 @@ Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readabl
 - “shared/base CI issue” is not itself a parity result. If CI noise outside PR D blocks a run, the verdict should wait for a clean merged-runtime execution instead of being inferred from branch-era logs.
 - Auth, proxy, DNS, and `/elevated full` truthfulness still come from PR B’s deterministic suites, so the final release claim needs both: a passing PR D parity verdict and green PR B truthfulness coverage.
 
-## Who should enable `strict-agentic`
+## Strict-agentic defaults and overrides
 
-Use `strict-agentic` when:
+After PR H landed, the strict-agentic contract is now the automatic default for GPT-5-family `openai` and `openai-codex` runs. Operators no longer need to configure `executionContract: "strict-agentic"` to get act-now enforcement on those providers — an unconfigured GPT-5 run automatically activates the contract and emits an explicit `"blocked"` liveness state at the strict-agentic blocked exit.
 
-- the agent is expected to act immediately when a next step is obvious
-- GPT-5.4 or Codex-family models are the primary runtime
+Override behavior:
+
+- **Auto-activated (default for GPT-5 on `openai` / `openai-codex`)**: no configuration required. The runtime enforces act-or-block on plan-only turns and surfaces a `"blocked"` liveness state on the blocked exit.
+- **Explicit opt-out**: set `executionContract: "default"` on the agent config to keep the pre-PR-H looser behavior. This is the escape hatch for prompt-testing workflows or third-party agents that rely on plan-only completion.
+- **Explicit opt-in for other providers**: set `executionContract: "strict-agentic"` to run the contract on Anthropic or any other provider. The auto-activation rule only fires for GPT-5-family OpenAI / OpenAI-Codex runs; other providers still require the explicit config.
+
+Keep the default auto-activation behavior when:
+
+- you want the runtime to guarantee act-or-block on GPT-5 flows without per-agent configuration
+- you are comparing GPT-5.4 against Opus 4.6 through the parity pack and want the contract enforced on the candidate side
 - you prefer explicit blocked states over “helpful” recap-only replies
 
-Keep the default contract when:
+Opt out (`executionContract: "default"`) when:
 
-- you want the existing looser behavior
-- you are not using GPT-5-family models
-- you are testing prompts rather than runtime enforcement
+- you are running prompt-engineering workflows that deliberately test plan-only turns
+- you are testing a third-party skill that expects the pre-PR-H behavior
+- you are using a non-GPT-5 model that should not be gated by the contract

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,7 +8,7 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in five reviewable slices: three merged runtime contracts, a proof-harness base, and a second-wave proof expansion.
+This parity program fixes those gaps in two waves: three merged runtime contracts, a merged proof-harness base, and a second-wave proof expansion that broadens the merged-main parity evidence.
 
 ## What changed
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -189,15 +189,26 @@ The pack is `QA_AGENTIC_PARITY_SCENARIOS` in `extensions/qa-lab/src/agentic-pari
 
 ## Running the harness end-to-end
 
-The harness is three commands. The CLI flags are `--model` / `--alt-model` on `openclaw qa suite` and `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`. The baseline lane only runs fully offline once PR K lands the Anthropic mock route — until then it needs real Anthropic credentials.
+There are two distinct parity runs:
+
+- the **mock structural gate**, which is CI-safe and proves the harness wiring, scenario registration, artifact generation, and pass/fail semantics
+- the **live-frontier proof run**, which is the release-evidence lane for the real GPT-5.4 vs Opus 4.6 claim
+
+Treat them differently. The mock gate is necessary, but it is not the final product claim by itself.
+
+### Mock structural gate
+
+Use this lane in CI and in reproducible local smoke runs:
 
 ```bash
 pnpm openclaw qa suite \
+  --provider-mode mock-openai \
   --model openai/gpt-5.4 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/gpt54
 
 pnpm openclaw qa suite \
+  --provider-mode mock-openai \
   --model anthropic/claude-opus-4-6 \
   --parity-pack agentic \
   --output-dir .artifacts/qa-e2e/opus46
@@ -207,6 +218,32 @@ pnpm openclaw qa parity-report \
   --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
   --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
   --output-dir .artifacts/qa-e2e/parity
+```
+
+This is what the parity-gate workflow should run. It keeps the job fenced away from real provider credentials and proves the harness structure is sound.
+
+### Live-frontier proof run
+
+Use this lane only when you want the release-evidence comparison against real frontier providers:
+
+```bash
+pnpm openclaw qa suite \
+  --provider-mode live-frontier \
+  --model openai/gpt-5.4 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/gpt54-live
+
+pnpm openclaw qa suite \
+  --provider-mode live-frontier \
+  --model anthropic/claude-opus-4-6 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/opus46-live
+
+pnpm openclaw qa parity-report \
+  --repo-root . \
+  --candidate-summary .artifacts/qa-e2e/gpt54-live/qa-suite-summary.json \
+  --baseline-summary .artifacts/qa-e2e/opus46-live/qa-suite-summary.json \
+  --output-dir .artifacts/qa-e2e/parity-live
 ```
 
 `openclaw qa parity-report` writes the Markdown report and a JSON verdict, and exits nonzero on a gate failure so CI can block the release. After PR L lands, `qa-suite-summary.json` carries the `run` block that the parity report uses to label each input; until then, the report still works but trusts the caller's `--candidate-label` / `--baseline-label`.

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,7 +8,25 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in ten reviewable slices. PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that doubled the parity pack, tightened the runtime contract, added tool-call enforcement to the gate, expanded the mock server to cover both providers for offline parity runs, and self-described each run in its summary artifact.
+This parity program ships as ten reviewable slices plus a documentation follow-up (this page). PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that double the parity pack, tighten the runtime contract, add tool-call enforcement to the gate, expand the mock server to cover both providers for offline parity runs, and self-describe each run in its summary artifact.
+
+## Program status
+
+Sections that describe "after PR X" behavior are forward-looking and reflect the post-merge end state of the program, not what is currently on `main`. Reviewers and operators should read the wave-2 sections below through that lens until each wave-2 PR merges.
+
+| PR          | Title                                                  | Status                                                                 |
+| ----------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
+| PR A #64241 | strict-agentic execution                               | merged                                                                 |
+| PR B #64439 | runtime truthfulness                                   | merged                                                                 |
+| PR C #64300 | execution correctness                                  | merged                                                                 |
+| PR D #64441 | first-wave parity harness                              | merged                                                                 |
+| PR F #64675 | post-parity main stabilization                         | closed as superseded (all three fixes resolved upstream independently) |
+| PR E #64662 | second-wave parity scenarios                           | open                                                                   |
+| PR H #64679 | strict-agentic auto-activation + blocked-exit liveness | open                                                                   |
+| PR J #64681 | parity scenario tool-call enforcement                  | open                                                                   |
+| PR K #64685 | Anthropic `/v1/messages` mock route                    | open                                                                   |
+| PR L #64789 | `qa-suite-summary.json` run metadata                   | open                                                                   |
+| PR M #64837 | parity documentation catch-up (this page)              | open                                                                   |
 
 ## What changed
 
@@ -169,20 +187,22 @@ flowchart LR
 
 ## Dual-provider mock architecture
 
-The qa-lab mock server now exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans.
+After PR K #64685 merges, the qa-lab mock server exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans. Today (pre-PR-K on `main`) only the `/v1/responses` route exists.
 
 ```mermaid
 flowchart LR
-    A[QA suite runner] -- "candidate: gpt-5.4" --> B["POST /v1/responses"]
-    A -- "baseline: claude-opus-4-6" --> C["POST /v1/messages"]
-    B --> D[buildResponsesPayload]
-    C --> E[convertAnthropicMessagesToResponsesInput]
-    E --> D
-    D --> F[Scenario dispatcher]
-    F --> G["/debug/requests log"]
-    F --> H[Scenario-specific response]
-    H --> B
-    H --> C
+    Runner[QA suite runner]
+    Runner -- "candidate: gpt-5.4" --> ResponsesRoute["POST /v1/responses"]
+    Runner -- "baseline: claude-opus-4-6" --> MessagesRoute["POST /v1/messages"]
+    ResponsesRoute -- "OpenAI request body" --> Payload[buildResponsesPayload]
+    MessagesRoute -- "Anthropic request body" --> Adapter[convertAnthropicMessagesToResponsesInput]
+    Adapter -- "shared ResponsesInputItem[]" --> Payload
+    Payload --> Dispatcher[Scenario dispatcher]
+    Dispatcher --> DebugLog["/debug/requests log"]
+    Dispatcher --> OpenAIResponse[OpenAI-shaped response]
+    Dispatcher --> AnthropicResponse[Anthropic-shaped response]
+    OpenAIResponse -- "HTTP 200 JSON" --> Runner
+    AnthropicResponse -- "HTTP 200 JSON" --> Runner
 ```
 
 ## Parity run orchestration
@@ -202,20 +222,23 @@ flowchart TD
 
 ## Tool-call assertion seam
 
-Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. The tool-call assertion seam closes that gap by requiring the scenario to actually invoke the expected tool before the prose is accepted.
+Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. After PR J #64681 merges, the `source-docs-discovery-report` and `subagent-handoff` scenarios also read the mock server's `/debug/requests` log and require the scenario to actually invoke the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply is accepted. Today (pre-PR-J on `main`) these scenarios only assert the prose shape.
 
 ```mermaid
 flowchart LR
-    A[Scenario YAML qa-flow] -- "runAgentPrompt" --> B[Embedded Pi runner]
-    B -- "Responses API call" --> C[mock-openai-server]
-    C -- "record plannedToolName" --> D["/debug/requests store"]
-    A -- "fetchJson /debug/requests" --> D
-    A -- "assert plannedToolName matches" --> E[Pass or Fail]
+    Scenario[Scenario YAML qa-flow] -- "runAgentPrompt" --> Runner[Embedded Pi runner]
+    Runner -- "Responses API call" --> Mock[mock-openai-server]
+    Mock -- "record plannedToolName" --> DebugStore["/debug/requests store"]
+    Scenario -- "fetchJson /debug/requests" --> DebugStore
+    DebugStore -- "plannedToolName" --> Scenario
+    Scenario -- "assert matches expected tool" --> Verdict[Pass or Fail]
 ```
 
 ## Scenario pack
 
-The parity pack covers ten scenarios after the second-wave expansion:
+Wave 1 (PR D #64441, merged) registers the first five scenarios in the parity pack. Wave 2 (PR E #64662, open) registers the next five. The `QA_AGENTIC_PARITY_SCENARIOS` array in `extensions/qa-lab/src/agentic-parity.ts` is the single source of truth; reviewers can count the entries there to see which scenarios are currently wired into the gate.
+
+**Wave 1 scenarios (live on main):**
 
 ### `approval-turn-tool-followthrough`
 
@@ -236,6 +259,8 @@ Checks that mixed-mode tasks involving attachments remain actionable and do not 
 ### `compaction-retry-mutating-tool`
 
 Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
+
+**Wave 2 scenarios (registered in the pack after PR E #64662 merges; the scenario files already live under `qa/scenarios/` and run standalone):**
 
 ### `subagent-handoff`
 
@@ -274,13 +299,15 @@ Checks that a live capability change survives a config restart on the agent and 
 
 ## Running the parity gate end-to-end
 
-The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers.
+The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers. The shell commands below use the real CLI flag names (`--model` / `--alt-model` on `openclaw qa suite`, `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`).
+
+The baseline lane only runs end-to-end against the qa-lab mock server after PR K #64685 merges the Anthropic `/v1/messages` route. Until then, the baseline lane requires real Anthropic credentials.
 
 1. Run the suite against the candidate provider/model:
 
    ```bash
    pnpm openclaw qa suite \
-     --primary-model openai/gpt-5.4 \
+     --model openai/gpt-5.4 \
      --parity-pack agentic \
      --output-dir .artifacts/qa-e2e/gpt54
    ```
@@ -289,7 +316,7 @@ The parity gate is a three-step flow. Each step is reproducible against the qa-l
 
    ```bash
    pnpm openclaw qa suite \
-     --primary-model anthropic/claude-opus-4-6 \
+     --model anthropic/claude-opus-4-6 \
      --parity-pack agentic \
      --output-dir .artifacts/qa-e2e/opus46
    ```
@@ -304,7 +331,7 @@ The parity gate is a three-step flow. Each step is reproducible against the qa-l
      --output-dir .artifacts/qa-e2e/parity
    ```
 
-Each `qa-suite-summary.json` now carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
+After PR L #64789 merges, each `qa-suite-summary.json` carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. Until PR L merges, the summary only carries `{ scenarios, counts }` and the parity report trusts the caller-supplied labels. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
 
 ## Release gate
 

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -344,7 +344,7 @@ Parity evidence is intentionally split across two layers:
 
 ## How to read the parity verdict
 
-Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the first-wave parity pack.
+Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the ten-scenario parity pack.
 
 - `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and did not regress on the agreed aggregate metrics.
 - `fail` means at least one hard gate tripped: weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, or mismatched scenario coverage.

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -1,155 +1,73 @@
-# GPT-5.4 / Codex Agentic Parity in OpenClaw
+# GPT-5.4 / Codex agentic parity in OpenClaw
 
-OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Codex-style models were still underperforming in a few practical ways:
+OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Codex-style models kept running into a handful of practical gaps that showed up in real sessions:
 
-- they could stop after planning instead of doing the work
-- they could use strict OpenAI/Codex tool schemas incorrectly
-- they could ask for `/elevated full` even when full access was impossible
-- they could lose long-running task state during replay or compaction
-- parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
+- they would stop after planning instead of doing the work
+- strict OpenAI/Codex tool schemas got rejected in confusing ways
+- `/elevated full` guidance was sometimes wrong
+- long-running tasks could lose state during replay or compaction
+- parity claims against Claude Opus 4.6 were anecdotal rather than something you could rerun
 
-This parity program ships as ten reviewable slices plus a documentation follow-up (this page). PRs A through D landed first and established the runtime contract, parity harness, and first-wave scenario pack. PRs E, H, J, K, and L are follow-up slices that double the parity pack, tighten the runtime contract, add tool-call enforcement to the gate, expand the mock server to cover both providers for offline parity runs, and self-describe each run in its summary artifact.
+The fixes landed in two waves, mostly because of the repo's 10-PR active cap. The first wave (PRs A through D) put the runtime contract in place and shipped the first parity harness. The second wave (E, H, J, K, L, plus this documentation pass as PR M) extends the harness from five to ten scenarios, tightens the runtime contract so it's on by default for GPT-5, adds tool-call enforcement to the gate, brings the mock server up to parity so the baseline lane can run offline, and teaches each summary artifact to describe itself. PR F started life as a stabilization slice but was closed after all three of its fixes landed upstream through unrelated commits during the review window.
 
-## Program status
+## Where things stand
 
-Sections that describe "after PR X" behavior are forward-looking and reflect the post-merge end state of the program, not what is currently on `main`. Reviewers and operators should read the wave-2 sections below through that lens until each wave-2 PR merges.
+| PR                                                     | Status              |
+| ------------------------------------------------------ | ------------------- |
+| #64241 strict-agentic execution (PR A)                 | merged              |
+| #64439 runtime truthfulness (PR B)                     | merged              |
+| #64300 execution correctness (PR C)                    | merged              |
+| #64441 first-wave parity harness (PR D)                | merged              |
+| #64675 post-parity main stabilization (PR F)           | closed (superseded) |
+| #64679 strict-agentic auto-activation (PR H)           | open                |
+| #64662 second-wave parity scenarios (PR E)             | open                |
+| #64685 Anthropic `/v1/messages` mock route (PR K)      | open                |
+| #64681 parity scenario tool-call enforcement (PR J)    | open                |
+| #64789 `qa-suite-summary.json` run metadata (PR L)     | open                |
+| #64837 parity documentation catch-up (PR M, this page) | open                |
 
-| PR          | Title                                                  | Status                                                                 |
-| ----------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
-| PR A #64241 | strict-agentic execution                               | merged                                                                 |
-| PR B #64439 | runtime truthfulness                                   | merged                                                                 |
-| PR C #64300 | execution correctness                                  | merged                                                                 |
-| PR D #64441 | first-wave parity harness                              | merged                                                                 |
-| PR F #64675 | post-parity main stabilization                         | closed as superseded (all three fixes resolved upstream independently) |
-| PR E #64662 | second-wave parity scenarios                           | open                                                                   |
-| PR H #64679 | strict-agentic auto-activation + blocked-exit liveness | open                                                                   |
-| PR J #64681 | parity scenario tool-call enforcement                  | open                                                                   |
-| PR K #64685 | Anthropic `/v1/messages` mock route                    | open                                                                   |
-| PR L #64789 | `qa-suite-summary.json` run metadata                   | open                                                                   |
-| PR M #64837 | parity documentation catch-up (this page)              | open                                                                   |
+A few sections below describe behavior that's still "after PR X" — I've kept those framings where the shape of the program is easier to see if you read the end state, and flagged them inline so nobody tries to run commands that rely on unmerged code.
 
-## What changed
+## The runtime contract
 
-### PR A: strict-agentic execution
+PR A introduced a `strict-agentic` execution contract for embedded Pi GPT-5 runs. When it's active, OpenClaw stops accepting a plan-only turn as "good enough": if the model describes what it's going to do and then stops without actually touching a tool, the runtime retries with an act-now steer and then fails closed with an explicit blocked state instead of quietly returning the plan text as a completed turn. It's the single biggest fix on the "GPT-5.4 stalled after planning" complaint.
 
-This slice adds the `strict-agentic` execution contract for embedded Pi GPT-5 runs.
+PR B made OpenClaw honest about two separate things: why a provider or runtime call actually failed, and whether `/elevated full` was actually available on the current runtime. That gives GPT-5.4 (and the user) real signals for missing scopes, auth refresh failures, 403 HTML auth errors, proxy issues, DNS or timeout failures, and blocked full-access modes. The model stops hallucinating the wrong remediation or asking for a permission mode the runtime can't grant.
 
-When enabled, OpenClaw stops accepting plan-only turns as “good enough” completion. If the model only says what it intends to do and does not actually use tools or make progress, OpenClaw retries with an act-now steer and then fails closed with an explicit blocked state instead of silently ending the task.
+PR C covered two kinds of correctness. On the tool side, it cut the friction that strict OpenAI/Codex tool registration used to hit — parameter-free tools, strict object-root expectations, schema normalization. On the liveness side, it made paused, blocked, and abandoned states visible in the runtime meta instead of collapsing them into a generic failure text that looked the same as success.
 
-This improves the GPT-5.4 experience most on:
+PR H (still open) is the piece that takes the strict-agentic contract from opt-in to the real default. An unconfigured GPT-5-family `openai` or `openai-codex` run now activates the contract automatically, and the strict-agentic blocked exit sets an explicit `"blocked"` liveness state on the final turn. Setting `executionContract: "default"` still opts out, and an explicit `strict-agentic` setting is honored on any provider. The intent here is that users shouldn't have to know about the contract for the runtime to enforce it — the fixed-by-default path is the one that closes criterion 1 of the release gate for real.
 
-- short “ok do it” follow-ups
-- code tasks where the first step is obvious
-- flows where `update_plan` should be progress tracking rather than filler text
+## The parity harness
 
-### PR B: runtime truthfulness
+PR D shipped the first-wave parity pack: five QA-lab scenarios that exercise GPT-5.4 and Opus 4.6 against the same workloads so "which one is better at agentic work" stops being a vibe check. Running the suite twice and feeding both summaries into `openclaw qa parity-report` produces a Markdown report and a machine-readable pass/fail verdict. PR D is the proof layer — it doesn't change runtime behavior by itself.
 
-This slice makes OpenClaw tell the truth about two things:
+PR E (open) doubles the pack from five to ten. The new scenarios cover delegation, fanout synthesis, memory recall across a context switch, thread-memory isolation, and a live capability flip across a config restart. PR E also parametrizes the parity report's Markdown header so non-default model pairs render with the labels you actually passed, and closes a parity-gate loophole where a required scenario that failed on both candidate and baseline would still come out as `pass: true` because the downstream metric comparisons were purely relative.
 
-- why the provider/runtime call failed
-- whether `/elevated full` is actually available
+PR K (open) adds an Anthropic `/v1/messages` route to the qa-lab mock server so the baseline lane can run offline through the same scenario dispatcher the OpenAI `/v1/responses` route already uses. Without it, running the baseline lane requires real Anthropic credentials — which is fine for production but blocks reproducible CI and local parity runs. The route rejects streaming requests with an explicit Anthropic-shaped 400 (since the runner only runs non-streaming in mock mode), and treats an empty-string `body.model` the same as absent, defaulting to `claude-opus-4-6`.
 
-That means GPT-5.4 gets better runtime signals for missing scope, auth refresh failures, HTML 403 auth failures, proxy issues, DNS or timeout failures, and blocked full-access modes. The model is less likely to hallucinate the wrong remediation or keep asking for a permission mode the runtime cannot provide.
+PR L (open) is the self-description layer. Each `qa-suite-summary.json` now carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`, so the parity report can verify the provider and model behind each input instead of trusting the caller-supplied labels. The writer-side parameter type was also switched to the canonical `QaProviderMode` union, which prevents the kind of type drift that keeps creeping back in when two places both declare the same literal union.
 
-### PR C: execution correctness
+## Tool-call enforcement
 
-This slice improves two kinds of correctness:
+Some parity scenarios used to gate on the textual shape of the agent's prose reply. That's necessary but not sufficient — a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. PR J (open) wires `/debug/requests` into the scenario YAML flows so `source-docs-discovery-report` (must actually invoke `read`) and `subagent-handoff` (must actually invoke `sessions_spawn`) fail when the required tool call isn't recorded before the prose reply. The assertions match on scenario-unique prompt substrings so neighboring scenarios like `subagent-fanout-synthesis`, which also produces its own `sessions_spawn` call, can't accidentally satisfy them.
 
-- provider-owned OpenAI/Codex tool-schema compatibility
-- replay and long-task liveness surfacing
+## Why this matters for users
 
-The tool-compat work reduces schema friction for strict OpenAI/Codex tool registration, especially around parameter-free tools and strict object-root expectations. The replay/liveness work makes long-running tasks more observable, so paused, blocked, and abandoned states are visible instead of disappearing into generic failure text.
+Before this work, GPT-5.4 on OpenClaw could feel less agentic than Opus in real coding sessions because the runtime tolerated a few behaviors that are especially bad for GPT-5-style models: commentary-only turns, schema friction on tools, vague permission feedback, and silent replay or compaction breakage. None of those are things you can prompt-engineer around cleanly.
 
-### PR D: first-wave parity harness
+The goal here isn't to make GPT-5.4 imitate Opus. It's to give GPT-5.4 a runtime contract that actually rewards real progress, cleans up the tool and permission semantics so the model can reason about them, and turns failure modes into explicit machine- and human-readable states. The experience moves from "the model had a good plan but stopped" to "the model either acted, or OpenClaw surfaced the exact reason it couldn't".
 
-This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be exercised through the same scenarios and compared using shared evidence.
-
-The parity pack is the proof layer. It does not change runtime behavior by itself.
-
-After you have two `qa-suite-summary.json` artifacts, generate the release-gate comparison with:
-
-```bash
-pnpm openclaw qa parity-report \
-  --repo-root . \
-  --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
-  --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
-  --output-dir .artifacts/qa-e2e/parity
-```
-
-That command writes:
-
-- a human-readable Markdown report
-- a machine-readable JSON verdict
-- an explicit `pass` / `fail` gate result
-
-### PR E: second-wave parity scenarios
-
-This slice doubles the parity pack from the first-wave five scenarios to ten. The new scenarios exercise delegation, fanout synthesis, memory recall after a context switch, thread-memory isolation, and a live capability flip across a config restart. They run through the same `openclaw qa parity-report` gate and the same `QA_AGENTIC_PARITY_SCENARIOS` registration so the verdict covers the full pack without a CLI flag change.
-
-PR E also rewrites the parity report Markdown header to use the candidate and baseline labels passed to `buildQaAgenticParityComparison`, so reports generated for non-default model pairs no longer carry a hard-coded “GPT-5.4 / Opus 4.6” title.
-
-Criterion 5 of the release gate (GPT-5.4 matches or beats Opus 4.6 on the agreed metrics) now requires green outcomes across all ten scenarios on both sides.
-
-### PR F: post-parity main stabilization (subsumed by upstream main)
-
-This slice was a stabilization PR that addressed three inherited red-CI failures on main during the parity program. All three failures were resolved upstream through independent commits while the parity loop was in progress, so the PR was closed as superseded after verification. No follow-up work is needed from this slice.
-
-### PR H: strict-agentic auto-activation for GPT-5 + blocked-exit liveness
-
-This slice takes the PR A `strict-agentic` contract from an opt-in default to an automatic default for GPT-5-family OpenAI and OpenAI-Codex runs. Unconfigured runs on those providers now auto-activate strict-agentic and emit an explicit `"blocked"` liveness state at the strict-agentic blocked exit, instead of silently reporting a generic completion. Runs that set `executionContract: "default"` still opt out, and explicit `executionContract: "strict-agentic"` is always honored.
-
-This closes the remaining hole in criterion 1 (“GPT-5.4 no longer stalls after planning”): users no longer need to know about the contract for the runtime to enforce it.
-
-### PR J: parity scenario tool-call enforcement
-
-This slice adds tool-call assertions to the `source-docs-discovery-report` and `subagent-handoff` parity scenarios. Both scenarios previously asserted the textual shape of the agent's prose reply; the assertions now also read the mock server's `/debug/requests` log and require that the scenario actually invoked the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply.
-
-This closes the remaining hole in criterion 2 (“no fake progress or fake tool completion”): a model that hallucinates a report without reading files or delegates without actually spawning a subagent can no longer satisfy the scenario with prose alone.
-
-### PR K: Anthropic `/v1/messages` mock route
-
-This slice adds an Anthropic Messages API route to the qa-lab mock server so the parity baseline lane (`anthropic/claude-opus-4-6`) can run through the same scenario dispatcher without requiring real Anthropic API credentials. The route converts the Anthropic request shape into the shared `ResponsesInputItem[]` representation, dispatches through the same scenario logic the OpenAI `/v1/responses` route uses, and shapes the response back into an Anthropic Messages body.
-
-The route rejects streaming requests with an explicit Anthropic-shaped 400 (the runner always uses non-streaming in mock mode) and treats an empty-string `model` as absent, defaulting to `claude-opus-4-6` so the echoed model label matches what parity consumers expect.
-
-This closes the remaining hole in infrastructure for criterion 5: operators can now run the parity gate end-to-end offline against both providers.
-
-### PR L: qa-suite-summary.json run metadata
-
-This slice records `run.primaryProvider`, `run.primaryModel`, `run.providerMode`, and `run.scenarioIds` in each `qa-suite-summary.json` artifact. Parity consumers can now verify the provider, model, and mode of each input summary when reading the report, which means the parity report can distinguish two “qa-suite-summary.json” files by provenance instead of relying on filenames.
-
-The writer-side parameter type now reuses the canonical `QaProviderMode` union instead of re-declaring the string-literal union inline, so a future addition to the mode list propagates automatically.
-
-This closes the remaining self-description hole for criterion 5: the report no longer has to trust file paths to know which provider produced which summary.
-
-## Why this improves GPT-5.4 in practice
-
-Before this work, GPT-5.4 on OpenClaw could feel less agentic than Opus in real coding sessions because the runtime tolerated behaviors that are especially harmful for GPT-5-style models:
-
-- commentary-only turns
-- schema friction around tools
-- vague permission feedback
-- silent replay or compaction breakage
-
-The goal is not to make GPT-5.4 imitate Opus. The goal is to give GPT-5.4 a runtime contract that rewards real progress, supplies cleaner tool and permission semantics, and turns failure modes into explicit machine- and human-readable states.
-
-That changes the user experience from:
-
-- “the model had a good plan but stopped”
-
-to:
-
-- “the model either acted, or OpenClaw surfaced the exact reason it could not”
-
-## Before vs after for GPT-5.4 users
-
-| Before this program                                                                            | After PR A-D                                                                             |
-| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 could stop after a reasonable plan without taking the next tool step                   | PR A turns “plan only” into “act now or surface a blocked state”                         |
-| Strict tool schemas could reject parameter-free or OpenAI/Codex-shaped tools in confusing ways | PR C makes provider-owned tool registration and invocation more predictable              |
-| `/elevated full` guidance could be vague or wrong in blocked runtimes                          | PR B gives GPT-5.4 and the user truthful runtime and permission hints                    |
-| Replay or compaction failures could feel like the task silently disappeared                    | PR C surfaces paused, blocked, abandoned, and replay-invalid outcomes explicitly         |
-| “GPT-5.4 feels worse than Opus” was mostly anecdotal                                           | PR D turns that into the same scenario pack, the same metrics, and a hard pass/fail gate |
+| Symptom before                                                | After the program                                                            |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| GPT-5.4 stopped after a reasonable plan without taking action | PR A + PR H: act-or-block by default on unconfigured GPT-5 runs              |
+| Strict tool schemas rejected parameter-free or Codex tools    | PR C: provider-owned tool registration stays predictable                     |
+| `/elevated full` guidance was vague or wrong                  | PR B: guidance ties to actual runtime capability                             |
+| Replay or compaction failures looked like silent task loss    | PR C + PR H: explicit paused, blocked, abandoned, replay-invalid state       |
+| "GPT-5.4 feels worse than Opus" was anecdotal                 | PR D + PR E: same ten scenarios on both models, JSON verdict, pass/fail gate |
+| Parity scenarios could pass with prose alone                  | PR J: `/debug/requests` assertions on the tool-mediated lanes                |
+| Baseline parity needed live Anthropic credentials             | PR K: Anthropic mock route on the qa-lab server                              |
+| Parity report had to trust caller-supplied labels             | PR L: self-describing `run` block on every summary artifact                  |
 
 ## Architecture
 
@@ -172,7 +90,7 @@ flowchart TD
 
 ```mermaid
 flowchart LR
-    A["Merged runtime slices (PR A-C)"] --> B["Run GPT-5.4 parity pack"]
+    A["Merged runtime slices"] --> B["Run GPT-5.4 parity pack"]
     A --> C["Run Opus 4.6 parity pack"]
     B --> D["qa-suite-summary.json"]
     C --> E["qa-suite-summary.json"]
@@ -182,12 +100,12 @@ flowchart LR
     F --> H["qa-agentic-parity-summary.json"]
     H --> I{"Gate pass?"}
     I -- "yes" --> J["Evidence-backed parity claim"]
-    I -- "no" --> K["Keep runtime/review loop open"]
+    I -- "no" --> K["Keep runtime fixes in play"]
 ```
 
 ## Dual-provider mock architecture
 
-After PR K #64685 merges, the qa-lab mock server exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both routes feed into the same scenario dispatcher, so each parity scenario has one source of truth and both providers exercise the same response plans. Today (pre-PR-K on `main`) only the `/v1/responses` route exists.
+After PR K lands, the qa-lab mock server exposes both an OpenAI `/v1/responses` route and an Anthropic `/v1/messages` route. Both feed into the same scenario dispatcher, so each parity scenario has one response plan and both providers exercise it. Today only `/v1/responses` exists on `main`.
 
 ```mermaid
 flowchart LR
@@ -207,7 +125,7 @@ flowchart LR
 
 ## Parity run orchestration
 
-The release gate consumes two `qa-suite-summary.json` artifacts (one per provider) and produces the Markdown report plus the machine-readable verdict. Each summary file now carries a self-describing `run` block, so the parity consumer can label the inputs without relying on filenames.
+The release gate consumes two `qa-suite-summary.json` artifacts — one per provider — and produces the Markdown report plus the pass/fail verdict. After PR L lands, each summary file also carries its own `run` block so the parity consumer can verify the inputs without relying on filenames.
 
 ```mermaid
 flowchart TD
@@ -222,7 +140,7 @@ flowchart TD
 
 ## Tool-call assertion seam
 
-Several parity scenarios gate on the prose shape of the agent's reply. That is necessary but not sufficient, because a model can produce a plausible protocol report without ever reading the files or delegating to a subagent. After PR J #64681 merges, the `source-docs-discovery-report` and `subagent-handoff` scenarios also read the mock server's `/debug/requests` log and require the scenario to actually invoke the expected tool (`read` for discovery, `sessions_spawn` for delegation) before the prose reply is accepted. Today (pre-PR-J on `main`) these scenarios only assert the prose shape.
+After PR J lands, the scenarios that depend on a real tool call read the mock server's `/debug/requests` log and fail if the expected tool wasn't actually invoked before the prose reply. Before PR J, these scenarios only check the prose shape.
 
 ```mermaid
 flowchart LR
@@ -236,51 +154,23 @@ flowchart LR
 
 ## Scenario pack
 
-Wave 1 (PR D #64441, merged) registers the first five scenarios in the parity pack. Wave 2 (PR E #64662, open) registers the next five. The `QA_AGENTIC_PARITY_SCENARIOS` array in `extensions/qa-lab/src/agentic-parity.ts` is the single source of truth; reviewers can count the entries there to see which scenarios are currently wired into the gate.
+The pack is `QA_AGENTIC_PARITY_SCENARIOS` in `extensions/qa-lab/src/agentic-parity.ts`. PR D registers the first five; PR E adds the other five. The scenario markdown files themselves already live under `qa/scenarios/` and can run standalone — PR E is just the pack registration and gate wiring.
 
-**Wave 1 scenarios (live on main):**
+**Wave 1 (live on `main`):**
 
-### `approval-turn-tool-followthrough`
+- `approval-turn-tool-followthrough` — the model shouldn't stop at "I'll do that" after a short approval. It should take the first concrete action in the same turn.
+- `model-switch-tool-continuity` — tool-using work should stay coherent across a model or runtime switch instead of resetting into commentary.
+- `source-docs-discovery-report` — the model should read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping. After PR J, this scenario also requires a real `read` tool call to land before the prose reply is accepted.
+- `image-understanding-attachment` — mixed-mode tasks with attachments should stay actionable and not collapse into vague narration.
+- `compaction-retry-mutating-tool` — a task with a real mutating write should keep replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state.
 
-Checks that the model does not stop at “I’ll do that” after a short approval. It should take the first concrete action in the same turn.
+**Wave 2 (registered in the pack after PR E lands):**
 
-### `model-switch-tool-continuity`
-
-Checks that tool-using work remains coherent across model/runtime switching boundaries instead of resetting into commentary or losing execution context.
-
-### `source-docs-discovery-report`
-
-Checks that the model can read source and docs, synthesize findings, and continue the task agentically rather than producing a thin summary and stopping early. The scenario also requires a real `read` tool call to land before the prose reply is accepted.
-
-### `image-understanding-attachment`
-
-Checks that mixed-mode tasks involving attachments remain actionable and do not collapse into vague narration.
-
-### `compaction-retry-mutating-tool`
-
-Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
-
-**Wave 2 scenarios (registered in the pack after PR E #64662 merges; the scenario files already live under `qa/scenarios/` and run standalone):**
-
-### `subagent-handoff`
-
-Checks that a bounded delegation actually spawns a subagent via the `sessions_spawn` tool and folds the subagent's result back into the main flow, instead of producing a prose report that claims delegation occurred without a real subagent call.
-
-### `subagent-fanout-synthesis`
-
-Checks that a fanout across multiple subagents synthesizes results honestly and labels which sub-result contributed to which part of the final answer.
-
-### `memory-recall`
-
-Checks that a task can pull a prior detail back after an intervening context switch, instead of implicitly asking the user to restate it.
-
-### `thread-memory-isolation`
-
-Checks that memory recorded against one thread does not leak into an unrelated thread, so the runtime's isolation contract matches what the model behaves as if.
-
-### `config-restart-capability-flip`
-
-Checks that a live capability change survives a config restart on the agent and is visible to the next run without a stale feature flag cached in the agent's state.
+- `subagent-handoff` — a bounded delegation should actually spawn a subagent via `sessions_spawn` and fold the result back into the main flow. After PR J, this scenario also requires the `sessions_spawn` call to land before the prose reply.
+- `subagent-fanout-synthesis` — a fanout across multiple subagents should synthesize results honestly and label which sub-result contributed where.
+- `memory-recall` — the model should pull a prior detail back after an intervening context switch instead of implicitly asking the user to restate it.
+- `thread-memory-isolation` — memory recorded against one thread shouldn't leak into an unrelated thread.
+- `config-restart-capability-flip` — a live capability change should survive a config restart and be visible to the next run without a stale feature flag cached in the agent's state.
 
 ## Scenario matrix
 
@@ -297,105 +187,58 @@ Checks that a live capability change survives a config restart on the agent and 
 | `thread-memory-isolation`          | Cross-thread memory isolation           | Keeps memory scoped to the right thread and does not leak                      | a detail from thread A surfaces in thread B                                    |
 | `config-restart-capability-flip`   | Live capability change across restart   | Next run sees the new capability instead of the cached feature flag            | stale capability survives the restart and leaks into the next run              |
 
-## Running the parity gate end-to-end
+## Running the harness end-to-end
 
-The parity gate is a three-step flow. Each step is reproducible against the qa-lab mock server so an operator can run the whole thing offline before a release candidate reaches live providers. The shell commands below use the real CLI flag names (`--model` / `--alt-model` on `openclaw qa suite`, `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`).
+The harness is three commands. The CLI flags are `--model` / `--alt-model` on `openclaw qa suite` and `--candidate-summary` / `--baseline-summary` on `openclaw qa parity-report`. The baseline lane only runs fully offline once PR K lands the Anthropic mock route — until then it needs real Anthropic credentials.
 
-The baseline lane only runs end-to-end against the qa-lab mock server after PR K #64685 merges the Anthropic `/v1/messages` route. Until then, the baseline lane requires real Anthropic credentials.
+```bash
+pnpm openclaw qa suite \
+  --model openai/gpt-5.4 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/gpt54
 
-1. Run the suite against the candidate provider/model:
+pnpm openclaw qa suite \
+  --model anthropic/claude-opus-4-6 \
+  --parity-pack agentic \
+  --output-dir .artifacts/qa-e2e/opus46
 
-   ```bash
-   pnpm openclaw qa suite \
-     --model openai/gpt-5.4 \
-     --parity-pack agentic \
-     --output-dir .artifacts/qa-e2e/gpt54
-   ```
+pnpm openclaw qa parity-report \
+  --repo-root . \
+  --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
+  --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+  --output-dir .artifacts/qa-e2e/parity
+```
 
-2. Run the suite against the baseline provider/model:
-
-   ```bash
-   pnpm openclaw qa suite \
-     --model anthropic/claude-opus-4-6 \
-     --parity-pack agentic \
-     --output-dir .artifacts/qa-e2e/opus46
-   ```
-
-3. Generate the parity report and read the verdict:
-
-   ```bash
-   pnpm openclaw qa parity-report \
-     --repo-root . \
-     --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
-     --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
-     --output-dir .artifacts/qa-e2e/parity
-   ```
-
-After PR L #64789 merges, each `qa-suite-summary.json` carries a `run` block with `primaryProvider`, `primaryModel`, `providerMode`, and `scenarioIds`. The parity report consumes those fields to label the inputs in the Markdown report, so an operator can tell which side of the comparison came from which provider without opening the suite config. Until PR L merges, the summary only carries `{ scenarios, counts }` and the parity report trusts the caller-supplied labels. On a gate failure, `qa-agentic-parity-summary.json` records a machine-readable verdict and the parity-report command returns a nonzero exit code so CI can block the release.
+`openclaw qa parity-report` writes the Markdown report and a JSON verdict, and exits nonzero on a gate failure so CI can block the release. After PR L lands, `qa-suite-summary.json` carries the `run` block that the parity report uses to label each input; until then, the report still works but trusts the caller's `--candidate-label` / `--baseline-label`.
 
 ## Release gate
 
-GPT-5.4 can only be considered at parity or better when the merged runtime passes the full ten-scenario parity pack and the runtime-truthfulness regressions at the same time.
+GPT-5.4 can only be called at parity or better when the merged runtime passes the ten-scenario parity pack and the runtime-truthfulness regressions at the same time. The gate compares completion rate, unintended-stop rate, valid-tool-call rate, and fake-success count across candidate and baseline. After PR E, it also requires every required parity scenario to pass on _both_ sides (not just match each other) and honors the `/debug/requests` tool-call assertions from PR J on the tool-mediated scenarios.
 
-Required outcomes:
-
-- no plan-only stall when the next tool action is clear
-- no fake completion without real execution
-- no incorrect `/elevated full` guidance
-- no silent replay or compaction abandonment
-- parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline across all ten scenarios
-
-The gate compares:
-
-- completion rate
-- unintended-stop rate
-- valid-tool-call rate
-- fake-success count
-- required-scenario outcomes (any required scenario that fails on either side fails the gate, even if the baseline also failed)
-- tool-call assertions on the scenarios that require a real tool invocation (`read` for `source-docs-discovery-report`, `sessions_spawn` for `subagent-handoff`)
-
-Parity evidence is intentionally split across two layers:
-
-- PRs D and E prove same-scenario GPT-5.4 vs Opus 4.6 behavior through the ten-scenario QA-lab pack
-- PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
+Evidence lives in two layers on purpose. The parity harness (PRs D + E) proves same-scenario GPT-5.4 vs Opus 4.6 behavior. The deterministic runtime-truthfulness suites from PR B still own auth, proxy, DNS, and `/elevated full` truthfulness outside the harness, because those failure modes are better tested by contract than by scenario.
 
 ## Goal-to-evidence matrix
 
-| Completion gate item                                     | Owning PRs                | Evidence source                                                                                                  | Pass signal                                                                                                            |
-| -------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| GPT-5.4 no longer stalls after planning                  | PR A + PR H               | PR A runtime suites, `approval-turn-tool-followthrough`, PR H auto-activation regression                         | unconfigured GPT-5 runs auto-activate strict-agentic and approval turns trigger real work or an explicit blocked state |
-| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR J        | parity report scenario outcomes, fake-success count, `/debug/requests` tool-call assertions                      | no suspicious pass results and a real `read` / `sessions_spawn` call is recorded before prose is accepted              |
-| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B                      | deterministic truthfulness suites                                                                                | blocked reasons and full-access hints stay runtime-accurate                                                            |
-| Replay/liveness failures stay explicit                   | PR C + PR H               | PR C lifecycle/replay suites plus PR H strict-agentic blocked-exit liveness regression                           | mutating work keeps replay-unsafety explicit and the strict-agentic blocked exit emits `"blocked"`                     |
-| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, self-describing `run` block, dual-provider mock | full ten-scenario coverage on both providers with no regression on the agreed metrics, verifiable offline              |
+| Completion gate criterion                                | Owning PRs                | Evidence                                                                                                         | Pass signal                                                                                                             |
+| -------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| GPT-5.4 no longer stalls after planning                  | PR A + PR H               | strict-agentic runtime suites, `approval-turn-tool-followthrough`, PR H auto-activation regression               | unconfigured GPT-5 runs auto-activate strict-agentic and approval turns either act or surface an explicit blocked state |
+| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR J        | parity report scenario outcomes, fake-success count, `/debug/requests` tool-call assertions                      | no suspicious pass results; a real `read` or `sessions_spawn` call is recorded before prose is accepted                 |
+| No false `/elevated full` guidance                       | PR B                      | deterministic truthfulness suites                                                                                | blocked reasons and full-access hints stay runtime-accurate                                                             |
+| Replay/liveness failures stay explicit                   | PR C + PR H               | lifecycle/replay suites, strict-agentic blocked-exit liveness regression                                         | mutating work keeps replay-unsafety explicit; the strict-agentic blocked exit emits `"blocked"`                         |
+| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E + PR K + PR L | `qa-agentic-parity-report.md`, `qa-agentic-parity-summary.json`, self-describing `run` block, dual-provider mock | full ten-scenario coverage on both providers with no regression on the agreed metrics, verifiable offline               |
 
-## How to read the parity verdict
+## Reading the parity verdict
 
-Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the ten-scenario parity pack.
+`qa-agentic-parity-summary.json` is the final machine-readable decision for the ten-scenario parity pack. `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and didn't regress on the agreed aggregate metrics. `fail` means at least one hard gate tripped — weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, mismatched scenario coverage, or a required scenario that failed on either side.
 
-- `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and did not regress on the agreed aggregate metrics.
-- `fail` means at least one hard gate tripped: weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, or mismatched scenario coverage.
-- “shared/base CI issue” is not itself a parity result. If CI noise outside PR D blocks a run, the verdict should wait for a clean merged-runtime execution instead of being inferred from branch-era logs.
-- Auth, proxy, DNS, and `/elevated full` truthfulness still come from PR B’s deterministic suites, so the final release claim needs both: a passing PR D parity verdict and green PR B truthfulness coverage.
+"Shared/base CI issue" isn't a parity result. If CI noise outside the harness blocks a run, the verdict should wait for a clean merged-runtime execution instead of being inferred from branch-era logs. Auth, proxy, DNS, and `/elevated full` truthfulness still come from PR B's deterministic suites, so the final release claim needs both a passing parity verdict and green truthfulness coverage.
 
 ## Strict-agentic defaults and overrides
 
-After PR H landed, the strict-agentic contract is now the automatic default for GPT-5-family `openai` and `openai-codex` runs. Operators no longer need to configure `executionContract: "strict-agentic"` to get act-now enforcement on those providers — an unconfigured GPT-5 run automatically activates the contract and emits an explicit `"blocked"` liveness state at the strict-agentic blocked exit.
+Once PR H lands, the strict-agentic contract is the automatic default for GPT-5-family `openai` and `openai-codex` runs. Operators don't need to set `executionContract: "strict-agentic"` to get act-now enforcement — an unconfigured GPT-5 run picks it up automatically and emits a `"blocked"` liveness state at the strict-agentic blocked exit.
 
-Override behavior:
+Three configurations to know about:
 
-- **Auto-activated (default for GPT-5 on `openai` / `openai-codex`)**: no configuration required. The runtime enforces act-or-block on plan-only turns and surfaces a `"blocked"` liveness state on the blocked exit.
-- **Explicit opt-out**: set `executionContract: "default"` on the agent config to keep the pre-PR-H looser behavior. This is the escape hatch for prompt-testing workflows or third-party agents that rely on plan-only completion.
-- **Explicit opt-in for other providers**: set `executionContract: "strict-agentic"` to run the contract on Anthropic or any other provider. The auto-activation rule only fires for GPT-5-family OpenAI / OpenAI-Codex runs; other providers still require the explicit config.
-
-Keep the default auto-activation behavior when:
-
-- you want the runtime to guarantee act-or-block on GPT-5 flows without per-agent configuration
-- you are comparing GPT-5.4 against Opus 4.6 through the parity pack and want the contract enforced on the candidate side
-- you prefer explicit blocked states over “helpful” recap-only replies
-
-Opt out (`executionContract: "default"`) when:
-
-- you are running prompt-engineering workflows that deliberately test plan-only turns
-- you are testing a third-party skill that expects the pre-PR-H behavior
-- you are using a non-GPT-5 model that should not be gated by the contract
+- **Auto-activated** (default for GPT-5 on `openai` / `openai-codex`). No configuration required. Use this for the common case where you want the runtime to guarantee act-or-block on GPT-5 flows, and especially when running GPT-5.4 through the parity pack.
+- **Explicit opt-out** (`executionContract: "default"`). Keeps the pre-PR-H looser behavior. This is the escape hatch for prompt-engineering workflows that deliberately test plan-only turns or third-party skills that expect the older semantics.
+- **Explicit opt-in for other providers** (`executionContract: "strict-agentic"`). Runs the contract on Anthropic or any other provider. The auto-activation rule only fires for GPT-5-family OpenAI and OpenAI-Codex runs, so if you want strict-agentic somewhere else you still have to turn it on.

--- a/docs/help/gpt54-codex-agentic-parity.md
+++ b/docs/help/gpt54-codex-agentic-parity.md
@@ -8,7 +8,7 @@ OpenClaw already worked well with tool-using frontier models, but GPT-5.4 and Co
 - they could lose long-running task state during replay or compaction
 - parity claims against Claude Opus 4.6 were based on anecdotes instead of repeatable scenarios
 
-This parity program fixes those gaps in four reviewable slices.
+This parity program fixes those gaps in five reviewable slices: three merged runtime contracts, a proof-harness base, and a second-wave proof expansion.
 
 ## What changed
 
@@ -48,6 +48,16 @@ This slice adds the first-wave QA-lab parity pack so GPT-5.4 and Opus 4.6 can be
 
 The parity pack is the proof layer. It does not change runtime behavior by itself.
 
+### PR E: second-wave parity expansion
+
+This slice keeps the work proof-only and expands the parity pack with more agentic continuity lanes:
+
+- subagent delegation and synthesis
+- memory recall and thread isolation
+- restart-triggered capability recovery in the same session
+
+PR E does not add new runtime behavior. It makes the parity claim stronger by widening the proof surface and turning the final closeout into a merged-main ten-scenario comparison instead of a smaller first-wave sample.
+
 After you have two `qa-suite-summary.json` artifacts, generate the release-gate comparison with:
 
 ```bash
@@ -85,13 +95,13 @@ to:
 
 ## Before vs after for GPT-5.4 users
 
-| Before this program                                                                            | After PR A-D                                                                             |
-| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 could stop after a reasonable plan without taking the next tool step                   | PR A turns “plan only” into “act now or surface a blocked state”                         |
-| Strict tool schemas could reject parameter-free or OpenAI/Codex-shaped tools in confusing ways | PR C makes provider-owned tool registration and invocation more predictable              |
-| `/elevated full` guidance could be vague or wrong in blocked runtimes                          | PR B gives GPT-5.4 and the user truthful runtime and permission hints                    |
-| Replay or compaction failures could feel like the task silently disappeared                    | PR C surfaces paused, blocked, abandoned, and replay-invalid outcomes explicitly         |
-| “GPT-5.4 feels worse than Opus” was mostly anecdotal                                           | PR D turns that into the same scenario pack, the same metrics, and a hard pass/fail gate |
+| Before this program                                                                            | After PR A-E                                                                                     |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| GPT-5.4 could stop after a reasonable plan without taking the next tool step                   | PR A turns “plan only” into “act now or surface a blocked state”                                 |
+| Strict tool schemas could reject parameter-free or OpenAI/Codex-shaped tools in confusing ways | PR C makes provider-owned tool registration and invocation more predictable                      |
+| `/elevated full` guidance could be vague or wrong in blocked runtimes                          | PR B gives GPT-5.4 and the user truthful runtime and permission hints                            |
+| Replay or compaction failures could feel like the task silently disappeared                    | PR C surfaces paused, blocked, abandoned, and replay-invalid outcomes explicitly                 |
+| “GPT-5.4 feels worse than Opus” was mostly anecdotal                                           | PR D and PR E turn that into the same scenario pack, the same metrics, and a hard pass/fail gate |
 
 ## Architecture
 
@@ -129,7 +139,7 @@ flowchart LR
 
 ## Scenario pack
 
-The first-wave parity pack currently covers five scenarios:
+The parity pack now covers ten scenarios in two waves.
 
 ### `approval-turn-tool-followthrough`
 
@@ -151,6 +161,26 @@ Checks that mixed-mode tasks involving attachments remain actionable and do not 
 
 Checks that a task with a real mutating write keeps replay-unsafety explicit instead of quietly looking replay-safe if the run compacts, retries, or loses reply state under pressure.
 
+### `subagent-handoff`
+
+Checks that the agent can delegate one bounded task to a subagent and fold the child result back into the parent reply instead of stalling or leaving the user with a “waiting” placeholder.
+
+### `subagent-fanout-synthesis`
+
+Checks that the agent can launch two bounded subagent tasks, wait for both, and synthesize both results into a single coherent parent answer.
+
+### `memory-recall`
+
+Checks that the agent can remember a seeded fact, switch context, and later recall the same fact accurately instead of hallucinating or losing the state.
+
+### `thread-memory-isolation`
+
+Checks that a memory-backed answer requested inside a thread stays inside that thread and does not leak into the root channel.
+
+### `config-restart-capability-flip`
+
+Checks that a restart-triggering config change restores a capability and that the same live session actually uses the restored tool after wake-up instead of losing continuity.
+
 ## Scenario matrix
 
 | Scenario                           | What it tests                           | Good GPT-5.4 behavior                                                          | Failure signal                                                                 |
@@ -160,6 +190,11 @@ Checks that a task with a real mutating write keeps replay-unsafety explicit ins
 | `source-docs-discovery-report`     | Source reading + synthesis + action     | Finds sources, uses tools, and produces a useful report without stalling       | thin summary, missing tool work, or incomplete-turn stop                       |
 | `image-understanding-attachment`   | Attachment-driven agentic work          | Interprets the attachment, connects it to tools, and continues the task        | vague narration, attachment ignored, or no concrete next action                |
 | `compaction-retry-mutating-tool`   | Mutating work under compaction pressure | Performs a real write and keeps replay-unsafety explicit after the side effect | mutating write happens but replay safety is implied, missing, or contradictory |
+| `subagent-handoff`                 | Single delegated worker flow            | Launches one bounded subagent and folds the result back cleanly                | no delegation, dangling “waiting”, or missing child result                     |
+| `subagent-fanout-synthesis`        | Multi-worker synthesis                  | Launches two bounded subagents and combines both results in one parent answer  | only one child result lands, or synthesis collapses into partial output        |
+| `memory-recall`                    | Durable recall after context shift      | Remembers a seeded fact and recalls it accurately later                        | guessed fact, forgotten fact, or drift after the context switch                |
+| `thread-memory-isolation`          | Scoped threaded recall                  | Answers correctly inside the thread and keeps the root channel quiet           | answer leaks to the root channel or ignores the threaded memory task           |
+| `config-restart-capability-flip`   | Restart + capability continuity         | Same session resumes after restart and uses the restored tool successfully     | capability remains missing, wake-up fails, or the session loses acting context |
 
 ## Release gate
 
@@ -173,7 +208,7 @@ Required outcomes:
 - no silent replay or compaction abandonment
 - parity-pack metrics that are at least as strong as the agreed Opus 4.6 baseline
 
-For the first-wave harness, the gate compares:
+For the current parity pack, the gate compares:
 
 - completion rate
 - unintended-stop rate
@@ -182,22 +217,41 @@ For the first-wave harness, the gate compares:
 
 Parity evidence is intentionally split across two layers:
 
-- PR D proves same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
+- PR D and PR E prove same-scenario GPT-5.4 vs Opus 4.6 behavior with QA-lab
 - PR B deterministic suites prove auth, proxy, DNS, and `/elevated full` truthfulness outside the harness
 
 ## Goal-to-evidence matrix
 
-| Completion gate item                                     | Owning PR   | Evidence source                                                    | Pass signal                                                                              |
-| -------------------------------------------------------- | ----------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| GPT-5.4 no longer stalls after planning                  | PR A        | `approval-turn-tool-followthrough` plus PR A runtime suites        | approval turns trigger real work or an explicit blocked state                            |
-| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D | parity report scenario outcomes and fake-success count             | no suspicious pass results and no commentary-only completion                             |
-| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B        | deterministic truthfulness suites                                  | blocked reasons and full-access hints stay runtime-accurate                              |
-| Replay/liveness failures stay explicit                   | PR C + PR D | PR C lifecycle/replay suites plus `compaction-retry-mutating-tool` | mutating work keeps replay-unsafety explicit instead of silently disappearing            |
-| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json` | same scenario coverage and no regression on completion, stop behavior, or valid tool use |
+| Completion gate item                                     | Owning PR          | Evidence source                                                                             | Pass signal                                                                              |
+| -------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| GPT-5.4 no longer stalls after planning                  | PR A               | `approval-turn-tool-followthrough` plus PR A runtime suites                                 | approval turns trigger real work or an explicit blocked state                            |
+| GPT-5.4 no longer fakes progress or fake tool completion | PR A + PR D + PR E | parity report scenario outcomes and fake-success count                                      | no suspicious pass results and no commentary-only completion                             |
+| GPT-5.4 no longer gives false `/elevated full` guidance  | PR B               | deterministic truthfulness suites                                                           | blocked reasons and full-access hints stay runtime-accurate                              |
+| Replay/liveness failures stay explicit                   | PR C + PR D + PR E | PR C lifecycle/replay suites plus `compaction-retry-mutating-tool` and continuity scenarios | mutating work keeps replay-unsafety explicit instead of silently disappearing            |
+| GPT-5.4 matches or beats Opus 4.6 on the agreed metrics  | PR D + PR E        | `qa-agentic-parity-report.md` and `qa-agentic-parity-summary.json`                          | same scenario coverage and no regression on completion, stop behavior, or valid tool use |
+
+## Merged-main parity proof
+
+The final release claim should come from one merged-main run, not from branch-era anecdotes.
+
+Required inputs:
+
+- merged PR A, PR B, and PR C runtime behavior
+- merged PR D proof harness
+- merged PR E second-wave parity expansion
+- generated `qa-suite-summary.json` for GPT-5.4
+- generated `qa-suite-summary.json` for Opus 4.6
+
+Required outputs:
+
+- `qa-agentic-parity-report.md`
+- `qa-agentic-parity-summary.json`
+
+Only treat parity as complete when those generated artifacts come from the merged runtime and the full ten-scenario pack.
 
 ## How to read the parity verdict
 
-Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the first-wave parity pack.
+Use the verdict in `qa-agentic-parity-summary.json` as the final machine-readable decision for the merged-main parity pack.
 
 - `pass` means GPT-5.4 covered the same scenarios as Opus 4.6 and did not regress on the agreed aggregate metrics.
 - `fail` means at least one hard gate tripped: weaker completion, worse unintended stops, weaker valid tool use, any fake-success case, or mismatched scenario coverage.

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -7,6 +7,28 @@ import {
   type QaParitySuiteSummary,
 } from "./agentic-parity-report.js";
 
+const FULL_PARITY_PASS_SCENARIOS = [
+  { name: "Approval turn tool followthrough", status: "pass" as const },
+  { name: "Compaction retry after mutating tool", status: "pass" as const },
+  { name: "Model switch with tool continuity", status: "pass" as const },
+  { name: "Source and docs discovery report", status: "pass" as const },
+  { name: "Image understanding from attachment", status: "pass" as const },
+  { name: "Subagent handoff", status: "pass" as const },
+  { name: "Subagent fanout synthesis", status: "pass" as const },
+  { name: "Memory recall after context switch", status: "pass" as const },
+  { name: "Thread memory isolation", status: "pass" as const },
+  { name: "Config restart capability flip", status: "pass" as const },
+];
+
+function withScenarioOverride(
+  name: string,
+  override: Partial<(typeof FULL_PARITY_PASS_SCENARIOS)[number]>,
+) {
+  return FULL_PARITY_PASS_SCENARIOS.map((scenario) =>
+    scenario.name === name ? { ...scenario, ...override } : scenario,
+  );
+}
+
 describe("qa agentic parity report", () => {
   it("computes first-wave parity metrics from suite summaries", () => {
     const summary: QaParitySuiteSummary = {
@@ -216,21 +238,9 @@ describe("qa agentic parity report", () => {
     // whole parity pack as pass on both sides except the one scenario we
     // deliberately fail on both sides, so the assertion can pin the
     // isolated gate failure under test.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-    const scenariosWithBothFail = parityPassScenarios.map((scenario, index) =>
-      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
-    );
+    const scenariosWithBothFail = withScenarioOverride("Approval turn tool followthrough", {
+      status: "fail",
+    });
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
@@ -254,26 +264,14 @@ describe("qa agentic parity report", () => {
     // by the relative completion-rate comparison, but surface it as a
     // named required-scenario failure too so operators see a concrete
     // scenario name alongside the rate differential.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-    const candidateWithOneFail = parityPassScenarios.map((scenario, index) =>
-      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
-    );
+    const candidateWithOneFail = withScenarioOverride("Approval turn tool followthrough", {
+      status: "fail",
+    });
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: { scenarios: candidateWithOneFail },
-      baselineSummary: { scenarios: parityPassScenarios },
+      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
 
@@ -286,28 +284,16 @@ describe("qa agentic parity report", () => {
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
     // Cover the full second-wave pack on both sides so the suspicious-pass assertion
     // below is the isolated gate failure under test (no coverage-gap noise).
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: parityPassScenarios,
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
       },
       baselineSummary: {
-        scenarios: parityPassScenarios.map((scenario, index) =>
-          index === 0 ? { ...scenario, details: "timed out before it continued" } : scenario,
-        ),
+        scenarios: withScenarioOverride("Approval turn tool followthrough", {
+          details: "timed out before it continued",
+        }),
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -506,28 +492,15 @@ Follow-up:
   });
 
   it("accepts matching run.primaryProvider labels without throwing", () => {
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: parityPassScenarios,
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
       },
       baselineSummary: {
-        scenarios: parityPassScenarios,
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -538,26 +511,31 @@ Follow-up:
   it("skips run.primaryProvider verification when the summary is missing a run block (legacy summaries)", () => {
     // Pre-PR-L summaries don't carry a `run` block. The gate must still
     // work against those, trusting the caller-supplied label.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
-
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
-      candidateSummary: { scenarios: parityPassScenarios },
-      baselineSummary: { scenarios: parityPassScenarios },
+      candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
+      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("skips provider verification for arbitrary display labels when run metadata is present", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "GPT-5.4 candidate",
+      baselineLabel: "Opus 4.6 baseline",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
     expect(comparison.pass).toBe(true);
   });
 
@@ -565,23 +543,11 @@ Follow-up:
     // Cover the full 10-scenario parity pack on both sides so the pass
     // verdict is not disrupted by required-scenario coverage failures
     // added by the second-wave expansion.
-    const parityPassScenarios = [
-      { name: "Approval turn tool followthrough", status: "pass" as const },
-      { name: "Compaction retry after mutating tool", status: "pass" as const },
-      { name: "Model switch with tool continuity", status: "pass" as const },
-      { name: "Source and docs discovery report", status: "pass" as const },
-      { name: "Image understanding from attachment", status: "pass" as const },
-      { name: "Subagent handoff", status: "pass" as const },
-      { name: "Subagent fanout synthesis", status: "pass" as const },
-      { name: "Memory recall after context switch", status: "pass" as const },
-      { name: "Thread memory isolation", status: "pass" as const },
-      { name: "Config restart capability flip", status: "pass" as const },
-    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
-      candidateSummary: { scenarios: parityPassScenarios },
-      baselineSummary: { scenarios: parityPassScenarios },
+      candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
+      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -377,27 +377,26 @@ Follow-up:
   });
 
   it("renders a readable markdown parity report", () => {
+    // Cover the full 10-scenario parity pack on both sides so the pass
+    // verdict is not disrupted by required-scenario coverage failures
+    // added by the second-wave expansion.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
-      candidateSummary: {
-        scenarios: [
-          { name: "Approval turn tool followthrough", status: "pass" },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
-      },
-      baselineSummary: {
-        scenarios: [
-          { name: "Approval turn tool followthrough", status: "pass" },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
-      },
+      candidateSummary: { scenarios: parityPassScenarios },
+      baselineSummary: { scenarios: parityPassScenarios },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -208,32 +208,30 @@ describe("qa agentic parity report", () => {
   });
 
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
-    // Cover the full first-wave pack on both sides so the suspicious-pass assertion
+    // Cover the full second-wave pack on both sides so the suspicious-pass assertion
     // below is the isolated gate failure under test (no coverage-gap noise).
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.4",
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
-        scenarios: [
-          { name: "Approval turn tool followthrough", status: "pass" },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
+        scenarios: parityPassScenarios,
       },
       baselineSummary: {
-        scenarios: [
-          {
-            name: "Approval turn tool followthrough",
-            status: "pass",
-            details: "timed out before it continued",
-          },
-          { name: "Compaction retry after mutating tool", status: "pass" },
-          { name: "Model switch with tool continuity", status: "pass" },
-          { name: "Source and docs discovery report", status: "pass" },
-          { name: "Image understanding from attachment", status: "pass" },
-        ],
+        scenarios: parityPassScenarios.map((scenario, index) =>
+          index === 0 ? { ...scenario, details: "timed out before it continued" } : scenario,
+        ),
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -4,10 +4,11 @@ import {
   computeQaAgenticParityMetrics,
   QaParityLabelMismatchError,
   renderQaAgenticParityMarkdownReport,
+  type QaParityReportScenario,
   type QaParitySuiteSummary,
 } from "./agentic-parity-report.js";
 
-const FULL_PARITY_PASS_SCENARIOS = [
+const FULL_PARITY_PASS_SCENARIOS: QaParityReportScenario[] = [
   { name: "Approval turn tool followthrough", status: "pass" as const },
   { name: "Compaction retry after mutating tool", status: "pass" as const },
   { name: "Model switch with tool continuity", status: "pass" as const },
@@ -22,7 +23,7 @@ const FULL_PARITY_PASS_SCENARIOS = [
 
 function withScenarioOverride(
   name: string,
-  override: Partial<(typeof FULL_PARITY_PASS_SCENARIOS)[number]>,
+  override: Partial<QaParityReportScenario>,
 ) {
   return FULL_PARITY_PASS_SCENARIOS.map((scenario) =>
     scenario.name === name ? { ...scenario, ...override } : scenario,
@@ -416,6 +417,22 @@ Follow-up:
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
   });
 
+  it("does not flag structured status lines that end in `done`", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Compaction retry after mutating tool",
+          status: "pass",
+          details: `Confirmed, replay unsafe after write.
+compactionCount=0
+status=done`,
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
   it("does not flag positive-tone passes when the scenario shows real tool-call evidence", () => {
     // A legitimate tool-mediated pass that happens to include
     // "successfully" in its prose must not be flagged. The
@@ -520,11 +537,19 @@ Follow-up:
       baselineLabel: "anthropic/claude-opus-4-6",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -550,11 +575,19 @@ Follow-up:
       baselineLabel: "Opus 4.6 baseline",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -568,11 +601,19 @@ Follow-up:
       baselineLabel: "Opus 4.6 / baseline",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });
@@ -587,16 +628,24 @@ Follow-up:
         baselineLabel: "anthropic/claude-opus-4-6",
         candidateSummary: {
           scenarios: FULL_PARITY_PASS_SCENARIOS,
-          run: { primaryProvider: "openai", primaryModel: "gpt-5.4-alt" },
+          run: {
+            primaryProvider: "openai",
+            primaryModel: "openai/gpt-5.4-alt",
+            primaryModelName: "gpt-5.4-alt",
+          },
         },
         baselineSummary: {
           scenarios: FULL_PARITY_PASS_SCENARIOS,
-          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+          run: {
+            primaryProvider: "anthropic",
+            primaryModel: "anthropic/claude-opus-4-6",
+            primaryModelName: "claude-opus-4-6",
+          },
         },
         comparedAt: "2026-04-11T00:00:00.000Z",
       }),
     ).toThrow(
-      /candidate summary run\.primaryProvider=openai and run\.primaryModel=gpt-5\.4-alt do not match --candidate-label=openai\/gpt-5\.4/,
+      /candidate summary run\.primaryProvider=openai and run\.primaryModel=openai\/gpt-5\.4-alt do not match --candidate-label=openai\/gpt-5\.4/,
     );
   });
 
@@ -606,11 +655,19 @@ Follow-up:
       baselineLabel: "anthropic:claude-opus-4-6",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4",
+          primaryModelName: "gpt-5.4",
+        },
       },
       baselineSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6",
+          primaryModelName: "claude-opus-4-6",
+        },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
     });

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -207,6 +207,81 @@ describe("qa agentic parity report", () => {
     );
   });
 
+  it("fails the parity gate when a required parity scenario fails on both sides", () => {
+    // Regression for the loop-7 Codex-connector P1 finding: without this
+    // check, a required parity scenario that fails on both candidate and
+    // baseline still produces pass=true because the downstream metric
+    // comparisons are purely relative (candidate vs baseline). Cover the
+    // whole parity pack as pass on both sides except the one scenario we
+    // deliberately fail on both sides, so the assertion can pin the
+    // isolated gate failure under test.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+    const scenariosWithBothFail = parityPassScenarios.map((scenario, index) =>
+      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
+    );
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: { scenarios: scenariosWithBothFail },
+      baselineSummary: { scenarios: scenariosWithBothFail },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.4=fail, anthropic/claude-opus-4-6=fail.",
+    );
+    // Metric comparisons are relative, so a same-on-both-sides failure
+    // must not appear as a relative metric failure. The required-scenario
+    // failure line is the only thing keeping the gate honest here.
+    expect(comparison.failures.some((failure) => failure.includes("completion rate"))).toBe(false);
+  });
+
+  it("fails the parity gate when a required parity scenario fails on the candidate only", () => {
+    // A candidate regression below a passing baseline is already caught
+    // by the relative completion-rate comparison, but surface it as a
+    // named required-scenario failure too so operators see a concrete
+    // scenario name alongside the rate differential.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+    const candidateWithOneFail = parityPassScenarios.map((scenario, index) =>
+      index === 0 ? { ...scenario, status: "fail" as const } : scenario,
+    );
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: { scenarios: candidateWithOneFail },
+      baselineSummary: { scenarios: parityPassScenarios },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(false);
+    expect(comparison.failures).toContain(
+      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.4=fail, anthropic/claude-opus-4-6=pass.",
+    );
+  });
+
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
     // Cover the full second-wave pack on both sides so the suspicious-pass assertion
     // below is the isolated gate failure under test (no coverage-gap noise).

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildQaAgenticParityComparison,
   computeQaAgenticParityMetrics,
+  QaParityLabelMismatchError,
   renderQaAgenticParityMarkdownReport,
   type QaParitySuiteSummary,
 } from "./agentic-parity-report.js";
@@ -374,6 +375,190 @@ Follow-up:
     };
 
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
+  });
+
+  it("flags positive-tone fake success when the scenario has no tool-call evidence", () => {
+    // A prose-only pass that says "Successfully completed the delegation"
+    // without any recorded `plannedToolName` or tool-call evidence is
+    // exactly the fake-success shape the old failure-tone-only regex set
+    // missed. This regression pins the positive-tone branch.
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Subagent handoff",
+          status: "pass",
+          details: "Successfully completed the delegation. The subagent returned its result.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
+  });
+
+  it("flags a bare `Done.` prose pass as fake success", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Approval turn tool followthrough",
+          status: "pass",
+          details: "Done.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
+  });
+
+  it("does not flag positive-tone passes when the scenario shows real tool-call evidence", () => {
+    // A legitimate tool-mediated pass that happens to include
+    // "successfully" in its prose must not be flagged. The
+    // `plannedToolName` evidence (or any of the other tool-call
+    // evidence patterns) exempts the scenario from positive-tone
+    // detection. Without this exemption, real tool-backed passes with
+    // self-congratulatory prose would count as fake successes and break
+    // the gate.
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Source and docs discovery report",
+          status: "pass",
+          details:
+            "Successfully completed the report. plannedToolName=read recorded via /debug/requests.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
+  it("flags positive-tone passes alongside failure-tone passes when both occur", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Approval turn tool followthrough",
+          status: "pass",
+          details: "Task executed successfully without errors.",
+        },
+        {
+          name: "Subagent handoff",
+          status: "pass",
+          details: "Tool call completed, but an error occurred mid-turn.",
+        },
+      ],
+    };
+
+    // Both scenarios should count: one is positive-tone (evasive fake
+    // success), the other is failure-tone (classic fake success).
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(2);
+  });
+
+  it("throws QaParityLabelMismatchError when the candidate run.primaryProvider does not match the label", () => {
+    // Regression for the gate footgun: if an operator swaps the
+    // --candidate-summary and --baseline-summary paths, the gate would
+    // silently produce a reversed verdict. PR L #64789 ships the `run`
+    // block on every summary so the parity report can verify it against
+    // the caller-supplied label; this test pins the precondition check.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+    ];
+
+    expect(() =>
+      buildQaAgenticParityComparison({
+        candidateLabel: "openai/gpt-5.4",
+        baselineLabel: "anthropic/claude-opus-4-6",
+        candidateSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        },
+        baselineSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        },
+        comparedAt: "2026-04-11T00:00:00.000Z",
+      }),
+    ).toThrow(QaParityLabelMismatchError);
+  });
+
+  it("throws QaParityLabelMismatchError when the baseline run.primaryProvider does not match the label", () => {
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+    ];
+
+    expect(() =>
+      buildQaAgenticParityComparison({
+        candidateLabel: "openai/gpt-5.4",
+        baselineLabel: "anthropic/claude-opus-4-6",
+        candidateSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "openai" },
+        },
+        baselineSummary: {
+          scenarios: parityPassScenarios,
+          run: { primaryProvider: "openai" },
+        },
+        comparedAt: "2026-04-11T00:00:00.000Z",
+      }),
+    ).toThrow(/baseline summary run.primaryProvider=openai does not match --baseline-label/);
+  });
+
+  it("accepts matching run.primaryProvider labels without throwing", () => {
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: {
+        scenarios: parityPassScenarios,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: parityPassScenarios,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("skips run.primaryProvider verification when the summary is missing a run block (legacy summaries)", () => {
+    // Pre-PR-L summaries don't carry a `run` block. The gate must still
+    // work against those, trusting the caller-supplied label.
+    const parityPassScenarios = [
+      { name: "Approval turn tool followthrough", status: "pass" as const },
+      { name: "Compaction retry after mutating tool", status: "pass" as const },
+      { name: "Model switch with tool continuity", status: "pass" as const },
+      { name: "Source and docs discovery report", status: "pass" as const },
+      { name: "Image understanding from attachment", status: "pass" as const },
+      { name: "Subagent handoff", status: "pass" as const },
+      { name: "Subagent fanout synthesis", status: "pass" as const },
+      { name: "Memory recall after context switch", status: "pass" as const },
+      { name: "Thread memory isolation", status: "pass" as const },
+      { name: "Config restart capability flip", status: "pass" as const },
+    ];
+
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4",
+      baselineLabel: "anthropic/claude-opus-4-6",
+      candidateSummary: { scenarios: parityPassScenarios },
+      baselineSummary: { scenarios: parityPassScenarios },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+    expect(comparison.pass).toBe(true);
   });
 
   it("renders a readable markdown parity report", () => {

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -33,8 +33,12 @@ describe("qa agentic parity report", () => {
   it("computes first-wave parity metrics from suite summaries", () => {
     const summary: QaParitySuiteSummary = {
       scenarios: [
-        { name: "Scenario A", status: "pass" },
-        { name: "Scenario B", status: "fail", details: "incomplete turn detected" },
+        { name: "Approval turn tool followthrough", status: "pass" },
+        {
+          name: "Compaction retry after mutating tool",
+          status: "fail",
+          details: "incomplete turn detected",
+        },
       ],
     };
 
@@ -48,6 +52,23 @@ describe("qa agentic parity report", () => {
       validToolCallCount: 1,
       validToolCallRate: 0.5,
       fakeSuccessCount: 0,
+    });
+  });
+
+  it("keeps non-tool scenarios out of the valid-tool-call metric", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        { name: "Approval turn tool followthrough", status: "pass" },
+        { name: "Memory recall after context switch", status: "pass" },
+        { name: "Image understanding from attachment", status: "pass" },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary)).toMatchObject({
+      totalScenarios: 3,
+      passedScenarios: 3,
+      validToolCallCount: 1,
+      validToolCallRate: 1,
     });
   });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -19,6 +19,7 @@ const FULL_PARITY_PASS_SCENARIOS: QaParityReportScenario[] = [
   { name: "Memory recall after context switch", status: "pass" as const },
   { name: "Thread memory isolation", status: "pass" as const },
   { name: "Config restart capability flip", status: "pass" as const },
+  { name: "Instruction followthrough repo contract", status: "pass" as const },
 ];
 
 function withScenarioOverride(name: string, override: Partial<QaParityReportScenario>) {
@@ -452,25 +453,6 @@ status=done`,
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
   });
 
-  it("does not flag positive-tone prose on non-tool scenarios", () => {
-    const summary: QaParitySuiteSummary = {
-      scenarios: [
-        {
-          name: "Memory recall after context switch",
-          status: "pass",
-          details: "Successfully completed the recall and returned the remembered fact.",
-        },
-        {
-          name: "Image understanding from attachment",
-          status: "pass",
-          details: "Done. Successfully identified the attachment contents.",
-        },
-      ],
-    };
-
-    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
-  });
-
   it("flags positive-tone passes alongside failure-tone passes when both occur", () => {
     const summary: QaParitySuiteSummary = {
       scenarios: [
@@ -691,34 +673,8 @@ status=done`,
     expect(comparison.pass).toBe(true);
   });
 
-  it("accepts structured labels whose model ref contains nested path segments", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.4/reasoning",
-      baselineLabel: "anthropic/claude-opus-4-6/extended",
-      candidateSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "openai",
-          primaryModel: "openai/gpt-5.4/reasoning",
-          primaryModelName: "gpt-5.4/reasoning",
-        },
-      },
-      baselineSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-6/extended",
-          primaryModelName: "claude-opus-4-6/extended",
-        },
-      },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
-
-    expect(comparison.pass).toBe(true);
-  });
-
   it("renders a readable markdown parity report", () => {
-    // Cover the full 10-scenario parity pack on both sides so the pass
+    // Cover the full parity pack on both sides so the pass
     // verdict is not disrupted by required-scenario coverage failures
     // added by the second-wave expansion.
     const comparison = buildQaAgenticParityComparison({

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -21,10 +21,7 @@ const FULL_PARITY_PASS_SCENARIOS: QaParityReportScenario[] = [
   { name: "Config restart capability flip", status: "pass" as const },
 ];
 
-function withScenarioOverride(
-  name: string,
-  override: Partial<QaParityReportScenario>,
-) {
+function withScenarioOverride(name: string, override: Partial<QaParityReportScenario>) {
   return FULL_PARITY_PASS_SCENARIOS.map((scenario) =>
     scenario.name === name ? { ...scenario, ...override } : scenario,
   );
@@ -455,6 +452,25 @@ status=done`,
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
   });
 
+  it("does not flag positive-tone prose on non-tool scenarios", () => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: "Memory recall after context switch",
+          status: "pass",
+          details: "Successfully completed the recall and returned the remembered fact.",
+        },
+        {
+          name: "Image understanding from attachment",
+          status: "pass",
+          details: "Done. Successfully identified the attachment contents.",
+        },
+      ],
+    };
+
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+  });
+
   it("flags positive-tone passes alongside failure-tone passes when both occur", () => {
     const summary: QaParitySuiteSummary = {
       scenarios: [
@@ -667,6 +683,32 @@ status=done`,
           primaryProvider: "anthropic",
           primaryModel: "anthropic/claude-opus-4-6",
           primaryModelName: "claude-opus-4-6",
+        },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("accepts structured labels whose model ref contains nested path segments", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4/reasoning",
+      baselineLabel: "anthropic/claude-opus-4-6/extended",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: {
+          primaryProvider: "openai",
+          primaryModel: "openai/gpt-5.4/reasoning",
+          primaryModelName: "gpt-5.4/reasoning",
+        },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: {
+          primaryProvider: "anthropic",
+          primaryModel: "anthropic/claude-opus-4-6/extended",
+          primaryModelName: "claude-opus-4-6/extended",
         },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -328,9 +328,30 @@ Follow-up:
 
     const report = renderQaAgenticParityMarkdownReport(comparison);
 
-    expect(report).toContain("# OpenClaw GPT-5.4 / Opus 4.6 Agentic Parity Report");
+    expect(report).toContain(
+      "# OpenClaw Agentic Parity Report — openai/gpt-5.4 vs anthropic/claude-opus-4-6",
+    );
     expect(report).toContain("| Completion rate | 100.0% | 100.0% |");
     expect(report).toContain("### Approval turn tool followthrough");
     expect(report).toContain("- Verdict: pass");
+  });
+
+  it("parametrizes the markdown header from the comparison labels", () => {
+    // Regression for the loop-7 Copilot finding: callers that configure
+    // non-gpt-5.4 / non-opus labels (for example an internal candidate vs
+    // another candidate) must see the labels in the rendered H1 instead of
+    // the hardcoded "GPT-5.4 / Opus 4.6" title that would otherwise confuse
+    // readers of saved reports.
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai/gpt-5.4-alt",
+      baselineLabel: "openai/gpt-5.4",
+      candidateSummary: { scenarios: [] },
+      baselineSummary: { scenarios: [] },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+    const report = renderQaAgenticParityMarkdownReport(comparison);
+    expect(report).toContain(
+      "# OpenClaw Agentic Parity Report — openai/gpt-5.4-alt vs openai/gpt-5.4",
+    );
   });
 });

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -484,11 +484,13 @@ Follow-up:
         },
         baselineSummary: {
           scenarios: parityPassScenarios,
-          run: { primaryProvider: "openai" },
+          run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
         },
         comparedAt: "2026-04-11T00:00:00.000Z",
       }),
-    ).toThrow(/baseline summary run.primaryProvider=openai does not match --baseline-label/);
+    ).toThrow(
+      /baseline summary run\.primaryProvider=openai and run\.primaryModel=gpt-5\.4 do not match --baseline-label/,
+    );
   });
 
   it("accepts matching run.primaryProvider labels without throwing", () => {
@@ -525,6 +527,62 @@ Follow-up:
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "GPT-5.4 candidate",
       baselineLabel: "Opus 4.6 baseline",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("skips provider verification for mixed-case or decorated display labels", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "Candidate: GPT-5.4",
+      baselineLabel: "Opus 4.6 / baseline",
+      candidateSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },
+      },
+      baselineSummary: {
+        scenarios: FULL_PARITY_PASS_SCENARIOS,
+        run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+      },
+      comparedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(comparison.pass).toBe(true);
+  });
+
+  it("throws when a structured label mismatches the recorded model even if the provider matches", () => {
+    expect(() =>
+      buildQaAgenticParityComparison({
+        candidateLabel: "openai/gpt-5.4",
+        baselineLabel: "anthropic/claude-opus-4-6",
+        candidateSummary: {
+          scenarios: FULL_PARITY_PASS_SCENARIOS,
+          run: { primaryProvider: "openai", primaryModel: "gpt-5.4-alt" },
+        },
+        baselineSummary: {
+          scenarios: FULL_PARITY_PASS_SCENARIOS,
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+        },
+        comparedAt: "2026-04-11T00:00:00.000Z",
+      }),
+    ).toThrow(
+      /candidate summary run\.primaryProvider=openai and run\.primaryModel=gpt-5\.4-alt do not match --candidate-label=openai\/gpt-5\.4/,
+    );
+  });
+
+  it("accepts colon-delimited structured labels when provider and model both match", () => {
+    const comparison = buildQaAgenticParityComparison({
+      candidateLabel: "openai:gpt-5.4",
+      baselineLabel: "anthropic:claude-opus-4-6",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: { primaryProvider: "openai", primaryModel: "gpt-5.4" },

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -191,13 +191,11 @@ export function computeQaAgenticParityMetrics(
     if (scenarioHasPattern(scenario, SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS)) {
       return true;
     }
-    // Positive-tone patterns only fire on tool-backed scenarios that
-    // don't also show real tool-call evidence. Non-tool lanes like
-    // memory recall or image understanding can legitimately pass with
-    // short positive prose and should not be treated as fake successes
-    // just because they never emit `plannedToolName=...`.
+    // Positive-tone patterns only fire when the scenario doesn't also show
+    // real tool-call evidence. A legitimate tool-mediated pass with
+    // self-congratulatory prose stays clean; a prose-only pass with
+    // "Successfully completed the delegation" gets flagged.
     if (
-      toolBackedTitleSet.has(scenario.name) &&
       scenarioHasPattern(scenario, SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS) &&
       scenarioLacksToolCallEvidence(scenario)
     ) {
@@ -276,7 +274,7 @@ function parseStructuredLabelRef(label: string): StructuredQaParityLabel | null 
   if (trimmed !== trimmed.toLowerCase()) {
     return null;
   }
-  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._/-]*)$/.exec(trimmed);
+  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._-]*)$/.exec(trimmed);
   if (!separatorMatch) {
     return null;
   }

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -149,9 +149,10 @@ function scopeSummaryToParityPack(
   summary: QaParitySuiteSummary,
   parityTitleSet: ReadonlySet<string>,
 ): QaParitySuiteSummary {
-  // The parity verdict must only consider the declared first-wave parity scenarios.
-  // Drop `counts` so the metric helper recomputes totals from the filtered scenario
-  // list instead of inheriting the caller's full-suite counters.
+  // The parity verdict must only consider the declared parity scenarios
+  // (the full first-wave + second-wave pack from QA_AGENTIC_PARITY_SCENARIOS).
+  // Drop `counts` so the metric helper recomputes totals from the filtered
+  // scenario list instead of inheriting the caller's full-suite counters.
   return {
     scenarios: summary.scenarios.filter((scenario) => parityTitleSet.has(scenario.name)),
   };
@@ -281,8 +282,13 @@ export function buildQaAgenticParityComparison(params: {
 }
 
 export function renderQaAgenticParityMarkdownReport(comparison: QaAgenticParityComparison): string {
+  // Title is parametrized from the candidate / baseline labels so reports
+  // for any candidate/baseline pair (not only gpt-5.4 vs opus 4.6) render
+  // with an accurate header. The default CLI labels are still
+  // openai/gpt-5.4 vs anthropic/claude-opus-4-6, but the helper works for
+  // any parity comparison a caller configures.
   const lines = [
-    "# OpenClaw GPT-5.4 / Opus 4.6 Agentic Parity Report",
+    `# OpenClaw Agentic Parity Report — ${comparison.candidateLabel} vs ${comparison.baselineLabel}`,
     "",
     `- Compared at: ${comparison.comparedAt}`,
     `- Candidate: ${comparison.candidateLabel}`,

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -13,6 +13,19 @@ export type QaParityReportScenario = {
   steps?: QaParityReportStep[];
 };
 
+/**
+ * Optional self-describing run metadata written by PR L (#64789). Before
+ * that PR merges, older summaries only have `scenarios` + `counts`; the
+ * parity report treats a missing `run` block as "unknown provenance" and
+ * skips the label-match verification rather than failing open.
+ */
+export type QaParityRunBlock = {
+  primaryProvider?: string;
+  primaryModel?: string;
+  providerMode?: string;
+  scenarioIds?: readonly string[] | null;
+};
+
 export type QaParitySuiteSummary = {
   scenarios: QaParityReportScenario[];
   counts?: {
@@ -20,6 +33,8 @@ export type QaParitySuiteSummary = {
     passed?: number;
     failed?: number;
   };
+  /** Self-describing run metadata — see PR L #64789 for the writer side. */
+  run?: QaParityRunBlock;
 };
 
 export type QaAgenticParityMetrics = {
@@ -64,7 +79,11 @@ const UNINTENDED_STOP_PATTERNS = [
   /did not continue/i,
 ] as const;
 
-const SUSPICIOUS_PASS_PATTERNS = [
+// Failure-tone patterns: a passing scenario whose details text matches any
+// of these is treated as a "fake success" — the scenario is marked pass but
+// the supporting text reveals something went wrong. Adding new patterns here
+// widens the net for bad prose that correlates with runtime failure modes.
+const SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS = [
   /incomplete turn/i,
   /\btimed out\b/i,
   /\btimeout\b/i,
@@ -75,6 +94,49 @@ const SUSPICIOUS_PASS_PATTERNS = [
   /error occurred/i,
   /an error was/i,
 ] as const;
+
+// Positive-tone patterns: a passing scenario whose details read as plausible
+// self-congratulatory prose ("Successfully completed", "Done.", "Task
+// executed successfully") is ALSO suspicious — it's the shape of a fake
+// success that evades the failure-tone net above. Criterion 2 of the
+// GPT-5.4 parity completion gate (#64227) specifically targets this: a
+// model that says "I did the thing" without actually doing it should not
+// count as a pass. A positive-tone pattern only fires as a suspicious pass
+// when the scenario is ALSO missing a recorded tool-call assertion in its
+// prose — see `scenarioLacksToolCallEvidence` below. That keeps the check
+// from false-positiving on legitimate tool-mediated scenarios that happen
+// to include "successfully" in their details.
+const SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS = [
+  /successfully (?:completed|executed|finished|handled|delegated|ran)/i,
+  /\bdone\.?\s*$/im,
+  /task (?:done|executed|completed|handled|finished) successfully/i,
+  /everything (?:worked|ran) (?:as expected|successfully)/i,
+  /finished the operation/i,
+  /all (?:steps|tasks) (?:completed|finished) successfully/i,
+] as const;
+
+// Evidence a scenario actually did its tool-mediated work. A scenario
+// whose details contain any of these is considered tool-backed and is
+// exempt from the positive-tone fake-success check. The patterns match
+// the `plannedToolName=...` / `tool call succeeded` / `executed tool`
+// phrases scenarios emit when their `/debug/requests` assertions fire
+// (PR J #64681), so a scenario with real tool evidence is never flagged
+// even if its prose also includes "successfully".
+const TOOL_CALL_EVIDENCE_PATTERNS = [
+  /plannedToolName/i,
+  /tool call (?:succeeded|completed|returned)/i,
+  /executed tool/i,
+  /function_call_output/i,
+  /tool_use/i,
+] as const;
+
+function scenarioLacksToolCallEvidence(scenario: QaParityReportScenario): boolean {
+  const text = scenarioText(scenario);
+  if (text.length === 0) {
+    return true;
+  }
+  return !TOOL_CALL_EVIDENCE_PATTERNS.some((pattern) => pattern.test(text));
+}
 
 function normalizeScenarioStatus(status: string | undefined): "pass" | "fail" | "skip" {
   return status === "pass" || status === "fail" || status === "skip" ? status : "fail";
@@ -112,10 +174,28 @@ export function computeQaAgenticParityMetrics(
     (scenario) =>
       scenario.status !== "pass" && scenarioHasPattern(scenario, UNINTENDED_STOP_PATTERNS),
   ).length;
-  const fakeSuccessCount = scenarios.filter(
-    (scenario) =>
-      scenario.status === "pass" && scenarioHasPattern(scenario, SUSPICIOUS_PASS_PATTERNS),
-  ).length;
+  const fakeSuccessCount = scenarios.filter((scenario) => {
+    if (scenario.status !== "pass") {
+      return false;
+    }
+    // Failure-tone patterns catch obviously-broken passes regardless of
+    // whether the scenario shows tool-call evidence — "timed out" under a
+    // pass is always fake.
+    if (scenarioHasPattern(scenario, SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS)) {
+      return true;
+    }
+    // Positive-tone patterns only fire when the scenario doesn't also show
+    // real tool-call evidence. A legitimate tool-mediated pass with
+    // self-congratulatory prose stays clean; a prose-only pass with
+    // "Successfully completed the delegation" gets flagged.
+    if (
+      scenarioHasPattern(scenario, SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS) &&
+      scenarioLacksToolCallEvidence(scenario)
+    ) {
+      return true;
+    }
+    return false;
+  }).length;
 
   // First-wave parity scenarios are all tool-mediated tasks, so a passing scenario is our
   // verified unit of valid tool-backed execution in this harness.
@@ -155,7 +235,78 @@ function scopeSummaryToParityPack(
   // scenario list instead of inheriting the caller's full-suite counters.
   return {
     scenarios: summary.scenarios.filter((scenario) => parityTitleSet.has(scenario.name)),
+    ...(summary.run ? { run: summary.run } : {}),
   };
+}
+
+/**
+ * Normalize a provider label into the `provider` half of a `provider/model`
+ * string. Accepts bare provider names (`"openai"`), provider/model tuples
+ * (`"openai/gpt-5.4"`), and colon-separated forms (`"openai:gpt-5.4"`).
+ * Returns the provider portion lowercased so comparisons against the
+ * `run.primaryProvider` field don't get confused by case drift.
+ */
+function extractProviderFromLabel(label: string): string | null {
+  const trimmed = label.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const separatorMatch = /^([^/:]+)[/:]/.exec(trimmed);
+  if (separatorMatch) {
+    return separatorMatch[1]?.toLowerCase() ?? null;
+  }
+  return trimmed.toLowerCase();
+}
+
+/**
+ * Verify the `run.primaryProvider` field on a summary matches the caller-
+ * supplied label. PR L #64789 ships the `run` block; before it lands, older
+ * summaries don't have the field and this check is a no-op.
+ *
+ * Throws `QaParityLabelMismatchError` when the summary reports a different
+ * provider than the caller claimed — this catches the "swapped candidate
+ * and baseline summary paths" footgun the earlier adversarial review
+ * flagged. Returns silently when the field is absent (legacy summaries) or
+ * when the fields match.
+ */
+function verifySummaryLabelMatch(params: {
+  summary: QaParitySuiteSummary;
+  label: string;
+  role: "candidate" | "baseline";
+}): void {
+  const runProvider = params.summary.run?.primaryProvider?.trim();
+  if (!runProvider) {
+    return;
+  }
+  const labelProvider = extractProviderFromLabel(params.label);
+  if (!labelProvider) {
+    return;
+  }
+  if (runProvider.toLowerCase() === labelProvider) {
+    return;
+  }
+  throw new QaParityLabelMismatchError({
+    role: params.role,
+    label: params.label,
+    runProvider,
+  });
+}
+
+export class QaParityLabelMismatchError extends Error {
+  readonly role: "candidate" | "baseline";
+  readonly label: string;
+  readonly runProvider: string;
+
+  constructor(params: { role: "candidate" | "baseline"; label: string; runProvider: string }) {
+    super(
+      `${params.role} summary run.primaryProvider=${params.runProvider} does not match --${params.role}-label=${params.label}. ` +
+        `Check that the --candidate-summary / --baseline-summary paths weren't swapped.`,
+    );
+    this.name = "QaParityLabelMismatchError";
+    this.role = params.role;
+    this.label = params.label;
+    this.runProvider = params.runProvider;
+  }
 }
 
 export function buildQaAgenticParityComparison(params: {
@@ -165,6 +316,22 @@ export function buildQaAgenticParityComparison(params: {
   baselineSummary: QaParitySuiteSummary;
   comparedAt?: string;
 }): QaAgenticParityComparison {
+  // Precondition: verify the `run.primaryProvider` field on each summary
+  // matches the caller-supplied label (when the `run` block is present).
+  // Throws `QaParityLabelMismatchError` on mismatch so the release gate
+  // fails loudly instead of silently producing a reversed verdict when an
+  // operator swaps the --candidate-summary and --baseline-summary paths.
+  // Legacy summaries without a `run` block are accepted as-is.
+  verifySummaryLabelMatch({
+    summary: params.candidateSummary,
+    label: params.candidateLabel,
+    role: "candidate",
+  });
+  verifySummaryLabelMatch({
+    summary: params.baselineSummary,
+    label: params.baselineLabel,
+    role: "baseline",
+  });
   const parityTitleSet: ReadonlySet<string> = new Set<string>(QA_AGENTIC_PARITY_SCENARIO_TITLES);
   // Rates and fake-success counts are computed from the parity-scoped summaries only,
   // so extra non-parity scenarios in the input (for example when a caller feeds a full

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -239,35 +239,47 @@ function scopeSummaryToParityPack(
   };
 }
 
+type StructuredQaParityLabel = {
+  provider: string;
+  model: string;
+};
+
 /**
- * Normalize a provider label into the `provider` half of a `provider/model`
- * string. Accepts bare provider names (`"openai"`), provider/model tuples
- * (`"openai/gpt-5.4"`), and colon-separated forms (`"openai:gpt-5.4"`).
- * Returns the provider portion lowercased so comparisons against the
- * `run.primaryProvider` field don't get confused by case drift.
+ * Only treat caller labels as provenance-checked identifiers when they are
+ * exact lower-case provider/model refs. Human-facing display labels like
+ * "GPT-5.4 candidate" or "Candidate: GPT-5.4" should render in the report
+ * without being misread as structured provider ids.
  */
-function extractProviderFromLabel(label: string): string | null {
+function parseStructuredLabelRef(label: string): StructuredQaParityLabel | null {
   const trimmed = label.trim();
   if (trimmed.length === 0) {
     return null;
   }
-  const separatorMatch = /^([^/:]+)[/:]/.exec(trimmed);
-  if (separatorMatch) {
-    return separatorMatch[1]?.toLowerCase() ?? null;
+  if (trimmed !== trimmed.toLowerCase()) {
+    return null;
   }
-  return null;
+  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._-]*)$/.exec(trimmed);
+  if (!separatorMatch) {
+    return null;
+  }
+  return {
+    provider: separatorMatch[1] ?? "",
+    model: separatorMatch[2] ?? "",
+  };
 }
 
 /**
- * Verify the `run.primaryProvider` field on a summary matches the caller-
- * supplied label. PR L #64789 ships the `run` block; before it lands, older
- * summaries don't have the field and this check is a no-op.
+ * Verify the `run.primaryProvider` + `run.primaryModel` fields on a summary
+ * match the caller-supplied label when that label is a structured
+ * `provider/model` or `provider:model` ref. PR L #64789 ships the `run`
+ * block; before it lands, older summaries don't have the field and this check
+ * is a no-op.
  *
  * Throws `QaParityLabelMismatchError` when the summary reports a different
- * provider than the caller claimed — this catches the "swapped candidate
- * and baseline summary paths" footgun the earlier adversarial review
- * flagged. Returns silently when the field is absent (legacy summaries) or
- * when the fields match.
+ * provider/model than the caller claimed — this catches the "swapped
+ * candidate and baseline summary paths" footgun the earlier adversarial
+ * review flagged. Returns silently when the fields are absent (legacy
+ * summaries) or when the fields match.
  */
 function verifySummaryLabelMatch(params: {
   summary: QaParitySuiteSummary;
@@ -275,20 +287,25 @@ function verifySummaryLabelMatch(params: {
   role: "candidate" | "baseline";
 }): void {
   const runProvider = params.summary.run?.primaryProvider?.trim();
-  if (!runProvider) {
+  const runModel = params.summary.run?.primaryModel?.trim();
+  if (!runProvider || !runModel) {
     return;
   }
-  const labelProvider = extractProviderFromLabel(params.label);
-  if (!labelProvider) {
+  const labelRef = parseStructuredLabelRef(params.label);
+  if (!labelRef) {
     return;
   }
-  if (runProvider.toLowerCase() === labelProvider) {
+  if (
+    runProvider.toLowerCase() === labelRef.provider &&
+    runModel.toLowerCase() === labelRef.model
+  ) {
     return;
   }
   throw new QaParityLabelMismatchError({
     role: params.role,
     label: params.label,
     runProvider,
+    runModel,
   });
 }
 
@@ -296,16 +313,23 @@ export class QaParityLabelMismatchError extends Error {
   readonly role: "candidate" | "baseline";
   readonly label: string;
   readonly runProvider: string;
+  readonly runModel: string;
 
-  constructor(params: { role: "candidate" | "baseline"; label: string; runProvider: string }) {
+  constructor(params: {
+    role: "candidate" | "baseline";
+    label: string;
+    runProvider: string;
+    runModel: string;
+  }) {
     super(
-      `${params.role} summary run.primaryProvider=${params.runProvider} does not match --${params.role}-label=${params.label}. ` +
+      `${params.role} summary run.primaryProvider=${params.runProvider} and run.primaryModel=${params.runModel} do not match --${params.role}-label=${params.label}. ` +
         `Check that the --candidate-summary / --baseline-summary paths weren't swapped.`,
     );
     this.name = "QaParityLabelMismatchError";
     this.role = params.role;
     this.label = params.label;
     this.runProvider = params.runProvider;
+    this.runModel = params.runModel;
   }
 }
 

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -255,7 +255,7 @@ function extractProviderFromLabel(label: string): string | null {
   if (separatorMatch) {
     return separatorMatch[1]?.toLowerCase() ?? null;
   }
-  return trimmed.toLowerCase();
+  return null;
 }
 
 /**

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -1,4 +1,7 @@
-import { QA_AGENTIC_PARITY_SCENARIO_TITLES } from "./agentic-parity.js";
+import {
+  QA_AGENTIC_PARITY_SCENARIO_TITLES,
+  QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES,
+} from "./agentic-parity.js";
 
 export type QaParityReportStep = {
   name: string;
@@ -165,6 +168,7 @@ export function computeQaAgenticParityMetrics(
     ...scenario,
     status: normalizeScenarioStatus(scenario.status),
   }));
+  const toolBackedTitleSet: ReadonlySet<string> = new Set(QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES);
   const totalScenarios = summary.counts?.total ?? scenarios.length;
   const passedScenarios =
     summary.counts?.passed ?? scenarios.filter((scenario) => scenario.status === "pass").length;
@@ -197,11 +201,20 @@ export function computeQaAgenticParityMetrics(
     return false;
   }).length;
 
-  // First-wave parity scenarios are all tool-mediated tasks, so a passing scenario is our
-  // verified unit of valid tool-backed execution in this harness.
-  const validToolCallCount = passedScenarios;
+  // Count only the scenarios that are supposed to exercise a real tool,
+  // subagent, or capability invocation. Memory recall and image-only
+  // understanding lanes stay in the parity pack, but they should not inflate
+  // the tool-call metric just by passing.
+  const toolBackedScenarioCount = scenarios.filter((scenario) =>
+    toolBackedTitleSet.has(scenario.name),
+  ).length;
+  const validToolCallCount = scenarios.filter(
+    (scenario) => toolBackedTitleSet.has(scenario.name) && scenario.status === "pass",
+  ).length;
 
   const rate = (value: number) => (totalScenarios > 0 ? value / totalScenarios : 0);
+  const toolRate = (value: number) =>
+    toolBackedScenarioCount > 0 ? value / toolBackedScenarioCount : 0;
   return {
     totalScenarios,
     passedScenarios,
@@ -210,7 +223,7 @@ export function computeQaAgenticParityMetrics(
     unintendedStopCount,
     unintendedStopRate: rate(unintendedStopCount),
     validToolCallCount,
-    validToolCallRate: rate(validToolCallCount),
+    validToolCallRate: toolRate(validToolCallCount),
     fakeSuccessCount,
   };
 }

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -191,11 +191,13 @@ export function computeQaAgenticParityMetrics(
     if (scenarioHasPattern(scenario, SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS)) {
       return true;
     }
-    // Positive-tone patterns only fire when the scenario doesn't also show
-    // real tool-call evidence. A legitimate tool-mediated pass with
-    // self-congratulatory prose stays clean; a prose-only pass with
-    // "Successfully completed the delegation" gets flagged.
+    // Positive-tone patterns only fire on tool-backed scenarios that
+    // don't also show real tool-call evidence. Non-tool lanes like
+    // memory recall or image understanding can legitimately pass with
+    // short positive prose and should not be treated as fake successes
+    // just because they never emit `plannedToolName=...`.
     if (
+      toolBackedTitleSet.has(scenario.name) &&
       scenarioHasPattern(scenario, SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS) &&
       scenarioLacksToolCallEvidence(scenario)
     ) {
@@ -274,7 +276,7 @@ function parseStructuredLabelRef(label: string): StructuredQaParityLabel | null 
   if (trimmed !== trimmed.toLowerCase()) {
     return null;
   }
-  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._-]*)$/.exec(trimmed);
+  const separatorMatch = /^([a-z0-9][a-z0-9-]*)[/:]([a-z0-9][a-z0-9._/-]*)$/.exec(trimmed);
   if (!separatorMatch) {
     return null;
   }

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -25,6 +25,7 @@ export type QaParityReportScenario = {
 export type QaParityRunBlock = {
   primaryProvider?: string;
   primaryModel?: string;
+  primaryModelName?: string;
   providerMode?: string;
   scenarioIds?: readonly string[] | null;
 };
@@ -111,7 +112,7 @@ const SUSPICIOUS_PASS_FAILURE_TONE_PATTERNS = [
 // to include "successfully" in their details.
 const SUSPICIOUS_PASS_POSITIVE_TONE_PATTERNS = [
   /successfully (?:completed|executed|finished|handled|delegated|ran)/i,
-  /\bdone\.?\s*$/im,
+  /^\s*(?:[-*]\s*)?done\.?\s*$/im,
   /task (?:done|executed|completed|handled|finished) successfully/i,
   /everything (?:worked|ran) (?:as expected|successfully)/i,
   /finished the operation/i,
@@ -168,7 +169,9 @@ export function computeQaAgenticParityMetrics(
     ...scenario,
     status: normalizeScenarioStatus(scenario.status),
   }));
-  const toolBackedTitleSet: ReadonlySet<string> = new Set(QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES);
+  const toolBackedTitleSet: ReadonlySet<string> = new Set(
+    QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES,
+  );
   const totalScenarios = summary.counts?.total ?? scenarios.length;
   const passedScenarios =
     summary.counts?.passed ?? scenarios.filter((scenario) => scenario.status === "pass").length;
@@ -301,6 +304,7 @@ function verifySummaryLabelMatch(params: {
 }): void {
   const runProvider = params.summary.run?.primaryProvider?.trim();
   const runModel = params.summary.run?.primaryModel?.trim();
+  const runModelName = params.summary.run?.primaryModelName?.trim();
   if (!runProvider || !runModel) {
     return;
   }
@@ -308,9 +312,14 @@ function verifySummaryLabelMatch(params: {
   if (!labelRef) {
     return;
   }
+  const normalizedRunModel = runModel.toLowerCase();
+  const normalizedRunModelName = runModelName?.toLowerCase();
+  const normalizedLabelModel = labelRef.model;
   if (
     runProvider.toLowerCase() === labelRef.provider &&
-    runModel.toLowerCase() === labelRef.model
+    (normalizedRunModel === normalizedLabelModel ||
+      normalizedRunModelName === normalizedLabelModel ||
+      normalizedRunModel === `${labelRef.provider}/${normalizedLabelModel}`)
   ) {
     return;
   }

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -204,7 +204,7 @@ export function buildQaAgenticParityComparison(params: {
     });
 
   const failures: string[] = [];
-  const requiredScenarioCoverage = QA_AGENTIC_PARITY_SCENARIO_TITLES.map((name) => {
+  const requiredScenarioStatuses = QA_AGENTIC_PARITY_SCENARIO_TITLES.map((name) => {
     const candidate = candidateByName.get(name);
     const baseline = baselineByName.get(name);
     return {
@@ -212,7 +212,8 @@ export function buildQaAgenticParityComparison(params: {
       candidateStatus: requiredCoverageStatus(candidate),
       baselineStatus: requiredCoverageStatus(baseline),
     };
-  }).filter(
+  });
+  const requiredScenarioCoverage = requiredScenarioStatuses.filter(
     (scenario) =>
       scenario.candidateStatus === "missing" ||
       scenario.baselineStatus === "missing" ||
@@ -222,6 +223,26 @@ export function buildQaAgenticParityComparison(params: {
   for (const scenario of requiredScenarioCoverage) {
     failures.push(
       `Missing required parity scenario coverage for ${scenario.name}: ${params.candidateLabel}=${scenario.candidateStatus}, ${params.baselineLabel}=${scenario.baselineStatus}.`,
+    );
+  }
+  // Required parity scenarios that ran on both sides but FAILED also fail
+  // the gate. Without this check, a run where both models fail the same
+  // required scenarios still produced pass=true, because the downstream
+  // metric comparisons are purely relative (candidate vs baseline) and
+  // the suspicious-pass fake-success check only catches passes that carry
+  // failure-sounding details. Excluding missing/skip here keeps operator
+  // output from double-counting the same scenario with two lines.
+  const requiredScenarioFailures = requiredScenarioStatuses.filter(
+    (scenario) =>
+      scenario.candidateStatus !== "missing" &&
+      scenario.baselineStatus !== "missing" &&
+      scenario.candidateStatus !== "skip" &&
+      scenario.baselineStatus !== "skip" &&
+      (scenario.candidateStatus === "fail" || scenario.baselineStatus === "fail"),
+  );
+  for (const scenario of requiredScenarioFailures) {
+    failures.push(
+      `Required parity scenario ${scenario.name} failed: ${params.candidateLabel}=${scenario.candidateStatus}, ${params.baselineLabel}=${scenario.baselineStatus}.`,
     );
   }
   // Required parity scenarios are already reported via `requiredScenarioCoverage`

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -4,42 +4,52 @@ export const QA_AGENTIC_PARITY_SCENARIOS = [
   {
     id: "approval-turn-tool-followthrough",
     title: "Approval turn tool followthrough",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "model-switch-tool-continuity",
     title: "Model switch with tool continuity",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "source-docs-discovery-report",
     title: "Source and docs discovery report",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "image-understanding-attachment",
     title: "Image understanding from attachment",
+    countsTowardValidToolCallRate: false,
   },
   {
     id: "compaction-retry-mutating-tool",
     title: "Compaction retry after mutating tool",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "subagent-handoff",
     title: "Subagent handoff",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "subagent-fanout-synthesis",
     title: "Subagent fanout synthesis",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "memory-recall",
     title: "Memory recall after context switch",
+    countsTowardValidToolCallRate: false,
   },
   {
     id: "thread-memory-isolation",
     title: "Thread memory isolation",
+    countsTowardValidToolCallRate: true,
   },
   {
     id: "config-restart-capability-flip",
     title: "Config restart capability flip",
+    countsTowardValidToolCallRate: true,
   },
 ] as const;
 
@@ -47,6 +57,9 @@ export const QA_AGENTIC_PARITY_SCENARIO_IDS = QA_AGENTIC_PARITY_SCENARIOS.map(({
 export const QA_AGENTIC_PARITY_SCENARIO_TITLES = QA_AGENTIC_PARITY_SCENARIOS.map(
   ({ title }) => title,
 );
+export const QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES = QA_AGENTIC_PARITY_SCENARIOS.filter(
+  ({ countsTowardValidToolCallRate }) => countsTowardValidToolCallRate,
+).map(({ title }) => title);
 
 export function resolveQaParityPackScenarioIds(params: {
   parityPack?: string;

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -51,6 +51,11 @@ export const QA_AGENTIC_PARITY_SCENARIOS = [
     title: "Config restart capability flip",
     countsTowardValidToolCallRate: true,
   },
+  {
+    id: "instruction-followthrough-repo-contract",
+    title: "Instruction followthrough repo contract",
+    countsTowardValidToolCallRate: true,
+  },
 ] as const;
 
 export const QA_AGENTIC_PARITY_SCENARIO_IDS = QA_AGENTIC_PARITY_SCENARIOS.map(({ id }) => id);

--- a/extensions/qa-lab/src/agentic-parity.ts
+++ b/extensions/qa-lab/src/agentic-parity.ts
@@ -21,6 +21,26 @@ export const QA_AGENTIC_PARITY_SCENARIOS = [
     id: "compaction-retry-mutating-tool",
     title: "Compaction retry after mutating tool",
   },
+  {
+    id: "subagent-handoff",
+    title: "Subagent handoff",
+  },
+  {
+    id: "subagent-fanout-synthesis",
+    title: "Subagent fanout synthesis",
+  },
+  {
+    id: "memory-recall",
+    title: "Memory recall after context switch",
+  },
+  {
+    id: "thread-memory-isolation",
+    title: "Thread memory isolation",
+  },
+  {
+    id: "config-restart-capability-flip",
+    title: "Config restart capability flip",
+  },
 ] as const;
 
 export const QA_AGENTIC_PARITY_SCENARIO_IDS = QA_AGENTIC_PARITY_SCENARIOS.map(({ id }) => id);

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -340,6 +340,7 @@ describe("qa cli runtime", () => {
           "memory-recall",
           "thread-memory-isolation",
           "config-restart-capability-flip",
+          "instruction-followthrough-repo-contract",
         ],
       }),
     );

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -335,6 +335,11 @@ describe("qa cli runtime", () => {
           "source-docs-discovery-report",
           "image-understanding-attachment",
           "compaction-retry-mutating-tool",
+          "subagent-handoff",
+          "subagent-fanout-synthesis",
+          "memory-recall",
+          "thread-memory-isolation",
+          "config-restart-capability-flip",
         ],
       }),
     );

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -64,6 +64,11 @@ describe("buildQaRuntimeEnv", () => {
     expect(env.GEMINI_API_KEY).toBe("gemini-live");
   });
 
+  it("defaults gateway-child provider mode to mock-openai when omitted", () => {
+    expect(__testing.resolveQaGatewayChildProviderMode(undefined)).toBe("mock-openai");
+    expect(__testing.resolveQaGatewayChildProviderMode("live-frontier")).toBe("live-frontier");
+  });
+
   it("keeps explicit provider env vars over live aliases", () => {
     const env = buildQaRuntimeEnv({
       ...createParams({

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -280,6 +280,88 @@ describe("buildQaRuntimeEnv", () => {
     });
   });
 
+  it("stages placeholder mock auth profiles per agent dir so mock-openai runs can resolve credentials", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "qa-mock-auth-"));
+    cleanups.push(async () => {
+      await rm(stateDir, { recursive: true, force: true });
+    });
+
+    const cfg = await __testing.stageQaMockAuthProfiles({
+      cfg: {},
+      stateDir,
+    });
+
+    // Config side: both providers should have a profile entry with mode
+    // "api_key" so the runtime picks up the staging without any further
+    // config mutation.
+    expect(cfg.auth?.profiles?.["qa-mock-openai"]).toMatchObject({
+      provider: "openai",
+      mode: "api_key",
+      displayName: "QA mock openai credential",
+    });
+    expect(cfg.auth?.profiles?.["qa-mock-anthropic"]).toMatchObject({
+      provider: "anthropic",
+      mode: "api_key",
+      displayName: "QA mock anthropic credential",
+    });
+
+    // Store side: each agent dir should have its own auth-profiles.json
+    // containing the placeholder credential for each staged provider. This
+    // is what the scenario runner actually reads when it resolves auth
+    // before calling the mock.
+    for (const agentId of ["main", "qa"]) {
+      const storeRaw = await readFile(
+        path.join(stateDir, "agents", agentId, "agent", "auth-profiles.json"),
+        "utf8",
+      );
+      const parsed = JSON.parse(storeRaw) as {
+        profiles: Record<string, { type: string; provider: string; key: string }>;
+      };
+      expect(parsed.profiles["qa-mock-openai"]).toMatchObject({
+        type: "api_key",
+        provider: "openai",
+        key: "sk-qa-mock",
+      });
+      expect(parsed.profiles["qa-mock-anthropic"]).toMatchObject({
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-qa-mock",
+      });
+    }
+  });
+
+  it("stages mock profiles only for the requested agents and providers when callers override the defaults", async () => {
+    const stateDir = await mkdtemp(path.join(os.tmpdir(), "qa-mock-auth-override-"));
+    cleanups.push(async () => {
+      await rm(stateDir, { recursive: true, force: true });
+    });
+
+    const cfg = await __testing.stageQaMockAuthProfiles({
+      cfg: {},
+      stateDir,
+      agentIds: ["qa"],
+      providers: ["openai"],
+    });
+
+    expect(cfg.auth?.profiles?.["qa-mock-openai"]).toMatchObject({
+      provider: "openai",
+      mode: "api_key",
+    });
+    // Anthropic should NOT be staged when the caller restricts providers.
+    expect(cfg.auth?.profiles?.["qa-mock-anthropic"]).toBeUndefined();
+
+    const qaStore = JSON.parse(
+      await readFile(path.join(stateDir, "agents", "qa", "agent", "auth-profiles.json"), "utf8"),
+    ) as { profiles: Record<string, unknown> };
+    expect(qaStore.profiles["qa-mock-openai"]).toBeDefined();
+    expect(qaStore.profiles["qa-mock-anthropic"]).toBeUndefined();
+
+    // main/agent should not exist because it wasn't in the agentIds list.
+    await expect(
+      readFile(path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"), "utf8"),
+    ).rejects.toThrow(/ENOENT/);
+  });
+
   it("allows loopback gateway health probes through the SSRF guard", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -297,6 +297,69 @@ export async function stageQaLiveAnthropicSetupToken(params: {
   });
 }
 
+/** Providers the mock-openai harness stages placeholder credentials for. */
+export const QA_MOCK_AUTH_PROVIDERS = Object.freeze(["openai", "anthropic"] as const);
+
+/** Agent IDs the mock-openai harness stages credentials under. */
+export const QA_MOCK_AUTH_AGENT_IDS = Object.freeze(["main", "qa"] as const);
+
+export function buildQaMockProfileId(provider: string): string {
+  return `qa-mock-${provider}`;
+}
+
+/**
+ * In mock-openai mode the qa suite runs against the embedded mock server
+ * instead of a real provider API. The mock does not validate credentials, but
+ * the agent auth layer still needs a matching `api_key` auth profile in
+ * `auth-profiles.json` before it will route the request through
+ * `providerBaseUrl`. Without this staging step, every scenario fails with
+ * `FailoverError: No API key found for provider "openai"` before the mock
+ * server ever sees a request.
+ *
+ * Stages a placeholder `api_key` profile per provider in each of the agent
+ * dirs the qa suite uses (`main` for the runtime config, `qa` for scenario
+ * runs) and returns a config with matching `auth.profiles` entries so the
+ * runtime accepts the profile on the first lookup.
+ *
+ * The placeholder value `sk-qa-mock` is intentionally not a real API key
+ * shape. It has to be non-empty to pass the credential serializer; anything
+ * beyond that is ignored by the mock.
+ */
+export async function stageQaMockAuthProfiles(params: {
+  cfg: OpenClawConfig;
+  stateDir: string;
+  agentIds?: readonly string[];
+  providers?: readonly string[];
+}): Promise<OpenClawConfig> {
+  const agentIds = params.agentIds ?? QA_MOCK_AUTH_AGENT_IDS;
+  const providers = params.providers ?? QA_MOCK_AUTH_PROVIDERS;
+  let next = params.cfg;
+  for (const agentId of agentIds) {
+    const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    for (const provider of providers) {
+      const profileId = buildQaMockProfileId(provider);
+      upsertAuthProfile({
+        profileId,
+        credential: {
+          type: "api_key",
+          provider,
+          key: "sk-qa-mock",
+          displayName: `QA mock ${provider} credential`,
+        },
+        agentDir,
+      });
+      next = applyAuthProfileConfig(next, {
+        profileId,
+        provider,
+        mode: "api_key",
+        displayName: `QA mock ${provider} credential`,
+      });
+    }
+  }
+  return next;
+}
+
 function isRetryableGatewayCallError(details: string): boolean {
   return (
     details.includes("handshake timeout") ||
@@ -334,6 +397,7 @@ export const __testing = {
   readQaLiveProviderConfigOverrides,
   resolveQaLiveAnthropicSetupToken,
   stageQaLiveAnthropicSetupToken,
+  stageQaMockAuthProfiles,
   resolveQaLiveCliAuthEnv,
   resolveQaOwnerPluginIdsForProviderIds,
   resolveQaBundledPluginsSourceRoot,
@@ -801,6 +865,17 @@ export async function startQaGatewayChild(params: {
     cfg,
     stateDir,
   });
+  // Mock-openai mode never sees a real API key (the env stripper above
+  // removes every provider credential). Stage a placeholder `api_key`
+  // profile per provider in each agent dir so the auth resolver finds a
+  // match before routing the request through `providerBaseUrl` to the
+  // embedded mock server.
+  if (params.providerMode === "mock-openai") {
+    cfg = await stageQaMockAuthProfiles({
+      cfg,
+      stateDir,
+    });
+  }
   cfg = params.mutateConfig ? params.mutateConfig(cfg) : cfg;
   await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, {
     encoding: "utf8",

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -128,6 +128,12 @@ export function normalizeQaProviderModeEnv(
   return env;
 }
 
+export function resolveQaGatewayChildProviderMode(
+  providerMode?: "mock-openai" | "live-frontier",
+): "mock-openai" | "live-frontier" {
+  return providerMode ?? "mock-openai";
+}
+
 function resolveQaLiveCliAuthEnv(
   baseEnv: NodeJS.ProcessEnv,
   opts?: {
@@ -331,8 +337,8 @@ export async function stageQaMockAuthProfiles(params: {
   agentIds?: readonly string[];
   providers?: readonly string[];
 }): Promise<OpenClawConfig> {
-  const agentIds = params.agentIds ?? QA_MOCK_AUTH_AGENT_IDS;
-  const providers = params.providers ?? QA_MOCK_AUTH_PROVIDERS;
+  const agentIds = [...new Set(params.agentIds ?? QA_MOCK_AUTH_AGENT_IDS)];
+  const providers = [...new Set(params.providers ?? QA_MOCK_AUTH_PROVIDERS)];
   let next = params.cfg;
   for (const agentId of agentIds) {
     const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
@@ -349,13 +355,15 @@ export async function stageQaMockAuthProfiles(params: {
         },
         agentDir,
       });
-      next = applyAuthProfileConfig(next, {
-        profileId,
-        provider,
-        mode: "api_key",
-        displayName: `QA mock ${provider} credential`,
-      });
     }
+  }
+  for (const provider of providers) {
+    next = applyAuthProfileConfig(next, {
+      profileId: buildQaMockProfileId(provider),
+      provider,
+      mode: "api_key",
+      displayName: `QA mock ${provider} credential`,
+    });
   }
   return next;
 }
@@ -395,6 +403,7 @@ export const __testing = {
   fetchLocalGatewayHealth,
   isRetryableGatewayCallError,
   readQaLiveProviderConfigOverrides,
+  resolveQaGatewayChildProviderMode,
   resolveQaLiveAnthropicSetupToken,
   stageQaLiveAnthropicSetupToken,
   stageQaMockAuthProfiles,
@@ -839,6 +848,7 @@ export async function startQaGatewayChild(params: {
           providerConfigs: liveProviderConfigs,
         })
       : undefined;
+  const providerMode = resolveQaGatewayChildProviderMode(params.providerMode);
   let cfg = buildQaGatewayConfig({
     bind: "loopback",
     gatewayPort,
@@ -852,7 +862,7 @@ export async function startQaGatewayChild(params: {
       controlUiEnabled: params.controlUiEnabled,
     }),
     controlUiAllowedOrigins: params.controlUiAllowedOrigins,
-    providerMode: params.providerMode,
+    providerMode,
     primaryModel: params.primaryModel,
     alternateModel: params.alternateModel,
     enabledPluginIds,
@@ -870,7 +880,7 @@ export async function startQaGatewayChild(params: {
   // profile per provider in each agent dir so the auth resolver finds a
   // match before routing the request through `providerBaseUrl` to the
   // embedded mock server.
-  if (params.providerMode === "mock-openai") {
+  if (providerMode === "mock-openai") {
     cfg = await stageQaMockAuthProfiles({
       cfg,
       stateDir,
@@ -917,7 +927,7 @@ export async function startQaGatewayChild(params: {
     xdgCacheHome,
     bundledPluginsDir,
     compatibilityHostVersion: runtimeHostVersion,
-    providerMode: params.providerMode,
+    providerMode,
     forwardHostHomeForClaudeCli: liveProviderIds.includes("claude-cli"),
     claudeCliAuthMode: params.claudeCliAuthMode,
   });

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -1077,4 +1077,95 @@ describe("qa mock openai server", () => {
     expect(textBlock?.text).toContain("Delegated task");
     expect(textBlock?.text).toContain("Evidence");
   });
+
+  it("places tool_result after the parent user message even in mixed-content turns", async () => {
+    // Regression for the loop-6 Copilot / Greptile finding: a user message
+    // that mixes a tool_result block with fresh text blocks must still land
+    // the function_call_output AFTER the parent user message in the
+    // converted ResponsesInputItem[], otherwise extractToolOutput (which
+    // scans AFTER the last user-role index) fails to see the tool output
+    // and the downstream scenario dispatcher behaves as if no tool output
+    // was returned. We verify the conversion directly via the snapshot
+    // that /debug/last-request exposes: the last-request `toolOutput`
+    // field should be the stringified tool_result content, and `prompt`
+    // should be the trailing fresh-text block.
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Delegate one bounded QA task to a subagent.",
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_mock_spawn_mixed",
+                name: "sessions_spawn",
+                input: { task: "Inspect the QA workspace", label: "qa-sidecar", thread: false },
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_mock_spawn_mixed",
+                content: "SUBAGENT-OK",
+              },
+              // A trailing fresh text block in the same user turn. Before
+              // the loop-6 fix, the tool_result was pushed BEFORE the
+              // parent user message, so extractToolOutput saw the text
+              // turn as the last user-role item and found no
+              // function_call_output after it → returned "". The
+              // downstream dispatcher then behaved as if no tool output
+              // was present at all.
+              {
+                type: "text",
+                text: "Keep going with the fanout.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+
+    const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
+    expect(debugResponse.status).toBe(200);
+    const debug = (await debugResponse.json()) as {
+      prompt: string;
+      allInputText: string;
+      toolOutput: string;
+    };
+    // extractToolOutput should surface the tool_result content because
+    // the function_call_output item is placed AFTER the parent user
+    // message in the converted input array.
+    expect(debug.toolOutput).toBe("SUBAGENT-OK");
+    // extractLastUserText should surface the fresh-text block (the parent
+    // user message that was pushed BEFORE the function_call_output).
+    expect(debug.prompt).toBe("Keep going with the fanout.");
+    // The converted history still records both turns, including the
+    // original delegate prompt from the first user turn.
+    expect(debug.allInputText).toContain("Delegate one bounded QA task");
+  });
 });

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { startQaMockOpenAiServer } from "./mock-openai-server.js";
+import { resolveProviderVariant, startQaMockOpenAiServer } from "./mock-openai-server.js";
 
 const cleanups: Array<() => Promise<void>> = [];
 const QA_IMAGE_PNG_BASE64 =
@@ -1245,5 +1245,121 @@ describe("qa mock openai server", () => {
     expect(debugResponse.status).toBe(200);
     const debug = (await debugResponse.json()) as { model: string };
     expect(debug.model).toBe("claude-opus-4-6");
+  });
+});
+
+describe("resolveProviderVariant", () => {
+  it("tags prefix-qualified openai models", () => {
+    expect(resolveProviderVariant("openai/gpt-5.4")).toBe("openai");
+    expect(resolveProviderVariant("openai:gpt-5.4")).toBe("openai");
+    expect(resolveProviderVariant("openai-codex/gpt-5.4")).toBe("openai");
+  });
+
+  it("tags prefix-qualified anthropic models", () => {
+    expect(resolveProviderVariant("anthropic/claude-opus-4-6")).toBe("anthropic");
+    expect(resolveProviderVariant("anthropic:claude-opus-4-6")).toBe("anthropic");
+    expect(resolveProviderVariant("claude-cli/claude-opus-4-6")).toBe("anthropic");
+  });
+
+  it("tags bare model names by prefix", () => {
+    expect(resolveProviderVariant("gpt-5.4")).toBe("openai");
+    expect(resolveProviderVariant("gpt-5.4-alt")).toBe("openai");
+    expect(resolveProviderVariant("gpt-4.5")).toBe("openai");
+    expect(resolveProviderVariant("o1-preview")).toBe("openai");
+    expect(resolveProviderVariant("claude-opus-4-6")).toBe("anthropic");
+    expect(resolveProviderVariant("claude-sonnet-4-6")).toBe("anthropic");
+  });
+
+  it("handles case drift and whitespace", () => {
+    expect(resolveProviderVariant("  OpenAI/GPT-5.4  ")).toBe("openai");
+    expect(resolveProviderVariant("ANTHROPIC/CLAUDE-OPUS-4-6")).toBe("anthropic");
+  });
+
+  it("falls through to unknown for unrecognized providers", () => {
+    expect(resolveProviderVariant("")).toBe("unknown");
+    expect(resolveProviderVariant(undefined)).toBe("unknown");
+    expect(resolveProviderVariant("mistral/mistral-large")).toBe("unknown");
+    expect(resolveProviderVariant("some-random-model")).toBe("unknown");
+  });
+});
+
+describe("qa mock openai server provider variant tagging", () => {
+  it("records providerVariant on /debug/last-request for openai requests", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "openai/gpt-5.4",
+        stream: false,
+        input: [{ role: "user", content: [{ type: "input_text", text: "Heartbeat check" }] }],
+      }),
+    });
+
+    const debug = (await (await fetch(`${server.baseUrl}/debug/last-request`)).json()) as {
+      model: string;
+      providerVariant: string;
+    };
+    expect(debug.model).toBe("openai/gpt-5.4");
+    expect(debug.providerVariant).toBe("openai");
+  });
+
+  it("records providerVariant=anthropic on /v1/messages requests", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        messages: [{ role: "user", content: "Heartbeat check" }],
+      }),
+    });
+
+    const debug = (await (await fetch(`${server.baseUrl}/debug/last-request`)).json()) as {
+      model: string;
+      providerVariant: string;
+    };
+    expect(debug.model).toBe("claude-opus-4-6");
+    expect(debug.providerVariant).toBe("anthropic");
+  });
+
+  it("records providerVariant=unknown for unrecognized models", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mistral/mistral-large",
+        stream: false,
+        input: [{ role: "user", content: [{ type: "input_text", text: "Heartbeat check" }] }],
+      }),
+    });
+
+    const debug = (await (await fetch(`${server.baseUrl}/debug/last-request`)).json()) as {
+      providerVariant: string;
+    };
+    expect(debug.providerVariant).toBe("unknown");
   });
 });

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -169,6 +169,42 @@ describe("qa mock openai server", () => {
     ]);
   });
 
+  it("keeps remember prompts prose-only even when they mention repo cleanup", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: true,
+        model: "gpt-5.4",
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Remembered ALPHA-7.");
+    expect(body).not.toContain('"name":"read"');
+  });
+
   it("drives the compaction retry mutating tool parity flow", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",
@@ -1169,13 +1205,7 @@ describe("qa mock openai server", () => {
     expect(debug.allInputText).toContain("Delegate one bounded QA task");
   });
 
-  it("rejects Anthropic /v1/messages streaming requests with a 400", async () => {
-    // Regression for the loop-7 Copilot finding: the /v1/messages handler
-    // used to ignore `body.stream: true` and silently return a
-    // non-streaming JSON response. That masks a real caller bug because
-    // the runner expects either an SSE stream or an explicit error.
-    // The mock should now return an Anthropic-shaped 400 so the failure
-    // mode is visible.
+  it("streams Anthropic /v1/messages tool_use responses as SSE", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",
       port: 0,
@@ -1194,19 +1224,85 @@ describe("qa mock openai server", () => {
         messages: [
           {
             role: "user",
-            content: "Read the plan",
+            content: [
+              {
+                type: "text",
+                text: "Read the seeded docs and report worked, failed, blocked, and follow-up items.",
+              },
+            ],
           },
         ],
       }),
     });
-    expect(response.status).toBe(400);
-    const body = (await response.json()) as {
-      type: string;
-      error: { type: string; message: string };
-    };
-    expect(body.type).toBe("error");
-    expect(body.error.type).toBe("invalid_request_error");
-    expect(body.error.message).toContain("streaming is not supported");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    const body = await response.text();
+    expect(body).toContain("event: message_start");
+    expect(body).toContain("event: content_block_start");
+    expect(body).toContain('"type":"tool_use"');
+    expect(body).toContain('"name":"read"');
+    expect(body).toContain("QA_SCENARIO_PLAN.md");
+    expect(body).toContain("event: message_delta");
+    expect(body).toContain("event: message_stop");
+  });
+
+  it("streams Anthropic /v1/messages tool_result follow-ups as text deltas", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        stream: true,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Delegate one bounded QA task to a subagent, wait for it to finish, then reply with Delegated task, Result, and Evidence sections.",
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_mock_spawn_1",
+                name: "sessions_spawn",
+                input: { task: "Inspect the QA workspace", label: "qa-sidecar", thread: false },
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_mock_spawn_1",
+                content: "SUBAGENT-OK",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    const body = await response.text();
+    expect(body).toContain("event: content_block_delta");
+    expect(body).toContain('"type":"text_delta"');
+    expect(body).toContain("Delegated task");
+    expect(body).toContain("Evidence");
   });
 
   it("rejects malformed Anthropic /v1/messages JSON with an invalid_request_error", async () => {
@@ -1386,5 +1482,96 @@ describe("qa mock openai server provider variant tagging", () => {
       providerVariant: string;
     };
     expect(debug.providerVariant).toBe("unknown");
+  });
+});
+
+describe("Anthropic exact-reply precedence", () => {
+  it("keeps Anthropic remember prompts on the prose branch even when system text mentions HEARTBEAT", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        stream: true,
+        system: [
+          {
+            type: "text",
+            text: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
+          },
+        ],
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Remembered ALPHA-7.");
+    expect(body).not.toContain("HEARTBEAT_OK");
+    expect(body).not.toContain('"name":"read"');
+  });
+
+  it("prefers the prompt-local exact reply directive over heartbeat context", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        stream: true,
+        system: [
+          {
+            type: "text",
+            text: [
+              "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
+              "If the current user message is a heartbeat poll and nothing needs attention, reply exactly:",
+              "HEARTBEAT_OK",
+            ].join("\n"),
+          },
+        ],
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Remembered ALPHA-7.");
+    expect(body).not.toContain("HEARTBEAT_OK");
   });
 });

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -1168,4 +1168,82 @@ describe("qa mock openai server", () => {
     // original delegate prompt from the first user turn.
     expect(debug.allInputText).toContain("Delegate one bounded QA task");
   });
+
+  it("rejects Anthropic /v1/messages streaming requests with a 400", async () => {
+    // Regression for the loop-7 Copilot finding: the /v1/messages handler
+    // used to ignore `body.stream: true` and silently return a
+    // non-streaming JSON response. That masks a real caller bug because
+    // the runner expects either an SSE stream or an explicit error.
+    // The mock should now return an Anthropic-shaped 400 so the failure
+    // mode is visible.
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        stream: true,
+        messages: [
+          {
+            role: "user",
+            content: "Read the plan",
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      type: string;
+      error: { type: string; message: string };
+    };
+    expect(body.type).toBe("error");
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("streaming is not supported");
+  });
+
+  it("defaults empty-string Anthropic /v1/messages model to claude-opus-4-6", async () => {
+    // Regression for the loop-7 Copilot finding: a bare `typeof
+    // body.model === "string"` check lets an empty-string model leak
+    // through to `lastRequest.model` and `responseBody.model`. Empty
+    // strings must be treated the same as absent and default to
+    // `"claude-opus-4-6"` so parity consumers can trust the echoed label.
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "",
+        max_tokens: 256,
+        messages: [
+          {
+            role: "user",
+            content: "Read the plan",
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { model: string };
+    expect(body.model).toBe("claude-opus-4-6");
+
+    const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
+    expect(debugResponse.status).toBe(200);
+    const debug = (await debugResponse.json()) as { model: string };
+    expect(debug.model).toBe("claude-opus-4-6");
+  });
 });

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -11,42 +11,15 @@ afterEach(async () => {
   }
 });
 
-async function startMockServer() {
-  const server = await startQaMockOpenAiServer({
-    host: "127.0.0.1",
-    port: 0,
-  });
-  cleanups.push(async () => {
-    await server.stop();
-  });
-  return server;
-}
-
-async function postResponses(server: { baseUrl: string }, body: unknown) {
-  return fetch(`${server.baseUrl}/v1/responses`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-}
-
-async function expectResponsesText(server: { baseUrl: string }, body: unknown) {
-  const response = await postResponses(server, body);
-  expect(response.status).toBe(200);
-  return response.text();
-}
-
-async function expectResponsesJson<T>(server: { baseUrl: string }, body: unknown) {
-  const response = await postResponses(server, body);
-  expect(response.status).toBe(200);
-  return (await response.json()) as T;
-}
-
 describe("qa mock openai server", () => {
   it("serves health and streamed responses", async () => {
-    const server = await startMockServer();
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
 
     const health = await fetch(`${server.baseUrl}/healthz`);
     expect(health.status).toBe(200);
@@ -75,22 +48,36 @@ describe("qa mock openai server", () => {
   });
 
   it("prefers path-like refs over generic quoted keys in prompts", async () => {
-    const server = await startMockServer();
-
-    const body = await expectResponsesText(server, {
-      stream: true,
-      input: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: 'Please inspect "message_id" metadata first, then read `./QA_KICKOFF_TASK.md`.',
-            },
-          ],
-        },
-      ],
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
     });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: true,
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: 'Please inspect "message_id" metadata first, then read `./QA_KICKOFF_TASK.md`.',
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.text();
     expect(body).toContain('"arguments":"{\\"path\\":\\"QA_KICKOFF_TASK.md\\"}"');
 
     const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
@@ -103,7 +90,13 @@ describe("qa mock openai server", () => {
   });
 
   it("drives the Lobster Invaders write flow and memory recall responses", async () => {
-    const server = await startMockServer();
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
 
     const lobster = await fetch(`${server.baseUrl}/v1/responses`, {
       method: "POST",
@@ -132,32 +125,40 @@ describe("qa mock openai server", () => {
     expect(lobsterBody).toContain('"name":"write"');
     expect(lobsterBody).toContain("lobster-invaders.html");
 
-    const payload = await expectResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      stream: false,
-      model: "gpt-5.4-alt",
-      input: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "Please remember this fact for later: the QA canary code is ALPHA-7.",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "What was the QA canary code I asked you to remember earlier?",
-            },
-          ],
-        },
-      ],
+    const recall = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: false,
+        model: "gpt-5.4-alt",
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Please remember this fact for later: the QA canary code is ALPHA-7.",
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "What was the QA canary code I asked you to remember earlier?",
+              },
+            ],
+          },
+        ],
+      }),
     });
+    expect(recall.status).toBe(200);
+    const payload = (await recall.json()) as {
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    };
     expect(payload.output?.[0]?.content?.[0]?.text).toContain("ALPHA-7");
 
     const requests = await fetch(`${server.baseUrl}/debug/requests`);
@@ -204,8 +205,121 @@ describe("qa mock openai server", () => {
     expect(body).not.toContain('"name":"read"');
   });
 
+  it("drives repo-contract followthrough as read-read-read-write-then-report", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const prompt =
+      "Repo contract followthrough check. Read AGENT.md, SOUL.md, and FOLLOWTHROUGH_INPUT.md first. Then follow the repo contract exactly, write ./repo-contract-summary.txt, and reply with three labeled lines: Read, Wrote, Status.";
+
+    const first = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stream: true,
+        model: "gpt-5.4",
+        input: [{ role: "user", content: [{ type: "input_text", text: prompt }] }],
+      }),
+    });
+    expect(first.status).toBe(200);
+    expect(await first.text()).toContain('"arguments":"{\\"path\\":\\"AGENT.md\\"}"');
+
+    const second = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stream: true,
+        model: "gpt-5.4",
+        input: [
+          { role: "user", content: [{ type: "input_text", text: prompt }] },
+          {
+            type: "function_call_output",
+            output:
+              "# Repo contract\n\nStep order:\n1. Read AGENT.md.\n2. Read SOUL.md.\n3. Read FOLLOWTHROUGH_INPUT.md.\n4. Write ./repo-contract-summary.txt.\n",
+          },
+        ],
+      }),
+    });
+    expect(second.status).toBe(200);
+    expect(await second.text()).toContain('"arguments":"{\\"path\\":\\"SOUL.md\\"}"');
+
+    const third = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stream: true,
+        model: "gpt-5.4",
+        input: [
+          { role: "user", content: [{ type: "input_text", text: prompt }] },
+          {
+            type: "function_call_output",
+            output: "# Execution style\n\nStay brief, honest, and action-first.\n",
+          },
+        ],
+      }),
+    });
+    expect(third.status).toBe(200);
+    expect(await third.text()).toContain('"arguments":"{\\"path\\":\\"FOLLOWTHROUGH_INPUT.md\\"}"');
+
+    const fourth = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stream: true,
+        model: "gpt-5.4",
+        input: [
+          { role: "user", content: [{ type: "input_text", text: prompt }] },
+          {
+            type: "function_call_output",
+            output:
+              "Mission: prove you followed the repo contract.\nEvidence path: AGENT.md -> SOUL.md -> FOLLOWTHROUGH_INPUT.md -> repo-contract-summary.txt\n",
+          },
+        ],
+      }),
+    });
+    expect(fourth.status).toBe(200);
+    const fourthBody = await fourth.text();
+    expect(fourthBody).toContain('"name":"write"');
+    expect(fourthBody).toContain("repo-contract-summary.txt");
+
+    const fifth = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stream: false,
+        model: "gpt-5.4",
+        input: [
+          { role: "user", content: [{ type: "input_text", text: prompt }] },
+          {
+            type: "function_call_output",
+            output:
+              "Successfully wrote repo-contract-summary.txt\nMission: prove you followed the repo contract.\nStatus: complete\n",
+          },
+        ],
+      }),
+    });
+    expect(fifth.status).toBe(200);
+    const payload = (await fifth.json()) as {
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    };
+    expect(payload.output?.[0]?.content?.[0]?.text).toContain("Read: AGENT.md, SOUL.md");
+    expect(payload.output?.[0]?.content?.[0]?.text).toContain("Wrote: repo-contract-summary.txt");
+    expect(payload.output?.[0]?.content?.[0]?.text).toContain("Status: complete");
+  });
+
   it("drives the compaction retry mutating tool parity flow", async () => {
-    const server = await startMockServer();
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
 
     const writePlan = await fetch(`${server.baseUrl}/v1/responses`, {
       method: "POST",
@@ -237,27 +351,35 @@ describe("qa mock openai server", () => {
     expect(writePlanBody).toContain('"name":"write"');
     expect(writePlanBody).toContain("compaction-retry-summary.txt");
 
-    const finalPayload = await expectResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      stream: false,
-      model: "gpt-5.4",
-      input: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.",
-            },
-          ],
-        },
-        {
-          type: "function_call_output",
-          output: "Successfully wrote 41 bytes to compaction-retry-summary.txt.",
-        },
-      ],
+    const finalReply = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: false,
+        model: "gpt-5.4",
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.",
+              },
+            ],
+          },
+          {
+            type: "function_call_output",
+            output: "Successfully wrote 41 bytes to compaction-retry-summary.txt.",
+          },
+        ],
+      }),
     });
+    expect(finalReply.status).toBe(200);
+    const finalPayload = (await finalReply.json()) as {
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    };
     expect(finalPayload.output?.[0]?.content?.[0]?.text).toContain("replay unsafe after write");
   });
 
@@ -318,22 +440,36 @@ describe("qa mock openai server", () => {
   });
 
   it("requests non-threaded subagent handoff for QA channel runs", async () => {
-    const server = await startMockServer();
-
-    const body = await expectResponsesText(server, {
-      stream: true,
-      input: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "Delegate a bounded QA task to a subagent, then summarize the delegated result clearly.",
-            },
-          ],
-        },
-      ],
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
     });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: true,
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Delegate a bounded QA task to a subagent, then summarize the delegated result clearly.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.text();
     expect(body).toContain('"name":"sessions_spawn"');
     expect(body).toContain('\\"label\\":\\"qa-sidecar\\"');
     expect(body).toContain('\\"thread\\":false');
@@ -564,10 +700,20 @@ describe("qa mock openai server", () => {
   });
 
   it("answers heartbeat prompts without spawning extra subagents", async () => {
-    const server = await startMockServer();
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
 
-    expect(
-      await expectResponsesJson(server, {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
         stream: false,
         input: [
           {
@@ -581,7 +727,10 @@ describe("qa mock openai server", () => {
           },
         ],
       }),
-    ).toMatchObject({
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
       output: [
         {
           content: [{ text: "HEARTBEAT_OK" }],
@@ -659,10 +808,20 @@ describe("qa mock openai server", () => {
   });
 
   it("uses the latest exact marker directive from conversation history", async () => {
-    const server = await startMockServer();
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
 
-    expect(
-      await expectResponsesJson(server, {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
         stream: false,
         input: [
           {
@@ -685,7 +844,10 @@ describe("qa mock openai server", () => {
           },
         ],
       }),
-    ).toMatchObject({
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
       output: [
         {
           content: [{ text: "NEW_TOKEN" }],
@@ -745,33 +907,45 @@ describe("qa mock openai server", () => {
   });
 
   it("describes reattached generated images in the roundtrip flow", async () => {
-    const server = await startMockServer();
-
-    const payload = await expectResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      stream: false,
-      model: "mock-openai/gpt-5.4",
-      input: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "Roundtrip image inspection check: describe the generated lighthouse attachment in one short sentence.",
-            },
-            {
-              type: "input_image",
-              source: {
-                type: "base64",
-                mime_type: "image/png",
-                data: QA_IMAGE_PNG_BASE64,
-              },
-            },
-          ],
-        },
-      ],
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
     });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stream: false,
+        model: "mock-openai/gpt-5.4",
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Roundtrip image inspection check: describe the generated lighthouse attachment in one short sentence.",
+              },
+              {
+                type: "input_image",
+                source: {
+                  type: "base64",
+                  mime_type: "image/png",
+                  data: QA_IMAGE_PNG_BASE64,
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    };
     const text = payload.output?.[0]?.content?.[0]?.text ?? "";
     expect(text.toLowerCase()).toContain("lighthouse");
   });
@@ -818,10 +992,20 @@ describe("qa mock openai server", () => {
   });
 
   it("returns continuity language after the model-switch reread completes", async () => {
-    const server = await startMockServer();
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
 
-    expect(
-      await expectResponsesJson(server, {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
         stream: false,
         model: "gpt-5.4-alt",
         input: [
@@ -840,7 +1024,10 @@ describe("qa mock openai server", () => {
           },
         ],
       }),
-    ).toMatchObject({
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
       output: [
         {
           content: [
@@ -854,10 +1041,20 @@ describe("qa mock openai server", () => {
   });
 
   it("returns NO_REPLY for unmentioned group chatter", async () => {
-    const server = await startMockServer();
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
 
-    expect(
-      await expectResponsesJson(server, {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
         stream: false,
         input: [
           {
@@ -871,7 +1068,9 @@ describe("qa mock openai server", () => {
           },
         ],
       }),
-    ).toMatchObject({
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
       output: [
         {
           content: [{ text: "NO_REPLY" }],
@@ -1213,6 +1412,95 @@ describe("qa mock openai server", () => {
     expect(body).toContain("Evidence");
   });
 
+  it("keeps Anthropic remember prompts on the prose branch even when system text mentions HEARTBEAT", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        stream: true,
+        system: [
+          {
+            type: "text",
+            text: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
+          },
+        ],
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Remembered ALPHA-7.");
+    expect(body).not.toContain("HEARTBEAT_OK");
+    expect(body).not.toContain('"name":"read"');
+  });
+
+  it("prefers the prompt-local exact reply directive over heartbeat context", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        stream: true,
+        system: [
+          {
+            type: "text",
+            text: [
+              "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
+              "If the current user message is a heartbeat poll and nothing needs attention, reply exactly:",
+              "HEARTBEAT_OK",
+            ].join("\n"),
+          },
+        ],
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Remembered ALPHA-7.");
+    expect(body).not.toContain("HEARTBEAT_OK");
+  });
+
   it("rejects malformed Anthropic /v1/messages JSON with an invalid_request_error", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",
@@ -1390,96 +1678,5 @@ describe("qa mock openai server provider variant tagging", () => {
       providerVariant: string;
     };
     expect(debug.providerVariant).toBe("unknown");
-  });
-});
-
-describe("Anthropic exact-reply precedence", () => {
-  it("keeps Anthropic remember prompts on the prose branch even when system text mentions HEARTBEAT", async () => {
-    const server = await startQaMockOpenAiServer({
-      host: "127.0.0.1",
-      port: 0,
-    });
-    cleanups.push(async () => {
-      await server.stop();
-    });
-
-    const response = await fetch(`${server.baseUrl}/v1/messages`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        model: "claude-opus-4-6",
-        max_tokens: 256,
-        stream: true,
-        system: [
-          {
-            type: "text",
-            text: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
-          },
-        ],
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored.",
-              },
-            ],
-          },
-        ],
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    const body = await response.text();
-    expect(body).toContain("Remembered ALPHA-7.");
-    expect(body).not.toContain("HEARTBEAT_OK");
-    expect(body).not.toContain('"name":"read"');
-  });
-
-  it("prefers the prompt-local exact reply directive over heartbeat context", async () => {
-    const server = await startQaMockOpenAiServer({
-      host: "127.0.0.1",
-      port: 0,
-    });
-    cleanups.push(async () => {
-      await server.stop();
-    });
-
-    const response = await fetch(`${server.baseUrl}/v1/messages`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        model: "claude-opus-4-6",
-        max_tokens: 256,
-        stream: true,
-        system: [
-          {
-            type: "text",
-            text: [
-              "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
-              "If the current user message is a heartbeat poll and nothing needs attention, reply exactly:",
-              "HEARTBEAT_OK",
-            ].join("\n"),
-          },
-        ],
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored.",
-              },
-            ],
-          },
-        ],
-      }),
-    });
-
-    expect(response.status).toBe(200);
-    const body = await response.text();
-    expect(body).toContain("Remembered ALPHA-7.");
-    expect(body).not.toContain("HEARTBEAT_OK");
   });
 });

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -935,4 +935,146 @@ describe("qa mock openai server", () => {
       ],
     });
   });
+
+  it("advertises Anthropic claude-opus-4-6 baseline model on /v1/models", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/models`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: Array<{ id: string }> };
+    const ids = body.data.map((entry) => entry.id);
+    expect(ids).toContain("claude-opus-4-6");
+    expect(ids).toContain("gpt-5.4");
+  });
+
+  it("dispatches an Anthropic /v1/messages read tool call for source discovery prompts", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Read the seeded docs and report worked, failed, blocked, and follow-up items.",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      type: string;
+      role: string;
+      model: string;
+      stop_reason: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(body.type).toBe("message");
+    expect(body.role).toBe("assistant");
+    expect(body.model).toBe("claude-opus-4-6");
+    expect(body.stop_reason).toBe("tool_use");
+    const toolUseBlock = body.content.find((block) => block.type === "tool_use") as
+      | { name: string; input: Record<string, unknown> }
+      | undefined;
+    expect(toolUseBlock?.name).toBe("read");
+    expect(toolUseBlock?.input).toEqual({ path: "QA_SCENARIO_PLAN.md" });
+
+    const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
+    expect(debugResponse.status).toBe(200);
+    expect(await debugResponse.json()).toMatchObject({
+      model: "claude-opus-4-6",
+      plannedToolName: "read",
+    });
+  });
+
+  it("dispatches Anthropic /v1/messages tool_result follow-ups through the shared scenario logic", async () => {
+    // This verifies the Anthropic adapter correctly feeds tool_result
+    // content blocks into the shared scenario dispatcher so downstream
+    // "has this scenario already called a tool?" logic fires the same way
+    // it does on the OpenAI /v1/responses route. The subagent handoff
+    // scenario is ideal because the mock has a two-stage flow: first
+    // delegate prompt → sessions_spawn tool_use, then tool_result →
+    // "Delegated task: ..." prose summary.
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 256,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Delegate one bounded QA task to a subagent, wait for it to finish, then reply with Delegated task, Result, and Evidence sections.",
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_mock_spawn_1",
+                name: "sessions_spawn",
+                input: { task: "Inspect the QA workspace", label: "qa-sidecar", thread: false },
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_mock_spawn_1",
+                content: "SUBAGENT-OK",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      stop_reason: string;
+      content: Array<{ type: string; text?: string }>;
+    };
+    expect(body.stop_reason).toBe("end_turn");
+    const textBlock = body.content.find((block) => block.type === "text") as
+      | { text: string }
+      | undefined;
+    // The mock's subagent-handoff branch echoes "Delegated task", a
+    // tool-output evidence line, and a folded-back "Evidence" marker.
+    expect(textBlock?.text).toContain("Delegated task");
+    expect(textBlock?.text).toContain("Evidence");
+  });
 });

--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -1209,6 +1209,31 @@ describe("qa mock openai server", () => {
     expect(body.error.message).toContain("streaming is not supported");
   });
 
+  it("rejects malformed Anthropic /v1/messages JSON with an invalid_request_error", async () => {
+    const server = await startQaMockOpenAiServer({
+      host: "127.0.0.1",
+      port: 0,
+    });
+    cleanups.push(async () => {
+      await server.stop();
+    });
+
+    const response = await fetch(`${server.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"model":"claude-opus-4-6","messages":[',
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      type: string;
+      error: { type: string; message: string };
+    };
+    expect(body.type).toBe("error");
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("Malformed JSON body");
+  });
+
   it("defaults empty-string Anthropic /v1/messages model to claude-opus-4-6", async () => {
     // Regression for the loop-7 Copilot finding: a bare `typeof
     // body.model === "string"` check lets an empty-string model leak

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -33,6 +33,41 @@ type MockOpenAiRequestSnapshot = {
   plannedToolName?: string;
 };
 
+// Anthropic /v1/messages request/response shapes the mock actually needs.
+// This is a subset of the real Anthropic Messages API — just enough so the
+// QA suite can run its parity pack against a "baseline" Anthropic provider
+// without needing real API keys. The scenarios drive their dispatch through
+// the shared mock scenario logic (buildResponsesPayload), so whatever
+// behavior the OpenAI mock exposes is automatically mirrored on this route.
+type AnthropicMessageContentBlock =
+  | { type: "text"; text: string }
+  | {
+      type: "tool_use";
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+    }
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content: string | Array<{ type: "text"; text: string }>;
+    }
+  | { type: "image"; source: Record<string, unknown> };
+
+type AnthropicMessage = {
+  role: "user" | "assistant";
+  content: string | AnthropicMessageContentBlock[];
+};
+
+type AnthropicMessagesRequest = {
+  model?: string;
+  max_tokens?: number;
+  system?: string | Array<{ type: "text"; text: string }>;
+  messages?: AnthropicMessage[];
+  tools?: Array<Record<string, unknown>>;
+  stream?: boolean;
+};
+
 const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0nQAAAAASUVORK5CYII=";
 let subagentFanoutPhase = 0;
@@ -715,6 +750,252 @@ async function buildResponsesPayload(body: Record<string, unknown>) {
   return buildAssistantEvents(buildAssistantText(input, body));
 }
 
+// ---------------------------------------------------------------------------
+// Anthropic /v1/messages adapter
+// ---------------------------------------------------------------------------
+//
+// The QA parity gate needs two comparable scenario runs: one against the
+// "candidate" (openai/gpt-5.4) and one against the "baseline"
+// (anthropic/claude-opus-4-6). The OpenAI mock above already dispatches all
+// the scenario prompt branches we care about. Rather than duplicating that
+// machinery, the /v1/messages route below translates Anthropic request
+// shapes into the shared ResponsesInputItem[] format, calls the same
+// buildResponsesPayload() dispatcher, and then re-serializes the resulting
+// events into an Anthropic response. This gives the parity harness a
+// baseline lane that exercises the same scenario logic without requiring
+// real Anthropic API keys.
+//
+// Scope: handles non-streaming Anthropic Messages requests with text and
+// tool_result content blocks, which is what the QA suite runner actually
+// sends. Streaming is intentionally out of scope for this mock because the
+// suite runner supports non-streaming fallback.
+
+function normalizeAnthropicSystemToString(
+  system: AnthropicMessagesRequest["system"],
+): string | undefined {
+  if (typeof system === "string") {
+    return system.trim() || undefined;
+  }
+  if (Array.isArray(system)) {
+    const joined = system
+      .map((block) => (block?.type === "text" ? block.text : ""))
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    return joined || undefined;
+  }
+  return undefined;
+}
+
+function stringifyToolResultContent(
+  content: Extract<AnthropicMessageContentBlock, { type: "tool_result" }>["content"],
+): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => (block?.type === "text" ? block.text : ""))
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+function convertAnthropicMessagesToResponsesInput(params: {
+  system?: AnthropicMessagesRequest["system"];
+  messages: AnthropicMessage[];
+}): ResponsesInputItem[] {
+  const items: ResponsesInputItem[] = [];
+  const systemText = normalizeAnthropicSystemToString(params.system);
+  if (systemText) {
+    items.push({
+      role: "system",
+      content: [{ type: "input_text", text: systemText }],
+    });
+  }
+  for (const message of params.messages) {
+    const content = message.content;
+    if (typeof content === "string") {
+      items.push({
+        role: message.role,
+        content: [
+          message.role === "assistant"
+            ? { type: "output_text", text: content }
+            : { type: "input_text", text: content },
+        ],
+      });
+      continue;
+    }
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    const textPieces: Array<{ type: "input_text" | "output_text"; text: string }> = [];
+    const imagePieces: Array<{ type: "input_image"; image_url: string }> = [];
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      if (block.type === "text") {
+        textPieces.push({
+          type: message.role === "assistant" ? "output_text" : "input_text",
+          text: block.text ?? "",
+        });
+        continue;
+      }
+      if (block.type === "image") {
+        // Mock only needs to count image inputs; a placeholder URL is fine.
+        imagePieces.push({ type: "input_image", image_url: "anthropic-mock:image" });
+        continue;
+      }
+      if (block.type === "tool_result") {
+        const output = stringifyToolResultContent(block.content);
+        if (output.trim()) {
+          items.push({ type: "function_call_output", output });
+        }
+        continue;
+      }
+      if (block.type === "tool_use") {
+        // Mirror OpenAI's function_call output_item shape so downstream
+        // prompt extraction still sees "the assistant just emitted a tool
+        // call". The scenario dispatcher looks for tool_output on the next
+        // user turn, not the assistant's prior tool_use, so a minimal
+        // placeholder is enough.
+        items.push({
+          type: "function_call",
+          name: block.name,
+          arguments: JSON.stringify(block.input ?? {}),
+          call_id: block.id,
+        });
+        continue;
+      }
+    }
+    if (textPieces.length > 0 || imagePieces.length > 0) {
+      const combinedContent: Array<Record<string, unknown>> = [...textPieces, ...imagePieces];
+      items.push({ role: message.role, content: combinedContent });
+    }
+  }
+  return items;
+}
+
+type ExtractedAssistantOutput = {
+  text: string;
+  toolCalls: Array<{ id: string; name: string; input: Record<string, unknown> }>;
+};
+
+function extractFinalAssistantOutputFromEvents(events: StreamEvent[]): ExtractedAssistantOutput {
+  const toolCalls: ExtractedAssistantOutput["toolCalls"] = [];
+  let text = "";
+  for (const event of events) {
+    if (event.type !== "response.output_item.done") {
+      continue;
+    }
+    const item = event.item as {
+      type?: unknown;
+      name?: unknown;
+      call_id?: unknown;
+      id?: unknown;
+      arguments?: unknown;
+      content?: unknown;
+    };
+    if (item.type === "function_call" && typeof item.name === "string") {
+      let input: Record<string, unknown> = {};
+      if (typeof item.arguments === "string" && item.arguments.trim()) {
+        try {
+          const parsed = JSON.parse(item.arguments) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            input = parsed as Record<string, unknown>;
+          }
+        } catch {
+          // keep empty input on malformed args — mock dispatcher owns arg shape
+        }
+      }
+      toolCalls.push({
+        id: typeof item.call_id === "string" ? item.call_id : `toolu_mock_${toolCalls.length + 1}`,
+        name: item.name,
+        input,
+      });
+      continue;
+    }
+    if (item.type === "message" && Array.isArray(item.content)) {
+      for (const piece of item.content as Array<{ type?: unknown; text?: unknown }>) {
+        if (piece?.type === "output_text" && typeof piece.text === "string") {
+          text = piece.text;
+        }
+      }
+    }
+  }
+  return { text, toolCalls };
+}
+
+function buildAnthropicMessageResponse(params: {
+  model: string;
+  extracted: ExtractedAssistantOutput;
+}): Record<string, unknown> {
+  const content: Array<Record<string, unknown>> = [];
+  if (params.extracted.text) {
+    content.push({ type: "text", text: params.extracted.text });
+  }
+  for (const call of params.extracted.toolCalls) {
+    content.push({
+      type: "tool_use",
+      id: call.id,
+      name: call.name,
+      input: call.input,
+    });
+  }
+  if (content.length === 0) {
+    content.push({ type: "text", text: "" });
+  }
+  const stopReason = params.extracted.toolCalls.length > 0 ? "tool_use" : "end_turn";
+  const approxInputTokens = 64;
+  const approxOutputTokens = Math.max(
+    16,
+    countApproxTokens(params.extracted.text) + params.extracted.toolCalls.length * 16,
+  );
+  return {
+    id: `msg_mock_${Math.floor(Math.random() * 1_000_000).toString(16)}`,
+    type: "message",
+    role: "assistant",
+    model: params.model || "claude-opus-4-6",
+    content,
+    stop_reason: stopReason,
+    stop_sequence: null,
+    usage: {
+      input_tokens: approxInputTokens,
+      output_tokens: approxOutputTokens,
+    },
+  };
+}
+
+async function buildMessagesPayload(body: AnthropicMessagesRequest): Promise<{
+  events: StreamEvent[];
+  input: ResponsesInputItem[];
+  extracted: ExtractedAssistantOutput;
+  responseBody: Record<string, unknown>;
+}> {
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  const input = convertAnthropicMessagesToResponsesInput({
+    system: body.system,
+    messages,
+  });
+  // Dispatch through the same scenario logic the /v1/responses route uses.
+  // The mock dispatcher only reads `body.input`, `body.model`, and
+  // `body.stream`, so a synthetic shim body is sufficient.
+  const dispatchBody: Record<string, unknown> = {
+    input,
+    model: typeof body.model === "string" ? body.model : "claude-opus-4-6",
+    stream: false,
+  };
+  const events = await buildResponsesPayload(dispatchBody);
+  const extracted = extractFinalAssistantOutputFromEvents(events);
+  const responseBody = buildAnthropicMessageResponse({
+    model: typeof body.model === "string" ? body.model : "claude-opus-4-6",
+    extracted,
+  });
+  return { events, input, extracted, responseBody };
+}
+
 export async function startQaMockOpenAiServer(params?: { host?: string; port?: number }) {
   const host = params?.host ?? "127.0.0.1";
   subagentFanoutPhase = 0;
@@ -734,6 +1015,8 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
           { id: "gpt-5.4-alt", object: "model" },
           { id: "gpt-image-1", object: "model" },
           { id: "text-embedding-3-small", object: "model" },
+          { id: "claude-opus-4-6", object: "model" },
+          { id: "claude-sonnet-4-6", object: "model" },
         ],
       });
       return;
@@ -818,6 +1101,34 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
         return;
       }
       writeSse(res, events);
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/v1/messages") {
+      const raw = await readBody(req);
+      const body = raw ? (JSON.parse(raw) as AnthropicMessagesRequest) : {};
+      const { events, input, responseBody } = await buildMessagesPayload(body);
+      // Record the adapted request snapshot so /debug/requests gives the QA
+      // suite the same plannedToolName / allInputText / toolOutput signals
+      // on the Anthropic route that the OpenAI route already exposes. This
+      // is what lets a single parity run diff assertions across both lanes.
+      lastRequest = {
+        raw,
+        body: body as Record<string, unknown>,
+        prompt: extractLastUserText(input),
+        allInputText: extractAllInputTexts(input),
+        toolOutput: extractToolOutput(input),
+        model: typeof body.model === "string" ? body.model : "",
+        imageInputCount: countImageInputs(input),
+        plannedToolName: extractPlannedToolName(events),
+      };
+      requests.push(lastRequest);
+      if (requests.length > 50) {
+        requests.splice(0, requests.length - 50);
+      }
+      // Anthropic Messages API supports streaming via SSE, but the QA suite
+      // runner always falls back to non-streaming for mock provider mode so
+      // this route only needs the JSON completion path.
+      writeJson(res, 200, responseBody);
       return;
     }
     writeJson(res, 404, { error: "not found" });

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -22,6 +22,58 @@ type StreamEvent =
       };
     };
 
+/**
+ * Provider variant tag for `body.model`. The mock previously ignored
+ * `body.model` for dispatch and only echoed it in the prose output, which
+ * made the parity gate tautological when run against the mock alone
+ * (both providers produced identical scenario plans by construction).
+ * Tagging requests with a normalized variant lets individual scenario
+ * branches opt into provider-specific behavior while the rest of the
+ * dispatcher stays shared, and lets `/debug/requests` consumers verify
+ * which provider lane a given request came from without re-parsing the
+ * raw model string.
+ *
+ * Policy:
+ * - `openai/*`, `gpt-*`, `o1-*`, anything starting with `gpt-` → `"openai"`
+ * - `anthropic/*`, `claude-*` → `"anthropic"`
+ * - Everything else (including empty strings) → `"unknown"`
+ *
+ * The `/v1/messages` route always feeds `body.model` straight through,
+ * so an Anthropic request with an `openai/gpt-5.4` model string is still
+ * classified as `"openai"`. That matches the parity program's convention
+ * where the provider label is the source of truth, not the HTTP route.
+ */
+export type MockOpenAiProviderVariant = "openai" | "anthropic" | "unknown";
+
+export function resolveProviderVariant(model: string | undefined): MockOpenAiProviderVariant {
+  if (typeof model !== "string") {
+    return "unknown";
+  }
+  const trimmed = model.trim().toLowerCase();
+  if (trimmed.length === 0) {
+    return "unknown";
+  }
+  // Prefer the explicit `provider/model` or `provider:model` prefix when
+  // the caller supplied one — that's the most reliable signal.
+  const separatorMatch = /^([^/:]+)[/:]/.exec(trimmed);
+  const provider = separatorMatch?.[1] ?? trimmed;
+  if (provider === "openai" || provider === "openai-codex") {
+    return "openai";
+  }
+  if (provider === "anthropic" || provider === "claude-cli") {
+    return "anthropic";
+  }
+  // Fall back to model-name prefix matching for bare model strings like
+  // `gpt-5.4` or `claude-opus-4-6`.
+  if (/^(?:gpt-|o1-|openai-)/.test(trimmed)) {
+    return "openai";
+  }
+  if (/^(?:claude-|anthropic-)/.test(trimmed)) {
+    return "anthropic";
+  }
+  return "unknown";
+}
+
 type MockOpenAiRequestSnapshot = {
   raw: string;
   body: Record<string, unknown>;
@@ -29,6 +81,7 @@ type MockOpenAiRequestSnapshot = {
   allInputText: string;
   toolOutput: string;
   model: string;
+  providerVariant: MockOpenAiProviderVariant;
   imageInputCount: number;
   plannedToolName?: string;
 };
@@ -1107,13 +1160,15 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
       const body = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
       const input = Array.isArray(body.input) ? (body.input as ResponsesInputItem[]) : [];
       const events = await buildResponsesPayload(body);
+      const resolvedModel = typeof body.model === "string" ? body.model : "";
       lastRequest = {
         raw,
         body,
         prompt: extractLastUserText(input),
         allInputText: extractAllInputTexts(input),
         toolOutput: extractToolOutput(input),
-        model: typeof body.model === "string" ? body.model : "",
+        model: resolvedModel,
+        providerVariant: resolveProviderVariant(resolvedModel),
         imageInputCount: countImageInputs(input),
         plannedToolName: extractPlannedToolName(events),
       };
@@ -1170,6 +1225,7 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
         allInputText: extractAllInputTexts(input),
         toolOutput: extractToolOutput(input),
         model: normalizedModel,
+        providerVariant: resolveProviderVariant(normalizedModel),
         imageInputCount: countImageInputs(input),
         plannedToolName: extractPlannedToolName(events),
       };

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -1190,7 +1190,19 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
     }
     if (req.method === "POST" && url.pathname === "/v1/messages") {
       const raw = await readBody(req);
-      const body = raw ? (JSON.parse(raw) as AnthropicMessagesRequest) : {};
+      let body: AnthropicMessagesRequest = {};
+      try {
+        body = raw ? (JSON.parse(raw) as AnthropicMessagesRequest) : {};
+      } catch {
+        writeJson(res, 400, {
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message: "Malformed JSON body for Anthropic Messages request.",
+          },
+        });
+        return;
+      }
       // Anthropic Messages supports SSE streaming in the real API, but the
       // QA suite runner always runs mock provider mode with streaming off.
       // Reject explicit streaming requests with an Anthropic-shaped 400 so

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -514,6 +514,19 @@ function buildAssistantText(input: ResponsesInputItem[], body: Record<string, un
   if (/tool continuity check/i.test(prompt) && toolOutput) {
     return `Protocol note: model switch handoff confirmed on ${model || "the requested model"}. QA mission from QA_KICKOFF_TASK.md still applies: understand this OpenClaw repo from source + docs before acting.`;
   }
+  if (toolOutput && /repo contract followthrough check/i.test(prompt)) {
+    if (
+      /successfully (?:wrote|created|updated|replaced)/i.test(toolOutput) ||
+      /status:\s*complete/i.test(toolOutput)
+    ) {
+      return [
+        "Read: AGENT.md, SOUL.md, FOLLOWTHROUGH_INPUT.md",
+        "Wrote: repo-contract-summary.txt",
+        "Status: complete",
+      ].join("\n");
+    }
+    return "";
+  }
   if (/session memory ranking check/i.test(prompt) && orbitCode) {
     return `Protocol note: I checked memory and the current Project Nebula codename is ${orbitCode}.`;
   }
@@ -795,6 +808,30 @@ async function buildResponsesPayload(body: Record<string, unknown>) {
   if (/tool continuity check/i.test(prompt) && !toolOutput) {
     return buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" });
   }
+  if (/repo contract followthrough check/i.test(prompt)) {
+    if (!toolOutput) {
+      return buildToolCallEventsWithArgs("read", { path: "AGENT.md" });
+    }
+    if (toolOutput.includes("# Repo contract")) {
+      return buildToolCallEventsWithArgs("read", { path: "SOUL.md" });
+    }
+    if (toolOutput.includes("# Execution style")) {
+      return buildToolCallEventsWithArgs("read", { path: "FOLLOWTHROUGH_INPUT.md" });
+    }
+    if (
+      toolOutput.includes("Mission: prove you followed the repo contract.") &&
+      toolOutput.includes("Evidence path: AGENT.md -> SOUL.md -> FOLLOWTHROUGH_INPUT.md")
+    ) {
+      return buildToolCallEventsWithArgs("write", {
+        path: "repo-contract-summary.txt",
+        content: [
+          "Mission: prove you followed the repo contract.",
+          "Evidence: AGENT.md -> SOUL.md -> FOLLOWTHROUGH_INPUT.md",
+          "Status: complete",
+        ].join("\n"),
+      });
+    }
+  }
   if ((/\bdelegate\b/i.test(prompt) || /subagent handoff/i.test(prompt)) && !toolOutput) {
     return buildToolCallEventsWithArgs("sessions_spawn", {
       task: "Inspect the QA workspace and return one concise protocol note.",
@@ -844,9 +881,10 @@ async function buildResponsesPayload(body: Record<string, unknown>) {
 // baseline lane that exercises the same scenario logic without requiring
 // real Anthropic API keys.
 //
-// Scope: handles Anthropic Messages requests with text and tool_result
-// content blocks, including SSE streaming, which is what the QA suite uses
-// for the structural parity lane.
+// Scope: handles non-streaming Anthropic Messages requests with text and
+// tool_result content blocks, which is what the QA suite runner actually
+// sends. Streaming is intentionally out of scope for this mock because the
+// suite runner supports non-streaming fallback.
 
 function normalizeAnthropicSystemToString(
   system: AnthropicMessagesRequest["system"],

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -996,27 +996,34 @@ async function buildMessagesPayload(body: AnthropicMessagesRequest): Promise<{
   input: ResponsesInputItem[];
   extracted: ExtractedAssistantOutput;
   responseBody: Record<string, unknown>;
+  model: string;
 }> {
   const messages = Array.isArray(body.messages) ? body.messages : [];
   const input = convertAnthropicMessagesToResponsesInput({
     system: body.system,
     messages,
   });
+  // Treat empty-string model the same as absent. A bare typeof check lets
+  // `""` leak through to `responseBody.model` and `lastRequest.model`,
+  // which then confuses parity consumers that assume the mock always
+  // echoes the real provider label. Normalize once and reuse everywhere.
+  const normalizedModel =
+    typeof body.model === "string" && body.model.trim() !== "" ? body.model : "claude-opus-4-6";
   // Dispatch through the same scenario logic the /v1/responses route uses.
   // The mock dispatcher only reads `body.input`, `body.model`, and
   // `body.stream`, so a synthetic shim body is sufficient.
   const dispatchBody: Record<string, unknown> = {
     input,
-    model: typeof body.model === "string" ? body.model : "claude-opus-4-6",
+    model: normalizedModel,
     stream: false,
   };
   const events = await buildResponsesPayload(dispatchBody);
   const extracted = extractFinalAssistantOutputFromEvents(events);
   const responseBody = buildAnthropicMessageResponse({
-    model: typeof body.model === "string" ? body.model : "claude-opus-4-6",
+    model: normalizedModel,
     extracted,
   });
-  return { events, input, extracted, responseBody };
+  return { events, input, extracted, responseBody, model: normalizedModel };
 }
 
 export async function startQaMockOpenAiServer(params?: { host?: string; port?: number }) {
@@ -1129,18 +1136,40 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
     if (req.method === "POST" && url.pathname === "/v1/messages") {
       const raw = await readBody(req);
       const body = raw ? (JSON.parse(raw) as AnthropicMessagesRequest) : {};
-      const { events, input, responseBody } = await buildMessagesPayload(body);
+      // Anthropic Messages supports SSE streaming in the real API, but the
+      // QA suite runner always runs mock provider mode with streaming off.
+      // Reject explicit streaming requests with an Anthropic-shaped 400 so
+      // the failure mode is obvious instead of silently returning a
+      // non-streaming JSON response that the caller never asked for.
+      if (body.stream === true) {
+        writeJson(res, 400, {
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message: "Anthropic Messages streaming is not supported by the qa-lab mock server.",
+          },
+        });
+        return;
+      }
+      const {
+        events,
+        input,
+        responseBody,
+        model: normalizedModel,
+      } = await buildMessagesPayload(body);
       // Record the adapted request snapshot so /debug/requests gives the QA
       // suite the same plannedToolName / allInputText / toolOutput signals
       // on the Anthropic route that the OpenAI route already exposes. This
       // is what lets a single parity run diff assertions across both lanes.
+      // Reuse the normalized model so an empty-string body.model no longer
+      // leaks through to `lastRequest.model`.
       lastRequest = {
         raw,
         body: body as Record<string, unknown>,
         prompt: extractLastUserText(input),
         allInputText: extractAllInputTexts(input),
         toolOutput: extractToolOutput(input),
-        model: typeof body.model === "string" ? body.model : "",
+        model: normalizedModel,
         imageInputCount: countImageInputs(input),
         plannedToolName: extractPlannedToolName(events),
       };
@@ -1148,9 +1177,6 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
       if (requests.length > 50) {
         requests.splice(0, requests.length - 50);
       }
-      // Anthropic Messages API supports streaming via SSE, but the QA suite
-      // runner always falls back to non-streaming for mock provider mode so
-      // this route only needs the JSON completion path.
       writeJson(res, 200, responseBody);
       return;
     }

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -155,6 +155,23 @@ function writeSse(res: ServerResponse, events: StreamEvent[]) {
   res.end(body);
 }
 
+type AnthropicStreamEvent = Record<string, unknown> & {
+  type: string;
+};
+
+function writeAnthropicSse(res: ServerResponse, events: AnthropicStreamEvent[]) {
+  const body = events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+    "content-length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
 function countApproxTokens(text: string) {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -419,11 +436,11 @@ function extractLastCapture(text: string, pattern: RegExp) {
 }
 
 function extractExactReplyDirective(text: string) {
-  const colonMatch = extractLastCapture(text, /reply(?: with)? exactly:\s*([^\n]+)/i);
-  if (colonMatch) {
-    return colonMatch;
+  const backtickedMatch = extractLastCapture(text, /reply(?: with)? exactly\s+`([^`]+)`/i);
+  if (backtickedMatch) {
+    return backtickedMatch;
   }
-  return extractLastCapture(text, /reply(?: with)? exactly\s+`([^`]+)`/i);
+  return extractLastCapture(text, /reply(?: with)? exactly:\s*([^\n]+)/i);
 }
 
 function extractExactMarkerDirective(text: string) {
@@ -435,7 +452,11 @@ function extractExactMarkerDirective(text: string) {
 }
 
 function isHeartbeatPrompt(text: string) {
-  return /Read HEARTBEAT\.md if it exists/i.test(text);
+  const trimmed = text.trim();
+  if (!trimmed || /remember this fact/i.test(trimmed)) {
+    return false;
+  }
+  return /(?:^|\n)Read HEARTBEAT\.md if it exists\b/i.test(trimmed);
 }
 
 function buildAssistantText(input: ResponsesInputItem[], body: Record<string, unknown>) {
@@ -454,8 +475,10 @@ function buildAssistantText(input: ResponsesInputItem[], body: Record<string, un
         : toolOutput;
   const orbitCode = extractOrbitCode(memorySnippet);
   const mediaPath = /MEDIA:([^\n]+)/.exec(toolOutput)?.[1]?.trim();
-  const exactReplyDirective = extractExactReplyDirective(allInputText);
-  const exactMarkerDirective = extractExactMarkerDirective(allInputText);
+  const exactReplyDirective =
+    extractExactReplyDirective(prompt) ?? extractExactReplyDirective(allInputText);
+  const exactMarkerDirective =
+    extractExactMarkerDirective(prompt) ?? extractExactMarkerDirective(allInputText);
   const imageInputCount = countImageInputs(input);
 
   if (/what was the qa canary code/i.test(prompt) && rememberedFact) {
@@ -622,6 +645,9 @@ async function buildResponsesPayload(body: Record<string, unknown>) {
   const allInputText = extractAllInputTexts(input);
   const isGroupChat = allInputText.includes('"is_group_chat": true');
   const isBaselineUnmentionedChannelChatter = /\bno bot ping here\b/i.test(prompt);
+  if (/remember this fact/i.test(prompt)) {
+    return buildAssistantEvents(buildAssistantText(input, body));
+  }
   if (isHeartbeatPrompt(prompt)) {
     return buildAssistantEvents("HEARTBEAT_OK");
   }
@@ -818,10 +844,9 @@ async function buildResponsesPayload(body: Record<string, unknown>) {
 // baseline lane that exercises the same scenario logic without requiring
 // real Anthropic API keys.
 //
-// Scope: handles non-streaming Anthropic Messages requests with text and
-// tool_result content blocks, which is what the QA suite runner actually
-// sends. Streaming is intentionally out of scope for this mock because the
-// suite runner supports non-streaming fallback.
+// Scope: handles Anthropic Messages requests with text and tool_result
+// content blocks, including SSE streaming, which is what the QA suite uses
+// for the structural parity lane.
 
 function normalizeAnthropicSystemToString(
   system: AnthropicMessagesRequest["system"],
@@ -1044,11 +1069,107 @@ function buildAnthropicMessageResponse(params: {
   };
 }
 
+function buildAnthropicMessageStreamEvents(params: {
+  model: string;
+  extracted: ExtractedAssistantOutput;
+}): AnthropicStreamEvent[] {
+  const approxInputTokens = 64;
+  const approxOutputTokens = Math.max(
+    16,
+    countApproxTokens(params.extracted.text) + params.extracted.toolCalls.length * 16,
+  );
+  const messageId = `msg_mock_${Math.floor(Math.random() * 1_000_000).toString(16)}`;
+  const events: AnthropicStreamEvent[] = [
+    {
+      type: "message_start",
+      message: {
+        id: messageId,
+        type: "message",
+        role: "assistant",
+        model: params.model || "claude-opus-4-6",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: approxInputTokens,
+          output_tokens: 0,
+        },
+      },
+    },
+  ];
+  let index = 0;
+  if (params.extracted.text || params.extracted.toolCalls.length === 0) {
+    events.push({
+      type: "content_block_start",
+      index,
+      content_block: {
+        type: "text",
+        text: "",
+      },
+    });
+    if (params.extracted.text) {
+      events.push({
+        type: "content_block_delta",
+        index,
+        delta: {
+          type: "text_delta",
+          text: params.extracted.text,
+        },
+      });
+    }
+    events.push({
+      type: "content_block_stop",
+      index,
+    });
+    index += 1;
+  }
+  for (const call of params.extracted.toolCalls) {
+    events.push({
+      type: "content_block_start",
+      index,
+      content_block: {
+        type: "tool_use",
+        id: call.id,
+        name: call.name,
+        input: {},
+      },
+    });
+    events.push({
+      type: "content_block_delta",
+      index,
+      delta: {
+        type: "input_json_delta",
+        partial_json: JSON.stringify(call.input ?? {}),
+      },
+    });
+    events.push({
+      type: "content_block_stop",
+      index,
+    });
+    index += 1;
+  }
+  events.push({
+    type: "message_delta",
+    delta: {
+      stop_reason: params.extracted.toolCalls.length > 0 ? "tool_use" : "end_turn",
+    },
+    usage: {
+      input_tokens: approxInputTokens,
+      output_tokens: approxOutputTokens,
+    },
+  });
+  events.push({
+    type: "message_stop",
+  });
+  return events;
+}
+
 async function buildMessagesPayload(body: AnthropicMessagesRequest): Promise<{
   events: StreamEvent[];
   input: ResponsesInputItem[];
   extracted: ExtractedAssistantOutput;
   responseBody: Record<string, unknown>;
+  streamEvents: AnthropicStreamEvent[];
   model: string;
 }> {
   const messages = Array.isArray(body.messages) ? body.messages : [];
@@ -1076,7 +1197,11 @@ async function buildMessagesPayload(body: AnthropicMessagesRequest): Promise<{
     model: normalizedModel,
     extracted,
   });
-  return { events, input, extracted, responseBody, model: normalizedModel };
+  const streamEvents = buildAnthropicMessageStreamEvents({
+    model: normalizedModel,
+    extracted,
+  });
+  return { events, input, extracted, responseBody, streamEvents, model: normalizedModel };
 }
 
 export async function startQaMockOpenAiServer(params?: { host?: string; port?: number }) {
@@ -1203,25 +1328,11 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
         });
         return;
       }
-      // Anthropic Messages supports SSE streaming in the real API, but the
-      // QA suite runner always runs mock provider mode with streaming off.
-      // Reject explicit streaming requests with an Anthropic-shaped 400 so
-      // the failure mode is obvious instead of silently returning a
-      // non-streaming JSON response that the caller never asked for.
-      if (body.stream === true) {
-        writeJson(res, 400, {
-          type: "error",
-          error: {
-            type: "invalid_request_error",
-            message: "Anthropic Messages streaming is not supported by the qa-lab mock server.",
-          },
-        });
-        return;
-      }
       const {
         events,
         input,
         responseBody,
+        streamEvents,
         model: normalizedModel,
       } = await buildMessagesPayload(body);
       // Record the adapted request snapshot so /debug/requests gives the QA
@@ -1244,6 +1355,10 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
       requests.push(lastRequest);
       if (requests.length > 50) {
         requests.splice(0, requests.length - 50);
+      }
+      if (body.stream === true) {
+        writeAnthropicSse(res, streamEvents);
+        return;
       }
       writeJson(res, 200, responseBody);
       return;

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -830,8 +830,19 @@ function convertAnthropicMessagesToResponsesInput(params: {
     if (!Array.isArray(content)) {
       continue;
     }
+    // Buffer each block type so we can push in OpenAI-Responses order instead
+    // of the order they appear in the Anthropic content array. The parent
+    // role message must precede any function_call_output items from the same
+    // turn, otherwise extractToolOutput() (which scans for
+    // function_call_output AFTER the last user-role index) will not see the
+    // output and the downstream scenario dispatcher will behave as if no
+    // tool output was returned. Similarly, assistant tool_use blocks become
+    // function_call items that must follow the assistant text message they
+    // narrate.
     const textPieces: Array<{ type: "input_text" | "output_text"; text: string }> = [];
     const imagePieces: Array<{ type: "input_image"; image_url: string }> = [];
+    const toolResultItems: ResponsesInputItem[] = [];
+    const toolUseItems: ResponsesInputItem[] = [];
     for (const block of content) {
       if (!block || typeof block !== "object") {
         continue;
@@ -851,7 +862,7 @@ function convertAnthropicMessagesToResponsesInput(params: {
       if (block.type === "tool_result") {
         const output = stringifyToolResultContent(block.content);
         if (output.trim()) {
-          items.push({ type: "function_call_output", output });
+          toolResultItems.push({ type: "function_call_output", output });
         }
         continue;
       }
@@ -861,7 +872,7 @@ function convertAnthropicMessagesToResponsesInput(params: {
         // call". The scenario dispatcher looks for tool_output on the next
         // user turn, not the assistant's prior tool_use, so a minimal
         // placeholder is enough.
-        items.push({
+        toolUseItems.push({
           type: "function_call",
           name: block.name,
           arguments: JSON.stringify(block.input ?? {}),
@@ -873,6 +884,18 @@ function convertAnthropicMessagesToResponsesInput(params: {
     if (textPieces.length > 0 || imagePieces.length > 0) {
       const combinedContent: Array<Record<string, unknown>> = [...textPieces, ...imagePieces];
       items.push({ role: message.role, content: combinedContent });
+    }
+    // Emit tool_use (assistant prior calls) and tool_result (user-side
+    // returns) AFTER the parent role message so extractLastUserText and
+    // extractToolOutput walk the array in the order they expect. For a
+    // tool_result-only user turn with no text/image blocks, the parent
+    // message is intentionally omitted — the function_call_output itself
+    // represents the user's "return the tool output" turn.
+    for (const toolUse of toolUseItems) {
+      items.push(toolUse);
+    }
+    for (const toolResult of toolResultItems) {
+      items.push(toolResult);
     }
   }
   return items;

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -29,8 +29,11 @@ describe("buildQaGatewayConfig", () => {
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("mock-openai/gpt-5.4");
     expect(cfg.models?.providers?.["mock-openai"]?.baseUrl).toBe("http://127.0.0.1:44080/v1");
+    expect(cfg.models?.providers?.["mock-openai"]?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.openai?.baseUrl).toBe("http://127.0.0.1:44080/v1");
+    expect(cfg.models?.providers?.openai?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.anthropic?.baseUrl).toBe("http://127.0.0.1:44080");
+    expect(cfg.models?.providers?.anthropic?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-channel"]);
     expect(cfg.plugins?.entries?.["memory-core"]).toEqual({ enabled: true });
     expect(cfg.plugins?.entries?.["qa-channel"]).toEqual({ enabled: true });
@@ -53,9 +56,11 @@ describe("buildQaGatewayConfig", () => {
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.4");
     expect(cfg.models?.providers?.openai?.api).toBe("openai-responses");
+    expect(cfg.models?.providers?.openai?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.openai?.models.map((model) => model.id)).toContain("gpt-5.4");
     expect(cfg.models?.providers?.anthropic?.api).toBe("anthropic-messages");
     expect(cfg.models?.providers?.anthropic?.baseUrl).toBe("http://127.0.0.1:44080");
+    expect(cfg.models?.providers?.anthropic?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.anthropic?.models.map((model) => model.id)).toContain(
       "claude-opus-4-6",
     );

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -29,11 +29,37 @@ describe("buildQaGatewayConfig", () => {
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("mock-openai/gpt-5.4");
     expect(cfg.models?.providers?.["mock-openai"]?.baseUrl).toBe("http://127.0.0.1:44080/v1");
+    expect(cfg.models?.providers?.openai?.baseUrl).toBe("http://127.0.0.1:44080/v1");
+    expect(cfg.models?.providers?.anthropic?.baseUrl).toBe("http://127.0.0.1:44080");
     expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-channel"]);
     expect(cfg.plugins?.entries?.["memory-core"]).toEqual({ enabled: true });
     expect(cfg.plugins?.entries?.["qa-channel"]).toEqual({ enabled: true });
     expect(cfg.plugins?.entries?.openai).toBeUndefined();
     expect(cfg.gateway?.reload?.deferralTimeoutMs).toBe(1_000);
+  });
+
+  it("maps provider-qualified openai and anthropic refs through the mock provider lane", () => {
+    const cfg = buildQaGatewayConfig({
+      bind: "loopback",
+      gatewayPort: 18789,
+      gatewayToken: "token",
+      providerBaseUrl: "http://127.0.0.1:44080/v1",
+      qaBusBaseUrl: "http://127.0.0.1:43124",
+      workspaceDir: "/tmp/qa-workspace",
+      providerMode: "mock-openai",
+      primaryModel: "openai/gpt-5.4",
+      alternateModel: "anthropic/claude-opus-4-6",
+    });
+
+    expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.4");
+    expect(cfg.models?.providers?.openai?.api).toBe("openai-responses");
+    expect(cfg.models?.providers?.openai?.models.map((model) => model.id)).toContain("gpt-5.4");
+    expect(cfg.models?.providers?.anthropic?.api).toBe("anthropic-messages");
+    expect(cfg.models?.providers?.anthropic?.baseUrl).toBe("http://127.0.0.1:44080");
+    expect(cfg.models?.providers?.anthropic?.models.map((model) => model.id)).toContain(
+      "claude-opus-4-6",
+    );
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-channel"]);
   });
 
   it("can omit qa-channel for live transport gateway children", () => {

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -44,6 +44,10 @@ export function normalizeQaThinkingLevel(input: unknown): QaThinkingLevel | unde
   return undefined;
 }
 
+function trimTrailingApiV1(baseUrl: string) {
+  return baseUrl.replace(/\/v1\/?$/i, "");
+}
+
 export function mergeQaControlUiAllowedOrigins(extraOrigins?: string[]) {
   const normalizedExtra = (extraOrigins ?? [])
     .map((origin) => origin.trim())
@@ -74,6 +78,7 @@ export function buildQaGatewayConfig(params: {
 }): OpenClawConfig {
   const includeQaChannel = params.includeQaChannel !== false;
   const mockProviderBaseUrl = params.providerBaseUrl ?? "http://127.0.0.1:44080/v1";
+  const mockAnthropicBaseUrl = trimTrailingApiV1(mockProviderBaseUrl);
   const mockOpenAiProvider: ModelProviderConfig = {
     baseUrl: mockProviderBaseUrl,
     apiKey: "test",
@@ -122,6 +127,47 @@ export function buildQaGatewayConfig(params: {
           cacheWrite: 0,
         },
         contextWindow: 128_000,
+        maxTokens: 4096,
+      },
+    ],
+  };
+  const mockNamedOpenAiProvider: ModelProviderConfig = {
+    ...mockOpenAiProvider,
+    models: mockOpenAiProvider.models.map((model) => ({ ...model })),
+  };
+  const mockAnthropicProvider: ModelProviderConfig = {
+    baseUrl: mockAnthropicBaseUrl,
+    apiKey: "test",
+    api: "anthropic-messages",
+    models: [
+      {
+        id: "claude-opus-4-6",
+        name: "claude-opus-4-6",
+        api: "anthropic-messages",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        contextWindow: 200_000,
+        maxTokens: 4096,
+      },
+      {
+        id: "claude-sonnet-4-6",
+        name: "claude-sonnet-4-6",
+        api: "anthropic-messages",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        contextWindow: 200_000,
         maxTokens: 4096,
       },
     ],
@@ -265,6 +311,8 @@ export function buildQaGatewayConfig(params: {
             mode: "replace",
             providers: {
               "mock-openai": mockOpenAiProvider,
+              openai: mockNamedOpenAiProvider,
+              anthropic: mockAnthropicProvider,
             },
           },
         }

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -83,6 +83,9 @@ export function buildQaGatewayConfig(params: {
     baseUrl: mockProviderBaseUrl,
     apiKey: "test",
     api: "openai-responses",
+    request: {
+      allowPrivateNetwork: true,
+    },
     models: [
       {
         id: "gpt-5.4",
@@ -139,6 +142,9 @@ export function buildQaGatewayConfig(params: {
     baseUrl: mockAnthropicBaseUrl,
     apiKey: "test",
     api: "anthropic-messages",
+    request: {
+      allowPrivateNetwork: true,
+    },
     models: [
       {
         id: "claude-opus-4-6",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -122,6 +122,26 @@ describe("qa scenario catalog", () => {
     expect(imageRequestExpr).toContain("/debug/requests");
   });
 
+  it("adds a repo-instruction followthrough scenario to the parity pack", () => {
+    const scenario = readQaScenarioById("instruction-followthrough-repo-contract");
+    const config = readQaScenarioExecutionConfig("instruction-followthrough-repo-contract") as
+      | {
+          workspaceFiles?: Record<string, string>;
+          prompt?: string;
+          expectedReplyAll?: string[];
+        }
+      | undefined;
+
+    expect(config?.workspaceFiles?.["AGENT.md"]).toContain("Step order:");
+    expect(config?.workspaceFiles?.["SOUL.md"]).toContain("action-first");
+    expect(config?.workspaceFiles?.["FOLLOWTHROUGH_INPUT.md"]).toContain(
+      "Mission: prove you followed the repo contract.",
+    );
+    expect(config?.prompt).toContain("Repo contract followthrough check.");
+    expect(config?.expectedReplyAll).toEqual(["read:", "wrote:", "status:"]);
+    expect(scenario.title).toBe("Instruction followthrough repo contract");
+  });
+
   it("rejects malformed string matcher lists before running a flow", () => {
     expect(() =>
       validateQaScenarioExecutionConfig({

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -112,6 +112,16 @@ describe("qa scenario catalog", () => {
     );
   });
 
+  it("keeps mock-only image debug assertions guarded in live-frontier runs", () => {
+    const scenario = readQaScenarioById("image-understanding-attachment");
+    const imageRequestExpr = scenario.execution.flow?.steps
+      .flatMap((step) => step.actions ?? [])
+      .find((action) => action.set === "imageRequest")?.value?.expr;
+
+    expect(imageRequestExpr).toContain("env.mock ?");
+    expect(imageRequestExpr).toContain("/debug/requests");
+  });
+
   it("rejects malformed string matcher lists before running a flow", () => {
     expect(() =>
       validateQaScenarioExecutionConfig({

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -3,9 +3,12 @@ import { buildQaSuiteSummaryJson } from "./suite.js";
 
 describe("buildQaSuiteSummaryJson", () => {
   const baseParams = {
+    // Test scenarios include a `steps: []` field to match the real suite
+    // scenario-result shape so downstream consumers that rely on the shape
+    // (parity gate, report render) stay aligned.
     scenarios: [
-      { name: "Scenario A", status: "pass" as const },
-      { name: "Scenario B", status: "fail" as const, details: "something broke" },
+      { name: "Scenario A", status: "pass" as const, steps: [] },
+      { name: "Scenario B", status: "fail" as const, details: "something broke", steps: [] },
     ],
     startedAt: new Date("2026-04-11T00:00:00.000Z"),
     finishedAt: new Date("2026-04-11T00:05:00.000Z"),
@@ -40,7 +43,18 @@ describe("buildQaSuiteSummaryJson", () => {
       ...baseParams,
       scenarioIds,
     });
-    expect((json.run as { scenarioIds?: readonly string[] }).scenarioIds).toEqual(scenarioIds);
+    expect(json.run.scenarioIds).toEqual(scenarioIds);
+  });
+
+  it("treats an empty scenarioIds array as unspecified (no filter)", () => {
+    // A CLI path that omits --scenario passes an empty array to runQaSuite.
+    // The summary must encode that as null so downstream parity/report
+    // tooling doesn't interpret a full run as an explicit empty selection.
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      scenarioIds: [],
+    });
+    expect(json.run.scenarioIds).toBeNull();
   });
 
   it("records an Anthropic baseline lane cleanly for parity runs", () => {

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { buildQaSuiteSummaryJson } from "./suite.js";
+
+describe("buildQaSuiteSummaryJson", () => {
+  const baseParams = {
+    scenarios: [
+      { name: "Scenario A", status: "pass" as const },
+      { name: "Scenario B", status: "fail" as const, details: "something broke" },
+    ],
+    startedAt: new Date("2026-04-11T00:00:00.000Z"),
+    finishedAt: new Date("2026-04-11T00:05:00.000Z"),
+    providerMode: "mock-openai" as const,
+    primaryModel: "openai/gpt-5.4",
+    alternateModel: "openai/gpt-5.4-alt",
+    fastMode: true,
+    concurrency: 2,
+  };
+
+  it("records provider/model/mode so parity gates can verify labels", () => {
+    const json = buildQaSuiteSummaryJson(baseParams);
+    expect(json.run).toMatchObject({
+      startedAt: "2026-04-11T00:00:00.000Z",
+      finishedAt: "2026-04-11T00:05:00.000Z",
+      providerMode: "mock-openai",
+      primaryModel: "openai/gpt-5.4",
+      primaryProvider: "openai",
+      primaryModelName: "gpt-5.4",
+      alternateModel: "openai/gpt-5.4-alt",
+      alternateProvider: "openai",
+      alternateModelName: "gpt-5.4-alt",
+      fastMode: true,
+      concurrency: 2,
+      scenarioIds: null,
+    });
+  });
+
+  it("includes scenarioIds in run metadata when provided", () => {
+    const scenarioIds = ["approval-turn-tool-followthrough", "subagent-handoff", "memory-recall"];
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      scenarioIds,
+    });
+    expect((json.run as { scenarioIds?: readonly string[] }).scenarioIds).toEqual(scenarioIds);
+  });
+
+  it("records an Anthropic baseline lane cleanly for parity runs", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      primaryModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-sonnet-4-6",
+    });
+    expect(json.run).toMatchObject({
+      primaryModel: "anthropic/claude-opus-4-6",
+      primaryProvider: "anthropic",
+      primaryModelName: "claude-opus-4-6",
+      alternateModel: "anthropic/claude-sonnet-4-6",
+      alternateProvider: "anthropic",
+      alternateModelName: "claude-sonnet-4-6",
+    });
+  });
+
+  it("leaves split fields null when a model ref is malformed", () => {
+    const json = buildQaSuiteSummaryJson({
+      ...baseParams,
+      primaryModel: "not-a-real-ref",
+      alternateModel: "",
+    });
+    expect(json.run).toMatchObject({
+      primaryModel: "not-a-real-ref",
+      primaryProvider: null,
+      primaryModelName: null,
+      alternateModel: "",
+      alternateProvider: null,
+      alternateModelName: null,
+    });
+  });
+
+  it("keeps scenarios and counts alongside the run metadata", () => {
+    const json = buildQaSuiteSummaryJson(baseParams);
+    expect(json.scenarios).toHaveLength(2);
+    expect(json.counts).toEqual({
+      total: 2,
+      passed: 1,
+      failed: 1,
+    });
+  });
+});

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1328,6 +1328,53 @@ function createQaSuiteReportNotes(params: {
   ];
 }
 
+export type QaSuiteSummaryJsonParams = {
+  scenarios: QaSuiteScenarioResult[];
+  startedAt: Date;
+  finishedAt: Date;
+  providerMode: "mock-openai" | "live-frontier";
+  primaryModel: string;
+  alternateModel: string;
+  fastMode: boolean;
+  concurrency: number;
+  scenarioIds?: readonly string[];
+};
+
+/**
+ * Pure-ish JSON builder for qa-suite-summary.json. Exported so the GPT-5.4
+ * parity gate (agentic-parity-report.ts, #64441) and any future parity
+ * runner can assert-and-trust the provider/model that produced a given
+ * summary instead of blindly accepting the caller's candidateLabel /
+ * baselineLabel. Without the `run` block, a maintainer who swaps candidate
+ * and baseline summary paths could silently produce a mislabeled verdict.
+ */
+export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): Record<string, unknown> {
+  const primarySplit = splitModelRef(params.primaryModel);
+  const alternateSplit = splitModelRef(params.alternateModel);
+  return {
+    scenarios: params.scenarios,
+    counts: {
+      total: params.scenarios.length,
+      passed: params.scenarios.filter((scenario) => scenario.status === "pass").length,
+      failed: params.scenarios.filter((scenario) => scenario.status === "fail").length,
+    },
+    run: {
+      startedAt: params.startedAt.toISOString(),
+      finishedAt: params.finishedAt.toISOString(),
+      providerMode: params.providerMode,
+      primaryModel: params.primaryModel,
+      primaryProvider: primarySplit?.provider ?? null,
+      primaryModelName: primarySplit?.model ?? null,
+      alternateModel: params.alternateModel,
+      alternateProvider: alternateSplit?.provider ?? null,
+      alternateModelName: alternateSplit?.model ?? null,
+      fastMode: params.fastMode,
+      concurrency: params.concurrency,
+      scenarioIds: params.scenarioIds ? [...params.scenarioIds] : null,
+    },
+  };
+}
+
 async function writeQaSuiteArtifacts(params: {
   outputDir: string;
   startedAt: Date;
@@ -1338,6 +1385,7 @@ async function writeQaSuiteArtifacts(params: {
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
+  scenarioIds?: readonly string[];
 }) {
   const report = renderQaMarkdownReport({
     title: "OpenClaw QA Scenario Suite",
@@ -1357,18 +1405,7 @@ async function writeQaSuiteArtifacts(params: {
   await fs.writeFile(reportPath, report, "utf8");
   await fs.writeFile(
     summaryPath,
-    `${JSON.stringify(
-      {
-        scenarios: params.scenarios,
-        counts: {
-          total: params.scenarios.length,
-          passed: params.scenarios.filter((scenario) => scenario.status === "pass").length,
-          failed: params.scenarios.filter((scenario) => scenario.status === "fail").length,
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(buildQaSuiteSummaryJson(params), null, 2)}\n`,
     "utf8",
   );
   return { report, reportPath, summaryPath };
@@ -1527,6 +1564,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
         alternateModel,
         fastMode,
         concurrency,
+        scenarioIds: params?.scenarioIds,
       });
       lab.setLatestReport({
         outputPath: reportPath,
@@ -1670,6 +1708,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       alternateModel,
       fastMode,
       concurrency,
+      scenarioIds: params?.scenarioIds,
     });
     const latestReport = {
       outputPath: reportPath,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1332,12 +1332,41 @@ export type QaSuiteSummaryJsonParams = {
   scenarios: QaSuiteScenarioResult[];
   startedAt: Date;
   finishedAt: Date;
-  providerMode: "mock-openai" | "live-frontier";
+  providerMode: QaProviderMode;
   primaryModel: string;
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
   scenarioIds?: readonly string[];
+};
+
+/**
+ * Strongly-typed shape of `qa-suite-summary.json`. The GPT-5.4 parity gate
+ * (agentic-parity-report.ts, #64441) and any future parity wrapper can
+ * import this type instead of re-declaring the shape, so changes to the
+ * summary schema propagate through to every consumer at type-check time.
+ */
+export type QaSuiteSummaryJson = {
+  scenarios: QaSuiteScenarioResult[];
+  counts: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+  run: {
+    startedAt: string;
+    finishedAt: string;
+    providerMode: QaProviderMode;
+    primaryModel: string;
+    primaryProvider: string | null;
+    primaryModelName: string | null;
+    alternateModel: string;
+    alternateProvider: string | null;
+    alternateModelName: string | null;
+    fastMode: boolean;
+    concurrency: number;
+    scenarioIds: string[] | null;
+  };
 };
 
 /**
@@ -1347,8 +1376,14 @@ export type QaSuiteSummaryJsonParams = {
  * summary instead of blindly accepting the caller's candidateLabel /
  * baselineLabel. Without the `run` block, a maintainer who swaps candidate
  * and baseline summary paths could silently produce a mislabeled verdict.
+ *
+ * `scenarioIds` is only recorded when the caller passed a non-empty array
+ * (an explicit scenario selection). A missing or empty array means "no
+ * filter, full lane-selected catalog", which the summary encodes as `null`
+ * so parity/report tooling doesn't mistake a full run for an explicit
+ * empty selection.
  */
-export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): Record<string, unknown> {
+export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSuiteSummaryJson {
   const primarySplit = splitModelRef(params.primaryModel);
   const alternateSplit = splitModelRef(params.alternateModel);
   return {
@@ -1370,7 +1405,8 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): Recor
       alternateModelName: alternateSplit?.model ?? null,
       fastMode: params.fastMode,
       concurrency: params.concurrency,
-      scenarioIds: params.scenarioIds ? [...params.scenarioIds] : null,
+      scenarioIds:
+        params.scenarioIds && params.scenarioIds.length > 0 ? [...params.scenarioIds] : null,
     },
   };
 }

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1600,7 +1600,13 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
         alternateModel,
         fastMode,
         concurrency,
-        scenarioIds: params?.scenarioIds,
+        // Record the scenario ids that actually ran (post-selectQaSuiteScenarios
+        // normalization) so the summary metadata matches the executed selection,
+        // not the raw caller input. selectQaSuiteScenarios dedupes via Set and
+        // reorders to catalog order, so passing params.scenarioIds directly
+        // would mislabel runs that repeated --scenario flags or used
+        // non-catalog order.
+        scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
       });
       lab.setLatestReport({
         outputPath: reportPath,
@@ -1744,7 +1750,9 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       alternateModel,
       fastMode,
       concurrency,
-      scenarioIds: params?.scenarioIds,
+      // Record the post-selection scenario ids (see the sibling
+      // writeQaSuiteArtifacts call above for the full reasoning).
+      scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
     });
     const latestReport = {
       outputPath: reportPath,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1416,7 +1416,11 @@ async function writeQaSuiteArtifacts(params: {
   startedAt: Date;
   finishedAt: Date;
   scenarios: QaSuiteScenarioResult[];
-  providerMode: "mock-openai" | "live-frontier";
+  // Reuse the canonical QaProviderMode union instead of re-declaring it
+  // inline. Loop 6 already unified `QaSuiteSummaryJsonParams.providerMode`
+  // on this type; keeping the writer in sync prevents drift when model-
+  // selection.ts adds a new provider mode.
+  providerMode: QaProviderMode;
   primaryModel: string;
   alternateModel: string;
   fastMode: boolean;

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1600,13 +1600,16 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
         alternateModel,
         fastMode,
         concurrency,
-        // Record the scenario ids that actually ran (post-selectQaSuiteScenarios
-        // normalization) so the summary metadata matches the executed selection,
-        // not the raw caller input. selectQaSuiteScenarios dedupes via Set and
-        // reorders to catalog order, so passing params.scenarioIds directly
-        // would mislabel runs that repeated --scenario flags or used
-        // non-catalog order.
-        scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
+        // When the caller supplied an explicit non-empty --scenario filter,
+        // record the executed (post-selectQaSuiteScenarios-normalized) ids
+        // so the summary matches what actually ran. When the caller passed
+        // nothing or an empty array ("no filter, full lane catalog"),
+        // preserve the unfiltered = null semantic so the summary stays
+        // distinguishable from an explicit all-scenarios selection.
+        scenarioIds:
+          params?.scenarioIds && params.scenarioIds.length > 0
+            ? selectedCatalogScenarios.map((scenario) => scenario.id)
+            : undefined,
       });
       lab.setLatestReport({
         outputPath: reportPath,
@@ -1750,9 +1753,12 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       alternateModel,
       fastMode,
       concurrency,
-      // Record the post-selection scenario ids (see the sibling
-      // writeQaSuiteArtifacts call above for the full reasoning).
-      scenarioIds: selectedCatalogScenarios.map((scenario) => scenario.id),
+      // Same "filtered → executed list, unfiltered → null" convention as
+      // the concurrent-path writeQaSuiteArtifacts call above.
+      scenarioIds:
+        params?.scenarioIds && params.scenarioIds.length > 0
+          ? selectedCatalogScenarios.map((scenario) => scenario.id)
+          : undefined,
     });
     const latestReport = {
       outputPath: reportPath,

--- a/qa/scenarios/config-restart-capability-flip.md
+++ b/qa/scenarios/config-restart-capability-flip.md
@@ -151,6 +151,19 @@ steps:
                     ref: imageStartedAtMs
                   timeoutMs:
                     expr: liveTurnTimeoutMs(env, 45000)
+            # Tool-call assertion (criterion 2 of the parity completion
+            # gate in #64227): the restored `image_generate` capability
+            # must have actually fired as a real tool call. Without this
+            # assertion, a prose reply that just mentions a MEDIA path
+            # could satisfy the scenario, so strengthen it by requiring
+            # the mock to have recorded `plannedToolName: "image_generate"`
+            # against a post-restart request. Scoped to `!env.mock` so
+            # live-frontier runs (which don't expose `/debug/requests`)
+            # still pass the rest of the scenario.
+            - assert:
+                expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => String(request.allInputText ?? '').toLowerCase().includes('capability flip image check') && request.plannedToolName === 'image_generate')"
+                message:
+                  expr: "`expected image_generate tool call during capability flip scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].filter((request) => String(request.allInputText ?? '').toLowerCase().includes('capability flip image check')).map((request) => request.plannedToolName ?? null))}`"
           finally:
             - call: patchConfig
               args:

--- a/qa/scenarios/image-understanding-attachment.md
+++ b/qa/scenarios/image-understanding-attachment.md
@@ -64,9 +64,26 @@ steps:
           expr: "!missingColorGroup"
           message:
             expr: "`missing expected colors in image description: ${outbound.text}`"
+      # Image-processing assertion: verify the mock actually received an
+      # image on the scenario-unique prompt. This is as strong as a
+      # tool-call assertion for this scenario — unlike the
+      # `source-docs-discovery-report` / `subagent-handoff` /
+      # `config-restart-capability-flip` scenarios that rely on a real
+      # tool call to satisfy the parity criterion, image understanding
+      # is handled inside the provider's vision capability and does NOT
+      # emit a tool call the mock can record as `plannedToolName`. The
+      # `imageInputCount` field IS the tool-call evidence for vision
+      # scenarios: it proves the attachment reached the provider, which
+      # is the only thing an external harness can verify in mock mode.
+      # Match on the scenario-unique prompt substring so the assertion
+      # can't be accidentally satisfied by some other scenario's image
+      # request that happens to share a debug log with this one.
+      - set: imageRequest
+        value:
+          expr: "[...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].find((request) => String(request.prompt ?? '').includes('Image understanding check'))"
       - assert:
-          expr: "!env.mock || (((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.prompt ?? '').includes('Image understanding check'))?.imageInputCount ?? 0) >= 1)"
+          expr: "!env.mock || (imageRequest && (imageRequest.imageInputCount ?? 0) >= 1)"
           message:
-            expr: "`expected at least one input image, got ${String((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.prompt ?? '').includes('Image understanding check'))?.imageInputCount ?? 0)}`"
+            expr: "`expected at least one input image on the Image understanding check request, got imageInputCount=${String(imageRequest?.imageInputCount ?? 0)}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/image-understanding-attachment.md
+++ b/qa/scenarios/image-understanding-attachment.md
@@ -80,7 +80,7 @@ steps:
       # request that happens to share a debug log with this one.
       - set: imageRequest
         value:
-          expr: "[...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].find((request) => String(request.prompt ?? '').includes('Image understanding check'))"
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].find((request) => String(request.prompt ?? '').includes('Image understanding check')) : null"
       - assert:
           expr: "!env.mock || (imageRequest && (imageRequest.imageInputCount ?? 0) >= 1)"
           message:

--- a/qa/scenarios/instruction-followthrough-repo-contract.md
+++ b/qa/scenarios/instruction-followthrough-repo-contract.md
@@ -1,0 +1,127 @@
+# Instruction followthrough repo contract
+
+```yaml qa-scenario
+id: instruction-followthrough-repo-contract
+title: Instruction followthrough repo contract
+surface: repo-contract
+objective: Verify the agent reads repo instruction files first, follows the required tool order, and completes the first feasible action instead of stopping at a plan.
+successCriteria:
+  - Agent reads the seeded instruction files before writing the requested artifact.
+  - Agent writes the requested artifact in the same run instead of returning only a plan.
+  - Agent does not ask for permission before the first feasible action.
+  - Final reply makes the completed read/write sequence explicit.
+docsRefs:
+  - docs/help/testing.md
+  - docs/channels/qa-channel.md
+codeRefs:
+  - src/agents/system-prompt.ts
+  - src/agents/pi-embedded-runner/run/incomplete-turn.ts
+  - extensions/qa-lab/src/mock-openai-server.ts
+execution:
+  kind: flow
+  summary: Verify the agent reads repo instructions first, then completes the first bounded followthrough task without stalling.
+  config:
+    workspaceFiles:
+      AGENT.md: |-
+        # Repo contract
+
+        Step order:
+        1. Read AGENT.md.
+        2. Read SOUL.md.
+        3. Read FOLLOWTHROUGH_INPUT.md.
+        4. Write ./repo-contract-summary.txt.
+        5. Reply with three labeled lines exactly once: Read, Wrote, Status.
+
+        Do not stop after planning.
+        Do not ask for permission before the first feasible action.
+      SOUL.md: |-
+        # Execution style
+
+        Stay brief, honest, and action-first.
+        If the next tool action is feasible, do it before replying.
+      FOLLOWTHROUGH_INPUT.md: |-
+        Mission: prove you followed the repo contract.
+        Evidence path: AGENT.md -> SOUL.md -> FOLLOWTHROUGH_INPUT.md -> repo-contract-summary.txt
+    prompt: |-
+      Repo contract followthrough check. Read AGENT.md, SOUL.md, and FOLLOWTHROUGH_INPUT.md first.
+      Then follow the repo contract exactly, write ./repo-contract-summary.txt, and reply with
+      three labeled lines: Read, Wrote, Status.
+      Do not stop after planning and do not ask for permission before the first feasible action.
+    expectedReplyAll:
+      - "read:"
+      - "wrote:"
+      - "status:"
+    forbiddenNeedles:
+      - need permission
+      - need your approval
+      - can you approve
+      - i would
+      - i can
+      - next i would
+```
+
+```yaml qa-flow
+steps:
+  - name: follows repo instructions instead of stopping at a plan
+    actions:
+      - call: reset
+      - forEach:
+          items:
+            expr: "Object.entries(config.workspaceFiles ?? {})"
+          item: workspaceFile
+          actions:
+            - call: fs.writeFile
+              args:
+                - expr: "path.join(env.gateway.workspaceDir, String(workspaceFile[0]))"
+                - expr: "`${String(workspaceFile[1] ?? '').trimEnd()}\\n`"
+                - utf8
+      - set: artifactPath
+        value:
+          expr: "path.join(env.gateway.workspaceDir, 'repo-contract-summary.txt')"
+      - call: runAgentPrompt
+        args:
+          - ref: env
+          - sessionKey: agent:qa:repo-contract
+            message:
+              expr: config.prompt
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 40000)
+      - call: waitForCondition
+        saveAs: artifact
+        args:
+          - lambda:
+              async: true
+              expr: "((await fs.readFile(artifactPath, 'utf8').catch(() => null))?.includes('Mission: prove you followed the repo contract.') ? await fs.readFile(artifactPath, 'utf8').catch(() => null) : undefined)"
+          - expr: liveTurnTimeoutMs(env, 30000)
+          - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+      - set: expectedReplyAll
+        value:
+          expr: config.expectedReplyAll.map(normalizeLowercaseStringOrEmpty)
+      - call: waitForCondition
+        saveAs: outbound
+        args:
+          - lambda:
+              expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && expectedReplyAll.every((needle) => normalizeLowercaseStringOrEmpty(candidate.text).includes(needle))).at(-1)"
+          - expr: liveTurnTimeoutMs(env, 30000)
+          - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+      - assert:
+          expr: "!config.forbiddenNeedles.some((needle) => normalizeLowercaseStringOrEmpty(outbound.text).includes(needle))"
+          message:
+            expr: "`repo contract followthrough bounced for permission or stalled: ${outbound.text}`"
+      - set: followthroughDebugRequests
+        value:
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].filter((request) => /repo contract followthrough check/i.test(String(request.allInputText ?? ''))) : []"
+      - assert:
+          expr: "!env.mock || followthroughDebugRequests.filter((request) => request.plannedToolName === 'read').length >= 3"
+          message:
+            expr: "`expected three read tool calls before write, saw plannedToolNames=${JSON.stringify(followthroughDebugRequests.map((request) => request.plannedToolName ?? null))}`"
+      - assert:
+          expr: "!env.mock || followthroughDebugRequests.some((request) => request.plannedToolName === 'write')"
+          message:
+            expr: "`expected write tool call during repo contract followthrough, saw plannedToolNames=${JSON.stringify(followthroughDebugRequests.map((request) => request.plannedToolName ?? null))}`"
+      - assert:
+          expr: "!env.mock || (() => { const firstRead = followthroughDebugRequests.findIndex((request) => request.plannedToolName === 'read'); const firstWrite = followthroughDebugRequests.findIndex((request) => request.plannedToolName === 'write'); return firstRead >= 0 && firstWrite > firstRead; })()"
+          message:
+            expr: "`expected read-before-write ordering during repo contract followthrough, saw plannedToolNames=${JSON.stringify(followthroughDebugRequests.map((request) => request.plannedToolName ?? null))}`"
+    detailsExpr: outbound.text
+```

--- a/qa/scenarios/memory-recall.md
+++ b/qa/scenarios/memory-recall.md
@@ -1,5 +1,35 @@
 # Memory recall after context switch
 
+<!--
+  This scenario deliberately stays prose-only and does NOT gate on a
+  `/debug/requests` tool-call assertion, even though it is one of the ten
+  scenarios in the parity pack. The adversarial review in the umbrella
+  #64227 thread called this out as a coverage gap, but the underlying
+  behavior the scenario tests is legitimately prose-shaped: the agent is
+  supposed to pull a prior-turn fact ("ALPHA-7") back across an
+  intervening context switch and reply with the code. In a real
+  conversation, the model can do this EITHER by calling a memory-search
+  tool (which the qa-lab mock server doesn't currently expose) OR by
+  reading the fact directly from prior-turn context in its own
+  conversation window. Both strategies are valid parity behavior.
+
+  Forcing a `plannedToolName` assertion here would either require
+  extending the mock with a synthetic `memory_search` tool lane (PR O
+  scope, not PR J) or fabricating a tool-call requirement the real
+  providers never implement. Either path would make this scenario test
+  the harness, not the models. So we keep it prose-only, covered by the
+  `recallExpectedAny` / `rememberAckAny` assertions above, and flag the
+  exception explicitly rather than silently.
+
+  Criterion 2 of the parity completion gate (no fake progress or fake
+  tool completion) is still enforced here through the parity report's
+  fake-success detector: a scenario that's marked `pass` but whose
+  details text matches a positive-tone or failure-tone fake-success
+  pattern gets flagged via `SUSPICIOUS_PASS_PATTERNS` in
+  `extensions/qa-lab/src/agentic-parity-report.ts`. See PR E #64662 for
+  the detector extension that catches positive-tone evasions.
+-->
+
 ```yaml qa-scenario
 id: memory-recall
 title: Memory recall after context switch

--- a/qa/scenarios/model-switch-tool-continuity.md
+++ b/qa/scenarios/model-switch-tool-continuity.md
@@ -74,7 +74,7 @@ steps:
           message:
             expr: "`expected read after switch, got ${String((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))?.plannedToolName ?? '')}`"
       - assert:
-          expr: "!env.mock || (((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))?.model) === 'gpt-5.4-alt')"
+          expr: "!env.mock || (((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))?.model) === String(alternate?.model ?? ''))"
           message:
             expr: "`expected alternate model, got ${String((await fetchJson(`${env.mock.baseUrl}/debug/requests`)).find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))?.model ?? '')}`"
     detailsExpr: outbound.text

--- a/qa/scenarios/source-docs-discovery-report.md
+++ b/qa/scenarios/source-docs-discovery-report.md
@@ -60,9 +60,10 @@ steps:
       # require an actual read tool call before the prose report. Without this,
       # a model could fabricate a plausible Worked/Failed/Blocked/Follow-up
       # report without ever touching the repo files the prompt names. The
-      # debug request log is fetched once, lowercased for case-insensitive
-      # matching (the real prompt says "Worked, Failed, Blocked"), and
-      # reused for both the assertion and its failure-message diagnostic.
+      # debug request log is fetched once and reused for both the assertion
+      # and its failure-message diagnostic. Each request's allInputText is
+      # lowercased inline at match time (the real prompt writes it as
+      # "Worked, Failed, Blocked") so the contains check is case-insensitive.
       - set: discoveryDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"

--- a/qa/scenarios/source-docs-discovery-report.md
+++ b/qa/scenarios/source-docs-discovery-report.md
@@ -56,5 +56,13 @@ steps:
           expr: "!reportsDiscoveryScopeLeak(outbound.text)"
           message:
             expr: "`discovery report drifted beyond scope: ${outbound.text}`"
+      # Parity gate criterion 2 (no fake progress / fake tool completion):
+      # require an actual read tool call before the prose report. Without this,
+      # a model could fabricate a plausible Worked/Failed/Blocked/Follow-up
+      # report without ever touching the repo files the prompt names.
+      - assert:
+          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => String(request.allInputText ?? '').includes('worked, failed, blocked') && request.plannedToolName === 'read')"
+          message:
+            expr: "`expected at least one read tool call during discovery report scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/source-docs-discovery-report.md
+++ b/qa/scenarios/source-docs-discovery-report.md
@@ -59,10 +59,16 @@ steps:
       # Parity gate criterion 2 (no fake progress / fake tool completion):
       # require an actual read tool call before the prose report. Without this,
       # a model could fabricate a plausible Worked/Failed/Blocked/Follow-up
-      # report without ever touching the repo files the prompt names.
+      # report without ever touching the repo files the prompt names. The
+      # debug request log is fetched once, lowercased for case-insensitive
+      # matching (the real prompt says "Worked, Failed, Blocked"), and
+      # reused for both the assertion and its failure-message diagnostic.
+      - set: discoveryDebugRequests
+        value:
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => String(request.allInputText ?? '').includes('worked, failed, blocked') && request.plannedToolName === 'read')"
+          expr: "!env.mock || discoveryDebugRequests.some((request) => String(request.allInputText ?? '').toLowerCase().includes('worked, failed, blocked') && request.plannedToolName === 'read')"
           message:
-            expr: "`expected at least one read tool call during discovery report scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
+            expr: "`expected at least one read tool call during discovery report scenario, saw plannedToolNames=${JSON.stringify(discoveryDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/subagent-fanout-synthesis.md
+++ b/qa/scenarios/subagent-fanout-synthesis.md
@@ -113,6 +113,28 @@ steps:
                                   expr: "sawAlpha && sawBeta"
                                   message:
                                     expr: "`fanout child sessions missing (alpha=${String(sawAlpha)} beta=${String(sawBeta)})`"
+                              # Tool-call assertion (criterion 2 of the
+                              # parity completion gate in #64227): the
+                              # scenario must have actually invoked
+                              # `sessions_spawn` at least twice with
+                              # distinct labels, not just ended up with
+                              # two rows in the session store through
+                              # prose trickery. The session store alone
+                              # can be populated by other flows or by a
+                              # model that fabricates "delegation"
+                              # narration. `plannedToolName` on the
+                              # mock's `/debug/requests` log is the
+                              # tool-call ground truth: two recorded
+                              # sessions_spawn requests with distinct
+                              # labels means the model really dispatched
+                              # both subagents.
+                              - set: fanoutSpawnRequests
+                                value:
+                                  expr: "[...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].filter((request) => request.plannedToolName === 'sessions_spawn' && /subagent fanout synthesis check/i.test(String(request.allInputText ?? '')))"
+                              - assert:
+                                  expr: "fanoutSpawnRequests.length >= 2"
+                                  message:
+                                    expr: "`expected at least two sessions_spawn tool calls during subagent fanout scenario, saw ${fanoutSpawnRequests.length}`"
                         - set: details
                           value:
                             expr: "outbound.text"

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -46,5 +46,14 @@ steps:
           expr: "!['failed to delegate','could not delegate','subagent unavailable'].some((needle) => normalizeLowercaseStringOrEmpty(outbound.text).includes(needle))"
           message:
             expr: "`subagent handoff reported failure: ${outbound.text}`"
+      # Parity gate criterion 2 (no fake progress / fake tool completion):
+      # require an actual sessions_spawn tool call. Without this, a model
+      # could produce the three labeled sections ("Delegated task", "Result",
+      # "Evidence") as free-form prose without ever delegating to a real
+      # subagent.
+      - assert:
+          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
+          message:
+            expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,14 +50,17 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent. The debug request log is fetched once and the match is
-      # narrowed to the most recent matching request so a stale prior
-      # scenario on the same mock server cannot satisfy the gate.
+      # subagent. The debug request log is fetched once and filtered to
+      # pre-tool requests (no toolOutput) because that is when the mock
+      # server plans sessions_spawn; the follow-up request after the tool
+      # runs has plannedToolName unset, so a reverse-find on any matching
+      # input would often land on that post-tool request and fail even when
+      # the handoff succeeded.
       - set: subagentDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || (subagentDebugRequests.slice().reverse().find((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')))?.plannedToolName === 'sessions_spawn')"
+          expr: "!env.mock || subagentDebugRequests.some((request) => !request.toolOutput && /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
           message:
             expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify(subagentDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,16 +50,15 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent. The assertion must be pinned to THIS scenario's request
-      # window, so it matches the scenario-unique prompt text
-      # "Delegate one bounded QA task" (not a broad /delegate|subagent/
-      # regex) — otherwise the earlier subagent-fanout-synthesis scenario
-      # in catalog order also produces a pre-tool sessions_spawn request
-      # and would satisfy the assertion even when the current handoff run
-      # never delegates. The match is also pinned to pre-tool requests
-      # (no toolOutput) because the mock only plans sessions_spawn on
-      # requests with no toolOutput; the follow-up request after the tool
-      # runs has plannedToolName unset.
+      # subagent. The assertion is pinned to THIS scenario by matching the
+      # scenario-unique prompt substring "Delegate one bounded QA task"
+      # (not a broad /delegate|subagent/ regex) so the earlier
+      # subagent-fanout-synthesis scenario — which also contains "delegate"
+      # and produces its own pre-tool sessions_spawn request — cannot
+      # satisfy the assertion here. The match is also constrained to
+      # pre-tool requests (no toolOutput) because the mock only plans
+      # sessions_spawn on requests with no toolOutput; the follow-up
+      # request after the tool runs has plannedToolName unset.
       - set: subagentDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,17 +50,21 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent. The debug request log is fetched once and filtered to
-      # pre-tool requests (no toolOutput) because that is when the mock
-      # server plans sessions_spawn; the follow-up request after the tool
-      # runs has plannedToolName unset, so a reverse-find on any matching
-      # input would often land on that post-tool request and fail even when
-      # the handoff succeeded.
+      # subagent. The assertion must be pinned to THIS scenario's request
+      # window, so it matches the scenario-unique prompt text
+      # "Delegate one bounded QA task" (not a broad /delegate|subagent/
+      # regex) — otherwise the earlier subagent-fanout-synthesis scenario
+      # in catalog order also produces a pre-tool sessions_spawn request
+      # and would satisfy the assertion even when the current handoff run
+      # never delegates. The match is also pinned to pre-tool requests
+      # (no toolOutput) because the mock only plans sessions_spawn on
+      # requests with no toolOutput; the follow-up request after the tool
+      # runs has plannedToolName unset.
       - set: subagentDebugRequests
         value:
           expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || subagentDebugRequests.some((request) => !request.toolOutput && /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
+          expr: "!env.mock || subagentDebugRequests.some((request) => !request.toolOutput && /delegate one bounded qa task/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
           message:
             expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify(subagentDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text

--- a/qa/scenarios/subagent-handoff.md
+++ b/qa/scenarios/subagent-handoff.md
@@ -50,10 +50,15 @@ steps:
       # require an actual sessions_spawn tool call. Without this, a model
       # could produce the three labeled sections ("Delegated task", "Result",
       # "Evidence") as free-form prose without ever delegating to a real
-      # subagent.
+      # subagent. The debug request log is fetched once and the match is
+      # narrowed to the most recent matching request so a stale prior
+      # scenario on the same mock server cannot satisfy the gate.
+      - set: subagentDebugRequests
+        value:
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))] : []"
       - assert:
-          expr: "!env.mock || [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].some((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn')"
+          expr: "!env.mock || (subagentDebugRequests.slice().reverse().find((request) => /delegate|subagent handoff/i.test(String(request.allInputText ?? '')))?.plannedToolName === 'sessions_spawn')"
           message:
-            expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].map((request) => request.plannedToolName ?? null))}`"
+            expr: "`expected sessions_spawn tool call during subagent handoff scenario, saw plannedToolNames=${JSON.stringify(subagentDebugRequests.map((request) => request.plannedToolName ?? null))}`"
     detailsExpr: outbound.text
 ```


### PR DESCRIPTION
## Summary

This is the parity proof rollup for the GPT-5.4 / Codex parity program.

It supersedes:

- #64662
- #64681
- #64685
- #64789
- #64837
- #64909

The goal is to make the remaining proof/release-certification work reviewable as one coherent qa-lab/docs PR instead of six small slices.

## What This Fixes From The Original GPT-5.4 Prompt

The original prompt was not just “make GPT-5.4 look better in anecdotes.” It was “make GPT-5.4 behave more agentically in practice, prove it, and make sure it really follows repo instructions instead of only reading them.”

This rollup carries forward the proof-side work needed for that:

- expands the parity pack and gate behavior onto one proof branch
- enforces real tool evidence on prose-shaped scenarios
- adds the Anthropic mock baseline lane, including `/v1/messages` routing and SSE support
- keeps remember-prompt and exact-reply handling honest in the mock server
- makes `qa-suite-summary.json` self-describing with run provenance
- carries the mock auth staging needed for offline parity runs
- rewrites the docs/runbook around the final 2-PR closeout
- adds `instruction-followthrough-repo-contract`, the missing proof for the original AGENT.md / SOUL.md followthrough complaint

No new public runtime API is introduced here.

## Verification

Branch-owned proof coverage passed locally:

```bash
CI=1 pnpm exec vitest run \
  extensions/qa-lab/src/agentic-parity-report.test.ts \
  extensions/qa-lab/src/cli.runtime.test.ts \
  extensions/qa-lab/src/scenario-catalog.test.ts \
  extensions/qa-lab/src/mock-openai-server.test.ts \
  extensions/qa-lab/src/qa-gateway-config.test.ts \
  extensions/qa-lab/src/suite.summary-json.test.ts \
  extensions/qa-lab/src/gateway-child.test.ts
```

That suite passed `143/143` locally.

Workflow sanity also passed:

```bash
npx github-actionlint .github/workflows/parity-gate.yml
```

On the merged runtime+proof integration branch:

1. the new `instruction-followthrough-repo-contract` scenario passed on the real QA harness
2. the full offline structural parity rerun passed end to end

```bash
pnpm openclaw qa suite \
  --provider-mode mock-openai \
  --model openai/gpt-5.4 \
  --alt-model openai/gpt-5.4-alt \
  --parity-pack agentic \
  --output-dir .artifacts/qa-rollup/gpt54-mock

pnpm openclaw qa suite \
  --provider-mode mock-openai \
  --model anthropic/claude-opus-4-6 \
  --alt-model anthropic/claude-sonnet-4-6 \
  --parity-pack agentic \
  --output-dir .artifacts/qa-rollup/opus46-mock

pnpm openclaw qa parity-report \
  --repo-root . \
  --candidate-summary .artifacts/qa-rollup/gpt54-mock/qa-suite-summary.json \
  --baseline-summary .artifacts/qa-rollup/opus46-mock/qa-suite-summary.json \
  --candidate-label openai/gpt-5.4 \
  --baseline-label anthropic/claude-opus-4-6 \
  --output-dir .artifacts/qa-rollup/parity-mock
```

That produced a green offline parity verdict on the merged 11-scenario pack:

- candidate: 11/11 pass
- baseline: 11/11 pass
- parity verdict: pass
- fake-success count: 0 on both sides

Separately, we already have a live GPT-5.4 10/10 harness pass on the patched stack. This PR does **not** overclaim a finished live Opus baseline; it keeps the structural parity proof and release artifacts merge-ready so the final live-provider proof can be attached cleanly once provider access is stable.

## Dependency Note

This PR is the proof half of the 2-PR closeout. It is intended to land alongside the runtime completion rollup, while keeping A/B/C/D closed and preserving their review history.
