### PR TITLE
fix(status): reflect observed heartbeat state

### DIFF
--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -3,6 +3,7 @@ import type { HealthSummary } from "./health.js";
 import {
   buildStatusFooterLines,
   buildStatusHealthRows,
+  buildStatusHeartbeatValue,
   buildStatusPairingRecoveryLines,
   buildStatusPluginCompatibilityLines,
   buildStatusSecurityAuditLines,
@@ -207,5 +208,52 @@ describe("status.command-sections", () => {
       { key: "Status", header: "Status", minWidth: 8 },
       { key: "Detail", header: "Detail", flex: true, minWidth: 28 },
     ]);
+  });
+
+  it("shows observed running state for enabled heartbeat agents", () => {
+    const value = buildStatusHeartbeatValue({
+      summary: {
+        heartbeat: {
+          defaultAgentId: "main",
+          agents: [
+            {
+              agentId: "main",
+              enabled: true,
+              every: "30m",
+              everyMs: 1_800_000,
+              observedState: "running",
+            },
+            {
+              agentId: "devclaw",
+              enabled: false,
+              every: "disabled",
+              everyMs: null,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(value).toBe("30m (main, running), disabled (devclaw)");
+  });
+
+  it("falls back to disabled when no heartbeat agents are enabled", () => {
+    const value = buildStatusHeartbeatValue({
+      summary: {
+        heartbeat: {
+          defaultAgentId: "main",
+          agents: [
+            {
+              agentId: "main",
+              enabled: false,
+              every: "disabled",
+              everyMs: null,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(value).toBe("disabled (main)");
   });
 });

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -82,7 +82,8 @@ export function buildStatusHeartbeatValue(params: { summary: Pick<SummaryLike, "
       if (!agent.enabled || !agent.everyMs) {
         return `disabled (${agent.agentId})`;
       }
-      return `${agent.every} (${agent.agentId})`;
+      const observed = agent.observedState ? `, ${agent.observedState}` : "";
+      return `${agent.every} (${agent.agentId}${observed})`;
     })
     .filter(Boolean);
   return parts.length > 0 ? parts.join(", ") : "disabled";

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -3,6 +3,16 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const statusSummaryMocks = vi.hoisted(() => ({
   hasPotentialConfiguredChannels: vi.fn(() => true),
   buildChannelSummary: vi.fn(async () => ["ok"]),
+  listGatewayAgentsBasic: vi.fn(() => ({
+    defaultId: "main",
+    agents: [{ id: "main" }],
+  })),
+  resolveHeartbeatSummaryForAgent: vi.fn(() => ({
+    enabled: true,
+    every: "5m",
+    everyMs: 300_000,
+  })),
+  getLastHeartbeatEvent: vi.fn(() => null),
 }));
 
 vi.mock("../channels/config-presence.js", () => ({
@@ -35,10 +45,7 @@ vi.mock("../config/io.js", () => ({
 }));
 
 vi.mock("../gateway/agent-list.js", () => ({
-  listGatewayAgentsBasic: vi.fn(() => ({
-    defaultId: "main",
-    agents: [{ id: "main" }],
-  })),
+  listGatewayAgentsBasic: statusSummaryMocks.listGatewayAgentsBasic,
 }));
 
 vi.mock("../infra/channel-summary.js", () => ({
@@ -46,11 +53,11 @@ vi.mock("../infra/channel-summary.js", () => ({
 }));
 
 vi.mock("../infra/heartbeat-summary.js", () => ({
-  resolveHeartbeatSummaryForAgent: vi.fn(() => ({
-    enabled: true,
-    every: "5m",
-    everyMs: 300_000,
-  })),
+  resolveHeartbeatSummaryForAgent: statusSummaryMocks.resolveHeartbeatSummaryForAgent,
+}));
+
+vi.mock("../infra/heartbeat-events.js", () => ({
+  getLastHeartbeatEvent: statusSummaryMocks.getLastHeartbeatEvent,
 }));
 
 vi.mock("../infra/system-events.js", () => ({
@@ -127,6 +134,16 @@ describe("getStatusSummary", () => {
     vi.clearAllMocks();
     statusSummaryMocks.hasPotentialConfiguredChannels.mockReturnValue(true);
     statusSummaryMocks.buildChannelSummary.mockResolvedValue(["ok"]);
+    statusSummaryMocks.listGatewayAgentsBasic.mockReturnValue({
+      defaultId: "main",
+      agents: [{ id: "main" }],
+    });
+    statusSummaryMocks.resolveHeartbeatSummaryForAgent.mockReturnValue({
+      enabled: true,
+      every: "5m",
+      everyMs: 300_000,
+    });
+    statusSummaryMocks.getLastHeartbeatEvent.mockReturnValue(null);
   });
 
   it("includes runtimeVersion in the status payload", async () => {
@@ -137,6 +154,81 @@ describe("getStatusSummary", () => {
     expect(summary.channelSummary).toEqual(["ok"]);
     expect(summary.tasks.active).toBe(0);
     expect(summary.taskAudit.warnings).toBe(1);
+  });
+
+  it("marks enabled heartbeat agents as running when a recent tick was observed", async () => {
+    const now = Date.now();
+    statusSummaryMocks.getLastHeartbeatEvent.mockReturnValue({
+      ts: now - 60_000,
+      status: "ok",
+      channel: "telegram",
+      accountId: "default",
+    });
+
+    const summary = await getStatusSummary();
+
+    expect(summary.heartbeat.agents).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        enabled: true,
+        observedState: "running",
+        lastTickTs: now - 60_000,
+      }),
+    ]);
+  });
+
+  it("marks enabled heartbeat agents as stale when the last observed tick is too old", async () => {
+    const now = Date.now();
+    statusSummaryMocks.getLastHeartbeatEvent.mockReturnValue({
+      ts: now - 700_000,
+      status: "ok",
+      channel: "telegram",
+    });
+
+    const summary = await getStatusSummary();
+
+    expect(summary.heartbeat.agents).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        enabled: true,
+        observedState: "stale",
+        lastTickTs: now - 700_000,
+      }),
+    ]);
+  });
+
+  it("keeps disabled agents disabled even when another agent heartbeat was observed", async () => {
+    statusSummaryMocks.listGatewayAgentsBasic.mockReturnValue({
+      defaultId: "main",
+      agents: [{ id: "main" }, { id: "devclaw" }],
+    });
+    statusSummaryMocks.resolveHeartbeatSummaryForAgent.mockImplementation(
+      (_cfg: unknown, agentId: string) =>
+        agentId === "devclaw"
+          ? { enabled: false, every: "disabled", everyMs: null }
+          : { enabled: true, every: "30m", everyMs: 1_800_000 },
+    );
+    statusSummaryMocks.getLastHeartbeatEvent.mockReturnValue({
+      ts: Date.now() - 60_000,
+      status: "ok",
+      channel: "telegram",
+    });
+
+    const summary = await getStatusSummary();
+
+    expect(summary.heartbeat.agents).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        enabled: true,
+        observedState: "running",
+      }),
+      expect.objectContaining({
+        agentId: "devclaw",
+        enabled: false,
+        observedState: undefined,
+        lastTickTs: null,
+      }),
+    ]);
   });
 
   it("skips channel summary imports when no channels are configured", async () => {

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -6,6 +6,7 @@ import { readSessionStoreReadOnly } from "../config/sessions/store-read.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
+import { getLastHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
 import { peekSystemEvents } from "../infra/system-events.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
@@ -124,13 +125,31 @@ export async function getStatusSummary(
       )
     : null;
   const agentList = listGatewayAgentsBasic(cfg);
+  const lastHeartbeatEvent = getLastHeartbeatEvent();
+  const lastHeartbeatTs = lastHeartbeatEvent?.ts ?? null;
   const heartbeatAgents: HeartbeatStatus[] = agentList.agents.map((agent) => {
     const summary = resolveHeartbeatSummaryForAgent(cfg, agent.id);
+    let observedState: HeartbeatStatus["observedState"] = undefined;
+    if (summary.enabled) {
+      if (
+        lastHeartbeatTs &&
+        summary.everyMs &&
+        Date.now() - lastHeartbeatTs <= summary.everyMs * 2
+      ) {
+        observedState = "running";
+      } else if (lastHeartbeatTs && summary.everyMs) {
+        observedState = "stale";
+      } else {
+        observedState = "unknown";
+      }
+    }
     return {
       agentId: agent.id,
       enabled: summary.enabled,
       every: summary.every,
       everyMs: summary.everyMs,
+      observedState,
+      lastTickTs: summary.enabled ? lastHeartbeatTs : null,
     } satisfies HeartbeatStatus;
   });
   const channelSummary = needsChannelPlugins

--- a/src/commands/status.types.ts
+++ b/src/commands/status.types.ts
@@ -34,6 +34,8 @@ export type HeartbeatStatus = {
   enabled: boolean;
   every: string;
   everyMs: number | null;
+  observedState?: "running" | "stale" | "unknown";
+  lastTickTs?: number | null;
 };
 
 export type StatusSummary = {


### PR DESCRIPTION
## Summary
- add observed heartbeat state to status summaries using the latest runtime heartbeat event
- show that observed state in the `Heartbeat` line so running agents are not reported as only disabled/configured
- cover running, stale, and disabled-agent cases with targeted status tests

## Testing
- corepack pnpm test -- src/commands/status.summary.test.ts src/commands/status.command-sections.test.ts src/commands/status-runtime-shared.test.ts src/commands/status-json-runtime.test.ts src/commands/health.snapshot.test.ts
