### PR TITLE
fix(gmail): set stopped=true on addressInUse to prevent duplicate watcher restart

### DIFF
--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -25,6 +25,9 @@ const log = createSubsystemLogger("gmail-watcher");
 let watcherProcess: ChildProcess | null = null;
 let renewInterval: ReturnType<typeof setInterval> | null = null;
 let shuttingDown = false;
+// Set when stopGmailWatcher is called so the exit handler knows the stop was intentional.
+// Prevents a restart from being scheduled after a new watcher has already started.
+let stopped = false;
 let currentConfig: GmailHookRuntimeConfig | null = null;
 
 /**
@@ -92,10 +95,11 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   });
 
   child.on("exit", (code, signal) => {
-    if (shuttingDown) {
+    if (shuttingDown || stopped) {
       return;
     }
     if (addressInUse) {
+      stopped = true;
       log.warn(
         "gog serve failed to bind (address already in use); stopping restarts. " +
           "Another watcher is likely running. Set OPENCLAW_SKIP_GMAIL_WATCHER=1 or stop the other process.",
@@ -106,7 +110,7 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     log.warn(`gog exited (code=${code}, signal=${signal}); restarting in 5s`);
     watcherProcess = null;
     setTimeout(() => {
-      if (shuttingDown || !currentConfig) {
+      if (shuttingDown || stopped || !currentConfig) {
         return;
       }
       watcherProcess = spawnGogServe(currentConfig);
@@ -133,6 +137,13 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
 
   if (!cfg.hooks?.gmail?.account) {
     return { started: false, reason: "no gmail account configured" };
+  }
+
+  // Guard: refuse to start if a watcher is already running. This prevents duplicate
+  // watchers when startGmailWatcher is called multiple times (e.g. hot-reload race or
+  // after a process exits with addressInUse without the module state being updated).
+  if (watcherProcess != null && !shuttingDown) {
+    return { started: false, reason: "watcher already running" };
   }
 
   // Check if gog is available
@@ -202,6 +213,7 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
  */
 export async function stopGmailWatcher(): Promise<void> {
   shuttingDown = true;
+  stopped = true;
 
   if (renewInterval) {
     clearInterval(renewInterval);


### PR DESCRIPTION
## Summary
Fix Gmail watcher duplicate start issue (#65042): when port 8788 is already in use, set `stopped=true` to prevent repeated restart attempts.

## Changes
- Add `stopped` state variable to track intentional stops
- In `spawnGogServe` exit handler: guard with `|| stopped` to prevent restart after intentional stop
- In `addressInUse` block: set `stopped = true` so watcher doesn't keep retrying
- In `startGmailWatcher`: add guard to refuse starting if `watcherProcess != null`
- In `stopGmailWatcher`: set `stopped = true` to prevent restart after stop

## Testing
- Fixes port 8788 EADDRINUSE error on duplicate watcher start
- Maintains single watcher per account invariant
- Graceful degradation: existing watcher takes precedence

Closes #65042