### PR TITLE
fix(cron): guard job.state before accessing in planStartupCatchup

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -965,6 +965,13 @@ async function planStartupCatchup(
     if (missed.length === 0) {
       return { candidates: [], deferredJobIds: [] };
     }
+    // Guard: ensure job.state exists before accessing. Jobs loaded from storage
+    // may be missing state if created via CronJobCreate (where state is optional).
+    for (const job of missed) {
+      if (!job.state) {
+        job.state = {};
+      }
+    }
     const sorted = missed.toSorted(
       (a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0),
     );
@@ -987,6 +994,9 @@ async function planStartupCatchup(
       );
     }
     for (const job of startupCandidates) {
+      if (!job.state) {
+        job.state = {};
+      }
       job.state.runningAtMs = now;
       job.state.lastError = undefined;
     }


### PR DESCRIPTION
## Summary\nFixes TypeError when cron service starts up and accesses `job.state.runningAtMs` on jobs whose `state` is undefined.\n\n## Root Cause\nJobs loaded from the persistent store may be missing the `state` field if they were created via `CronJobCreate` (where `state` is optional). When `planStartupCatchup` runs after gateway restart, it accesses `job.state.nextRunAtMs` (in sort comparator) and `job.state.runningAtMs` (in loop) without guarding against undefined state, causing:\n```\nTypeError: Cannot read properties of undefined (reading 'runningAtMs')\n```\n\n## Changes\n- Add `job.state` guard in `planStartupCatchup` before accessing `job.state` in the sort comparator\n- Add `job.state` guard before setting `runningAtMs` in the startupCandidates loop\n\n## Testing\n- Fixes v2026.4.9 regression where cron crashes on restart due to missing job state\n- No behavior change for jobs with properly initialized state\n\nCloses #65193