### PR TITLE
docs(agents): split scoped workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,12 @@
   - `src/plugins/AGENTS.md` expands plugin loading, registry, and manifest rules.
   - `src/gateway/protocol/AGENTS.md` expands typed Gateway protocol rules.
   - `test/helpers/AGENTS.md` and `test/helpers/channels/AGENTS.md` expand shared test helper boundary rules.
+- Plugin architecture direction:
+  - Keep a manifest-first control plane: discovery, validation, enablement, setup hints, and activation planning should stay metadata-driven by default.
+  - Keep runtime execution separate: actual provider/channel/tool execution should resolve through narrow targeted loaders, not broad registry materialization.
+  - Host loads plugins; plugins do not load host internals. Prefer a small versioned host/kernel seam plus documented SDK entrypoints over ambient reachability.
+  - Treat broad runtime registries and mutable global plugin state as transitional compatibility surfaces, not the target architecture.
+  - If a setup or config flow truly needs plugin runtime, make that explicit instead of silently importing runtime code on the cold path.
 
 ## Scoped Workflow Guides
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,22 +36,54 @@
   - `src/channels/AGENTS.md`
   - `src/plugins/AGENTS.md`
   - `src/gateway/protocol/AGENTS.md`
-- `extensions/AGENTS.md` owns extension/plugin boundary rules.
-- `src/channels/AGENTS.md` owns core channel boundary and hot-path rules.
-- `src/plugin-sdk/AGENTS.md` owns public SDK contract rules.
-- `src/plugins/AGENTS.md` owns plugin loading, registry, and manifest rules.
-- `src/gateway/protocol/AGENTS.md` owns typed Gateway protocol rules.
-- `test/helpers/AGENTS.md` and `test/helpers/channels/AGENTS.md` own shared test helper boundary rules.
-- Cross-cutting invariants that still apply repo-wide:
-  - Core must stay extension-agnostic. Adding a bundled or third-party extension should not require unrelated core edits just to teach core that the extension exists.
-  - Do not add hardcoded bundled extension/provider/channel/capability id lists, maps, or named special cases in core when a manifest, capability, registry, or plugin-owned contract can express the same behavior.
-  - For legacy config specifically, prefer doctor-owned repair paths over startup/load-time core migrations. Do not add new plugin-specific legacy migration logic to shared core/runtime surfaces when `openclaw doctor --fix` can own it.
-  - Compatibility matters. New seams are allowed, but they must be documented, additive, and backwards-compatible unless the work is explicitly major-version scoped.
+- Plugin and extension boundary:
+  - Public docs: `docs/plugins/building-plugins.md`, `docs/plugins/architecture.md`, `docs/plugins/sdk-overview.md`, `docs/plugins/sdk-entrypoints.md`, `docs/plugins/sdk-runtime.md`, `docs/plugins/manifest.md`, `docs/plugins/sdk-channel-plugins.md`, `docs/plugins/sdk-provider-plugins.md`
+  - Definition files: `src/plugin-sdk/plugin-entry.ts`, `src/plugin-sdk/core.ts`, `src/plugin-sdk/provider-entry.ts`, `src/plugin-sdk/channel-contract.ts`, `scripts/lib/plugin-sdk-entrypoints.json`, `package.json`
+  - Invariant: core must stay extension-agnostic. Adding a bundled or third-party extension should not require unrelated core edits just to teach core that the extension exists.
+  - Rule: extensions must cross into core only through `openclaw/plugin-sdk/*`, manifest metadata, and documented runtime helpers. Do not import `src/**` from extension production code.
+  - Rule: core code and tests must not deep-import bundled plugin internals such as a plugin's `src/**` files or `onboard.js`. If core needs a bundled plugin helper, expose it through that plugin's `api.ts` and, when it is a real cross-package contract, through `src/plugin-sdk/<id>.ts`.
+  - Rule: do not add hardcoded bundled extension/provider/channel/capability id lists, maps, or named special cases in core when a manifest, capability, registry, or plugin-owned contract can express the same behavior.
+  - Rule: extension-owned compatibility behavior belongs to the owning extension. Core may orchestrate generic doctor/config flows, but extension-specific legacy repairs, detection rules, onboarding, auth detection, and provider defaults should live in plugin-owned contracts.
+  - Rule: for legacy config specifically, prefer doctor-owned repair paths over startup/load-time core migrations. Do not add new plugin-specific legacy migration logic to shared core/runtime surfaces when `openclaw doctor --fix` can own it.
+  - Rule: when a test is asserting extension-specific behavior, keep that coverage in the owning extension when feasible. Core tests should assert generic contracts and registry/capability behavior, not extension internals.
+  - Refactor trigger: if you encounter core code or tests that name a specific extension/provider/channel for extension-owned behavior, refactor toward a generic registry/capability/plugin-owned seam instead of adding another special case.
+  - Compatibility: new plugin seams are allowed, but they must be added as documented, backwards-compatible, versioned contracts. We have third-party plugins in the wild and do not break them casually.
+- Channel boundary:
+  - Public docs: `docs/plugins/sdk-channel-plugins.md`, `docs/plugins/architecture.md`
+  - Definition files: `src/channels/plugins/types.plugin.ts`, `src/channels/plugins/types.core.ts`, `src/channels/plugins/types.adapters.ts`, `src/plugin-sdk/core.ts`, `src/plugin-sdk/channel-contract.ts`
+  - Rule: `src/channels/**` is core implementation. If plugin authors need a new seam, add it to the Plugin SDK instead of telling them to import channel internals.
+- Provider/model boundary:
+  - Public docs: `docs/plugins/sdk-provider-plugins.md`, `docs/concepts/model-providers.md`, `docs/plugins/architecture.md`
+  - Definition files: `src/plugins/types.ts`, `src/plugin-sdk/provider-entry.ts`, `src/plugin-sdk/provider-auth.ts`, `src/plugin-sdk/provider-catalog-shared.ts`, `src/plugin-sdk/provider-model-shared.ts`
+  - Rule: core owns the generic inference loop; provider plugins own provider-specific behavior through registration and typed hooks. Do not solve provider needs by reaching into unrelated core internals.
+  - Rule: avoid ad hoc reads of `plugins.entries.<id>.config` from unrelated core code. If core needs plugin-owned auth/config behavior, add or use a generic seam (`resolveSyntheticAuth`, public SDK/helper facades, manifest metadata, plugin auto-enable hooks) and honor plugin disablement plus SecretRef semantics.
+  - Rule: vendor-owned tools and settings belong in the owning plugin. Do not add provider-specific tool config, secret collection, or runtime enablement to core `tools.*` surfaces unless the tool is intentionally core-owned.
+- Gateway protocol boundary:
+  - Public docs: `docs/gateway/protocol.md`, `docs/gateway/bridge-protocol.md`, `docs/concepts/architecture.md`
+  - Definition files: `src/gateway/protocol/schema.ts`, `src/gateway/protocol/schema/*.ts`, `src/gateway/protocol/index.ts`
+  - Rule: protocol changes are contract changes. Prefer additive evolution; incompatible changes require explicit versioning, docs, and client/codegen follow-through.
 - Config contract boundary:
   - Canonical public config lives in exported config types, zod/schema surfaces, schema help/labels, generated config metadata, config baselines, and any user-facing gateway/config payloads. Keep those surfaces aligned.
   - When a legacy config key is retired from the public contract, remove it from every public config surface above. Keep backward compatibility only through raw-config migration/doctor seams unless explicit product policy says otherwise.
   - Do not reintroduce removed legacy aliases into public types/schema/help/baselines “for convenience”. If old configs still need to load, handle that in `legacy.migrations.*`, config ingest, or `openclaw doctor --fix`.
   - `hooks.internal.entries` is the canonical public hook config model. `hooks.internal.handlers` is compatibility-only input and must not be re-exposed in public schema/help/baseline surfaces.
+- Bundled plugin contract boundary:
+  - Public docs: `docs/plugins/architecture.md`, `docs/plugins/manifest.md`, `docs/plugins/sdk-overview.md`
+  - Definition files: `src/plugins/contracts/registry.ts`, `src/plugins/types.ts`, `src/plugins/public-artifacts.ts`
+  - Rule: keep manifest metadata, runtime registration, public SDK exports, and contract tests aligned. Do not create a hidden path around the declared plugin interfaces.
+- Extension test boundary:
+  - Keep extension-owned onboarding/config/provider coverage under the owning bundled plugin package when feasible.
+  - If core tests need bundled plugin behavior, consume it through public `src/plugin-sdk/<id>.ts` facades or the plugin's `api.ts`, not private extension modules.
+  - Shared helpers under `test/helpers/**` are part of that same boundary. Do not hardcode repo-relative `extensions/**` imports there, and do not keep plugin-local deep mocks in shared helpers just because multiple tests use them.
+  - When core tests or shared helpers need bundled plugin public surfaces, use `src/test-utils/bundled-plugin-public-surface.ts` for `api.ts`, `runtime-api.ts`, `contract-api.ts`, `test-api.ts`, plugin entrypoint `index.js`, and resolved module ids for dynamic import or mocking.
+  - If a core test is asserting extension-specific behavior instead of a generic contract, move it to the owning extension package.
+- Scoped guides still matter:
+  - `extensions/AGENTS.md` expands extension/plugin boundary rules.
+  - `src/channels/AGENTS.md` expands core channel boundary and hot-path rules.
+  - `src/plugin-sdk/AGENTS.md` expands public SDK contract rules.
+  - `src/plugins/AGENTS.md` expands plugin loading, registry, and manifest rules.
+  - `src/gateway/protocol/AGENTS.md` expands typed Gateway protocol rules.
+  - `test/helpers/AGENTS.md` and `test/helpers/channels/AGENTS.md` expand shared test helper boundary rules.
 
 ## Scoped Workflow Guides
 
@@ -146,7 +178,7 @@
 - In tests, prefer per-instance stubs over prototype mutation (`SomeClass.prototype.method = ...`) unless a test explicitly documents why prototype-level patching is required.
 - Add brief code comments for tricky or non-obvious logic.
 - Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
-- Keep files concise and split/refactor when size starts hurting clarity, reviewability, or testability. The real enforcement lives in repo checks, not this guidance line.
+- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
 - Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
 - Written English: use American spelling and grammar in code, comments, docs, and UI strings (e.g. "color" not "colour", "behavior" not "behaviour", "analyze" not "analyse").
 
@@ -267,7 +299,7 @@
   - Only ask when changes are semantic (logic/data/behavior).
 - **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
 - Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
-- Code style: add brief comments for tricky logic; keep files concise and split/refactor when a file gets unwieldy.
+- Code style: add brief comments for tricky logic; keep files under ~700 LOC when feasible (split/refactor as needed).
 - Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
 - Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
 - Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,83 +30,34 @@
   - `src/plugins/*` = plugin discovery, manifest validation, loader, registry, and contract enforcement
   - `src/gateway/protocol/*` = typed Gateway control-plane and node wire protocol
 - Progressive disclosure lives in local boundary guides:
-  - bundled-plugin-tree `AGENTS.md`
+  - repo root `AGENTS.md`
+  - bundled-plugin-tree `extensions/AGENTS.md`
   - `src/plugin-sdk/AGENTS.md`
   - `src/channels/AGENTS.md`
   - `src/plugins/AGENTS.md`
   - `src/gateway/protocol/AGENTS.md`
-- Plugin and extension boundary:
-  - Public docs: `docs/plugins/building-plugins.md`, `docs/plugins/architecture.md`, `docs/plugins/sdk-overview.md`, `docs/plugins/sdk-entrypoints.md`, `docs/plugins/sdk-runtime.md`, `docs/plugins/manifest.md`, `docs/plugins/sdk-channel-plugins.md`, `docs/plugins/sdk-provider-plugins.md`
-  - Definition files: `src/plugin-sdk/plugin-entry.ts`, `src/plugin-sdk/core.ts`, `src/plugin-sdk/provider-entry.ts`, `src/plugin-sdk/channel-contract.ts`, `scripts/lib/plugin-sdk-entrypoints.json`, `package.json`
-  - Invariant: core must stay extension-agnostic. Adding a bundled or third-party extension should not require unrelated core edits just to teach core that the extension exists.
-  - Rule: extensions must cross into core only through `openclaw/plugin-sdk/*`, manifest metadata, and documented runtime helpers. Do not import `src/**` from extension production code.
-  - Rule: core code and tests must not deep-import bundled plugin internals such as a plugin's `src/**` files or `onboard.js`. If core needs a bundled plugin helper, expose it through that plugin's `api.ts` and, when it is a real cross-package contract, through `src/plugin-sdk/<id>.ts`.
-  - Rule: do not add hardcoded bundled extension/provider/channel/capability id lists, maps, or named special cases in core when a manifest, capability, registry, or plugin-owned contract can express the same behavior.
-  - Rule: extension-owned compatibility behavior belongs to the owning extension. Core may orchestrate generic doctor/config flows, but extension-specific legacy repairs, detection rules, onboarding, auth detection, and provider defaults should live in plugin-owned contracts.
-  - Rule: for legacy config specifically, prefer doctor-owned repair paths over startup/load-time core migrations. Do not add new plugin-specific legacy migration logic to shared core/runtime surfaces when `openclaw doctor --fix` can own it.
-  - Rule: when a test is asserting extension-specific behavior, keep that coverage in the owning extension when feasible. Core tests should assert generic contracts and registry/capability behavior, not extension internals.
-  - Refactor trigger: if you encounter core code or tests that name a specific extension/provider/channel for extension-owned behavior, refactor toward a generic registry/capability/plugin-owned seam instead of adding another special case.
-  - Compatibility: new plugin seams are allowed, but they must be added as documented, backwards-compatible, versioned contracts. We have third-party plugins in the wild and do not break them casually.
-- Channel boundary:
-  - Public docs: `docs/plugins/sdk-channel-plugins.md`, `docs/plugins/architecture.md`
-  - Definition files: `src/channels/plugins/types.plugin.ts`, `src/channels/plugins/types.core.ts`, `src/channels/plugins/types.adapters.ts`, `src/plugin-sdk/core.ts`, `src/plugin-sdk/channel-contract.ts`
-  - Rule: `src/channels/**` is core implementation. If plugin authors need a new seam, add it to the Plugin SDK instead of telling them to import channel internals.
-- Provider/model boundary:
-  - Public docs: `docs/plugins/sdk-provider-plugins.md`, `docs/concepts/model-providers.md`, `docs/plugins/architecture.md`
-  - Definition files: `src/plugins/types.ts`, `src/plugin-sdk/provider-entry.ts`, `src/plugin-sdk/provider-auth.ts`, `src/plugin-sdk/provider-catalog-shared.ts`, `src/plugin-sdk/provider-model-shared.ts`
-  - Rule: core owns the generic inference loop; provider plugins own provider-specific behavior through registration and typed hooks. Do not solve provider needs by reaching into unrelated core internals.
-  - Rule: avoid ad hoc reads of `plugins.entries.<id>.config` from unrelated core code. If core needs plugin-owned auth/config behavior, add or use a generic seam (`resolveSyntheticAuth`, public SDK/helper facades, manifest metadata, plugin auto-enable hooks) and honor plugin disablement plus SecretRef semantics.
-  - Rule: vendor-owned tools and settings belong in the owning plugin. Do not add provider-specific tool config, secret collection, or runtime enablement to core `tools.*` surfaces unless the tool is intentionally core-owned.
-- Gateway protocol boundary:
-  - Public docs: `docs/gateway/protocol.md`, `docs/gateway/bridge-protocol.md`, `docs/concepts/architecture.md`
-  - Definition files: `src/gateway/protocol/schema.ts`, `src/gateway/protocol/schema/*.ts`, `src/gateway/protocol/index.ts`
-  - Rule: protocol changes are contract changes. Prefer additive evolution; incompatible changes require explicit versioning, docs, and client/codegen follow-through.
+- `extensions/AGENTS.md` owns extension/plugin boundary rules.
+- `src/channels/AGENTS.md` owns core channel boundary and hot-path rules.
+- `src/plugin-sdk/AGENTS.md` owns public SDK contract rules.
+- `src/plugins/AGENTS.md` owns plugin loading, registry, and manifest rules.
+- `src/gateway/protocol/AGENTS.md` owns typed Gateway protocol rules.
+- `test/helpers/AGENTS.md` and `test/helpers/channels/AGENTS.md` own shared test helper boundary rules.
+- Cross-cutting invariants that still apply repo-wide:
+  - Core must stay extension-agnostic. Adding a bundled or third-party extension should not require unrelated core edits just to teach core that the extension exists.
+  - Do not add hardcoded bundled extension/provider/channel/capability id lists, maps, or named special cases in core when a manifest, capability, registry, or plugin-owned contract can express the same behavior.
+  - For legacy config specifically, prefer doctor-owned repair paths over startup/load-time core migrations. Do not add new plugin-specific legacy migration logic to shared core/runtime surfaces when `openclaw doctor --fix` can own it.
+  - Compatibility matters. New seams are allowed, but they must be documented, additive, and backwards-compatible unless the work is explicitly major-version scoped.
 - Config contract boundary:
   - Canonical public config lives in exported config types, zod/schema surfaces, schema help/labels, generated config metadata, config baselines, and any user-facing gateway/config payloads. Keep those surfaces aligned.
   - When a legacy config key is retired from the public contract, remove it from every public config surface above. Keep backward compatibility only through raw-config migration/doctor seams unless explicit product policy says otherwise.
   - Do not reintroduce removed legacy aliases into public types/schema/help/baselines “for convenience”. If old configs still need to load, handle that in `legacy.migrations.*`, config ingest, or `openclaw doctor --fix`.
   - `hooks.internal.entries` is the canonical public hook config model. `hooks.internal.handlers` is compatibility-only input and must not be re-exposed in public schema/help/baseline surfaces.
-- Bundled plugin contract boundary:
-  - Public docs: `docs/plugins/architecture.md`, `docs/plugins/manifest.md`, `docs/plugins/sdk-overview.md`
-- Definition files: `src/plugins/contracts/registry.ts`, `src/plugins/types.ts`, `src/plugins/public-artifacts.ts`
-  - Rule: keep manifest metadata, runtime registration, public SDK exports, and contract tests aligned. Do not create a hidden path around the declared plugin interfaces.
-- Extension test boundary:
-  - Keep extension-owned onboarding/config/provider coverage under the owning bundled plugin package when feasible.
-  - If core tests need bundled plugin behavior, consume it through public `src/plugin-sdk/<id>.ts` facades or the plugin's `api.ts`, not private extension modules.
-  - Shared helpers under `test/helpers/**` are part of that same boundary. Do not hardcode repo-relative `extensions/**` imports there, and do not keep plugin-local deep mocks in shared helpers just because multiple tests use them.
-  - When core tests or shared helpers need bundled plugin public surfaces, use `src/test-utils/bundled-plugin-public-surface.ts` for `api.ts`, `runtime-api.ts`, `contract-api.ts`, `test-api.ts`, plugin entrypoint `index.js`, and resolved module ids for dynamic import or mocking.
-  - If a core test is asserting extension-specific behavior instead of a generic contract, move it to the owning extension package.
 
-## Docs Linking (Mintlify)
+## Scoped Workflow Guides
 
-- Docs are hosted on Mintlify (docs.openclaw.ai).
-- Internal doc links in `docs/**/*.md`: root-relative, no `.md`/`.mdx` (example: `[Config](/configuration)`).
-- When working with documentation, read the mintlify skill.
-- For docs, UI copy, and picker lists, order services/providers alphabetically unless the section is explicitly describing runtime behavior (for example auto-detection or execution order).
-- Section cross-references: use anchors on root-relative paths (example: `[Hooks](/configuration#hooks)`).
-- Doc headings and anchors: avoid em dashes and apostrophes in headings because they break Mintlify anchor links.
-- When the user asks for links, reply with full `https://docs.openclaw.ai/...` URLs (not root-relative).
-- When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
-- README (GitHub): keep absolute docs URLs (`https://docs.openclaw.ai/...`) so links work on GitHub.
-- Docs content must be generic: no personal device names/hostnames/paths; use placeholders like `user@gateway-host` and “gateway host”.
-
-## Docs i18n (generated publish locales)
-
-- Foreign-language docs are not maintained in this repo. The generated publish output lives in the separate `openclaw/docs` repo (often cloned locally as the sibling `openclaw-docs` directory); do not add or edit localized docs under `docs/<locale>/**` here.
-- Those localized docs are autogenerated. Treat this repo's English docs plus glossary files as the source of truth, and let the publish/translation pipeline update `openclaw/docs`.
-- Pipeline: update English docs here → adjust the matching `docs/.i18n/glossary.<locale>.json` entries → let the publish-repo sync + `scripts/docs-i18n` run in `openclaw/docs` / local `openclaw-docs` clone → apply targeted fixes only if instructed.
-- Before rerunning `scripts/docs-i18n`, add glossary entries for any new technical terms, page titles, or short nav labels that must stay in English or use a fixed translation (for example `Doctor` or `Polls`).
-- `pnpm docs:check-i18n-glossary` enforces glossary coverage for changed English doc titles and short internal doc labels before translation reruns.
-- Translation memory lives in generated `docs/.i18n/*.tm.jsonl` files in the publish repo.
-- See `docs/.i18n/README.md`.
-- The pipeline can be slow/inefficient; if it’s dragging, ping @jospalmbier on Discord instead of hacking around it.
-
-## Control UI i18n (generated in repo)
-
-- Control UI foreign-language locale bundles are generated in this repo; do not hand-edit `ui/src/i18n/locales/*.ts` for non-English locales or `ui/src/i18n/.i18n/*` unless a targeted generated-output fix is explicitly requested.
-- Source of truth is `ui/src/i18n/locales/en.ts` plus the generator/runtime wiring in `scripts/control-ui-i18n.ts`, `ui/src/i18n/lib/types.ts`, and `ui/src/i18n/lib/registry.ts`.
-- Pipeline: update English control UI strings and locale wiring here → run `pnpm ui:i18n:sync` (or let `Control UI Locale Refresh` do it) → commit the regenerated locale bundles and `.i18n` metadata.
-- If the control UI locale outputs drift, regenerate them; do not manually translate or hand-maintain the generated locale files by default.
+- `docs/AGENTS.md` owns Mintlify docs, docs links, and docs i18n rules.
+- `ui/AGENTS.md` owns Control UI i18n and generated locale rules.
+- `scripts/AGENTS.md` owns script-runner, local-check lock, and test/lint wrapper rules.
 
 ## exe.dev VM ops (general)
 
@@ -195,7 +146,7 @@
 - In tests, prefer per-instance stubs over prototype mutation (`SomeClass.prototype.method = ...`) unless a test explicitly documents why prototype-level patching is required.
 - Add brief code comments for tricky or non-obvious logic.
 - Keep files concise; extract helpers instead of “V2” copies. Use existing patterns for CLI options and dependency injection via `createDefaultDeps`.
-- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
+- Keep files concise and split/refactor when size starts hurting clarity, reviewability, or testability. The real enforcement lives in repo checks, not this guidance line.
 - Naming: use **OpenClaw** for product/app/docs headings; use `openclaw` for CLI command, package/binary, paths, and config keys.
 - Written English: use American spelling and grammar in code, comments, docs, and UI strings (e.g. "color" not "colour", "behavior" not "behaviour", "analyze" not "analyse").
 
@@ -316,7 +267,7 @@
   - Only ask when changes are semantic (logic/data/behavior).
 - **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
 - Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
-- Code style: add brief comments for tricky logic; keep files under ~500 LOC when feasible (split/refactor as needed).
+- Code style: add brief comments for tricky logic; keep files concise and split/refactor when a file gets unwieldy.
 - Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
 - Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
 - Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,9 +8,6 @@ This directory owns docs authoring, Mintlify link rules, and docs i18n policy.
 - Internal doc links in `docs/**/*.md` must stay root-relative with no `.md` or `.mdx` suffix (example: `[Config](/configuration)`).
 - Section cross-references should use anchors on root-relative paths (example: `[Hooks](/configuration#hooks)`).
 - Doc headings should avoid em dashes and apostrophes because Mintlify anchor generation is brittle there.
-- When working on docs, use the Mintlify skill.
-- When the user asks for links, reply with full `https://docs.openclaw.ai/...` URLs.
-- When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
 - README and other GitHub-rendered docs should keep absolute docs URLs so links work outside Mintlify.
 - Docs content must stay generic: no personal device names, hostnames, or local paths; use placeholders like `user@gateway-host`.
 
@@ -29,4 +26,3 @@ This directory owns docs authoring, Mintlify link rules, and docs i18n policy.
 - `pnpm docs:check-i18n-glossary` is the guard for changed English doc titles and short internal doc labels.
 - Translation memory lives in generated `docs/.i18n/*.tm.jsonl` files in the publish repo.
 - See `docs/.i18n/README.md`.
-- If the docs i18n pipeline is dragging, ping @jospalmbier on Discord instead of hacking around it.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,32 @@
+# Docs Guide
+
+This directory owns docs authoring, Mintlify link rules, and docs i18n policy.
+
+## Mintlify Rules
+
+- Docs are hosted on Mintlify (`https://docs.openclaw.ai`).
+- Internal doc links in `docs/**/*.md` must stay root-relative with no `.md` or `.mdx` suffix (example: `[Config](/configuration)`).
+- Section cross-references should use anchors on root-relative paths (example: `[Hooks](/configuration#hooks)`).
+- Doc headings should avoid em dashes and apostrophes because Mintlify anchor generation is brittle there.
+- When working on docs, use the Mintlify skill.
+- When the user asks for links, reply with full `https://docs.openclaw.ai/...` URLs.
+- When you touch docs, end the reply with the `https://docs.openclaw.ai/...` URLs you referenced.
+- README and other GitHub-rendered docs should keep absolute docs URLs so links work outside Mintlify.
+- Docs content must stay generic: no personal device names, hostnames, or local paths; use placeholders like `user@gateway-host`.
+
+## Docs Content Rules
+
+- For docs, UI copy, and picker lists, order services/providers alphabetically unless the section is explicitly describing runtime order or auto-detection order.
+- Keep bundled plugin naming consistent with the repo-wide plugin terminology rules in the root `AGENTS.md`.
+
+## Docs i18n
+
+- Foreign-language docs are not maintained in this repo. The generated publish output lives in the separate `openclaw/docs` repo (often cloned locally as `../openclaw-docs`).
+- Do not add or edit localized docs under `docs/<locale>/**` here.
+- Treat English docs in this repo plus glossary files as the source of truth.
+- Pipeline: update English docs here, update `docs/.i18n/glossary.<locale>.json` as needed, then let the publish-repo sync and `scripts/docs-i18n` run in `openclaw/docs`.
+- Before rerunning `scripts/docs-i18n`, add glossary entries for any new technical terms, page titles, or short nav labels that must stay in English or use a fixed translation.
+- `pnpm docs:check-i18n-glossary` is the guard for changed English doc titles and short internal doc labels.
+- Translation memory lives in generated `docs/.i18n/*.tm.jsonl` files in the publish repo.
+- See `docs/.i18n/README.md`.
+- If the docs i18n pipeline is dragging, ping @jospalmbier on Discord instead of hacking around it.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -51,6 +51,15 @@ third-party plugins see.
   provider needs OpenAI-style Anthropic tool payload compat, Gemini schema
   cleanup, or an XAI compat patch, use a named shared helper instead of
   inlining the policy knobs again.
+- Keep control-plane metadata separate from runtime logic. Discovery, config
+  validation, setup hints, onboarding hints, and activation planning should be
+  expressible from manifest/descriptors whenever possible.
+- If setup truly requires runtime execution, make that explicit in the plugin's
+  declared setup/runtime surface instead of letting metadata flows import
+  runtime code accidentally.
+- Do not rely on eager global registry seeding or import-time side effects to
+  make a plugin “available”. Plugin availability should come from manifest
+  ownership plus targeted activation.
 
 ## Expanding The Boundary
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,26 @@
+# Scripts Guide
+
+This directory owns local tooling, script wrappers, and generated-artifact helper rules.
+
+## Wrapper Rules
+
+- Prefer existing wrappers over raw tool entrypoints when the repo already has a curated seam.
+- For tests, prefer `scripts/run-vitest.mjs` or the root `pnpm test ...` entrypoints over raw `vitest run` calls.
+- For lint/typecheck flows, prefer `scripts/run-oxlint.mjs` and `scripts/run-tsgo.mjs` when adding or editing package scripts or CI steps that should honor repo-local runtime behavior.
+
+## Local Heavy-Check Lock
+
+- Respect the local heavy-check lock behavior in `scripts/lib/local-heavy-check-runtime.mjs`.
+- Do not bypass that lock for real heavy commands just to make a local loop look faster.
+- Metadata-only or explicitly narrow commands may skip the lock when the existing helper logic says that is safe.
+- If you change the lock heuristics, add or update the narrow tests under `test/scripts/`.
+
+## Generated Outputs
+
+- If a script writes generated artifacts, keep the source-of-truth generator, the package script, and the matching verification/check command aligned.
+- Prefer additive generator/check pairs like `*:gen` and `*:check` over one-off undocumented scripts.
+
+## Scope
+
+- Keep script-runner behavior, wrapper expectations, and generated-artifact guidance here.
+- Leave repo-global verification policy in the root `AGENTS.md`.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/plugin-sdk/AGENTS.md
+++ b/src/plugin-sdk/AGENTS.md
@@ -22,6 +22,10 @@ can affect bundled plugins and third-party plugins.
 
 ## Boundary Rules
 
+- Host loads plugins; plugins should not reach through the SDK into arbitrary
+  host internals.
+- Prefer a small versioned host/kernel seam plus narrow documented SDK
+  entrypoints over broad convenience barrels.
 - Prefer narrow, purpose-built subpaths over broad convenience re-exports.
 - Do not expose implementation convenience from `src/channels/**`,
   `src/agents/**`, `src/plugins/**`, or other internals unless you are
@@ -52,6 +56,12 @@ can affect bundled plugins and third-party plugins.
 - Keep transport/runtime policy and plugin-facing helpers aligned. If the same
   behavior is used in plugin registration and in core runtime paths, expose one
   shared helper instead of letting the two paths drift.
+- SDK subpaths should help callers resolve one capability or runtime need at a
+  time. Do not grow new surfaces that require broad runtime registry access as
+  the default path.
+- If a proposed SDK export mainly exists to let setup/config/control-plane code
+  execute plugin runtime, that is usually a boundary smell. Prefer metadata or
+  descriptor-driven control-plane seams first.
 
 ## Verification
 

--- a/src/plugins/AGENTS.md
+++ b/src/plugins/AGENTS.md
@@ -18,6 +18,10 @@ assembly, and contract enforcement.
 
 ## Boundary Rules
 
+- Keep control-plane and runtime-plane concerns separate:
+  discovery, manifest parsing, config validation, setup/onboarding hints, and
+  activation planning belong to the control plane; actual plugin execution
+  belongs to runtime resolution.
 - Preserve manifest-first behavior: discovery, config validation, and setup
   should work from metadata before plugin runtime executes.
 - Keep loader behavior aligned with the documented Plugin SDK and manifest
@@ -31,6 +35,9 @@ assembly, and contract enforcement.
   needs the heavy module.
 - If a loader or registry change affects plugin authors, update the public SDK,
   docs, and contract tests instead of relying on incidental internals.
+- Prefer explicit activation planning from manifest/descriptor ownership over
+  “load everything in this scope” behavior. Broad registry materialization
+  should be the exception, not the design center.
 - Do not normalize "plugin-owned" into "core-owned" by scattering direct reads
   of `plugins.entries.<id>.config` through unrelated core paths. Prefer generic
   helpers, plugin runtime hooks, manifest metadata, and explicit auto-enable
@@ -52,6 +59,12 @@ assembly, and contract enforcement.
 - When a provider hook grows a nested chain of wrapper composition or repeated
   compat flags, treat that as a regression signal. Extract the shared helper or
   composer instead of letting one more plugin carry a near-copy.
+- Treat mutable global runtime registry state as compatibility scaffolding, not
+  the desired source of truth for request-time execution. Prefer immutable or
+  request-scoped handles when adding new runtime flows.
+- If setup, discovery, or doctor flows need plugin runtime, make that need
+  explicit and narrow. Do not let cold control-plane paths quietly import broad
+  runtime surfaces.
 
 ## Verification
 

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,19 @@
+# Control UI Guide
+
+This directory owns Control UI-specific guidance that should not live in the repo root.
+
+## i18n Rules
+
+- Foreign-language locale bundles in `ui/src/i18n/locales/*.ts` are generated output.
+- Do not hand-edit non-English locale bundles or `ui/src/i18n/.i18n/*` unless a targeted generated-output fix is explicitly requested.
+- The source of truth is `ui/src/i18n/locales/en.ts` plus the generator/runtime wiring in:
+  - `scripts/control-ui-i18n.ts`
+  - `ui/src/i18n/lib/types.ts`
+  - `ui/src/i18n/lib/registry.ts`
+- Pipeline: update English strings and locale wiring here, then run `pnpm ui:i18n:sync` and commit the regenerated locale bundles plus `.i18n` metadata.
+- If locale outputs drift, regenerate them. Do not manually translate or hand-maintain generated locale files by default.
+
+## Scope
+
+- Keep UI-specific rules here.
+- Leave repo-global architecture, verification, and git workflow rules in the root `AGENTS.md`.

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Problem: the repo root `AGENTS.md` had grown into a mixed policy file, ops note dump, and duplicated boundary guide, with repeated rules already owned by scoped `AGENTS.md` files.
- Why it matters: duplicated instructions drift, and the root file already had a real contradiction on file-size guidance.
- What changed: added scoped `AGENTS.md` guides for `docs/`, `ui/`, and `scripts/`, added matching `CLAUDE.md` symlinks, and trimmed the root file so it points to scoped guides instead of restating them.
- What did NOT change (scope boundary): no runtime code, tests, CI behavior, or package boundaries changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the root guide accumulated domain-specific policy that should have lived in scoped files, so the same rules existed in multiple places and one file-size guideline drifted into contradiction.
- Missing detection / guardrail: no scoped `AGENTS.md` existed for `docs/`, `ui/`, or `scripts/`, so the root file became the dumping ground.
- Contributing context (if known): the repo already had a good scoped pattern for `extensions/`, `src/plugin-sdk/`, `src/channels/`, `src/plugins/`, and shared test helpers, but it was not applied consistently.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `AGENTS.md`, `docs/AGENTS.md`, `ui/AGENTS.md`, `scripts/AGENTS.md`
- Scenario the test should lock in: scoped instructions exist where domain-specific policy lives, and the root file no longer carries contradictory LOC guidance.
- Why this is the smallest reliable guardrail: this is documentation/policy structure, not runtime behavior.
- Existing test that already covers this (if any): `git diff --check`
- If no new test is added, why not: there is no executable behavior change to lock with unit or integration coverage.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[root AGENTS] -> [repo-global rules + docs rules + UI rules + scripts rules + duplicated boundary rules]

After:
[root AGENTS] -> [repo-global rules + pointers]
              -> [docs/AGENTS]
              -> [ui/AGENTS]
              -> [scripts/AGENTS]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Audit repo-local `AGENTS.md` files and compare scope overlap.
2. Split docs/UI/scripts guidance into scoped guides and add required `CLAUDE.md` symlinks.
3. Trim root `AGENTS.md` duplication and remove contradictory LOC guidance.

### Expected

- Root guide stays repo-global.
- Domain-specific rules live in scoped guides.
- No duplicate numeric LOC guidance remains in the root file.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: audited all repo-local `AGENTS.md` files, confirmed new scoped guides exist, confirmed `CLAUDE.md` symlinks point at `AGENTS.md`, confirmed root diff removes duplicated boundary/docs/UI content.
- Edge cases checked: root no longer contains conflicting `500` vs `700` LOC guidance; no stray numeric LOC text remains in the new scoped guides.
- What you did **not** verify: no runtime/test/CI behavior because this PR does not change code paths.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a moved rule could become harder to find if reviewers only read the root file.
  - Mitigation: the root guide now explicitly points at `docs/AGENTS.md`, `ui/AGENTS.md`, and `scripts/AGENTS.md`.


## Plugin Architecture Alignment

This PR now also tightens the plugin-related AGENTS guidance around the current architecture direction captured in `~/.spec/2026-04-11_ocplugins.md`:

- manifest-first control plane
- targeted activation planning
- narrow runtime resolution instead of broad registry materialization
- versioned host/kernel seam over ambient host reachability
- global mutable runtime registry treated as transitional compatibility, not target design
