### PR TITLE
fix(acp): bypass bound slash commands to local handlers

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { shouldBypassAcpDispatchForCommand } from "./dispatch-acp-command-bypass.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 describe("shouldBypassAcpDispatchForCommand", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
   it("returns false for plain-text ACP turns", () => {
     const ctx = buildTestCtx({
       Provider: "discord",
@@ -64,10 +70,54 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
-  it("returns true for slash commands when text commands are disabled", () => {
+  it("returns false for text slash commands on native command surfaces when text commands are disabled", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: createChannelTestPluginBase({
+            id: "discord",
+            capabilities: { nativeCommands: true, chatTypes: ["direct"] },
+          }),
+        },
+      ]),
+    );
+
     const ctx = buildTestCtx({
       Provider: "discord",
       Surface: "discord",
+      CommandBody: "/acp cancel",
+      BodyForCommands: "/acp cancel",
+      BodyForAgent: "/acp cancel",
+      CommandSource: "text",
+    });
+    const cfg = {
+      commands: {
+        text: false,
+      },
+    } as OpenClawConfig;
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(false);
+  });
+
+  it("returns true for text slash commands on non-native command surfaces when text commands are disabled", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: createChannelTestPluginBase({
+            id: "discord",
+            capabilities: { nativeCommands: true, chatTypes: ["direct"] },
+          }),
+        },
+      ]),
+    );
+
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
       CommandBody: "/acp cancel",
       BodyForCommands: "/acp cancel",
       BodyForAgent: "/acp cancel",

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -15,7 +15,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(false);
   });
 
-  it("returns false for ACP slash commands", () => {
+  it("returns true for ACP slash commands", () => {
     const ctx = buildTestCtx({
       Provider: "discord",
       Surface: "discord",
@@ -24,7 +24,19 @@ describe("shouldBypassAcpDispatchForCommand", () => {
       BodyForAgent: "/acp cancel",
     });
 
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(false);
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
+  it("returns true for /unfocus in a bound conversation", () => {
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      CommandBody: "/unfocus",
+      BodyForCommands: "/unfocus",
+      BodyForAgent: "/unfocus",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
   it("returns true for ACP reset-tail slash commands", () => {
@@ -52,7 +64,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
-  it("returns false for slash commands when text commands are disabled", () => {
+  it("returns true for slash commands when text commands are disabled", () => {
     const ctx = buildTestCtx({
       Provider: "discord",
       Surface: "discord",
@@ -67,7 +79,7 @@ describe("shouldBypassAcpDispatchForCommand", () => {
       },
     } as OpenClawConfig;
 
-    expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(false);
+    expect(shouldBypassAcpDispatchForCommand(ctx, cfg)).toBe(true);
   });
 
   it("returns false for unauthorized bang-prefixed commands", () => {

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.ts
@@ -41,12 +41,12 @@ export function shouldBypassAcpDispatchForCommand(
     surface: ctx.Surface ?? ctx.Provider ?? "",
     commandSource: ctx.CommandSource,
   });
-  if (!normalized.startsWith("/") && maybeResolveTextAlias(candidate, cfg) != null) {
-    return allowTextCommands;
-  }
-
   if (isResetCommandCandidate(normalized)) {
     return true;
+  }
+
+  if (maybeResolveTextAlias(candidate, cfg) != null) {
+    return allowTextCommands;
   }
 
   if (!normalized.startsWith("!")) {


### PR DESCRIPTION
## Summary
- bypass recognized slash commands before dispatching a bound conversation to the ACP runtime
- keep `/acp ...` and `/unfocus` routed to OpenClaw's local command handlers even when the conversation is currently ACP-bound
- update command-bypass tests to cover ACP control commands and `/unfocus`

## Problem
In a Telegram DM bound to an ACP session, control commands like `/acp close` and `/unfocus` were being forwarded into the harness as plain text instead of being handled by OpenClaw.

In practice this left the DM stuck on the ACP session:
- `/acp close` never removed the binding
- `/unfocus` never unfocused the conversation
- the harness transcript showed inputs like `Unknown skill: acp` / `Unknown skill: unfocus`

That behavior contradicts the documented ACP control flow, where `/acp close` should close the session and remove bindings, and `/unfocus` should release the current conversation.

## Root cause
`shouldBypassAcpDispatchForCommand()` only bypassed ACP dispatch for reset commands and non-slash aliases, but not for recognized slash commands such as `/acp cancel`, `/acp close`, or `/unfocus`.

So once a conversation was bound to ACP, those commands stayed on the ACP path instead of escaping back to the local command handlers.

## Testing
- `./node_modules/.bin/vitest run --config vitest.config.ts src/auto-reply/reply/dispatch-acp-command-bypass.test.ts src/plugin-sdk/acp-runtime.test.ts`
