### PR TITLE
feat(plugins): narrow explicit provider loads from manifests

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -527,9 +527,12 @@ actual behavior such as hooks, tools, commands, or provider flows.
 Optional manifest `activation` and `setup` blocks stay on the control plane.
 They are metadata-only descriptors for activation planning and setup discovery;
 they do not replace runtime registration, `register(...)`, or `setupEntry`.
-The first activation consumer now uses manifest command hints to narrow CLI
-plugin loading when a primary command is known, instead of always loading every
-CLI-capable plugin up front.
+The first live activation consumers now use manifest command and provider hints
+to narrow plugin loading before broader registry materialization:
+
+- CLI loading narrows to plugins that own the requested primary command
+- explicit provider setup/runtime resolution narrows to plugins that own the
+  requested provider id
 
 Setup discovery now prefers descriptor-owned ids such as `setup.providers` and
 `setup.cliBackends` to narrow candidate plugins before it falls back to

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -222,8 +222,8 @@ should activate it later.
 This block is metadata only. It does not register runtime behavior, and it does
 not replace `register(...)`, `setupEntry`, or other runtime/plugin entrypoints.
 Current consumers use it as a narrowing hint before broader plugin loading, so
-missing activation metadata only costs performance; it should not change
-correctness.
+missing activation metadata usually only costs performance; it should not
+change correctness while legacy manifest ownership fallbacks still exist.
 
 ```json
 {
@@ -245,9 +245,13 @@ correctness.
 | `onRoutes`       | No       | `string[]`                                           | Route kinds that should activate this plugin.                     |
 | `onCapabilities` | No       | `Array<"provider" \| "channel" \| "tool" \| "hook">` | Broad capability hints used by control-plane activation planning. |
 
-For command-triggered planning specifically, OpenClaw still falls back to
-legacy `commandAliases[].cliCommand` or `commandAliases[].name` when a plugin
-has not added explicit `activation.onCommands` metadata yet.
+Current live consumers:
+
+- command-triggered CLI planning falls back to legacy
+  `commandAliases[].cliCommand` or `commandAliases[].name`
+- provider-triggered setup/runtime planning falls back to legacy
+  `providers[]` and top-level `cliBackends[]` ownership when explicit provider
+  activation metadata is missing
 
 ## setup reference
 

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -50,6 +50,8 @@ export type BundledPluginCompatibleActivationInputs = PluginActivationInputs & {
 export function withActivatedPluginIds(params: {
   config?: OpenClawConfig;
   pluginIds: readonly string[];
+  overrideGlobalDisable?: boolean;
+  overrideExplicitDisable?: boolean;
 }): OpenClawConfig | undefined {
   if (params.pluginIds.length === 0) {
     return params.config;
@@ -64,12 +66,14 @@ export function withActivatedPluginIds(params: {
       continue;
     }
     allow.add(normalized);
+    const existingEntry = entries[normalized];
     entries[normalized] = {
-      ...entries[normalized],
-      enabled: true,
+      ...existingEntry,
+      enabled: existingEntry?.enabled !== false || params.overrideExplicitDisable === true,
     };
   }
-  const forcePluginsEnabled = params.config?.plugins?.enabled === false;
+  const forcePluginsEnabled =
+    params.overrideGlobalDisable === true && params.config?.plugins?.enabled === false;
   return {
     ...params.config,
     plugins: {

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -8,6 +8,7 @@ import {
   type PluginLoadOptions,
 } from "./loader.js";
 import {
+  resolveDiscoverableProviderOwnerPluginIds,
   resolveDiscoveredProviderPluginIds,
   resolveEnabledProviderPluginIds,
   resolveBundledProviderCompatPluginIds,
@@ -132,22 +133,28 @@ function resolveSetupProviderPluginLoadState(
   base: ReturnType<typeof resolvePluginProviderLoadBase>,
 ) {
   const providerPluginIds = resolveDiscoveredProviderPluginIds({
-    config: base.runtimeConfig,
+    config: params.config,
     workspaceDir: base.workspaceDir,
     env: base.env,
     onlyPluginIds: base.requestedPluginIds,
     includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
   });
-  if (providerPluginIds.length === 0) {
-    if (base.explicitOwnerPluginIds.length === 0) {
-      return undefined;
-    }
+  const explicitOwnerPluginIds = resolveDiscoverableProviderOwnerPluginIds({
+    pluginIds: base.explicitOwnerPluginIds,
+    config: params.config,
+    workspaceDir: base.workspaceDir,
+    env: base.env,
+    includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
+  });
+  const setupPluginIds = mergeExplicitOwnerPluginIds(providerPluginIds, explicitOwnerPluginIds);
+  if (setupPluginIds.length === 0) {
+    return undefined;
   }
   const loadOptions = buildPluginRuntimeLoadOptionsFromValues(
     {
       config: withActivatedPluginIds({
         config: base.runtimeConfig,
-        pluginIds: mergeExplicitOwnerPluginIds(providerPluginIds, base.explicitOwnerPluginIds),
+        pluginIds: setupPluginIds,
       }),
       activationSourceConfig: base.runtimeConfig,
       autoEnabledReasons: {},
@@ -156,7 +163,7 @@ function resolveSetupProviderPluginLoadState(
       logger: createPluginRuntimeLoaderLogger(),
     },
     {
-      onlyPluginIds: mergeExplicitOwnerPluginIds(providerPluginIds, base.explicitOwnerPluginIds),
+      onlyPluginIds: setupPluginIds,
       pluginSdkResolution: params.pluginSdkResolution,
       cache: params.cache ?? false,
       activate: params.activate ?? false,

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -182,7 +182,7 @@ function resolveRuntimeProviderPluginLoadState(
     includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
   });
   const runtimeRequestedPluginIds =
-    params.onlyPluginIds?.length || explicitOwnerPluginIds.length > 0
+    base.requestedPluginIds !== undefined
       ? dedupeSortedPluginIds([...(params.onlyPluginIds ?? []), ...explicitOwnerPluginIds])
       : undefined;
   const requestConfig = withActivatedPluginIds({

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -8,6 +8,7 @@ import {
   type PluginLoadOptions,
 } from "./loader.js";
 import {
+  resolveActivatableProviderOwnerPluginIds,
   resolveDiscoverableProviderOwnerPluginIds,
   resolveDiscoveredProviderPluginIds,
   resolveEnabledProviderPluginIds,
@@ -115,16 +116,12 @@ function resolvePluginProviderLoadBase(params: {
     ...providerOwnedPluginIds,
     ...modelOwnedPluginIds,
   ]);
-  const runtimeConfig = withActivatedPluginIds({
-    config: params.config,
-    pluginIds: explicitOwnerPluginIds,
-  });
   return {
     env,
     workspaceDir,
     requestedPluginIds,
     explicitOwnerPluginIds,
-    runtimeConfig,
+    rawConfig: params.config,
   };
 }
 
@@ -150,13 +147,14 @@ function resolveSetupProviderPluginLoadState(
   if (setupPluginIds.length === 0) {
     return undefined;
   }
+  const setupConfig = withActivatedPluginIds({
+    config: base.rawConfig,
+    pluginIds: setupPluginIds,
+  });
   const loadOptions = buildPluginRuntimeLoadOptionsFromValues(
     {
-      config: withActivatedPluginIds({
-        config: base.runtimeConfig,
-        pluginIds: setupPluginIds,
-      }),
-      activationSourceConfig: base.runtimeConfig,
+      config: setupConfig,
+      activationSourceConfig: setupConfig,
       autoEnabledReasons: {},
       workspaceDir: base.workspaceDir,
       env: base.env,
@@ -176,11 +174,26 @@ function resolveRuntimeProviderPluginLoadState(
   params: Parameters<typeof resolvePluginProviders>[0],
   base: ReturnType<typeof resolvePluginProviderLoadBase>,
 ) {
+  const explicitOwnerPluginIds = resolveActivatableProviderOwnerPluginIds({
+    pluginIds: base.explicitOwnerPluginIds,
+    config: base.rawConfig,
+    workspaceDir: base.workspaceDir,
+    env: base.env,
+    includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
+  });
+  const runtimeRequestedPluginIds =
+    params.onlyPluginIds?.length || explicitOwnerPluginIds.length > 0
+      ? dedupeSortedPluginIds([...(params.onlyPluginIds ?? []), ...explicitOwnerPluginIds])
+      : undefined;
+  const requestConfig = withActivatedPluginIds({
+    config: base.rawConfig,
+    pluginIds: explicitOwnerPluginIds,
+  });
   const activation = resolveBundledPluginCompatibleActivationInputs({
-    rawConfig: base.runtimeConfig,
+    rawConfig: requestConfig,
     env: base.env,
     workspaceDir: base.workspaceDir,
-    onlyPluginIds: base.requestedPluginIds,
+    onlyPluginIds: runtimeRequestedPluginIds,
     applyAutoEnable: true,
     compatMode: {
       allowlist: params.bundledProviderAllowlistCompat,
@@ -201,9 +214,9 @@ function resolveRuntimeProviderPluginLoadState(
       config,
       workspaceDir: base.workspaceDir,
       env: base.env,
-      onlyPluginIds: base.requestedPluginIds,
+      onlyPluginIds: runtimeRequestedPluginIds,
     }),
-    base.explicitOwnerPluginIds,
+    explicitOwnerPluginIds,
   );
   const loadOptions = buildPluginRuntimeLoadOptionsFromValues(
     {

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -1,5 +1,6 @@
 import { withActivatedPluginIds } from "./activation-context.js";
 import { resolveBundledPluginCompatibleActivationInputs } from "./activation-context.js";
+import { resolveManifestActivationPluginIds } from "./activation-planner.js";
 import {
   isPluginRegistryLoadInFlight,
   loadOpenClawPlugins,
@@ -21,6 +22,54 @@ import {
 } from "./runtime/load-context.js";
 import type { ProviderPlugin } from "./types.js";
 
+function dedupeSortedPluginIds(values: Iterable<string>): string[] {
+  return [...new Set(values)].toSorted((left, right) => left.localeCompare(right));
+}
+
+function resolveExplicitProviderOwnerPluginIds(params: {
+  providerRefs: readonly string[];
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+}): string[] {
+  return dedupeSortedPluginIds(
+    params.providerRefs.flatMap((provider) => {
+      const plannedPluginIds = resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "provider",
+          provider,
+        },
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      });
+      if (plannedPluginIds.length > 0) {
+        return plannedPluginIds;
+      }
+      // Keep legacy provider/CLI-backend ownership working until every owner is
+      // expressible through activation descriptors.
+      return (
+        resolveOwningPluginIdsForProvider({
+          provider,
+          config: params.config,
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+        }) ?? []
+      );
+    }),
+  );
+}
+
+function mergeExplicitOwnerPluginIds(
+  providerPluginIds: readonly string[],
+  explicitOwnerPluginIds: readonly string[],
+): string[] {
+  if (explicitOwnerPluginIds.length === 0) {
+    return [...providerPluginIds];
+  }
+  return dedupeSortedPluginIds([...providerPluginIds, ...explicitOwnerPluginIds]);
+}
+
 function resolvePluginProviderLoadBase(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
@@ -32,19 +81,12 @@ function resolvePluginProviderLoadBase(params: {
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
   const providerOwnedPluginIds = params.providerRefs?.length
-    ? [
-        ...new Set(
-          params.providerRefs.flatMap(
-            (provider) =>
-              resolveOwningPluginIdsForProvider({
-                provider,
-                config: params.config,
-                workspaceDir,
-                env,
-              }) ?? [],
-          ),
-        ),
-      ]
+    ? resolveExplicitProviderOwnerPluginIds({
+        providerRefs: params.providerRefs,
+        config: params.config,
+        workspaceDir,
+        env,
+      })
     : [];
   const modelOwnedPluginIds = params.modelRefs?.length
     ? resolveOwningPluginIdsForModelRefs({
@@ -68,14 +110,19 @@ function resolvePluginProviderLoadBase(params: {
           ]),
         ].toSorted((left, right) => left.localeCompare(right))
       : undefined;
+  const explicitOwnerPluginIds = dedupeSortedPluginIds([
+    ...providerOwnedPluginIds,
+    ...modelOwnedPluginIds,
+  ]);
   const runtimeConfig = withActivatedPluginIds({
     config: params.config,
-    pluginIds: [...providerOwnedPluginIds, ...modelOwnedPluginIds],
+    pluginIds: explicitOwnerPluginIds,
   });
   return {
     env,
     workspaceDir,
     requestedPluginIds,
+    explicitOwnerPluginIds,
     runtimeConfig,
   };
 }
@@ -92,13 +139,15 @@ function resolveSetupProviderPluginLoadState(
     includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
   });
   if (providerPluginIds.length === 0) {
-    return undefined;
+    if (base.explicitOwnerPluginIds.length === 0) {
+      return undefined;
+    }
   }
   const loadOptions = buildPluginRuntimeLoadOptionsFromValues(
     {
       config: withActivatedPluginIds({
         config: base.runtimeConfig,
-        pluginIds: providerPluginIds,
+        pluginIds: mergeExplicitOwnerPluginIds(providerPluginIds, base.explicitOwnerPluginIds),
       }),
       activationSourceConfig: base.runtimeConfig,
       autoEnabledReasons: {},
@@ -107,7 +156,7 @@ function resolveSetupProviderPluginLoadState(
       logger: createPluginRuntimeLoaderLogger(),
     },
     {
-      onlyPluginIds: providerPluginIds,
+      onlyPluginIds: mergeExplicitOwnerPluginIds(providerPluginIds, base.explicitOwnerPluginIds),
       pluginSdkResolution: params.pluginSdkResolution,
       cache: params.cache ?? false,
       activate: params.activate ?? false,
@@ -140,12 +189,15 @@ function resolveRuntimeProviderPluginLoadState(
         env: base.env,
       })
     : activation.config;
-  const providerPluginIds = resolveEnabledProviderPluginIds({
-    config,
-    workspaceDir: base.workspaceDir,
-    env: base.env,
-    onlyPluginIds: base.requestedPluginIds,
-  });
+  const providerPluginIds = mergeExplicitOwnerPluginIds(
+    resolveEnabledProviderPluginIds({
+      config,
+      workspaceDir: base.workspaceDir,
+      env: base.env,
+      onlyPluginIds: base.requestedPluginIds,
+    }),
+    base.explicitOwnerPluginIds,
+  );
   const loadOptions = buildPluginRuntimeLoadOptionsFromValues(
     {
       config,

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -546,7 +546,7 @@ describe("resolvePluginProviders", () => {
             "workspace-provider",
           ]),
           entries: expect.objectContaining({
-            google: { enabled: true },
+            google: { enabled: false },
             kilocode: { enabled: true },
             moonshot: { enabled: true },
             "workspace-provider": { enabled: true },
@@ -799,6 +799,29 @@ describe("resolvePluginProviders", () => {
     ).toEqual([]);
   });
 
+  it("does not activate explicit runtime owners outside the allowlist", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "activation-owned-provider",
+        providerIds: [],
+        activation: {
+          onProviders: ["activation-owned"],
+        },
+      }),
+    ]);
+
+    expect(
+      resolveActivatableProviderOwnerPluginIds({
+        pluginIds: ["activation-owned-provider"],
+        config: {
+          plugins: {
+            allow: ["other-plugin"],
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
   it("uses setup.providers to keep explicit provider owners on the setup path", () => {
     setManifestPlugins([
       createManifestProviderPlugin({
@@ -826,6 +849,78 @@ describe("resolvePluginProviders", () => {
             allow: ["setup-owned-provider"],
             entries: {
               "setup-owned-provider": { enabled: true },
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not override global plugin disable during setup owner loading", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "setup-owned-provider",
+        providerIds: [],
+        setup: {
+          providers: [{ id: "setup-owned" }],
+        },
+      }),
+    ]);
+
+    resolvePluginProviders({
+      config: {
+        plugins: {
+          enabled: false,
+        },
+      },
+      providerRefs: ["setup-owned"],
+      activate: true,
+      mode: "setup",
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            enabled: false,
+            allow: ["setup-owned-provider"],
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not override explicitly disabled setup owners", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "setup-owned-provider",
+        providerIds: [],
+        setup: {
+          providers: [{ id: "setup-owned" }],
+        },
+      }),
+    ]);
+
+    resolvePluginProviders({
+      config: {
+        plugins: {
+          entries: {
+            "setup-owned-provider": { enabled: false },
+          },
+        },
+      },
+      providerRefs: ["setup-owned"],
+      activate: true,
+      mode: "setup",
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["setup-owned-provider"],
+            entries: {
+              "setup-owned-provider": { enabled: false },
             },
           }),
         }),
@@ -881,6 +976,69 @@ describe("resolvePluginProviders", () => {
     expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         config: {},
+        onlyPluginIds: [],
+      }),
+    );
+  });
+
+  it("does not auto-activate workspace runtime owners by default", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "workspace-activation-owner",
+        providerIds: [],
+        origin: "workspace",
+        activation: {
+          onProviders: ["workspace-activation"],
+        },
+      }),
+    ]);
+    resolveRuntimePluginRegistryMock.mockReturnValue(createEmptyPluginRegistry());
+
+    const providers = resolvePluginProviders({
+      config: {},
+      providerRefs: ["workspace-activation"],
+      activate: true,
+    });
+
+    expect(providers).toEqual([]);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {},
+        onlyPluginIds: [],
+      }),
+    );
+  });
+
+  it("keeps explicit provider requests scoped when runtime owner activation resolves nothing", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "activation-owned-provider",
+        providerIds: [],
+        activation: {
+          onProviders: ["activation-owned"],
+        },
+      }),
+    ]);
+    resolveRuntimePluginRegistryMock.mockReturnValue(createEmptyPluginRegistry());
+
+    const providers = resolvePluginProviders({
+      config: {
+        plugins: {
+          allow: ["other-plugin"],
+        },
+      },
+      providerRefs: ["activation-owned"],
+      activate: true,
+    });
+
+    expect(providers).toEqual([]);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          plugins: {
+            allow: ["other-plugin"],
+          },
+        },
         onlyPluginIds: [],
       }),
     );

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -32,6 +32,8 @@ function createManifestProviderPlugin(params: {
   origin?: "bundled" | "workspace";
   enabledByDefault?: boolean;
   modelSupport?: { modelPrefixes?: string[]; modelPatterns?: string[] };
+  activation?: PluginManifestRecord["activation"];
+  setup?: PluginManifestRecord["setup"];
 }): PluginManifestRecord {
   return {
     id: params.id,
@@ -40,6 +42,8 @@ function createManifestProviderPlugin(params: {
     providers: params.providerIds,
     cliBackends: params.cliBackends ?? [],
     modelSupport: params.modelSupport,
+    activation: params.activation,
+    setup: params.setup,
     skills: [],
     hooks: [],
     origin: params.origin ?? "bundled",
@@ -703,6 +707,98 @@ describe("resolvePluginProviders", () => {
             allow: ["openai"],
             entries: {
               openai: { enabled: true },
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("uses activation.onProviders to keep explicit provider owners on the runtime path", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "activation-owned-provider",
+        providerIds: [],
+        activation: {
+          onProviders: ["activation-owned"],
+        },
+      }),
+    ]);
+
+    resolvePluginProviders({
+      config: {},
+      providerRefs: ["activation-owned"],
+      activate: true,
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["activation-owned-provider"],
+        activate: true,
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["activation-owned-provider"],
+            entries: {
+              "activation-owned-provider": { enabled: true },
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("uses setup.providers to keep explicit provider owners on the setup path", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "setup-owned-provider",
+        providerIds: [],
+        setup: {
+          providers: [{ id: "setup-owned" }],
+        },
+      }),
+    ]);
+
+    resolvePluginProviders({
+      config: {},
+      providerRefs: ["setup-owned"],
+      activate: true,
+      mode: "setup",
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["setup-owned-provider"],
+        activate: true,
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["setup-owned-provider"],
+            entries: {
+              "setup-owned-provider": { enabled: true },
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps legacy CLI backend ownership as the explicit provider fallback", () => {
+    setOwningProviderManifestPlugins();
+
+    resolvePluginProviders({
+      config: {},
+      providerRefs: ["claude-cli"],
+      activate: true,
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["anthropic"],
+        activate: true,
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["anthropic"],
+            entries: {
+              anthropic: { enabled: true },
             },
           }),
         }),

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -22,6 +22,7 @@ const applyPluginAutoEnableMock = vi.fn<ApplyPluginAutoEnable>();
 let resolveOwningPluginIdsForProvider: typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 let resolveOwningPluginIdsForModelRef: typeof import("./providers.js").resolveOwningPluginIdsForModelRef;
 let resolveEnabledProviderPluginIds: typeof import("./providers.js").resolveEnabledProviderPluginIds;
+let resolveDiscoverableProviderOwnerPluginIds: typeof import("./providers.js").resolveDiscoverableProviderOwnerPluginIds;
 let resolvePluginProviders: typeof import("./providers.runtime.js").resolvePluginProviders;
 let setActivePluginRegistry: SetActivePluginRegistry;
 
@@ -287,6 +288,7 @@ describe("resolvePluginProviders", () => {
       resolveOwningPluginIdsForProvider,
       resolveOwningPluginIdsForModelRef,
       resolveEnabledProviderPluginIds,
+      resolveDiscoverableProviderOwnerPluginIds,
     } = await import("./providers.js"));
     ({ resolvePluginProviders } = await import("./providers.runtime.js"));
     ({ setActivePluginRegistry } = await import("./runtime.js"));
@@ -779,6 +781,59 @@ describe("resolvePluginProviders", () => {
         }),
       }),
     );
+  });
+
+  it("filters explicit setup owners through the untrusted workspace discovery gate", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "workspace-activation-owner",
+        providerIds: [],
+        origin: "workspace",
+        activation: {
+          onProviders: ["workspace-activation"],
+        },
+      }),
+    ]);
+
+    const providers = resolvePluginProviders({
+      config: {},
+      providerRefs: ["workspace-activation"],
+      activate: true,
+      mode: "setup",
+      includeUntrustedWorkspacePlugins: false,
+    });
+
+    expect(providers).toEqual([]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicitly trusted disabled workspace setup owners discoverable", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "workspace-activation-owner",
+        providerIds: [],
+        origin: "workspace",
+        activation: {
+          onProviders: ["workspace-activation"],
+        },
+      }),
+    ]);
+
+    expect(
+      resolveDiscoverableProviderOwnerPluginIds({
+        pluginIds: ["workspace-activation-owner"],
+        config: {
+          plugins: {
+            enabled: true,
+            allow: ["workspace-activation-owner"],
+            entries: {
+              "workspace-activation-owner": { enabled: false },
+            },
+          },
+        },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual(["workspace-activation-owner"]);
   });
 
   it("keeps legacy CLI backend ownership as the explicit provider fallback", () => {

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -21,6 +21,7 @@ const applyPluginAutoEnableMock = vi.fn<ApplyPluginAutoEnable>();
 
 let resolveOwningPluginIdsForProvider: typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 let resolveOwningPluginIdsForModelRef: typeof import("./providers.js").resolveOwningPluginIdsForModelRef;
+let resolveActivatableProviderOwnerPluginIds: typeof import("./providers.js").resolveActivatableProviderOwnerPluginIds;
 let resolveEnabledProviderPluginIds: typeof import("./providers.js").resolveEnabledProviderPluginIds;
 let resolveDiscoverableProviderOwnerPluginIds: typeof import("./providers.js").resolveDiscoverableProviderOwnerPluginIds;
 let resolvePluginProviders: typeof import("./providers.runtime.js").resolvePluginProviders;
@@ -285,6 +286,7 @@ describe("resolvePluginProviders", () => {
         loadPluginManifestRegistryMock(...args),
     }));
     ({
+      resolveActivatableProviderOwnerPluginIds,
       resolveOwningPluginIdsForProvider,
       resolveOwningPluginIdsForModelRef,
       resolveEnabledProviderPluginIds,
@@ -749,6 +751,54 @@ describe("resolvePluginProviders", () => {
     );
   });
 
+  it("does not activate explicit runtime owners when plugins are globally disabled", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "activation-owned-provider",
+        providerIds: [],
+        activation: {
+          onProviders: ["activation-owned"],
+        },
+      }),
+    ]);
+
+    expect(
+      resolveActivatableProviderOwnerPluginIds({
+        pluginIds: ["activation-owned-provider"],
+        config: {
+          plugins: {
+            enabled: false,
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not activate explicit runtime owners disabled in config", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "activation-owned-provider",
+        providerIds: [],
+        activation: {
+          onProviders: ["activation-owned"],
+        },
+      }),
+    ]);
+
+    expect(
+      resolveActivatableProviderOwnerPluginIds({
+        pluginIds: ["activation-owned-provider"],
+        config: {
+          plugins: {
+            entries: {
+              "activation-owned-provider": { enabled: false },
+            },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
   it("uses setup.providers to keep explicit provider owners on the setup path", () => {
     setManifestPlugins([
       createManifestProviderPlugin({
@@ -807,6 +857,35 @@ describe("resolvePluginProviders", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("does not auto-activate untrusted workspace runtime owners when requested", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "workspace-activation-owner",
+        providerIds: [],
+        origin: "workspace",
+        activation: {
+          onProviders: ["workspace-activation"],
+        },
+      }),
+    ]);
+    resolveRuntimePluginRegistryMock.mockReturnValue(createEmptyPluginRegistry());
+
+    const providers = resolvePluginProviders({
+      config: {},
+      providerRefs: ["workspace-activation"],
+      activate: true,
+      includeUntrustedWorkspacePlugins: false,
+    });
+
+    expect(providers).toEqual([]);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {},
+        onlyPluginIds: [],
+      }),
+    );
+  });
+
   it("keeps explicitly trusted disabled workspace setup owners discoverable", () => {
     setManifestPlugins([
       createManifestProviderPlugin({
@@ -834,6 +913,34 @@ describe("resolvePluginProviders", () => {
         includeUntrustedWorkspacePlugins: false,
       }),
     ).toEqual(["workspace-activation-owner"]);
+  });
+
+  it("does not auto-activate explicitly disabled trusted workspace runtime owners", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "workspace-activation-owner",
+        providerIds: [],
+        origin: "workspace",
+        activation: {
+          onProviders: ["workspace-activation"],
+        },
+      }),
+    ]);
+
+    expect(
+      resolveActivatableProviderOwnerPluginIds({
+        pluginIds: ["workspace-activation-owner"],
+        config: {
+          plugins: {
+            allow: ["workspace-activation-owner"],
+            entries: {
+              "workspace-activation-owner": { enabled: false },
+            },
+          },
+        },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual([]);
   });
 
   it("keeps legacy CLI backend ownership as the explicit provider fallback", () => {

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -164,7 +164,6 @@ function isProviderPluginEligibleForRuntimeOwnerActivation(params: {
   plugin: PluginManifestRecord;
   normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
   rootConfig?: PluginLoadOptions["config"];
-  includeUntrustedWorkspacePlugins?: boolean;
 }): boolean {
   if (!params.normalizedConfig.enabled) {
     return false;
@@ -175,16 +174,22 @@ function isProviderPluginEligibleForRuntimeOwnerActivation(params: {
   if (params.normalizedConfig.entries[params.plugin.id]?.enabled === false) {
     return false;
   }
-  if (params.includeUntrustedWorkspacePlugins === false && params.plugin.origin === "workspace") {
-    return resolveEffectivePluginActivationState({
-      id: params.plugin.id,
-      origin: params.plugin.origin,
-      config: params.normalizedConfig,
-      rootConfig: params.rootConfig,
-      enabledByDefault: params.plugin.enabledByDefault,
-    }).activated;
+  if (
+    params.normalizedConfig.allow.length > 0 &&
+    !params.normalizedConfig.allow.includes(params.plugin.id)
+  ) {
+    return false;
   }
-  return true;
+  if (params.plugin.origin !== "workspace") {
+    return true;
+  }
+  return resolveEffectivePluginActivationState({
+    id: params.plugin.id,
+    origin: params.plugin.origin,
+    config: params.normalizedConfig,
+    rootConfig: params.rootConfig,
+    enabledByDefault: params.plugin.enabledByDefault,
+  }).activated;
 }
 
 export function resolveActivatableProviderOwnerPluginIds(params: {
@@ -212,7 +217,6 @@ export function resolveActivatableProviderOwnerPluginIds(params: {
           plugin,
           normalizedConfig,
           rootConfig: params.config,
-          includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
         }),
     )
     .map((plugin) => plugin.id)

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -160,7 +160,67 @@ export function resolveDiscoverableProviderOwnerPluginIds(params: {
     .toSorted((left, right) => left.localeCompare(right));
 }
 
+function isProviderPluginEligibleForRuntimeOwnerActivation(params: {
+  plugin: PluginManifestRecord;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  rootConfig?: PluginLoadOptions["config"];
+  includeUntrustedWorkspacePlugins?: boolean;
+}): boolean {
+  if (!params.normalizedConfig.enabled) {
+    return false;
+  }
+  if (params.normalizedConfig.deny.includes(params.plugin.id)) {
+    return false;
+  }
+  if (params.normalizedConfig.entries[params.plugin.id]?.enabled === false) {
+    return false;
+  }
+  if (params.includeUntrustedWorkspacePlugins === false && params.plugin.origin === "workspace") {
+    return resolveEffectivePluginActivationState({
+      id: params.plugin.id,
+      origin: params.plugin.origin,
+      config: params.normalizedConfig,
+      rootConfig: params.rootConfig,
+      enabledByDefault: params.plugin.enabledByDefault,
+    }).activated;
+  }
+  return true;
+}
+
+export function resolveActivatableProviderOwnerPluginIds(params: {
+  pluginIds: readonly string[];
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+  includeUntrustedWorkspacePlugins?: boolean;
+}): string[] {
+  if (params.pluginIds.length === 0) {
+    return [];
+  }
+  const pluginIdSet = new Set(params.pluginIds);
+  const registry = loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  return registry.plugins
+    .filter(
+      (plugin) =>
+        pluginIdSet.has(plugin.id) &&
+        isProviderPluginEligibleForRuntimeOwnerActivation({
+          plugin,
+          normalizedConfig,
+          rootConfig: params.config,
+          includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
+        }),
+    )
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
 export const __testing = {
+  resolveActivatableProviderOwnerPluginIds,
   resolveEnabledProviderPluginIds,
   resolveDiscoveredProviderPluginIds,
   resolveDiscoverableProviderOwnerPluginIds,

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -89,26 +89,73 @@ export function resolveDiscoveredProviderPluginIds(params: {
       if (!(plugin.providers.length > 0 && (!onlyPluginIdSet || onlyPluginIdSet.has(plugin.id)))) {
         return false;
       }
-      if (!shouldFilterUntrustedWorkspacePlugins || plugin.origin !== "workspace") {
-        return true;
-      }
-      const activation = resolveEffectivePluginActivationState({
-        id: plugin.id,
-        origin: plugin.origin,
-        config: normalizedConfig,
+      return isProviderPluginEligibleForSetupDiscovery({
+        plugin,
+        shouldFilterUntrustedWorkspacePlugins,
+        normalizedConfig,
         rootConfig: params.config,
-        enabledByDefault: plugin.enabledByDefault,
       });
-      if (activation.activated) {
-        return true;
-      }
-      const explicitlyTrustedButDisabled =
-        normalizedConfig.enabled &&
-        !normalizedConfig.deny.includes(plugin.id) &&
-        normalizedConfig.allow.includes(plugin.id) &&
-        normalizedConfig.entries[plugin.id]?.enabled === false;
-      return explicitlyTrustedButDisabled;
     })
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function isProviderPluginEligibleForSetupDiscovery(params: {
+  plugin: PluginManifestRecord;
+  shouldFilterUntrustedWorkspacePlugins: boolean;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  rootConfig?: PluginLoadOptions["config"];
+}): boolean {
+  if (!params.shouldFilterUntrustedWorkspacePlugins || params.plugin.origin !== "workspace") {
+    return true;
+  }
+  const activation = resolveEffectivePluginActivationState({
+    id: params.plugin.id,
+    origin: params.plugin.origin,
+    config: params.normalizedConfig,
+    rootConfig: params.rootConfig,
+    enabledByDefault: params.plugin.enabledByDefault,
+  });
+  if (activation.activated) {
+    return true;
+  }
+  const explicitlyTrustedButDisabled =
+    params.normalizedConfig.enabled &&
+    !params.normalizedConfig.deny.includes(params.plugin.id) &&
+    params.normalizedConfig.allow.includes(params.plugin.id) &&
+    params.normalizedConfig.entries[params.plugin.id]?.enabled === false;
+  return explicitlyTrustedButDisabled;
+}
+
+export function resolveDiscoverableProviderOwnerPluginIds(params: {
+  pluginIds: readonly string[];
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+  includeUntrustedWorkspacePlugins?: boolean;
+}): string[] {
+  if (params.pluginIds.length === 0) {
+    return [];
+  }
+  const pluginIdSet = new Set(params.pluginIds);
+  const registry = loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  const shouldFilterUntrustedWorkspacePlugins = params.includeUntrustedWorkspacePlugins === false;
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  return registry.plugins
+    .filter(
+      (plugin) =>
+        pluginIdSet.has(plugin.id) &&
+        isProviderPluginEligibleForSetupDiscovery({
+          plugin,
+          shouldFilterUntrustedWorkspacePlugins,
+          normalizedConfig,
+          rootConfig: params.config,
+        }),
+    )
     .map((plugin) => plugin.id)
     .toSorted((left, right) => left.localeCompare(right));
 }
@@ -116,6 +163,7 @@ export function resolveDiscoveredProviderPluginIds(params: {
 export const __testing = {
   resolveEnabledProviderPluginIds,
   resolveDiscoveredProviderPluginIds,
+  resolveDiscoverableProviderOwnerPluginIds,
   resolveBundledProviderCompatPluginIds,
   withBundledProviderVitestCompat,
 } as const;


### PR DESCRIPTION
## Summary

- Problem: explicit `providerRefs` setup/runtime loads still relied on older manifest ownership helpers, so descriptor-first provider activation hints were not actually narrowing those paths.
- Why it matters: provider-targeted setup/runtime flows could still over-load plugins, and explicit owner ids discovered from manifest activation/setup metadata could get dropped by the legacy `providers.length > 0` filter.
- What changed: provider runtime/setup loading now plans explicit provider owners from manifest activation metadata first, keeps legacy provider/CLI-backend ownership as fallback, and preserves explicit owner ids through the final load options.
- What did NOT change (scope boundary): no new global activation snapshot model, no broad registry rewrite, no repo-wide manifest backfill.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: explicit provider targeting on setup/runtime paths still routed through legacy manifest ownership helpers instead of the new activation-planner seam.
- Missing detection / guardrail: there was no focused test proving `activation.onProviders` or `setup.providers` owners survived all the way into provider load options.
- Contributing context (if known): the CLI planning slice landed first, so provider-specific paths were still on the older ownership logic.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/providers.test.ts`
- Scenario the test should lock in: explicit provider-targeted setup/runtime loads keep activation/setup-descriptor owners, while legacy CLI-backend ownership still works as fallback.
- Why this is the smallest reliable guardrail: the regression lives in provider load planning before runtime execution, so a focused providers-runtime unit test catches it without booting the full plugin graph.
- Existing test that already covers this (if any): none before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[providerRefs] -> [legacy ownership helper] -> [enabled/discovered provider filter] -> [activation/setup-only owner can be dropped]

After:
[providerRefs] -> [manifest activation planner] -> [legacy fallback if needed] -> [explicit owner ids preserved into load options]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: N/A
- Integration/channel (if any): plugin/provider load path
- Relevant config (redacted): default local dev config

### Steps

1. Add a plugin manifest owner that declares `activation.onProviders` or `setup.providers` for an explicit provider id without the older `providers[]` static metadata.
2. Resolve plugin providers with `providerRefs` on runtime or setup paths.
3. Inspect the final `onlyPluginIds` / activated config used for provider loading.

### Expected

- Explicit provider owners resolved from manifest metadata stay in the provider load options.
- Legacy CLI-backend ownership still resolves when activation metadata is absent.

### Actual

- Fixed by this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: explicit runtime provider ownership via `activation.onProviders`; explicit setup provider ownership via `setup.providers`; legacy CLI-backend fallback via `claude-cli`; existing provider runtime tests still green.
- Edge cases checked: explicit owner ids survive the legacy provider filter; setup and runtime paths both covered.
- What you did **not** verify: full repo `pnpm check`; broad end-to-end plugin flows.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: manifest activation metadata could over-target a plugin if its provider ownership is declared incorrectly.
  - Mitigation: legacy fallback remains in place, and new focused tests lock the explicit-owner load behavior.
