### PR TITLE
fix(compaction): clamp reserveTokens to at most 90% of context window in precheck

### DIFF
--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -140,6 +140,39 @@ describe("preemptive-compaction", () => {
     expect(result.toolResultReducibleChars).toBeGreaterThan(0);
   });
 
+  it("clamps reserveTokens that equal the full context window to leave usable prompt budget", () => {
+    // Regression: #65218 — when reserveTokens equals contextTokenBudget,
+    // promptBudgetBeforeReserve collapses to 1, causing guaranteed overflow.
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 16_384,
+      reserveTokens: 16_384,
+    });
+
+    // With the clamp, promptBudgetBeforeReserve should be at least 10% of
+    // the context window (1638 tokens), not 1.
+    expect(result.promptBudgetBeforeReserve).toBeGreaterThan(1);
+    expect(result.promptBudgetBeforeReserve).toBeGreaterThanOrEqual(Math.floor(16_384 * 0.1));
+    expect(result.shouldCompact).toBe(false);
+  });
+
+  it("clamps reserveTokens exceeding context window to the 90% cap", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 10_000,
+      reserveTokens: 50_000,
+    });
+
+    // Effective reserve should be capped at 9000 (90% of 10000).
+    // Prompt budget = 10000 - 9000 = 1000.
+    expect(result.promptBudgetBeforeReserve).toBe(1_000);
+    expect(result.shouldCompact).toBe(false);
+  });
+
   it("treats mixed oversized-plus-aggregate tool tails as cumulative recovery potential", () => {
     const oversized = "x".repeat(45_000);
     const medium = "alpha beta gamma delta epsilon ".repeat(500);

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -48,9 +48,19 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   toolResultReducibleChars: number;
 } {
   const estimatedPromptTokens = estimatePrePromptTokens(params);
+  // Clamp reserveTokens to at most 90% of the context window.
+  // When the Pi settings manager returns a reserve equal to the full context
+  // budget (e.g. when config overrides do not propagate correctly), the prompt
+  // budget collapses to 1 token, causing guaranteed overflow for any prompt.
+  // See #65218.
+  const maxReserve = Math.floor(params.contextTokenBudget * 0.9);
+  const effectiveReserveTokens = Math.min(
+    Math.max(0, Math.floor(params.reserveTokens)),
+    maxReserve,
+  );
   const promptBudgetBeforeReserve = Math.max(
     1,
-    Math.floor(params.contextTokenBudget) - Math.max(0, Math.floor(params.reserveTokens)),
+    Math.floor(params.contextTokenBudget) - effectiveReserveTokens,
   );
   const overflowTokens = Math.max(0, estimatedPromptTokens - promptBudgetBeforeReserve);
   const toolResultPotential = estimateToolResultReductionPotential({


### PR DESCRIPTION
## Problem

When the Pi settings manager returns a compaction reserve value equal to (or exceeding) the full context token budget, the preemptive overflow precheck computes:

```
promptBudgetBeforeReserve = contextTokenBudget - reserveTokens
                         = 16384 - 16384 = 0 → clamped to 1
```

This guarantees context overflow for any prompt, even a minimal heartbeat. The logs show:

```
estimatedPromptTokens=35 promptBudgetBeforeReserve=1 reserveTokens=16384
```

This was observed on embedded heartbeat sessions using small local models (ollama/qwen2.5:3b, ctx=16384) where the user explicitly configured `reserveTokens: 1000` and `reserveTokensFloor: 0`, but the Pi settings manager still returned 16384 at runtime.

## Fix

Add a safety clamp in `shouldPreemptivelyCompactBeforePrompt` that caps `reserveTokens` to at most 90% of the context window. This ensures at least 10% of the context budget (1638 tokens for a 16K window) is always available for the system prompt + user prompt, preventing the degenerate zero-budget scenario regardless of how the upstream settings manager resolves the reserve.

The clamp is defense-in-depth — it does not address the root cause of the config override not propagating (which may be in the external Pi settings manager), but it prevents the catastrophic symptom.

## Changes

- **`preemptive-compaction.ts`**: Compute `maxReserve = floor(contextTokenBudget × 0.9)` and clamp `reserveTokens` before computing prompt budget.
- **`preemptive-compaction.test.ts`**: Two new test cases:
  - `reserveTokens == contextTokenBudget` → prompt budget > 1 (was guaranteed overflow)
  - `reserveTokens >> contextTokenBudget` → correctly capped at 90%

## Test Results

All 9 tests pass (7 existing + 2 new).

Closes #65218