### PR TITLE
feat(test): use host-aware local full-suite defaults

### DIFF
--- a/scripts/lib/vitest-local-scheduling.d.mts
+++ b/scripts/lib/vitest-local-scheduling.d.mts
@@ -1,0 +1,40 @@
+export type VitestHostInfo = {
+  cpuCount?: number;
+  loadAverage1m?: number;
+  totalMemoryBytes?: number;
+};
+
+export type LocalVitestScheduling = {
+  maxWorkers: number;
+  fileParallelism: boolean;
+  throttledBySystem: boolean;
+};
+
+export const DEFAULT_LOCAL_FULL_SUITE_PARALLELISM: number;
+export const LARGE_LOCAL_FULL_SUITE_PARALLELISM: number;
+export const DEFAULT_LOCAL_FULL_SUITE_VITEST_WORKERS: number;
+export const LARGE_LOCAL_FULL_SUITE_VITEST_WORKERS: number;
+
+export function isCiLikeEnv(env?: Record<string, string | undefined>): boolean;
+export function detectVitestHostInfo(): Required<VitestHostInfo>;
+export function resolveLocalVitestMaxWorkers(
+  env?: Record<string, string | undefined>,
+  system?: VitestHostInfo,
+  pool?: "forks" | "threads",
+): number;
+export function resolveLocalVitestScheduling(
+  env?: Record<string, string | undefined>,
+  system?: VitestHostInfo,
+  pool?: "forks" | "threads",
+): LocalVitestScheduling;
+export function shouldUseLargeLocalFullSuiteProfile(
+  env?: Record<string, string | undefined>,
+  system?: VitestHostInfo,
+): boolean;
+export function resolveLocalFullSuiteProfile(
+  env?: Record<string, string | undefined>,
+  system?: VitestHostInfo,
+): {
+  shardParallelism: number;
+  vitestMaxWorkers: number;
+};

--- a/scripts/lib/vitest-local-scheduling.mjs
+++ b/scripts/lib/vitest-local-scheduling.mjs
@@ -1,0 +1,162 @@
+/** @typedef {{ cpuCount?: number, loadAverage1m?: number, totalMemoryBytes?: number }} VitestHostInfo */
+/** @typedef {{ maxWorkers: number, fileParallelism: boolean, throttledBySystem: boolean }} LocalVitestScheduling */
+
+import os from "node:os";
+
+export const DEFAULT_LOCAL_FULL_SUITE_PARALLELISM = 4;
+export const LARGE_LOCAL_FULL_SUITE_PARALLELISM = 10;
+export const DEFAULT_LOCAL_FULL_SUITE_VITEST_WORKERS = 1;
+export const LARGE_LOCAL_FULL_SUITE_VITEST_WORKERS = 2;
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+function parsePositiveInt(value) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function isSystemThrottleDisabled(env) {
+  const normalized = env.OPENCLAW_VITEST_DISABLE_SYSTEM_THROTTLE?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+export function isCiLikeEnv(env = process.env) {
+  return env.CI === "true" || env.GITHUB_ACTIONS === "true";
+}
+
+export function detectVitestHostInfo() {
+  return {
+    cpuCount:
+      typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length,
+    loadAverage1m: os.loadavg()[0] ?? 0,
+    totalMemoryBytes: os.totalmem(),
+  };
+}
+
+export function resolveLocalVitestMaxWorkers(
+  env = process.env,
+  system = detectVitestHostInfo(),
+  pool = "threads",
+) {
+  return resolveLocalVitestScheduling(env, system, pool).maxWorkers;
+}
+
+/**
+ * @param {Record<string, string | undefined>} env
+ * @param {VitestHostInfo} system
+ * @param {"forks" | "threads"} pool
+ * @returns {LocalVitestScheduling}
+ */
+export function resolveLocalVitestScheduling(
+  env = process.env,
+  system = detectVitestHostInfo(),
+  pool = "threads",
+) {
+  const override = parsePositiveInt(env.OPENCLAW_VITEST_MAX_WORKERS ?? env.OPENCLAW_TEST_WORKERS);
+  if (override !== null) {
+    const maxWorkers = clamp(override, 1, 16);
+    return {
+      maxWorkers,
+      fileParallelism: maxWorkers > 1,
+      throttledBySystem: false,
+    };
+  }
+
+  const cpuCount = Math.max(1, system.cpuCount ?? 1);
+  const loadAverage1m = Math.max(0, system.loadAverage1m ?? 0);
+  const totalMemoryGb = (system.totalMemoryBytes ?? 0) / 1024 ** 3;
+
+  let inferred =
+    cpuCount <= 2
+      ? 1
+      : cpuCount <= 4
+        ? 2
+        : cpuCount <= 8
+          ? 4
+          : Math.max(1, Math.floor(cpuCount * 0.75));
+
+  if (totalMemoryGb <= 16) {
+    inferred = Math.min(inferred, 2);
+  } else if (totalMemoryGb <= 32) {
+    inferred = Math.min(inferred, 4);
+  } else if (totalMemoryGb <= 64) {
+    inferred = Math.min(inferred, 6);
+  } else if (totalMemoryGb <= 128) {
+    inferred = Math.min(inferred, 8);
+  } else if (totalMemoryGb <= 256) {
+    inferred = Math.min(inferred, 12);
+  } else {
+    inferred = Math.min(inferred, 16);
+  }
+
+  const loadRatio = loadAverage1m > 0 ? loadAverage1m / cpuCount : 0;
+  if (loadRatio >= 1) {
+    inferred = Math.max(1, Math.floor(inferred / 2));
+  } else if (loadRatio >= 0.75) {
+    inferred = Math.max(1, inferred - 2);
+  } else if (loadRatio >= 0.5) {
+    inferred = Math.max(1, inferred - 1);
+  }
+
+  if (pool === "forks") {
+    inferred = Math.min(inferred, 8);
+  }
+
+  inferred = clamp(inferred, 1, 16);
+
+  if (isSystemThrottleDisabled(env)) {
+    return {
+      maxWorkers: inferred,
+      fileParallelism: true,
+      throttledBySystem: false,
+    };
+  }
+
+  if (loadRatio >= 1) {
+    const maxWorkers = Math.max(1, Math.floor(inferred / 2));
+    return {
+      maxWorkers,
+      fileParallelism: maxWorkers > 1,
+      throttledBySystem: maxWorkers < inferred,
+    };
+  }
+
+  if (loadRatio >= 0.75) {
+    const maxWorkers = Math.max(2, Math.ceil(inferred * 0.75));
+    return {
+      maxWorkers,
+      fileParallelism: true,
+      throttledBySystem: maxWorkers < inferred,
+    };
+  }
+
+  return {
+    maxWorkers: inferred,
+    fileParallelism: true,
+    throttledBySystem: false,
+  };
+}
+
+export function shouldUseLargeLocalFullSuiteProfile(
+  env = process.env,
+  system = detectVitestHostInfo(),
+) {
+  if (isCiLikeEnv(env)) {
+    return false;
+  }
+  const scheduling = resolveLocalVitestScheduling(env, system, "threads");
+  return scheduling.maxWorkers >= 5 && !scheduling.throttledBySystem;
+}
+
+export function resolveLocalFullSuiteProfile(env = process.env, system = detectVitestHostInfo()) {
+  if (shouldUseLargeLocalFullSuiteProfile(env, system)) {
+    return {
+      shardParallelism: LARGE_LOCAL_FULL_SUITE_PARALLELISM,
+      vitestMaxWorkers: LARGE_LOCAL_FULL_SUITE_VITEST_WORKERS,
+    };
+  }
+  return {
+    shardParallelism: DEFAULT_LOCAL_FULL_SUITE_PARALLELISM,
+    vitestMaxWorkers: DEFAULT_LOCAL_FULL_SUITE_VITEST_WORKERS,
+  };
+}

--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -128,7 +128,7 @@ function applyDefaultParallelVitestWorkerBudget(specs, env) {
   if (env.OPENCLAW_VITEST_MAX_WORKERS || env.OPENCLAW_TEST_WORKERS || isCiLikeEnv(env)) {
     return specs;
   }
-  const { vitestMaxWorkers } = resolveLocalFullSuiteProfile(env, hostInfo);
+  const { vitestMaxWorkers } = resolveLocalFullSuiteProfile(env);
   return specs.map((spec) => ({
     ...spec,
     env: {

--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { acquireLocalHeavyCheckLockSync } from "./lib/local-heavy-check-runtime.mjs";
+import { isCiLikeEnv, resolveLocalFullSuiteProfile } from "./lib/vitest-local-scheduling.mjs";
 import { spawnPnpmRunner } from "./pnpm-runner.mjs";
 import { resolveVitestCliEntry, resolveVitestNodeArgs } from "./run-vitest.mjs";
 import {
@@ -124,14 +125,15 @@ function runVitestSpec(spec) {
 }
 
 function applyDefaultParallelVitestWorkerBudget(specs, env) {
-  if (env.OPENCLAW_VITEST_MAX_WORKERS || env.OPENCLAW_TEST_WORKERS) {
+  if (env.OPENCLAW_VITEST_MAX_WORKERS || env.OPENCLAW_TEST_WORKERS || isCiLikeEnv(env)) {
     return specs;
   }
+  const { vitestMaxWorkers } = resolveLocalFullSuiteProfile(env, hostInfo);
   return specs.map((spec) => ({
     ...spec,
     env: {
       ...spec.env,
-      OPENCLAW_VITEST_MAX_WORKERS: "1",
+      OPENCLAW_VITEST_MAX_WORKERS: String(vitestMaxWorkers),
     },
   }));
 }
@@ -214,6 +216,7 @@ async function main() {
   if (isFullSuiteRun) {
     const concurrency = resolveParallelFullSuiteConcurrency(runSpecs.length, process.env);
     if (concurrency > 1) {
+      const localFullSuiteProfile = resolveLocalFullSuiteProfile(process.env);
       const parallelSpecs = applyDefaultParallelVitestWorkerBudget(
         applyParallelVitestCachePaths(orderFullSuiteSpecsForParallelRun(runSpecs), {
           cwd: process.cwd(),
@@ -221,6 +224,16 @@ async function main() {
         }),
         process.env,
       );
+      if (
+        !isCiLikeEnv(process.env) &&
+        !process.env.OPENCLAW_TEST_PROJECTS_PARALLEL &&
+        !process.env.OPENCLAW_VITEST_MAX_WORKERS &&
+        !process.env.OPENCLAW_TEST_WORKERS &&
+        localFullSuiteProfile.shardParallelism === 10 &&
+        localFullSuiteProfile.vitestMaxWorkers === 2
+      ) {
+        console.error("[test] using host-aware local full-suite profile: shards=10 workers=2");
+      }
       console.error(
         `[test] running ${parallelSpecs.length} Vitest shards with parallelism ${concurrency}`,
       );

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -32,6 +32,7 @@ import {
   isBoundaryTestFile,
   isBundledPluginDependentUnitTestFile,
 } from "../test/vitest/vitest.unit-paths.mjs";
+import { isCiLikeEnv, resolveLocalFullSuiteProfile } from "./lib/vitest-local-scheduling.mjs";
 import { resolveVitestCliEntry, resolveVitestNodeArgs } from "./run-vitest.mjs";
 
 const DEFAULT_VITEST_CONFIG = "test/vitest/vitest.unit.config.ts";
@@ -88,7 +89,6 @@ const UTILS_VITEST_CONFIG = "test/vitest/vitest.utils.config.ts";
 const WIZARD_VITEST_CONFIG = "test/vitest/vitest.wizard.config.ts";
 const INCLUDE_FILE_ENV_KEY = "OPENCLAW_VITEST_INCLUDE_FILE";
 const FS_MODULE_CACHE_PATH_ENV_KEY = "OPENCLAW_VITEST_FS_MODULE_CACHE_PATH";
-const DEFAULT_LOCAL_FULL_SUITE_PARALLELISM = 4;
 const CHANGED_ARGS_PATTERN = /^--changed(?:=(.+))?$/u;
 const VITEST_CONFIG_BY_KIND = {
   acp: ACP_VITEST_CONFIG,
@@ -670,7 +670,7 @@ function hasConservativeVitestWorkerBudget(env) {
   return workerBudget !== null && workerBudget <= 1;
 }
 
-export function resolveParallelFullSuiteConcurrency(specCount, env = process.env) {
+export function resolveParallelFullSuiteConcurrency(specCount, env = process.env, hostInfo) {
   const override = parsePositiveInt(env.OPENCLAW_TEST_PROJECTS_PARALLEL);
   if (override !== null) {
     return Math.min(override, specCount);
@@ -678,7 +678,7 @@ export function resolveParallelFullSuiteConcurrency(specCount, env = process.env
   if (env.OPENCLAW_TEST_PROJECTS_SERIAL === "1") {
     return 1;
   }
-  if (env.CI === "true" || env.GITHUB_ACTIONS === "true") {
+  if (isCiLikeEnv(env)) {
     return 1;
   }
   if (hasConservativeVitestWorkerBudget(env)) {
@@ -690,7 +690,7 @@ export function resolveParallelFullSuiteConcurrency(specCount, env = process.env
   ) {
     return 1;
   }
-  return Math.min(DEFAULT_LOCAL_FULL_SUITE_PARALLELISM, specCount);
+  return Math.min(resolveLocalFullSuiteProfile(env, hostInfo).shardParallelism, specCount);
 }
 
 function sanitizeVitestCachePathSegment(value) {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -5,6 +5,7 @@ import {
   buildFullSuiteVitestRunPlans,
   buildVitestRunPlans,
   resolveChangedTargetArgs,
+  resolveParallelFullSuiteConcurrency,
 } from "../../scripts/test-projects.test-support.mjs";
 
 describe("scripts/test-projects changed-target routing", () => {
@@ -196,6 +197,52 @@ describe("scripts/test-projects changed-target routing", () => {
 });
 
 describe("scripts/test-projects full-suite sharding", () => {
+  it("uses the large host-aware local profile on roomy local hosts", () => {
+    expect(
+      resolveParallelFullSuiteConcurrency(
+        61,
+        {},
+        {
+          cpuCount: 14,
+          loadAverage1m: 0,
+          totalMemoryBytes: 48 * 1024 ** 3,
+        },
+      ),
+    ).toBe(10);
+  });
+
+  it("keeps CI full-suite runs serial even on roomy hosts", () => {
+    expect(
+      resolveParallelFullSuiteConcurrency(
+        61,
+        {
+          CI: "true",
+        },
+        {
+          cpuCount: 14,
+          loadAverage1m: 0,
+          totalMemoryBytes: 48 * 1024 ** 3,
+        },
+      ),
+    ).toBe(1);
+  });
+
+  it("keeps explicit parallel overrides ahead of the host-aware profile", () => {
+    expect(
+      resolveParallelFullSuiteConcurrency(
+        61,
+        {
+          OPENCLAW_TEST_PROJECTS_PARALLEL: "3",
+        },
+        {
+          cpuCount: 14,
+          loadAverage1m: 0,
+          totalMemoryBytes: 48 * 1024 ** 3,
+        },
+      ),
+    ).toBe(3);
+  });
+
   it("splits untargeted runs into fixed core shards and per-extension configs", () => {
     const previousParallel = process.env.OPENCLAW_TEST_PROJECTS_PARALLEL;
     const previousSerial = process.env.OPENCLAW_TEST_PROJECTS_SERIAL;

--- a/test/scripts/vitest-local-scheduling.test.ts
+++ b/test/scripts/vitest-local-scheduling.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveLocalFullSuiteProfile,
+  resolveLocalVitestScheduling,
+  shouldUseLargeLocalFullSuiteProfile,
+} from "../../scripts/lib/vitest-local-scheduling.mjs";
+
+describe("vitest local full-suite profile", () => {
+  it("selects the large local profile on roomy hosts that are not throttled", () => {
+    const env = {};
+    const hostInfo = {
+      cpuCount: 14,
+      loadAverage1m: 0,
+      totalMemoryBytes: 48 * 1024 ** 3,
+    };
+
+    expect(resolveLocalVitestScheduling(env, hostInfo, "threads")).toEqual({
+      maxWorkers: 6,
+      fileParallelism: true,
+      throttledBySystem: false,
+    });
+    expect(shouldUseLargeLocalFullSuiteProfile(env, hostInfo)).toBe(true);
+    expect(resolveLocalFullSuiteProfile(env, hostInfo)).toEqual({
+      shardParallelism: 10,
+      vitestMaxWorkers: 2,
+    });
+  });
+
+  it("keeps the smaller local profile when the host is already throttled", () => {
+    const hostInfo = {
+      cpuCount: 14,
+      loadAverage1m: 14,
+      totalMemoryBytes: 48 * 1024 ** 3,
+    };
+
+    expect(shouldUseLargeLocalFullSuiteProfile({}, hostInfo)).toBe(false);
+    expect(resolveLocalFullSuiteProfile({}, hostInfo)).toEqual({
+      shardParallelism: 4,
+      vitestMaxWorkers: 1,
+    });
+  });
+
+  it("never selects the large local profile in CI", () => {
+    const hostInfo = {
+      cpuCount: 14,
+      loadAverage1m: 0,
+      totalMemoryBytes: 48 * 1024 ** 3,
+    };
+
+    expect(shouldUseLargeLocalFullSuiteProfile({ CI: "true" }, hostInfo)).toBe(false);
+    expect(resolveLocalFullSuiteProfile({ CI: "true" }, hostInfo)).toEqual({
+      shardParallelism: 4,
+      vitestMaxWorkers: 1,
+    });
+  });
+});

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -1,25 +1,18 @@
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { pluginSdkSubpaths } from "../../scripts/lib/plugin-sdk-entries.mjs";
+import {
+  detectVitestHostInfo as detectVitestHostInfoImpl,
+  isCiLikeEnv,
+  resolveLocalVitestMaxWorkers as resolveLocalVitestMaxWorkersImpl,
+  resolveLocalVitestScheduling as resolveLocalVitestSchedulingImpl,
+} from "../../scripts/lib/vitest-local-scheduling.mjs";
 import {
   BUNDLED_PLUGIN_ROOT_DIR,
   BUNDLED_PLUGIN_TEST_GLOB,
 } from "./vitest.bundled-plugin-paths.ts";
 import { loadVitestExperimentalConfig } from "./vitest.performance-config.ts";
 import { shouldPrintVitestThrottle } from "./vitest.system-load.ts";
-
-const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
-
-function parsePositiveInt(value: string | undefined): number | null {
-  const parsed = Number.parseInt(value ?? "", 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-function isSystemThrottleDisabled(env: Record<string, string | undefined>): boolean {
-  const normalized = env.OPENCLAW_VITEST_DISABLE_SYSTEM_THROTTLE?.trim().toLowerCase();
-  return normalized === "1" || normalized === "true";
-}
 
 type VitestHostInfo = {
   cpuCount?: number;
@@ -45,12 +38,7 @@ export const jsdomOptimizedDeps = {
 };
 
 function detectVitestHostInfo(): Required<VitestHostInfo> {
-  return {
-    cpuCount:
-      typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length,
-    loadAverage1m: os.loadavg()[0] ?? 0,
-    totalMemoryBytes: os.totalmem(),
-  };
+  return detectVitestHostInfoImpl() as Required<VitestHostInfo>;
 }
 
 export function resolveLocalVitestMaxWorkers(
@@ -58,7 +46,7 @@ export function resolveLocalVitestMaxWorkers(
   system: VitestHostInfo = detectVitestHostInfo(),
   pool: OpenClawVitestPool = resolveDefaultVitestPool(env),
 ): number {
-  return resolveLocalVitestScheduling(env, system, pool).maxWorkers;
+  return resolveLocalVitestMaxWorkersImpl(env, system, pool);
 }
 
 export function resolveLocalVitestScheduling(
@@ -66,91 +54,7 @@ export function resolveLocalVitestScheduling(
   system: VitestHostInfo = detectVitestHostInfo(),
   pool: OpenClawVitestPool = resolveDefaultVitestPool(env),
 ): LocalVitestScheduling {
-  const override = parsePositiveInt(env.OPENCLAW_VITEST_MAX_WORKERS ?? env.OPENCLAW_TEST_WORKERS);
-  if (override !== null) {
-    const maxWorkers = clamp(override, 1, 16);
-    return {
-      maxWorkers,
-      fileParallelism: maxWorkers > 1,
-      throttledBySystem: false,
-    };
-  }
-
-  const cpuCount = Math.max(1, system.cpuCount ?? 1);
-  const loadAverage1m = Math.max(0, system.loadAverage1m ?? 0);
-  const totalMemoryGb = (system.totalMemoryBytes ?? 0) / 1024 ** 3;
-
-  // Keep smaller hosts conservative, but let large local boxes actually use
-  // their cores. Thread workers scale much better than the old fork-first cap.
-  let inferred =
-    cpuCount <= 2
-      ? 1
-      : cpuCount <= 4
-        ? 2
-        : cpuCount <= 8
-          ? 4
-          : Math.max(1, Math.floor(cpuCount * 0.75));
-
-  if (totalMemoryGb <= 16) {
-    inferred = Math.min(inferred, 2);
-  } else if (totalMemoryGb <= 32) {
-    inferred = Math.min(inferred, 4);
-  } else if (totalMemoryGb <= 64) {
-    inferred = Math.min(inferred, 6);
-  } else if (totalMemoryGb <= 128) {
-    inferred = Math.min(inferred, 8);
-  } else if (totalMemoryGb <= 256) {
-    inferred = Math.min(inferred, 12);
-  } else {
-    inferred = Math.min(inferred, 16);
-  }
-
-  const loadRatio = loadAverage1m > 0 ? loadAverage1m / cpuCount : 0;
-  if (loadRatio >= 1) {
-    inferred = Math.max(1, Math.floor(inferred / 2));
-  } else if (loadRatio >= 0.75) {
-    inferred = Math.max(1, inferred - 2);
-  } else if (loadRatio >= 0.5) {
-    inferred = Math.max(1, inferred - 1);
-  }
-
-  if (pool === "forks") {
-    inferred = Math.min(inferred, 8);
-  }
-
-  inferred = clamp(inferred, 1, 16);
-
-  if (isSystemThrottleDisabled(env)) {
-    return {
-      maxWorkers: inferred,
-      fileParallelism: true,
-      throttledBySystem: false,
-    };
-  }
-
-  if (loadRatio >= 1) {
-    const maxWorkers = Math.max(1, Math.floor(inferred / 2));
-    return {
-      maxWorkers,
-      fileParallelism: maxWorkers > 1,
-      throttledBySystem: maxWorkers < inferred,
-    };
-  }
-
-  if (loadRatio >= 0.75) {
-    const maxWorkers = Math.max(2, Math.ceil(inferred * 0.75));
-    return {
-      maxWorkers,
-      fileParallelism: true,
-      throttledBySystem: maxWorkers < inferred,
-    };
-  }
-
-  return {
-    maxWorkers: inferred,
-    fileParallelism: true,
-    throttledBySystem: false,
-  };
+  return resolveLocalVitestSchedulingImpl(env, system, pool) as LocalVitestScheduling;
 }
 
 export function resolveDefaultVitestPool(
@@ -164,7 +68,7 @@ export const nonIsolatedRunnerPath = path.join(repoRoot, "test", "non-isolated-r
 export function resolveRepoRootPath(value: string): string {
   return path.isAbsolute(value) ? value : path.join(repoRoot, value);
 }
-const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+const isCI = isCiLikeEnv(process.env);
 const isWindows = process.platform === "win32";
 const defaultPool = resolveDefaultVitestPool();
 const localScheduling = resolveLocalVitestScheduling(


### PR DESCRIPTION
## Summary

- Problem: local `pnpm test` kept using the conservative `4x1` full-suite defaults even on large local machines, while Vitest already had a host-aware local scheduler.
- Why it matters: larger developer machines can run the local full suite much faster, but only by setting manual env overrides.
- What changed: extracted the existing host-aware Vitest scheduling logic into a shared helper and reused it in the local full-suite test orchestration so large, non-throttled local hosts default to `10` shard parallelism and `2` Vitest workers.
- What did NOT change (scope boundary): CI / GitHub Actions behavior, explicit env override precedence, and per-project Vitest config semantics.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: local full-suite test orchestration used static defaults (`4x1`) instead of reusing the existing host-aware Vitest scheduler.
- Missing detection / guardrail: the outer `pnpm test` orchestration layer did not consume the same local-capacity signal already used inside Vitest config.
- Contributing context (if known): developers had to export `OPENCLAW_TEST_PROJECTS_PARALLEL` / `OPENCLAW_VITEST_MAX_WORKERS` manually to benefit from large local machines.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `test/scripts/vitest-local-scheduling.test.ts`
  - `test/scripts/test-projects.test.ts`
- Scenario the test should lock in:
  - roomy local hosts use `10x2`
  - CI stays serial / unchanged
  - explicit env overrides still win
- Why this is the smallest reliable guardrail:
  - the change is in local orchestration and scheduling selection, so focused test-runner coverage is the tightest seam.
- Existing test that already covers this (if any): `src/infra/vitest-config.test.ts` still covers the underlying Vitest worker inference.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- On large, non-throttled local machines, plain `pnpm test` now defaults to the host-aware full-suite profile (`shards=10`, `workers=2`).
- CI remains unchanged.

## Diagram (if applicable)

```text
Before:
local pnpm test -> static full-suite defaults -> 4 shards x 1 worker

After:
local pnpm test -> existing host-aware Vitest scheduler signal -> large local host -> 10 shards x 2 workers
                                                 \-> CI / busy / smaller host -> existing conservative behavior
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node / pnpm dev env
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test` on a roomy local machine with no explicit test env overrides.
2. Verify local full-suite orchestration chooses the host-aware large profile.
3. Run under `CI=true` and verify current CI semantics remain unchanged in tests.

### Expected

- Large local host uses `10x2`.
- CI remains unchanged.
- Explicit overrides still win.

### Actual

- Implemented and covered by focused tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test test/scripts/vitest-local-scheduling.test.ts test/scripts/test-projects.test.ts src/infra/vitest-config.test.ts`
  - `pnpm build`
- Edge cases checked:
  - CI / GitHub Actions path stays unchanged in tests
  - explicit env override precedence stays intact in tests
- What you did **not** verify:
  - full repeated end-to-end stability of the new default after this code change

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: large local hosts may surface existing flaky tests more often because the default local profile is more aggressive.
  - Mitigation: only enable the profile when the existing scheduler classifies the host as large and not throttled; keep CI unchanged and preserve explicit overrides.
