### PR TITLE
tests(agents): mock timeout compaction side effects at runtime seam

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -488,6 +488,10 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     runPostCompactionSideEffects: mockedRunPostCompactionSideEffects,
   }));
 
+  vi.doMock("./compaction-hooks.js", () => ({
+    runPostCompactionSideEffects: mockedRunPostCompactionSideEffects,
+  }));
+
   vi.doMock("./utils.js", () => ({
     describeUnknownError: vi.fn((err: unknown) => {
       if (err instanceof Error) {


### PR DESCRIPTION
## Summary

- CI pipeline: `checks-node-agentic`
- Failing problem: `src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts` -> `fires compaction hooks during timeout recovery for ownsCompaction engines`
- Problem: the shared overflow-compaction harness still mocked `./compact.js` after `run.ts` switched to importing `runPostCompactionSideEffects` from `./compaction-hooks.js`
- Why it matters: timeout-recovery coverage for owns-compaction engines started failing even though runtime behavior was still calling the side-effect seam
- What changed: mock the current `./compaction-hooks.js` seam in the shared harness while keeping the existing `./compact.js` mock for compatibility
- What did NOT change (scope boundary): runtime compaction behavior, hook execution order, and non-agent surfaces

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #64154
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the test harness mocked the old barrel seam after `src/agents/pi-embedded-runner/run.ts` started importing `runPostCompactionSideEffects` directly from `src/agents/pi-embedded-runner/compaction-hooks.ts`
- Missing detection / guardrail: the shared harness did not keep its mocked module path aligned with the runtime import boundary
- Contributing context (if known): overflow and timeout recovery share the same harness, so the stale mock only showed up once a test asserted the post-compaction side-effect call directly

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts`
- Scenario the test should lock in: owns-compaction timeout recovery fires post-compaction side effects through the same runtime seam that `run.ts` imports
- Why this is the smallest reliable guardrail: the failure came from the shared mock boundary rather than the core timeout-recovery logic itself
- Existing test that already covers this (if any): `src/agents/pi-embedded-runner/run.overflow-compaction.test.ts` exercises the same harness for overflow recovery
- If no new test is added, why not: existing targeted coverage was sufficient once the harness mocked the right seam

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

```text
Before:
run.ts -> compaction-hooks.ts -> side effects
harness -> mocks compact.ts only
=> timeout recovery assertion misses the real call site

After:
run.ts -> compaction-hooks.ts -> mocked side effects seam
harness -> mocks compaction-hooks.ts (and keeps compact.ts compatibility mock)
=> timeout recovery assertion observes the runtime call path
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default test harness config

### Steps

1. Run `pnpm test src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
2. Observe timeout-recovery owns-compaction coverage
3. Confirm both timeout and overflow compaction suites pass

### Expected

- The timeout-recovery test sees `runPostCompactionSideEffects` invoked through the current runtime seam.

### Actual

- Before this change, the timeout-recovery test failed because the harness mocked the wrong module path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: timeout-triggered compaction and overflow compaction both pass with the shared harness after mocking `./compaction-hooks.js`
- Edge cases checked: kept the legacy `./compact.js` mock in place so older callers remain covered by the same harness
- What you did **not** verify: full repo-wide agent/contract suites

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another harness or test could drift from the runtime import seam in the future
  - Mitigation: this shared harness now mocks both the legacy barrel and the runtime seam used by `run.ts`
